### PR TITLE
OBSDOCS-555: Added docs for using the logging console plug-in

### DIFF
--- a/_attributes/attributes-openshift-dedicated.adoc
+++ b/_attributes/attributes-openshift-dedicated.adoc
@@ -21,6 +21,7 @@
 :SMProductName: Red Hat OpenShift Service Mesh
 :pipelines-title: Red Hat OpenShift Pipelines
 :logging-sd: Red Hat OpenShift Logging
+:log-plug: logging subsystem Console Plugin
 :ServerlessProductName: OpenShift Serverless
 :rh-openstack-first: Red Hat OpenStack Platform (RHOSP)
 :rh-openstack: RHOSP

--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -136,6 +136,7 @@ endif::[]
 :clo: Red Hat OpenShift Logging Operator
 :loki-op: Loki Operator
 :es-op: Elasticsearch Operator
+:log-plug: logging subsystem Console plugin
 //serverless
 :ServerlessProductName: OpenShift Serverless
 :ServerlessProductShortName: Serverless

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2516,6 +2516,8 @@ Topics:
   Topics:
   - Name: About log visualization
     File: log-visualization
+  - Name: Log visualization with the web console
+    File: log-visualization-ocp-console
   - Name: Viewing cluster dashboards
     File: cluster-logging-dashboards
   - Name: Log visualization with Kibana

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -1044,6 +1044,8 @@ Topics:
   Topics:
   - Name: About log visualization
     File: log-visualization
+  - Name: Log visualization with the web console
+    File: log-visualization-ocp-console
   - Name: Viewing cluster dashboards
     File: cluster-logging-dashboards
   - Name: Log visualization with Kibana

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1215,6 +1215,8 @@ Topics:
   Topics:
   - Name: About log visualization
     File: log-visualization
+  - Name: Log visualization with the web console
+    File: log-visualization-ocp-console
   - Name: Viewing cluster dashboards
     File: cluster-logging-dashboards
   - Name: Log visualization with Kibana

--- a/logging/cluster-logging.adoc
+++ b/logging/cluster-logging.adoc
@@ -22,6 +22,10 @@ Because the internal {product-title} Elasticsearch log store does not provide se
 
 include::modules/logging-architecture-overview.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../logging/log_visualization/log-visualization-ocp-console.adoc#log-visualization-ocp-console[Log visualization with the web console]
+
 include::modules/cluster-logging-about.adoc[leveloffset=+1]
 
 ifdef::openshift-rosa,openshift-dedicated[]

--- a/logging/log_visualization/log-visualization-ocp-console.adoc
+++ b/logging/log_visualization/log-visualization-ocp-console.adoc
@@ -1,0 +1,17 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+[id="log-visualization-ocp-console"]
+= Log visualization with the web console
+:context: log-visualization-ocp-console
+
+toc::[]
+
+You can use the {product-title} web console to visualize log data by configuring the {log-plug}.
+
+For information about configuring the plugin during the {logging} installation, see xref:../../logging/cluster-logging-deploying.adoc#cluster-logging-deploy-console_cluster-logging-deploying[Installing the {logging} using the web console].
+
+If you have already installed the {logging} and want to configure the plugin, use one of the following procedures.
+
+include::modules/enabling-log-console-plugin.adoc[leveloffset=+1]
+include::modules/logging-plugin-es-loki.adoc[leveloffset=+1]

--- a/modules/cluster-logging-deploy-console.adoc
+++ b/modules/cluster-logging-deploy-console.adoc
@@ -23,7 +23,7 @@ include::snippets/logging-compatibility-snip.adoc[]
 +
 This option sets the `openshift.io/cluster-monitoring: "true"` label in the Namespace object. You must select this option to ensure that cluster monitoring scrapes the `openshift-logging` namespace.
 
-. Select *stable-5.x* as the *Update channel*.
+. Select *stable-5.y* as the *Update channel*.
 +
 --
 include::snippets/logging-stable-updates-snip.adoc[]
@@ -33,7 +33,7 @@ include::snippets/logging-stable-updates-snip.adoc[]
 ** The *Automatic* strategy allows Operator Lifecycle Manager (OLM) to automatically update the Operator when a new version is available.
 ** The *Manual* strategy requires a user with appropriate credentials to approve the Operator update.
 
-. Select *Enable* or *Disable* for the Console plugin.
+. Select *Enable* or *Disable* for the *Console plugin*.
 . Click *Install*.
 
 .Verification

--- a/modules/enabling-log-console-plugin.adoc
+++ b/modules/enabling-log-console-plugin.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * logging/log_visualization/log-visualization-ocp-console.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="enabling-log-console-plugin_{context}"]
+= Enabling the {log-plug} after you have installed the {clo}
+
+You can enable the {log-plug} as part of the {clo} installation, but you can also enable the plugin if you have already installed the {clo} with the plugin disabled.
+
+.Prerequisites
+
+* You have administrator permissions.
+* You have installed the {clo} and selected *Disabled* for the *Console plugin*.
+* You have access to the {product-title} web console.
+
+.Procedure
+
+. In the {product-title} web console *Administrator* perspective, navigate to *Operators* -> *Installed Operators*.
+. Click *Red Hat OpenShift Logging*. This takes you to the Operator *Details* page.
+. In the *Details* page, click *Disabled* for the *Console plugin* option.
+. In the *Console plugin enablement* dialog, select *Enable*.
+. Click *Save*.
+. Verify that the *Console plugin* option now shows *Enabled*.
+. The web console displays a pop-up window when changes have been applied. The window prompts you to reload the web console. Refresh the browser when you see the pop-up window to apply the changes.

--- a/modules/logging-architecture-overview.adoc
+++ b/modules/logging-architecture-overview.adoc
@@ -20,7 +20,7 @@ Log store:: The log store stores log data for analysis and is the default output
 include::snippets/logging-elastic-dep-snip.adoc[]
 --
 
-Visualization:: You can use a UI component to view a visual representation of your log data. The UI provides a graphical interface to search, query, and view stored logs. If you are using LokiStack as the default log storage, the {product-title} web console UI is provided by enabling the {product-title} console plugin. If you are using Elasticsearch as the default log storage, you can use Kibana.
+Visualization:: You can use a UI component to view a visual representation of your log data. The UI provides a graphical interface to search, query, and view stored logs. The {product-title} web console UI is provided by enabling the {product-title} console plugin.
 +
 --
 include::snippets/logging-kibana-dep-snip.adoc[]

--- a/modules/logging-plugin-es-loki.adoc
+++ b/modules/logging-plugin-es-loki.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies:
+//
+// * logging/log_visualization/log-visualization-ocp-console.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="logging-plugin-es-loki_{context}"]
+= Configuring the {log-plug} when you have the Elasticsearch log store and LokiStack installed
+
+In the {logging} version 5.8 and later, if the Elasticsearch log store is your default log store but you have also installed the LokiStack, you can enable the {log-plug} by using the following procedure.
+
+.Prerequisites
+
+* You have administrator permissions.
+* You have installed the {clo}, the {es-op}, and the {loki-op}.
+* You have installed the {oc-first}.
+* You have created a `ClusterLogging` custom resource (CR).
+
+.Procedure
+
+. Ensure that the {log-plug} is enabled by running the following command:
++
+[source,terminal]
+----
+$ oc get consoles.operator.openshift.io cluster -o yaml |grep logging-view-plugin  \
+|| oc patch consoles.operator.openshift.io cluster  --type=merge \
+--patch '{ "spec": { "plugins": ["logging-view-plugin"]}}'
+----
+
+. Add the `.metadata.annotations.logging.openshift.io/ocp-console-migration-target: lokistack-dev` annotation to the `ClusterLogging` CR, by running the following command:
++
+[source,terminal]
+----
+$ oc patch clusterlogging instance --type=merge --patch \
+'{ "metadata": { "annotations": { "logging.openshift.io/ocp-console-migration-target": "lokistack-dev" }}}' \
+-n openshift-logging
+----
++
+.Example output
+[source,terminal]
+----
+clusterlogging.logging.openshift.io/instance patched
+----
+
+.Verification
+
+* Verify that the annotation was added successfully, by running the following command and observing the output:
++
+[source,terminal]
+----
+$ oc get clusterlogging instance \
+-o=jsonpath='{.metadata.annotations.logging\.openshift\.io/ocp-console-migration-target}' \
+-n openshift-logging
+----
++
+.Example output
+[source,terminal]
+----
+"lokistack-dev"
+----
+
+The {log-plug} pod is now deployed. You can view logging data by navigating to the {product-title} web console and viewing the *Observe* -> *Logs* page.


### PR DESCRIPTION
Version(s):
4.11+ but 4.11 requires a manual cherrypick to remove 5.8 content

Issue:
https://issues.redhat.com/browse/OBSDOCS-555

Link to docs preview:
- https://67963--docspreview.netlify.app/openshift-enterprise/latest/logging/log_visualization/log-visualization-ocp-console
- https://67963--docspreview.netlify.app/openshift-enterprise/latest/logging/cluster-logging#logging-architecture-overview_cluster-logging

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
