### PR TITLE
OSDOCS-8729: Reviewed AWS Secrets Manager on ROSA migration

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-aws-secret-manager.adoc
+++ b/cloud_experts_tutorials/cloud-experts-aws-secret-manager.adoc
@@ -17,23 +17,33 @@ toc::[]
 //   - Chris Kang
 // ---
 
-The AWS Secrets and Configuration Provider (ASCP) provides a way to expose AWS Secrets as Kubernetes storage volumes. With the ASCP, you can store and manage your secrets in Secrets Manager and then retrieve them through your workloads running on ROSA.
-
-This is made even easier and more secure through the use of AWS STS and Kubernetes PodIdentity.
+The AWS Secrets and Configuration Provider (ASCP) provides a way to expose AWS Secrets as Kubernetes storage volumes. With the ASCP, you can store and manage your secrets in Secrets Manager and then retrieve them through your workloads running on {product-title} (ROSA).
 
 [id="cloud-experts-aws-secret-manager-prerequisites"]
 == Prerequisites
 
+Ensure that you have the following resources and tools before starting this process:
+
 * A ROSA cluster deployed with STS
 * Helm 3
-* aws CLI
-* oc CLI
-* jq
+* `aws` CLI
+* `oc` CLI
+* `jq` CLI
 
+[discrete]
 [id="cloud-experts-aws-secret-manager-preparing-environment"]
-== Preparing Environment
+=== Additional environment requirements
 
-. Validate that your cluster has STS:
+. Log in to your ROSA cluster by running the following command:
++
+[source,terminal]
+----
+$ oc login --token=<your-token> --server=<your-server-url>
+----
++
+You can find your login token by accessing your cluster in {cluster-manager-url-pull}.
+
+. Validate that your cluster has STS by running the following command:
 +
 [source,terminal]
 ----
@@ -41,14 +51,16 @@ $ oc get authentication.config.openshift.io cluster -o json \
   | jq .spec.serviceAccountIssuer
 ----
 +
-You should see something like the following, if not you should not proceed, instead look to the link:https://docs.openshift.com/rosa/rosa_getting_started_sts/rosa_creating_a_cluster_with_sts/rosa-sts-creating-a-cluster-quickly.html[Red Hat documentation on creating an STS cluster].
+.Example output
 +
 [source,terminal]
 ----
 "https://xxxxx.cloudfront.net/xxxxx"
 ----
++
+If your output is different, do not proceed. See xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-a-cluster-quickly[Red Hat documentation on creating an STS cluster] before continuing this process.
 
-. Set SecurityContextConstraints to allow the CSI driver to run:
+. Set the `SecurityContextConstraints` permission to allow the CSI driver to run by running the following command:
 +
 [source,terminal]
 ----
@@ -59,7 +71,7 @@ $ oc adm policy add-scc-to-user privileged \
     system:serviceaccount:csi-secrets-store:csi-secrets-store-provider-aws
 ----
 
-. Create some environment variables to refer to later:
+. Create environment variables to use later in this process by running the following command:
 +
 [source,terminal]
 ----
@@ -71,9 +83,9 @@ $ export AWS_PAGER=""
 ----
 
 [id="cloud-experts-aws-secret-manager-deply-aws-secrets"]
-== Deploy the AWS Secrets and Configuration Provider
+== Deploying the AWS Secrets and Configuration Provider
 
-. Use Helm to register the secrets store CSI driver:
+. Use Helm to register the secrets store CSI driver by running the following command:
 +
 [source,terminal]
 ----
@@ -81,14 +93,14 @@ $ helm repo add secrets-store-csi-driver \
     https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
 ----
 
-. Update your Helm repositories:
+. Update your Helm repositories by running the following command:
 +
 [source,terminal]
 ----
 $ helm repo update
 ----
 
-. Install the secrets store CSI driver:
+. Install the secrets store CSI driver by running the following command:
 +
 [source,terminal]
 ----
@@ -96,7 +108,7 @@ $ helm upgrade --install -n csi-secrets-store \
     csi-secrets-store-driver secrets-store-csi-driver/secrets-store-csi-driver
 ----
 
-. Deploy the AWS provider:
+. Deploy the AWS provider by running the following command:
 +
 [source,terminal]
 ----
@@ -104,7 +116,7 @@ $ oc -n csi-secrets-store apply -f \
     https://raw.githubusercontent.com/rh-mobb/documentation/main/content/misc/secrets-store-csi/aws-provider-installer.yaml
 ----
 
-. Check that both Daemonsets are running:
+. Check that both Daemonsets are running by running the following command:
 +
 [source,terminal]
 ----
@@ -113,7 +125,7 @@ $ oc -n csi-secrets-store get ds \
     csi-secrets-store-driver-secrets-store-csi-driver
 ----
 
-. Label the Secrets Store CSI Driver to allow use with the restricted pod security profile:
+. Label the Secrets Store CSI Driver to allow use with the restricted pod security profile by running the following command:
 +
 [source,terminal]
 ----
@@ -123,7 +135,7 @@ $ oc label csidriver.storage.k8s.io/secrets-store.csi.k8s.io security.openshift.
 [id="cloud-experts-aws-secret-manager-create-iam-polices"]
 == Creating a Secret and IAM Access Policies
 
-. Create a secret in Secrets Manager:
+. Create a secret in Secrets Manager by running the following command:
 +
 [source,terminal]
 ----
@@ -134,7 +146,7 @@ $ SECRET_ARN=$(aws --region "$REGION" secretsmanager create-secret \
 $ echo $SECRET_ARN
 ----
 
-. Create an IAM Access Policy document:
+. Create an IAM Access Policy document by running the following command:
 +
 [source,terminal]
 ----
@@ -153,7 +165,7 @@ $ cat << EOF > policy.json
 EOF
 ----
 
-. Create an IAM Access Policy:
+. Create an IAM Access Policy by running the following command:
 +
 [source,terminal]
 ----
@@ -164,11 +176,11 @@ $ POLICY_ARN=$(aws --region "$REGION" --query Policy.Arn \
 $ echo $POLICY_ARN
 ----
 
-. Create an IAM Role trust policy document:
+. Create an IAM Role trust policy document by running the following command:
 +
 [NOTE]
 ====
-The trust policy is locked down to the default service account of a namespace you will create later.
+The trust policy is locked down to the default service account of a namespace you create later in this process.
 ====
 +
 [source,terminal]
@@ -194,7 +206,7 @@ $ cat <<EOF > trust-policy.json
 EOF
 ----
 
-. Create an IAM role:
+. Create an IAM role by running the following command:
 +
 [source,terminal]
 ----
@@ -204,7 +216,7 @@ $ ROLE_ARN=$(aws iam create-role --role-name openshift-access-to-mysecret \
 $ echo $ROLE_ARN
 ----
 
-. Attach the role to the policy:
+. Attach the role to the policy by running the following command:
 +
 [source,terminal]
 ----
@@ -215,14 +227,14 @@ $ aws iam attach-role-policy --role-name openshift-access-to-mysecret \
 [id="cloud-experts-aws-secret-manager-creating-application"]
 == Create an Application to use this secret
 
-. Create an OpenShift project:
+. Create an OpenShift project by running the following command:
 +
 [source,terminal]
 ----
 $ oc new-project my-application
 ----
 
-. Annotate the default service account to use the STS Role:
+. Annotate the default service account to use the STS Role by running the following command:
 +
 [source,terminal]
 ----
@@ -230,7 +242,7 @@ $ oc annotate -n my-application serviceaccount default \
     eks.amazonaws.com/role-arn=$ROLE_ARN
 ----
 
-. Create a secret provider class to access our secret:
+. Create a secret provider class to access our secret by running the following command:
 +
 [source,terminal]
 ----
@@ -248,7 +260,7 @@ spec:
 EOF
 ----
 
-. Create a Deployment using our secret:
+. Create a Deployment by using our secret in the following command:
 +
 [source,terminal]
 ----
@@ -280,7 +292,7 @@ spec:
 EOF
 ----
 
-. Verify the Pod has the secret mounted:
+. Verify the Pod has the secret mounted by running the following commandv:
 +
 [source,terminal]
 ----
@@ -290,21 +302,21 @@ $ oc exec -it my-application -- cat /mnt/secrets-store/MySecret
 [id="cloud-experts-aws-secret-manager-cleanup"]
 == Clean up
 
-. Delete the application:
+. Delete the application by running the following command:
 +
 [source,terminal]
 ----
 $ oc delete project my-application
 ----
 
-. Delete the secrets store csi driver:
+. Delete the secrets store csi driver by running the following command:
 +
 [source,terminal]
 ----
 $ helm delete -n csi-secrets-store csi-secrets-store-driver
 ----
 
-. Delete Security Context Constraints:
+. Delete Security Context Constraints by running the following command:
 +
 [source,terminal]
 ----
@@ -314,7 +326,7 @@ $ oc adm policy remove-scc-from-user privileged \
     system:serviceaccount:csi-secrets-store:csi-secrets-store-provider-aws
 ----
 
-. Delete the AWS provider:
+. Delete the AWS provider by running the following command:
 +
 [source,terminal]
 ----
@@ -322,7 +334,7 @@ $ oc -n csi-secrets-store delete -f \
 https://raw.githubusercontent.com/rh-mobb/documentation/main/content/misc/secrets-store-csi/aws-provider-installer.yaml
 ----
 
-. Delete AWS Roles and Policies:
+. Delete AWS Roles and Policies by running the following command:
 +
 [source,terminal]
 ----
@@ -332,7 +344,7 @@ $ aws iam delete-role --role-name openshift-access-to-mysecret
 $ aws iam delete-policy --policy-arn $POLICY_ARN
 ----
 
-. Delete the Secrets Manager secret:
+. Delete the Secrets Manager secret by running the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
`enterprise-4.14+`

Issue:
[OSDOCS-8729](https://issues.redhat.com/browse/OSDOCS-8729)

Link to docs preview:
- [Using AWS Secrets Manager CSI on ROSA with STS](https://file.rdu.redhat.com/eponvell/OSDOCS-8729_AWS-Secrets-Manager-MOBB/cloud_experts_tutorials/cloud-experts-aws-secret-manager.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Reviewed "Using AWS Secrets Manager CSI on ROSA with STS" for style and clarity. This PR requires QE approval.
