### PR TITLE
OCPBUGS-23402: Fix missing "remediationTemplate"

### DIFF
--- a/modules/mgmt-power-remediation-baremetal-about.adoc
+++ b/modules/mgmt-power-remediation-baremetal-about.adoc
@@ -138,7 +138,7 @@ spec:
       machine.openshift.io/cluster-api-machine-role: <role>
       machine.openshift.io/cluster-api-machine-type: <role>
       machine.openshift.io/cluster-api-machineset: <cluster_name>-<label>-<zone>
-  selector:
+  remediationTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3RemediationTemplate
     name: metal3-remediation-template


### PR DESCRIPTION
Fix the example MachineHealthCheck to include "remediationTemplate"
