### PR TITLE
OSDOCS#8037: Added secgroups to cluster and machine pool creation via UI

### DIFF
--- a/modules/creating-a-machine-pool-cli.adoc
+++ b/modules/creating-a-machine-pool-cli.adoc
@@ -45,7 +45,7 @@ endif::openshift-rosa[]
 ifdef::openshift-rosa[]
 <8> Optional: Specifies the worker node disk size. The value can be in GB, GiB, TB, or TiB. Replace `<disk_size>` with a numeric value and unit, for example `--disk-size=200GiB`.
 <9> Optional: For Multi-AZ clusters, you can create a machine pool in a Single-AZ of your choice. Replace `<az>` with a Single-AZ.
-<10> Optional: For machine pools in clusters that do not have Red Hat managed VPCs, you can select additional custom security groups to use in your machine pools. You must have already created the security groups and associated them with the VPC you selected for this cluster. For more information, see the requirements for _Security groups_ in _Prepare your environment_.
+<10> Optional: For machine pools in clusters that do not have Red Hat managed VPCs, you can select additional custom security groups to use in your machine pools. You must have already created the security groups and associated them with the VPC you selected for this cluster. You cannot add or edit security groups after you create the machine pool. For more information, see the requirements for _Security groups_ under _Additional resources_.
 endif::openshift-rosa[]
 +
 [IMPORTANT]

--- a/modules/creating-a-machine-pool-ocm.adoc
+++ b/modules/creating-a-machine-pool-ocm.adoc
@@ -41,7 +41,7 @@ ifdef::openshift-rosa[]
 endif::openshift-rosa[]
 ifndef::openshift-rosa[]
 * You created an {product-title} cluster.
-endif::[]
+endif::openshift-rosa[]
 
 .Procedure
 
@@ -51,7 +51,7 @@ endif::[]
 
 . Add a *Machine pool name*.
 
-. Select a *Worker node instance type* from the drop-down menu. The instance type defines the vCPU and memory allocation for each compute node in the machine pool.
+. Select a *Compute node instance type* from the drop-down menu. The instance type defines the vCPU and memory allocation for each compute node in the machine pool.
 +
 [NOTE]
 ====
@@ -77,8 +77,8 @@ Alternatively, you can set your autoscaling preferences for the machine pool aft
 ====
 
 . If you did not enable autoscaling, select a compute node count:
-* If you deployed your cluster using a single availability zone, select a *Worker node count* from the drop-down menu. This defines the number of compute nodes to provision to the machine pool for the zone.
-* If you deployed your cluster using multiple availability zones, select a *Worker node count (per zone)* from the drop-down menu. This defines the number of compute nodes to provision to the machine pool per zone.
+* If you deployed your cluster using a single availability zone, select a *Compute node count* from the drop-down menu. This defines the number of compute nodes to provision to the machine pool for the zone.
+* If you deployed your cluster using multiple availability zones, select a *Compute node count (per zone)* from the drop-down menu. This defines the number of compute nodes to provision to the machine pool per zone.
 ifdef::openshift-rosa[]
 . Optional: Configure *Root disk size*.
 endif::openshift-rosa[]
@@ -97,6 +97,10 @@ Creating a machine pool with taints is only possible if the cluster already has 
 ====
 Alternatively, you can add the node labels and taints after you create the machine pool.
 ====
+
+ifdef::openshift-rosa[]
+. Optional: Select additional custom security groups to use for nodes in this machine pool. You must have already created the security groups and associated them with the VPC you selected for this cluster. You cannot add or edit security groups after you create the machine pool. For more information, see the requirements for _Security groups_ under _Additional resources_.
+endif::openshift-rosa[]
 
 ifdef::openshift-dedicated[]
 . Optional: If you deployed {product-title} on AWS using the Customer Cloud Subscription (CCS) model, use Amazon EC2 Spot Instances if you want to configure your machine pool to deploy machines as non-guaranteed AWS Spot Instances:

--- a/modules/rosa-create-objects.adoc
+++ b/modules/rosa-create-objects.adoc
@@ -117,7 +117,7 @@ $ rosa create cluster --cluster-name=<cluster_name> [arguments]
 |Option |Definition
 
 |--additional-compute-security-group-ids <sec_group_id>
-|The identifier of one or more additional security groups to use in addition to the default security groups. For more information on additional security groups, see the requirements for _Security groups_ in _Prepare your environment_.
+|The identifier of one or more additional security groups to use in addition to the default security groups. For more information on additional security groups, see the requirements for _Security groups_ under _Additional resources_.
 
 a|--cluster-name <cluster_name>
 |Required. The name of the cluster. When used with the `create cluster` command, this argument is used to set the cluster name and to generate a sub-domain for your cluster on `openshiftapps.com`. The value for this argument must be unique within your organization.
@@ -505,7 +505,7 @@ $ rosa create machinepool --cluster=<cluster_name> | <cluster_id> --replicas=<nu
 
 // Note for writers: This command works the same way as rosa create --additional-compute-security-group-ids but all subsequent machinepools are compute only so we don't specify compute here yet; consistency across commands to come in OCM-3111.
 |--additional-security-group-ids <sec_group_id>
-|The identifier of one or more additional security groups to use in addition to the default security groups for this machine pool. For more information on additional security groups, see the requirements for _Security groups_ in _Prepare your environment_.
+|The identifier of one or more additional security groups to use in addition to the default security groups for this machine pool. For more information on additional security groups, see the requirements for _Security groups_ under _Additional resources_.
 
 a|--cluster <cluster_name>\|<cluster_id>
 |Required: The name or ID of the cluster to which the machine pool will be added.

--- a/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
@@ -293,7 +293,7 @@ Only persistent volumes (PVs) created from the default storage class are encrypt
 PVs created by using any other storage class are still encrypted, but the PVs are not encrypted with this key unless the storage class is specifically configured to use this key.
 ====
 
-<10> Optional: You can select additional custom security groups to use in your cluster. You must have already created the security groups and associated them with the VPC you selected for this cluster. For more information, see the requirements for _Security groups_ in _Prepare your environment_.
+<10> Optional: You can select additional custom security groups to use in your cluster. You must have already created the security groups and associated them with the VPC you selected for this cluster. You cannot add or edit security groups for the default machine pools after you create the machine pool. For more information, see the requirements for _Security groups_ under _Additional resources_.
 <11> Optional: Enable this option only if your use case requires etcd key value encryption in addition to the control plane storage encryption that encrypts the etcd volumes by default. With this option, the etcd key values are encrypted but not the keys.
 +
 [IMPORTANT]

--- a/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
@@ -301,6 +301,12 @@ If you opted to use private API endpoints, you must use an existing VPC and Priv
 ====
 You must ensure that your VPC is configured with a public and a private subnet for each availability zone that you want the cluster installed into. If you opted to use PrivateLink, only private subnets are required.
 ====
+// Commented out until OCMUI-302 and OCMUI-1039 are complete
+//.. Optional: Expand *Additional security groups* and select additional custom security groups to apply to nodes in the machine pools created by default. You must have already created the security groups and associated them with the VPC you selected for this cluster. You cannot add or edit security groups to the default machine pools after you create the cluster.
+//+
+//By default, the security groups you specify will be added for all node types. Uncheck the *Apply the same security groups to all node types* checkbox to apply different security groups for each node type.
+//+
+//For more information, see the requirements for _Security groups_ under _Additional resources_.
 
 . If you opted to configure a cluster-wide proxy, provide your proxy configuration details on the *Cluster-wide proxy* page:
 +

--- a/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc
+++ b/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc
@@ -13,6 +13,11 @@ You can edit machine pool configuration options such as scaling, adding node lab
 
 include::modules/creating-a-machine-pool.adoc[leveloffset=+1]
 include::modules/creating-a-machine-pool-ocm.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc#rosa-security-groups_prerequisites[Security groups]
+
 include::modules/creating-a-machine-pool-cli.adoc[leveloffset=+2]
 
 [role="_additional-resources"]


### PR DESCRIPTION
This PR is for the ROSA Day 1 Security Groups UI release which is scheduled for 27 Nov.
DO NOT MERGE until 27 Nov 2023.

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-8037

Link to docs preview:
- https://68185--docspreview.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes#creating_machine_pools_ocm_rosa-managing-worker-nodes
- https://68185--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations#rosa-sts-creating-cluster-customizations-ocm_rosa-sts-creating-a-cluster-with-customizations

- Also updated CLI process to note that secgroups configuration cannot be changed after creation of cluster or machine pool:
- https://68185--docspreview.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes#creating_machine_pools_cli_rosa-managing-worker-nodes
- https://68185--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations#rosa-sts-creating-cluster-customizations-cli_rosa-sts-creating-a-cluster-with-customizations

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->