### PR TITLE
OSDOCS-8376: Migrate "Getting Started with Rosa - Deploy the Cluster (HCP)"

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -129,6 +129,8 @@ Topics:
       File: cloud-experts-getting-started-simple-cli-guide
     - Name: Detailed CLI guide
       File: cloud-experts-getting-started-detailed-cli-guide
+    - Name: Hosted Control Planes guide
+      File: cloud-experts-getting-started-hcp
 ---
 Name: Getting started
 Dir: rosa_getting_started

--- a/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-hcp.adoc
+++ b/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-hcp.adoc
@@ -1,0 +1,140 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="cloud-experts-getting-started-detailed-ui-guide"]
+= Tutorial: Hosted Control Planes guide
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: cloud-experts-getting-started-hcp
+
+toc::[]
+
+//rosaworkshop.io content metadata
+//Brought into ROSA product docs 2023-11-21
+
+This tutorial outlines deploying a {hcp-title-first} cluster.  
+
+With {hcp-title}, you can decouple the control plane from the data plane. This is a new deployment model for ROSA in which the control plane is hosted in a Red Hat-owned AWS account. The control plane is no longer hosted in your AWS account, reducing your AWS infrastructure expenses. The control plane is dedicated to a single cluster and is highly available. For more information, see the xref:../../../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly[{hcp-title} documentation].
+
+== Prerequisites
+
+Before deploying a {hcp-title} cluster, you must have the following resources:
+
+* VPC - This is a bring-your-own VPC model, also referred to as BYO-VPC.
+* OIDC - OIDC configuration and an OIDC provider with that specific configuration.
+* ROSA version 1.2.31 or higher
+
+In this tutorial, we will create these resources first. We will also set up some environment variables so that it is easier to run the command to create the {hcp-title} cluster.
+
+=== Creating a VPC
+. First, ensure that your AWS CLI (`aws`) is configured to use a region where {hcp-title} is available. To find out which regions are supported run the following command:
++
+[source,terminal]
+----
+rosa list regions --hosted-cp
+----
+    
+. Create the VPC. For this tutorial, the following script will create the VPC and its required components for you. It will use the region configured for the `aws` CLI.
++
+[source,terminal]
+----
+curl https://raw.githubusercontent.com/openshift-cs/rosaworkshop/master/rosa-workshop/rosa/resources/setup-vpc.sh | bash
+----
++
+For more about VPC requirements, see the xref:../../../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-vpc_rosa-sts-aws-prereqs[VPC documentation].
+
+. The above script outputs two commands. Set the commands as environment variables to make running the `create cluster` command easier. Copy them from the output and run them as shown:
++
+[source,terminal]
+----
+export PUBLIC_SUBNET_ID=<public subnet id here>
+export PRIVATE_SUBNET_ID=<private subnet id here>
+----
+
+. Confirm that the environment variables are set by running the following command:
++
+[source,terminal]
+----
+echo "Public Subnet: $PUBLIC_SUBNET_ID"; echo "Private Subnet: $PRIVATE_SUBNET_ID"
+----
++
+.Example output
++
+[source,terminal]
+----
+Public Subnet: subnet-0faeeeb0000000000
+Private Subnet: subnet-011fe340000000000
+----
+
+=== Creating your OIDC configuration
+
+In this tutorial, we will use the automatic mode when creating the OIDC configuration. We will also store the OIDC ID as an environment variable for later use. The command uses the ROSA CLI to create your cluster's unique OIDC configuration. 
+
+* To create the OIDC configuration for this tutorial, run the following command:
++
+[source,terminal]
+----
+export OIDC_ID=$(rosa create oidc-config --mode auto --managed --yes -o json | jq -r '.id')
+----
+
+=== Creating additional environment variables
+
+* Run the following command to set up some environment variables so that it is easier to run the command to create the {hcp-title} cluster:
++
+[source,terminal]
+----
+export CLUSTER_NAME=<enter cluster name>
+export REGION=<region VPC was created in>
+----
++
+[TIP]
+====
+Run `rosa whoami` to find the VPC region.
+====
+
+== Creating the cluster
+If this is the _first time_ you are deploying ROSA in this account and you have _not_ yet created the account roles, create the account-wide roles and policies, including the Operator policies. Since ROSA uses AWS Security Token Service (STS), this step creates the AWS IAM roles and policies that are needed for ROSA to interact with your account.
+
+. Run the following command to create the account-wide roles:
++
+[source,terminal]
+----
+rosa create account-roles --mode auto --yes
+----
+
+. Run the following command to create the cluster:
++
+[source,terminal]
+----
+rosa create cluster --cluster-name $CLUSTER_NAME \
+    --subnet-ids ${PUBLIC_SUBNET_ID},${PRIVATE_SUBNET_ID} \
+    --hosted-cp \
+    --region $REGION \
+    --oidc-config-id $OIDC_ID \
+    --sts --mode auto --yes
+----
+
+The cluster is ready and completely usable after about 10 minutes. The cluster will have a control plane across three AWS availability zones in your selected region and create two worker nodes in your AWS account.  
+
+== Checking the installation status
+. Run one of the following commands to check the status of the cluster:
++
+* For a detailed view of the cluster status, run:
++
+[source,terminal]
+----
+rosa describe cluster --cluster $CLUSTER_NAME
+----
++
+* For an abridged view of the cluster status, run:
++
+[source,terminal]
+----
+rosa list clusters
+----
++
+* To watch the log as it progresses, run:
++
+[source,terminal]
+----
+rosa logs install --cluster $CLUSTER_NAME --watch
+----
+
+. Once the state changes to “ready” your cluster is installed. It might take a few more minutes for the worker nodes to come online.


### PR DESCRIPTION
[OSDOCS-8376](https://issues.redhat.com//browse/OSDOCS-8376): Migrate "Getting Started with Rosa - Deploy the Cluster (HCP)" from rosaworkshop.io into product documentation.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+
Issue:
https://issues.redhat.com/browse/OSDOCS-8376

Link to docs preview:
https://68291--docspreview.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-hcp

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
