### PR TITLE
[OKD] Point latest reference to 4.14

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -142,7 +142,7 @@
 
         <span>
           <div class="alert alert-danger" role="alert" id="support-alert">
-            <strong>You are viewing documentation for a release that is no longer maintained.</strong> To view the documentation for the most recent version, see the <a href="https://docs.okd.io/4.11/welcome/index.html" style="color: #545454 !important" class="link-primary">latest OKD docs</a>.
+            <strong>You are viewing documentation for a release that is no longer maintained.</strong> To view the documentation for the most recent version, see the <a href="https://docs.okd.io/4.14/welcome/index.html" style="color: #545454 !important" class="link-primary">latest OKD docs</a>.
           </div>
         </span>
 


### PR DESCRIPTION
The "To view the documentation for the most recent version, see the [latest OKD docs](https://docs.okd.io/4.11/welcome/index.html)." text on any page points to version 4.11, what isn't the latest release of OKD. Here I just set the pointer to 4.14.