### PR TITLE
OADP Operator fails silently

### DIFF
--- a/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
@@ -79,6 +79,7 @@ include::modules/migration-debugging-velero-admission-webhooks-ibm-appconnect.ad
 * xref:../../architecture/admission-plug-ins.adoc#admission-webhook-types_admission-plug-ins[Types of webhook admission plugins]
 
 include::modules/oadp-installation-issues.adoc[leveloffset=+1]
+include::modules/oadp-operator-issues.adoc[leveloffset=+1]
 include::modules/oadp-timeouts.adoc[leveloffset=+1]
 include::modules/oadp-restic-timeouts.adoc[leveloffset=+2]
 include::modules/oadp-velero-timeouts.adoc[leveloffset=+2]

--- a/modules/oadp-operator-issues.adoc
+++ b/modules/oadp-operator-issues.adoc
@@ -1,0 +1,93 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/troubleshooting.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="oadp-operator-issues_{context}"]
+= OADP Operator issues
+
+The {oadp-first} Operator might encounter issues caused by problems it is not able to resolve.
+
+[id="oadp-operator-fails-silently_{context}"]
+== OADP Operator fails silently
+
+The S3 buckets of an OADP Operator might be empty, but when you run the command `oc get po -n <OADP_Operator_namespace>`, you see that the Operator has a status of `Running`.  In such a case, the Operator is said to have _failed silently_ because it incorrectly reports that it is running.
+
+.Cause
+
+The problem is caused when cloud credentials provide insufficient permissions.
+
+.Solution
+
+Retrieve a list of backup storage locations (BSLs) and check the manifest of each BSL for credential issues.
+
+.Procedure
+
+. Run one of the following commands to retrieve a list of BSLs:
+
+.. Using the OpenShift CLI:
++
+[source,terminal]
+----
+$ oc get backupstoragelocation -A
+----
+
+.. Using the Velero CLI:
++
+[source,terminal]
+----
+$ velero backup-location get -n <OADP_Operator_namespace>
+----
+
+. Using the list of BSLs, run the following command to display the manifest of each BSL, and examine each manifest for an error.
++
+[source,terminal]
+----
+$ oc get backupstoragelocation -n <namespace> -o yaml
+----
+
+.Example result
+
+[source, yaml]
+----
+apiVersion: v1
+items:
+- apiVersion: velero.io/v1
+  kind: BackupStorageLocation
+  metadata:
+    creationTimestamp: "2023-11-03T19:49:04Z"
+    generation: 9703
+    name: example-dpa-1
+    namespace: openshift-adp-operator
+    ownerReferences:
+    - apiVersion: oadp.openshift.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: DataProtectionApplication
+      name: example-dpa
+      uid: 0beeeaff-0287-4f32-bcb1-2e3c921b6e82
+    resourceVersion: "24273698"
+    uid: ba37cd15-cf17-4f7d-bf03-8af8655cea83
+  spec:
+    config:
+      enableSharedConfig: "true"
+      region: us-west-2
+    credential:
+      key: credentials
+      name: cloud-credentials
+    default: true
+    objectStorage:
+      bucket: example-oadp-operator
+      prefix: example
+    provider: aws
+  status:
+    lastValidationTime: "2023-11-10T22:06:46Z"
+    message: "BackupStorageLocation \"example-dpa-1\" is unavailable: rpc
+      error: code = Unknown desc = WebIdentityErr: failed to retrieve credentials\ncaused
+      by: AccessDenied: Not authorized to perform sts:AssumeRoleWithWebIdentity\n\tstatus
+      code: 403, request id: d3f2e099-70a0-467b-997e-ff62345e3b54"
+    phase: Unavailable
+kind: List
+metadata:
+  resourceVersion: ""
+----

--- a/modules/oadp-velero-default-timeouts.adoc
+++ b/modules/oadp-velero-default-timeouts.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="velero-default-item-operation-timeout_{context}"]
-= Velereo default item operation timeout
+= Velero default item operation timeout
 
 `defaultItemOperationTimeout` defines how long to wait on asynchronous `BackupItemActions` and `RestoreItemActions` to complete before timing out. The default value is `1h`.
 

--- a/modules/oadp-velero-timeouts.adoc
+++ b/modules/oadp-velero-timeouts.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="velero-timeout_{context}"]
-= Velereo resource timeout
+= Velero resource timeout
 
 `resourceTimeout` defines how long to wait for several Velero resources before timeout occurs, such as Velero custom resource definition (CRD) availability, `volumeSnapshot` deletion, and repository availability. The default is `10m`.
 


### PR DESCRIPTION
OADP 1.2+, OCP 4.11+

Resolves https://issues.redhat.com/browse/OADP-3068 by adding a new section, "OADP Operator issues" to the "Troubleshooting" section of the OADP user guide.

Preview: https://67917--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting#oadp-operator-issues_oadp-troubleshooting

PR passed OADP QE. 