### PR TITLE
OSDOCS-8683: Removed the hyperthreading parameter from the vSphere docs

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -553,7 +553,7 @@ See _Supported installation methods for different platforms_ in _Installing_ doc
 endif::aws[]
 |String
 endif::openshift-origin[]
-
+ifndef::vsphere[]
 |`compute.hyperthreading`
 |Whether to enable or disable simultaneous multithreading, or `hyperthreading`, on compute machines. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores.
 [IMPORTANT]
@@ -562,6 +562,7 @@ If you disable simultaneous multithreading, ensure that your capacity planning
 accounts for the dramatically decreased machine performance.
 ====
 |`Enabled` or `Disabled`
+endif::vsphere[]
 
 |`compute.name`
 |Required if you use `compute`. The name of the machine pool.
@@ -620,6 +621,7 @@ endif::aws[]
 |String
 endif::openshift-origin[]
 
+ifndef::vsphere[]
 |`controlPlane.hyperthreading`
 |Whether to enable or disable simultaneous multithreading, or `hyperthreading`, on control plane machines. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores.
 [IMPORTANT]
@@ -628,6 +630,7 @@ If you disable simultaneous multithreading, ensure that your capacity planning
 accounts for the dramatically decreased machine performance.
 ====
 |`Enabled` or `Disabled`
+endif::vsphere[]
 
 |`controlPlane.name`
 |Required if you use `controlPlane`. The name of the machine pool.

--- a/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
+++ b/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
@@ -32,29 +32,27 @@ parameters.
 apiVersion: v1
 baseDomain: example.com <1>
 compute: <2>
-- hyperthreading: Enabled <3>
   name: worker
   replicas: 3
   platform:
-    vsphere: <4>
+    vsphere: <3>
       cpus: 2
       coresPerSocket: 2
       memoryMB: 8192
       osDisk:
         diskSizeGB: 120
 controlPlane: <2>
-  hyperthreading: Enabled <3>
   name: master
   replicas: 3
   platform:
-    vsphere: <4>
+    vsphere: <3>
       cpus: 4
       coresPerSocket: 2
       memoryMB: 16384
       osDisk:
         diskSizeGB: 120
 metadata:
-  name: cluster <5>
+  name: cluster <4>
 ifdef::network[]
 networking:
   clusterNetwork:
@@ -79,14 +77,14 @@ platform:
     datacenter: datacenter
     defaultDatastore: datastore
     folder: folder
-    resourcePool: resource_pool <6>
-    diskType: thin <7>
+    resourcePool: resource_pool <5>
+    diskType: thin <6>
     network: VM_Network
-    cluster: vsphere_cluster_name <8>
+    cluster: vsphere_cluster_name <7>
     apiVIP: api_vip
     ingressVIP: ingress_vip
 ifdef::restricted[]
-    clusterOSImage: http://mirror.example.com/images/rhcos-47.83.202103221318-0-vmware.x86_64.ova <9>
+    clusterOSImage: http://mirror.example.com/images/rhcos-47.83.202103221318-0-vmware.x86_64.ova <8>
 endif::restricted[]
 ifndef::openshift-origin[]
 fips: false
@@ -95,15 +93,15 @@ ifndef::restricted[]
 pullSecret: '{"auths": ...}'
 endif::restricted[]
 ifdef::restricted[]
-pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <10>
+pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <9>
 endif::restricted[]
 sshKey: 'ssh-ed25519 AAAA...'
 ifdef::restricted[]
-additionalTrustBundle: | <11>
+additionalTrustBundle: | <10>
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
   -----END CERTIFICATE-----
-imageContentSources: <12>
+imageContentSources: <11>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -114,22 +112,16 @@ endif::restricted[]
 ----
 <1> The base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.
 <2> The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Only one control plane pool is used.
-<3> Whether to enable or disable simultaneous multithreading, or `hyperthreading`. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores. You can disable it by setting the parameter value to `Disabled`. If you disable simultaneous multithreading in some cluster machines, you must disable it in all cluster machines.
-+
-[IMPORTANT]
-====
-If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance. Your machines must use at least 8 CPUs and 32 GB of RAM if you disable simultaneous multithreading.
-====
-<4> Optional: Provide additional configuration for the machine pool parameters for the compute and control plane machines. 
-<5> The cluster name that you specified in your DNS records.
-<6> Optional: Provide an existing resource pool for machine creation. If you do not specify a value, the installation program uses the root resource pool of the vSphere cluster.
-<7> The vSphere disk provisioning method.
-<8> The vSphere cluster to install the {product-title} cluster in.
+<3> Optional: Provide additional configuration for the machine pool parameters for the compute and control plane machines. 
+<4> The cluster name that you specified in your DNS records.
+<5> Optional: Provide an existing resource pool for machine creation. If you do not specify a value, the installation program uses the root resource pool of the vSphere cluster.
+<6> The vSphere disk provisioning method.
+<7> The vSphere cluster to install the {product-title} cluster in.
 ifdef::restricted[]
-<9> The location of the {op-system-first} image that is accessible from the bastion server.
-<10> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example `registry.example.com` or `registry.example.com:5000`. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
-<11> Provide the contents of the certificate file that you used for your mirror registry.
-<12> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+<8> The location of the {op-system-first} image that is accessible from the bastion server.
+<9> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example `registry.example.com` or `registry.example.com:5000`. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
+<10> Provide the contents of the certificate file that you used for your mirror registry.
+<11> Provide the `imageContentSources` section from the output of the command to mirror the repository.
 endif::restricted[]
 
 ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]

--- a/modules/installation-minimum-resource-requirements.adoc
+++ b/modules/installation-minimum-resource-requirements.adoc
@@ -9,6 +9,7 @@
 // * installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc
 // * installing/installing_aws/installing-aws-user-infra.adoc
 // * installing/installing_aws/installing-restricted-networks-aws.adoc
+// * installing/installing_aws/installing-aws-outposts-remote-workers.adoc
 // * installing/installing_azure/installing-azure-customizations.adoc
 // * installing/installing_azure/installing-azure-government-region.adoc
 // * installing/installing_azure/installing-azure-network-customizations.adoc
@@ -37,6 +38,10 @@
 // * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
 // * installing/installing_ibm_z/installing-ibm-z.adoc
 // * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-private.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
 
 ifeval::["{context}" == "installing-azure-customizations"]
 :azure:
@@ -77,6 +82,27 @@ endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
 :ibm-z:
 endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-customizations"]
+:ibm-cloud-vpc:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-network-customizations"]
+:ibm-cloud-vpc:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-vpc"]
+:ibm-cloud-vpc:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-private"]
+:ibm-cloud-vpc:
+endif::[]
+ifeval::["{context}" == "installing-vsphere"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-network-customizations"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-vsphere"]
+:vsphere:
+endif::[]
 
 :_mod-docs-content-type: CONCEPT
 [id="installation-minimum-resource-requirements_{context}"]
@@ -91,7 +117,12 @@ Each cluster machine must meet the following minimum requirements:
 |Machine
 |Operating System
 ifndef::bare-metal[]
+ifndef::ibm-cloud-vpc,vsphere[]
 |vCPU ^[1]^
+endif::ibm-cloud-vpc,vsphere[]
+ifdef::ibm-cloud-vpc,vsphere[]
+|vCPU
+endif::ibm-cloud-vpc,vsphere[]
 |Virtual RAM
 endif::bare-metal[]
 ifdef::bare-metal[]
@@ -99,12 +130,15 @@ ifdef::bare-metal[]
 |RAM
 endif::bare-metal[]
 |Storage
-ifndef::ibm-z[]
+ifndef::ibm-z,ibm-cloud-vpc,vsphere[]
 |IOPS ^[2]^
-endif::ibm-z[]
-ifdef::ibm-z[]
+endif::ibm-z,ibm-cloud-vpc,vsphere[]
+ifdef::vsphere[]
+|Input/Output Per Second (IOPS)^[1]^
+endif::vsphere[]
+ifdef::ibm-z,ibm-cloud-vpc[]
 |IOPS
-endif::ibm-z[]
+endif::ibm-z,ibm-cloud-vpc[]
 
 |Bootstrap
 |{op-system}
@@ -135,8 +169,9 @@ endif::ibm-z[]
 
 ifndef::openshift-origin[]
 |Compute
-ifdef::ibm-z,ibm-power[|{op-system}]
-ifndef::ibm-z,ibm-power[|{op-system}, {op-system-base} 8.6, 8.7, or 8.8 ^[3]^]
+ifdef::ibm-z,ibm-power,ibm-cloud-vpc[|{op-system}]
+ifndef::ibm-z,ibm-power,ibm-cloud-vpc,vsphere[|{op-system}, {op-system-base} 8.6, {op-system-base} 8.7, or {op-system-base} 8.8 ^[3]^]
+ifdef::vsphere[|{op-system}, {op-system-base} 8.6, {op-system-base} 8.7, or {op-system-base} 8.8 ^[2]^]
 |2
 |8 GB
 |100 GB
@@ -170,16 +205,20 @@ endif::ibm-z[]
 ifdef::bare-metal[]
 1. One CPU is equivalent to one physical core when simultaneous multithreading (SMT), or hyperthreading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio: (threads per core × cores) × sockets = CPUs.
 endif::bare-metal[]
-ifndef::ibm-z,bare-metal[]
+ifndef::ibm-z,bare-metal,ibm-cloud-vpc,vsphere[]
 1. One vCPU is equivalent to one physical core when simultaneous multithreading (SMT), or hyperthreading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio: (threads per core × cores) × sockets = vCPUs.
-endif::ibm-z,bare-metal[]
-ifndef::ibm-z,ibm-power[]
+endif::ibm-z,bare-metal,ibm-cloud-vpc,vsphere[]
+ifndef::ibm-z,ibm-power,ibm-cloud-vpc,vsphere[]
 2. {product-title} and Kubernetes are sensitive to disk performance, and faster storage is recommended, particularly for etcd on the control plane nodes which require a 10 ms p99 fsync duration. Note that on many cloud platforms, storage size and IOPS scale together, so you might need to over-allocate storage volume to obtain sufficient performance.
 3. As with all user-provisioned installations, if you choose to use {op-system-base} compute machines in your cluster, you take responsibility for all operating system life cycle management and maintenance, including performing system updates, applying patches, and completing all other required tasks. Use of {op-system-base} 7 compute machines is deprecated and has been removed in {product-title} 4.10 and later.
-endif::ibm-z,ibm-power[]
+endif::ibm-z,ibm-power,ibm-cloud-vpc,vsphere[]
 ifdef::ibm-power[]
 2. {product-title} and Kubernetes are sensitive to disk performance, and faster storage is recommended, particularly for etcd on the control plane nodes. Note that on many cloud platforms, storage size and IOPS scale together, so you might need to over-allocate storage volume to obtain sufficient performance.
 endif::ibm-power[]
+ifdef::vsphere[]
+1. {product-title} and Kubernetes are sensitive to disk performance, and faster storage is recommended, particularly for etcd on the control plane nodes which require a 10 ms p99 fsync duration. Note that on many cloud platforms, storage size and IOPS scale together, so you might need to over-allocate storage volume to obtain sufficient performance.
+2. As with all user-provisioned installations, if you choose to use {op-system-base} compute machines in your cluster, you take responsibility for all operating system life cycle management and maintenance, including performing system updates, applying patches, and completing all other required tasks. Use of {op-system-base} 7 compute machines is deprecated and has been removed in {product-title} 4.10 and later.
+endif::vsphere[]
 --
 
 ifdef::azure[]
@@ -229,4 +268,25 @@ ifeval::["{context}" == "installing-ibm-z"]
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
 :!ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-customizations"]
+:!ibm-cloud-vpc:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-network-customizations"]
+:!ibm-cloud-vpc:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-vpc"]
+:!ibm-cloud-vpc:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-private"]
+:!ibm-cloud-vpc:
+endif::[]
+ifeval::["{context}" == "installing-vsphere"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-network-customizations"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-vsphere"]
+:!vsphere:
 endif::[]

--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -29,66 +29,51 @@ parameters.
 apiVersion: v1
 baseDomain: example.com <1>
 compute: <2>
-- hyperthreading: Enabled <3>
   name: worker
-  replicas: 0 <4>
+  replicas: 0 <3>
 controlPlane: <2>
-  hyperthreading: Enabled <3>
   name: master
-  replicas: 3 <5>
+  replicas: 3 <4>
 metadata:
-  name: test <6>
+  name: test <5>
 platform:
   vsphere:
-    vcenter: your.vcenter.server <7>
-    username: username <8>
-    password: password <9>
-    datacenter: datacenter <10>
-    defaultDatastore: datastore <11>
-    folder: "/<datacenter_name>/vm/<folder_name>/<subfolder_name>" <12>
-    resourcePool: "/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>" <13>
-    diskType: thin <14>
+    vcenter: your.vcenter.server <6>
+    username: username <7>
+    password: password <8>
+    datacenter: datacenter <9>
+    defaultDatastore: datastore <10>
+    folder: "/<datacenter_name>/vm/<folder_name>/<subfolder_name>" <11>
+    resourcePool: "/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>" <12>
+    diskType: thin <13>
 ifndef::restricted[]
 ifndef::openshift-origin[]
-fips: false <15>
+fips: false <14>
 endif::openshift-origin[]
 ifndef::openshift-origin[]
-pullSecret: '{"auths": ...}' <16>
-endif::openshift-origin[]
-ifdef::openshift-origin[]
 pullSecret: '{"auths": ...}' <15>
 endif::openshift-origin[]
+ifdef::openshift-origin[]
+pullSecret: '{"auths": ...}' <14>
+endif::openshift-origin[]
 endif::restricted[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-fips: false <15>
-pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <16>
-endif::openshift-origin[]
-ifdef::openshift-origin[]
+fips: false <14>
 pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <15>
 endif::openshift-origin[]
+ifdef::openshift-origin[]
+pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <14>
+endif::openshift-origin[]
 endif::restricted[]
 ifndef::openshift-origin[]
-sshKey: 'ssh-ed25519 AAAA...' <17>
+sshKey: 'ssh-ed25519 AAAA...' <16>
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-sshKey: 'ssh-ed25519 AAAA...' <16>
+sshKey: 'ssh-ed25519 AAAA...' <15>
 endif::openshift-origin[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-additionalTrustBundle: | <18>
-  -----BEGIN CERTIFICATE-----
-  ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
-  -----END CERTIFICATE-----
-imageContentSources: <19>
-- mirrors:
-  - <local_registry>/<local_repository_name>/release
-  source: quay.io/openshift-release-dev/ocp-release
-- mirrors:
-  - <local_registry>/<local_repository_name>/release
-  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-endif::openshift-origin[]
-ifdef::openshift-origin[]
 additionalTrustBundle: | <17>
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
@@ -101,34 +86,41 @@ imageContentSources: <18>
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 endif::openshift-origin[]
+ifdef::openshift-origin[]
+additionalTrustBundle: | <16>
+  -----BEGIN CERTIFICATE-----
+  ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+  -----END CERTIFICATE-----
+imageContentSources: <17>
+- mirrors:
+  - <local_registry>/<local_repository_name>/release
+  source: quay.io/openshift-release-dev/ocp-release
+- mirrors:
+  - <local_registry>/<local_repository_name>/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+endif::openshift-origin[]
 endif::restricted[]
 ----
 <1> The base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.
 <2> The `controlPlane` section is a single mapping, but the compute section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, (`-`), and the first line of the `controlPlane` section must not. Although both sections currently define a single machine pool, it is possible that future versions of {product-title} will support defining multiple compute pools during installation. Only one control plane pool is used.
-<3> Whether to enable or disable simultaneous multithreading, or `hyperthreading`. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores. You can disable it by setting the parameter value to `Disabled`. If you disable simultaneous multithreading in some cluster machines, you must disable it in all cluster machines.
-+
-[IMPORTANT]
-====
-If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance. Your machines must use at least 8 CPUs and 32 GB of RAM if you disable simultaneous multithreading.
-====
-<4> You must set the value of the `replicas` parameter to `0`. This parameter controls the number of workers that the cluster creates and manages for you, which are functions that the cluster does not perform when you use user-provisioned infrastructure. You must manually deploy worker machines for the cluster to use before you finish installing {product-title}.
-<5> The number of control plane machines that you add to the cluster. Because the cluster uses this values as the number of etcd endpoints in the cluster, the value must match the number of control plane machines that you deploy.
-<6> The cluster name that you specified in your DNS records.
-<7> The fully-qualified hostname or IP address of the vCenter server.
+<3> You must set the value of the `replicas` parameter to `0`. This parameter controls the number of workers that the cluster creates and manages for you, which are functions that the cluster does not perform when you use user-provisioned infrastructure. You must manually deploy worker machines for the cluster to use before you finish installing {product-title}.
+<4> The number of control plane machines that you add to the cluster. Because the cluster uses this values as the number of etcd endpoints in the cluster, the value must match the number of control plane machines that you deploy.
+<5> The cluster name that you specified in your DNS records.
+<6> The fully-qualified hostname or IP address of the vCenter server.
 +
 [IMPORTANT]
 ====
 The Cluster Cloud Controller Manager Operator performs a connectivity check on a provided hostname or IP address. Ensure that you specify a hostname or an IP address to a reachable vCenter server. If you provide metadata to a non-existent vCenter server, installation of the cluster fails at the bootstrap stage.
 ====
-<8> The name of the user for accessing the server.
-<9> The password associated with the vSphere user.
-<10> The vSphere datacenter.
-<11> The default vSphere datastore to use.
-<12> Optional parameter: For installer-provisioned infrastructure, the absolute path of an existing folder where the installation program creates the virtual machines, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`. If you do not provide this value, the installation program creates a top-level folder in the datacenter virtual machine folder that is named with the infrastructure ID. If you are providing the infrastructure for the cluster and you do not want to use the default `StorageClass` object, named `thin`, you can omit the `folder` parameter from the `install-config.yaml` file.
-<13> Optional parameter: For installer-provisioned infrastructure, the absolute path of an existing folder where the installation program creates the virtual machines, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`. If you do not provide this value, the installation program creates a top-level folder in the datacenter virtual machine folder that is named with the infrastructure ID. If you are providing the infrastructure for the cluster, omit this parameter.
-<14> The vSphere disk provisioning method.
+<7> The name of the user for accessing the server.
+<8> The password associated with the vSphere user.
+<9> The vSphere datacenter.
+<10> The default vSphere datastore to use.
+<11> Optional parameter: For installer-provisioned infrastructure, the absolute path of an existing folder where the installation program creates the virtual machines, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`. If you do not provide this value, the installation program creates a top-level folder in the datacenter virtual machine folder that is named with the infrastructure ID. If you are providing the infrastructure for the cluster and you do not want to use the default `StorageClass` object, named `thin`, you can omit the `folder` parameter from the `install-config.yaml` file.
+<12> Optional parameter: For installer-provisioned infrastructure, the absolute path of an existing folder where the installation program creates the virtual machines, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`. If you do not provide this value, the installation program creates a top-level folder in the datacenter virtual machine folder that is named with the infrastructure ID. If you are providing the infrastructure for the cluster, omit this parameter.
+<13> The vSphere disk provisioning method.
 ifndef::openshift-origin[]
-<15> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<14> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
 [IMPORTANT]
 ====
@@ -137,13 +129,13 @@ To enable FIPS mode for your cluster, you must run the installation program from
 endif::openshift-origin[]
 ifndef::restricted[]
 ifndef::openshift-origin[]
-<16> The pull secret that you obtained from {cluster-manager-url}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
-<17> The public portion of the default SSH key for the `core` user in
+<15> The pull secret that you obtained from {cluster-manager-url}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
+<16> The public portion of the default SSH key for the `core` user in
 {op-system-first}.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<15> You obtained the {cluster-manager-url-pull}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
-<16> The public portion of the default SSH key for the `core` user in {op-system-first}.
+<14> You obtained the {cluster-manager-url-pull}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
+<15> The public portion of the default SSH key for the `core` user in {op-system-first}.
 +
 [NOTE]
 ====
@@ -153,8 +145,8 @@ endif::openshift-origin[]
 endif::restricted[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-<16> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example `registry.example.com` or `registry.example.com:5000`. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
-<17> The public portion of the default SSH key for the `core` user in {op-system-first}.
+<15> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example `registry.example.com` or `registry.example.com:5000`. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
+<16> The public portion of the default SSH key for the `core` user in {op-system-first}.
 +
 [NOTE]
 ====
@@ -162,8 +154,8 @@ For production {product-title} clusters on which you want to perform installatio
 ====
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<15> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example, `registry.example.com` or `registry.example.com:5000`. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
-<16> The public portion of the default SSH key for the `core` user in {op-system-first}.
+<14> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example, `registry.example.com` or `registry.example.com:5000`. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
+<15> The public portion of the default SSH key for the `core` user in {op-system-first}.
 +
 [NOTE]
 ====
@@ -173,12 +165,12 @@ endif::openshift-origin[]
 endif::restricted[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-<18> Provide the contents of the certificate file that you used for your mirror registry.
-<19> Provide the `imageContentSources` section from the output of the command to mirror the repository.
-endif::openshift-origin[]
-ifdef::openshift-origin[]
 <17> Provide the contents of the certificate file that you used for your mirror registry.
 <18> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+<16> Provide the contents of the certificate file that you used for your mirror registry.
+<17> Provide the `imageContentSources` section from the output of the command to mirror the repository.
 endif::openshift-origin[]
 endif::restricted[]
 


### PR DESCRIPTION
Cherry picking from #67569 from commit 153bd358039cbb14b727127bef4f9e604ce1d406


[OSDOCS-8693](https://issues.redhat.com/browse/OSDOCS-8683)

Version(s):
4.11

Link to docs preview:
* [Installing a cluster on vSphere with customizations](https://68045--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations#installation-installer-provisioned-vsphere-config-yaml_installing-vsphere-installer-provisioned-customizations)
* [Installing a cluster on vSphere with network customizations](https://68045--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations#installation-installer-provisioned-vsphere-config-yaml_installing-vsphere-installer-provisioned-network-customizations)
* [Installing a cluster on vSphere with user-provisioned infrastructure-changed](https://68045--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere#installation-vsphere-config-yaml_installing-vsphere)
* [Installing a cluster on vSphere with network customizations-changed](https://68045--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-network-customizations#installation-vsphere-config-yaml_installing-vsphere-network-customizations)
* [Installing a cluster on vSphere in a restricted network](https://68045--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere#installation-installer-provisioned-vsphere-config-yaml_installing-restricted-networks-installer-provisioned-vsphere)
* [Installing a cluster on vSphere in a restricted network with user-provisioned infrastructure - changed](https://68045--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-restricted-networks-vsphere#installation-vsphere-config-yaml_installing-restricted-networks-vsphere)
* [Installation configuration parameters](https://68045--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations#installation-configuration-parameters_installing-vsphere-installer-provisioned-network-customizations)
* [Mininimum resource requirements for cluster installation](https://68045--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* We cannot use the [.small] role because it might collide with the CSS "small" syntax. See [Slack thread](https://app.slack.com/client/E030G10V24F?selected_team_id=E030G10V24F#:~:text=It%27s%20an%20arbitrary%20Asciidoctor%20markup%20that%20IMO%20should%20not%20be%20used%20for%20docs.%20it%27s%20not%20that%20it%27s%20deprecated%2C%20just%20that%20%5Bsmall%5D%20maps%20to%20a%20css%20.small%20class%20which%20may%20or%20may%20not%20be%20included%20in%20the%20next%20portal%20build).
