### PR TITLE
PR for SRVOCF-504: Added the content related to "Developing Go functions" section in the downstream (Openshift-serverless) documents.

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -76,6 +76,8 @@ Topics:
     File: serverless-developing-typescript-functions
   - Name: Developing Python functions
     File: serverless-developing-python-functions
+  - Name: Developing Go functions
+    File: serverless-developing-go-functions
 - Name: Configuring functions
   Dir: configuring
   Topics:

--- a/about/about-serverless.adoc
+++ b/about/about-serverless.adoc
@@ -9,6 +9,7 @@ toc::[]
 
 {ServerlessProductName} provides Kubernetes native building blocks that enable developers to create and deploy serverless, event-driven applications on {ocp-product-title}. {ServerlessProductName} is based on the open source link:https://knative.dev/docs/[Knative project], which provides portability and consistency for hybrid and multi-cloud environments by enabling an enterprise-grade serverless platform.
 
+
 [NOTE]
 ====
 Because {ServerlessProductName} releases on a different cadence from {ocp-product-title}, the {ServerlessProductName} documentation is now available as separate documentation sets for each minor version of the product. 
@@ -22,7 +23,7 @@ In addition, the {ServerlessProductName} documentation is also available on the 
 For additional information about the {ServerlessProductName} life cycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift#ossrvless[Platform Life Cycle Policy].
 ====
 
-// add something about CLI tools?
+// Add something about CLI tools?
 
 
 [id="additional-resources_about-serverless"]


### PR DESCRIPTION
**Affected versions for cherry-picking:**
- Serverless 1.31
- Serverless 1.30

**Tracking JIRA:** https://issues.redhat.com/browse/SRVOCF-504

**Doc preview & Description:**
[Developing Go functions (Downstream documentation)](https://68375--docspreview.netlify.app/openshift-serverless/latest/functions/reference/serverless-developing-go-functions)
The "Developing Go functions" section from the downstream document is now visible. 