### PR TITLE
OSDOCS-8359: Added the rosa describe machine pool command

### DIFF
--- a/modules/creating-a-machine-pool-cli.adoc
+++ b/modules/creating-a-machine-pool-cli.adoc
@@ -114,7 +114,9 @@ I: To view all machine pools, run 'rosa list machinepools -c mycluster'
 
 .Verification
 
-. List the available machine pools in your cluster:
+You can list all machine pools on your cluster or describe individual machine pools.
+
+. List the available machine pools on your cluster:
 +
 [source,terminal]
 ----
@@ -127,6 +129,30 @@ $ rosa list machinepools --cluster=<cluster_name>
 ID             AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS                  TAINTS    AVAILABILITY ZONES                    SPOT INSTANCES
 Default        No           3         m5.xlarge                                        us-east-1a, us-east-1b, us-east-1c    N/A
 mymachinepool  Yes          3-6       m5.xlarge      app=db, tier=backend              us-east-1a, us-east-1b, us-east-1c    No
+----
+
+. Describe the information of a specific machine pool in your cluster:
++
+[source,terminal]
+----
+$ rosa describe machinepool --cluster=<cluster_name> mymachinepool
+----
++
+.Example output
+[source,terminal]
+----
+ID:                         mymachinepool
+Cluster ID:                 27iimopsg1mge0m81l0sqivkne2qu6dr
+Autoscaling:                Yes
+Replicas:                   3-6
+Instance type:              m5.xlarge
+Labels:                     app=db, tier=backend
+Taints:
+Availability zones:         us-east-1a, us-east-1b, us-east-1c
+Subnets:
+Spot instances:             No
+Disk size:                  300 GiB
+Security Group IDs:
 ----
 
 . Verify that the machine pool is included in the output and the configuration is as expected.

--- a/modules/rosa-adding-node-labels.adoc
+++ b/modules/rosa-adding-node-labels.adoc
@@ -99,19 +99,28 @@ I: Updated machine pool 'db-nodes-mp' on cluster 'mycluster'
 
 .Verification
 
-. List the available machine pools in your cluster:
+. Describe the details of the machine pool with the new labels:
 +
 [source,terminal]
 ----
-$ rosa list machinepools --cluster=<cluster_name>
+$ rosa describe machinepool --cluster=<cluster_name> <machine-pool-name>
 ----
 +
 .Example output
 [source,terminal]
 ----
-ID           AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS                  TAINTS    AVAILABILITY ZONES    SPOT INSTANCES   DISK SIZE   SG IDs
-Default      No           2         m5.xlarge                                        us-east-1a            N/A              300 GiB     sg-0e375ff0ec4a6cfa2
-db-nodes-mp  No           2         m5.xlarge      app=db, tier=backend              us-east-1a            No               300 GiB     sg-0e375ff0ec4a6cfa2
+ID:                         db-nodes-mp
+Cluster ID:                 <ID_of_cluster>
+Autoscaling:                No
+Replicas:                   2
+Instance type:              m5.xlarge
+Labels:                     app=db, tier=backend
+Taints:
+Availability zones:         us-east-1a
+Subnets:
+Spot instances:             No
+Disk size:                  300 GiB
+Security Group IDs:
 ----
 
 . Verify that the labels are included for your machine pool in the output.

--- a/modules/rosa-adding-taints-cli.adoc
+++ b/modules/rosa-adding-taints-cli.adoc
@@ -100,19 +100,28 @@ I: Updated machine pool 'db-nodes-mp' on cluster 'mycluster'
 
 .Verification
 
-. List the available machine pools in your cluster by running the following command:
+. Describe the details of the machine pool with the new taints:
 +
 [source,terminal]
 ----
-$ rosa list machinepools --cluster=<cluster_name>
+$ rosa describe machinepool --cluster=<cluster_name> <machine-pool-name>
 ----
 +
 .Example output
 [source,terminal]
 ----
-ID           AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS    TAINTS                                           AVAILABILITY ZONES    SPOT INSTANCES  DISK SIZE   SG IDs
-Default      No           2         m5.xlarge                                                                 us-east-1a            N/A             300GiB      sg-0e375ff0ec4a6cfa2
-db-nodes-mp  No           2         m5.xlarge                key1=value1:NoSchedule, key2=value2:NoExecute    us-east-1a            No              300GiB      sg-0e375ff0ec4a6cfa2
+ID:                         db-nodes-mp
+Cluster ID:                 <ID_of_cluster>
+Autoscaling:                No
+Replicas:                   2
+Instance type:              m5.xlarge
+Labels:
+Taints:                     key1=value1:NoSchedule, key2=value2:NoExecute
+Availability zones:         us-east-1a
+Subnets:
+Spot instances:             No
+Disk size:                  300 GiB
+Security Group IDs:
 ----
 
 . Verify that the taints are included for your machine pool in the output.

--- a/modules/rosa-adding-tuning.adoc
+++ b/modules/rosa-adding-tuning.adoc
@@ -16,14 +16,14 @@ This feature is only supported on {hcp-title-first} clusters.
 .Prerequisites
 
 * You installed and configured the latest {product-title} (ROSA) CLI, `rosa`, on your workstation.
-* You logged in to your Red Hat account using the ROSA CLI.
+* You logged in to your Red Hat account by using the ROSA CLI.
 * You created a {hcp-title-first} cluster.
 * You have an existing machine pool.
 * You have an existing tuning configuration.
 
 .Procedure
 
-. List the machine pools in the cluster:
+. List all of the machine pools in the cluster:
 +
 [source,terminal]
 ----
@@ -34,9 +34,9 @@ $ rosa list machinepools --cluster=<cluster_name>
 +
 [source,terminal]
 ----
-ID           AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS    TAINTS    AVAILABILITY ZONES    SUBNETS  VERSION  AUTOREPAIR  TUNING CONFIGS  MESSAGE
-Default      No           2         m5.xlarge                          us-east-1a            N/A      4.12.14  Yes
-db-nodes-mp  No           2         m5.xlarge                          us-east-1a            No       4.12.14  Yes         
+ID          AUTOSCALING  REPLICAS  INSTANCE TYPE [...] AVAILABILITY ZONES  SUBNET  VERSION  AUTOREPAIR  TUNING CONFIGS
+workers      No           2         m5.xlarge    [...] us-east-1a          N/A     4.12.14  Yes
+db-nodes-mp  No           2         m5.xlarge    [...] us-east-1a          No      4.12.14  Yes
 ----
 
 . You can add tuning configurations to an existing or new machine pool.
@@ -81,9 +81,9 @@ $ rosa list machinepools --cluster=<cluster_name>
 .Example output
 [source,terminal]
 ----
-ID          AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS  TAINTS  AVAILABILITY ZONES  SUBNET  VERSION  AUTOREPAIR  TUNING CONFIGS MESSAGE
-Default      No           2         m5.xlarge                     us-east-1a          N/A     4.12.14  Yes
-db-nodes-mp  No           2         m5.xlarge                     us-east-1a          No      4.12.14  Yes          sample-tuning
+ID          AUTOSCALING  REPLICAS  INSTANCE TYPE [...] AVAILABILITY ZONES  SUBNET  VERSION  AUTOREPAIR  TUNING CONFIGS
+workers      No           2         m5.xlarge    [...] us-east-1a          N/A     4.12.14  Yes
+db-nodes-mp  No           2         m5.xlarge    [...] us-east-1a          No      4.12.14  Yes          sample-tuning
 ----
 
 . Verify that the tuning config is included for your machine pool in the output.


### PR DESCRIPTION
Version(s):
`enterprise-4.14+`

Issue:
[OSDOCS-8359](https://issues.redhat.com/browse/OSDOCS-8359)

Link to docs preview:

Added `rosa describe` to these two sections: 
 - [Adding taints to a machine pool](https://file.rdu.redhat.com/eponvell/OSDOCS-8359_machine-pool-describe/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html#rosa-adding-taints-clirosa-managing-worker-nodes)
 - [Adding node labels to a machine pool](https://file.rdu.redhat.com/eponvell/OSDOCS-8359_machine-pool-describe/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html#rosa-adding-node-labels_rosa-managing-worker-nodes)

Since tuning-configs aren't displayed with `rosa describe`, I omitted the empty columns to reduce the space in the `rosa list` output.
 *  [Adding node tuning to a machine pool](https://file.rdu.redhat.com/eponvell/OSDOCS-8359_machine-pool-describe/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html#rosa-adding-tuning_rosa-managing-worker-nodes)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added a verification step that uses `rosa describe machinepool`