### PR TITLE
[gitops-docs-1.9] Documentation for GitOps 1.9.3 release notes.

### DIFF
--- a/modules/gitops-release-notes-1-9-3.adoc
+++ b/modules/gitops-release-notes-1-9-3.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assembly:
+//
+// * release_notes/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="gitops-release-notes-1-9-3_{context}"]
+= Release notes for {gitops-title} 1.9.3
+
+{gitops-title} 1.9.3 is now available on {OCP} 4.12, 4.13, and 4.14.
+
+[id="errata-updates-1-9-3_{context}"]
+== Errata updates
+
+[id="gitops-1-9-3-security-update-advisory_{context}"]
+=== RHSA-2023:7345 - {gitops-title} 1.9.3 security update advisory
+
+Issued: 2023-11-20
+
+The list of security fixes that are included in this release is documented in the following advisory:
+
+* link:https://access.redhat.com/errata/RHSA-2023:7345[RHSA-2023:7345]
+
+If you have installed the {gitops-title} Operator in the default namespace, to view the container images in this release, run the following command:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-gitops-operator
+----

--- a/release_notes/gitops-release-notes.adoc
+++ b/release_notes/gitops-release-notes.adoc
@@ -22,6 +22,8 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+include::modules/gitops-release-notes-1-9-3.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-9-2.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-9-1.adoc[leveloffset=+1]


### PR DESCRIPTION
Conflicts:

**This is a manual CP of  [PR-67075](https://github.com/openshift/openshift-docs/pull/67075) to gitops-docs-1.9**

[doc-preview](https://68316--docspreview.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes#gitops-release-notes-1-9-3_gitops-release-notes)