### PR TITLE
[WIP] OCPBUGS#23355: Evaluate openshift-origin clause in vSphere doc

### DIFF
--- a/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-vsphere-network-customizations"]
-= Installing a cluster on vSphere with network customizations
+= Installing a cluster on vSphere with network customizations (UPI)
 include::_attributes/common-attributes.adoc[]
 :context: installing-vsphere-network-customizations
 

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -122,7 +122,7 @@ ifndef::openshift-origin[]
    }
 }
 ----
-endif::[]
+endif::openshift-origin[]
 
 ifdef::ibm-power-vs[]
 |platform:

--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -1,16 +1,22 @@
-// Module included in the following assemblies:
+// Module included in the following vSphere user-provisioned infrastructure assemblies:
 //
-// * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
-// * installing/installing_vsphere/installing-vsphere.adoc
+// * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc (Installing a cluster on vSphere in a restricted network with user-provisioned infrastructure)
+// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc (Installing a cluster on vSphere with user-provisioned infrastructure and network customizations)
+// * installing/installing_vsphere/installing-vsphere.adoc (Installing a cluster on vSphere with user-provisioned infrastructure)
+
+// TIPS:
+// * If you get WARNING messages about callouts from running asciibinder, consider commented out sections of the callout descriptions to determine the problems. 
+// * To avoid build errors, separate the openshift-origin ifdef or ifndef statement from restricted ones.
 
 ifeval::["{context}" == "installing-restricted-networks-vsphere"]
 :restricted:
 endif::[]
-// Verify the validity of the following ifdef statement in a later Jira
+
+////
 ifdef::openshift-origin[]
 :restricted:
 endif::[]
+////
 
 :_mod-docs-content-type: CONCEPT
 [id="installation-vsphere-config-yaml_{context}"]
@@ -63,34 +69,16 @@ platform:
       server: <fully_qualified_domain_name> <12>
       user: administrator@vsphere.local
     diskType: thin <13>
-ifndef::restricted[]
-ifndef::openshift-origin[]
+#ifndef::openshift-origin[]
 fips: false <14>
-endif::openshift-origin[]
-ifndef::openshift-origin[]
+#endif::openshift-origin[]
+ifndef::restricted[] # add openshift-origin
 pullSecret: '{"auths": ...}' <15>
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-pullSecret: '{"auths": ...}' <14>
-endif::openshift-origin[]
-endif::restricted[]
-ifdef::restricted[]
-ifndef::openshift-origin[]
-fips: false <14>
-pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <15>
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <14>
-endif::openshift-origin[]
-endif::restricted[]
-ifndef::openshift-origin[]
 sshKey: 'ssh-ed25519 AAAA...' <16>
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-sshKey: 'ssh-ed25519 AAAA...' <15>
-endif::openshift-origin[]
+endif::restricted[] # add openshift-origin
 ifdef::restricted[]
-ifndef::openshift-origin[]
+pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <15>
+sshKey: 'ssh-ed25519 AAAA...' <16>
 additionalTrustBundle: | <17>
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
@@ -102,88 +90,92 @@ imageContentSources: <18>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-additionalTrustBundle: | <16>
-  -----BEGIN CERTIFICATE-----
-  ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
-  -----END CERTIFICATE-----
-imageContentSources: <17>
-- mirrors:
-  - <local_registry>/<local_repository_name>/release
-  source: quay.io/openshift-release-dev/ocp-release
-- mirrors:
-  - <local_registry>/<local_repository_name>/release
-  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-endif::openshift-origin[]
 endif::restricted[]
+#ifdef::openshift-origin[]
+#pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <14>
+#sshKey: 'ssh-ed25519 AAAA...' <15>
+#additionalTrustBundle: | <16>
+#  -----BEGIN CERTIFICATE-----
+#  ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+#  -----END CERTIFICATE-----
+#imageContentSources: <17>
+#- mirrors:
+#  - <local_registry>/<local_repository_name>/release
+#  source: quay.io/openshift-release-dev/ocp-release
+#- mirrors:
+#  - <local_registry>/<local_repository_name>/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#endif::openshift-origin[]
 ----
+// baseDomain
 <1> The base domain of the cluster. All DNS records must be sub-domains of this
 base and include the cluster name.
+// compute and controlPlane
 <2> The `controlPlane` section is a single mapping, but the compute section is a
 sequence of mappings. To meet the requirements of the different data structures,
 the first line of the `compute` section must begin with a hyphen, `-`, and the
 first line of the `controlPlane` section must not. Both sections define a single machine pool, so only one control plane is used. {product-title} does not support defining multiple compute pools.
+// compute.replicas
 <3> You must set the value of the `replicas` parameter to `0`. This parameter
 controls the number of workers that the cluster creates and manages for you,
 which are functions that the cluster does not perform when you
 use user-provisioned infrastructure. You must manually deploy worker
 machines for the cluster to use before you finish installing {product-title}.
+// controlPlane.replicas
 <4> The number of control plane machines that you add to the cluster. Because
 the cluster uses this values as the number of etcd endpoints in the cluster, the
 value must match the number of control plane machines that you deploy.
+// name
 <5> The cluster name that you specified in your DNS records.
+// failureDomains
 <6> Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
+// datacenter
 <7> The vSphere datacenter.
+// datastore
 <8> The path to the vSphere datastore that holds virtual machine files, templates, and ISO images.
 +
 [IMPORTANT]
 ====
-You can specify the path of any datastore that exists in a datastore cluster. By default, Storage vMotion is automatically enabled for a datastore cluster. Red Hat does not support Storage vMotion, so you must disable Storage vMotion to avoid data loss issues for your {product-title} cluster.
-
-If you must specify VMs across multiple datastores, use a `datastore` object to specify a failure domain in your cluster's `install-config.yaml` configuration file. For more information, see "VMware vSphere region and zone enablement".
+You can specify the path of any datastore that exists in a datastore cluster. By default, Storage vMotion is automatically enabled for a datastore cluster. Red Hat does not support Storage vMotion, so you must disable Storage vMotion to avoid data loss issues for your {product-title} cluster. If you must specify VMs across multiple datastores, use a `datastore` object to specify a failure domain in your cluster's `install-config.yaml` configuration file. For more information, see "VMware vSphere region and zone enablement".
 ====
+// resourcePool 
 <9> Optional: For installer-provisioned infrastructure, the absolute path of an existing resource pool where the installation program creates the virtual machines, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`. If you do not specify a value, resources are installed in the root of the cluster `/example_datacenter/host/example_cluster/Resources`.
+// folder
 <10> Optional: For installer-provisioned infrastructure, the absolute path of an existing folder where the installation program creates the virtual machines, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`. If you do not provide this value, the installation program creates a top-level folder in the datacenter virtual machine folder that is named with the infrastructure ID. If you are providing the infrastructure for the cluster and you do not want to use the default `StorageClass` object, named `thin`, you can omit the `folder` parameter from the `install-config.yaml` file.
+// password
 <11> The password associated with the vSphere user.
+// server
 <12> The fully-qualified hostname or IP address of the vCenter server.
 +
 [IMPORTANT]
 ====
 The Cluster Cloud Controller Manager Operator performs a connectivity check on a provided hostname or IP address. Ensure that you specify a hostname or an IP address to a reachable vCenter server. If you provide metadata to a non-existent vCenter server, installation of the cluster fails at the bootstrap stage.
 ====
+// diskType
 <13> The vSphere disk provisioning method.
-ifndef::openshift-origin[]
+//ifndef::openshift-origin[]
+// fips
 <14> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
 [IMPORTANT]
 ====
 To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
 ====
-endif::openshift-origin[]
+//endif::openshift-origin[]
 ifndef::restricted[]
-ifndef::openshift-origin[]
+// pullSecret
 <15> The pull secret that you obtained from {cluster-manager-url}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
+// sshKey
 <16> The public portion of the default SSH key for the `core` user in
 {op-system-first}.
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-<15> You obtained the {cluster-manager-url-pull}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
-<16> The public portion of the default SSH key for the `core` user in
-{op-system-first}.
-+
-[NOTE]
-====
-For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
-====
-endif::openshift-origin[]
 endif::restricted[]
 ifdef::restricted[]
-ifndef::openshift-origin[]
+// pullSecret
 <15> For `<local_registry>`, specify the registry domain name, and optionally the
 port, that your mirror registry uses to serve content. For example
 `registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
 specify the base64-encoded user name and password for your mirror registry.
+// sshKey
 <16> The public portion of the default SSH key for the `core` user in
 {op-system-first}.
 +
@@ -191,39 +183,30 @@ specify the base64-encoded user name and password for your mirror registry.
 ====
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
-endif::openshift-origin[]
+// additionalTrustBundle
+<17> Provide the contents of the certificate file that you used for your mirror
+registry.
+// imageContentSources
+<18> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+endif::restricted[]
+////
 ifdef::openshift-origin[]
-<14> For `<local_registry>`, specify the registry domain name, and optionally the
-port, that your mirror registry uses to serve content. For example
-`registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
-specify the base64-encoded user name and password for your mirror registry.
-<15> The public portion of the default SSH key for the `core` user in
-{op-system-first}.
+// pullSecret
+<14> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example `registry.example.com` or `registry.example.com:5000`. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
+// sshKey
+<15> The public portion of the default SSH key for the `core` user in {op-system-first}.
 +
 [NOTE]
 ====
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
+// additionalTrustBundle
+<16> Provide the contents of the certificate file that you used for your mirror registry.
+// imageContentSources
+<17> Provide the `imageContentSources` section from the output of the command to mirror the repository.
 endif::openshift-origin[]
-endif::restricted[]
-ifdef::restricted[]
-ifndef::openshift-origin[]
-<17> Provide the contents of the certificate file that you used for your mirror
-registry.
-<18> Provide the `imageContentSources` section from the output of the command to
-mirror the repository.
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-<16> Provide the contents of the certificate file that you used for your mirror
-registry.
-<17> Provide the `imageContentSources` section from the output of the command to
-mirror the repository.
-endif::openshift-origin[]
-endif::restricted[]
+////
 
 ifeval::["{context}" == "installing-restricted-networks-vsphere"]
-:!restricted:
-endif::[]
-ifdef::openshift-origin[]
 :!restricted:
 endif::[]


### PR DESCRIPTION
[OCPBUGS-23355](https://issues.redhat.com/browse/OCPBUGS-23355)

Version(s):
4.15 to 4.12

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* Consider checking the master.xml to verify changes. 
* [OKD docs](https://docs.okd.io/4.14/installing/installing_vsphere/installing-restricted-networks-vsphere.html)

Results:
* The original file seems its held together in a very specific way to stop the file from breaking. It is the only file that specifies `openshift-origin` with a unique variable name. I've tried multiple combinations and the file for the 15 + callouts for openshift-origin and restricted are causing issues. I tried the following adjustements
** Removed all ifndef statements and left only ifdef
** Removed the initial openshift-origin statement
** Removed and added + symbols
** Removed all notes
** Commented out openshift-origin lines - File works, so problem stems from openshift-origin, especially around the `fips` ifndef statement
** Commmented out restricted lines

