### PR TITLE
[OSDOCS 5590]: Creating an AWS KMS key for customer encryption

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -172,6 +172,8 @@ Distros: openshift-rosa
 Topics:
 - Name: Creating ROSA with HCP clusters using the default options
   File: rosa-hcp-sts-creating-a-cluster-quickly
+- Name: Creating ROSA with HCP clusters using a custom AWS KMS encryption key
+  File: rosa-hcp-creating-cluster-with-aws-kms-key
 - Name: Using the Node Tuning Operator on ROSA with HCP
   File: rosa-tuning-config
 ---

--- a/modules/creating-cluster-with-aws-kms-key.adoc
+++ b/modules/creating-cluster-with-aws-kms-key.adoc
@@ -1,0 +1,170 @@
+// Module included in the following assemblies:
+//
+// * monitoring/enabling-monitoring-for-user-defined-projects.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="creating-cluster-with-aws-kms-key"]
+= Creating a ROSA cluster using a custom AWS KMS key
+
+You can create a {product-title} (ROSA) cluster with a customer-provided KMS key that is used to encrypt either node root volumes, the etcd database, or both. A different KMS key ARN can be provided for each option.
+
+[NOTE]
+====
+{hcp-title} does not automatically configure the `default` storage class to encrypt persistent volumes with the customer-provided KMS key. This is something that can be configured in-cluster after installation.
+====
+
+
+.Procedure
+
+. Create a custom AWS customer-managed KMS key by running the following command:
++
+[source,terminal]
+----
+$ KMS_ARN=$(aws kms create-key --region $AWS_REGION --description 'Custom ROSA Encryption Key' --tags TagKey=red-hat,TagValue=true --query KeyMetadata.Arn --output text)
+----
++
+This command saves the Amazon Resource Name (ARN) output of this custom key for further steps.
++
+[NOTE]
+====
+Customers must provide the `--tags TagKey=red-hat,TagValue=true` argument that is required for a customer KMS key.
+====
+
+
+. Verify the KMS key has been created by running the following command:
++
+[source,terminal]
+----
+$ echo $KMS_ARN
+----
+
+. Set your AWS account ID to an environment variable.
++
+[source,terminal]
+----
+$ AWS_ACCOUNT_ID=<aws_account_id>
+----
+. Add the ARN for the account-wide installer role and operator roles that you created in the preceding step to the `Statement.Principal.AWS` section in the file. In the following example, the ARN for the default `ManagedOpenShift-HCP-ROSA-Installer-Role` role is added:
+
++
+[source,terminal]
+----
+{
+  "Version": "2012-10-17",
+  "Id": "key-rosa-policy-1",
+  "Statement": [
+  {
+              "Sid": "Enable IAM User Permissions",
+              "Effect": "Allow",
+              "Principal": {
+                  "AWS": "arn:aws:iam::${AWS_ACCOUNT_ID}:root"
+              },
+              "Action": "kms:*",
+              "Resource": "*"
+          },
+        {
+              "Sid": "Installer Permissions",
+              "Effect": "Allow",
+              "Principal": {
+                  "AWS": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/ManagedOpenShift-HCP-ROSA-Installer-Role"
+              },
+              "Action": [
+                  "kms:CreateGrant",
+                  "kms:DescribeKey",
+                  "kms:GenerateDataKeyWithoutPlaintext"
+              ],
+              "Resource": "*"
+          },
+          {
+              "Sid": "ROSA KubeControllerManager Permissions",
+              "Effect": "Allow",
+              "Principal": {
+                  "AWS": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/<operator_role_prefix>-kube-system-kube-controller-manager"
+
+              },
+              "Action": "kms:DescribeKey",
+              "Resource": "*"
+          },
+          {
+              "Sid": "ROSA KMS Provider Permissions",
+              "Effect": "Allow",
+              "Principal": {
+                  "AWS": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/<operator_role_prefix>-kube-system-kms-provider"
+              },
+              "Action": [
+                  "kms:Encrypt",
+                  "kms:Decrypt",
+                  "kms:DescribeKey"
+              ],
+              "Resource": "*"
+          },
+          {
+              "Sid": "ROSA NodeManager Permissions",
+              "Effect": "Allow",
+              "Principal": {
+                  "AWS": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/<operator_role_prefix>-kube-system-capa-controller-manager"
+              },
+              "Action": [
+                  "kms:DescribeKey",
+                  "kms:GenerateDataKeyWithoutPlaintext",
+                  "kms:CreateGrant"
+              ],
+              "Resource": "*"
+          }
+      ]
+  } 
+----
+
+. Confirm the details of the policy file created by running the following command:
++
+[source,terminal]
+----
+$ cat rosa-key-policy.json
+----
+
+. Apply the newly generated key policy to the custom KMS key by running the following command:
+
++
+[source,terminal]
+----
+$ aws kms put-key-policy --key-id $KMS_ARN \
+--policy file://rosa-key-policy.json \
+--policy-name default
+----
+
+. Create the cluster by running the following command:
+
++
+[source,terminal]
+----
+$ rosa create cluster --cluster-name <cluster_name> \
+--subnet-ids <private_subnet_id>,<public_subnet_id> \
+--sts \
+--mode auto \
+--machine-cidr 10.0.0.0/16 \
+--compute-machine-type m5.xlarge \
+--hosted-cp \
+--region <aws_region> \
+--oidc-config-id $OIDC_ID \
+--kms-key-arn $KMS_ARN \ <1>
+--etcd-encryption-kms-arn $KMS_ARN \ <2>
+--operator-roles-prefix $OPERATOR_ROLES_PREFIX
+----
+<1> This KMS key ARN is used to encrypt all worker node root volumes. It is not required if only etcd database encryption is needed.
+<2> This KMS key ARN is used to encrypt the etcd database. The etcd database is always encrypted by default with an AES cipher block, but can be encrypted instead with a KMS key. It is not required if only node root volume encryption is needed.
+
+.Verification
+
+You can verify that your KMS key works by using {cluster-manager-url}. 
+
+. Navigate to {cluster-manager-url} and select *Instances*.
+
+. Select your instance.
+
+. Click the *Storage* tab.
+
+. Copy the *KMS key ID*.
+
+. Search and select *Key Management Service*.
+
+. Enter your copied _KMS key ID_ in the *Filter* field.

--- a/modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc
+++ b/modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc
@@ -3,7 +3,7 @@
 [id="rosa-sts-creating-account-wide-sts-roles-and-policies_{context}"]
 = Creating the account-wide STS roles and policies
 
-Before using the {product-title} (ROSA) CLI, `rosa`, to create {hcp-title-first} clusters, create the required account-wide roles and policies, including the Operator policies.
+Before using the {product-title} (ROSA) CLI (`rosa`) to create {hcp-title-first} clusters, create the required account-wide roles and policies, including the Operator policies.
 
 [NOTE]
 ====
@@ -20,9 +20,21 @@ Before using the {product-title} (ROSA) CLI, `rosa`, to create {hcp-title-first}
 
 .Procedure
 
-. If they do not exist in your AWS account, create the required account-wide STS roles and attach the policies by running the following command:
+* If they do not exist in your AWS account, create the required account-wide STS roles and attach the policies by running the following command:
 +
 [source,terminal]
 ----
 $ rosa create account-roles --hosted-cp
 ----
++
+[source,terminal]
+----
+$ ACCOUNT_ROLES_PREFIX="${ACCOUNT_ROLES_PREFIX}"
+----
++
+[source,terminal]
+----
+$ rosa create account-roles --hosted-cp --prefix $ACCOUNT_ROLES_PREFIX
+----
++
+For more information regarding AWS managed IAM policies for ROSA, see link:https://docs.aws.amazon.com/ROSA/latest/userguide/security-iam-awsmanpol.html[AWS managed IAM policies for ROSA].

--- a/modules/rosa-operator-config.adoc
+++ b/modules/rosa-operator-config.adoc
@@ -1,8 +1,9 @@
+
 // Module included in the following assemblies:
 //
 // * rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="rosa-operator-config_{context}"]
 = Creating Operator roles and policies
 
@@ -11,16 +12,23 @@ When using a {hcp-title} cluster, you must create the Operator IAM roles that ar
 .Prerequisites
 
 * You have completed the AWS prerequisites for {hcp-title}.
-* You have installed and configured the latest {product-title} (ROSA) CLI, `rosa`, on your installation host.
+* You have installed and configured the latest {product-title} ROSA CLI (`rosa`), on your installation host.
 * You created the account-wide AWS roles.
 
 .Procedure
 
-* To create your Operator roles, run the following command:
+. Set your prefix name to an environment variable using the following command:
 +
 [source,terminal]
 ----
-$ rosa create operator-roles --hosted-cp --prefix <prefix-name> --oidc-config-id <oidc-config-id>
+$ OPERATOR_ROLES_PREFIX=<prefix_name>
+----
+. To create your Operator roles, run the following command:
+
++
+[source,terminal]
+----
+$ rosa create operator-roles --hosted-cp --prefix $OPERATOR_ROLES_PREFIX --oidc-config-id $OIDC_ID --installer-role-arn arn:aws:iam::${AWS_ACCOUNT_ID}:role/${ACCOUNT_ROLES_PREFIX}-HCP-ROSA-Installer-Role
 ----
 +
 The following breakdown provides options for the Operator role creation.
@@ -28,13 +36,15 @@ The following breakdown provides options for the Operator role creation.
 [source,terminal]
 ----
 $ rosa create operator-roles --hosted-cp
-	--prefix <prefix-name> <1>
-	--oidc-config-id <oidc-config-id> <2>
+	--prefix $OPERATOR_ROLES_PREFIX <1>
+	--oidc-config-id $OIDC_ID <2>
+	--installer-role-arn arn:aws:iam::${AWS_ACCOUNT_ID}:role/${ACCOUNT_ROLES_PREFIX}-HCP-ROSA-Installer-Role <3>
 ----
 +
 --
 <1> You must supply a prefix when creating these Operator roles. Failing to do so produces an error. See the Additional resources of this section for information on the Operator prefix.
 <2> This value is the OIDC configuration ID that you created for your {hcp-title} cluster.
+<3> This value is the installer role ARN that you created when you created the ROSA account roles.
 --
 +
 You must include the `--hosted-cp` parameter to create the correct roles for {hcp-title} clusters. This command returns the following information.
@@ -48,7 +58,7 @@ You must include the `--hosted-cp` parameter to create the correct roles for {hc
 ? OIDC Configuration ID: 23soa2bgvpek9kmes9s7os0a39i13qm4 | https://dvbwgdztaeq9o.cloudfront.net/23soa2bgvpek9kmes9s7os0a39i13qm4 <2>
 ? Create hosted control plane operator roles: Yes
 W: More than one Installer role found
-? Installer role ARN: arn:aws:iam::4540112244:role/<prefix>-Installer-Role
+? Installer role ARN: arn:aws:iam::4540112244:role/<prefix>-HCP-ROSA-Installer-Role
 ? Permissions boundary ARN (optional):
 I: Reusable OIDC Configuration detected. Validating trusted relationships to operator roles:
 I: Creating roles using 'arn:aws:iam::4540112244:user/<userName>'
@@ -65,7 +75,7 @@ I: To create a cluster with these roles, run the following command:
 ----
 +
 --
-<1> This field is prefilled with the prefix that you set in the initial creation command.
+<1> This field is prepopulated with the prefix that you set in the initial creation command.
 <2> This field requires you to select an OIDC configuration that you created for your {hcp-title} cluster.
 --
 +
@@ -73,7 +83,7 @@ The Operator roles are now created and ready to use for creating your {hcp-title
 
 .Verification
 
-. You can list the Operator roles associated with your ROSA account. Run the following command:
+* You can list the Operator roles associated with your ROSA account. Run the following command:
 +
 [source,terminal]
 ----

--- a/modules/rosa-sts-byo-oidc.adoc
+++ b/modules/rosa-sts-byo-oidc.adoc
@@ -83,7 +83,7 @@ $ 30f5dqmk
 
 .Verification
 
-. You can list the possible OIDC configurations available for your clusters that are associated with your user organization. Run the following command:
+* You can list the possible OIDC configurations available for your clusters that are associated with your user organization. Run the following command:
 +
 [source,terminal]
 ----

--- a/rosa_hcp/rosa-hcp-creating-cluster-with-aws-kms-key.adoc
+++ b/rosa_hcp/rosa-hcp-creating-cluster-with-aws-kms-key.adoc
@@ -1,0 +1,82 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="rosa-hcp-creating-cluster-with-aws-kms-key"]
+= Creating ROSA with HCP clusters using a custom AWS KMS encryption key
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: rosa-hcp-creating-cluster-with-aws-kms-key
+
+toc::[]
+
+Create a {product-title} (ROSA) with a {hcp} (HCP) cluster  using a custom AWS Key Management Service (KMS) key.
+
+//include::modules/rosa-sts-creating-a-cluster-quickly-ocm.adoc[leveloffset=+1]
+//include::modules/rosa-sts-associating-your-aws-account.adoc[leveloffset=+2]
+
+[id="rosa-hcp-creating-cluster-with-aws-kms-key-prereqs"]
+== {hcp-title} Prerequisites
+
+To create a {hcp-title} cluster, you must have the following items:
+
+* A configured virtual private cloud (VPC)
+* Account-wide roles
+* An OIDC configuration
+* Operator roles
+
+[id="rosa-hcp-creating-cluster-with-aws-kms-key-creating-vpc"]
+=== Creating a Virtual Private Cloud for your {hcp-title} clusters
+
+You must have a Virtual Private Cloud (VPC) to create {hcp-title} cluster. You can use the following methods to create a VPC: 
+
+* Create a VPC by using a Terraform template
+* Manually create the VPC resources in the AWS console
+
+[NOTE]
+====
+The Terraform instructions are for testing and demonstration purposes. Your own installation requires some modifications to the VPC for your own use. You should also ensure that when you use this Terraform script it is in the same region that you intend to install your cluster. In these examples, use `us-east-2`.
+====
+
+[discrete]
+include::modules/rosa-hcp-vpc-terraform.adoc[leveloffset=+3]
+
+[role="_additional-resources"]
+.Additional resources
+
+* See the link:https://github.com/openshift-cs/terraform-vpc-example[Terraform VPC] repository for a detailed list of all options available when customizing the VPC for your needs.
+
+[discrete]
+include::modules/rosa-hcp-vpc-manual.adoc[leveloffset=+3]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.aws.amazon.com/vpc/latest/userguide/vpc-getting-started.html[Get Started with Amazon VPC]
+* link:https://developer.hashicorp.com/terraform[HashiCorp Terraform documentation]
+
+include::modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc[leveloffset=+2]
+
+include::modules/rosa-sts-byo-oidc.adoc[leveloffset=+2]
+
+include::modules/rosa-operator-config.adoc[leveloffset=+2]
+
+include::modules/creating-cluster-with-aws-kms-key.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="additional-resources_rosa-hcp-operator-prefix"]
+
+[id="next-steps-2_{context}"]
+== Next steps
+
+* xref:../rosa_install_access_delete_clusters/rosa-sts-accessing-cluster.adoc#rosa-sts-accessing-cluster[Accessing a ROSA cluster]
+
+[role="_additional-resources"]
+[id="additional-resources_rosa-hcp-creating-cluster-with-aws-kms-key"]
+== Additional resources
+
+* For information on using the CLI to create a cluster, see xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-cli_rosa-hcp-sts-creating-a-cluster-quickly[Creating a ROSA with HCP cluster using the CLI].
+* For steps to deploy a ROSA cluster using manual mode, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-sts-creating-cluster-using-customizations_rosa-sts-creating-a-cluster-with-customizations[Creating a cluster using customizations].
+* For more information about the AWS Identity Access Management (IAM) resources required to deploy {product-title} with STS, see xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-iam-resources[About IAM resources for clusters that use STS].
+* For details about optionally setting an Operator role name prefix, see xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-operator-role-prefixes_rosa-sts-about-iam-resources[About custom Operator IAM role prefixes].
+* For information about the prerequisites to installing ROSA with STS, see xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prereqs[AWS prerequisites for ROSA with STS].
+* For details about using the `auto` and `manual` modes to create the required STS resources, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-understanding-deployment-modes_rosa-sts-creating-a-cluster-with-customizations[Understanding the auto and manual deployment modes].
+* For more information about using OpenID Connect (OIDC) identity providers in AWS IAM, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html[Creating OpenID Connect (OIDC) identity providers].
+* For more information about troubleshooting ROSA cluster installations, see xref:../support/troubleshooting/rosa-troubleshooting-installations.adoc#rosa-troubleshooting-installations[Troubleshooting installations].
+* For steps to contact Red Hat Support for assistance, see xref:../support/getting-support.adoc#getting-support[Getting support for Red Hat OpenShift Service on AWS].


### PR DESCRIPTION
Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-5990

Link to docs preview:
https://67957--docspreview.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-creating-cluster-with-aws-kms-key

QE review:
- [x] QE has approved this change.


