### PR TITLE
OSDOCS-7831: Create index.adoc landing page explaining Tutorials

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -88,6 +88,8 @@ Name: Tutorials
 Dir: cloud_experts_tutorials
 Distros: openshift-rosa
 Topics:
+- Name: Tutorials overview
+  File: index
 #- Name: ROSA prerequisites
 #  File: rosa-mobb-prerequisites-tutorial
 - Name: Verifying Permissions for a ROSA STS Deployment

--- a/cloud_experts_tutorials/index.adoc
+++ b/cloud_experts_tutorials/index.adoc
@@ -1,0 +1,9 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="tutorials-overview"]
+= Tutorials overview
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: tutorials-overview
+
+Step-by-step tutorials from Red Hat experts to help you get the most out of your Managed OpenShift cluster.
+
+In an effort to make this Cloud Expert tutorial content available quickly, it may not yet be tested on every supported configuration.


### PR DESCRIPTION
Replaces https://github.com/openshift/openshift-docs/pull/67613.

Version(s):
4.14+ 

Issue:
https://issues.redhat.com/browse/OSDOCS-7831

Link to docs preview:
https://68026--docspreview.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/

QE review:
Index page with no technical info. No QE review required. 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
