### PR TITLE
[enterprise-4.13] [OSDOCS-8304] Peer review backport to 4.13 and earlier

### DIFF
--- a/authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc
@@ -18,7 +18,7 @@ This credentials strategy is supported for only new {product-title} clusters and
 
 In manual mode with GCP Workload Identity, the individual {product-title} cluster components can impersonate IAM service accounts using short-term, limited-privilege credentials.
 
-Requests for new and refreshed credentials are automated by using an appropriately configured OpenID Connect (OIDC) identity provider, combined with IAM service accounts. {product-title} signs service account tokens that are trusted by GCP, and can be projected into a pod and used for authentication. Tokens are refreshed after one hour by default.
+Requests for new and refreshed credentials are automated by using an appropriately configured OpenID Connect (OIDC) identity provider combined with IAM service accounts. Service account tokens that are trusted by GCP are signed by {product-title} and can be projected into a pod and used for authentication. Tokens are refreshed after one hour.
 
 .Workload Identity authentication flow
 image::347_OpenShift_credentials_with_STS_updates_0623_GCP.png[Detailed authentication flow between GCP and the cluster when using GCP Workload Identity]

--- a/authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
@@ -44,7 +44,7 @@ The following diagram illustrates the authentication flow between AWS and the {p
 .AWS Security Token Service authentication flow
 image::347_OpenShift_credentials_with_STS_updates_0623_AWS.png[Detailed authentication flow between AWS and the cluster when using AWS STS]
 
-Requests for new and refreshed credentials are automated by using an appropriately configured AWS IAM OpenID Connect (OIDC) identity provider, combined with AWS IAM roles. {product-title} signs service account tokens that are trusted by AWS IAM, and can be projected into a pod and used for authentication.
+Requests for new and refreshed credentials are automated by using an appropriately configured AWS IAM OpenID Connect (OIDC) identity provider combined with AWS IAM roles. Service account tokens that are trusted by AWS IAM are signed by {product-title} and can be projected into a pod and used for authentication.
 
 [id="cco-short-term-creds-auth-flow-aws-refresh-policy_{context}"]
 === Token refreshing for AWS STS


### PR DESCRIPTION
Version(s):
4.11-4.13

Issue:
#67750

Link to docs preview:
* [About manual mode with AWS Security Token Service](https://68100--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts#sts-mode-about_cco-mode-sts)
* [About manual mode with GCP Workload Identity](https://68100--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity#gcp-workload-identity-mode-about_cco-mode-gcp-workload-identity)

QE review:
N/A this is a manual cherrypick

Additional information:
Peer review feedback on #67750 cannot be cherrypicked to 4.11-4.13. Opening a PR against 4.13, which should cherrypick into 4.11-4.12 without issue.