### PR TITLE
RHDEVDOCS-5692 - Change redirects

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -246,12 +246,12 @@ AddType text/vtt                            vtt
     # Builds using Shipwright landing page
     RewriteRule ^container-platform/(4\.14)/cicd/builds_using_shipwright/overview-openshift-builds.html /builds/latest/about/overview-openshift-builds.html  [L,R=302]
 
-    # redirect gitops latest to 1.10
+    # redirect gitops latest to 1.11
     RewriteRule ^gitops/?$ /gitops/latest [R=302]
-    RewriteRule ^gitops/latest/?(.*)$ /gitops/1\.10/$1 [NE,R=302]
+    RewriteRule ^gitops/latest/?(.*)$ /gitops/1\.11/$1 [NE,R=302]
 
     # redirect top-level without filespec to the about file
-    RewriteRule ^gitops/(1\.8|1\.9|1\.10)/?$ /gitops/$1/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]
+    RewriteRule ^gitops/(1\.8|1\.9|1\.10|1\.11)/?$ /gitops/$1/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]
 
     # GitOps landing page
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/about-redhat-openshift-gitops.html /gitops/latest/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]


### PR DESCRIPTION
**This PR is for the GitOps 1.11 release that is scheduled for Dec 7, 2023. Do not merge until this date.**


**Version(s):** `main` only

**Issue:**
-  [RHDEVDOCS 5692](https://issues.redhat.com/browse/RHDEVDOCS-5692)

**Link to docs preview:**
https://68321--docspreview.netlify.app/

**SME and QE review:** Not applicable

**Additional information:** This PR updates the redirects in the 01-commercial.conf file in the `main` for the 1.11 GitOps standalone doc. It does not alter documentation content.