### PR TITLE
TELCODOCS-1453: Adding SNO post-install config for OLM

### DIFF
--- a/modules/ztp-sno-du-reducing-resource-usage-with-olm-pprof.adoc
+++ b/modules/ztp-sno-du-reducing-resource-usage-with-olm-pprof.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ztp-sno-du-reducing-resource-usage-with-olm-pprof_{context}"]
+= Operator Lifecycle Manager
+
+{sno-caps} clusters that run distributed unit workloads require consistent access to CPU resources. Operator Lifecycle Manager (OLM) collects performance data from Operators at regular intervals, resulting in an increase in CPU utilisation. The following `ConfigMap` custom resource (CR) disables the collection of Operator performance data by OLM.
+
+.Recommended cluster OLM configuration (`ReduceOLMFootprint.yaml`)
+[source,yaml]
+----
+include::snippets/ztp_ReduceOLMFootprint.yaml[]
+----

--- a/scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc
@@ -88,6 +88,8 @@ include::modules/ztp-sno-du-removing-the-console-operator.adoc[leveloffset=+2]
 
 include::modules/ztp-sno-du-reducing-resource-usage-with-cluster-monitoring.adoc[leveloffset=+2]
 
+include::modules/ztp-sno-du-reducing-resource-usage-with-olm-pprof.adoc[leveloffset=+2]
+
 include::modules/ztp-sno-du-configuring-lvms.adoc[leveloffset=+2]
 
 include::modules/ztp-sno-du-disabling-network-diagnostics.adoc[leveloffset=+2]

--- a/snippets/ztp_ReduceOLMFootprint.yaml
+++ b/snippets/ztp_ReduceOLMFootprint.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: collect-profiles-config
+  namespace: openshift-operator-lifecycle-manager
+data:
+  pprof-config.yaml: |
+    disabled: True
+    


### PR DESCRIPTION
[TELCODOCS-1453](https://issues.redhat.com//browse/TELCODOCS-1453): SNO post-install recommended config to remove OLM monitoring component.

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1453

Link to docs preview:
https://68117--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu#ztp-sno-du-reducing-resource-usage-with-olm-pprof_sno-configure-for-vdu

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


