### PR TITLE
[MULTIARCH-4021] Remove VirtIO section in IBM Z recommended host practices. 

### DIFF
--- a/modules/ibm-z-rhel-kvm-host-recommendations.adoc
+++ b/modules/ibm-z-rhel-kvm-host-recommendations.adoc
@@ -10,24 +10,6 @@ Optimizing a KVM virtual server environment strongly depends on the workloads of
 
 The following section introduces some best practices when using {product-title} with {op-system-base} KVM on {ibm-z-name} and {ibm-linuxone-name} environments.
 
-[id="use-multiple-queues-for-your-virtio-network-interfaces_{context}"]
-== Use multiple queues for your VirtIO network interfaces
-
-With multiple virtual CPUs, you can transfer packages in parallel if you provide multiple queues for incoming and outgoing packets. Use the `queues` attribute of the `driver` element to configure multiple queues. Specify an integer of at least 2 that does not exceed the number of virtual CPUs of the virtual server.
-
-The following example specification configures two input and output queues for a network interface:
-
-[source,xml]
-----
-<interface type="direct">
-    <source network="net01"/>
-    <model type="virtio"/>
-    <driver ... queues="2"/>
-</interface>
-----
-
-Multiple queues are designed to provide enhanced performance for a network interface, but they also use memory and CPU resources. Start with defining two queues for busy interfaces. Next, try two queues for interfaces with less traffic or more than two queues for busy interfaces.
-
 [id="use-io-threads-for-your-virtual-block-devices_{context}"]
 == Use I/O threads for your virtual block devices
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/MULTIARCH-4021
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://68118--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ibm-z-recommended-host-practices
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
