### PR TITLE
RHDEVDOCS-5697-update: uncommenting builds using shipwright files

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1890,12 +1890,12 @@ Distros: openshift-enterprise,openshift-origin,openshift-online
 Topics:
 - Name: CI/CD overview
   File: index
-# - Name: Builds using Shipwright
-#  Dir: builds_using_shipwright
-#  Distros: openshift-enterprise
-#  Topics:
-#  - Name: Overview of Builds
-#    File: overview-openshift-builds
+- Name: Builds using Shipwright
+  Dir: builds_using_shipwright
+  Distros: openshift-enterprise
+  Topics:
+  - Name: Overview of Builds
+    File: overview-openshift-builds
 - Name: Builds using BuildConfig
   Dir: builds
   Distros: openshift-enterprise,openshift-origin,openshift-online

--- a/cicd/index.adoc
+++ b/cicd/index.adoc
@@ -15,19 +15,15 @@ toc::[]
 
 [id="openshift-builds"]
 == OpenShift Builds
-OpenShift Builds provides you the following option to configure and run a build:
+OpenShift Builds provides you the following options to configure and run a build:
 
-// * Builds using Shipwright
-// +
-// An extensible build framework based on the Shipwright project, which you can use to build container images on an {product-title} cluster. You can build container images from source code and Dockerfile by using image build tools, such as Source-to-Image (S2I) and Buildah.
-// +
-// For more information, see link:https://docs.openshift.com/builds/latest/about/overview-openshift-builds.html[Overview of Builds].
+* Builds using Shipwright is an extensible build framework based on the Shipwright project. You can use it to build container images on an {product-title} cluster. You can build container images from source code and Dockerfile by using image build tools, such as Source-to-Image (S2I) and Buildah.
++
+For more information, see link:https://docs.openshift.com/builds/latest/about/overview-openshift-builds.html[Overview of Builds].
 
-* Builds using BuildConfig
+* Builds using `BuildConfig` objects is a declarative build process to create cloud-native apps. You can define the build process in a YAML file that you use to create a `BuildConfig` object. This definition includes attributes such as build triggers, input parameters, and source code. When deployed, the `BuildConfig` object builds a runnable image and pushes the image to a container image registry. With the `BuildConfig` object, you can create a Docker, Source-to-image (S2I), or custom build.
 +
-A declarative build process to create cloud-native apps. You can define the build process in a YAML file that you use to create a `BuildConfig` object. This definition includes attributes such as build triggers, input parameters, and source code. When deployed, the `BuildConfig` object builds a runnable image and pushes the image to a container image registry. With the `BuildConfig` object, you can create a Docker, Source-to-image (S2I), or custom build.
-+
-For more information, see xref:../cicd/builds/understanding-image-builds.adoc#understanding-image-builds[Understanding image builds]
+For more information, see xref:../cicd/builds/understanding-image-builds.adoc#understanding-image-builds[Understanding image builds].
 
 [id="openshift-pipelines"]
 == {pipelines-shortname}


### PR DESCRIPTION
**This PR is for the builds for Red Hat OpenShift 1.0 release that is scheduled for 27th November in the next week. Do not merge until this date.**

**Purpose**: To resolve this issue: https://issues.redhat.com/browse/RHDEVDOCS-5697

**Aligned team**: DevTools

**Version for cherrypicking**: enterprise-4.14 and later

**Content for preview**: https://67909--docspreview.netlify.app/openshift-enterprise/latest/cicd/

**Peer review**: @ShaunaDiaz 

**Merge review**: @opayne1 @JoeAldinger 

**Note** : The release of Builds using Shipwright is planned for next week. So, uncommenting the builds using Shipwright files that were commented out as [part of this PR](https://github.com/openshift/openshift-docs/pull/66936). 