### PR TITLE
adding .ci-operator.yaml for prow build config

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  namespace: openshift
+  name: release
+  tag: golang-1.15


### PR DESCRIPTION
For prow, to configure the build_root in the repo alongside the code instead of inside the ci-operator config, we need to create  a `.ci-operator.yaml` file in the root of the repo.

https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image