### PR TITLE
GH#38141: Remove invalid identity provider parameter

### DIFF
--- a/modules/identity-provider-parameters.adoc
+++ b/modules/identity-provider-parameters.adoc
@@ -24,12 +24,6 @@ lookup:: Looks up an existing identity, user identity mapping, and user,
 but does not automatically provision users or identities. This allows cluster
 administrators to set up identities and users manually, or using an external
 process. Using this method requires you to manually provision users.
-generate:: Provisions a user with the identity's preferred user name. If a
-user with the preferred user name is already mapped to an existing identity, a
-unique user name is generated. For example, `myuser2`. This method should not be
-used in combination with external processes that require exact matches between
-{product-title} user names and identity provider user names, such as LDAP group
-sync.
 add:: Provisions a user with the identity's preferred user name. If a user
 with that user name already exists, the identity is mapped to the existing user,
 adding to any existing identity mappings for the user. Required when multiple


### PR DESCRIPTION
GH#38141: remove invalid "generate" identity provider parameter

This misinformation can be found in all versions of the docs for OCP and OKD.

Version(s):
OCP and OKD all versions back to 4.1.

Issue:
GitHub #38141. Reproduced on a test OKD cluster:
```
~: cat htpasswd-provider-test.yaml 
apiVersion: config.openshift.io/v1
kind: OAuth
metadata:
  name: cluster
spec:
  identityProviders:
  - name: htpasswd_provider_test 
    mappingMethod: generate
    type: HTPasswd
    htpasswd:
      fileData:
        name: htpass-secret-test
~: oc create -f htpasswd-provider-test.yaml 
The OAuth "cluster" is invalid: spec.identityProviders[0].mappingMethod: Unsupported value: "generate": supported values: "add", "claim", "lookup"
```

Preview link: https://68395--docspreview.netlify.app/openshift-enterprise/latest/authentication/understanding-identity-provider#identity-provider-parameters_understanding-identity-provider