### PR TITLE
OCPBUGS#23312: Announcing cron job time zones as GA

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -1114,6 +1114,13 @@ Beginning with {product-title} 4.14, new installs use Control Groups version 2 b
 
 For more information, see xref:../nodes/clusters/nodes-cluster-cgroups-2.adoc#nodes-clusters-cgroups-2[Configuring the Linux cgroup version on your nodes].
 
+[id="ocp-4-14-node-cron-job-time-zone-ga"]
+==== Cron job time zones general availability
+
+Setting a time zone for a cron job schedule is now generally available. If a time zone is not specified, the Kubernetes controller manager interprets the schedule relative to its local time zone.
+
+For more information, see xref:../nodes/jobs/nodes-nodes-jobs.adoc#nodes-nodes-jobs-creating-cron_nodes-nodes-jobs[Creating cron jobs].
+
 [id="ocp-4-14-monitoring"]
 === Monitoring
 
@@ -2445,7 +2452,7 @@ In the following tables, features are marked with the following statuses:
 |Cron job time zones
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|General Availability
 
 |`MaxUnavailableStatefulSet` featureset
 |Not Available


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14 only

Issue:
https://issues.redhat.com/browse/OCPBUGS-23312

Link to docs preview:
* https://67947--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-node-cron-job-time-zone-ga
* https://67947--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#node-technology-preview-features

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
 **This PR requires docs change management**
