### PR TITLE
OSDOCS#8726:QE and Style Revisions of MOBB Content for Dynamically issuing certificates using the cert-manager Operator on ROSA

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-dynamic-certificate-custom-domain.adoc
+++ b/cloud_experts_tutorials/cloud-experts-dynamic-certificate-custom-domain.adoc
@@ -17,17 +17,22 @@ toc::[]
 //   Kevin Collins
 //---
 
-While wildcard certificates provide simplicity by securing all first-level subdomains of a given domain with a single certificate, other use cases may require the use of individual certificates per domain. This tutorial guides you through using the link:https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html[cert-manager Operator for Red Hat OpenShift] and link:https://letsencrypt.org/[Let's Encrypt] to dynamically issue certificates for routes created using a custom domain.
+While wildcard certificates provide simplicity by securing all first-level subdomains of a given domain with a single certificate, other use cases can require the use of individual certificates per domain.
 
+Learn how to use the link:https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html[cert-manager Operator for Red Hat OpenShift] and link:https://letsencrypt.org/[Let's Encrypt] to dynamically issue certificates for routes created using a custom domain.
+
+[id="cloud-experts-dynamic-certificate-custom-domain-prerequisites"]
 == Prerequisites
 
 * A ROSA cluster
-* You have access to the OpenShift CLI (`oc`)
-* You have access to the AWS CLI (`aws`)
-* A unique domain, such as *.apps.<company_name>.io
+* A user account with `cluster-admin` privileges
+* The OpenShift CLI (`oc`)
+* The Amazon Web Services (AWS) CLI (`aws`)
+* A unique domain, such as `*.apps.<company_name>.io`
 * An Amazon Route 53 public hosted zone for the above domain
 
-=== Setting up your environment
+[id="cloud-experts-dynamic-certificate-custom-domain-environment-setup"]
+== Setting up your environment
 
 . Configure the following environment variables:
 +
@@ -42,22 +47,28 @@ $ export REGION=$(oc get infrastructure cluster -o=jsonpath="{.status.platformSt
 $ export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 $ export SCRATCH="/tmp/${CLUSTER_NAME}/dynamic-certs"
 $ mkdir -p ${SCRATCH}
-$ echo "Cluster: ${CLUSTER_NAME}, Region: ${REGION}, OIDC Endpoint: ${OIDC_ENDPOINT}, AWS Account ID: ${AWS_ACCOUNT_ID}"
 ----
 <1> The custom domain.
 <2> The e-mail Let's Encrypt will use to send notifications about your certificates.
+. Ensure all fields output correctly before moving to the next section:
++
+[source,terminal]
+----
+$ echo "Cluster: ${CLUSTER_NAME}, Region: ${REGION}, OIDC Endpoint: ${OIDC_ENDPOINT}, AWS Account ID: ${AWS_ACCOUNT_ID}"
+----
 
+[id="cloud-experts-dynamic-certificate-prep-aws"]
 == Preparing your AWS account
 
-When cert-manager requests a certificate from Let’s Encrypt (or another ACME certificate issuer), Let's Encrypt servers validate that you control the domain name in that certificate using “challenges". For this tutorial, you are using a link:https://letsencrypt.org/docs/challenge-types/#dns-01-challenge[DNS-01 challenge] that proves that you control the DNS for your domain name by putting a specific value in a TXT record under that domain name. This is all done automatically by cert-manager. To allow cert-manager permission to modify the Amazon Route 53 public hosted zone for your domain, you need to create an IAM role with specific policy permissions and a trust relationship to allow access to the pod.
+When cert-manager requests a certificate from Let’s Encrypt (or another ACME certificate issuer), Let's Encrypt servers validate that you control the domain name in that certificate using _challenges_. For this tutorial, you are using a link:https://letsencrypt.org/docs/challenge-types/#dns-01-challenge[DNS-01 challenge] that proves that you control the DNS for your domain name by putting a specific value in a TXT record under that domain name. This is all done automatically by cert-manager. To allow cert-manager permission to modify the Amazon Route 53 public hosted zone for your domain, you need to create an Identity Access Management (IAM) role with specific policy permissions and a trust relationship to allow access to the pod.
 
-The public hosted zone that is used in this tutorial is in the same account as the ROSA cluster. If your public hosted zone is in a different account, a few additional steps for link:https://cert-manager.io/docs/configuration/acme/dns01/route53/#cross-account-access[Cross Account Access] are required.
+The public hosted zone that is used in this tutorial is in the same AWS account as the ROSA cluster. If your public hosted zone is in a different account, a few additional steps for link:https://cert-manager.io/docs/configuration/acme/dns01/route53/#cross-account-access[Cross Account Access] are required.
 
 . Retrieve the Amazon Route 53 public hosted zone ID:
 +
 [NOTE]
 ====
-This command will look for a public hosted zone that matches the custom domain you specified earlier. You can manually specify the Amazon Route 53 public hosted zone by running `export ZONE_ID=<zone_ID>` and replacing `<zone_ID>` with your specific Amazon Route 53 public hosted zone ID.
+This command looks for a public hosted zone that matches the custom domain you specified earlier as the `DOMAIN` environment variable. You can manually specify the Amazon Route 53 public hosted zone by running `export ZONE_ID=<zone_ID>`, replacing `<zone_ID>` with your specific Amazon Route 53 public hosted zone ID.
 ====
 +
 [source,terminal]
@@ -66,7 +77,7 @@ $ export ZONE_ID=$(aws route53 list-hosted-zones-by-name --output json \
   --dns-name "${DOMAIN}." --query 'HostedZones[0]'.Id --out text | sed 's/\/hostedzone\///')
 ----
 +
-. Create an AWS IAM policy document for the cert-manager Operator that provides the ability to update _only_ the specified public hosted zone:
+. Create an AWS IAM policy document for the `cert-manager` Operator that provides the ability to update _only_ the specified public hosted zone:
 +
 [source,terminal]
 ----
@@ -97,7 +108,7 @@ $ cat <<EOF > "${SCRATCH}/cert-manager-policy.json"
 EOF
 ----
 +
-. Create the IAM Policy using the file you created in the previous step:
+. Create the IAM policy using the file you created in the previous step:
 +
 [source,terminal]
 ----
@@ -105,7 +116,7 @@ $ POLICY_ARN=$(aws iam create-policy --policy-name "${CLUSTER_NAME}-cert-manager
   --policy-document file://${SCRATCH}/cert-manager-policy.json \
   --query 'Policy.Arn' --output text)
 ----
-. Create an AWS IAM trust policy for the cert-manager Operator:
+. Create an AWS IAM trust policy for the `cert-manager` Operator:
 +
 [source,terminal]
 ----
@@ -130,7 +141,7 @@ $ cat <<EOF > "${SCRATCH}/trust-policy.json"
 EOF
 ----
 +
-. Create an IAM Role for the cert-manager Operator using the trust policy you created in the previous step:
+. Create an IAM role for the `cert-manager` Operator using the trust policy you created in the previous step:
 +
 [source,terminal]
 ----
@@ -147,9 +158,10 @@ $ aws iam attach-role-policy --role-name "${CLUSTER_NAME}-cert-manager-operator"
   --policy-arn ${POLICY_ARN}
 ----
 
+[id="cloud-experts-dynamic-certificate-custom-domain-install-cert-man-op"]
 == Installing the cert-manager Operator
 
-. Create a project to install the cert-manager Operator into:
+. Create a project to install the `cert-manager` Operator into:
 +
 [source,terminal]
 ----
@@ -158,10 +170,10 @@ $ oc new-project cert-manager-operator
 +
 [IMPORTANT]
 ====
-Do not attempt to use more than one cert-manager Operator in your cluster. If you have a community cert-manager Operator installed in your cluster, you must uninstall it before installing the cert-manager Operator for Red Hat OpenShift.
+Do not attempt to use more than one `cert-manager` Operator in your cluster. If you have a community `cert-manager` Operator installed in your cluster, you must uninstall it before installing the `cert-manager` Operator for Red Hat OpenShift.
 ====
 +
-. Install the cert-manager Operator for Red Hat OpenShift:
+. Install the `cert-manager` Operator for Red Hat OpenShift:
 +
 [source,terminal]
 ----
@@ -191,10 +203,10 @@ EOF
 +
 [NOTE]
 ====
-It will take a few minutes for this Operator to install and complete its set up.
+It takes a few minutes for this Operator to install and complete its set up.
 ====
 +
-. Verify that the cert-manager Operator is running:
+. Verify that the `cert-manager` Operator is running:
 +
 [source,terminal]
 ----
@@ -208,14 +220,14 @@ NAME                                                        READY   STATUS    RE
 cert-manager-operator-controller-manager-84b8799db5-gv8mx   2/2     Running   0          12s
 ----
 +
-. Annotate the service account used by the cert-manager pods with the AWS IAM role you created earlier:
+. Annotate the service account used by the `cert-manager` pods with the AWS IAM role you created earlier:
 +
 [source,terminal]
 ----
 $ oc -n cert-manager annotate serviceaccount cert-manager eks.amazonaws.com/role-arn=${ROLE_ARN}
 ----
 +
-. Restart the existing cert-manager controller pod by running the following command:
+. Restart the existing `cert-manager` controller pod by running the following command:
 +
 [source,terminal]
 ----
@@ -256,7 +268,7 @@ spec:
 EOF
 ----
 +
-. Check the `ClusterIssuer` resource to confirm it is ready:
+. Verify the `ClusterIssuer` resource is ready:
 +
 [source,terminal]
 ----
@@ -271,7 +283,8 @@ NAME                     READY   AGE
 letsencrypt-production   True    47s
 ----
 
-== Creating a custom domain ingress controller
+[id="cloud-experts-dynamic-certificate-custom-domain-create-cd-ingress-con"]
+== Creating a custom domain Ingress Controller
 
 . Create a new project:
 +
@@ -280,13 +293,12 @@ letsencrypt-production   True    47s
 $ oc new-project custom-domain-ingress
 ----
 +
-. Create a certificate resource to provision a certificate for the custom domain Ingress Controller:
+. Create and configure a certificate resource to provision a certificate for the custom domain Ingress Controller:
 +
 [NOTE]
 ====
 The following example uses a single domain certificate. SAN and wildcard certificates are also supported.
 ====
-. Configure the certificate:
 +
 [source,terminal]
 ----
@@ -311,7 +323,7 @@ EOF
 +
 [NOTE]
 ====
-It will take a few minutes for this certificate to be issued by Let's Encrypt. If it takes longer than 5 minutes, run `oc -n custom-domain-ingress describe certificate.cert-manager.io/custom-domain-ingress-cert` to see any issues reported by cert-manager.
+It takes a few minutes for this certificate to be issued by Let's Encrypt. If it takes longer than 5 minutes, run `oc -n custom-domain-ingress describe certificate.cert-manager.io/custom-domain-ingress-cert` to see any issues reported by cert-manager.
 ====
 +
 [source,terminal]
@@ -345,7 +357,7 @@ spec:
     namespace: custom-domain-ingress
 EOF
 ----
-. Verify that your custom domain Ingress Controller has been deployed and is ready:
+. Verify that your custom domain Ingress Controller has been deployed and has a `Ready` status:
 +
 [source,terminal]
 ----
@@ -396,13 +408,14 @@ $ aws route53 change-resource-record-sets \
 While the wildcard CNAME record avoids the need to create a new record for every new application you deploy using the custom domain Ingress Controller, the certificate that each of these applications use *is not* a wildcard certificate.
 ====
 
+[id="cloud-experts-dynamic-certificate-custom-domain-config-dynamic-cert"]
 == Configuring dynamic certificates for custom domain routes
 
-At this stage, you can expose cluster applications on any first-level subdomains of the specified domain, but the connection will not be secured with a TLS certificate that matches the domain of the application. To ensure these cluster applications have valid certificates for each domain name, configure cert-manager to dynamically issue a certificate to every new route created under this domain.
+Now you can expose cluster applications on any first-level subdomains of the specified domain, but the connection will not be secured with a TLS certificate that matches the domain of the application. To ensure these cluster applications have valid certificates for each domain name, configure cert-manager to dynamically issue a certificate to every new route created under this domain.
 
-. Create the necessary OpenShift resources cert-manager requires to manage certificates for OpenShift routes:
+. Create the necessary OpenShift resources cert-manager requires to manage certificates for OpenShift routes.
 +
-This step creates a new deployment (and therefore a pod) that specifically monitors annotated routes in the cluster. If the issuer-kind and issuer-name annotations are found in a new route, it requests the Issuer (ClusterIssuer in this case) for a new certificate that is unique to this route and which will honor the hostname that was specified while creating the route.
+This step creates a new deployment (and therefore a pod) that specifically monitors annotated routes in the cluster. If the `issuer-kind` and `issuer-name` annotations are found in a new route, it requests the Issuer (ClusterIssuer in this case) for a new certificate that is unique to this route and which will honor the hostname that was specified while creating the route.
 +
 [NOTE]
 ====
@@ -420,7 +433,7 @@ The following additional OpenShift resources are also created in this step:
 * `ServiceAccount` - uses permissions to run the newly created pod
 * `ClusterRoleBinding` -  binds these two resources
 +
-. Ensure that the new pod `cert-manager-openshift-routes` is running successfully by running the following command:
+. Ensure that the new `cert-manager-openshift-routes` pod is running successfully:
 +
 [source,terminal]
 ----
@@ -438,7 +451,10 @@ cert-manager-openshift-routes-75b6bb44cd-f8kd5   1/1     Running   0          6s
 cert-manager-webhook-8498785dd9-bvfdf            1/1     Running   0          4h41m
 ----
 
+[id="cloud-experts-dynamic-certificate-custom-domain-config-deploy-sample-app"]
 == Deploying a sample application
+
+Now that dynamic certificates are configured, you can deploy a sample application to confirm that certificates are provisioned and trusted when you expose a new route.
 
 . Create a new project for your sample application:
 +
@@ -488,7 +504,7 @@ $ oc -n hello-world annotate route hello-openshift-tls cert-manager.io/issuer-ki
 +
 [NOTE]
 ====
-It will take a 2-3 minutes for the certificate to be created. The renewal of the certificate will automatically be managed by the cert-manager Operator as it approaches expiration.
+It takes 2-3 minutes for the certificate to be created. The renewal of the certificate will automatically be managed by the `cert-manager` Operator as it approaches expiration.
 ====
 . Verify the certificate for the route is now trusted:
 +
@@ -509,19 +525,20 @@ set-cookie: 52e4465485b6fb4f8a1b1bed128d0f3b=68676068bb32d24f0f558f094ed8e4d7; p
 cache-control: private
 ----
 
-== Debugging
+[id="cloud-experts-dynamic-certificate-custom-domain-troubleshoot"]
+== Troubleshooting dynamic certificate provisioning
 [NOTE]
 ====
 The validation process usually takes 2-3 minutes to complete while creating certificates.
 ====
 
-If you face issues during the certificate create step, run `oc describe` against each of the `certificate`,`certificaterequest`,`order`, and `challenge` resources to view the events or reasons that will help identify the cause of the issue.
+If annotating your route does not trigger certificate creation during the certificate create step, run `oc describe` against each of the `certificate`,`certificaterequest`,`order`, and `challenge` resources to view the events or reasons that can help identify the cause of the issue.
 
 [source,terminal]
 ----
 $ oc get certificate,certificaterequest,order,challenge
 ----
 
-This is a very link:https://cert-manager.io/docs/faq/acme/[helpful guide in debugging certificates] as well.
+For troubleshooting, you can refer to this link:https://cert-manager.io/docs/faq/acme/[helpful guide in debugging certificates].
 
-You can also use the link:https://cert-manager.io/docs/reference/cmctl/[cmctl] CLI tool for various certificate management activities, such checking the status of certificates and testing renewals.
+You can also use the link:https://cert-manager.io/docs/reference/cmctl/[cmctl] CLI tool for various certificate management activities, such as checking the status of certificates and testing renewals.


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-8726](https://issues.redhat.com/browse/OSDOCS-8726)

Link to docs preview:
[Dynamically issuing certificates using the cert-manager Operator on ROSA](https://68041--docspreview.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-dynamic-certificate-custom-domain)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
