### PR TITLE
OCPBUGS-15054 - Remove old PTP rest API endpoint

### DIFF
--- a/modules/cnf-fast-event-notifications-api-refererence.adoc
+++ b/modules/cnf-fast-event-notifications-api-refererence.adoc
@@ -117,32 +117,6 @@ Returns details for the subscription with ID `<subscription_id>`
 }
 ----
 
-== api/ocloudNotifications/v1/subscriptions/status/<subscription_id>
-
-[discrete]
-=== HTTP method
-
-`PUT api/ocloudNotifications/v1/subscriptions/status/<subscription_id>`
-
-[discrete]
-==== Description
-
-Creates a new status ping request for subscription with ID `<subscription_id>`. If a subscription is present, the status request is successful and a `202 Accepted` status code is returned.
-
-.Query parameters
-|===
-| Parameter | Type
-
-| `<subscription_id>`
-| string
-|===
-
-.Example API response
-[source,json]
-----
-{"status":"ping sent"}
-----
-
 == api/ocloudNotifications/v1/health/
 
 [discrete]


### PR DESCRIPTION
api/ocloudNotifications/v1/subscriptions/status/ is no longer supported.


Version(s):
enterprise-4.10+

Issue:
https://issues.redhat.com/browse/OCPBUGS-15054

Link to docs preview:
https://68303--docspreview.netlify.app/openshift-enterprise/latest/networking/using-ptp#cnf-fast-event-notifications-api-refererence_using-ptp

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
