### PR TITLE
OSDOCS-8836: bug fix add Service field to proxy config

### DIFF
--- a/modules/microshift-cri-o-container-runtime.adoc
+++ b/modules/microshift-cri-o-container-runtime.adoc
@@ -6,18 +6,31 @@
 [id="microshift-CRI-O-container-engine_{context}"]
 = Using a proxy in the CRI-O container runtime
 
-To use an HTTP(S) proxy in `CRI-O`, you need to set the `HTTP_PROXY` and `HTTPS_PROXY` environment variables. You can also set the `NO_PROXY` variable to exclude a list of hosts from being proxied.
+To use an HTTP(S) proxy in `CRI-O`, you must add a `Service` section to the configuration file and set the `HTTP_PROXY` and `HTTPS_PROXY` environment variables. You can also set the `NO_PROXY` variable to exclude a list of hosts from being proxied.
 
 .Procedure
+
+. Create the directory for the configuration file if it does not exist:
++
+[source,terminal]
+----
+$ sudo mkdir /etc/systemd/system/crio.service.d/
+----
 
 . Add the following settings to the `/etc/systemd/system/crio.service.d/00-proxy.conf` file:
 +
 [source,config]
 ----
+[Service]
 Environment=NO_PROXY="localhost,127.0.0.1"
 Environment=HTTP_PROXY="http://$PROXY_USER:$PROXY_PASSWORD@$PROXY_SERVER:$PROXY_PORT/"
 Environment=HTTPS_PROXY="http://$PROXY_USER:$PROXY_PASSWORD@$PROXY_SERVER:$PROXY_PORT/"
 ----
++
+[IMPORTANT]
+====
+You must define the `Service` section of the configuration file for the environment variables or the proxy settings fail to apply.
+====
 
 . Reload the configuration settings:
 +
@@ -26,9 +39,32 @@ Environment=HTTPS_PROXY="http://$PROXY_USER:$PROXY_PASSWORD@$PROXY_SERVER:$PROXY
 $ sudo systemctl daemon-reload
 ----
 
-. Restart the CRI-O service to apply the settings:
+. Restart the CRI-O service:
 +
 [source,terminal]
 ----
 $ sudo systemctl restart crio
+----
+
+. Restart the {microshift-short} service to apply the settings:
++
+[source,terminal]
+----
+$ sudo systemctl restart microshift
+----
+
+.Verification
+
+. Verify that pods are started by running the following command and examining the output:
++
+[source,terminal]
+----
+$ oc get all -A
+----
+
+. Verify that {microshift-short} is able to pull container images by running the following command and examining the output:
++
+[source,terminal]
+----
+$ sudo crictl images
 ----

--- a/modules/microshift-rpm-ostree-https.adoc
+++ b/modules/microshift-rpm-ostree-https.adoc
@@ -6,14 +6,15 @@
 [id="microshift-rpm-ostree-https_{context}"]
 = Using the RPM-OStree HTTP(S) proxy
 
-To use the HTTP(S) proxy in RPM-OStree, set the `http_proxy environment` variable for the `rpm-ostreed` service.
+To use the HTTP(S) proxy in RPM-OStree, you must add a `Service` section to the configuration file and set the `http_proxy environment` variable for the `rpm-ostreed` service.
 
 .Procedure
 
-. Add this setting to the `/etc/systemd/system/rpm-ostreed.service.d/00-proxy.conf` file by running the following command:
+. Add this setting to the `/etc/systemd/system/rpm-ostreed.service.d/00-proxy.conf` file:
 +
 [source,terminal]
 ----
+[Service]
 Environment="http_proxy=http://$PROXY_USER:$PROXY_PASSWORD@$PROXY_SERVER:$PROXY_PORT/"
 ----
 
@@ -25,7 +26,7 @@ Environment="http_proxy=http://$PROXY_USER:$PROXY_PASSWORD@$PROXY_SERVER:$PROXY_
 ----
 $ sudo systemctl daemon-reload
 ----
-.. Restart the rpm-ostree service by running the following command:
+.. Restart the `rpm-ostreed` service by running the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-8836

Link to docs preview:
[MicroShift CRI-O container runtime settings](https://68465--docspreview.netlify.app/microshift/latest/microshift_networking/microshift-networking-settings#microshift-CRI-O-container-engine_microshift-networking)
[Using rpm-ostree proxy settings](https://68465--docspreview.netlify.app/microshift/latest/microshift_networking/microshift-networking-settings#microshift-rpm-ostree-https_microshift-networking)

QE review:
- [x] QE has approved this change.

Additional information:
Customer case resolution, see Issue for links and details

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
