### PR TITLE
OSDOCS-8683: Removed the hyperthreading parameter from the vSphere docs

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -659,8 +659,9 @@ See _Supported installation methods for different platforms_ in _Installing_ doc
 endif::aws[]
 |String
 endif::openshift-origin[]
-
-|`compute.hyperthreading`
+ifndef::vsphere[]
+|compute:
+  hyperthreading:
 |Whether to enable or disable simultaneous multithreading, or `hyperthreading`, on compute machines. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores.
 [IMPORTANT]
 ====
@@ -668,6 +669,7 @@ If you disable simultaneous multithreading, ensure that your capacity planning
 accounts for the dramatically decreased machine performance.
 ====
 |`Enabled` or `Disabled`
+endif::vsphere[]
 
 |`compute.name`
 |Required if you use `compute`. The name of the machine pool.
@@ -733,7 +735,9 @@ endif::aws[]
 |String
 endif::openshift-origin[]
 
-|`controlPlane.hyperthreading`
+ifndef::vsphere[]
+|controlPlane:
+  hyperthreading:
 |Whether to enable or disable simultaneous multithreading, or `hyperthreading`, on control plane machines. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores.
 [IMPORTANT]
 ====
@@ -741,6 +745,7 @@ If you disable simultaneous multithreading, ensure that your capacity planning
 accounts for the dramatically decreased machine performance.
 ====
 |`Enabled` or `Disabled`
+endif::vsphere[]
 
 |`controlPlane.name`
 |Required if you use `controlPlane`. The name of the machine pool.
@@ -876,6 +881,32 @@ ifdef::ibm-power-vs[]
 |The system type must be either `e980` or `s922`.
 endif::ibm-power-vs[]
 |====
+[.small]
+--
+1. Not all CCO modes are supported for all cloud providers. For more information about CCO modes, see the "Managing cloud provider credentials" entry in the _Authentication and authorization_ content.
+ifdef::aws,gcp[]
++
+[NOTE]
+====
+ifdef::aws[If your AWS account has service control policies (SCP) enabled, you must configure the `credentialsMode` parameter to `Mint`, `Passthrough`, or `Manual`.]
+ifdef::gcp[If you are installing on GCP into a shared virtual private cloud (VPC), `credentialsMode` must be set to `Passthrough` or `Manual`.]
+====
+endif::aws,gcp[]
+ifdef::aws,gcp,azure[]
++
+[IMPORTANT]
+====
+Setting this parameter to `Manual` enables alternatives to storing administrator-level secrets in the `kube-system` project, which require additional configuration steps. For more information, see "Alternatives to storing administrator-level secrets in the kube-system project".
+====
+endif::aws,gcp,azure[]
+ifdef::ibm-power-vs[]
++
+[NOTE]
+====
+Cloud connections are no longer supported in the `install-config.yaml` while deploying in the `dal10` region, as they have been replaced by the Power Edge Router (PER).
+====
+endif::ibm-power-vs[]
+--
 
 ifdef::aws[]
 [id="installation-configuration-parameters-optional-aws_{context}"]

--- a/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
+++ b/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
@@ -33,19 +33,17 @@ apiVersion: v1
 baseDomain: example.com <1>
 compute: <2>
 - architecture: amd64
-  hyperthreading: Enabled <3>
   name:  <worker_node>
   platform: {}
   replicas: 3
 controlPlane: <2>
   architecture: amd64
-  hyperthreading: Enabled <3>
   name: <parent_node>
   platform: {}
   replicas: 3
 metadata:
   creationTimestamp: null
-  name: test <4>
+  name: test <3>
 ifdef::network[]
 networking:
   clusterNetwork:
@@ -58,17 +56,17 @@ networking:
   - 172.30.0.0/16
 endif::network[]
 platform:
-  vsphere: <5>
-    apiVIPs: 
+  vsphere: <4>
+    apiVIPs:
       - 10.0.0.1
-    failureDomains: <6>
+    failureDomains: <5>
     - name: <failure_domain_name>
       region: <default_region_name>
       server: <fully_qualified_domain_name>
       topology:
         computeCluster: "/<datacenter>/host/<cluster>"
         datacenter: <datacenter>
-        datastore: "/<datacenter>/datastore/<datastore>"
+        datastore: "/<datacenter>/datastore/<datastore>" <6>
         networks:
         - <VM_Network_name>
         resourcePool: "/<datacenter>/host/<cluster>/Resources/<resourcePool>" <7>
@@ -83,7 +81,7 @@ platform:
       port: 443
       server: <fully_qualified_domain_name> 
       user: administrator@vsphere.local
-    diskType: thin <8>    
+    diskType: thin <8>
 ifdef::restricted[]
     clusterOSImage: http://mirror.example.com/images/rhcos-47.83.202103221318-0-vmware.x86_64.ova <9>
 endif::restricted[]
@@ -113,17 +111,18 @@ endif::restricted[]
 ----
 <1> The base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.
 <2> The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Only one control plane pool is used.
-<3> Whether to enable or disable simultaneous multithreading, or `hyperthreading`. By default, simultaneous multithreading is enabled
-to increase the performance of your machines' cores. You can disable it by setting the parameter value to `Disabled`. If you disable simultaneous multithreading in some cluster machines, you must disable it in all cluster machines.
+<3> The cluster name that you specified in your DNS records.
+<4> Optional: Provides additional configuration for the machine pool parameters for the compute and control plane machines.
+<5> Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
+<6> The path to the vSphere datastore that holds virtual machine files, templates, and ISO images. 
 +
 [IMPORTANT]
 ====
-If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance. Your machines must use at least 8 CPUs and 32 GB of RAM if you disable simultaneous multithreading.
+You can specify the path of any datastore that exists in a datastore cluster. By default, Storage vMotion is automatically enabled for a datastore cluster. Red Hat does not support Storage vMotion, so you must disable Storage vMotion to avoid data loss issues for your {product-title} cluster.
+
+If you must specify VMs across multiple datastores, use a `datastore` object to specify a failure domain in your cluster's `install-config.yaml` configuration file. For more information, see "VMware vSphere region and zone enablement".
 ====
-<4> The cluster name that you specified in your DNS records.
-<5> Optional parameter for providing additional configuration for the machine pool parameters for the compute and control plane machines.
-<6> Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
-<7> Optional parameter for providing an existing resource pool for machine creation. If you do not specify a value, the installation program uses the root resource pool of the vSphere cluster.
+<7> Optional: Provides an existing resource pool for machine creation. If you do not specify a value, the installation program uses the root resource pool of the vSphere cluster.
 <8> The vSphere disk provisioning method.
 ifdef::network[]
 <9> The cluster network plugin to install. The supported values are `OVNKubernetes` and `OpenShiftSDN`. The default value is `OVNKubernetes`.

--- a/modules/installation-minimum-resource-requirements.adoc
+++ b/modules/installation-minimum-resource-requirements.adoc
@@ -64,6 +64,12 @@ endif::[]
 ifeval::["{context}" == "installing-azure-user-infra"]
 :azure:
 endif::[]
+ifeval::["{context}" == "installing-restricted-networks-azure-installer-provisioned"]
+:azure:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-azure-user-provisioned"]
+:azure:
+endif::[]
 ifeval::["{context}" == "installing-bare-metal"]
 :bare-metal:
 endif::[]
@@ -103,6 +109,15 @@ endif::[]
 ifeval::["{context}" == "installing-ibm-cloud-private"]
 :ibm-cloud-vpc:
 endif::[]
+ifeval::["{context}" == "installing-vsphere"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-network-customizations"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-vsphere"]
+:vsphere:
+endif::[]
 
 :_mod-docs-content-type: CONCEPT
 [id="installation-minimum-resource-requirements_{context}"]
@@ -117,12 +132,12 @@ Each cluster machine must meet the following minimum requirements:
 |Machine
 |Operating System
 ifndef::bare-metal[]
-ifndef::ibm-cloud-vpc[]
+ifndef::ibm-cloud-vpc,vsphere[]
 |vCPU ^[1]^
-endif::ibm-cloud-vpc[]
-ifdef::ibm-cloud-vpc[]
+endif::ibm-cloud-vpc,vsphere[]
+ifdef::ibm-cloud-vpc,vsphere[]
 |vCPU
-endif::ibm-cloud-vpc[]
+endif::ibm-cloud-vpc,vsphere[]
 |Virtual RAM
 endif::bare-metal[]
 ifdef::bare-metal[]
@@ -130,9 +145,12 @@ ifdef::bare-metal[]
 |RAM
 endif::bare-metal[]
 |Storage
-ifndef::ibm-z,ibm-cloud-vpc[]
+ifndef::ibm-z,ibm-cloud-vpc,vsphere[]
 |Input/Output Per Second (IOPS)^[2]^
-endif::ibm-z,ibm-cloud-vpc[]
+endif::ibm-z,ibm-cloud-vpc,vsphere[]
+ifdef::vsphere[]
+|Input/Output Per Second (IOPS)^[1]^
+endif::vsphere[]
 ifdef::ibm-z,ibm-cloud-vpc[]
 |Input/Output Per Second (IOPS)
 endif::ibm-z,ibm-cloud-vpc[]
@@ -167,7 +185,8 @@ endif::ibm-z[]
 ifndef::openshift-origin[]
 |Compute
 ifdef::ibm-z,ibm-power,ibm-cloud-vpc[|{op-system}]
-ifndef::ibm-z,ibm-power,ibm-cloud-vpc[|{op-system}, {op-system-base} 8.6, {op-system-base} 8.7, or {op-system-base} 8.8 ^[3]^]
+ifndef::ibm-z,ibm-power,ibm-cloud-vpc,vsphere[|{op-system}, {op-system-base} 8.6, {op-system-base} 8.7, or {op-system-base} 8.8 ^[3]^]
+ifdef::vsphere[|{op-system}, {op-system-base} 8.6, {op-system-base} 8.7, or {op-system-base} 8.8 ^[2]^]
 |2
 |8 GB
 |100 GB
@@ -201,16 +220,20 @@ endif::ibm-z[]
 ifdef::bare-metal[]
 1. One CPU is equivalent to one physical core when simultaneous multithreading (SMT), or hyperthreading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio: (threads per core × cores) × sockets = CPUs.
 endif::bare-metal[]
-ifndef::ibm-z,bare-metal,ibm-cloud-vpc[]
+ifndef::ibm-z,bare-metal,ibm-cloud-vpc,vsphere[]
 1. One vCPU is equivalent to one physical core when simultaneous multithreading (SMT), or hyperthreading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio: (threads per core × cores) × sockets = vCPUs.
-endif::ibm-z,bare-metal,ibm-cloud-vpc[]
-ifndef::ibm-z,ibm-power,ibm-cloud-vpc[]
+endif::ibm-z,bare-metal,ibm-cloud-vpc,vsphere[]
+ifndef::ibm-z,ibm-power,ibm-cloud-vpc,vsphere[]
 2. {product-title} and Kubernetes are sensitive to disk performance, and faster storage is recommended, particularly for etcd on the control plane nodes which require a 10 ms p99 fsync duration. Note that on many cloud platforms, storage size and IOPS scale together, so you might need to over-allocate storage volume to obtain sufficient performance.
 3. As with all user-provisioned installations, if you choose to use {op-system-base} compute machines in your cluster, you take responsibility for all operating system life cycle management and maintenance, including performing system updates, applying patches, and completing all other required tasks. Use of {op-system-base} 7 compute machines is deprecated and has been removed in {product-title} 4.10 and later.
-endif::ibm-z,ibm-power,ibm-cloud-vpc[]
+endif::ibm-z,ibm-power,ibm-cloud-vpc,vsphere[]
 ifdef::ibm-power[]
 2. {product-title} and Kubernetes are sensitive to disk performance, and faster storage is recommended, particularly for etcd on the control plane nodes. Note that on many cloud platforms, storage size and IOPS scale together, so you might need to over-allocate storage volume to obtain sufficient performance.
 endif::ibm-power[]
+ifdef::vsphere[]
+1. {product-title} and Kubernetes are sensitive to disk performance, and faster storage is recommended, particularly for etcd on the control plane nodes which require a 10 ms p99 fsync duration. Note that on many cloud platforms, storage size and IOPS scale together, so you might need to over-allocate storage volume to obtain sufficient performance.
+2. As with all user-provisioned installations, if you choose to use {op-system-base} compute machines in your cluster, you take responsibility for all operating system life cycle management and maintenance, including performing system updates, applying patches, and completing all other required tasks. Use of {op-system-base} 7 compute machines is deprecated and has been removed in {product-title} 4.10 and later.
+endif::vsphere[]
 --
 
 ifdef::azure[]
@@ -238,6 +261,12 @@ ifeval::["{context}" == "installing-azure-vnet"]
 :!azure:
 endif::[]
 ifeval::["{context}" == "installing-azure-user-infra"]
+:!azure:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-azure-installer-provisioned"]
+:!azure:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-azure-user-provisioned"]
 :!azure:
 endif::[]
 ifeval::["{context}" == "installing-bare-metal"]
@@ -278,4 +307,13 @@ ifeval::["{context}" == "installing-ibm-cloud-vpc"]
 endif::[]
 ifeval::["{context}" == "installing-ibm-cloud-private"]
 :!ibm-cloud-vpc:
+endif::[]
+ifeval::["{context}" == "installing-vsphere"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-network-customizations"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-vsphere"]
+:!vsphere:
 endif::[]

--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -10,6 +10,7 @@
 ifeval::["{context}" == "installing-restricted-networks-vsphere"]
 :restricted:
 endif::[]
+// Verify the validity of the following ifdef statement in a later Jira
 ifdef::openshift-origin[]
 :restricted:
 endif::[]
@@ -32,31 +33,29 @@ apiVersion: v1
 baseDomain: example.com <1>
 compute: <2>
 - architecture: amd64
-  hyperthreading: Enabled <3>
   name: <worker_node>
   platform: {}
-  replicas: 0 <4>
+  replicas: 0 <3>
 controlPlane: <2>
   architecture: amd64
-  hyperthreading: Enabled <3>
   name: <parent_node>
   platform: {}
-  replicas: 3 <5>
+  replicas: 3 <4>
 metadata:
   creationTimestamp: null
-  name: test <6>
+  name: test <5>
 networking:
 ---
 platform:
   vsphere:
-    failureDomains: <7>
+    failureDomains: <6>
     - name: <failure_domain_name>
       region: <default_region_name>
       server: <fully_qualified_domain_name>
       topology:
         computeCluster: "/<datacenter>/host/<cluster>"
-        datacenter: <datacenter> <8>
-        datastore: "/<datacenter>/datastore/<datastore>"
+        datacenter: <datacenter> <7>
+        datastore: "/<datacenter>/datastore/<datastore>" <8>
         networks:
         - <VM_Network_name>
         resourcePool: "/<datacenter>/host/<cluster>/Resources/<resourcePool>" <9>
@@ -65,9 +64,9 @@ platform:
     vcenters:
     - datacenters:
       - <datacenter>
-      password: <password> <12>
+      password: <password> <11>
       port: 443
-      server: <fully_qualified_domain_name> <11>
+      server: <fully_qualified_domain_name> <12>
       user: administrator@vsphere.local
     diskType: thin <13>
 ifndef::restricted[]
@@ -131,43 +130,37 @@ base and include the cluster name.
 sequence of mappings. To meet the requirements of the different data structures,
 the first line of the `compute` section must begin with a hyphen, `-`, and the
 first line of the `controlPlane` section must not. Both sections define a single machine pool, so only one control plane is used. {product-title} does not support defining multiple compute pools.
-<3> Whether to enable or disable simultaneous multithreading, or
-`hyperthreading`. By default, simultaneous multithreading is enabled
-to increase the performance of your machines' cores. You can disable it by
-setting the parameter value to `Disabled`. If you disable simultaneous
-multithreading in some cluster machines, you must disable it in all cluster
-machines.
-+
-[IMPORTANT]
-====
-If you disable simultaneous multithreading, ensure that your capacity planning
-accounts for the dramatically decreased machine performance.
-Your machines must use at least 8 CPUs and 32 GB of RAM if you disable
-simultaneous multithreading.
-====
-<4> You must set the value of the `replicas` parameter to `0`. This parameter
+<3> You must set the value of the `replicas` parameter to `0`. This parameter
 controls the number of workers that the cluster creates and manages for you,
 which are functions that the cluster does not perform when you
 use user-provisioned infrastructure. You must manually deploy worker
 machines for the cluster to use before you finish installing {product-title}.
-<5> The number of control plane machines that you add to the cluster. Because
+<4> The number of control plane machines that you add to the cluster. Because
 the cluster uses this values as the number of etcd endpoints in the cluster, the
 value must match the number of control plane machines that you deploy.
-<6> The cluster name that you specified in your DNS records.
-<7> Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
-<8> The vSphere datacenter.
-<9> Optional parameter. For installer-provisioned infrastructure, the absolute path of an existing resource pool where the installation program creates the virtual machines, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`. If you do not specify a value, resources are installed in the root of the cluster `/example_datacenter/host/example_cluster/Resources`.
-<10> Optional parameter For installer-provisioned infrastructure, the absolute path of an existing folder where the installation program creates the virtual machines, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`. If you do not provide this value, the installation program creates a top-level folder in the datacenter virtual machine folder that is named with the infrastructure ID. If you are providing the infrastructure for the cluster and you do not want to use the default `StorageClass` object, named `thin`, you can omit the `folder` parameter from the `install-config.yaml` file.
-<11> The fully-qualified hostname or IP address of the vCenter server.
+<5> The cluster name that you specified in your DNS records.
+<6> Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
+<7> The vSphere datacenter.
+<8> The path to the vSphere datastore that holds virtual machine files, templates, and ISO images.
++
+[IMPORTANT]
+====
+You can specify the path of any datastore that exists in a datastore cluster. By default, Storage vMotion is automatically enabled for a datastore cluster. Red Hat does not support Storage vMotion, so you must disable Storage vMotion to avoid data loss issues for your {product-title} cluster.
+
+If you must specify VMs across multiple datastores, use a `datastore` object to specify a failure domain in your cluster's `install-config.yaml` configuration file. For more information, see "VMware vSphere region and zone enablement".
+====
+<9> Optional: For installer-provisioned infrastructure, the absolute path of an existing resource pool where the installation program creates the virtual machines, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`. If you do not specify a value, resources are installed in the root of the cluster `/example_datacenter/host/example_cluster/Resources`.
+<10> Optional: For installer-provisioned infrastructure, the absolute path of an existing folder where the installation program creates the virtual machines, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`. If you do not provide this value, the installation program creates a top-level folder in the datacenter virtual machine folder that is named with the infrastructure ID. If you are providing the infrastructure for the cluster and you do not want to use the default `StorageClass` object, named `thin`, you can omit the `folder` parameter from the `install-config.yaml` file.
+<11> The password associated with the vSphere user.
+<12> The fully-qualified hostname or IP address of the vCenter server.
 +
 [IMPORTANT]
 ====
 The Cluster Cloud Controller Manager Operator performs a connectivity check on a provided hostname or IP address. Ensure that you specify a hostname or an IP address to a reachable vCenter server. If you provide metadata to a non-existent vCenter server, installation of the cluster fails at the bootstrap stage.
 ====
-<12> The password associated with the vSphere user.
 <13> The vSphere disk provisioning method.
 ifndef::openshift-origin[]
-<14> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
+<14> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
 [IMPORTANT]
 ====


### PR DESCRIPTION
Cherry picking from #67569 from commit 153bd358039cbb14b727127bef4f9e604ce1d406


[OSDOCS-8693](https://issues.redhat.com/browse/OSDOCS-8683)

Version(s):
4.13

Link to docs preview:
* [Installing a cluster on vSphere with customizations](https://68038--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations#installation-installer-provisioned-vsphere-config-yaml_installing-vsphere-installer-provisioned-customizations)
* [Installing a cluster on vSphere with network customizations](https://68038--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations#installation-installer-provisioned-vsphere-config-yaml_installing-vsphere-installer-provisioned-network-customizations)
* [Installing a cluster on vSphere with user-provisioned infrastructure-changed](https://68038--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere#installation-vsphere-config-yaml_installing-vsphere)
* [Installing a cluster on vSphere with network customizations-changed](https://68038--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-network-customizations#installation-vsphere-config-yaml_installing-vsphere-network-customizations)
* [Installing a cluster on vSphere in a restricted network](https://68038--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere#installation-installer-provisioned-vsphere-config-yaml_installing-restricted-networks-installer-provisioned-vsphere)
* [Installing a cluster on vSphere in a restricted network with user-provisioned infrastructure - changed](https://68038--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-restricted-networks-vsphere#installation-vsphere-config-yaml_installing-restricted-networks-vsphere)
* [Installation configuration parameters-AWS](https://68038--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations#installation-configuration-parameters_installing-aws-customizations)
* [Installation configuration parameters for GCP](https://68038--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-network-customizations#installation-configuration-parameters_installing-gcp-network-customizations)
* [Installation configuration parameters for Azure](https://68038--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-customizations#installation-configuration-parameters_installing-azure-customizations)
* [Installation configuration parameters for IBM Power Virtual Server](https://68038--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/installing-ibm-power-vs-customizations#installation-configuration-parameters_installing-ibm-power-vs-customizations)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* We cannot use the [.small] role because it might collide with the CSS "small" syntax. See [Slack thread](https://app.slack.com/client/E030G10V24F?selected_team_id=E030G10V24F#:~:text=It%27s%20an%20arbitrary%20Asciidoctor%20markup%20that%20IMO%20should%20not%20be%20used%20for%20docs.%20it%27s%20not%20that%20it%27s%20deprecated%2C%20just%20that%20%5Bsmall%5D%20maps%20to%20a%20css%20.small%20class%20which%20may%20or%20may%20not%20be%20included%20in%20the%20next%20portal%20build).
