### PR TITLE
OSDOCS#6653: Temporarily removing the Kube API removals section since…

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -612,10 +612,10 @@ Topics:
 - Name: Preparing to update a cluster
   Dir: preparing_for_updates
   Topics:
-  - Name: Preparing to update to OpenShift Container Platform 4.14
+  - Name: Preparing to update to OpenShift Container Platform 4.15
     File: updating-cluster-prepare
     Distros: openshift-enterprise
-  - Name: Preparing to update to OKD 4.14
+  - Name: Preparing to update to OKD 4.15
     File: updating-cluster-prepare
     Distros: openshift-origin
   - Name: Preparing to update a cluster with manually maintained credentials
@@ -2897,13 +2897,13 @@ Topics:
     File: oadp-intro
   - Name: OADP release notes
     Dir: release-notes
-    Topics:    
-    - Name: OADP 1.3 release notes 
+    Topics:
+    - Name: OADP 1.3 release notes
       File: oadp-release-notes-1-3
-    - Name: OADP 1.2 release notes 
+    - Name: OADP 1.2 release notes
       File: oadp-release-notes-1-2
-    - Name: OADP 1.1 release notes 
-      File: oadp-release-notes-1-1        
+    - Name: OADP 1.1 release notes
+      File: oadp-release-notes-1-1
   - Name: OADP features and plugins
     File: oadp-features-plugins
   - Name: Installing and configuring OADP

--- a/updating/preparing_for_updates/updating-cluster-prepare.adoc
+++ b/updating/preparing_for_updates/updating-cluster-prepare.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="updating-cluster-prepare"]
-= Preparing to update to {product-title} 4.14
+= Preparing to update to {product-title} 4.15
 include::_attributes/common-attributes.adoc[]
 :context: updating-cluster-prepare
 
@@ -15,8 +15,12 @@ To do: Remove this comment once 4.13 docs are EOL.
 Learn more about administrative tasks that cluster admins must perform to successfully initialize an update, as well as optional guidelines for ensuring a successful update.
 
 [id="kube-api-removals_{context}"]
-== Kubernetes API deprecations and removals
+== Kubernetes API removals
 
+There are no Kubernetes API removals in {product-title} 4.15.
+
+// Commenting out this section because there are no APIs being removed in OCP 4.15 / Kube 1.28. But we'll need this section again for 4.16
+////
 {product-title} 4.14 uses Kubernetes 1.27, which removed several deprecated APIs.
 
 A cluster administrator must provide a manual acknowledgment before the cluster can be updated from {product-title} 4.13 to 4.14. This is to help prevent issues after upgrading to {product-title} 4.14, where APIs that have been removed are still in use by workloads, tools, or other components running on or interacting with the cluster. Administrators must evaluate their cluster for any APIs in use that will be removed and migrate the affected components to use the appropriate new API version. After this evaluation and migration is complete, the administrator can provide the acknowledgment.
@@ -45,6 +49,7 @@ include::modules/update-preparing-migrate.adoc[leveloffset=+2]
 
 // Providing the administrator acknowledgment
 include::modules/update-preparing-ack.adoc[leveloffset=+2]
+////
 
 // Assessing the risk of conditional updates
 include::modules/update-preparing-conditional.adoc[leveloffset=+1]


### PR DESCRIPTION
… it doesn't apply for 4.15

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-6653

Link to docs preview:
https://67989--docspreview.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare#kube-api-removals_updating-cluster-prepare

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
