### PR TITLE
OSSM-4104: Service Mesh 2.5 Release Notes (2.5 Release)

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -168,8 +168,8 @@ endif::[]
 :product-rosa: Red Hat OpenShift Service on AWS
 :SMProductName: Red Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 2.4.5
-:MaistraVersion: 2.4
+:SMProductVersion: 2.5
+:MaistraVersion: 2.5
 //Service Mesh v1
 :SMProductVersion1x: 1.1.18.2
 //Windows containers

--- a/modules/ossm-rn-deprecated-features.adoc
+++ b/modules/ossm-rn-deprecated-features.adoc
@@ -15,6 +15,17 @@ Deprecated functionality is still included in {product-title} and continues to b
 
 Removed functionality no longer exists in the product.
 
+[id="deprecated-removed-features-ossm-2-5"]
+== Deprecated and removed features in {SMProductName} 2.5
+
+The v2.2 `ServiceMeshControlPlane` resource is no longer supported. Customers should update their mesh deployments to use a later version of the `ServiceMeshControlPlane` resource.
+
+Support for the Jaeger Operator is deprecated. To collect trace spans, use the {DTProductName} (Tempo) Stack.
+
+Support for the Elastic Search Operator is deprecated. 
+
+Istio will remove support for first-party JSON Web Tokens (JWTs). Istio will still support third-Party JWTs. 
+
 == Deprecated and removed features in {SMProductName} 2.4
 
 The v2.1 `ServiceMeshControlPlane` resource is no longer supported. Customers should upgrade their mesh deployments to use a later version of the `ServiceMeshControlPlane` resource.

--- a/modules/ossm-rn-fixed-issues.adoc
+++ b/modules/ossm-rn-fixed-issues.adoc
@@ -16,6 +16,17 @@ Provide the following info for each issue if possible:
 
 The following issue has been resolved in the current release:
 
+* https://issues.redhat.com/browse/OSSM-1397[OSSM-1397] Previously, if you removed the `maistra.io/member-of` label from a namespace, the {SMProductShortName} Operator did not automatically reapply the label to the namespace. As a result, sidecar injection did not work in the namespace.
++
+The Operator would reapply the label to the namespace when you made changes to the `ServiceMeshMember` object, which triggered the reconciliation of this member object.
++
+Now, any change to the namespace also triggers the member object reconciliation.
+
+The following issues have been resolved in previous releases:
+
+[id="ossm-rn-fixed-issues-ossm_{context}"]
+== {SMProductShortName} fixed issues
+
 * https://issues.redhat.com/browse/OSSM-3647[OSSM-3647] Previously, in the {SMProductShortName} control plane (SMCP) v2.2 (Istio 1.12), WasmPlugins were applied only to inbound listeners. Since SMCP v2.3 (Istio 1.14), WasmPlugins have been applied to inbound and outbound listeners by default, which introduced regression for users of the 3scale WasmPlugin. Now, the environment variable `APPLY_WASM_PLUGINS_TO_INBOUND_ONLY` is added, which allows safe migration from SMCP v2.2 to v2.3 and v2.4. 
 +
 The following setting should be added to the SMCP config:
@@ -40,11 +51,6 @@ To ensure safe migration, perform the following steps:
 . Set `spec.match[].mode: SERVER` in WasmPlugins.
 . Remove the previously-added environment variable.
 --
-
-The following issues have been resolved in previous releases:
-
-[id="ossm-rn-fixed-issues-ossm_{context}"]
-== {SMProductShortName} fixed issues
 
 * https://issues.redhat.com/browse/OSSM-4851[OSSM-4851] Previously, an error occurred in the operator deploying new pods in a namespace scoped inside the mesh when `runAsGroup`, `runAsUser`, or `fsGroup` parameters were `nil`. Now, a yaml validation has been added to avoid the `nil` value.
 

--- a/modules/ossm-rn-known-issues.adoc
+++ b/modules/ossm-rn-known-issues.adoc
@@ -36,6 +36,40 @@ endif::openshift-rosa[]
 
 These are the known issues in {SMProductName}:
 
+* https://issues.redhat.com/browse/OSSM-6099[OSSM-6099] Installing the OpenShift {SMProductShortName} Console (OSSMC) plugin fails on an IPv6 cluster. 
++
+Workaround: Install the OSSMC plugin on an IPv4 cluster.
+
+* https://issues.redhat.com/browse/OSSM-5556[OSSM-5556] Gateways are skipped when istio-system labels do not match discovery selectors. 
++
+Workaround: Label the control plane namespace to match discovery selectors to avoid skipping the Gateway configurations.
++
+.Example `ServiceMeshControlPlane` resource
+[source,YAML]
+----
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata: 
+  name: basic
+  namespace: istio-system
+spec: 
+  mode: ClusterWide
+  meshConfig: 
+    discoverySelectors: 
+    - matchLabels: 
+        istio-discovery: enabled
+  gateways:
+    ingress:
+      enabled: true
+----
++
+Then, run the following command at the command line:
++
+[source,terminal]
+----
+oc label namespace istio-system istio-discovery=enabled
+----
+
 * https://issues.redhat.com/browse/OSSM-3890[OSSM-3890] Attempting to use the Gateway API in a multitenant mesh deployment generates an error message similar to the following:
 +
 [source,text]

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -15,6 +15,131 @@ Module included in the following assemblies:
 
 This release adds improvements related to the following components and concepts.
 
+[id="new-features-ossm-2-5"]
+== New features {SMProductName} version 2.5
+
+This release of {SMProductName} adds new features, addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.13 and later.
+
+This release ends maintenance support for OpenShift {SMProductShortName} version 2.2. If you are using OpenShift {SMProductShortName} version 2.2, you should update to a supported version.
+
+=== Component versions for {SMProductName} version 2.5
+
+|===
+|Component |Version
+
+|Istio
+|1.18.5
+
+|Envoy Proxy
+|1.26.8
+
+|Kiali
+|1.73.4
+|===
+
+=== Istio 1.18 support
+
+Service Mesh 2.5 is based on Istio 1.18, which brings in new features and product enhancements. While {SMProductName} supports many Istio 1.18 features, the following exceptions should be noted:
+
+* Ambient mesh is not supported
+* QuickAssist Technology (QAT) PrivateKeyProvider in Istio is not supported
+
+=== Cluster-Wide mesh migration
+
+This release adds documentation for migrating from a multitenant mesh to a cluster-wide mesh. For more information, see the following documentation:
+
+* "About migrating to a cluster-wide mesh"
+* "Excluding namespaces from a cluster-wide mesh"
+* "Defining which namespaces receive sidecar injection in a cluster-wide mesh"
+* "Excluding individual pods from a cluster-wide mesh"
+
+=== {SMProductName} Operator on ARM-based clusters
+
+This release provides the {SMProductName} Operator on ARM-based clusters as a generally available feature. 
+
+=== Integration with {DTProductName} (Tempo) Stack
+
+This release introduces a generally available integration of the tracing extension provider(s). You can expose tracing data to the {DTProductName} (Tempo) stack by appending a named element and the `zipkin` provider to the `spec.meshConfig.extensionProviders` specification. Then, a telemetry custom resource configures Istio proxies to collect trace spans and send them to the Tempo distributor service endpoint.
+
+[NOTE]
+====
+{DTProductName} (Tempo) Stack is not supported on {ibm-z-title}. 
+====
+
+=== OpenShift Service Mesh Console plugin
+
+This release introduces a generally available version of the OpenShift {SMProductShortName} Console (OSSMC) plugin. 
+
+The OSSMC plugin is an extension to the OpenShift Console that provides visibility into your Service Mesh. With the OSSMC plugin installed, a new Service Mesh menu option is available in the left-hand navigation of the web console, as well as new Service Mesh tabs that enhance existing Workloads and Service console pages. 
+
+The features of the OSSMC plugin are very similar to those of the standalone Kiali Console. The OSSMC plugin does not replace the Kiali Console, and after installing the OSSMC plugin, you can still access the standalone Kiali Console. 
+
+=== Istio OpenShift Routing (IOR) default setting change
+
+The default setting for Istio OpenShift Routing (IOR) has changed. Starting with this release, automatic routes are disabled by default for new instances of the `ServiceMeshControlPlane` resource. 
+
+For new  instances of the `ServiceMeshControlPlane` resources, you can use automatic routes by setting the `enabled` field to `true` in the `gateways.openshiftRoute` specification of the `ServiceMeshControlPlane` resource.
+
+.Example `ServiceMeshControlPlane` resource
+[source,yaml]
+----
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+spec:
+  gateways:
+    openshiftRoute:
+      enabled: true
+----
+
+When updating existing instances of the `ServiceMeshControlPlane` resource to {SMProductName} version 2.5, automatic routes remain enabled by default.
+
+=== Istio proxy concurrency configuration enhancement
+
+The `concurrency` parameter in the `networking.istio` API configures how many worker threads the Istio proxy runs. 
+
+For consistency across deployments, Istio now configures the `concurrency` parameter based upon the CPU limit allocated to the proxy container. For example, a limit of 2500m would set the `concurrency` parameter to `3`. If you set the `concurrency` parameter to a different value, then Istio uses that value to configure how many threads the proxy runs instead of using the CPU limit. 
+
+Previously, the default setting for the parameter was `2`. 
+
+=== Gateway API CRD versions
+:FeatureName: {product-title} Gateway API support
+include::snippets/technology-preview.adoc[]
+
+A new version of the Gateway API custom resource definition (CRD) is now available. Refer to the following table to determine which Gateway API version should be installed with the OpenShift {SMProductShortName} version you are using:
+
+|===
+|Service Mesh Version | Istio Version | Gateway API Version | Notes
+
+|2.5.x
+|1.18.x
+|0.6.2
+|Use the experimental branch because `ReferenceGrand` is missing in v0.6.2
+
+|2.4.x
+|1.16.x
+|0.5.1
+|For multitenant mesh deployment, all Gateway API CRDs must be present. Use the experimental branch.
+|===
+
+[id="new-features-ossm-2-4-6"]
+== New features {SMProductName} version 2.4.6
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.13 and later.
+
+=== Component versions for {SMProductName} version 2.4.6
+|===
+|Component |Version
+
+|Istio
+|1.16.7
+
+|Envoy Proxy
+|1.24.12
+
+|Kiali
+|1.65.11
+|===
+
 == New features {SMProductName} version 2.4.5
 
 This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.11 and later versions.
@@ -33,9 +158,6 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 
 |Envoy Proxy
 |1.24.12
-
-|Jaeger
-|1.47.0
 
 |Kiali
 |1.65.11
@@ -285,6 +407,26 @@ endif::openshift-rosa[]
 * HBONE protocol for sidecars is an experimental feature that is not supported.
 * {SMProductShortName} on ARM64 architecture is not supported.
 * OpenTelemetry API remains a Technology Preview feature.
+
+[id="new-features-ossm-2-3-10"]
+== New features {SMProductName} version 2.3.10
+//Update with 2.5
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.13 and later.
+
+=== Component versions for {SMProductName} version 2.3.10
+|===
+|Component |Version
+
+|Istio
+|1.14.5
+
+|Envoy Proxy
+|1.22.11
+
+|Kiali
+|1.57.14
+|===
 
 == New features {SMProductName} version 2.3.9
 //Update with 2.4.5


### PR DESCRIPTION
**PR for Service Mesh 2.5/2.4.6/2.3.10 layered product release. All content for prior releases was previously reviewed and approved. Target date for release March 18.**

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): OCP 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSSM-4104
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 

https://68434--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes#new-features-red-hat-openshift-service-mesh-version-2-5

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
