### PR TITLE
OSDOCS#8454: Adds notes for MS 4.14.3 release

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -339,3 +339,12 @@ Issued: 2023-11-16
 {product-title} release 4.14.2, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:6839[RHSA-2023:6839] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:6837[RHSA-2023:6837] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-14-3-dp"]
+=== RHBA-2023:7319 - {microshift-short} 4.14.3 bug fix update advisory
+
+Issued: 2023-11-21
+
+{product-title} release 4.14.3, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:7319[RHSA-2023:7319] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7315[RHSA-2023:7315] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
OSDOCS#8454: Adds notes for MS 4.14.3 release

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-8454

Link to docs preview:
https://68297--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes#microshift-4-14-3-dp

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
