### PR TITLE
[gitops-docs-1.10] CP Documentation for GitOps 1.8.6 release notes to 1.10

### DIFF
--- a/modules/gitops-release-notes-1-8-6.adoc
+++ b/modules/gitops-release-notes-1-8-6.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assembly:
+//
+// * release_notes/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="gitops-release-notes-1-8-6_{context}"]
+= Release notes for {gitops-title} 1.8.6
+
+{gitops-title} 1.8.6 is now available on {OCP} 4.10, 4.11, 4.12, and 4.13.
+
+[id="errata-updates-1-8-6_{context}"]
+== Errata updates
+
+[id="gitops-1-8-6-security-update-advisory_{context}"]
+=== RHSA-2023:6788 - {gitops-title} 1.8.6 security update advisory
+
+Issued: 2023-11-08
+
+The list of security fixes that are included in this release is documented in the following advisory:
+
+* link:https://access.redhat.com/errata/RHSA-2023:6788[RHSA-2023:6788]
+
+If you have installed the {gitops-title} Operator in the default namespace, run the following command to view the container images in this release:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-gitops-operator
+----

--- a/release_notes/gitops-release-notes.adoc
+++ b/release_notes/gitops-release-notes.adoc
@@ -36,6 +36,8 @@ include::modules/gitops-release-notes-1-9-0.adoc[leveloffset=+1]
 .Additional resources
 * link:https://docs.openshift.com/container-platform/latest/operators/admin/olm-configuring-proxy-support.html#olm-inject-custom-ca_olm-configuring-proxy-support[Injecting a custom CA certificate]
 
+include::modules/gitops-release-notes-1-8-6.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-8-5.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-8-4.adoc[leveloffset=+1]


### PR DESCRIPTION
Conflicts: 
**Manual cherry-pick of [PR-67076](https://github.com/openshift/openshift-docs/pull/67076) to gitops 1.10**

[doc-preview](https://67923--docspreview.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes#gitops-release-notes-1-8-6_gitops-release-notes)