### PR TITLE
OADP-1068: Missing CSI snapshot API details

### DIFF
--- a/modules/oadp-plugins.adoc
+++ b/modules/oadp-plugins.adoc
@@ -36,6 +36,8 @@ OADP also provides plugins for {product-title} resource backups, OpenShift Virtu
 --
 1. Mandatory.
 2. Virtual machine disks are backed up with CSI snapshots or Restic.
-3. The `csi` plugin uses the link:https://velero.io/docs/main/csi/[Velero CSI beta snapshot API].
+3. The `csi` plugin uses the Kubernetes CSI snapshot API.
+* OADP 1.1 or later uses `snapshot.storage.k8s.io/v1`
+* OADP 1.0 uses `snapshot.storage.k8s.io/v1beta1`
 4. OADP 1.2 only.
 --


### PR DESCRIPTION
### PR

* [OADP-1068](https://issues.redhat.com/browse/OADP-1068)

### OCP version

* OCP 4.11 → branch/enterprise-4.11
* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15


### Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
* [OADP Plugins](https://68274--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-features-plugins#oadp-plugins_oadp-features-plugins)

| Image |
| ------ |
| ![image](https://github.com/openshift/openshift-docs/assets/106804821/b1bedf76-de4c-4f9c-9918-d95777a198dd)|


### QE review:

* [X ] QE has approved this change. - Changes approved by Prasad Joshi in [PR-59662](https://github.com/openshift/openshift-docs/pull/59662)

* PR was [rotten](https://github.com/openshift/openshift-docs/pull/59662#issuecomment-1754763341)



<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
