### PR TITLE
OCPBUGS-23402 HealthCheck docs list selector twice

### DIFF
--- a/modules/mgmt-power-remediation-baremetal-about.adoc
+++ b/modules/mgmt-power-remediation-baremetal-about.adoc
@@ -138,7 +138,7 @@ spec:
       machine.openshift.io/cluster-api-machine-role: <role>
       machine.openshift.io/cluster-api-machine-type: <role>
       machine.openshift.io/cluster-api-machineset: <cluster_name>-<label>-<zone>
-  selector:
+  remediationTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3RemediationTemplate
     name: metal3-remediation-template


### PR DESCRIPTION
[OCPBUGS-23402]: HealthCheck docs list "selector" twice

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):enterprise-4.14, enterprise-4.13, enterprise-4.15, main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-23402
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://68468--docspreview.netlify.app/openshift-enterprise/latest/machine_management/deploying-machine-health-checks.html#mgmt-creating-mhc-baremetal_deploying-machine-health-checks
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
