### PR TITLE
OCPBUGS-22921: CIDR range definitions for OCP

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1257,6 +1257,8 @@ Topics:
     File: default-network-policy
   - Name: Configuring multitenant isolation with network policy
     File: multitenant-network-policy
+- Name: CIDR range definitions
+  File: cidr-range-definitions
 - Name: AWS Load Balancer Operator
   Dir: aws_load_balancer_operator
   Distros: openshift-enterprise,openshift-origin

--- a/networking/cidr-range-definitions.adoc
+++ b/networking/cidr-range-definitions.adoc
@@ -1,7 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cidr-range-definitions"]
 = CIDR range definitions
+include::_attributes/common-attributes.adoc[]
+ifdef::openshift-dedicated,openshift-rosa[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
+endif::openshift-dedicated,openshift-rosa[]
 :context: cidr-range-definitions
 
 toc::[]
@@ -24,7 +27,12 @@ OVN-Kubernetes, the default network provider in {product-title} 4.11 and later, 
 
 [id="machine-cidr-description"]
 == Machine CIDR
-In the Machine CIDR field, you must specify the IP address range for machines or cluster nodes. This range must encompass all CIDR address ranges for your virtual private cloud (VPC) subnets. Subnets must be contiguous. A minimum IP address range of 128 addresses, using the subnet prefix `/25`, is supported for single availability zone deployments. A minimum address range of 256 addresses, using the subnet prefix `/24`, is supported for deployments that use multiple availability zones. The default is `10.0.0.0/16`. This range must not conflict with any connected networks.
+In the Machine CIDR field, you must specify the IP address range for machines or cluster nodes. 
+ifdef::openshift-rosa,openshift-dedicated[]
+This range must encompass all CIDR address ranges for your virtual private cloud (VPC) subnets. Subnets must be contiguous.  A minimum IP address range of 128 addresses, using the subnet prefix `/25`, is supported for single availability zone deployments. A minimum address range of 256 addresses, using the subnet prefix `/24`, is supported for deployments that use multiple availability zones. 
+endif::openshift-rosa,openshift-dedicated[]
+
+The default is `10.0.0.0/16`. This range must not conflict with any connected networks.
 
 ifdef::openshift-rosa[]
 [NOTE]
@@ -35,12 +43,40 @@ endif::[]
 
 [id="service-cidr-description"]
 == Service CIDR
-In the Service CIDR field, you must specify the IP address range for services. It is recommended, but not required, that the address block is the same between clusters. This will not create IP address conflicts. The range must be large enough to accommodate your workload. The address block must not overlap with any external service accessed from within the cluster. The default is `172.30.0.0/16`.
+In the Service CIDR field, you must specify the IP address range for services. 
+ifdef::openshift-rosa,openshift-dedicated[]
+It is recommended, but not required, that the address block is the same between clusters. This will not create IP address conflicts. 
+endif::openshift-rosa,openshift-dedicated[]
+The range must be large enough to accommodate your workload. The address block must not overlap with any external service accessed from within the cluster. The default is `172.30.0.0/16`.
 
 [id="pod-cidr-description"]
 == Pod CIDR
-In the pod CIDR field, you must specify the IP address range for pods. It is recommended, but not required, that the address block is the same between clusters. This will not create IP address conflicts. The range must be large enough to accommodate your workload. The address block must not overlap with any external service accessed from within the cluster. The default is `10.128.0.0/14`.
+In the pod CIDR field, you must specify the IP address range for pods. 
+
+ifdef::openshift-enterprise[]
+The pod CIDR is the same as the `clusterNetwork` CIDR and the cluster CIDR. 
+endif::openshift-enterprise[]
+ifdef::openshift-rosa,openshift-dedicated[]
+It is recommended, but not required, that the address block is the same between clusters. This will not create IP address conflicts. 
+endif::openshift-rosa,openshift-dedicated[]
+The range must be large enough to accommodate your workload. The address block must not overlap with any external service accessed from within the cluster. The default is `10.128.0.0/14`. 
+ifdef::openshift-enterprise[]
+You can expand the range after cluster installation.
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../networking/cluster-network-operator.adoc#nw-operator-cr-cno-object_cluster-network-operator[Cluster Network Operator Configuration] 
+* xref:../networking/configuring-cluster-network-range.adoc#configuring-cluster-network-range[Configuring the cluster network range]
+endif::openshift-enterprise[]
 
 [id="host-prefix-description"]
 == Host Prefix
-In the Host Prefix field, you must Specify the subnet prefix length assigned to pods scheduled to individual machines. The host prefix determines the pod IP address pool for each machine. For example, if the host prefix is set to `/23`, each machine is assigned a `/23` subnet from the pod CIDR address range. The default is `/23`, allowing 512 cluster nodes, and 512 pods per node (both of which are beyond our maximum supported).
+In the Host Prefix field, you must specify the subnet prefix length assigned to pods scheduled to individual machines. The host prefix determines the pod IP address pool for each machine.
+
+ifdef::openshift-rosa,openshift-dedicated[]
+For example, if the host prefix is set to `/23`, each machine is assigned a `/23` subnet from the pod CIDR address range. The default is `/23`, allowing 512 cluster nodes, and 512 pods per node (both of which are beyond our maximum supported).
+endif::openshift-rosa,openshift-dedicated[]
+
+ifdef::openshift-enterprise[]
+For example, if the host prefix is set to `/23`, each machine is assigned a `/23` subnet from the pod CIDR address range. The default is `/23`, allowing 510 cluster nodes, and 510 pod IP addresses per node.
+endif::openshift-enterprise[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.11+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-22921
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
OpenShift: https://68086--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/cidr-range-definitions
ROSA: https://68086--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/cidr-range-definitions
*NOTE*: No technical changes were made to the ROSA definitions. The only changes made were to add conditional text to the content in these definitions that only pertains to OCP. The only meaningful changes are in the `openshift-enterprise` `ifdef/endif` tags where some technical changes were made that only apply to OpenShift.
QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
These CIDR definitions are currently only published in the ROSA docs. However, there's a customer request to publish CIDR definitions in OpenShift documentation. I think ROSA and OpenShift can share this file, since some portions of the definitions are similar. There is some info in these definitions that only belongs in the ROSA docs, and I have added `ifdef` and `endif` tags to make sure that information only goes to ROSA docs. There is also some information that only belongs in OpenShift enterpise docs, and likewise, I have conditional tagging to include that information only in the OpenShift documentation. 
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
