### PR TITLE
OSDOCS-6894:Added ControlPlaneMachineSet support for vSphere

### DIFF
--- a/machine_management/control_plane_machine_management/cpmso-configuration.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-configuration.adoc
@@ -97,6 +97,13 @@ Some sections of the control plane machine set CR are provider-specific. The fol
 //Sample VMware vSphere provider specification
 include::modules/cpmso-yaml-provider-spec-vsphere.adoc[leveloffset=+2]
 
+//Sample VMware vSphere failure domain configuration
+include::modules/cpmso-yaml-failure-domain-vsphere.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* For an example of a cluster-wide infrastructure CRD that defines resources for each failure domain, see xref:../../post_installation_configuration/post-install-vsphere-zones-regions-configuration.adoc#specifying-regions-zones-infrastructure-vsphere_post-install-vsphere-zones-regions-configuration[Specifying multiple regions and zones for your cluster on vSphere]
+
 [id="cpmso-sample-yaml-openstack_{context}"]
 == Sample YAML for configuring {rh-openstack-first} clusters
 

--- a/machine_management/control_plane_machine_management/cpmso-getting-started.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-getting-started.adoc
@@ -49,8 +49,8 @@ The status of the control plane machine set after installation depends on your c
 |
 
 |VMware vSphere
-|
-|
+|X ^[4]^
+|X ^[4]^
 |X
 
 |{rh-openstack-first}
@@ -63,6 +63,7 @@ The status of the control plane machine set after installation depends on your c
 1. AWS clusters that are upgraded from version 4.11 or earlier require xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-activating_cpmso-getting-started[CR activation].
 2. GCP and Azure clusters that are upgraded from version 4.12 or earlier require xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-activating_cpmso-getting-started[CR activation].
 3. Nutanix and {rh-openstack} clusters that are upgraded from version 4.13 or earlier require xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-activating_cpmso-getting-started[CR activation].
+4. In {product-title} {product-version}, installing a cluster with an active generated CR on VWware vSphere is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] feature. To enable the feature, set the `featureSet` parameter to `TechPreviewNoUpgrade` in the `install-config.yaml file`.
 --
 
 //Checking the control plane machine set custom resource state

--- a/modules/cpmso-creating-cr.adoc
+++ b/modules/cpmso-creating-cr.adoc
@@ -67,11 +67,6 @@ Before you activate the CR, you must ensure that its configuration is correct fo
 <3> Specify the update strategy for the cluster. Valid values are `OnDelete` and `RollingUpdate`. The default value is `RollingUpdate`. For more information about update strategies, see "Updating the control plane configuration".
 <4> Specify your cloud provider platform name. Valid values are `AWS`, `Azure`, `GCP`, `Nutanix`, `VSphere`, and `OpenStack`.
 <5> Add the `<platform_failure_domains>` configuration for the cluster. The format and values of this section are provider-specific. For more information, see the sample failure domain configuration for your cloud provider.
-+
-[NOTE]
-====
-VMware vSphere does not support failure domains. For vSphere clusters, replace `<platform_failure_domains>` with an empty `failureDomains:` parameter.
-====
 <6> Specify the infrastructure ID.
 <7> Add the `<platform_provider_spec>` configuration for the cluster. The format and values of this section are provider-specific. For more information, see the sample provider specification for your cloud provider.
 --

--- a/modules/cpmso-yaml-failure-domain-vsphere.adoc
+++ b/modules/cpmso-yaml-failure-domain-vsphere.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * machine_management/cpmso-configuration.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="cpmso-yaml-failure-domain-vsphere_{context}"]
+= Sample VMware vSphere failure domain configuration
+
+On VMware vSphere infrastructure, the cluster-wide infrastructure Custom Resource Definition (CRD), `infrastructures.config.openshift.io`, defines failure domains for your cluster. The `providerSpec` in the `ControlPlaneMachineSet` custom resource (CR) specifies names for failure domains. A failure domain is an infrastructure resource that comprises a control plane machine set, a vCenter datacenter, vCenter datastore, and a network. 
+
+By using a failure domain resource, you can use a control plane machine set to deploy control plane machines on hardware that is separate from the primary VMware vSphere infrastructure. A control plane machine set also balances control plane machines across defined failure domains to provide fault tolerance capabilities to your infrastructure.
+
+[NOTE]
+====
+If you modify the `ProviderSpec` configuration in the `ControlPlaneMachineSet` CR, the control plane machine set updates all control plane machines deployed on the primary infrastructure and each failure domain infrastructure.
+====
+
+:FeatureName: Defining a failure domain for a control plane machine set
+include::snippets/technology-preview.adoc[]
+
+.Example ProviderSpec configuration with specified failure domain names
+[source,yaml]
+----
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+metadata:
+  name: cluster
+  namespace: openshift-machine-api
+spec:
+# ...
+  template:
+    machineType: machines_v1beta1_machine_openshift_io
+    machines_v1beta1_machine_openshift_io:
+      failureDomains: <1>
+        platform: VSphere
+        vsphere: <2>
+        - name: <failure_domain_name1>
+        - name: <failure_domain_name2> 
+# ...    
+----
+<1> A failure domain defines the vCenter location for {product-title} cluster nodes.
+<2> Defines failure domains by name for the control plane machine set.
+
+[IMPORTANT]
+====
+Each `failureDomains.platform.vsphere.name` field value in the `ControlPlaneMachineSet` CR must match the corresponding value defined in the `failureDomains.name` field of the cluster-wide infrastructure CRD. Currently, the `vsphere.name` field is the only supported failure domain field that you can specify in the `ControlPlaneMachineSet` CR.
+====

--- a/modules/cpmso-yaml-sample-cr.adoc
+++ b/modules/cpmso-yaml-sample-cr.adoc
@@ -59,9 +59,4 @@ Before you activate the Operator, you must ensure that the `ControlPlaneMachineS
 <5> Specifies the update strategy for the cluster. The allowed values are `OnDelete` and `RollingUpdate`. The default value is `RollingUpdate`. For more information about update strategies, see "Updating the control plane configuration".
 <6> Specifies the cloud provider platform name. Do not change this value.
 <7> Specifies the `<platform_failure_domains>` configuration for the cluster. The format and values of this section are provider-specific. For more information, see the sample failure domain configuration for your cloud provider.
-+
-[NOTE]
-====
-VMware vSphere does not support failure domains.
-====
 <8> Specifies the `<platform_provider_spec>` configuration for the cluster. The format and values of this section are provider-specific. For more information, see the sample provider specification for your cloud provider.

--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -38,10 +38,6 @@ ifeval::["{context}" == "installing-azure-stack-hub-user-infra"]
 :ash:
 :azure-user-infra:
 endif::[]
-ifeval::["{context}" == "installing-restricted-networks-vsphere"]
-:vsphere:
-:restricted:
-endif::[]
 ifeval::["{context}" == "installing-bare-metal"]
 :baremetal:
 endif::[]
@@ -72,6 +68,16 @@ endif::[]
 ifeval::["{context}" == "installing-vsphere"]
 :vsphere:
 :three-node-cluster:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-network-customizations"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-vsphere"]
+:vsphere:
+:restricted:
 endif::[]
 ifeval::["{context}" == "installing-platform-agnostic"]
 :baremetal:
@@ -532,6 +538,12 @@ endif::[]
 ifeval::["{context}" == "installing-vsphere"]
 :!vsphere:
 :!three-node-cluster:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-network-customizations"]
+:!vsphere:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-vsphere"]
 :!vsphere:


### PR DESCRIPTION
[OSDOCS-6894](https://issues.redhat.com/browse/OSDOCS-6894)

Version(s):
4.15 (release notes TP table update required)

Link to docs preview:
* [Supported cloud providers](https://68190--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-getting-started#cpmso-platform-matrix_cpmso-getting-started)
* [Sample VMware vSphere failure domain configuration](https://68190--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration#cpmso-yaml-failure-domain-vsphere_cpmso-configuration)

SME review:
- [x] SME has approved this change.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* [Git Gist](https://gist.github.com/rvanderp3/c74a19970d4878cc1da820e3d763495b)
* [GH update](https://github.com/openshift/cluster-control-plane-machine-set-operator/pull/267/files)
