### PR TITLE
OCPBUGS#13670: Added poland central zone to Azure docs

### DIFF
--- a/modules/installation-azure-regions.adoc
+++ b/modules/installation-azure-regions.adoc
@@ -37,6 +37,7 @@ The installation program dynamically generates the list of available Microsoft A
 * `northcentralus` (North Central US)
 * `northeurope` (North Europe)
 * `norwayeast` (Norway East)
+* `polandcentral` (Poland Central)
 * `qatarcentral` (Qatar Central)
 * `southafricanorth` (South Africa North)
 //* southafricawest (South Africa West)


### PR DESCRIPTION
[OCPBUGS-13670](https://issues.redhat.com/browse/OCPBUGS-13670)

Version(s):
4.15 to 4.11

Link to docs preview:
[Supported Azure public regions](https://68328--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-account#installation-azure-marketplace_installing-azure-account)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
