### PR TITLE
OSDOCS-6820 add External ID configuration description

### DIFF
--- a/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
@@ -229,31 +229,31 @@ I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role for 
 I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-ControlPlane-Role for the ControlPlane role
 I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Worker-Role for the Worker role
 I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role for the Support role
-? External ID (optional):
-? Operator roles prefix: <cluster_name>-<random_string> <5>
+? External ID (optional): <5>
+? Operator roles prefix: <cluster_name>-<random_string> <6>
 ? Deploy cluster using pre registered OIDC Configuration ID:
-? Tags (optional) <6>
-? Multiple availability zones (optional): No <7>
+? Tags (optional) <7>
+? Multiple availability zones (optional): No <8>
 ? AWS region: us-east-1
 ? PrivateLink cluster (optional): No
-? Install into an existing VPC (optional): Yes <8>
+? Install into an existing VPC (optional): Yes <9>
 ? Select availability zones (optional): No
-? Enable Customer Managed key (optional): No <9>
+? Enable Customer Managed key (optional): No <10>
 ? Compute nodes instance type (optional):
 ? Enable autoscaling (optional): No
 ? Compute nodes: 2
-? Additional Security Group IDs (optional): <10>
+? Additional Security Group IDs (optional): <11>
 ? > [*]  sg-0e375ff0ec4a6cfa2 ('sg-1')
 ? > [ ]  sg-0e525ef0ec4b2ada7 ('sg-2')
 ? Machine CIDR: 10.0.0.0/16
 ? Service CIDR: 172.30.0.0/16
 ? Pod CIDR: 10.128.0.0/14
 ? Host prefix: 23
-? Encrypt etcd data (optional): No <11>
+? Encrypt etcd data (optional): No <12>
 ? Disable Workload monitoring (optional): No
 I: Creating cluster '<cluster_name>'
 I: To create this cluster again in the future, you can run:
-   rosa create cluster --cluster-name <cluster_name> --role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role --master-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Worker-Role --operator-roles-prefix <cluster_name>-<random_string> --region us-east-1 --version 4.15.0 --additional-compute-security-group-ids sg-0e375ff0ec4a6cfa2 --additional-infra-security-group-ids sg-0e375ff0ec4a6cfa2 --additional-control-plane-security-group-ids sg-0e375ff0ec4a6cfa2 --replicas 2 --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23 <12>
+   rosa create cluster --cluster-name <cluster_name> --role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role --master-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Worker-Role --operator-roles-prefix <cluster_name>-<random_string> --region us-east-1 --version 4.15.0 --additional-compute-security-group-ids sg-0e375ff0ec4a6cfa2 --additional-infra-security-group-ids sg-0e375ff0ec4a6cfa2 --additional-control-plane-security-group-ids sg-0e375ff0ec4a6cfa2 --replicas 2 --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23 <13>
 I: To view a list of clusters and their status, run 'rosa list clusters'
 I: Cluster '<cluster_name>' has been created.
 I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.
@@ -268,13 +268,14 @@ I: Once the cluster is installed you will need to add an Identity Provider befor
 The Instance Metadata Service settings cannot be changed after your cluster is created.
 ====
 <4> If you have more than one set of account roles for your cluster version in your AWS account, an interactive list of options is provided.
-<5> By default, the cluster-specific Operator role names are prefixed with the cluster name and a random 4-digit hash. You can optionally specify a custom prefix to replace `<cluster_name>-<hash>` in the role names. The prefix is applied when you create the cluster-specific Operator IAM roles. For information about the prefix, see _Defining an Operator IAM role prefix_.
+<5> Optional: Specify an unique identifier that is passed by {product-title} and the OpenShift installer when an account role is assumed. This option is only required for custom account roles that expect an external ID.
+<6> By default, the cluster-specific Operator role names are prefixed with the cluster name and a random 4-digit hash. You can optionally specify a custom prefix to replace `<cluster_name>-<hash>` in the role names. The prefix is applied when you create the cluster-specific Operator IAM roles. For information about the prefix, see _Defining an Operator IAM role prefix_.
 +
 [NOTE]
 ====
 If you specified custom ARN paths when you created the associated account-wide roles, the custom path is automatically detected. The custom path is applied to the cluster-specific Operator roles when you create them in a later step.
 ====
-<6> Optional: Specify a tag that is used on all resources created by {product-title} in AWS. Tags can help you manage, identify, organize, search for, and filter resources within AWS. Tags are comma separated, for example: "key value, foo bar".
+<7> Optional: Specify a tag that is used on all resources created by {product-title} in AWS. Tags can help you manage, identify, organize, search for, and filter resources within AWS. Tags are comma separated, for example: "key value, foo bar".
 +
 [IMPORTANT]
 ====
@@ -283,8 +284,8 @@ Tags that are added by Red Hat are required for clusters to stay in compliance w
 
 {product-title} does not support adding additional tags outside of ROSA cluster-managed resources. These tags can be lost when AWS resources are managed by the ROSA cluster. In these cases, you might need custom solutions or tools to reconcile the tags and keep them intact.
 ====
-<7> Optional: Multiple availability zones are recommended for production workloads. The default is a single availability zone.
-<8> Optional: You can create a cluster in an existing VPC, or ROSA can create a new VPC to use.
+<8> Optional: Multiple availability zones are recommended for production workloads. The default is a single availability zone.
+<9> Optional: You can create a cluster in an existing VPC, or ROSA can create a new VPC to use.
 +
 [WARNING]
 ====
@@ -292,7 +293,7 @@ You cannot install a ROSA cluster into an existing VPC that was created by the O
 
 To verify whether a VPC was created by the OpenShift installer, check for the `owned` value on the `kubernetes.io/cluster/<infra-id>` tag. For example, when viewing the tags for the VPC named `mycluster-12abc-34def`, the `kubernetes.io/cluster/mycluster-12abc-34def` tag has a value of `owned`. Therefore, the VPC was created by the installer and must not be modified by the administrator.
 ====
-<9> Optional: Enable this option if you are using your own AWS KMS key to encrypt the control plane, infrastructure, worker node root volumes, and PVs. Specify the ARN for the KMS key that you added to the account-wide role ARN in the preceding step.
+<10> Optional: Enable this option if you are using your own AWS KMS key to encrypt the control plane, infrastructure, worker node root volumes, and PVs. Specify the ARN for the KMS key that you added to the account-wide role ARN in the preceding step.
 +
 [IMPORTANT]
 ====
@@ -301,15 +302,15 @@ Only persistent volumes (PVs) created from the default storage class are encrypt
 PVs created by using any other storage class are still encrypted, but the PVs are not encrypted with this key unless the storage class is specifically configured to use this key.
 ====
 
-<10> Optional: You can select additional custom security groups to use in each of the cluster nodes, compute, infra and control plane. You must have already created the security groups and associated them with the VPC you selected for this cluster. You cannot add or edit security groups for the default machine pools after you create the machine pool. For more information, see the requirements for _Security groups_ under _Additional resources_.
-<11> Optional: Enable this option only if your use case requires etcd key value encryption in addition to the control plane storage encryption that encrypts the etcd volumes by default. With this option, the etcd key values are encrypted but not the keys.
+<11> Optional: You can select additional custom security groups to use in your cluster. You must have already created the security groups and associated them with the VPC you selected for this cluster. You cannot add or edit security groups for the default machine pools after you create the machine pool. For more information, see the requirements for _Security groups_ under _Additional resources_.
+<12> Optional: Enable this option only if your use case requires etcd key value encryption in addition to the control plane storage encryption that encrypts the etcd volumes by default. With this option, the etcd key values are encrypted but not the keys.
 +
 [IMPORTANT]
 ====
 By enabling etcd encryption for the key values in etcd, you will incur a performance overhead of approximately 20%. The overhead is a result of introducing this second layer of encryption, in addition to the default control plane storage encryption that encrypts the etcd volumes. Red Hat recommends that you enable etcd encryption only if you specifically require it for your use case.
 ====
 +
-<12> The output includes a custom command that you can run to create a cluster with the same configuration in the future.
+<13> The output includes a custom command that you can run to create a cluster with the same configuration in the future.
 --
 +
 As an alternative to using the `--interactive` mode, you can specify the customization options directly when you run the `rosa create cluster` command. Run the `rosa create cluster --help` command to view a list of available CLI options, or see _create cluster_ in _Managing objects with the ROSA CLI_.


### PR DESCRIPTION
added External ID configuration description

Version(s):

4.13+

Issue:

https://issues.redhat.com/browse/OSDOCS-6820

Link to docs preview:

https://68156--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations#rosa-sts-creating-cluster-customizations-cli_rosa-sts-creating-a-cluster-with-customizations

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
