### PR TITLE
[WIP] RHDEVDOCS-5694 - Update _page_openshift.html.erb

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -240,6 +240,7 @@
               <%= distro %>
             </a>
             <select id="version-selector" onchange="versionSelector(this);">
+              <option value="1.11">1.11</option>  
               <option value="1.10">1.10</option>
               <option value="1.9">1.9</option>
               <option value="1.8">1.8</option>


### PR DESCRIPTION
**Version(s):** `main` only

**Issue:**
-  [RHDEVDOCS 5694](https://issues.redhat.com/browse/RHDEVDOCS-5694)

**Link to docs preview:**
https://68320--docspreview.netlify.app/

**SME and QE review:** Not applicable


**Additional information:** This PR updates the _page_openshift.html.erb template file in `main` for the 1.11 GitOps standalone doc. It does not alter documentation content.