### PR TITLE
OSDOCS#8632: Updating IMPORTANT admonition regarding installer created VPCs

### DIFF
--- a/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
@@ -196,9 +196,11 @@ You can reference the ARN of your KMS key when you create the cluster in the nex
 
 . Create a cluster with STS using custom installation options. You can use the `--interactive` mode to interactively specify custom settings:
 +
-[IMPORTANT]
+[WARNING]
 ====
-You cannot install a ROSA cluster into an existing managed VPC. Managed VPCs are created during the managed cluster deployment process, and must only be associated with a single cluster to ensure that cluster provisioning and deletion operations work correctly. To determine whether a VPC is managed, look for the `red-hat-managed` tag; managed VPCs are tagged with `red-hat-managed:true`.
+You cannot install a ROSA cluster into an existing VPC that was created by the OpenShift installer. These VPCs are created during the cluster deployment process and must only be associated with a single cluster to ensure that cluster provisioning and deletion operations work correctly.
+
+To verify whether a VPC was created by the OpenShift installer, check for the `owned` value on the `kubernetes.io/cluster/<infra-id>` tag. For example, when viewing the tags for the VPC named `mycluster-12abc-34def`, the `kubernetes.io/cluster/mycluster-12abc-34def` tag has a value of `owned`. Therefore, the VPC was created by the installer and must not be modified by the administrator.
 ====
 +
 [source,terminal]
@@ -280,9 +282,11 @@ Tags that are added by Red Hat are required for clusters to stay in compliance w
 <7> Optional: Multiple availability zones are recommended for production workloads. The default is a single availability zone.
 <8> Optional: You can create a cluster in an existing VPC, or ROSA can create a new VPC to use.
 +
-[IMPORTANT]
+[WARNING]
 ====
-You cannot install a ROSA cluster into an existing managed VPC. Managed VPCs are created during the managed cluster deployment process, and must only be associated with a single cluster to ensure that cluster provisioning and deletion operations work correctly. To determine whether a VPC is managed, look for the `red-hat-managed` tag; managed VPCs are tagged with `red-hat-managed:true`.
+You cannot install a ROSA cluster into an existing VPC that was created by the OpenShift installer. These VPCs are created during the cluster deployment process and must only be associated with a single cluster to ensure that cluster provisioning and deletion operations work correctly.
+
+To verify whether a VPC was created by the OpenShift installer, check for the `owned` value on the `kubernetes.io/cluster/<infra-id>` tag. For example, when viewing the tags for the VPC named `mycluster-12abc-34def`, the `kubernetes.io/cluster/mycluster-12abc-34def` tag has a value of `owned`. Therefore, the VPC was created by the installer and must not be modified by the administrator.
 ====
 <9> Optional: Enable this option if you are using your own AWS KMS key to encrypt the control plane, infrastructure, worker node root volumes, and PVs. Specify the ARN for the KMS key that you added to the account-wide role ARN in the preceding step.
 +

--- a/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
@@ -281,9 +281,11 @@ If you are using private API endpoints, you cannot access your cluster until you
 
 . Optional: If you opted to use public API endpoints, by default a new VPC is created for your cluster. If you want to install your cluster in an existing VPC instead, select *Install into an existing VPC*.
 +
-[IMPORTANT]
+[WARNING]
 ====
-You cannot install a ROSA cluster into an existing managed VPC. Managed VPCs are created during the managed cluster deployment process, and must only be associated with a single cluster to ensure that cluster provisioning and deletion operations work correctly. To determine whether a VPC is managed, look for the `red-hat-managed` tag; managed VPCs are tagged with `red-hat-managed:true`.
+You cannot install a ROSA cluster into an existing VPC that was created by the OpenShift installer. These VPCs are created during the cluster deployment process and must only be associated with a single cluster to ensure that cluster provisioning and deletion operations work correctly.
+
+To verify whether a VPC was created by the OpenShift installer, check for the `owned` value on the `kubernetes.io/cluster/<infra-id>` tag. For example, when viewing the tags for the VPC named `mycluster-12abc-34def`, the `kubernetes.io/cluster/mycluster-12abc-34def` tag has a value of `owned`. Therefore, the VPC was created by the installer and must not be modified by the administrator.
 ====
 +
 [NOTE]


### PR DESCRIPTION
Version(s):
4.14, 4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-8632

Link to docs preview:
- https://67907--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations#rosa-sts-creating-cluster-customizations-cli_rosa-sts-creating-a-cluster-with-customizations - two instances in this procedure
- https://67907--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations#rosa-sts-creating-cluster-customizations-ocm_rosa-sts-creating-a-cluster-with-customizations

QE review:
- [x] QE has approved this change.

Additional information:
- Fix provided by QE.
- Important admonition changed to warning because this can and will break a managed cluster.
- Does not work as a snippet because of the structure nesting in this file.