### PR TITLE
Update ipi-install-replacing-a-bare-metal-control-plane-node.adoc with correct versions. (4.13)

### DIFF
--- a/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
+++ b/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
@@ -39,7 +39,7 @@ $ oc get clusteroperator baremetal
 [source,terminal]
 ----
 NAME        VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
-baremetal   4.12.0   True        False         False      3d15h
+baremetal   4.13.0   True        False         False      3d15h
 ----
 
 . Remove the old `BareMetalHost` and `Machine` objects:
@@ -179,11 +179,11 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS      ROLES     AGE   VERSION
-control-plane-1.example.com    available   master    4m2s  v1.18.2
-control-plane-2.example.com    available   master    141m  v1.18.2
-control-plane-3.example.com    available   master    141m  v1.18.2
-compute-1.example.com          available   worker    87m   v1.18.2
-compute-2.example.com          available   worker    87m   v1.18.2
+control-plane-1.example.com    available   master    4m2s  v1.26.9
+control-plane-2.example.com    available   master    141m  v1.26.9
+control-plane-3.example.com    available   master    141m  v1.26.9
+compute-1.example.com          available   worker    87m   v1.26.9
+compute-2.example.com          available   worker    87m   v1.26.9
 ----
 +
 [NOTE]


### PR DESCRIPTION
Manual cherry pick for #68180 

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13

Issue:
OCP version updated to 4.13
Node version updated to: v1.26.9


Link to docs preview:
https://docs.openshift.com/container-platform/4.13/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html#replacing-a-bare-metal-control-plane-node_ipi-install-expanding

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

