### PR TITLE
PV1 Fix: OSDOCS 8020 fix incorrect link in topicmap that breaks the script build

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3386,14 +3386,14 @@ Topics:
     File: appliedclusterresourcequota-quota-openshift-io-v1
   - Name: 'ClusterResourceQuota [quota.openshift.io/v1]'
     File: clusterresourcequota-quota-openshift-io-v1
-  - Name: 'FlowSchema [flowcontrol.apiserver.k8s.io/v1beta1]'
-    File: flowschema-flowcontrol-apiserver-k8s-io-v1beta1
+  - Name: 'FlowSchema [flowcontrol.apiserver.k8s.io/v1beta3]'
+    File: flowschema-flowcontrol-apiserver-k8s-io-v1beta3
   - Name: 'LimitRange [undefined/v1]'
     File: limitrange-v1
   - Name: 'PriorityClass [scheduling.k8s.io/v1]'
     File: priorityclass-scheduling-k8s-io-v1
-  - Name: 'PriorityLevelConfiguration [flowcontrol.apiserver.k8s.io/v1beta1]'
-    File: prioritylevelconfiguration-flowcontrol-apiserver-k8s-io-v1beta1
+  - Name: 'PriorityLevelConfiguration [flowcontrol.apiserver.k8s.io/v1beta3]'
+    File: prioritylevelconfiguration-flowcontrol-apiserver-k8s-io-v1beta3
   - Name: 'ResourceQuota [undefined/v1]'
     File: resourcequota-v1
 - Name: Security APIs


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14 (please cp to enterprise-4.14) and 4.15

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
OSDOCS 8020 (umbrella for script work)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Following #67690 , _topic_map.yml in 4.14 and 4.15 (not in main) has references to two files that no longer exist. The references caused build_for_portal.py to fail , and additional issues with Portal sync appear to be downstream from this problem. This PR updates the topic map to refer to the new versions of the affected files. No factual doc changes involved.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
