### PR TITLE
OCPBUGS-23361 [DOC] Updated documentation to configure and verify different cgroup versions

### DIFF
--- a/modules/nodes-clusters-cgroups-2.adoc
+++ b/modules/nodes-clusters-cgroups-2.adoc
@@ -159,11 +159,13 @@ metadata:
   name: 05-worker-kernelarg-selinuxpermissive
 spec:
   kernelArguments:
-    systemd.unified_cgroup_hierarchy=0 <1>
-    systemd.legacy_systemd_cgroup_controller=1 <2>
+    systemd_unified_cgroup_hierarchy=1 <1>
+    cgroup_no_v1="all" <2>
+    psi=1 <3>
 ----
 <1> Enables cgroup v2 in systemd.
 <2> Disables cgroup v1.
+<3> Enables the Linux Pressure Stall Information (PSI) feature.
 +
 endif::nodes[]
 .Example output for cgroup v1
@@ -177,13 +179,11 @@ metadata:
   name: 05-worker-kernelarg-selinuxpermissive
 spec:
   kernelArguments:
-  - systemd_unified_cgroup_hierarchy=1 <1>
-  - cgroup_no_v1="all" <2>
-  - psi=1 <3>
+    systemd.unified_cgroup_hierarchy=0 <1>
+    systemd.legacy_systemd_cgroup_controller=1 <2>
 ----
-<1> Enables cgroup v1 in systemd.
-<2> Disables cgroup v2.
-<3> Enables the Linux Pressure Stall Information (PSI) feature.
+<1> Disables cgroup v2.
+<2> Enables cgroup v1 in systemd.
 
 . Check the nodes to see that scheduling on the nodes is disabled. This indicates that the change is being applied:
 +
@@ -243,13 +243,13 @@ $ stat -c %T -f /sys/fs/cgroup
 .Example output for cgroup v2
 [source,terminal]
 ----
-tmp2fs
+cgroup2fs
 ----
 +
 .Example output for cgroup v1
 [source,terminal]
 ----
-cgroup1fs
+tmpfs
 ----
 endif::nodes[]
 


### PR DESCRIPTION
OCPBUGS-23361 [DOC] This PR fixes the incorrect and erroneous information provided in the OCP documentation pertaining to the configuration and verification of different cgroups versions in RHCOS.

Version(s): 4.14+ onwards

Issue: https://issues.redhat.com/browse/OCPBUGS-23361

Link to docs preview:

QE review:

Additional information:

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
