### PR TITLE
BZ#2249724: Disable runbook context

### DIFF
--- a/virt/monitoring/virt-runbooks.adoc
+++ b/virt/monitoring/virt-runbooks.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+
+:!virt-runbooks:
 You can use the procedures in these runbooks to diagnose and resolve issues that trigger {VirtProductName} xref:../../monitoring/managing-alerts.adoc#managing-alerts[alerts].
 
 {VirtProductName} alerts are displayed on the *Virtualization* -> *Overview* -> xref:../../virt/getting_started/virt-web-console-overview.adoc#overview-overview_virt-web-console-overview[*Overview* tab] in the web console.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Disable context attribute so that runbook URLs do not pick it up if old files are present downstream. 
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [BZ#2249724](https://bugzilla.redhat.com/show_bug.cgi?id=2249724)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
