### PR TITLE
fix-ibm-release-notes-4-14

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -27,7 +27,7 @@ You must use {op-system} machines for the control plane, and you can use either 
 //TODO: Add this for 4.14
 Starting with {product-title} 4.12, an additional six months is added to the Extended Update Support (EUS) phase on even numbered releases from 18 months to two years. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
 
-Starting with {product-title} {product-version}, Extended Update Support (EUS) is extended to 64-bit ARM, {ibmpowerProductName} (ppc64le), and {ibmzProductName} (s390x) platforms.  For more information, see the link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
+Starting with {product-title} {product-version}, Extended Update Support (EUS) is extended to 64-bit ARM, {ibm-power-name} (ppc64le), and {ibm-z-name} (s390x) platforms.  For more information, see the link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
 
 //TODO: Add the line below for EUS releases.
 {product-title} {product-version} is an Extended Update Support (EUS) release. More information on Red Hat OpenShift EUS is available in link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[OpenShift Life Cycle] and link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
@@ -347,14 +347,14 @@ A new `oc` CLI flag, `--import-mode`, has been added to the `oc new-app` command
 For more information, see xref:../applications/creating_applications/creating-applications-using-cli.adoc#setting-the-import-mode[Setting the import mode].
 
 [id="ocp-4-14-ibm-z"]
-=== {ibmzProductName} and {linuxoneProductName}
+=== {ibm-z-title} and {ibm-linuxone-title}
 
-With this release, {ibmzRegProductName} and {linuxoneProductName} are now compatible with {product-title} {product-version}. The installation can be performed with z/VM or {op-system-base-full} Kernel-based Virtual Machine (KVM). For installation instructions, see the following documentation:
+With this release, {ibm-z-name} and {ibm-linuxone-name} are now compatible with {product-title} {product-version}. The installation can be performed with z/VM or {op-system-base-full} Kernel-based Virtual Machine (KVM). For installation instructions, see the following documentation:
 
-* xref:../installing/installing_ibm_z/installing-ibm-z.adoc#installing-ibm-z[Installing a cluster with z/VM on {ibmzRegProductName} and {linuxoneProductName}]
-* xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc#installing-restricted-networks-ibm-z[Installing a cluster with z/VM on {ibmzRegProductName} and {linuxoneProductName} in a restricted network]
-* xref:../installing/installing_ibm_z/installing-ibm-z-kvm.adoc#installing-ibm-z-kvm[Installing a cluster with {op-system-base} KVM on {ibmzRegProductName} and {linuxoneProductName}]
-* xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc#installing-restricted-networks-ibm-z-kvm[Installing a cluster with RHEL KVM on {ibmzRegProductName} and {linuxoneProductName} in a restricted network]
+* xref:../installing/installing_ibm_z/installing-ibm-z.adoc#installing-ibm-z[Installing a cluster with z/VM on {ibm-z-name} and {ibm-linuxone-name}]
+* xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc#installing-restricted-networks-ibm-z[Installing a cluster with z/VM on {ibm-z-name} and {ibm-linuxone-name} in a restricted network]
+* xref:../installing/installing_ibm_z/installing-ibm-z-kvm.adoc#installing-ibm-z-kvm[Installing a cluster with {op-system-base} KVM on {ibm-z-name} and {ibm-linuxone-name}]
+* xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc#installing-restricted-networks-ibm-z-kvm[Installing a cluster with RHEL KVM on {ibm-z-name} and {ibm-linuxone-name} in a restricted network]
 
 [IMPORTANT]
 ====
@@ -362,13 +362,13 @@ Compute nodes must run {op-system-first}.
 ====
 
 [discrete]
-==== {ibmzRegProductName} and {linuxoneProductName} notable enhancements
+==== {ibm-z-title} and {ibm-linuxone-title} notable enhancements
 
-Starting in {product-title} {product-version}, Extended Update Support (EUS) is extended to the {ibmzRegProductName} platform. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
+Starting in {product-title} {product-version}, Extended Update Support (EUS) is extended to the {ibm-z-name} platform. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
 
-The {ibmzRegProductName} and {linuxoneProductName} release on {product-title} {product-version} adds improvements and new capabilities to {product-title} components and concepts.
+The {ibm-z-name} and {ibm-linuxone-name} release on {product-title} {product-version} adds improvements and new capabilities to {product-title} components and concepts.
 
-This release introduces support for the following features on {ibmzRegProductName} and {linuxoneProductName}:
+This release introduces support for the following features on {ibm-z-name} and {ibm-linuxone-name}:
 
 * Assisted Installer with z/VM
 * Installing on a single node
@@ -379,19 +379,19 @@ This release introduces support for the following features on {ibmzRegProductNam
 [discrete]
 ==== IBM Secure Execution
 
-{product-title} now supports configuring {op-system-first} nodes for IBM Secure Execution on {ibmzRegProductName} and {linuxoneProductName} (s390x architecture).
+{product-title} now supports configuring {op-system-first} nodes for IBM Secure Execution on {ibm-z-name} and {ibm-linuxone-name} (s390x architecture).
 
 For installation instructions, see the following documentation:
 
 * xref:../installing/installing_ibm_z/installing-ibm-z-kvm.html#installing-rhcos-using-ibm-secure-execution_installing-ibm-z-kvm[Installing {op-system} using IBM Secure Execution]
 
 [id="ocp-4-14-ibm-power"]
-=== {ibmpowerRegProductName}
+=== {ibm-power-title}
 
-{ibmpowerRegProductName} is now compatible with {product-title} {product-version}. For installation instructions, see the following documentation:
+{ibm-power-name} is now compatible with {product-title} {product-version}. For installation instructions, see the following documentation:
 
-* xref:../installing/installing_ibm_power/installing-ibm-power.adoc#installing-ibm-power_installing-ibm-power[Installing a cluster on {ibmpowerProductName}]
-* xref:../installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc#installing-restricted-networks-ibm-power_installing-restricted-networks-ibm-power[Installing a cluster on {ibmpowerProductName} in a restricted network]
+* xref:../installing/installing_ibm_power/installing-ibm-power.adoc#installing-ibm-power_installing-ibm-power[Installing a cluster on {ibm-power-name}]
+* xref:../installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc#installing-restricted-networks-ibm-power_installing-restricted-networks-ibm-power[Installing a cluster on {ibm-power-name} in a restricted network]
 
 [IMPORTANT]
 ====
@@ -399,27 +399,27 @@ Compute nodes must run {op-system-first}.
 ====
 
 [discrete]
-==== {ibmpowerRegProductName} notable enhancements
+==== {ibm-power-title} notable enhancements
 
-Starting in {product-title} {product-version}, Extended Update Support (EUS) is extended to the {ibmpowerRegProductName} platform.  For more information, see the link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
+Starting in {product-title} {product-version}, Extended Update Support (EUS) is extended to the {ibm-power-name} platform.  For more information, see the link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
 
-The {ibmpowerRegProductName} release on {product-title} {product-version} adds improvements and new capabilities to {product-title} components.
+The {ibm-power-name} release on {product-title} {product-version} adds improvements and new capabilities to {product-title} components.
 
-This release introduces support for the following features on {ibmpowerProductName}:
+This release introduces support for the following features on {ibm-power-name}:
 
-* {ibmpowerProductName} Virtual Server Block CSI Driver Operator (Technology Preview)
+* {ibm-power-server-name} Block CSI Driver Operator (Technology Preview)
 * Installing on a single node
 //* Hosted control planes (Technology Preview)
 * Multi-architecture compute nodes
 * oc-mirror plugin
 
 [discrete]
-=== {ibmpowerRegProductName}, {ibmzRegProductName}, and {linuxoneProductName} support matrix
+=== {ibm-power-title}, {ibm-z-title}, and {ibm-linuxone-title} support matrix
 
 .{product-title} features
 [cols="3,1,1",options="header"]
 |====
-|Feature |{ibmpowerRegProductName} |{ibmzRegProductName} and {linuxoneProductName}
+|Feature |{ibm-power-name} |{ibm-z-name} and {ibm-linuxone-name}
 
 |Alternate authentication providers
 |Supported
@@ -473,11 +473,11 @@ This release introduces support for the following features on {ibmpowerProductNa
 |Unsupported
 |Supported
 
-|{ibmpowerProductName} Virtual Server Block CSI Driver Operator (Technology Preview)
+|{ibm-power-server-name} Block CSI Driver Operator (Technology Preview)
 |Supported
 |Unsupported
 
-|Installer-provisioned Infrastructure Enablement for {ibmpowerProductName} Virtual Server (Technology Preview)
+|Installer-provisioned Infrastructure Enablement for {ibm-power-server-name} (Technology Preview)
 |Supported
 |Unsupported
 
@@ -573,7 +573,7 @@ This release introduces support for the following features on {ibmpowerProductNa
 .Persistent storage options
 [cols="2,1,1",options="header"]
 |====
-|Feature |{ibmpowerProductName} |{ibmzProductName} and {linuxoneProductName}
+|Feature |{ibm-power-name} |{ibm-z-name} and {ibm-linuxone-name}
 |Persistent storage using iSCSI
 |Supported ^[1]^
 |Supported ^[1]^,^[2]^
@@ -607,7 +607,7 @@ This release introduces support for the following features on {ibmpowerProductNa
 .Operators
 [cols="2,1,1",options="header"]
 |====
-|Feature |{ibmpowerRegProductName} |{ibmzRegProductName} and {linuxoneProductName}
+|Feature |{ibm-power-name} |{ibm-z-name} and {ibm-linuxone-name}
 
 |Cluster Logging Operator
 |Supported
@@ -661,7 +661,7 @@ This release introduces support for the following features on {ibmpowerProductNa
 .Multus CNI plugins
 [cols="2,1,1",options="header"]
 |====
-|Feature |{ibmpowerRegProductName} |{ibmzRegProductName} and {linuxoneProductName}
+|Feature |{ibm-power-name} |{ibm-z-name} and {ibm-linuxone-name}
 
 |Bridge
 |Supported
@@ -683,7 +683,7 @@ This release introduces support for the following features on {ibmpowerProductNa
 .CSI Volumes
 [cols="2,1,1",options="header"]
 |====
-|Feature |{ibmpowerRegProductName} |{ibmzRegProductName} and {linuxoneProductName}
+|Feature |{ibm-power-name} |{ibm-z-name} and {ibm-linuxone-name}
 
 |Cloning
 |Supported
@@ -1552,17 +1552,17 @@ In the following tables, features are marked with the following statuses:
 |Removed
 |Removed
 
-|{ibmpowerProductName} AC922 (`ppc64le`)
+|{ibm-power-name} AC922 (`ppc64le`)
 |Deprecated
 |Removed
 |Removed
 
-|{ibmpowerProductName} IC922 (`ppc64le`)
+|{ibm-power-name} IC922 (`ppc64le`)
 |Deprecated
 |Removed
 |Removed
 
-|{ibmpowerProductName} LC922 (`ppc64le`)
+|{ibm-power-name} LC922 (`ppc64le`)
 |Deprecated
 |Removed
 |Removed
@@ -1572,12 +1572,12 @@ In the following tables, features are marked with the following statuses:
 |Removed
 |Removed
 
-|{linuxoneProductName} Emperor (`s390x`)
+|{ibm-linuxone-name} Emperor (`s390x`)
 |Deprecated
 |Removed
 |Removed
 
-|{linuxoneProductName} Rockhopper (`s390x`)
+|{ibm-linuxone-name} Rockhopper (`s390x`)
 |Deprecated
 |Removed
 |Removed
@@ -2164,7 +2164,7 @@ This behavior has been fixed, and the references are now accepted and correctly 
 [id="ocp-4-14-storage-bug-fixes"]
 ==== Storage
 
-* Previously, when the cluster-wide proxy is enabled on {ibmcloudVPCRegProductName} clusters, there was a failure to provision volumes. (link:https://issues.redhat.com/browse/OCPBUGS-18142[*OCPBUGS-18142*])
+* Previously, when the cluster-wide proxy is enabled on {ibm-cloud-name} clusters, there was a failure to provision volumes. (link:https://issues.redhat.com/browse/OCPBUGS-18142[*OCPBUGS-18142*])
 
 * The `vsphereStorageDriver` field of the Storage Operator object has been deprecated. This field was used to opt in to CSI migration on {product-title} 4.13 vSphere clusters, but it has no effect on {product-title} {product-version} and newer clusters. (link:https://issues.redhat.com/browse/OCPBUGS-13914[*OCPBUGS-13914*])
 
@@ -2327,7 +2327,7 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |General Availability
 
-|{ibmpowerProductName} Virtual Server Block CSI Driver Operator
+|{ibm-power-server-name} Block CSI Driver Operator
 |Not Available
 |Technology Preview
 |Technology Preview
@@ -2462,12 +2462,12 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.12 |4.13 |4.14
 
-|IBM Secure Execution on {ibmzProductName} and {linuxoneProductName}
+|IBM Secure Execution on {ibm-z-name} and {ibm-linuxone-name}
 |Technology Preview
 |General Availability
 |General Availability
 
-|{ibmpowerProductName} Virtual Server using installer-provisioned infrastructure
+|{ibm-power-server-name} using installer-provisioned infrastructure
 |Not Available
 |Technology Preview
 |Technology Preview
@@ -2846,7 +2846,7 @@ As a workaround, if you have an installation configuration file, update it with 
 
 * Booting fails in a large compute node. (link:https://issues.redhat.com/browse/OCPBUGS-20075[*OCPBUGS-20075*])
 
-* When you deploy a cluster with a Network Type of `OVNKubernetes` on {ibmpowerRegProductName}, compute nodes might reboot because of a kernel stack overflow. As a workaround, you can deploy the cluster with a Network Type of `OpenShiftSDN`. (link:https://issues.redhat.com/browse/RHEL-3901[*RHEL-3901*])
+* When you deploy a cluster with a Network Type of `OVNKubernetes` on {ibm-power-name}, compute nodes might reboot because of a kernel stack overflow. As a workaround, you can deploy the cluster with a Network Type of `OpenShiftSDN`. (link:https://issues.redhat.com/browse/RHEL-3901[*RHEL-3901*])
 
 * The following known issue applies to users who updated their {product-title} deployment to an early access version of {product-version} using release candidate 3 or 4:
 +


### PR DESCRIPTION
INTERNAL FIX - replace old IBM attributes with new attributes in the ocp-4-14-release-notes file

Version(s):
4.14

Link to docs preview:
[OCP 4.14 OCP Release Notes](https://68070--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes)

QE review:
- [ ] QE NOT REQUIRED


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
