### PR TITLE
WIP: OSDOCS-8784 Conditioned out FedRAMP footnote from ROSA docs.

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -126,7 +126,9 @@ endif::fedramp[]
 [.small]
 --
 1. In a firewall environment, ensure that the `access.redhat.com` resource is on the allowlist. This resource hosts a signature store that a container client requires for verifying images when pulling them from `registry.access.redhat.com`.
+ifdef::fedramp[]
 2. Both TCP and UDP ports.
+endif::fedramp[]
 --
 +
 When you add a site such as `quay.io` to your allowlist, do not add a wildcard entry such as `*.quay.io` to your denylist. In most cases, image registries use a content delivery network (CDN) to serve images. If a firewall blocks access, then image downloads are denied when the initial download request is redirected to a host name such as `cdn01.quay.io`.


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-8784

Link to docs preview:
- NIST URLs and footnote 2 do not appear in [OSD planning doc](https://68184--docspreview.netlify.app/openshift-dedicated/latest/osd_planning/aws-ccs#osd-aws-privatelink-firewall-prerequisites_aws-ccs)
- NIST URLs and footnote 2 do not appear in [non-STS  ROSA doc](https://68184--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_prerequisites)
- NIST URLs and footnote 2 do still appear in [STS ROSA doc](https://68184--docspreview.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs)

QE review:
- Not required for this change
