### PR TITLE
OSDOCS-8371: Migrate "Getting Started with Rosa - Deploy the Cluster (Choose your deployment method)"

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -124,11 +124,11 @@ Topics:
   Dir: cloud-experts-getting-started
   Distros: openshift-rosa
   Topics:
-  - Name: Setup
-    File: cloud-experts-getting-started-setup
   - Name: Deploying a cluster
     Dir: cloud-experts-getting-started-deploying
     Topics:
+    - Name: Choosing a deployment method
+      File: cloud-experts-getting-started-choose-deployment-method
     - Name: Simple CLI guide
       File: cloud-experts-getting-started-simple-cli-guide
     - Name: Detailed CLI guide

--- a/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-choose-deployment-method.adoc
+++ b/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-choose-deployment-method.adoc
@@ -1,0 +1,24 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="cloud-experts-getting-started-choose-deployment-method"]
+= Tutorial: Choosing a deployment method
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: cloud-experts-getting-started-choose-deployment-method
+
+toc::[]
+
+//rosaworkshop.io content metadata
+//Brought into ROSA product docs 2023-11-16
+
+There are a few different ways to deploy a cluster, and this tutorial outlines each method. You only need to choose one based on your preferences and needs. Use the decision tree below to find the deployment method that best fits your situation.
+
+== Deployment options
+
+For those who are thinking:
+
+* "Just tell me the commands I need to run!" - xref:../../cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-simple-cli-guide.adoc#cloud-experts-getting-started-simple-cli-guide[Simple CLI guide]
+* "I do not like CLI tools. Give me a user interface!" - xref:../../cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-simple-ui-guide.adoc#cloud-experts-getting-started-simple-ui-guide[Simple UI guide]
+* "I need details and want to use a CLI!" - xref:../../cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-detailed-cli-guide.adoc#cloud-experts-getting-started-detailed-cli-guide[Detailed CLI guide]
+* "I need details and want to use a user interface!" xref:../../cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-detailed-ui.adoc#cloud-experts-getting-started-detailed-ui[Detailed UI guide]
+* "I want to experiment with the newest technologies." - xref:../../cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-hcp.adoc#cloud-experts-getting-started-detailed-ui-guide[ROSA with HCP]
+
+All of the above deployment options work well for this workshop. If you are doing this workshop for the first time, the xref:../../cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-simple-cli-guide.adoc#cloud-experts-getting-started-simple-cli-guide[Simple CLI guide] is the simplest and recommended method.

--- a/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-simple-cli-guide.adoc
+++ b/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-simple-cli-guide.adoc
@@ -18,7 +18,7 @@ While this simple deployment works well for a tutorial setting, clusters used in
 
 == Prerequisites
 
-* You have completed the prerequisites in the xref:../../../cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-setup.adoc#cloud-experts-getting-started-setup[Setup] tutorial.
+* You have completed the prerequisites in the Setup tutorial.
 
 == Creating account roles
 Run the following command _once_ for each AWS account and y-stream OpenShift version:

--- a/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-simple-ui-guide.adoc
+++ b/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-simple-ui-guide.adoc
@@ -18,7 +18,7 @@ While this simple deployment works well for a workshop setting, clusters used in
 
 == Prerequisites
 
-* You have completed the prerequisites in the xref:../../../cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-setup.adoc#cloud-experts-getting-started-setup[Setup] tutorial.
+* You have completed the prerequisites in the Setup tutorial.
 
 == Creating account roles
 Run the following command _once_ for each AWS account and y-stream OpenShift version:


### PR DESCRIPTION
[OSDOCS-8371](https://issues.redhat.com//browse/OSDOCS-8371): Migrate "Getting Started with Rosa - Deploy the Cluster (Choose your deployment method)" from rosaworkshop.io content.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-8371

Link to docs preview:
https://68094--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-choose-deployment-method

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
