### PR TITLE
OSDOCS-8764 z-stream release notes 4.13.23

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -3479,3 +3479,44 @@ $ oc adm release info 4.13.22 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-13-23"]
+=== RHSA-2023:7323 - {product-title} 4.13.23 bug fix and security update
+
+Issued: 2023-11-21
+
+{product-title} release 4.13.23, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:7323[RHSA-2023:7323] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7325[RHSA-2023:7325] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.23 --pullspecs
+----
+
+
+[id="ocp-4-13-23-features"]
+==== Features
+
+[id="ocp-4-13-23-oc-logging-in-browser"]
+===== Logging in to the CLI using a web browser
+
+With this release, a new `oc` command-line interface (CLI) flag, `--web` is now available for the `oc login` command.
+
+With this enhancement, you can log in using a web browser, which allows you to avoid inserting your access token into the command line.
+
+For more information, see xref:../cli_reference/openshift_cli/getting-started-cli.adoc#cli-logging-in-web_cli-developer-commands[Logging in to the OpenShift CLI using a web browser].
+
+[id="ocp-4-13-23-bug-fixes"]
+==== Bug fixes
+
+* Previously, Ironic was not able to provision Cisco UCS hardware as a new baremetalhost because not all Redfish Virtual Media devices could be used to provision the hardware. With this release, Ironic looks at all possible devices to provision the hardware so Cisco UCS Hardware can now be provisioned using Redfish Virtual Media. (link:https://issues.redhat.com/browse/OCPBUGS-19078[*OCPBUGS-19078*])
+
+* Previously, metallb's controller restarted while having an IP assigned and unassigned LB services. This caused metallb's controller to move an already assigned IP to a different LB service which would break workloads. With this release, metallb's controller processes the services which already have an IP assigned. (link:https://issues.redhat.com/browse/OCPBUGS-23160[*OCPBUGS-23160*])
+
+[id="ocp-4-13-23-updating"]
+==== Updating
+
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-8764](https://issues.redhat.com/browse/OSDOCS-8764)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Preview](https://68163--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes#ocp-4-13-23)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
not needed
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Expected merge date is 11/21/2023, links will not work until then.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
