### PR TITLE
[OCPBUGS-23345] Adds step to set Azure resource group for AADWID install

### DIFF
--- a/installing/installing_azure/installing-restricted-networks-azure-installer-provisioned.adoc
+++ b/installing/installing_azure/installing-restricted-networks-azure-installer-provisioned.adoc
@@ -29,7 +29,6 @@ Because the installation media is on the mirror host, you can use that computer 
 ** The VNet contains the mirror registry
 ** The VNet has firewall rules or a peering connection to access the mirror registry hosted elsewhere
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
-* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_azure/installing-azure-customizations.adoc#manually-create-iam_installing-azure-customizations[manually create and maintain long-term credentials].
 * If you use customer-managed encryption keys, you xref:../../installing/installing_azure/enabling-user-managed-encryption-azure.adoc#enabling-user-managed-encryption-azure[prepared your Azure environment for encryption].
 
 include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
@@ -61,9 +60,37 @@ include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
-include::modules/installation-launching-installer.adoc[leveloffset=+1]
-
+//Installing the OpenShift CLI by downloading the binary: Moved up to precede manual cred (short and long) steps, which require the use of `oc`
 include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
+[id="installing-azure-manual-modes_{context}"]
+== Alternatives to storing administrator-level secrets in the kube-system project
+
+By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
+
+* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_azure/installing-restricted-networks-azure-installer-provisioned.adoc#manually-create-iam_installing-restricted-networks-azure-installer-provisioned[Manually creating long-term credentials].
+
+* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../installing/installing_azure/installing-restricted-networks-azure-installer-provisioned.adoc#installing-azure-with-short-term-creds_installing-restricted-networks-azure-installer-provisioned[Configuring an Azure cluster to use short-term credentials].
+
+//Manually creating long-term credentials
+include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
+
+//Supertask: Configuring an Azure cluster to use short-term credentials
+[id="installing-azure-with-short-term-creds_{context}"]
+=== Configuring an Azure cluster to use short-term credentials
+
+To install a cluster that uses Azure AD Workload Identity, you must configure the Cloud Credential Operator utility and create the required Azure resources for your cluster.
+
+//Task part 1: Configuring the Cloud Credential Operator utility
+include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
+
+//Task part 2: Creating the required Azure resources
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
+
+// Additional steps for the Cloud Credential Operator utility (`ccoctl`)
+include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
+
+include::modules/installation-launching-installer.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 

--- a/modules/cco-ccoctl-configuring.adoc
+++ b/modules/cco-ccoctl-configuring.adoc
@@ -33,6 +33,7 @@
 // * installing/installing_azure/installing-azure-network-customizations.adoc
 // * installing/installing_azure/installing-azure-private.adoc
 // * installing/installing_azure/installing-azure-vnet.adoc
+// * installing/installing_azure/installing-restricted-networks-azure-installer-provisioned.adoc
 
 //Platforms that must use `ccoctl` and update content
 ifeval::["{context}" == "configuring-iam-ibm-cloud"]
@@ -117,6 +118,9 @@ ifeval::["{context}" == "installing-azure-private"]
 :azure-workload-id:
 endif::[]
 ifeval::["{context}" == "installing-azure-vnet"]
+:azure-workload-id:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-azure-installer-provisioned"]
 :azure-workload-id:
 endif::[]
 
@@ -423,5 +427,8 @@ ifeval::["{context}" == "installing-azure-private"]
 :!azure-workload-id:
 endif::[]
 ifeval::["{context}" == "installing-azure-vnet"]
+:!azure-workload-id:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-azure-installer-provisioned"]
 :!azure-workload-id:
 endif::[]

--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -31,6 +31,7 @@
 // * installing/installing_azure/installing-azure-network-customizations.adoc
 // * installing/installing_azure/installing-azure-private.adoc
 // * installing/installing_azure/installing-azure-vnet.adoc
+// * installing/installing_azure/installing-restricted-networks-azure-installer-provisioned.adoc
 
 //Platforms that must use `ccoctl`
 ifeval::["{context}" == "installing-alibaba-default"]
@@ -109,6 +110,9 @@ ifeval::["{context}" == "installing-azure-private"]
 :azure-workload-id:
 endif::[]
 ifeval::["{context}" == "installing-azure-vnet"]
+:azure-workload-id:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-azure-installer-provisioned"]
 :azure-workload-id:
 endif::[]
 
@@ -478,5 +482,8 @@ ifeval::["{context}" == "installing-azure-private"]
 :!azure-workload-id:
 endif::[]
 ifeval::["{context}" == "installing-azure-vnet"]
+:!azure-workload-id:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-azure-installer-provisioned"]
 :!azure-workload-id:
 endif::[]

--- a/modules/cco-ccoctl-install-creating-manifests.adoc
+++ b/modules/cco-ccoctl-install-creating-manifests.adoc
@@ -26,6 +26,27 @@
 // * installing/installing_azure/installing-azure-network-customizations.adoc
 // * installing/installing_azure/installing-azure-private.adoc
 // * installing/installing_azure/installing-azure-vnet.adoc
+// * installing/installing_azure/installing-restricted-networks-azure-installer-provisioned.adoc
+
+//global Azure install assemblies
+ifeval::["{context}" == "installing-azure-customizations"]
+:azure-workload-id:
+endif::[]
+ifeval::["{context}" == "installing-azure-government-region"]
+:azure-workload-id:
+endif::[]
+ifeval::["{context}" == "installing-azure-network-customizations"]
+:azure-workload-id:
+endif::[]
+ifeval::["{context}" == "installing-azure-private"]
+:azure-workload-id:
+endif::[]
+ifeval::["{context}" == "installing-azure-vnet"]
+:azure-workload-id:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-azure-installer-provisioned"]
+:azure-workload-id:
+endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="cco-ccoctl-install-creating-manifests_{context}"]
@@ -52,6 +73,23 @@ credentialsMode: Manual
 # ...
 ----
 
+ifdef::azure-workload-id[]
+. If you used the `ccoctl` utility to create a new Azure resource group instead of using an existing resource group, modify the `resourceGroupName` parameter in the `install-config.yaml` as shown:
++
+.Sample configuration file snippet
+[source,yaml]
+----
+apiVersion: v1
+baseDomain: example.com
+# ...
+platform:
+  azure:
+    resourceGroupName: <azure_infra_name> # <1>
+# ...
+----
+<1> This value must match the user-defined name for Azure resources that was specified with the `--name` argument of the `ccoctl azure create-all` command.
+endif::azure-workload-id[]
+
 . If you have not previously created installation manifest files, do so by running the following command:
 +
 [source,terminal]
@@ -72,3 +110,23 @@ $ cp /<path_to_ccoctl_output_dir>/manifests/* ./manifests/
 ----
 $ cp -a /<path_to_ccoctl_output_dir>/tls .
 ----
+
+//global Azure install assemblies
+ifeval::["{context}" == "installing-azure-customizations"]
+:!azure-workload-id:
+endif::[]
+ifeval::["{context}" == "installing-azure-government-region"]
+:!azure-workload-id:
+endif::[]
+ifeval::["{context}" == "installing-azure-network-customizations"]
+:!azure-workload-id:
+endif::[]
+ifeval::["{context}" == "installing-azure-private"]
+:!azure-workload-id:
+endif::[]
+ifeval::["{context}" == "installing-azure-vnet"]
+:!azure-workload-id:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-azure-installer-provisioned"]
+:!azure-workload-id:
+endif::[]

--- a/modules/manually-create-identity-access-management.adoc
+++ b/modules/manually-create-identity-access-management.adoc
@@ -29,6 +29,7 @@
 // * installing/installing_azure/installing-azure-network-customizations.adoc
 // * installing/installing_azure/installing-azure-private.adoc
 // * installing/installing_azure/installing-azure-vnet.adoc
+// * installing/installing_azure/installing-restricted-networks-azure-installer-provisioned.adoc
 
 //Platforms that must manually create IAM
 ifeval::["{context}" == "installing-azure-stack-hub-default"]
@@ -126,6 +127,10 @@ ifeval::["{context}" == "installing-azure-private"]
 :cco-multi-mode:
 endif::[]
 ifeval::["{context}" == "installing-azure-vnet"]
+:azure:
+:cco-multi-mode:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-azure-installer-provisioned"]
 :azure:
 :cco-multi-mode:
 endif::[]
@@ -414,6 +419,10 @@ ifeval::["{context}" == "installing-azure-private"]
 :!cco-multi-mode:
 endif::[]
 ifeval::["{context}" == "installing-azure-vnet"]
+:!azure:
+:!cco-multi-mode:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-azure-installer-provisioned"]
 :!azure:
 :!cco-multi-mode:
 endif::[]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OCPBUGS-23345](https://issues.redhat.com/browse/OCPBUGS-23345)

Peer reviewers: will squash after QE has a chance to verify the second commit :+1: 

Link to docs preview:
Incorporating the Cloud Credential Operator utility manifests in:
- [Installing a cluster on Azure with customizations](https://68162--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-customizations#cco-ccoctl-install-creating-manifests_installing-azure-customizations)
- [Installing a cluster on Azure with network customizations](https://68162--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-network-customizations#cco-ccoctl-install-creating-manifests_installing-azure-network-customizations)
- [Installing a cluster on Azure into an existing VNet](https://68162--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-vnet#cco-ccoctl-install-creating-manifests_installing-azure-vnet)
- [Installing a private cluster on Azure](https://68162--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-private#cco-ccoctl-install-creating-manifests_installing-azure-private)

Conditioned so it does not appear in e.g. [AWS](https://68162--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations#cco-ccoctl-install-creating-manifests_installing-aws-customizations) version of same.

Also added the [missing](https://github.com/openshift/openshift-docs/pull/68162#issuecomment-1828018489) AADWID install steps to the restricted network use case:
- [Alternatives to storing administrator-level secrets in the kube-system project](https://68162--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-restricted-networks-azure-installer-provisioned#installing-azure-manual-modes_installing-restricted-networks-azure-installer-provisioned)

QE review:
- [ ] QE has approved this change.

Additional information: