### PR TITLE
OSDOCS-8825: adds 4.14.4 MicroShift relnote

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -345,6 +345,20 @@ For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers
 
 Issued: 2023-11-21
 
-{product-title} release 4.14.3, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:7319[RHSA-2023:7319] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7315[RHSA-2023:7315] advisory.
+{product-title} release 4.14.3, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:7319[RHBA-2023:7319] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7315[RHSA-2023:7315] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-14-4-dp"]
+=== RHBA-2023:7472 - {microshift-short} 4.14.4 bug fix update advisory
+
+Issued: 2023-11-29
+
+{product-title} release 4.14.4, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:7472[RHBA-2023:7472] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7470[RHSA-2023:7470] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-14-4-bug-fixes"]
+==== Bug fixes
+
+* Previously, a backup was created every time the {microshift-short} service started. These backups caused system backups to fail. Now, automated backups only occur on full system starts. (link:https://issues.redhat.com/browse/OCPBUGS-23076[*OCPBUGS-23076*])


### PR DESCRIPTION
Version(s):
4.14 only

Issue:
https://issues.redhat.com/browse/OSDOCS-8825

Link to docs preview:
[4.14.4 release notes](https://68418--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes#microshift-4-14-4-dp)

QE review:
- N/A

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
