### PR TITLE
[enterprise-4.11] Manual CP OBSDOCS-618 - Logging 5.5.18 Release Notes

### DIFF
--- a/logging/logging_release_notes/logging-5-5-release-notes.adoc
+++ b/logging/logging_release_notes/logging-5-5-release-notes.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 include::snippets/logging-compatibility-snip.adoc[]
 
+include::modules/logging-release-notes-5-5-18.adoc[leveloffset=+1]
+
 include::modules/logging-rn-5.5.17.adoc[leveloffset=+1]
 
 include::modules/logging-rn-5.5.16.adoc[leveloffset=+1]

--- a/modules/logging-release-notes-5-5-18.adoc
+++ b/modules/logging-release-notes-5-5-18.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+// logging-5-5-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-5-5-18_{context}"]
+= Logging 5.5.18
+This release includes link:https://access.redhat.com/errata/RHSA-2023:6791[OpenShift Logging Bug Fix Release 5.5.18].
+
+[id="logging-release-notes-5-5-18-bug-fixes_{context}"]
+== Bug fixes
+None.
+
+[id="logging-release-notes-5-5-18-CVEs_{context}"]
+== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2023-40217[CVE-2023-40217]
+* link:https://access.redhat.com/security/cve/CVE-2023-44487[CVE-2023-44487]


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/openshift-docs/pull/67546

Fix version: 4.11

Doc preview: [Logging 5.5.18](https://68049--docspreview.netlify.app/openshift-enterprise/latest/logging/logging_release_notes/logging-5-5-release-notes#logging-release-notes-5-5-18_logging-5-5-release-notes)

cherry picked from: 7c8f9be1545e0adf5f11204112fab0527b8d4c2d