### PR TITLE
CNV#35113: Remove obsolete 4.13 note from upgrade assembly

### DIFF
--- a/virt/updating/upgrading-virt.adoc
+++ b/virt/updating/upgrading-virt.adoc
@@ -8,11 +8,6 @@ toc::[]
 
 Learn how Operator Lifecycle Manager (OLM) delivers z-stream and minor version updates for {VirtProductName}.
 
-[IMPORTANT]
-====
-Updating to {VirtProductName} 4.13 from {VirtProductName} 4.12.2 is not supported.
-====
-
 include::modules/virt-rhel-9.adoc[leveloffset=+1]
 
 include::modules/virt-about-upgrading-virt.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/CNV-35113

Link to docs preview:
https://68398--docspreview.netlify.app/openshift-enterprise/latest/virt/updating/upgrading-virt.html

QE review: NA

<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
