### PR TITLE
[OSDOCS-8070] OCP content port to ROSA and OSD: Service Mesh

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -1262,6 +1262,94 @@ Topics:
 - Name: Config map reference for the Cluster Monitoring Operator
   File: config-map-reference-for-the-cluster-monitoring-operator
 ---
+Name: Service Mesh
+Dir: service_mesh
+Distros: openshift-dedicated
+Topics:
+- Name: Service Mesh 2.x
+  Dir: v2x
+  Topics:
+  - Name: About OpenShift Service Mesh
+    File: ossm-about
+  - Name: Service Mesh 2.x release notes
+    File: servicemesh-release-notes
+  - Name: Service Mesh architecture
+    File: ossm-architecture
+  - Name: Service Mesh deployment models
+    File: ossm-deployment-models
+  - Name: Service Mesh and Istio differences
+    File: ossm-vs-community
+  - Name: Preparing to install Service Mesh
+    File: preparing-ossm-installation
+  - Name: Installing the Operators
+    File: installing-ossm
+  - Name: Creating the ServiceMeshControlPlane
+    File: ossm-create-smcp
+  - Name: Adding workloads to a service mesh
+    File: ossm-create-mesh
+  - Name: Enabling sidecar injection
+    File: prepare-to-deploy-applications-ossm
+  - Name: Upgrading Service Mesh
+    File: upgrading-ossm
+  - Name: Managing users and profiles
+    File: ossm-profiles-users
+  - Name: Security
+    File: ossm-security
+  - Name: Traffic management
+    File: ossm-traffic-manage
+  - Name: Metrics, logs, and traces
+    File: ossm-observability
+  - Name: Performance and scalability
+    File: ossm-performance-scalability
+  - Name: Deploying to production
+    File: ossm-deploy-production
+  - Name: Federation
+    File: ossm-federation
+  - Name: Extensions
+    File: ossm-extensions
+  - Name: 3scale WebAssembly for 2.1
+    File: ossm-threescale-webassembly-module
+  - Name: 3scale Istio adapter for 2.0
+    File: threescale-adapter
+  - Name: Troubleshooting Service Mesh
+    File: ossm-troubleshooting-istio
+  - Name: Control plane configuration reference
+    File: ossm-reference-smcp
+  - Name: Kiali configuration reference
+    File: ossm-reference-kiali
+  - Name: Jaeger configuration reference
+    File: ossm-reference-jaeger
+  - Name: Uninstalling Service Mesh
+    File: removing-ossm
+# Service Mesh 1.x is tech preview
+# - Name: Service Mesh 1.x
+#  Dir: v1x
+#  Topics:
+#  - Name: Service Mesh 1.x release notes
+#    File: servicemesh-release-notes
+#  - Name: Service Mesh architecture
+#    File: ossm-architecture
+#  - Name: Service Mesh and Istio differences
+#    File: ossm-vs-community
+#  - Name: Preparing to install Service Mesh
+#    File: preparing-ossm-installation
+#  - Name: Installing Service Mesh
+#    File: installing-ossm
+#  - Name: Security
+#    File: ossm-security
+#  - Name: Traffic management
+#    File: ossm-traffic-manage
+#  - Name: Deploying applications on Service Mesh
+#    File: prepare-to-deploy-applications-ossm
+#  - Name: Data visualization and observability
+#    File: ossm-observability
+#  - Name: Custom resources
+#    File: ossm-custom-resources
+#  - Name: 3scale Istio adapter for 1.x
+#    File: threescale-adapter
+#  - Name: Removing Service Mesh
+#    File: removing-ossm
+---
 Name: Serverless
 Dir: serverless
 Distros: openshift-dedicated

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1563,33 +1563,34 @@ Topics:
     File: ossm-reference-jaeger
   - Name: Uninstalling Service Mesh
     File: removing-ossm
-- Name: Service Mesh 1.x
-  Dir: v1x
-  Topics:
-  - Name: Service Mesh 1.x release notes
-    File: servicemesh-release-notes
-  - Name: Service Mesh architecture
-    File: ossm-architecture
-  - Name: Service Mesh and Istio differences
-    File: ossm-vs-community
-  - Name: Preparing to install Service Mesh
-    File: preparing-ossm-installation
-  - Name: Installing Service Mesh
-    File: installing-ossm
-  - Name: Security
-    File: ossm-security
-  - Name: Traffic management
-    File: ossm-traffic-manage
-  - Name: Deploying applications on Service Mesh
-    File: prepare-to-deploy-applications-ossm
-  - Name: Data visualization and observability
-    File: ossm-observability
-  - Name: Custom resources
-    File: ossm-custom-resources
-  - Name: 3scale Istio adapter for 1.x
-    File: threescale-adapter
-  - Name: Removing Service Mesh
-    File: removing-ossm
+# Service Mesh 1.x is tech preview
+# - Name: Service Mesh 1.x
+#  Dir: v1x
+#  Topics:
+#  - Name: Service Mesh 1.x release notes
+#    File: servicemesh-release-notes
+#  - Name: Service Mesh architecture
+#    File: ossm-architecture
+#  - Name: Service Mesh and Istio differences
+#    File: ossm-vs-community
+#  - Name: Preparing to install Service Mesh
+#    File: preparing-ossm-installation
+#  - Name: Installing Service Mesh
+#    File: installing-ossm
+#  - Name: Security
+#    File: ossm-security
+#  - Name: Traffic management
+#    File: ossm-traffic-manage
+#  - Name: Deploying applications on Service Mesh
+#    File: prepare-to-deploy-applications-ossm
+#  - Name: Data visualization and observability
+#    File: ossm-observability
+#  - Name: Custom resources
+#    File: ossm-custom-resources
+#  - Name: 3scale Istio adapter for 1.x
+#    File: threescale-adapter
+#  - Name: Removing Service Mesh
+#    File: removing-ossm
 ---
 Name: Serverless
 Dir: serverless

--- a/modules/distr-tracing-config-storage.adoc
+++ b/modules/distr-tracing-config-storage.adoc
@@ -645,6 +645,7 @@ spec:
 <3> Secret which defines environment variables ES_PASSWORD and ES_USERNAME. Created by kubectl create secret generic tracing-secret --from-literal=ES_PASSWORD=changeme --from-literal=ES_USERNAME=elastic
 <4> Volume mounts and volumes which are mounted into all storage components.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [id="distr-tracing-manage-es-certificates_{context}"]
 = Managing certificates with Elasticsearch
 
@@ -721,3 +722,4 @@ spec:
 The {JaegerName} Operator sets the Elasticsearch custom resource `name` to the value of `spec.storage.elasticsearch.name` from the Jaeger custom resource when provisioning Elasticsearch.
 
 The certificates are provisioned by the Red Hat Elasticsearch Operator and the {JaegerName} Operator injects the certificates.
+endif::openshift-rosa,openshift-dedicated[]

--- a/modules/ossm-about-smcp.adoc
+++ b/modules/ossm-about-smcp.adoc
@@ -25,3 +25,6 @@ The {SMProductShortName} documentation uses `istio-system` as the example projec
 ifdef::openshift-rosa[]
 If you are deploying the control plane for use on {product-rosa}, see the Red Hat Knowledgebase article link:https://access.redhat.com/solutions/6529231[OpenShift service mesh operator Istio basic not starting due to authentication errors], which discusses adding a new project and starting pods.
 endif::openshift-rosa[]
+ifdef::openshift-dedicated[]
+If you are deploying the control plane for use on {product-dedicated}, see the Red Hat Knowledgebase article link:https://access.redhat.com/solutions/6529231[OpenShift service mesh operator Istio basic not starting due to authentication errors], which discusses adding a new project and starting pods.
+endif::openshift-dedicated[]

--- a/modules/ossm-configuring-the-threescale-wasm-auth-module.adoc
+++ b/modules/ossm-configuring-the-threescale-wasm-auth-module.adoc
@@ -25,7 +25,9 @@ Configuring the WebAssembly extension is currently a manual process. Support for
 
 * Identify a Kubernetes workload and namespace on your {SMProductShortName} deployment that you will apply this module.
 * You must have a 3scale tenant account. See link:https://www.3scale.net/signup[SaaS] or link:https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.11/html-single/installing_3scale/index#install-threescale-on-openshift-guide[3scale 2.11 On-Premises] with a matching service and relevant applications and metrics defined.
+ifndef::openshift-rosa,openshift-dedicated[]
 * If you apply the module to the `<product_page>` microservice in the `bookinfo` namespace, see the xref:../../service_mesh/v1x/prepare-to-deploy-applications-ossm.adoc#ossm-tutorial-bookinfo-overview_deploying-applications-ossm-v1x[Bookinfo sample application].
+endif::openshift-rosa,openshift-dedicated[]
 ** The following example is the YAML format for the custom resource for `threescale-wasm-auth` module.
 This example refers to the upstream Maistra version of {SMProductShortName}, `WasmPlugin` API. You must declare the namespace where the `threescale-wasm-auth` module is deployed, alongside a `selector` to identify the set of applications the module will apply to:
 +

--- a/modules/ossm-control-plane-web.adoc
+++ b/modules/ossm-control-plane-web.adoc
@@ -11,7 +11,12 @@ You can deploy a basic `ServiceMeshControlPlane` by using the web console.  In t
 .Prerequisites
 
 * The {SMProductName} Operator must be installed.
-* An account with the `cluster-admin` role.
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to the {product-title} web console as `cluster-admin`.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to the {product-title} web console as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 
 .Procedure
 

--- a/modules/ossm-federation-across-cluster.adoc
+++ b/modules/ossm-federation-across-cluster.adoc
@@ -15,26 +15,30 @@ If the cluster runs on bare metal and fully supports `LoadBalancer` services, th
 
 If the cluster does not support `LoadBalancer` services, using a `NodePort` service could be an option if the nodes are accessible from the cluster running the other mesh. In the `ServiceMeshPeer` object, specify the IP addresses of the nodes in the `.spec.remote.addresses` field and the service's node ports in the `.spec.remote.discoveryPort` and `.spec.remote.servicePort` fields.
 
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-dedicated[]
 == Exposing the federation ingress on clusters running on {ibm-power-title} and {ibm-z-title}
 If the cluster runs on {ibm-power-name} or {ibm-z-name} infrastructure and fully supports `LoadBalancer` services, the IP address found in the `.status.loadBalancer.ingress.ip` field of the ingress gateway `Service` object should be specified as one of the entries in the `.spec.remote.addresses` field of the `ServiceMeshPeer` object.
 
 If the cluster does not support `LoadBalancer` services, using a `NodePort` service could be an option if the nodes are accessible from the cluster running the other mesh. In the `ServiceMeshPeer` object, specify the IP addresses of the nodes in the `.spec.remote.addresses` field and the service's node ports in the `.spec.remote.discoveryPort` and `.spec.remote.servicePort` fields.
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-dedicated[]
 
+ifndef::openshift-dedicated[]
 == Exposing the federation ingress on Amazon Web Services (AWS)
 By default, LoadBalancer services in clusters running on AWS do not support L4 load balancing. In order for {SMProductName} federation to operate correctly, the following annotation must be added to the ingress gateway service:
 
 service.beta.kubernetes.io/aws-load-balancer-type: nlb
 
 The Fully Qualified Domain Name found in the `.status.loadBalancer.ingress.hostname` field of the ingress gateway `Service` object should be specified as one of the entries in the `.spec.remote.addresses` field of the `ServiceMeshPeer` object.
+endif::openshift-dedicated[]
 
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-dedicated[]
 == Exposing the federation ingress on Azure
 On Microsoft Azure, merely setting the service type to `LoadBalancer` suffices for mesh federation to operate correctly.
 
 The IP address found in the `.status.loadBalancer.ingress.ip` field of the ingress gateway `Service` object should be specified as one of the entries in the `.spec.remote.addresses` field of the `ServiceMeshPeer` object.
+endif::openshift-rosa,openshift-dedicated[]
 
+ifndef::openshift-rosa[]
 == Exposing the federation ingress on Google Cloud Platform (GCP)
 On Google Cloud Platform, merely setting the service type to `LoadBalancer` suffices for mesh federation to operate correctly.
 

--- a/modules/ossm-federation-config-smcp.adoc
+++ b/modules/ossm-federation-config-smcp.adoc
@@ -11,6 +11,7 @@ Before a mesh can be federated, you must configure the `ServiceMeshControlPlane`
 
 In the following example, the administrator for the `red-mesh` is configuring the SMCP for federation with both the `green-mesh` and the `blue-mesh`.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 .Sample SMCP for red-mesh
 [source,yaml, subs="attributes,verbatim"]
 ----
@@ -82,7 +83,86 @@ spec:
     trust:
       domain: red-mesh.local
 ----
-
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+.Sample SMCP for red-mesh
+[source,yaml, subs="attributes,verbatim"]
+----
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: red-mesh
+  namespace: red-mesh-system
+spec:
+  version: v{MaistraVersion}
+  runtime:
+    defaults:
+      container:
+        imagePullPolicy: Always
+  gateways:
+    additionalEgress:
+      egress-green-mesh:
+        enabled: true
+        requestedNetworkView:
+        - green-network
+        routerMode: sni-dnat
+        service:
+          metadata:
+            labels:
+              federation.maistra.io/egress-for: egress-green-mesh
+          ports:
+          - port: 15443
+            name: tls
+          - port: 8188
+            name: http-discovery  #note HTTP here
+      egress-blue-mesh:
+        enabled: true
+        requestedNetworkView:
+        - blue-network
+        routerMode: sni-dnat
+        service:
+          metadata:
+            labels:
+              federation.maistra.io/egress-for: egress-blue-mesh
+          ports:
+          - port: 15443
+            name: tls
+          - port: 8188
+            name: http-discovery  #note HTTP here
+    additionalIngress:
+      ingress-green-mesh:
+        enabled: true
+        routerMode: sni-dnat
+        service:
+          type: LoadBalancer
+          metadata:
+            labels:
+              federation.maistra.io/ingress-for: ingress-green-mesh
+          ports:
+          - port: 15443
+            name: tls
+          - port: 8188
+            name: https-discovery  #note HTTPS here
+      ingress-blue-mesh:
+        enabled: true
+        routerMode: sni-dnat
+        service:
+          type: LoadBalancer
+          metadata:
+            labels:
+              federation.maistra.io/ingress-for: ingress-blue-mesh
+          ports:
+          - port: 15443
+            name: tls
+          - port: 8188
+            name: https-discovery  #note HTTPS here
+  security:
+    identity:
+      type: ThirdParty
+    trust:
+      domain: red-mesh.local
+----
+endif::openshift-rosa,openshift-dedicated[]
 
 .ServiceMeshControlPlane federation configuration parameters
 [options="header"]
@@ -141,7 +221,6 @@ To avoid naming conflicts between meshes, you must create separate egress and in
         requestedNetworkView:
 |Networks associated with exported services.
 |Set to the value of `spec.cluster.network` in the SMCP for the mesh, otherwise use <ServiceMeshPeer-name>-network. For example, if the `ServiceMeshPeer` resource for that mesh is named `west`, then the network would be named `west-network`.
-|
 |
 
 |spec:

--- a/modules/ossm-install-ossm-operator.adoc
+++ b/modules/ossm-install-ossm-operator.adoc
@@ -21,7 +21,12 @@ If you have already installed the OpenShift Elasticsearch Operator as part of Op
 
 .Procedure
 
-. Log in to the {product-title} web console as a user with the `cluster-admin` role. If you use {product-dedicated}, you must have an account with the `dedicated-admin` role.
+ifndef::openshift-rosa,openshift-dedicated[]
+. Log in to the {product-title} web console as a user with the `cluster-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+. Log in to the {product-title} web console as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 
 . In the {product-title} web console, click *Operators* -> *OperatorHub*.
 

--- a/modules/ossm-remove-cleanup.adoc
+++ b/modules/ossm-remove-cleanup.adoc
@@ -16,6 +16,7 @@ You can manually remove resources left behind after removing the {SMProductName}
 
 .Procedure
 
+ifndef::openshift-rosa,openshift-dedicated[]
 . Log in to the {product-title} CLI as a cluster administrator.
 
 . Run the following commands to clean up resources after uninstalling the Operators. If you intend to keep using {JaegerShortName} as a stand-alone service without service mesh, do not delete the Jaeger resources.
@@ -94,3 +95,56 @@ $ oc delete cm -n openshift-operators -lmaistra-version
 ----
 $ oc delete sa -n openshift-operators -lmaistra-version
 ----
+endif::openshift-rosa,openshift-dedicated[]
+
+// Hiding in ROSA/OSD, dedicated-admins cannot delete resource "mutatingwebhookconfigurations" or "validatingwebhookconfigurations" or "customresourcedefinitions"
+ifdef::openshift-rosa,openshift-dedicated[]
+. Log in to the {product-title} CLI as a cluster administrator.
+
+. Run the following commands to clean up resources after uninstalling the Operators. If you intend to keep using {JaegerShortName} as a stand-alone service without service mesh, do not delete the Jaeger resources.
++
+[NOTE]
+====
+The OpenShift Elasticsearch Operator is installed in `openshift-operators-redhat` by default. The other Operators are installed in the `openshift-operators` namespace by default. If you installed the Operators in another namespace, replace `openshift-operators` with the name of the project where the {SMProductName} Operator was installed.
+====
++
+[source,terminal]
+----
+$ oc delete svc maistra-admission-controller -n openshift-operators
+----
++
+[source,terminal]
+----
+$ oc -n openshift-operators delete ds -lmaistra-version
+----
++
+[source,terminal]
+----
+$ oc delete clusterrole/istio-admin clusterrole/istio-cni clusterrolebinding/istio-cni
+----
++
+[source,terminal]
+----
+$ oc delete clusterrole istio-view istio-edit
+----
++
+[source,terminal]
+----
+$ oc delete clusterrole jaegers.jaegertracing.io-v1-admin jaegers.jaegertracing.io-v1-crdview jaegers.jaegertracing.io-v1-edit jaegers.jaegertracing.io-v1-view
+----
++
+[source,terminal]
+----
+$ oc delete cm -n openshift-operators maistra-operator-cabundle
+----
++
+[source,terminal]
+----
+$ oc delete cm -n openshift-operators istio-cni-config istio-cni-config-v2-3
+----
++
+[source,terminal]
+----
+$ oc delete sa -n openshift-operators istio-cni
+----
+endif::openshift-rosa,openshift-dedicated[]

--- a/modules/ossm-rn-fixed-issues.adoc
+++ b/modules/ossm-rn-fixed-issues.adoc
@@ -207,9 +207,11 @@ Upgrading the operator to 2.0 might break client tools that read the SMCP status
 +
 This also causes the READY and STATUS columns to be empty when you run `oc get servicemeshcontrolplanes.v1.maistra.io`.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 * link:https://issues.jboss.org/browse/MAISTRA-1947[MAISTRA-1947] _Technology Preview_ Updates to ServiceMeshExtensions are not applied.
 +
 Workaround: Remove and recreate the `ServiceMeshExtensions`.
+endif::openshift-rosa,openshift-dedicated[]
 
 * link:https://issues.redhat.com/browse/MAISTRA-1983[MAISTRA-1983] _Migration to 2.0_ Upgrading to 2.0.0 with an existing invalid `ServiceMeshControlPlane` cannot easily be repaired. The invalid items in the `ServiceMeshControlPlane` resource caused an unrecoverable error. The fix makes the errors recoverable. You can delete the invalid resource and replace it with a new one or edit the resource to fix the errors. For more information about editing your resource, see [Configuring the Red Hat OpenShift Service Mesh installation].
 

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -193,7 +193,9 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 
 == New features {SMProductName} version 2.4.3
 
+ifndef::openshift-rosa,openshift-dedicated[]
 * The {SMProductName} Operator is now available on ARM-based clusters as a Technology Preview feature.
+endif::openshift-rosa,openshift-dedicated[]
 * The `envoyExtAuthzGrpc` field has been added, which is used to configure an external authorization provider using the gRPC API.
 * Common Vulnerabilities and Exposures (CVEs) have been addressed.
 * This release is supported on {product-title} 4.10 and newer versions.
@@ -219,11 +221,14 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 |===
 //COMPONENTS ABOVE MAY NEED TO BE UPDATED FOR 2.4.3
 
+// Tech Preview features not supported in OSA/OSD
+ifndef::openshift-rosa,openshift-dedicated[]
 === {SMProductName} operator to ARM-based clusters
 :FeatureName: {SMProductName} operator to ARM based clusters
 include::snippets/technology-preview.adoc[]
 
 This release makes the {SMProductName} Operator available on ARM-based clusters as a Technology Preview feature. Images are available for Istio, Envoy, Prometheus, Kiali, and Grafana. Images are not available for Jaeger, so Jaeger must be disabled as a {SMProductShortName} add-on.
+endif::openshift-rosa,openshift-dedicated[]
 
 === Remote Procedure Calls (gRPC) API support for external authorization configuration
 
@@ -359,11 +364,13 @@ This enhancement introduces generally available support for single stack IPv6 cl
 Single stack IPv6 support is not available on {ibm-power-name}, {ibm-z-name}, and {ibm-linuxone-name}.
 ====
 
+ifndef::openshift-rosa,openshift-dedicated[]
 === {product-title} Gateway API support
 :FeatureName: {product-title} Gateway API support
 include::snippets/technology-preview.adoc[]
 
 This enhancement introduces an updated Technology Preview version of the {product-title} Gateway API. By default, the {product-title} Gateway API is disabled.
+endif::openshift-rosa,openshift-dedicated[]
 
 ==== Enabling {product-title} Gateway API
 To enable the {product-title} Gateway API, set the value of the `enabled` field to `true` in the `techPreview.gatewayAPI` specification of the `ServiceMeshControlPlane` resource.
@@ -406,7 +413,9 @@ endif::openshift-rosa[]
 
 * HBONE protocol for sidecars is an experimental feature that is not supported.
 * {SMProductShortName} on ARM64 architecture is not supported.
+ifndef::openshift-rosa,openshift-dedicated[]
 * OpenTelemetry API remains a Technology Preview feature.
+endif::openshift-rosa,openshift-dedicated[]
 
 [id="new-features-ossm-2-3-10"]
 == New features {SMProductName} version 2.3.10
@@ -676,15 +685,20 @@ This release introduces generally available support for Gateway injection. Gatew
 {SMProductShortName} 2.3 is based on Istio 1.14, which brings in new features and product enhancements. While many Istio 1.14 features are supported, the following exceptions should be noted:
 
 * ProxyConfig API is supported with the exception of the image field.
+ifndef::openshift-rosa,openshift-dedicated[]
 * Telemetry API is a Technology Preview feature.
+endif::openshift-rosa,openshift-dedicated[]
 * SPIRE runtime is not a supported feature.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 === OpenShift Service Mesh Console
 :FeatureName: OpenShift Service Mesh Console
 include::snippets/technology-preview.adoc[]
 
 This release introduces a Technology Preview version of the {product-title} Service Mesh Console, which integrates the Kiali interface directly into the OpenShift web console. For additional information, see link:https://cloud.redhat.com/blog/introducing-the-openshift-service-mesh-console-a-developer-preview[Introducing the OpenShift Service Mesh Console (A Technology Preview)]
+endif::openshift-rosa,openshift-dedicated[]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 ===  Cluster-wide deployment
 :FeatureName: Cluster-wide deployment
 include::snippets/technology-preview.adoc[]
@@ -695,6 +709,7 @@ This release introduces cluster-wide deployment as a Technology Preview feature.
 ====
 This cluster-wide deployment documentation is only applicable for control planes deployed using SMCP v2.3. cluster-wide deployments created using SMCP v2.3 are not compatible with cluster-wide deployments created using SMCP v2.4.
 ====
+endif::openshift-rosa,openshift-dedicated[]
 
 ==== Configuring cluster-wide deployment
 
@@ -1055,6 +1070,7 @@ This release marks the end of support for {SMProductShortName} Control Planes ba
 * External control plane is not a supported feature.
 * Gateway injection is not a supported feature.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 === Kubernetes Gateway API
 :FeatureName: Kubernetes Gateway API
 include::snippets/technology-preview.adoc[]
@@ -1062,6 +1078,7 @@ include::snippets/technology-preview.adoc[]
 Kubernetes Gateway API is a technology preview feature that is disabled by default. If the Kubernetes API deployment controller is disabled, you must manually deploy and link an ingress gateway to the created Gateway object.
 
 If the Kubernetes API deployment controller is enabled, then an ingress gateway automatically deploys when a Gateway object is created.
+endif::openshift-rosa,openshift-dedicated[]
 
 ==== Installing the Gateway API CRDs
 The Gateway API CRDs do not come preinstalled by default on OpenShift clusters. Install the CRDs prior to enabling Gateway API support in the SMCP.
@@ -1822,4 +1839,6 @@ In addition, this release has the following new features:
 
 * Updates the ServiceMeshControlPlane resource to v2 with a streamlined configuration to make it easier to manage the {SMProductShortName} Control Plane.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 * Introduces WebAssembly extensions as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] feature.
+endif::openshift-rosa,openshift-dedicated[]

--- a/modules/ossm-supported-configurations.adoc
+++ b/modules/ossm-supported-configurations.adoc
@@ -15,12 +15,16 @@ The following configurations are supported for the current release of {SMProduct
 
 The {SMProductName} Operator supports multiple versions of the `ServiceMeshControlPlane` resource. Version {MaistraVersion} {SMProductShortName} control planes are supported on the following platform versions:
 
-* Red Hat {product-title} version 4.10 or later.
-* {product-dedicated} version 4.
-ifndef::openshift-rosa[]
-* Azure Red Hat OpenShift (ARO) version 4.
-endif::openshift-rosa[]
-* Red Hat OpenShift Service on AWS (ROSA).
+// Updating the list so that all 4 supported platforms appear in all versions; the wording works better that way and it removed the repeated ROSA listing.
+ifdef::openshift-rosa,openshift-dedicated[]
+* Red Hat OpenShift Container Platform version 4.10 or later
+endif::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-dedicated[]
+* Red Hat {product-title} version 4.10 or later
+endif::openshift-rosa,openshift-dedicated[]
+* {product-dedicated} version 4
+* Azure Red Hat OpenShift (ARO) version 4
+* Red Hat OpenShift Service on AWS (ROSA)
 
 [id="ossm-unsupported-configurations_{context}"]
 == Unsupported configurations

--- a/service_mesh/v1x/ossm-observability.adoc
+++ b/service_mesh/v1x/ossm-observability.adoc
@@ -12,7 +12,11 @@ You can view your application's topology, health and metrics in the Kiali consol
 
 .Before you begin
 
-You can observe the data flow through your application if you have an application installed. If you don't have your own application installed, you can see how observability works in {SMProductName} by installing the xref:../../service_mesh/v1x/prepare-to-deploy-applications-ossm.adoc#ossm-tutorial-bookinfo-overview_deploying-applications-ossm-v1x[Bookinfo sample application].
+You can observe the data flow through your application if you have an application installed.
+
+ifndef::openshift-rosa,openshift-dedicated[]
+If you don't have your own application installed, you can see how observability works in {SMProductName} by installing the xref:../../service_mesh/v1x/prepare-to-deploy-applications-ossm.adoc#ossm-tutorial-bookinfo-overview_deploying-applications-ossm-v1x[Bookinfo sample application].
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/ossm-observability-access.adoc[leveloffset=+1]
 

--- a/service_mesh/v2x/ossm-create-smcp.adoc
+++ b/service_mesh/v2x/ossm-create-smcp.adoc
@@ -14,7 +14,7 @@ include::modules/ossm-control-plane-cli.adoc[leveloffset=+2]
 
 include::modules/ossm-validate-smcp-cli.adoc[leveloffset=+2]
 
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-dedicated[]
 
 include::modules/ossm-about-control-plane-components-and-infrastructure-nodes.adoc[leveloffset=+1]
 
@@ -28,7 +28,7 @@ include::modules/ossm-config-individual-control-plane-infrastructure-node-cli.ad
 
 include::modules/ossm-confirm-smcp-infrastructure-node.adoc[leveloffset=+2]
 
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/ossm-about-control-plane-and-cluster-wide-deployment.adoc[leveloffset=+1]
 

--- a/service_mesh/v2x/ossm-observability.adoc
+++ b/service_mesh/v2x/ossm-observability.adoc
@@ -42,14 +42,18 @@ include::modules/ossm-access-grafana.adoc[leveloffset=+1]
 
 include::modules/ossm-access-prometheus.adoc[leveloffset=+1]
 
+// Hiding in ROSA/OSD, dedicated-admin cannot list "secrets"
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/ossm-integrating-with-user-workload-monitoring.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-dedicated[]
 
+// Hiding as these assemblies not in ROSA/OSD
+ifndef::openshift-rosa,openshift-dedicated[]
 [role="_additional-resources"]
 [id="additional-resources_user-workload-monitoring"]
 == Additional resources
 
-ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../../monitoring/enabling-monitoring-for-user-defined-projects.adoc[Enabling monitoring for user-defined projects]
 * xref:../../observability/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-installing.adoc[Installing the distributed tracing platform (Tempo)]
 * xref:../../observability/otel/otel-installing.adoc[Installing the Red Hat build of OpenTelemetry]
-endif::[]
+endif::openshift-rosa,openshift-dedicated[]

--- a/service_mesh/v2x/ossm-reference-smcp.adoc
+++ b/service_mesh/v2x/ossm-reference-smcp.adoc
@@ -20,7 +20,10 @@ For information about creating profiles, see the xref:../../service_mesh/v2x/oss
 
 For more detailed examples of security configuration, see xref:../../service_mesh/v2x/ossm-security.adoc#ossm-security-mtls_ossm-security[Mutual Transport Layer Security (mTLS)].
 
+// No tech preview in ROSA/OSD
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/ossm-cr-techPreview.adoc[leveloffset=+2]
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/ossm-cr-tracing.adoc[leveloffset=+2]
 

--- a/service_mesh/v2x/ossm-traffic-manage.adoc
+++ b/service_mesh/v2x/ossm-traffic-manage.adoc
@@ -10,9 +10,12 @@ Using {SMProductName}, you can control the flow of traffic and API calls between
 
 include::modules/ossm-gateways.adoc[leveloffset=+1]
 
+// Hiding in ROSA/OSD, dedicated-admin cannot create "services" or "deployments"
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/ossm-automatic-gateway-injection.adoc[leveloffset=+2]
 
 include::modules/ossm-deploying-automatic-gateway-injection.adoc[leveloffset=+2]
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/ossm-routing-ingress.adoc[leveloffset=+2]
 

--- a/service_mesh/v2x/ossm-troubleshooting-istio.adoc
+++ b/service_mesh/v2x/ossm-troubleshooting-istio.adoc
@@ -64,8 +64,10 @@ include::modules/support-knowledgebase-about.adoc[leveloffset=+2]
 
 include::modules/support-knowledgebase-search.adoc[leveloffset=+2]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/ossm-about-collecting-ossm-data.adoc[leveloffset=+2]
 
 For prompt support, supply diagnostic information for both {product-title} and {SMProductName}.
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/support-submitting-a-case.adoc[leveloffset=+2]

--- a/service_mesh/v2x/servicemesh-release-notes.adoc
+++ b/service_mesh/v2x/servicemesh-release-notes.adoc
@@ -12,7 +12,10 @@ include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::modules/ossm-rn-new-features.adoc[leveloffset=+1]
 
+// Tech preview not supported in ROSA/OSD
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/ossm-rn-technology-preview.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/ossm-rn-deprecated-features.adoc[leveloffset=+1]
 


### PR DESCRIPTION
This PR ports the Service Mesh book from OCP to the OSD and ROSA books using single-sourcing.

**PEER REVIEWER**
This PR is to add the "Service Mesh" book to OSD and ROSA. There is little or no new text. Most of the changes are hiding assemblies, adding ifdefs, updating links, etc. The peer review principally just needs a sanity-level review to make sure everything looks OK.

https://issues.redhat.com/browse/OSDOCS-8070

Previews
OCP: https://67901--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-about
ROSA: https://67901--ocpdocs-pr.netlify.app/openshift-rosa/latest/service_mesh/v2x/ossm-about
OSD: https://67901--ocpdocs-pr.netlify.app/openshift-dedicated/latest/service_mesh/v2x/ossm-about

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
