### PR TITLE
[RHACS] Remove technology preview designation from external db

### DIFF
--- a/installing/installing_ocp/install-central-ocp.adoc
+++ b/installing/installing_ocp/install-central-ocp.adoc
@@ -25,7 +25,7 @@ include::modules/install-acs-operator.adoc[leveloffset=+2]
 
 include::modules/install-central-operator.adoc[leveloffset=+2]
 include::modules/provision-postgresql-database.adoc[leveloffset=+2]
-include::modules/install-central-operator-tech-preview.adoc[leveloffset=+2]
+include::modules/install-central-operator-external-db.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/central-configuration-options-operator.adoc
+++ b/modules/central-configuration-options-operator.adoc
@@ -8,10 +8,7 @@
 [role="_abstract"]
 When you create a Central instance, the Operator lists the following configuration options for the `Central` custom resource.
 
-The following table includes settings for an external PostgreSQL database (Technology Preview).
-
-:FeatureName: External PostgreSQL support
-include::snippets/technology-preview.adoc[]
+The following table includes settings for an external PostgreSQL database.
 
 [id="central-settings_{context}"]
 == Central settings
@@ -87,7 +84,7 @@ If no PVC with the given name exists, it will be created. The default value is `
 | Specify a secret that has the database password in the `password` data item. Only use this parameter if you want to specify a connection string manually. If omitted, the operator auto-generates a password and stores it in the `password` item in the `central-db-password` secret.
 
 |`central.db.connectionString`
-a| (Technology Preview): Setting this parameter will not deploy Central DB, and Central will connect using the specified connection string. If you specify a value for this parameter, you must also specify a value for `central.db.passwordSecret.name`.
+a| Setting this parameter will not deploy Central DB, and Central will connect using the specified connection string. If you specify a value for this parameter, you must also specify a value for `central.db.passwordSecret.name`.
 This parameter has the following constraints:
 
 * Connection string must be in keyword/value format as described in the PostgreSQL documentation. For more information, see the links in the *Additional resources* section.

--- a/modules/central-services-public-config.adoc
+++ b/modules/central-services-public-config.adoc
@@ -82,10 +82,7 @@ Configurable parameters for Central.
 You must specify one parameter, either `central.exposure.loadBalancer`, `central.exposure.nodePort`, or `central.exposure.route`.
 When you do not specify any value for these parameters, you must manually expose Central or access it by using port-forwarding.
 
-The following table includes settings for an external PostgreSQL database (Technology Preview).
-
-:FeatureName: External PostgreSQL support
-include::snippets/technology-preview.adoc[]
+The following table includes settings for an external PostgreSQL database.
 
 |===
 | Parameter | Description
@@ -167,10 +164,10 @@ Red Hat recommends that you do not specify a port number if you are exposing {pr
 This parameter is only available for {ocp} clusters.
 
 | `central.db.external`
-| (Technology Preview) Use `true` to specify that Central DB should not be deployed and that an external database will be used.
+| Use `true` to specify that Central DB should not be deployed and that an external database will be used.
 
 | `central.db.source.connectionString`
-a| (Technology Preview) The connection string for Central to use to connect to the database. This is only used when `central.db.external` is set to true. The connection string must be in keyword/value format as described in the PostgreSQL documentation in "Additional resources".
+a| The connection string for Central to use to connect to the database. This is only used when `central.db.external` is set to true. The connection string must be in keyword/value format as described in the PostgreSQL documentation in "Additional resources".
 
 * Only PostgreSQL 13 is supported.
 * Connections through PgBouncer are not supported.

--- a/modules/install-central-operator-external-db.adoc
+++ b/modules/install-central-operator-external-db.adoc
@@ -2,11 +2,9 @@
 //
 // * installing/installing_ocp/install-central-ocp.adoc
 :_mod-docs-content-type: PROCEDURE
-[id="install-central-operator-tech-preview_{context}"]
-= Installing Central with an external database using the Operator method
+[id="install-central-operator-external-db_{context}"]
 
-:FeatureName: External PostgreSQL support
-include::snippets/technology-preview.adoc[]
+= Installing Central with an external database using the Operator method
 
 [role="_abstract"]
 The main component of {product-title} is called Central. You can install Central on {ocp} by using the `Central` custom resource. You deploy Central only once, and you can monitor multiple separate clusters by using the same Central installation.
@@ -67,7 +65,7 @@ spec:
 . Enter a name for your `Central` custom resource and add any labels you want to apply.
 . Navigate to *Central Component Settings* -> *Central DB Settings*.
 . For *Administrator Password* specify the referenced secret as `external-db-password` (or the secret name of the password created previously).
-. For *Connection String (Technology Preview)* specify the connection string in `keyword=value` format, for example, `host=<host> port=5432 database=stackrox user=stackrox sslmode=verify-ca`
+. For *Connection String* specify the connection string in `keyword=value` format, for example, `host=<host> port=5432 database=stackrox user=stackrox sslmode=verify-ca`
 . For *Persistence* -> *PersistentVolumeClaim* -> *Claim Name*, remove `central-db`.
 . If necessary, you can specify a Certificate Authority so that there is trust between the data base certificate and Central. To add this, go to the YAML view and add a TLS block under the top-level spec, as shown in the following example:
 +

--- a/modules/operator-upgrade-modify-central-custom-resource-external-db.adoc
+++ b/modules/operator-upgrade-modify-central-custom-resource-external-db.adoc
@@ -2,11 +2,8 @@
 //
 // * upgrading/upgrade-operator.adoc
 :_mod-docs-content-type: PROCEDURE
-[id="operator-upgrade-modify-central-custom-resource-tech-preview_{context}"]
+[id="operator-upgrade-modify-central-custom-resource-external-db_{context}"]
 = Modifying Central custom resource for external database
-
-:FeatureName: External PostgreSQL support
-include::snippets/technology-preview.adoc[]
 
 .Prerequisites
 * You must have a database in your database instance that supports PostgreSQL 13 and a user with the following permissions:

--- a/modules/provision-postgresql-database.adoc
+++ b/modules/provision-postgresql-database.adoc
@@ -8,9 +8,6 @@
 [role="_abstract"]
 You can use your existing PostgreSQL infrastructure to provision a database for {product-title-short}. Use this intructions in this section for configuring a PostgreSQL database environment, creating a user, database, schema, role, and granting required permissions.
 
-:FeatureName: External PostgreSQL support
-include::snippets/technology-preview.adoc[]
-
 .Procedure
 . Create a new user:
 +

--- a/upgrading/upgrade-operator.adoc
+++ b/upgrading/upgrade-operator.adoc
@@ -28,7 +28,7 @@ include::modules/prepare-operator-upgrades.adoc[leveloffset=+1]
 
 include::modules/operator-upgrade-modify-central-custom-resource.adoc[leveloffset=+1]
 
-include::modules/operator-upgrade-modify-central-custom-resource-tech-preview.adoc[leveloffset=+1]
+include::modules/operator-upgrade-modify-central-custom-resource-external-db.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

rhacs-docs, rhacs-docs-4.4

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

[ROX-20899](https://issues.redhat.com/browse/ROX-20899)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://68088--docspreview.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-ocp#install-central-operator-external-db_install-central-ocp

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
