### PR TITLE
MIG-1505: MTC 1.8.2 update attributes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -76,7 +76,7 @@ endif::[]
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers
 :mtc-version: 1.8
-:mtc-version-z: 1.8
+:mtc-version-z: 1.8.2
 // builds (Valid only in 4.11 and later)
 :builds-v2title: Builds for Red Hat OpenShift
 :builds-v2shortname: OpenShift Builds v2


### PR DESCRIPTION
### Jira

* [MIG-1505](https://issues.redhat.com/browse/MIG-1505)

* Updating the MTC version to 1.8.2 following Release (for confirmation please see [pull/67775](https://github.com/openshift/openshift-docs/pull/67775) )

![image](https://github.com/openshift/openshift-docs/assets/106804821/476ae6f7-651b-4a11-a17b-3fce56385e14)

> [!NOTE]
>
> For more details, see [pull/67789](https://github.com/openshift/openshift-docs/pull/67789)


### Version

* OCP 4.11 → branch/enterprise-4.11



QE review:
- [ X] QE has approved this change.

