### PR TITLE
TELCODOCS-1632 - api/cloudNotifications/v1/subscriptions/status/$subscription_id is no longer available

### DIFF
--- a/modules/cnf-rfhe-notifications-api-refererence.adoc
+++ b/modules/cnf-rfhe-notifications-api-refererence.adoc
@@ -18,8 +18,6 @@ Use the following API endpoints to subscribe the `cloud-event-consumer` applicat
 - `POST`: Creates a new subscription
 - `GET`: Retrieves a list of subscriptions
 * `/api/ocloudNotifications/v1/subscriptions/<subscription_id>`
-- `GET`: Returns details for the specified subscription ID
-* `api/ocloudNotifications/v1/subscriptions/status/<subscription_id>`
 - `PUT`: Creates a new status ping request for the specified subscription ID
 * `/api/ocloudNotifications/v1/health`
 - `GET`: Returns the health status of `ocloudNotifications` API
@@ -112,33 +110,6 @@ Returns details for the subscription with ID `<subscription_id>`
   "uriLocation":"http://localhost:8089/api/ocloudNotifications/v1/subscriptions/ca11ab76-86f9-428c-8d3a-666c24e34d32",
   "resource":"/cluster/node/openshift-worker-0.openshift.example.com/redfish/event"
 }
-----
-
-[discrete]
-== api/ocloudNotifications/v1/subscriptions/status/<subscription_id>
-
-[discrete]
-=== HTTP method
-
-`PUT api/ocloudNotifications/v1/subscriptions/status/<subscription_id>`
-
-[discrete]
-==== Description
-
-Creates a new status ping request for subscription with ID `<subscription_id>`. If a subscription is present, the status request is successful and a `202 Accepted` status code is returned.
-
-.Query parameters
-|===
-| Parameter | Type
-
-| `<subscription_id>`
-| string
-|===
-
-.Example API response
-[source,json]
-----
-{"status":"ping sent"}
 ----
 
 [discrete]


### PR DESCRIPTION
`api/cloudNotifications/v1/subscriptions/status/sub` is no longer available


Version(s):
enterprise-4.10+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1632

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

