### PR TITLE
Updated an example for "Using Pipelines as Code with GitLab"

### DIFF
--- a/modules/op-using-pipelines-as-code-with-gitlab.adoc
+++ b/modules/op-using-pipelines-as-code-with-gitlab.adoc
@@ -105,8 +105,9 @@ metadata:
   name: my-repo
   namespace: target-namespace
 spec:
-  url: "https://gitlab.com/owner/repo" <1>
+  url: "https://gitlab.com/owner/repo" # The repository URL
   git_provider:
+    #url: "https://gitlab.example.com/" #<1>
     secret:
       name: "gitlab-webhook-config"
       key: "provider.token" # Set this if you have a different key in your secret
@@ -114,7 +115,7 @@ spec:
       name: "gitlab-webhook-config"
       key: "webhook.secret" # Set this if you have a different key for your secret
 ----
-<1> Currently, {pac} does not automatically detects private instances for GitLab. In such cases, specify the API URL under the `git_provider.url` spec. In general, you can use the `git_provider.url` spec to manually override the API URL.
+<1> If you are using a private instance of GitLab and not GitLab.com, uncomment this field and set it to the URL of your GitLab API. The GitLab API is the same host as the repository. For example, if the repository is `\https://gitlab.example.com/owner/repo`, the API URL is `\https://gitlab.example.com/`.
 
 +
 [NOTE]


### PR DESCRIPTION
- Jira issue [RHDEVDOCS-5727](https://issues.redhat.com/browse/RHDEVDOCS-5727)
- -CherryPick versions: 
*pipelines-docs-1.10,*
*pipelines-docs-1.11,*
*pipelines-docs-1.12,*
and *pipelines-docs-1.13*  branches
- Doc preview: [Using Pipelines as Code with GitLab](https://68378--docspreview.netlify.app/openshift-pipelines/latest/pac/using-pipelines-as-code-repos#using-pipelines-as-code-with-gitlab_using-pipelines-as-code-repos)
- OCP team: DevTools
- SME reviews by: @chmouel 
- QE reviews by: 
- Peer reviews by: 