### PR TITLE
OADP-2257 CloudStorage: Cannot Restore CSI backups in different AWS region

### DIFF
--- a/modules/oadp-installing-oadp-rosa-sts.adoc
+++ b/modules/oadp-installing-oadp-rosa-sts.adoc
@@ -11,7 +11,14 @@ AWS Security Token Service (AWS STS) is a global web service that provides short
 
 [IMPORTANT]
 ====
-Restic is not supported in the OADP on ROSA with AWS STS environment. Ensure the Restic service is disabled. Use native snapshots to backup volumes. See _Known Issues_ for more information.
+Restic and Kopia are not supported in the OADP on ROSA with AWS STS environment. Make sure that the Restic/Kopia node agent is disabled. Use native snapshots or CSI snapshots to back up volumes. See _Known Issues_ for more information.
+====
+
+[IMPORTANT]
+====
+In an Amazon ROSA cluster using STS authentication, restoring backed-up data in a different AWS region is not supported.
+
+The Data Mover feature is not currently supported in ROSA clusters. You can use native AWS S3 tools for moving data.
 ====
 
 .Prerequisites


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/OADP-2257

OADP 1.3.0

OCP 4.14+

Preview: https://67918--docspreview.netlify.app/openshift-rosa/latest/rosa_backing_up_and_restoring_applications/backing-up-applications#oadp-installing-oadp-rosa-sts_rosa-backing-up-applications  (second 'IMPORTANT' note)
