### PR TITLE
OCPBUGS-20416: fixes typo in command DNS Operator

### DIFF
--- a/modules/nw-external-dns-operator.adoc
+++ b/modules/nw-external-dns-operator.adoc
@@ -28,7 +28,7 @@ install-zcvlr
 +
 [source,terminal]
 ----
-$ oc -n external-dns-operator get ip <install_plan_name> -o yaml | yq .status.phase'
+$ oc -n external-dns-operator get ip <install_plan_name> -o yaml | yq '.status.phase'
 ----
 +
 .Example output


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OCPBUGS-20416
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://68169--docspreview.netlify.app/openshift-enterprise/latest/networking/external_dns_operator/understanding-external-dns-operator#external-dns-operator:~:text=install%2Dzcvlr-,Check,-the%20status%20of
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
PTAL @alebedev87 and @lihongan 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
