### PR TITLE
PR for SRVOCF-568: Updated the tekton task links in the "Creating a function in the web console" section and deleted from the "Building and deploying a function on the cluster"section.

### DIFF
--- a/modules/odc-creating-functions.adoc
+++ b/modules/odc-creating-functions.adoc
@@ -18,19 +18,19 @@ You can create a function from a Git repository by using the *Developer* perspec
 .func-s2i task
 [source,terminal]
 ----
-$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.30/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
+$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.31/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
 ----
 +
 .func-deploy task
 [source,terminal]
 ----
-$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.30/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
+$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.31/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
 ----
 +
 .Node.js function
 [source,terminal]
 ----
-$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.30/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
+$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.31/pkg/pipelines/resources/tekton/pipeline/dev-console/0.1/nodejs-pipeline.yaml
 ----
 
 * You must log into the {ocp-product-title} web console.

--- a/modules/serverless-functions-creating-on-cluster-builds.adoc
+++ b/modules/serverless-functions-creating-on-cluster-builds.adoc
@@ -18,22 +18,6 @@ You can use the Knative (`kn`) CLI to initiate a function project build and then
 
 .Procedure
 
-. Create the following resources:
-
-.. Create the `s2i` Tekton task to be able to use Source-to-Image in the pipeline:
-+
-[source,terminal]
-----
-$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.31/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
-----
-
-.. Create the `kn func` deploy Tekton task to be able to deploy the function in the pipeline:
-+
-[source,terminal]
-----
-$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.31/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
-----
-
 . Create a function:
 +
 [source,terminal]


### PR DESCRIPTION
**Affected versions for cherry-picking:** Serverless 1.31

**Dedicated JIRA:** https://issues.redhat.com/browse/SRVOCF-568

**Description & Doc preview:** 
* In the **[Creating a function in the web console](https://68186--docspreview.netlify.app/openshift-serverless/latest/functions/serverless-functions-creating#odc-creating-functions_serverless-functions-creating)** section, updated the `func-s2i`, `func-deploy task`, `Node.js function` links for 1.31
* In the **[Building and deploying a function on the cluster](https://68186--docspreview.netlify.app/openshift-serverless/latest/functions/serverless-functions-on-cluster-builds#serverless-functions-creating-on-cluster-builds_serverless-functions-on-cluster-builds)** section, removed the links present in step no. 1 (a&b) for 1.31.