### PR TITLE
compute-fix: fixes vsphere ifdef

### DIFF
--- a/modules/installation-minimum-resource-requirements.adoc
+++ b/modules/installation-minimum-resource-requirements.adoc
@@ -184,7 +184,8 @@ endif::ibm-z[]
 ifndef::openshift-origin[]
 |Compute
 ifdef::ibm-z,ibm-power,ibm-cloud-vpc[|{op-system}]
-ifndef::ibm-z,ibm-power,ibm-cloud-vpc[|{op-system}, {op-system-base} 8.6 and later ^[3]^]
+ifndef::ibm-z,ibm-power,ibm-cloud-vpc,vsphere[|{op-system}, {op-system-base} 8.6 and later ^[3]^]
+ifdef::vsphere[|{op-system}, {op-system-base} 8.6 and later ^[2]^]
 |2
 |8 GB
 |100 GB


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
Original issue #67954
Accidentally deleted `^2^` from the Vsphere install so the footnotes need to be fixed.
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://68202--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-restricted-networks-vsphere#installation-minimum-resource-requirements_installing-restricted-networks-vsphere
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
This is putting back what was there and QE signed off on original PR.
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
