### PR TITLE
OSDOCS#6141:Added policy info for CSI drivers role in ROSA

### DIFF
--- a/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
@@ -27,12 +27,16 @@ Only public and AWS PrivateLink clusters are supported with STS. Regular private
 +
 [IMPORTANT]
 ====
-The EBS operator role is required in addition to the account roles to successfully create your cluster.
+The EBS Operator role is required in addition to the account roles to successfully create your cluster.
+
+This role must be attached with the `ManagedOpenShift-openshift-cluster-csi-drivers-ebs-cloud-credentials` policy, an IAM policy required by ROSA to manage back-end storage through the Container Storage Interface (CSI).
+
+For more information about the policies and permissions that the cluster Operators require, see _Methods of account-wide role creation_.
 
 .Example EBS Operator role
 `"arn:aws:iam::<aws_account_id>:role/<cluster_name>-xxxx-openshift-cluster-csi-drivers-ebs-cloud-credent"`
 
-After you create your Operator Roles, you must edit the _Key Policy_ in the link:https://console.aws.amazon.com/kms[*Key Management Service (KMS)* page of the AWS Console] to add the roles.
+After you create your Operator roles, you must edit the _Key Policy_ in the link:https://console.aws.amazon.com/kms[*Key Management Service (KMS)* page of the AWS Console] to add the roles.
 ====
 
 .Procedure
@@ -335,11 +339,15 @@ If you specified custom ARN paths when you created the associated account-wide r
 +
 [IMPORTANT]
 ====
-The EBS operator role is required in addition to the account roles to successfully create your cluster.
+The EBS Operator role is required in addition to the account roles to successfully create your cluster.
+
+This role must be attached with the `ManagedOpenShift-openshift-cluster-csi-drivers-ebs-cloud-credentials` policy, an IAM policy required by ROSA to manage back-end storage through the Container Storage Interface (CSI).
+
+For more information about the policies and permissions that the cluster Operators require, see _Methods of account-wide role creation_.
 .Example EBS Operator role
 `"arn:aws:iam::<aws_account_id>:role/<cluster_name>-xxxx-openshift-cluster-csi-drivers-ebs-cloud-credent"`
 
-After you create your Operator Roles, you must edit the _Key Policy_ in the link:https://console.aws.amazon.com/kms[*Key Management Service (KMS)* page of the AWS Console] to add the roles.
+After you create your Operator roles, you must edit the _Key Policy_ in the link:https://console.aws.amazon.com/kms[*Key Management Service (KMS)* page of the AWS Console] to add the roles.
 ====
 
 . Create the OpenID Connect (OIDC) provider that the cluster Operators use to authenticate:

--- a/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
@@ -219,12 +219,16 @@ PVs created by using any other storage class are only encrypted if the storage c
 +
 [IMPORTANT]
 ====
-The EBS operator role is required in addition to the account roles to successfully create your cluster.
+The EBS Operator role is required in addition to the account roles to successfully create your cluster.
+
+This role must be attached with the `ManagedOpenShift-openshift-cluster-csi-drivers-ebs-cloud-credentials` policy, an IAM policy required by ROSA to manage back-end storage through the Container Storage Interface (CSI).
+
+For more information about the policies and permissions that the cluster Operators require, see _Methods of account-wide role creation_.
 
 .Example EBS Operator role
 `"arn:aws:iam::<aws_account_id>:role/<cluster_name>-xxxx-openshift-cluster-csi-drivers-ebs-cloud-credent"`
 
-After you create your Operator Roles, you must edit the _Key Policy_ in the link:https://console.aws.amazon.com/kms[*Key Management Service (KMS)* page of the AWS Console] to add the roles.
+After you create your Operator roles, you must edit the _Key Policy_ in the link:https://console.aws.amazon.com/kms[*Key Management Service (KMS)* page of the AWS Console] to add the roles.
 ====
 
 .. Click *Next*.
@@ -416,11 +420,16 @@ If you opted to use *Auto* mode, {cluster-manager} creates the Operator roles an
 +
 [IMPORTANT]
 ====
-The EBS operator role is required in addition to the account roles to successfully create your cluster.
+The EBS Operator role is required in addition to the account roles to successfully create your cluster.
+
+This role must be attached with the `ManagedOpenShift-openshift-cluster-csi-drivers-ebs-cloud-credentials` policy, an IAM policy required by ROSA to manage back-end storage through the Container Storage Interface (CSI).
+
+For more information about the policies and permissions that the cluster Operators require, see _Methods of account-wide role creation_.
+
 .Example EBS Operator role
 `"arn:aws:iam::<aws_account_id>:role/<cluster_name>-xxxx-openshift-cluster-csi-drivers-ebs-cloud-credent"`
 
-After you create your Operator Roles, you must edit the _Key Policy_ in the link:https://console.aws.amazon.com/kms[*Key Management Service (KMS)* page of the AWS Console] to add the roles.
+After you create your Operator roles, you must edit the _Key Policy_ in the link:https://console.aws.amazon.com/kms[*Key Management Service (KMS)* page of the AWS Console] to add the roles.
 ====
 
 .Verification

--- a/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
+++ b/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
@@ -41,12 +41,14 @@ include::modules/rosa-sts-creating-a-cluster-using-customizations.adoc[leveloffs
 include::modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
-* xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-cluster-command_rosa-managing-objects-cli[create cluster] in _Managing objects with the ROSA CLI_.
+* xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-cluster-command_rosa-managing-objects-cli[create cluster] in _Managing objects with the ROSA CLI_
+* xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies-creation-methods_rosa-sts-about-iam-resources[Methods of account-wide role creation]
 
 include::modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 * xref:../rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc#rosa-security-groups_prerequisites[Security groups]
+* xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies-creation-methods_rosa-sts-about-iam-resources[Methods of account-wide role creation]
 
 [id="next-steps_{context}"]
 == Next steps


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-6141](https://issues.redhat.com/browse/OSDOCS-6141)

Link to docs preview:
[Creating a cluster with customizations by using OpenShift Cluster Manager](https://68399--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations#rosa-sts-creating-cluster-customizations-ocm_rosa-sts-creating-a-cluster-with-customizations)

[Creating a cluster with customizations using the CLI](https://68399--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations#rosa-sts-creating-cluster-customizations-cli_rosa-sts-creating-a-cluster-with-customizations)

QE review:
- [x] QE has approved this change.

Peer review:
- [x] Peer reviewer has approved this change. 



