### PR TITLE
RHDEVDOCS 5735 fix history link for Builds

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -234,7 +234,7 @@
             </a>
             <select id="version-selector" onchange="versionSelector(this);">
               <option value="1.0">1.0</option>
-            </select>   
+            </select>
         <% elsif (distro_key == "openshift-gitops") %>
             <a href="https://docs.openshift.com/gitops/<%= version %>/release_notes/gitops-release-notes.html">
               <%= distro %>
@@ -367,7 +367,7 @@
         </span>
       <% elsif (distro_key == "openshift-builds") %>
         <span text-align="right" style="float: right !important">
-          <a href="https://github.com/openshift/build-docs/commits/<%= (distro_key == "openshift-builds") ? "build-docs-#{version}" : "build-docs" %>/<%= repo_path %>">
+          <a href="https://github.com/openshift/openshift-docs/commits/<%= (distro_key == "openshift-builds") ? "build-docs-#{version}" : "build-docs" %>/<%= repo_path %>">
             <span class="material-icons-outlined" title="Page history">history
             </span>
           </a>
@@ -380,7 +380,7 @@
               <span class="material-icons-outlined" title="Print page (Save as PDF)">picture_as_pdf</span>
             </a>
           <% end %>
-        </span>  
+        </span>
       <% elsif (distro_key == "openshift-gitops") %>
         <span text-align="right" style="float: right !important">
           <a href="https://github.com/openshift/openshift-docs/commits/<%= (distro_key == "openshift-gitops") ? "gitops-docs-#{version}" : "gitops-docs" %>/<%= repo_path %>">


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
main only

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
RHDEVDOCS 5735

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

This should fix the history button on standalone Builds pages; no doc changes.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
