### PR TITLE
Service Mesh add dedicated-user prereq

### DIFF
--- a/modules/ossm-add-project-using-label-selectors-cli.adoc
+++ b/modules/ossm-add-project-using-label-selectors-cli.adoc
@@ -11,7 +11,12 @@ You can use label selectors to add a project to the {SMProductShortName} with th
 .Prerequisites
 * You have installed the {SMProductName} Operator.
 * The deployment has an existing `ServiceMeshMemberRoll` resource.
-* You are logged in as a user with the `cluster-admin` role. If you use {product-dedicated}, you are logged in as a user with the `dedicated-admin` role.
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as`cluster-admin`.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 
 .Procedure
 

--- a/modules/ossm-add-project-using-label-selectors-console.adoc
+++ b/modules/ossm-add-project-using-label-selectors-console.adoc
@@ -11,11 +11,14 @@ You can use labels selectors to add a project to the {SMProductShortName} with t
 .Prerequisites
 * You have installed the {SMProductName} Operator.
 * The deployment has an existing `ServiceMeshMemberRoll` resource.
-* You are logged in as a user with the `cluster-admin` role. If you use {product-dedicated}, you are logged in as a user with the `dedicated-admin` role.
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to the {product-title} web console as `cluster-admin`.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to the {product-title} web console as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 
 .Procedure
-
-. Log in to the {product-title} web console.
 
 . Navigate to *Operators* -> *Installed Operators*.
 

--- a/modules/ossm-config-control-plane-infrastructure-node-cli.adoc
+++ b/modules/ossm-config-control-plane-infrastructure-node-cli.adoc
@@ -13,7 +13,12 @@ If the control plane will run on a worker node, skip this task.
 .Prerequisites
 
 * You have installed the {SMProductName} Operator.
-* You are logged in as a user with the `cluster-admin` role. If you use {product-dedicated}, you are logged in as a user with the `dedicated-admin` role.
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as`cluster-admin`.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 
 .Procedure
 

--- a/modules/ossm-config-control-plane-infrastructure-node-console.adoc
+++ b/modules/ossm-config-control-plane-infrastructure-node-console.adoc
@@ -13,7 +13,12 @@ If the control plane will run on a worker node, skip this task.
 .Prerequisites
 
 * You have installed the {SMProductName} Operator.
-* You are logged in as a user with the `cluster-admin` role. If you use {product-dedicated}, you are logged in as a user with the `dedicated-admin` role.
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as`cluster-admin`.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 
 .Procedure
 

--- a/modules/ossm-config-individual-control-plane-infrastructure-node-cli.adoc
+++ b/modules/ossm-config-individual-control-plane-infrastructure-node-cli.adoc
@@ -13,7 +13,12 @@ If the control plane will run on a worker node, skip this task.
 .Prerequisites
 
 * You have installed the {SMProductName} Operator.
-* You are logged in as a user with the `cluster-admin` role. If you use {product-dedicated}, you are logged in as a user with the `dedicated-admin` role.
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as`cluster-admin`.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 
 .Procedure
 

--- a/modules/ossm-config-individual-control-plane-infrastructure-node-console.adoc
+++ b/modules/ossm-config-individual-control-plane-infrastructure-node-console.adoc
@@ -13,7 +13,12 @@ If the control plane will run on a worker node, skip this task.
 .Prerequisites
 
 * You have installed the {SMProductName} Operator.
-* You are logged in as a user with the `cluster-admin` role. If you use {product-dedicated}, you are logged in as a user with the `dedicated-admin` role.
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as`cluster-admin`.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 
 .Procedure
 

--- a/modules/ossm-control-plane-cli.adoc
+++ b/modules/ossm-control-plane-cli.adoc
@@ -12,16 +12,15 @@ You can deploy a basic `ServiceMeshControlPlane` from the command line.
 
 * The {SMProductName} Operator must be installed.
 * Access to the OpenShift CLI (`oc`).
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as`cluster-admin`.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 
 .Procedure
 
-. Log in to the {product-title} CLI as a user with the `cluster-admin` role. If you use {product-dedicated}, you must have an account with the `dedicated-admin` role.
-+
-[source,terminal]
-----
-$ oc login --username=<NAMEOFUSER> https://<HOSTNAME>:6443
-----
-+
 . Create a project named `istio-system`.
 +
 [source,terminal]

--- a/modules/ossm-deploy-cluster-wide-control-plane-cli.adoc
+++ b/modules/ossm-deploy-cluster-wide-control-plane-cli.adoc
@@ -12,16 +12,15 @@ You can configure the `ServiceMeshControlPlane` resource for cluster-wide deploy
 
 * The {SMProductName} Operator is installed.
 * You have access to the OpenShift CLI (`oc`).
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as`cluster-admin`.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 
 .Procedure
 
-. Log in to the {product-title} CLI as a user with the `cluster-admin` role. If you use {product-dedicated}, you must have an account with the `dedicated-admin` role.
-+
-[source,terminal]
-----
-$ oc login --username=<NAMEOFUSER> https://<HOSTNAME>:6443
-----
-+
 . Create a project named `istio-system`.
 +
 [source,terminal]

--- a/modules/ossm-deploy-cluster-wide-control-plane-console.adoc
+++ b/modules/ossm-deploy-cluster-wide-control-plane-console.adoc
@@ -11,7 +11,12 @@ You can configure the `ServiceMeshControlPlane` resource for cluster-wide deploy
 .Prerequisites
 
 * The {SMProductName} Operator is installed.
-* You are logged in using an account with the `cluster-admin` role, or if you use {product-dedicated} with the `dedicated-admin` role.
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as`cluster-admin`.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 
 .Procedure
 

--- a/modules/ossm-tutorial-bookinfo-install.adoc
+++ b/modules/ossm-tutorial-bookinfo-install.adoc
@@ -15,7 +15,12 @@ This tutorial walks you through how to create a sample application by creating a
 * {product-title} 4.1 or higher installed.
 * {SMProductName} {SMProductVersion} installed.
 * Access to the OpenShift CLI (`oc`).
-* An account with the `cluster-admin` role.
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as`cluster-admin`.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 
 ifndef::openshift-rosa[]
 [NOTE]
@@ -30,8 +35,6 @@ The commands in this section assume the {SMProductShortName} control plane proje
 ====
 
 .Procedure
-
-. Log in to the {product-title} web console as a user with cluster-admin rights. If you use {product-dedicated}, you must have an account with the `dedicated-admin` role.
 
 . Click *Home* -> *Projects*.
 

--- a/modules/ossm-tutorial-bookinfo-verify-install.adoc
+++ b/modules/ossm-tutorial-bookinfo-verify-install.adoc
@@ -14,10 +14,14 @@ To confirm that the sample Bookinfo application was successfully deployed, perfo
 
 * {SMProductName} installed.
 * Complete the steps for installing the Bookinfo sample app.
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as`cluster-admin`.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 
 .Procedure from CLI
-
-. Log in to the {product-title} CLI.
 
 . Verify that all pods are ready with this command:
 +
@@ -51,7 +55,7 @@ echo "http://$GATEWAY_URL/productpage"
 
 . Obtain the address for the Kiali web console.
 
-.. Log in to the {product-title} web console as a user with `cluster-admin` rights. If you use {product-dedicated}, you must have an account with the `dedicated-admin` role.
+.. Log in to the {product-title} web console.
 
 .. Navigate to *Networking* -> *Routes*.
 

--- a/modules/ossm-validate-smcp-cli.adoc
+++ b/modules/ossm-validate-smcp-cli.adoc
@@ -7,15 +7,19 @@ This module is included in the following assemblies:
 = Validating your SMCP installation with the CLI
 You can validate the creation of the `ServiceMeshControlPlane` from the command line.
 
+. Prerequisites
+
+* The {SMProductName} Operator must be installed.
+* Access to the OpenShift CLI (`oc`).
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as`cluster-admin`.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+
 .Procedure
 
-. Log in to the {product-title} CLI as a user with the `cluster-admin` role. If you use Red Hat OpenShift Dedicated, you must have an account with the `dedicated-admin` role.
-+
-[source,terminal]
-----
-$ oc login https://<HOSTNAME>:6443
-----
-+
 . Run the following command to verify the {SMProductShortName} control plane installation, where `istio-system` is the namespace where you installed the {SMProductShortName} control plane.
 +
 [source,terminal]

--- a/modules/ossm-validate-smcp-kiali.adoc
+++ b/modules/ossm-validate-smcp-kiali.adoc
@@ -8,11 +8,20 @@ This module is included in the following assemblies:
 
 You can use the Kiali console to validate your {SMProductShortName} installation. The Kiali console offers several ways to validate your {SMProductShortName} components are deployed and configured properly.
 
+. Prerequisites
+
+* The {SMProductName} Operator must be installed.
+* Access to the OpenShift CLI (`oc`).
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as`cluster-admin`.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+
 .Procedure
 
-. Log in to the {product-title} web console as a user with cluster-admin rights. If you use {product-dedicated}, you must have an account with the `dedicated-admin` role.
-
-. Navigate to *Networking* -> *Routes*.
+. In the {product-title} web console, navigate to *Networking* -> *Routes*.
 
 . On the *Routes* page, select the {SMProductShortName} control plane project, for example `istio-system`, from the *Namespace* menu.
 +


### PR DESCRIPTION
For the ROSA/OSD content port project, this PR adds the requirement to use the dedicated-admin user, rather than the cluster-admin. Made these changes separately to reduce the size of the content port PR