### PR TITLE
OADP-2786: OADP Velero received EOF, stopping recv loop

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
@@ -13,6 +13,7 @@ The default plugins enable Velero to integrate with certain cloud providers and 
 include::modules/oadp-features.adoc[leveloffset=+1]
 include::modules/oadp-plugins.adoc[leveloffset=+1]
 include::modules/oadp-configuring-velero-plugins.adoc[leveloffset=+1]
+include::modules/oadp-plugins-receiving-eof-message.adoc[leveloffset=+2]
 include::modules/oadp-supported-architecture.adoc[leveloffset=+1]
 
 [id="oadp-support-for-ibm-power-and-ibm-z"]

--- a/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
@@ -70,6 +70,7 @@ This section describes the additional steps required to restore resources for se
 
 include::modules/migration-debugging-velero-admission-webhooks-knative.adoc[leveloffset=+3]
 include::modules/migration-debugging-velero-admission-webhooks-ibm-appconnect.adoc[leveloffset=+3]
+include::modules/oadp-plugins-receiving-eof-message.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/oadp-plugins-receiving-eof-message.adoc
+++ b/modules/oadp-plugins-receiving-eof-message.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="oadp-plugins-receiving-eof-message_{context}"]
+
+= Velero plugins returning "received EOF, stopping recv loop" message
+
+[NOTE]
+====
+Velero plugins are started as separate processes. After the Velero operation has completed, either successfully or not, they exit. Receiving a `received EOF, stopping recv loop` message in the debug logs indicates that a plugin operation has completed. It does not mean that an error has occurred.
+====

--- a/modules/oadp-release-notes-1-1-4.adoc
+++ b/modules/oadp-release-notes-1-1-4.adoc
@@ -60,4 +60,8 @@ OADP backups might fail because a UID/GID range might have changed on the cluste
 
 A restoration might fail if ArgoCD is used during the process due to a label used by ArgoCD, `app.kubernetes.io/instance`. This label identifies which resources ArgoCD needs to manage, which can create a conflict with OADP's procedure for managing resources on restoration. To work around this issue, set `.spec.resourceTrackingMethod` on the ArgoCD YAML to `annotation+label` or `annotation`. If the issue continues to persist, then disable ArgoCD before beginning to restore, and enable it again when restoration is finished.
 
+.OADP Velero plugins returning "received EOF, stopping recv loop" message
+
+Velero plugins are started as separate processes. When the Velero operation has completed, either successfully or not, they exit. Therefore if you see a `received EOF, stopping recv loop` messages in debug logs, it does not mean an error occurred. The message indicates that a plugin operation has completed. link:https://issues.redhat.com/browse/OADP-2176[OADP-2176]
+
 For a complete list of all known issues in this release, see the list of link:https://issues.redhat.com/browse/OADP-1057?filter=12420908[OADP 1.1.4 known issues] in Jira.


### PR DESCRIPTION
> [!NOTE]
>
>
> Made a mess of the Squash... easier to re-create
> [Original PR ID #66242](https://github.com/openshift/openshift-docs/pull/66242)
>
> [QE approval](https://github.com/openshift/openshift-docs/pull/66242#issuecomment-1822415831)
> [Peer review approval](https://github.com/openshift/openshift-docs/pull/66242#pullrequestreview-1744553445)
> [Merge review approval](https://github.com/openshift/openshift-docs/pull/66242#issuecomment-1822904321)

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

* [OADP-2768](https://issues.redhat.com/browse/OADP-2768)
* I have added to **Known Issues for OADP 1.1.4 release notes**. I know it is not a known issue, but think the reader might look for it as a **Known Issue**. Plus it allows me to provide a link to the explanation of why this is `expected behaviour` and not a `bug`.

### Version

* OCP 4.11 → branch/enterprise-4.11
* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15

### OADP

* **OADP 1.1.4++**


### Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

* [https://issues.redhat.com/browse/OADP-2768](https://issues.redhat.com/browse/OADP-2768) 
