### PR TITLE
virt, DPDK: Update VM Configuration

### DIFF
--- a/modules/virt-configuring-vm-dpdk.adoc
+++ b/modules/virt-configuring-vm-dpdk.adoc
@@ -30,13 +30,14 @@ spec:
         cpu-load-balancing.crio.io: disable <1>
         cpu-quota.crio.io: disable <2>
         irq-load-balancing.crio.io: disable <3>
+        kubevirt.io/CPUManagerPolicyBetaOptions: full-pcpus-only <4>
     spec:
       nodeSelector:
-        node-role.kubernetes.io/worker-dpdk: "" <4>
+        node-role.kubernetes.io/worker-dpdk: "" <5>
       domain:
         cpu:
-          sockets: 1 <5>
-          cores: 5 <6>
+          sockets: 1 <6>
+          cores: 5 <7>
           threads: 2
           dedicatedCpuPlacement: true
           isolateEmulatorThread: true
@@ -51,24 +52,25 @@ spec:
           rng: {}
       memory:
         hugepages:
-          pageSize: 1Gi <7>
+          pageSize: 1Gi <8>
           guest: 8Gi
       networks:
         - name: default
           pod: {}
         - multus:
-            networkName: dpdk-net <8>
+            networkName: dpdk-net <9>
           name: nic-east
 # ...
 ----
 <1> This annotation specifies that load balancing is disabled for CPUs that are used by the container.
 <2> This annotation specifies that the CPU quota is disabled for CPUs that are used by the container.
 <3> This annotation specifies that Interrupt Request (IRQ) load balancing is disabled for CPUs that are used by the container.
-<4> The label that is used in the `MachineConfigPool` and `PerformanceProfile` manifests that were created when configuring the cluster for DPDK workloads.
-<5> The number of sockets inside the VM. This field must be set to `1` for the CPUs to be scheduled from the same Non-Uniform Memory Access (NUMA) node.
-<6> The number of cores inside the VM. This must be a value greater than or equal to `1`. In this example, the VM is scheduled with 5 hyper-threads or 10 CPUs.
-<7> The size of the huge pages. The possible values for x86-64 architecture are 1Gi and 2Mi. In this example, the request is for 8 huge pages of size 1Gi.
-<8> The name of the SR-IOV `NetworkAttachmentDefinition` object.
+<4> This annotation causes KubeVirt to request two dedicated CPUs for emulator thread isolation - required when running on compute nodes with Simultaneous Multithreading (SMT) enabled.
+<5> The label that is used in the `MachineConfigPool` and `PerformanceProfile` manifests that were created when configuring the cluster for DPDK workloads.
+<6> The number of sockets inside the VM. This field must be set to `1` for the CPUs to be scheduled from the same Non-Uniform Memory Access (NUMA) node.
+<7> The number of cores inside the VM. This must be a value greater than or equal to `1`. In this example, the VM is scheduled with 5 hyper-threads or 10 CPUs.
+<8> The size of the huge pages. The possible values for x86-64 architecture are 1Gi and 2Mi. In this example, the request is for 8 huge pages of size 1Gi.
+<9> The name of the SR-IOV `NetworkAttachmentDefinition` object.
 
 . Save and exit the editor.
 . Apply the `VirtualMachine` manifest:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
When the following conditions are met:
- The compute node has SMT [1] enabled
- Kubelet's CPUManager policy is set to static - full-pcpus-only [2]
- The VM is configured to have an even number of CPUs
- `dedicatedCpuPlacement` and `isolateEmulatorThread` are enabled

The VM is scheduled, but rejected by the kubelet with the following event:
```
SMT Alignment Error: requested 11 cpus not multiple cpus per core = 2
```

For additional details - see BZ#2228103 [3].

Add the annotation introduced by kubevirt/kubevirt#10593

[1] https://en.wikipedia.org/wiki/Simultaneous_multithreading
[2] https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy-options
[3] https://bugzilla.redhat.com/show_bug.cgi?id=2228103

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.15+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://68241--docspreview.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-using-dpdk-with-sriov#virt-configuring-vm-dpdk_virt-using-dpdk-with-sriov

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
