### PR TITLE
OSDOCS-8377: Migrate "Getting Started with Rosa - Create an Admin User"

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -133,9 +133,10 @@ Topics:
       File: cloud-experts-getting-started-hcp
     - Name: Simple UI guide
       File: cloud-experts-getting-started-simple-ui-guide
+  - Name: Creating an admin user
+    File: cloud-experts-getting-started-admin
   - Name: Setting up an identity provider
     File: cloud-experts-getting-started-idp
-    
 ---
 Name: Getting started
 Dir: rosa_getting_started

--- a/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-admin.adoc
+++ b/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-admin.adoc
@@ -1,0 +1,83 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="cloud-experts-getting-started-admin"]
+= Tutorial: Creating an admin user
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: cloud-experts-getting-started-admin
+
+toc::[]
+
+//rosaworkshop.io content metadata
+//Brought into ROSA product docs 2023-11-27
+
+Creating an administration (admin) user allows you to access your cluster quickly. Follow these steps to create an admin user. 
+
+[NOTE]
+====
+An admin user works well in this tutorial setting. For actual deployment, use a xref:../../authentication/sd-configuring-identity-providers.adoc#sd-configuring-identity-providers[formal identity provider] to access the cluster and grant the user admin privileges.
+====
+
+. Run the following command to create the admin user:
++
+[source,terminal]
+----
+rosa create admin --cluster=<cluster-name>
+----
++
+.Example output
++
+[source,terminal]
+----
+W: It is recommended to add an identity provider to login to this cluster. See 'rosa create idp --help' for more information.
+I: Admin account has been added to cluster 'my-rosa-cluster'. It may take up to a minute for the account to become active.
+I: To login, run the following command:
+oc login https://api.my-rosa-cluster.abcd.p1.openshiftapps.com:6443 \
+--username cluster-admin \
+--password FWGYL-2mkJI-00000-00000
+----
+
+. Copy the log in command returned to you in the previous step and paste it into your terminal. This will log you in to the cluster using the CLI so you can start using the cluster.
++
+[source,terminal]
+----
+$ oc login https://api.my-rosa-cluster.abcd.p1.openshiftapps.com:6443 \
+>    --username cluster-admin \
+>    --password FWGYL-2mkJI-00000-00000
+----
++
+.Example output
++
+[source,terminal]
+----
+Login successful.
+
+You have access to 79 projects, the list has been suppressed. You can list all projects with ' projects'
+
+Using project "default".
+----
+
+. To check that you are logged in as the admin user, run one of the following commands:
++
+* Option 1:
++
+[source,terminal]
+----
+$ oc whoami
+----
++
+.Example output
++
+[source,terminal]
+----
+cluster-admin
+----
++
+* Option 2:
++
+[source,terminal]
+----
+oc get all -n openshift-apiserver
+----
++
+Only an admin user can run this command without errors.
+
+. You can now use the cluster as an admin user, which will suffice for this tutorial. For actual deployment, it is highly recommended to set up an identity provider, which is explained in the xref:../../cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-idp.adoc#cloud-experts-getting-started-idp[next tutorial].


### PR DESCRIPTION
[OSDOCS-8377](https://issues.redhat.com//browse/OSDOCS-8377): Migrate "Getting Started with Rosa - Create an Admin User" to product documentation from rosaworkshop.io.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-8377

Link to docs preview:
https://68443--docspreview.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-admin

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
