### PR TITLE
[SRVKS-1090] Add the kourier-bootstrap customization docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -127,6 +127,8 @@ Topics:
     File: resolving-image-tags-to-digests
   - Name: Configuring TLS authentication
     File: serverless-config-tls
+  - Name: Configuring Kourier
+    File: configuring-kourier
   - Name: Restrictive network policies
     File: restrictive-network-policies
 - Name: Traffic splitting

--- a/knative-serving/config-applications/configuring-kourier.adoc
+++ b/knative-serving/config-applications/configuring-kourier.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="configuring-kourier"]
+= Configuring Kourier
+include::_attributes/common-attributes.adoc[]
+:context: configuring-kourier
+
+toc::[]
+
+Kourier is a lightweight Kubernetes-native Ingress for Knative Serving. Kourier acts as a gateway for Knative, routing HTTP traffic to Knative services.
+
+include::modules/customizing-kourier-bootstrap-for-kourier-getaways.adoc[leveloffset=+1]

--- a/modules/customizing-kourier-bootstrap-for-kourier-getaways.adoc
+++ b/modules/customizing-kourier-bootstrap-for-kourier-getaways.adoc
@@ -1,0 +1,33 @@
+:_content-type: PROCEDURE
+[id="customizing-kourier-bootstrap-for-kourier-getaways_{context}"]
+= Customizing kourier-bootstrap for Kourier getaways
+
+The Envoy proxy component in Kourier handles inbound and outbound HTTP traffic for the Knative services. By default, Kourier contains an Envoy bootstrap configuration in the `kourier-bootstrap` configuration map in the `knative-serving-ingress` namespace. You can change this configuration.
+
+.Prerequisites
+
+* You have installed the {ServerlessOperatorName} and Knative Serving.
+* You have cluster administrator permissions on {ocp-product-title}, or you have cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
+
+.Procedure
+
+* Specify a custom bootstrapping configuration map by changing the `spec.ingress.kourier.bootstrap-configmap` field in the `KnativeServing` custom resource (CR):
++
+.Example KnativeServing CR
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+spec:
+  config:
+    network:
+      ingress-class: kourier.ingress.networking.knative.dev
+  ingress:
+    kourier:
+      bootstrap-configmap: my-configmap
+      enabled: true
+# ...
+----


### PR DESCRIPTION
Version(s):
`serverless-docs-1.30`+

Issue:
https://issues.redhat.com/browse/SRVKS-1090

Link to docs preview:
https://68452--docspreview.netlify.app/openshift-serverless/latest/knative-serving/config-applications/configuring-kourier

QE review:
- [x] QE has approved this change.