### PR TITLE
OCP-4-13 OADP-2943: Rewrite of Restic Backup CR to include Kopia

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2782,7 +2782,7 @@ Topics:
       File: oadp-creating-backup-cr
     - Name: Backing up persistent volumes with CSI snapshots
       File: oadp-backing-up-pvs-csi-doc
-    - Name: Backing up applications with Restic
+    - Name: Backing up applications with File System Backup
       File: oadp-backing-up-applications-restic-doc
     - Name: Creating backup hooks
       File: oadp-creating-backup-hooks-doc

--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
@@ -18,7 +18,7 @@ include::snippets/technology-preview.adoc[]
 
 * If your cloud provider has a native snapshot API or supports CSI snapshots, the `Backup` CR backs up persistent volumes (PVs) by creating snapshots. For more information about working with CSI snapshots, see xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-pvs-csi-doc.adoc#oadp-backing-up-pvs-csi-doc[Backing up persistent volumes with CSI snapshots].
 
-* If your cloud provider does not support snapshots or if your applications are on NFS data volumes, you can create backups by using Restic. See xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#oadp-backing-up-applications-restic-doc[Backing up applications with Restic].
+* If your cloud provider does not support snapshots or if your applications are on NFS data volumes, you can create backups by using Restic. See xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#oadp-backing-up-applications-restic-doc[Backing up applications with File System Backup: Kopia or Restic].
 
 [IMPORTANT]
 ====

--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc
@@ -1,34 +1,44 @@
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: ASSEMBLY
 [id="oadp-backing-up-applications-restic-doc"]
-= Backing up applications with Restic
+= Backing up applications with File System Backup: Kopia or Restic
 include::_attributes/common-attributes.adoc[]
 :context: backing-up-applications
 
 toc::[]
 
-If your cloud provider does not support snapshots or if your applications are on NFS data volumes, you can create backups by using Restic.
+You can use OADP to back up and restore Kubernetes volumes attached to pods from the file system of the volumes. This process is called File System Backup (FSB) or Pod Volume Backup (PVB) and is accomplished by using modules from the following open source backup tools: Restic and Kopia.
+
+If your cloud provider does not support snapshots or if your applications are on NFS data volumes, you can create backups by using FSB.
 
 [NOTE]
 ====
-link:https://restic.net/[Restic] is installed by the OADP Operator by default.
+link:https://restic.net/[Restic] is installed by the OADP Operator by default. If you prefer, you can install link:https://kopia.io/[Kopia] instead.
 ====
 
-Restic integration with OADP provides a solution for backing up and restoring almost any type of Kubernetes volume. This integration is an addition to OADP’s capabilities, not a replacement for existing functionality.
+FSB integration with OADP provides a solution for backing up and restoring almost any type of Kubernetes volume. This integration is an additional capability of OADP and is not a replacement for existing functionality.
 
-You back up Kubernetes resources, internal images, and persistent volumes with Restic by editing the `Backup` custom resource (CR).
+You back up Kubernetes resources, internal images, and persistent volumes with Kopia or Restic by editing the `Backup` custom resource (CR).
 
 You do not need to specify a snapshot location in the `DataProtectionApplication` CR.
 
+[NOTE]
+====
+In OADP version 1.3 and later, you can use either Kopia or Restic for backing up applications.
+For the Built-in DataMover you must use Kopia.
+In OADP version 1.2 and earlier, you can only use Restic for backing up applications.
+====
+
 [IMPORTANT]
 ====
-Restic does not support backing up `hostPath` volumes. For more information, see link:https://{velero-domain}/docs/v{velero-version}/restic/#limitations[additional Restic limitations].
+FSB does not support backing up `hostPath` volumes. For more information, see link:https://velero.io/docs/v1.12/file-system-backup/#limitations[FSB limitations].
 ====
 
 .Prerequisites
 
 * You must install the OpenShift API for Data Protection (OADP) Operator.
-* You must not disable the default Restic installation by setting `spec.configuration.restic.enable` to `false` in the `DataProtectionApplication` CR.
+* You must not disable the default `nodeAgent` installation by setting `spec.configuration.nodeAgent.enable` to `false` in the `DataProtectionApplication` CR.
+* You must select Kopia or Restic as the uploader by setting `spec.configuration.nodeAgent.uploaderType` to `kopia` or `restic` in the `DataProtectionApplication` CR.
 * The `DataProtectionApplication` CR must be in a `Ready` state.
 
 .Procedure

--- a/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
@@ -34,7 +34,7 @@ To back up PVs with snapshots, you must have a cloud provider that supports eith
 
 include::snippets/oadp-ocp-compat.adoc[]
 
-If your cloud provider does not support snapshots or if your storage is NFS, you can back up applications with xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#backing-up-applications[Restic backups] on object storage.
+If your cloud provider does not support snapshots or if your storage is NFS, you can back up applications with xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#backing-up-applications[Backing up applications with File System Backup: Kopia or Restic] on object storage.
 
 You create a default `Secret` and then you install the Data Protection Application.
 

--- a/backup_and_restore/application_backup_and_restore/oadp-advanced-topics.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-advanced-topics.adoc
@@ -29,7 +29,7 @@ For more information about API group versions, see xref:../../backup_and_restore
 
 For more information about OADP Data Mover, see xref:../../backup_and_restore/application_backup_and_restore/installing/oadp-using-data-mover-for-csi-snapshots-doc.adoc#backing-up-applications[Using Data Mover for CSI snapshots].
 
-For more information about using Restic with OADP, see xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#backing-up-applications[Backing up applications with Restic].
+For more information about using Restic with OADP, see xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#backing-up-applications[Backing up applications with File System Backup: Kopia or Restic].
 
 
 :!oadp-advanced-topics:

--- a/backup_and_restore/index.adoc
+++ b/backup_and_restore/index.adoc
@@ -80,7 +80,7 @@ You back up applications by creating a `Backup` custom resource (CR). See xref:.
 
 * xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-scheduling-backups-doc.adoc#backing-up-applications[Scheduling backups]
 
-* xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#backing-up-applications[Restic backups]
+* xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#backing-up-applications[Backing up applications with File System Backup: Kopia or Restic]
 
 * You restore application backups by creating a `Restore` (CR). See xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr-doc#backing-up-applications[Creating a Restore CR].
 * You can configure xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications#oadp-creating-restore-hooks_restoring-applications[restore hooks] to run commands in init containers or in the application container during the restore operation.

--- a/modules/oadp-backing-up-applications-restic.adoc
+++ b/modules/oadp-backing-up-applications-restic.adoc
@@ -38,4 +38,4 @@ spec:
   defaultVolumesToFsBackup: true <1>
 ...
 ----
-<1> In OADP version 1.2 and later, add the `defaultVolumesToFsBackup: true` setting within the `spec` block. In OADP  version 1.1, add `defaultVolumesToRestic: true`.
+<1> In OADP version 1.2 and later, add the `defaultVolumesToFsBackup: true` setting within the `spec` block. In OADP version 1.1, add `defaultVolumesToRestic: true`.

--- a/virt/backup_restore/virt-backing-up-vms.adoc
+++ b/virt/backup_restore/virt-backing-up-vms.adoc
@@ -17,7 +17,7 @@ The `Backup` CR performs the following actions:
 * Backs up VM disks by using one of the following options:
 
 ** xref:../../virt/backup_restore/virt-backing-up-vms.adoc#oadp-backing-up-pvs-csi_virt-backing-up-vms[Container Storage Interface (CSI) snapshots] on CSI-enabled cloud storage, such as Ceph RBD or Ceph FS.
-** xref:../../virt/backup_restore/virt-backing-up-vms.adoc#oadp-backing-up-applications-restic_virt-backing-up-vms[Restic file system backups] on object storage.
+** xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#backing-up-applications[Backing up applications with File System Backup: Kopia or Restic] on object storage.
 
 [NOTE]
 ====


### PR DESCRIPTION
### Additional information

@CarmiWisemon had issues with a [Cherry Pick for 4.13](https://github.com/openshift/openshift-docs/pull/67067#issuecomment-1821248128), highlighted by @kcarmichael08  and he asked me to resolve.

I have made the following PR to resolve this problem. Carmi's [original PR](https://github.com/openshift/openshift-docs/pull/67067) had been approved and merged. 

### OADP Version

* OADP 1.3.0

### Jira 

* [OADP-2943](https://issues.redhat.com/browse/OADP-2943)

### OCP version 

* **4.13**

### Preview

* https://68461--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc

* https://68461--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications

* https://68461--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp

* https://68461--docspreview.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-backing-up-vms

### QE review:

* [ X] QE has approved this change. See [PR#67067](https://github.com/openshift/openshift-docs/pull/67067)

