### PR TITLE
fixed invalid EgressIPconfig sample config

### DIFF
--- a/modules/nw-egress-ips-config-object.adoc
+++ b/modules/nw-egress-ips-config-object.adoc
@@ -12,10 +12,11 @@ The following YAML describes changing the `reachabilityTotalTimeoutSeconds` from
 
 [source,yaml]
 ----
-apiVersion: k8s.ovn.org/v1
-kind: EgressIP
-  name: networks.operator.openshift.io
-  spec:
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23


### PR DESCRIPTION
This PR fixes the invalid example config referenced in the documentation.

A valid Network configuration can be found here:
https://docs.openshift.com/container-platform/4.12/networking/cluster-network-operator.html#nw-operator-example-cr_cluster-network-operator

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
This change should affect all versions referencing this sample (4.12+)

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
