### PR TITLE
OCPBUGS-19428: Issue in file scalability_and_performance/using-cpu-ma…

### DIFF
--- a/modules/nodes-pods-plugins-about.adoc
+++ b/modules/nodes-pods-plugins-about.adoc
@@ -42,7 +42,7 @@ service DevicePlugin {
 
       // PreStartcontainer is called, if indicated by Device Plug-in during
       // registration phase, before each container start. Device plug-in
-      // can run device specific operations such as reseting the device
+      // can run device specific operations such as resetting the device
       // before making devices available to the container
       rpc PreStartcontainer(PreStartcontainerRequest) returns (PreStartcontainerResponse) {}
 }

--- a/modules/setting-up-cpu-manager.adoc
+++ b/modules/setting-up-cpu-manager.adoc
@@ -1,10 +1,10 @@
 // Module included in the following assemblies:
 //
-// * scaling_and_performance/using-cpu-manager.adoc
+// * scalability_and_performance/using-cpu-manager.adoc
 // * post_installation_configuration/node-tasks.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="seting_up_cpu_manager_{context}"]
+[id="setting_up_cpu_manager_{context}"]
 = Setting up CPU Manager
 
 .Procedure

--- a/modules/setting-up-topology-manager.adoc
+++ b/modules/setting-up-topology-manager.adoc
@@ -1,10 +1,10 @@
 // Module included in the following assemblies:
 //
-// * scaling_and_performance/using-topology-manager.adoc
+// * scalability_and_performance/using-topology-manager.adoc
 // * post_installation_configuration/node-tasks.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="seting_up_topology_manager_{context}"]
+[id="setting_up_topology_manager_{context}"]
 = Setting up Topology Manager
 
 To use Topology Manager, you must configure an allocation policy in the `KubeletConfig` custom resource (CR) named `cpumanager-enabled`. This file might exist if you have set up CPU Manager. If the file does not exist, you can create the file.


### PR DESCRIPTION
…nager.adoc

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-19428
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://68206--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/using-cpu-manager#setting_up_cpu_manager_using-cpu-manager-and-topology_manager
https://68206--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks#nodes-pods-plugins-about_post-install-node-tasks
https://68206--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks#setting_up_topology_manager_post-install-node-tasks


<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: QE is not required, this is only a spelling correction. 
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Also corrected spelling errors in comments describing the section "scalability_and_performance"
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
