### PR TITLE
RHDEVDOCS 5735 fix GitOps page ocation for Netlify previews

### DIFF
--- a/scripts/ocpdocs/_previewpage
+++ b/scripts/ocpdocs/_previewpage
@@ -194,7 +194,7 @@
                 <a
                   role="button"
                   class="btn btn-primary"
-                  href="/openshift-gitops/latest/gitops/understanding-openshift-gitops.html"
+                  href="/openshift-gitops/latest/understanding_openshift_gitops/what-is-gitops.html"
                 >
                   <i class="fa fa-arrow-circle-o-right"></i> GitOps</a
                 >


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
main only

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
RHDEVDOCS 5735

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Changing the link for the Nellify preview for GitOps, no doc changes

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
