### PR TITLE
OCPBUGS#23920: Removed mention of IPv6 primary for vSphere dual-stack

### DIFF
--- a/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
@@ -11,7 +11,10 @@ endif::[]
 [id='modifying-install-config-for-dual-stack-network_{context}']
 = Optional: Deploying with dual-stack networking
 
-For dual-stack networking in {product-title} clusters, you can configure IPv4 and IPv6 address endpoints for cluster nodes. To configure IPv4 and IPv6 address endpoints for cluster nodes, edit the `machineNetwork`, `clusterNetwork`, and `serviceNetwork` configuration settings in the `install-config.yaml` file. Each setting must have two CIDR entries each. For a cluster with the IPv4 family as the primary address family, specify the IPv4 setting first. For a cluster with the IPv6 family as the primary address family, specify the IPv6 setting first.
+For dual-stack networking in {product-title} clusters, you can configure IPv4 and IPv6 address endpoints for cluster nodes. To configure IPv4 and IPv6 address endpoints for cluster nodes, edit the `machineNetwork`, `clusterNetwork`, and `serviceNetwork` configuration settings in the `install-config.yaml` file. Each setting must have two CIDR entries each. 
+ifndef::vsphere[]
+For a cluster with the IPv4 family as the primary address family, specify the IPv4 setting first. For a cluster with the IPv6 family as the primary address family, specify the IPv6 setting first.
+endif::[]
 
 [source,yaml]
 ----


### PR DESCRIPTION
Version(s): 4.13+

Issue: https://issues.redhat.com/browse/OCPBUGS-23920

Link to docs preview: 
vSphere (without IPv6 primary): https://68391--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations#modifying-install-config-for-dual-stack-network_installing-vsphere-installer-provisioned-network-customizations

BM (with IPv6 primary): https://68391--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow#modifying-install-config-for-dual-stack-network_ipi-install-installation-workflow

QE review:
- [ ] QE has approved this change.