### PR TITLE
OSDOCS-6446 updated node description ROSA concepts

### DIFF
--- a/modules/rosa-kubernetes-concept.adoc
+++ b/modules/rosa-kubernetes-concept.adoc
@@ -9,9 +9,13 @@
 
 {product-title} (ROSA) uses Red Hat OpenShift, which is an enterprise Kubernetes platform. Kubernetes is an open source platform for managing containerized workloads and services across multiple hosts, and offers management tools for deploying, automating, monitoring, and scaling containerized apps with minimal to no manual intervention. For complete information about Kubernetes, see the link:https://kubernetes.io/docs/home/?path=users&persona=app-developer&level=foundational[Kubernetes documentation].
 
-Cluster, compute pool, and compute node:: A Kubernetes cluster consists of a control plane and one or more compute nodes. Compute nodes are organized into compute pools of the type or profile of CPU, memory, operating system, attached disks, and other properties. The compute nodes correspond to the Kubernetes `Node` resource, and are managed by a Kubernetes control plane that centrally controls and monitors all Kubernetes resources in the cluster.
+Cluster and nodes:: A Kubernetes cluster uses nodes to ensure the resilience and scalability of the applications managed on the cluster. Nodes are physical or virtual computing machines that run resources for the cluster. Kubernetes organizes nodes into control plane nodes and worker nodes to support cluster operations. 
 +
-When you deploy the resources for a containerized app, the Kubernetes control plane decides which compute node to deploy those resources on, accounting for the deployment requirements and available capacity in the cluster. Kubernetes resources include services, deployments, and pods.
+The control plane nodes centrally control and monitor all resources in the cluster. When you deploy the resources for a containerized application, the Kubernetes control plane chooses the worker node to deploy those resources on, accounting for the deployment requirements and available capacity in the cluster. 
++
+The worker nodes run services to communicate with the control plane nodes and receive requests to run the applications authored in project pods.
+
+Machine pools:: An abstract grouping of a set of worker nodes that can be distributed across availability zones to offer application resilience.
 
 Namespace:: Kubernetes namespaces are a way to divide your cluster resources into separate areas that you can deploy apps and restrict access to, such as if you want to share the cluster with multiple teams. For example, system resources that are configured for you are kept in separate namespaces like `kube-system`. If you do not designate a namespace when you create a Kubernetes resource, the resource is automatically created in the `default` namespace.
 


### PR DESCRIPTION
Updated the description of the K8 node resources for accuracy. 

Version(s):

4.14+

Issue:

https://issues.redhat.com/browse/OSDOCS-6446

Link to docs preview:

https://68133--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_architecture_sub/rosa-basic-architecture-concepts#rosa-kubernetes-concept_rosa-basic-architecture-concepts

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
