### PR TITLE
Documentation for dynamic scaling of Argo CD application controller.

### DIFF
--- a/declarative_clusterconfig/sharding-clusters-across-argo-cd-application-controller-replicas.adoc
+++ b/declarative_clusterconfig/sharding-clusters-across-argo-cd-application-controller-replicas.adoc
@@ -14,4 +14,11 @@ include::modules/gitops-enabling-the-round-robin-sharding-algorithm-in-web-conso
 
 include::modules/gitops-enabling-the-round-robin-sharding-algorithm-using-cli.adoc[leveloffset=+2]
 
-//include the dynamic scaling here after the round-robin procedure
+//modules about dynamic scaling 
+include::modules/gitops-argo-cd-dynamic-scaling.adoc[leveloffset=+1]
+
+include::modules/gitops-argo-cd-dynamic-scaling-in-web-console.adoc[leveloffset=+2]
+
+include::modules/gitops-argo-cd-dynamic-scaling-by-using-cli.adoc[leveloffset=+2]
+
+

--- a/modules/gitops-argo-cd-dynamic-scaling-by-using-cli.adoc
+++ b/modules/gitops-argo-cd-dynamic-scaling-by-using-cli.adoc
@@ -1,0 +1,93 @@
+// Module included in the following assemblies:
+//
+// * declarative_clusterconfig/sharding-clusters-across-argo-cd-application-controller-replicas.adoc
+
+:_mod-docs-content-type: PROCEDURE
+
+:oc-first: pass:quotes[OpenShift CLI (`oc`)]
+
+[id="gitops-argo-cd-dynamic-scaling-by-using-cli_{context}"]
+= Enabling dynamic scaling of shards by using the CLI
+
+You can enable dynamic scaling of shards by using the {oc-first}.
+
+.Prerequisites
+* You have installed the {gitops-title} Operator in your cluster.
+* You have access to the cluster with `cluster-admin` privileges.
+
+.Procedure
+
+. Log in to the cluster by using the `oc` tool as a user with `cluster-admin` privileges.
+
+. Enable dynamic scaling by running the following command:
++
+[source,terminal]
+----
+$ oc patch argocd <argocd_instance> -n <namespace> --type=merge --patch='{"spec":{"controller":{"sharding":{"dynamicScalingEnabled":true,"minShards":<value>,"maxShards":<value>,"clustersPerShard":<value>}}}}'
+----
++
+.Example command
+[source,terminal]
+----
+$ oc patch argocd openshift-gitops -n openshift-gitops --type=merge --patch='{"spec":{"controller":{"sharding":{"dynamicScalingEnabled":true,"minShards":1,"maxShards":3,"clustersPerShard":1}}}}' <1>
+----
++
+<1> The example command enables dynamic scaling for the `openshift-gitops` Argo CD instance in the `openshift-gitops` namespace, and sets the minimum number of shards to `1`, the maximum number of shards to `3`, and the number of clusters per shard to `1`. The values of `minShard` and `clustersPerShard` must be set to `1` or greater. The value of `maxShard` must be equal to or greater than the value of `minShard`.
++
+.Example output
+[source,terminal]
+----
+argocd.argoproj.io/openshift-gitops patched
+----
+
+.Verification
+
+. Check the `spec.controller.sharding` properties of the Argo CD instance:
++
+[source,terminal]
+----
+$ oc get argocd <argocd_instance> -n <namespace> -o jsonpath='{.spec.controller.sharding}'
+----
++
+.Example command 
+[source,terminal]
+----
+$ oc get argocd openshift-gitops -n openshift-gitops -o jsonpath='{.spec.controller.sharding}'
+----
++
+.Example output when dynamic scaling of shards is enabled
+[source,terminal]
+----
+{"dynamicScalingEnabled":true,"minShards":1,"maxShards":3,"clustersPerShard":1}
+----
+
+. Optional: Verify that dynamic scaling is enabled by checking the configured `spec.controller.sharding` properties in the configuration `YAML` file of the Argo CD instance in the {OCP} web console.
+
+. Check the number of Argo CD Application Controller pods:
++
+[source,terminal]
+----
+$ oc get pods -n <namespace> -l app.kubernetes.io/name=<argocd_instance>-application-controller
+----
++
+.Example command
+[source,terminal]
+----
+$ oc get pods -n openshift-gitops -l app.kubernetes.io/name=openshift-gitops-application-controller
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                           READY   STATUS    RESTARTS   AGE
+openshift-gitops-application-controller-0      1/1     Running   0          2m  <1>
+----
++
+<1> The number of Argo CD Application Controller pods must be equal to or greater than the value of `minShard`.
+
+[role="_additional-resources"]
+[id="additional-resources_argocd-cr-properties"]
+= Additional resources
+* link:https://docs.openshift.com/gitops/1.11/argocd_instance/argo-cd-cr-component-properties.html#argo-cd-properties_argo-cd-cr-component-properties[Argo CD custom resource properties]
+
+* link:https://docs.openshift.com/container-platform/4.14/nodes/pods/nodes-pods-autoscaling.html[Automatically scaling pods with the horizontal pod autoscaler]

--- a/modules/gitops-argo-cd-dynamic-scaling-in-web-console.adoc
+++ b/modules/gitops-argo-cd-dynamic-scaling-in-web-console.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * declarative_clusterconfig/sharding-clusters-across-argo-cd-application-controller-replicas.adoc
+
+:_mod-docs-content-type: PROCEDURE
+
+[id="gitops-argo-cd-dynamic-scaling-in-web-console_{context}"]
+= Enabling dynamic scaling of shards in the web console
+
+You can enable dynamic scaling of shards by using the {OCP} web console.
+
+.Prerequisites
+* You have access to the cluster with `cluster-admin` privileges.
+* You have access to the {OCP} web console.
+* You have installed the {gitops-title} Operator in your cluster.
+
+.Procedure
+
+. In the *Administator* perspective of the {OCP} web console, go to *Operators* -> *Installed Operators*.
+
+. From the the list of *Installed Operators*, select the {gitops-title} Operator, and then click the *ArgoCD* tab.
+
+. Select the Argo CD instance name for which you want to enable dynamic scaling of shards, for example, `openshift-gitops`.
+
+. Click the *YAML* tab, and then edit and configure the `spec.controller.sharding` properties as follows:
++
+.Example Argo CD YAML file with dynamic scaling enabled
+[source,yaml]
+----
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: openshift-gitops
+  namespace: openshift-gitops
+spec:
+  controller:
+    sharding:
+      dynamicScalingEnabled: true <1>
+      minShards: 1 <2>
+      maxShards: 3 <3>
+      clustersPerShard: 1 <4>
+----
+<1> Set `dynamicScalingEnabled` to `true` to enable dynamic scaling.
+<2> Set `minShards` to the minimum number of shards that you want to have. The value must be set to `1` or greater.
+<3> Set `maxShards` to the maximum number of shards that you want to have. The value must be greater than the value of `minShards`.
+<4> Set `clustersPerShard` to the number of clusters that you want to have per shard. The value must be set to `1` or greater.
+
+. Click *Save*.
++
+A success notification alert, `openshift-gitops has been updated to version <version>`, appears.
++
+[NOTE]
+====
+If you edit the default `openshift-gitops` instance, the *Managed resource* dialog box is displayed. Click *Save* again to confirm the changes.
+====
+
+.Verification
+
+Verify that sharding is enabled by checking the number of pods in the namespace:
+
+. Go to *Workloads* -> *StatefulSets*.
+
+. Select the namespace where the Argo CD instance is deployed from the *Project* drop-down list, for example, `openshift-gitops`.
+
+. Click the name of the `StatefulSet` object that has the name of the Argo CD instance, for example `openshift-gitops-apllication-controller`.
+
+. Click the *Pods* tab, and then verify that the number of pods is equal to or greater than the value of `minShards` that you have set in the Argo CD `YAML` file.
+

--- a/modules/gitops-argo-cd-dynamic-scaling.adoc
+++ b/modules/gitops-argo-cd-dynamic-scaling.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * declarative_clusterconfig/sharding-clusters-across-argo-cd-application-controller-replicas.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="gitops-argo-cd-dynamic-scaling_{context}"]
+= Enabling dynamic scaling of shards of the Argo CD Application Controller
+
+:FeatureName: Dynamic scaling of shards
+include::snippets/technology-preview.adoc[]
+
+By default, the Argo CD Application Controller assigns clusters to shards indefinitely. If you are using the `round-robin` sharding algorithm, this static assignment can result in uneven distribution of shards, particularly when replicas are added or removed. You can enable dynamic scaling of shards to automatically adjust the number of shards based on the number of clusters managed by the Argo CD Application Controller at a given time. This ensures that shards are well-balanced and optimizes the use of compute resources.
+
+[NOTE]
+==== 
+After you enable dynamic scaling, you cannot manually modify the shard count. The system automatically adjusts the number of shards based on the number of clusters managed by the Argo CD Application Controller at a given time.
+====
+

--- a/modules/gitops-argo-cd-properties.adoc
+++ b/modules/gitops-argo-cd-properties.adoc
@@ -11,6 +11,7 @@ The Argo CD Custom Resource consists of the following properties:
 |===
 |*Name* |*Description* |*Default* | *Properties*
 |`ApplicationInstanceLabelKey` |The `metadata.label` key name where Argo CD injects the app name as a tracking label.|`app.kubernetes.io/instance` |
+
 |`ApplicationSet` 
 |`ApplicationSet` controller configuration options.
 | `_<Object>_`
@@ -20,7 +21,9 @@ a|* _<Image>_ - The container image for the `ApplicationSet` controller. This ov
   * _<LogLevel>_ - The log level used by the Argo CD Application Controller component. Valid options are `debug`, `info`, `error`, and `warn`.
   * _<LogFormat>_ - The log format used by the Argo CD Application Controller component. Valid options are `text` or `json`.
   * _<PrallelismLimit>_ - The kubectl parallelism limit to set for the controller `(--kubectl-parallelism-limit flag)`.
+
 |`ConfigManagementPlugins`    |Add a configuration management plugin.| `__<empty>__` |
+
 |`Controller`    |Argo CD Application Controller options.| `__<Object>__`
 a|* _<Processors.Operation>_ - The number of operation processors.
   * _<Processors.Status>_ - The number of status processors.
@@ -29,51 +32,78 @@ a|* _<Processors.Operation>_ - The number of operation processors.
   * _<AppSync>_ - AppSync is used to control the sync frequency of Argo CD applications
   * _<Sharding.enabled>_ - Enable sharding on the Argo CD Application Controller component. This property is used to manage a large number of clusters to relieve memory pressure on the controller component.
   * _<Sharding.replicas>_ - The number of replicas that will be used to support sharding of the Argo CD Application Controller.
+  * _<Sharding.dynamicScalingEnabled>_ - Enable dynamic scaling of the Argo CD Application Controller component. Use this property to allow the Operator to scale the number of replicas based on the number of clusters the controller component is managing presently. Setting this property to `true` overrides the configuration of the `Sharding.enabled` and `Sharding.replicas` properties.
+  * _<Sharding.minShards>_ - The minimum number of Argo CD Application Controller replicas.
+  * _<Sharding.maxShards>_ - The maximum number of Argo CD Application Controller replicas.
+  * _<Sharding.clusterPerShard>_ - The number of clusters that need to be managed by each shard. When the replica count reaches the `maxShards`, the shards manage more than one cluster.
   * _<Env>_ - Environment to set for the application controller workloads.
+
 |`DisableAdmin`    |Disables the built-in admin user.|`false` |
+
 |`GATrackingID`    |Use a Google Analytics tracking ID.|`__<empty>__` |
-|`GAAnonymizeusers`    |Enable hashed usernames sent to google analytics.|`false` |
+
+|`GAAnonymizeusers`    |Enable hashed usernames sent to Google Analytics.|`false` |
+
 |`HA`    |High availablity options.| `__<Object>__`
 a|* _<Enabled>_ - Toggle high availability support globally for Argo CD.
   * _<RedisProxyImage>_ - The Redis HAProxy container image. This overrides the `ARGOCD_REDIS_HA_PROXY_IMAGE` environment variable.
   * _<RedisProxyVersion>_ - The tag to use for the Redis HAProxy container image.
+
 |`HelpChatURL`    |URL for getting chat help (this will typically be your Slack channel for support).|`https://mycorp.slack.com/argo-cd` |
+
 |`HelpChatText`    |The text that appears in a text box for getting chat help.|`Chat now!`|
+
 |`Image`    |The container image for all Argo CD components. This overrides the `ARGOCD_IMAGE` environment variable.|`argoproj/argocd` |
+
 |`Ingress`    |Ingress configuration options.| `__<Object>__` |
+
 |`InitialRepositories`    |Initial Git repositories to configure Argo CD to use upon creation of the cluster.|`__<empty>__` |
+
 |`Notifications`    |Notifications controller configuration options.|`__<Object>__`
 a|* _<Enabled>_ - The toggle to start the notifications-controller.
   * _<Image>_ - The container image for all Argo CD components. This overrides the `ARGOCD_IMAGE` environment variable.
   * _<Version>_ - The tag to use with the Notifications container image.
   * _<Resources>_ - The container compute resources.
   * _<LogLevel>_ - The log level used by the Argo CD Application Controller component. Valid options are `debug`, `info`, `error`, and `warn`.
+
 |`RepositoryCredentials`    |Git repository credential templates to configure Argo CD to use upon creation of the cluster.| `__<empty>__` |
+
 |`InitialSSHKnownHosts`    |Initial SSH Known Hosts for Argo CD to use upon creation of the cluster.| `__<default_Argo_CD_Known_Hosts>__` |
+
 |`KustomizeBuildOptions`    |The build options and parameters to use with `kustomize build`.|`__<empty>__` |
+
 |`OIDCConfig` |The OIDC configuration as an alternative to Dex.|`__<empty>__` |
+
 |`NodePlacement` |Add the `nodeSelector` and the `tolerations`.|`__<empty>__` |
+
 |`Prometheus` |Prometheus configuration options.|`__<Object>__`
 a|* _<Enabled>_ - Toggle Prometheus support globally for Argo CD.
   * _<Host>_ - The hostname to use for Ingress or Route resources.
   * _<Ingress>_ - Toggles Ingress for Prometheus.
   * _<Route>_ - Route configuration options.
   * _<Size>_ - The replica count for the Prometheus `StatefulSet`.
+
 |`RBAC` |RBAC configuration options.|`__<Object>__`
 a|* _<DefaultPolicy>_ - The `policy.default` property in the `argocd-rbac-cm` config map. The name of the default role which Argo CD will fall back to, when authorizing API requests.
   * _<Policy>_ - The `policy.csv` property in the `argocd-rbac-cm` config map. CSV data containing user-defined RBAC policies and role definitions.
   * _<Scopes>_ - The scopes property in the `argocd-rbac-cm` config map. Controls which OIDC scopes to examine during RBAC enforcement (in addition to sub scope).
+
 |`Redis` |Redis configuration options.|`__<Object>__`
 a|* _<AutoTLS>_ - Use the provider to create the Redis server's TLS certificate (one of: openshift). Currently only available for {OCP}.
   * _<DisableTLSVerification>_ - Define whether the Redis server should be accessed using strict TLS validation.
   * _<Image>_ - The container image for Redis. This overrides the `ARGOCD_REDIS_IMAGE` environment variable.
   * _<Resources>_ - The container compute resources.
   * _<Version>_ - The tag to use with the Redis container image.
+
 |`ResourceHealthChecks` |Customize resource health check behavior.|`__<empty>__` |
 |`ResourceIgnoreDifferences` |Customize resource ignore difference behavior.|`__<empty>__` |
+
 |`ResourceActions` |Customize resource action behavior.|`__<empty>__` |
+
 |`ResourceExclusions` |Completely ignore entire classes of resource group.|`__<empty>__` |
+
 |`ResourceInclusions` |The configuration to configure which resource group/kinds are applied.|`__<empty>__` |
+
 |`Server` |Argo CD Server configuration options.|`__<Object>__`
 a|* _<Autoscale>_ - Server autoscale configuration options.
   * _<ExtraCommandArgs>_ - List of arguments added to the existing arguments set by the Operator.
@@ -88,17 +118,23 @@ a|* _<Autoscale>_ - Server autoscale configuration options.
   * _<LogLevel>_ - The log level to be used by the Argo CD Server component. Valid options are  `debug`, `info`, `error`, and `warn`.
   * _<LogFormat>_ - The log format used by the Argo CD Application Controller component. Valid options are `text` or `json`.
   * _<Env>_ - Environment to set for the server workloads.
+
 |`SSO` |Single Sign-on options.|`__<Object>__`
 a|* _<Keycloak>_ - Configuration options for Keycloak SSO provider.
   * _<Dex>_ - Configuration options for Dex SSO provider.
   * _<Provider>_ - The name of the provider used to configure Single Sign-on. For now the supported options are Dex and Keycloak.
+
 |`StatusBadgeEnabled` |Enable application status badge.|`true` |
+
 |`TLS` |TLS configuration options.|`__<Object>__`
 a|* _<CA.ConfigMapName>_ - The name of the `ConfigMap` which contains the CA certificate.
   * _<CA.SecretName>_ - The name of the secret which contains the CA Certificate and Key.
   * _<InitialCerts>_ - Initial set of certificates in the `argocd-tls-certs-cm` config map for connecting Git repositories via HTTPS.
+
 |`UserAnonyousEnabled` |Enable anonymous user access.|`true` |
+
 |`Version` |The tag to use with the container image for all Argo CD components.|Latest Argo CD version|
+
 |`Banner` |Add a UI banner message.|`__<Object>__`
 a|* _<Banner.Content>_ - The banner message content (required if a banner is displayed).
   * _<Banner.URL.SecretName>_ - The banner message link URL (optional). 


### PR DESCRIPTION
- Jira issue: [RHDEVDOCS-5617](https://issues.redhat.com/browse/RHDEVDOCS-5617)
- CherryPick versions: gitops-docs-1.10 and gitops-docs-1.11 branches
- Doc preview: [Dynamic scalling of Argo CD applications](https://67913--docspreview.netlify.app/openshift-gitops/latest/declarative_clusterconfig/sharding-clusters-across-argo-cd-application-controller-replicas#gitops-argo-cd-dynamic-scaling_sharding-clusters-across-argo-cd-application-controller-replicas)
- OCP team: DevTools
- SME reviews by: @ishitasequeira , @reginapizza 
- QE reviews by: @varshab1210 
- Peer reviews by: @ekristova (draft reviewer), @nalhadef 