### PR TITLE
RHDEVDOCS-5730: support /retest for pipelineRuns triggered on push event

### DIFF
--- a/modules/op-restarting-or-canceling-pipeline-run-using-pipelines-as-code.adoc
+++ b/modules/op-restarting-or-canceling-pipeline-run-using-pipelines-as-code.adoc
@@ -1,0 +1,68 @@
+// This module is included in the following assemblies:
+// * pac/managing-pipeline-runs-pac.adoc
+
+:_content-type: PROCEDURE
+[id="restarting-or-canceling-pipeline-run-using-pipelines-as-code_{context}"]
+= Restarting or canceling a pipeline run using {pac}
+
+You can restart or cancel a pipeline run with no events, such as sending a new commit to your branch or raising a pull request. To restart all pipeline runs, use the *Re-run all checks* feature in the GitHub App. 
+
+To restart all or specific pipeline runs, use the following comments:
+
+* The `/test` and `/retest` comment restarts all pipeline runs.
+
+* The `/test <pipeline_run_name>` and `/retest <pipeline_run_name>` comment restarts a specific pipeline run.
+
+To cancel all or specific pipeline runs, use the following comments:
+
+* The `/cancel` comment cancels all pipeline runs.
+
+* The `/cancel <pipeline_run_name>` comment cancels a specific pipeline run.
+
+The results of the comments are visible under the *Checks* tab of the GitHub App.
+
+.Procedure
+
+* If you target a pull request and you use the GitHub App, go to the *Checks* tab and click *Re-run all checks*.
+
+* If you target a pull or merge request, use the comments inside your pull request:
++
+.Example comment that cancels all pipeline runs
+[source]
+----
+This is a comment inside a pull request.
+/cancel
+----
+
+* If you target a push request, include the comments within your commit messages.
++
+[NOTE]
+====
+This feature is supported for the GitHub provider only.
+====
+
+.. Go to your GitHub repository.
+
+.. Click the *Commits* section.
+
+.. Click the commit where you want to restart a pipeline run.
+
+.. Click on the line number where you want to add a comment.
++
+.Example comment that retests a specific pipeline run
+[source]
+----
+This is a comment inside a commit.
+/retest <pipeline_run_name>
+----
++
+[NOTE]
+====
+If you run a command on a commit that exists in multiple branches within a push request, the branch with the latest commit is used.
+
+This results in two situations:
+
+* If you run a command on a commit without any argument, such as `/test`, the test is automatically performed on the `main` branch.
+
+* If you include a branch specification, such as `/test branch:user-branch`, the test is performed on the commit where the comment is located with the context of the `user-branch` branch.
+====

--- a/modules/op-running-pipeline-run-using-pipelines-as-code.adoc
+++ b/modules/op-running-pipeline-run-using-pipelines-as-code.adoc
@@ -49,20 +49,3 @@ $ tkn pac logs -n <my-pipeline-ci> <1>
 If you need to view a pipeline run other than the last one, you can use the `tkn pac logs` command to select a `PipelineRun` attached to the repository:
 
 If you have configured {pac} with a GitHub App, {pac} posts a URL in the *Checks* tab of the GitHub App. You can click the URL and follow the pipeline execution.
-
-[discrete]
-.Restarting a pipeline run
-
-You can restart a pipeline run with no events, such as sending a new commit to your branch or raising a pull request. On a GitHub App, go to the *Checks* tab and click *Re-run*.
-
-If you target a pull or merge request, use the following comments inside your pull request to restart all or specific pipeline runs:
-
-* The `/retest` comment restarts all pipeline runs.
-
-* The `/retest <pipelinerun-name>` comment restarts a specific pipeline run.
-
-* The `/cancel` comment cancels all pipeline runs.
-
-* The `/cancel <pipelinerun-name>` comment cancels a specific pipeline run.
-
-The results of the comments are visible under the *Checks* tab of a GitHub App.

--- a/pac/managing-pipeline-runs-pac.adoc
+++ b/pac/managing-pipeline-runs-pac.adoc
@@ -17,6 +17,8 @@ include::modules/op-creating-pipeline-run-using-pipelines-as-code.adoc[leveloffs
 
 include::modules/op-running-pipeline-run-using-pipelines-as-code.adoc[leveloffset=+1]
 
+include::modules/op-restarting-or-canceling-pipeline-run-using-pipelines-as-code.adoc[leveloffset=+1]
+
 include::modules/op-monitoring-pipeline-run-status-using-pipelines-as-code.adoc[leveloffset=+1]
 
 .Additional resources


### PR DESCRIPTION
**Version(s)**: CP to `pipelines-docs-1.13`

**Issue**: [RHDEVDOCS-5730](https://issues.redhat.com/browse/RHDEVDOCS-5730)

**Preview link**: [Restarting or canceling a pipeline run using Pipelines as Code](https://68386--docspreview.netlify.app/openshift-pipelines/latest/pac/managing-pipeline-runs-pac#restarting-or-canceling-pipeline-run-using-pipelines-as-code_managing-pipeline-runs-pac)

**SME review**: @savitaashture 

**QE review**: @ppitonak 