### PR TITLE
OSDOCS#6653: Adding notice of future Kubernetes API removal in 4.16

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -667,7 +667,7 @@ In the following tables, features are marked with the following statuses:
 [id="ocp-4-15-openshift-default-registry"]
 ==== Removal of the OPENSHIFT_DEFAULT_REGISTRY
 
-{product-title} {product-version} has removed support for the `OPENSHIFT_DEFAULT_REGISTRY` variable. This variable was primarily used to enable backwards compatibility of the internal image registry for earlier setups. The `REGISTRY_OPENSHIFT_SERVER_ADDR` variable can be used in its place. 
+{product-title} {product-version} has removed support for the `OPENSHIFT_DEFAULT_REGISTRY` variable. This variable was primarily used to enable backwards compatibility of the internal image registry for earlier setups. The `REGISTRY_OPENSHIFT_SERVER_ADDR` variable can be used in its place.
 
 .APIs removed from Kubernetes 1.27
 [cols="2,2,2",options="header",]
@@ -682,6 +682,16 @@ In the following tables, features are marked with the following statuses:
 
 [id="ocp-4-15-future-deprecation"]
 === Notice of future deprecation
+
+[id="ocp-4-15-future-removals"]
+=== Future Kubernetes API removals
+
+// TODO: Can update "is scheduled to remove" to "removed" after Kuberenets 1.29 is released
+The next minor release of {product-title} is expected to use Kubernetes 1.29. Currently, Kubernetes 1.29 is scheduled to remove a deprecated API.
+
+See the link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-29[Deprecated API Migration Guide] in the upstream Kubernetes documentation for the list of planned Kubernetes API removals.
+
+See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API deprecations and removals] for information about how to check your cluster for Kubernetes APIs that are planned for removal.
 
 [id="ocp-4-15-bug-fixes"]
 == Bug fixes


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-6653

Link to docs preview:
https://67990--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-future-removals

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
