### PR TITLE
OSD-19685 Remove invalid permission s3:GetBucketReplication

### DIFF
--- a/modules/installation-aws-permissions.adoc
+++ b/modules/installation-aws-permissions.adoc
@@ -187,7 +187,6 @@ If you have not created a load balancer in your AWS account, the IAM user also r
 * `s3:GetBucketLogging`
 * `s3:GetBucketPolicy`
 * `s3:GetBucketObjectLockConfiguration`
-* `s3:GetBucketReplication`
 * `s3:GetBucketRequestPayment`
 * `s3:GetBucketTagging`
 * `s3:GetBucketVersioning`

--- a/modules/rosa-sts-account-wide-roles-and-policies.adoc
+++ b/modules/rosa-sts-account-wide-roles-and-policies.adoc
@@ -236,7 +236,6 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
                 "s3:GetBucketLogging",
                 "s3:GetBucketObjectLockConfiguration",
                 "s3:GetBucketPolicy",
-                "s3:GetBucketReplication",
                 "s3:GetBucketRequestPayment",
                 "s3:GetBucketTagging",
                 "s3:GetBucketVersioning",


### PR DESCRIPTION
Remove invalid permission s3:GetBucketReplication

Version(s): 4.14

Issue:
[OSD-19685](https://issues.redhat.com//browse/OSD-19685)

Link to docs preview:
https://67902--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-sts-about-iam-resources

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This AWS action simply does not exist, if you use IAM Access Analyzer and attempt to add this action it will tell you:

> Invalid Action: The action s3:GetBucketReplication does not exist. Did you mean s3:GetReplicationConfiguration? The API called GetBucketReplication authorizes against the IAM action s3:GetReplicationConfiguration.

Both of these existing policies do in fact also contain the correct action `s3:GetReplicationConfiguration`, so we just need to remove the invalid action. For ROSA - this invalid action is being removed via https://github.com/openshift/managed-cluster-config/pull/1929