### PR TITLE
[OSDOCS-8743]:Remove outdated reference to "Node autoscaling is not available on OpenShift Dedicated at this time"

### DIFF
--- a/modules/sdpolicy-platform.adoc
+++ b/modules/sdpolicy-platform.adoc
@@ -47,7 +47,7 @@ The following table shows the frequency of backups:
 
 [id="autoscaling_{context}"]
 == Autoscaling
-Node autoscaling is not available on {product-title} at this time.
+Node autoscaling is available on {product-title}. See link:https://docs.openshift.com/dedicated/osd_cluster_admin/osd_nodes/osd-nodes-about-autoscaling-nodes.html[About autoscaling nodes on a cluster] for more information on autoscaling nodes on a cluster.
 
 [id="daemon-sets_{context}"]
 == Daemon sets
@@ -97,8 +97,8 @@ Red Hat workloads typically refer to Red Hat-provided Operators made available t
 * {rhq-short}
 * Red Hat Advanced Cluster Management
 * Red Hat Advanced Cluster Security
-* {SMProductName} 
-* {ServerlessProductName} 
+* {SMProductName}
+* {ServerlessProductName}
 * {logging-sd}
 * {pipelines-title}
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-8743
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://67966--docspreview.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-service-definition#autoscaling_osd-service-definition
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
**Reviewers; This ticket/PR was created in response to outdated info we have in OSD docs. Removed section that stated "Node autoscaling is not available on OSD at this time"; this  contradicts the newer included docs as seen here:  https://docs.openshift.com/dedicated/osd_cluster_admin/osd_nodes/osd-nodes-about-autoscaling-nodes.html**
![image](https://github.com/openshift/openshift-docs/assets/122639474/6869f2b7-4dd0-404d-8223-577b35edb8ed)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
