### PR TITLE
RHDEVDOCS 5668 enable building Pipelines 1.13 for standalone

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -288,7 +288,7 @@ openshift-acs:
       dir: acs/4.2
     rhacs-docs-4.3:
       name: '4.3'
-      dir: acs/4.3  
+      dir: acs/4.3
 microshift:
   name: Red Hat build of MicroShift
   author: OpenShift Documentation Project <openshift-docs@redhat.com>
@@ -356,6 +356,9 @@ openshift-pipelines:
     pipelines-docs-1.12:
       name: '1.12'
       dir: pipelines/1.12
+    pipelines-docs-1.13:
+      name: '1.13'
+      dir: pipelines/1.13
 openshift-builds:
   name: builds for Red Hat OpenShift
   author: OpenShift documentation team <openshift-docs@redhat.com>


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
main only

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
RHDEVDOCS 5668

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
Change the distro map to enable building of Pipelines 1.13 standalone. No doc change.


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
