### PR TITLE
4-11 OADP-1068: Missing CSI snapshot API details 

### DIFF
--- a/modules/oadp-plugins.adoc
+++ b/modules/oadp-plugins.adoc
@@ -34,5 +34,8 @@ OADP also provides plugins for {product-title} resource backups, OpenShift Virtu
 --
 1. Mandatory.
 2. Virtual machine disks are backed up with CSI snapshots or Restic.
-3. The `csi` plugin uses the link:https://velero.io/docs/main/csi/[Velero CSI beta snapshot API].
+3. The `csi` plugin uses the Kubernetes CSI snapshot API.
+* OADP 1.1 or later uses `snapshot.storage.k8s.io/v1`
+* OADP 1.0 uses `snapshot.storage.k8s.io/v1beta1`
+4. OADP 1.2 only.
 --


### PR DESCRIPTION
### Jira

* [OADP-1068](https://issues.redhat.com/browse/OADP-1068)

### Original PR for later branches

* [Original PR](https://github.com/openshift/openshift-docs/pull/68274)

### Check picked

*[pull id = 68274](https://github.com/openshift/openshift-docs/pull/68274)

### OCP version

* OCP 4.11 → branch/enterprise-4.11

See [this PR for details](https://github.com/openshift/openshift-docs/pull/68274) and peer-reviews


### Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
* [OADP Plugins](https://68274--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-features-plugins#oadp-plugins_oadp-features-plugins)

| Image |
| ------ |
| ![image](https://github.com/openshift/openshift-docs/assets/106804821/b1bedf76-de4c-4f9c-9918-d95777a198dd)|


### QE review:

* [X ] QE has approved this change. - Changes approved by Prasad Joshi in [PR-59662](https://github.com/openshift/openshift-docs/pull/59662)

* PR was [rotten](https://github.com/openshift/openshift-docs/pull/59662#issuecomment-1754763341)

