### PR TITLE
[enterprise-4.12] Manual CP: OBSDOCS-619 - Logging 5.6.13 Release Notes

### DIFF
--- a/logging/logging_release_notes/logging-5-6-release-notes.adoc
+++ b/logging/logging_release_notes/logging-5-6-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-6-13.adoc[leveloffset=+1]
+
 include::modules/logging-rn-5.6.12.adoc[leveloffset=+1]
 
 include::modules/logging-rn-5.6.11.adoc[leveloffset=+1]
@@ -18,9 +20,7 @@ include::modules/logging-rn-5.6.9.adoc[leveloffset=+1]
 
 include::modules/logging-rn-5.6.8.adoc[leveloffset=+1]
 
-include::modules/logging-rn-5.6.7.adoc[leveloffset=+1]
-
-include::modules/logging-rn-5.6.6.adoc[leveloffset=+1]
+// No release notes for 5.6.6 and 5.6.7 since these were CVE only releases. In the future, add a link to the CVE.
 
 include::modules/logging-rn-5.6.5.adoc[leveloffset=+1]
 

--- a/modules/logging-release-notes-5-6-13.adoc
+++ b/modules/logging-release-notes-5-6-13.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+// logging-5-6-release-notes.adoc
+:_content-type: REFERENCE
+[id="logging-release-notes-5-6-13_{context}"]
+= Logging 5.6.13
+This release includes link:https://access.redhat.com/errata/RHSA-2023:6790[OpenShift Logging Bug Fix Release 5.6.13].
+
+[id="logging-release-notes-5-6-13-bug-fixes"]
+== Bug fixes
+None.
+
+[id="logging-release-notes-5-6-13-CVEs"]
+== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2023-40217[CVE-2023-40217]
+* link:https://access.redhat.com/security/cve/CVE-2023-44487[CVE-2023-44487]

--- a/modules/logging-rn-5.6.12.adoc
+++ b/modules/logging-rn-5.6.12.adoc
@@ -1,13 +1,13 @@
 // Module included in the following assemblies:
 // logging-5-6-release-notes.adoc
-:_mod-docs-content-type: REFERENCE
+:_content-type: REFERENCE
 [id="cluster-logging-release-notes-5-6-12_{context}"]
 = Logging 5.6.12
 This release includes link:https://access.redhat.com/errata/RHSA-2023:5541[OpenShift Logging Bug Fix Release 5.6.12].
 
 [id="openshift-logging-5-6-12-bug-fixes_{context}"]
 == Bug fixes
-* Before this update, deploying a LokiStack on IPv6-only or dual-stack {product-title} clusters caused the LokiStack memberlist registration to fail. As a result, the distributor pods went into a crash loop. With this update, an administrator can enable IPv6 by setting the `lokistack.spec.hashRing.memberlist.enableIPv6:` value to `true`, which resolves the issue. (link:https://issues.redhat.com/browse/LOG-4570[LOG-4570])
+* Before this update, deploying a LokiStack on IPv6-only or dual-stack {product-title} clusters caused the LokiStack memberlist registration to fail. As a result, the distributor pods went into a crash loop. With this update, an administrator can enable IPv6 by setting the `lokistack.spec.hashRing.memberlist.enableIPv6:` value to `true`, which resolves the issue. Currently, the log alert is not available on an IPv6-enabled cluster. (link:https://issues.redhat.com/browse/LOG-4570[LOG-4570])
 
 * Before this update, there was an error in the query used for the *FluentD Buffer Availability* graph in the metrics dashboard created by the Cluster Logging Operator as it showed the minimum buffer usage. With this update, the graph shows the maximum buffer usage and is now renamed to *FluentD Buffer Usage*. (link:https://issues.redhat.com/browse/LOG-4579[LOG-4579])
 


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/openshift-docs/pull/67545

Fix version: 4.12

Doc preview: [Logging 5.6.13](https://68047--docspreview.netlify.app/openshift-enterprise/latest/logging/logging_release_notes/logging-5-6-release-notes#logging-release-notes-5-6-13_logging-5-6-release-notes)

cherry picked from: 6d6858ef76262f936268053d194c5462469d40ca 

Note: Included 5.6.12 Release Notes too as it wasn't displaying in 4.13 branch. Original PR for 5.6.12: https://github.com/openshift/openshift-docs/pull/65987 