### PR TITLE
[OSDOCS-8304] Typo fix

### DIFF
--- a/modules/cco-short-term-creds-auth-flow-aws.adoc
+++ b/modules/cco-short-term-creds-auth-flow-aws.adoc
@@ -31,7 +31,7 @@ The following diagram illustrates the authentication flow between AWS and the {p
 .AWS Security Token Service authentication flow
 image::347_OpenShift_credentials_with_STS_updates_0623_AWS.png[Detailed authentication flow between AWS and the cluster when using AWS STS]
 
-Requests for new and refreshed credentials are automated by using an appropriately configured AWS IAM OpenID Connect (OIDC) identity provider, combined with AWS IAM roles. {product-title} signs service account tokens that are trusted by AWS IAM, and can be projected into a pod and used for authentication. Tokens are refreshed after one hour.
+Requests for new and refreshed credentials are automated by using an appropriately configured AWS IAM OpenID Connect (OIDC) identity provider combined with AWS IAM roles. Service account tokens that are trusted by AWS IAM are signed by {product-title} and can be projected into a pod and used for authentication.
 
 [id="cco-short-term-creds-auth-flow-aws-refresh-policy_{context}"]
 == Token refreshing for AWS STS


### PR DESCRIPTION
Fixing a typo I missed because I had two PRs with changes in the same module open :facepalm: 

Original PRs:
#67750
#67829

Link to docs preview:
[Authentication flow for AWS STS](https://68412--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-short-term-creds#cco-short-term-creds-auth-flow-aws-diagram_cco-short-term-creds)