### PR TITLE
RHDEVDOCS-5695 Update _distro_map.yml

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -334,6 +334,9 @@ openshift-gitops:
     gitops-docs-1.10:
       name: '1.10'
       dir: gitops/1.10
+    gitops-docs-1.11:
+      name: '1.11'
+      dir: gitops/1.11
 openshift-pipelines:
   name: Red Hat OpenShift Pipelines
   author: OpenShift documentation team <openshift-docs@redhat.com>


### PR DESCRIPTION
**Version(s):** `main` only

**Issue:**
-  [RHDEVDOCS 5695](https://issues.redhat.com/browse/RHDEVDOCS-5695)

**Link to docs preview:**
https://68319--docspreview.netlify.app/

**SME and QE review:** Not applicable


**Additional information:** This PR updates the distro map in main for the 1.11 GitOps standalone doc. It does not alter documentation content.