### PR TITLE
[gitops-docs-1.9] Updated the supported ocp version in the compatibility matrix table f…

### DIFF
--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -23,7 +23,7 @@ In {OCP} 4.13, the `stable` channel has been removed. Before upgrading to {OCP} 
 |*OpenShift GitOps* 8+|*Component Versions*|*OpenShift Versions*
 
 |*Version* |*`kam`*    |*Helm*  |*Kustomize* |*Argo CD*|*Argo Rollouts*|*ApplicationSet* |*Dex*     |*RH SSO* |
-|1.9.0    |0.0.49 TP |3.11.2 GA|5.0.1 GA   |2.7.2 GA |1.5.0 TP |NA     |2.35.1 GA |7.5.1 GA |4.12-4.13
+|1.9.0    |0.0.49 TP |3.11.2 GA|5.0.1 GA   |2.7.2 GA |1.5.0 TP |NA     |2.35.1 GA |7.5.1 GA |4.12-4.14
 |1.8.0    |0.0.47 TP |3.10.0 GA|4.5.7 GA   |2.6.3 GA |NA     |NA     |2.35.1 GA |7.5.1 GA |4.10-4.13
 |1.7.0    |0.0.46 TP |3.10.0 GA|4.5.7 GA   |2.5.4 GA |NA     |NA     |2.35.1 GA |7.5.1 GA |4.10-4.12
 |===


### PR DESCRIPTION
Update:

This update is part of the [PR-68316](https://github.com/openshift/openshift-docs/pull/68316), which was missed during manual cherry-pick to gitops-docs-1.9.


**SME and QE review, not required.**

[doc-preview](https://68469--docspreview.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes#GitOps-compatibility-support-matrix_gitops-release-notes)