### PR TITLE
Slim down Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,4 @@
-FROM ruby:3.1.2-alpine AS builder
-
-RUN apk update && apk add --virtual build-dependencies build-base
-
-RUN gem install listen asciidoctor asciidoctor-diagram ascii_binder
-
 FROM ruby:3.1.2-alpine
-
-COPY --from=builder /usr/local/bundle /usr/local/bundle
 
 RUN apk add --update --no-cache git bash
 


### PR DESCRIPTION
Since we tag a pre-built image into the pipeline for Prow, there is no need to install stuff in the base Dockerfile. 