### PR TITLE
OSDOCS#7077: adding note about not recommended updates to CLI update doc

### DIFF
--- a/modules/update-upgrading-cli.adoc
+++ b/modules/update-upgrading-cli.adoc
@@ -7,8 +7,7 @@
 [id="update-upgrading-cli_{context}"]
 = Updating a cluster by using the CLI
 
-If updates are available, you can update your cluster by using the
-OpenShift CLI (`oc`).
+You can use the OpenShift CLI (`oc`) to review and request cluster updates.
 
 You can find information about available {product-title} advisories and updates
 link:https://access.redhat.com/downloads/content/290[in the errata section]
@@ -51,8 +50,10 @@ Recommended updates:
 +
 [NOTE]
 ====
-For details and information on how to perform an `EUS-to-EUS` channel update, please refer to the
-_Preparing to perform an EUS-to-EUS upgrade_ page, listed in the Additional resources section.
+* If there are no available updates, updates that are supported but not recommended might still be available.
+See _Updating along a conditional update path_ for more information.
+
+* For details and information on how to perform an `EUS-to-EUS` channel update, please refer to the _Preparing to perform an EUS-to-EUS upgrade_ page, listed in the Additional resources section.
 ====
 
 . Based on your organization requirements, set the appropriate update channel. For example, you can set your channel to `stable-4.13` or `fast-4.13`. For more information about channels, refer to _Understanding update channels and releases_ listed in the Additional resources section.

--- a/updating/updating_a_cluster/updating-cluster-cli.adoc
+++ b/updating/updating_a_cluster/updating-cluster-cli.adoc
@@ -60,6 +60,7 @@ include::modules/update-upgrading-cli.adoc[leveloffset=+1]
 .Additional resources
 
 * xref:../../updating/updating_a_cluster/eus-eus-update.adoc#eus-eus-update[Performing an EUS-to-EUS update]
+* xref:../../updating/updating_a_cluster/updating-cluster-cli.adoc#update-conditional-upgrade-pathupdating-cluster-cli[Updating along a conditional update path]
 * xref:../../updating/understanding_updates/understanding-update-channels-release.adoc#understanding-update-channels-releases[Understanding update channels and releases]
 
 // Updating along a conditional update path


### PR DESCRIPTION
[OSDOCS-7077](https://issues.redhat.com/browse/OSDOCS-7077)

Versions: 4.11+ (note to merge reviewer, CPs to 4.11, 4.12, and 4.13 will almost certainly fail and require me to make manual CPs)

QE review:
- [x] QE has approved this change.

Preview: [Updating a cluster by using the CLI](https://68012--docspreview.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-cluster-cli#update-upgrading-cli_updating-cluster-cli)