### PR TITLE
OSDOCS-8693: add Getting Support assembly MicroShift

### DIFF
--- a/_attributes/attributes-microshift.adoc
+++ b/_attributes/attributes-microshift.adoc
@@ -19,5 +19,6 @@
 :op-system-version: 9.2
 :op-system-version-major: 9
 :op-system-bundle: Red Hat Device Edge
+:rhde-version: 4
 :rpm-repo-version: rhocp-4.14
 :VirtProductName: OpenShift Virtualization

--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -79,6 +79,8 @@ Topics:
   File: microshift-etcd
 - Name: The sos report tool
   File: microshift-sos-report
+- Name: Getting support
+  File: microshift-getting-support
 ---
 Name: API reference
 Dir: microshift_rest_api

--- a/microshift_support/microshift-getting-support.adoc
+++ b/microshift_support/microshift-getting-support.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="microshift-getting-support"]
+= Getting support
+include::_attributes/attributes-microshift.adoc[]
+:context: getting-support
+
+toc::[]
+
+// Getting support; note these modules are OCP
+
+include::modules/support.adoc[leveloffset=+1]
+include::modules/microshift-provide-feedback-jira-link.adoc[leveloffset=+1]
+include::modules/support-knowledgebase-about.adoc[leveloffset=+1]
+include::modules/support-knowledgebase-search.adoc[leveloffset=+1]
+include::modules/microshift-submitting-a-case.adoc[leveloffset=+1]

--- a/modules/microshift-provide-feedback-jira-link.adoc
+++ b/modules/microshift-provide-feedback-jira-link.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// microshift_support/
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-provide-feedback-jira-link_{context}"]
+= Providing documentation feedback
+
+To report an error or to improve our documentation, log in to your link:https://issues.redhat.com[Red Hat Jira account] and submit a link:https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12332330&issuetype=1&components=12370455&priority=10200&summary=[Jira issue].

--- a/modules/microshift-submitting-a-case.adoc
+++ b/modules/microshift-submitting-a-case.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * microshift_support/microshift-getting-support.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-support-submitting-a-case_{context}"]
+= Submitting a support case
+
+.Prerequisites
+
+* The {microshift-short} service is running.
+* You have installed the OpenShift CLI (`oc`).
+* You have a Red Hat Customer Portal account.
+* You have a Red Hat Standard or Premium subscription.
+
+.Procedure
+
+. Log in to link:https://access.redhat.com/support/cases/#/case/list[the *Customer Support* page] of the Red Hat Customer Portal.
+
+. Click *Get support*.
+
+. On the *Cases* tab of the *Customer Support* page:
+
+.. Optional: Change the pre-filled account and owner details if needed.
+
+.. Select the appropriate category for your issue, such as *Bug or Defect*, and click *Continue*.
+
+. Enter the following information:
+
+.. In the *Summary* field, enter a concise but descriptive problem summary and further details about the symptoms being experienced, as well as your expectations.
+
+.. Select *{op-system-bundle}* from the *Product* drop-down menu.
+
+.. Select *{rhde-version}* from the *Version* drop-down.
+
+. Review the list of suggested Red Hat Knowledgebase solutions for a potential match against the problem that is being reported. If the suggested articles do not address the issue, click *Continue*.
+
+. Review the updated list of suggested Red Hat Knowledgebase solutions for a potential match against the problem that is being reported. The list is refined as you provide more information during the case creation process. If the suggested articles do not address the issue, click *Continue*.
+
+. Ensure that the account information presented is as expected, and if not, amend accordingly.
+
+. Complete the following questions where prompted. Include which type of install type you are using, either RPM or embedded-image. Click *Continue*:
++
+* What are you experiencing? What are you expecting to happen?
+* Define the value or impact to you or the business.
+* Where are you experiencing this behavior? What environment?
+* When does this behavior occur? Frequency? Repeatedly? At certain times?
+
+. Upload relevant diagnostic data files and click *Continue*. Include data gathered using the `sos` tool or etcd as a starting point, plus any issue-specific data that is not collected in those logs.
+
+. Add relevant case management details and click *Continue*.
+
+. Preview the case details and click *Submit*.

--- a/modules/support-knowledgebase-about.adoc
+++ b/modules/support-knowledgebase-about.adoc
@@ -4,6 +4,7 @@
 // * support/getting-support.adoc
 // * service_mesh/v2x/ossm-troubleshooting-istio.adoc
 // * osd_architecture/osd-support.adoc
+// * microshift_support/microshift-getting-support.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="support-knowledgebase-about_{context}"]

--- a/modules/support-knowledgebase-search.adoc
+++ b/modules/support-knowledgebase-search.adoc
@@ -4,6 +4,7 @@
 // * support/getting-support.adoc
 // * service_mesh/v2x/ossm-troubleshooting-istio.adoc
 // * osd_architecture/osd-support.adoc
+// * microshift_support/microshift-getting-support.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="support-knowledgebase-search_{context}"]

--- a/modules/support-submitting-a-case.adoc
+++ b/modules/support-submitting-a-case.adoc
@@ -23,7 +23,7 @@ ifdef::openshift-dedicated[]
 endif::openshift-dedicated[]
 * You have a Red Hat Customer Portal account.
 ifndef::openshift-dedicated[]
-* You have a Red Hat standard or premium Subscription.
+* You have a Red Hat Standard or Premium subscription.
 endif::openshift-dedicated[]
 
 .Procedure
@@ -34,9 +34,9 @@ endif::openshift-dedicated[]
 
 . On the *Cases* tab of the *Customer Support* page:
 
-.. Optional: Change the pre-filled account and owner, if needed.
+.. Optional: Change the pre-filled account and owner details if needed.
 
-.. Select the appropriate category for your issue,such as *Bug or Defect*, and click *Continue*.
+.. Select the appropriate category for your issue, such as *Bug or Defect*, and click *Continue*.
 
 . Enter the following information:
 
@@ -82,9 +82,10 @@ endif::openshift-dedicated[]
 
 . Complete the following questions where prompted and then click *Continue*:
 +
-* Where are you experiencing the behavior? What environment?
-* When does the behavior occur? Frequency? Repeatedly? At certain times?
-* What information can you provide around time-frames and the business impact?
+* What are you experiencing? What are you expecting to happen?
+* Define the value or impact to you or the business.
+* Where are you experiencing this behavior? What environment?
+* When does this behavior occur? Frequency? Repeatedly? At certain times?
 
 . Upload relevant diagnostic data files and click *Continue*.
 ifndef::openshift-dedicated[]

--- a/modules/support.adoc
+++ b/modules/support.adoc
@@ -17,20 +17,23 @@
 // * distr_tracing/distr_tracing_rn/distr-tracing-rn-2-7.adoc
 // * distr_tracing/distr_tracing_rn/distr-tracing-rn-2-8.adoc
 // * distr_tracing/distr_tracing_rn/distr-tracing-rn-2-9.adoc
+// * microshift_support/microshift-getting-support.adoc
 
 [id="support_{context}"]
 = Getting support
 
-If you experience difficulty with a procedure described in this documentation, or with {product-title} in general, visit the link:http://access.redhat.com[Red Hat Customer Portal]. From the Customer Portal, you can:
+If you experience difficulty with a procedure described in this documentation, or with {product-title} in general, visit the link:http://access.redhat.com[Red Hat Customer Portal].
+
+From the Customer Portal, you can:
 
 * Search or browse through the Red Hat Knowledgebase of articles and solutions relating to Red Hat products.
 * Submit a support case to Red Hat Support.
-// TODO: xref
 * Access other product documentation.
 
+ifndef::microshift[]
 To identify issues with your cluster, you can use Insights in {cluster-manager-url}. Insights provides details about issues and, if available, information on how to solve a problem.
 
 // TODO: verify that these settings apply for Service Mesh and OpenShift virtualization, etc.
 If you have a suggestion for improving this documentation or have found an
-error, submit a link:https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12332330&summary=Documentation_issue&issuetype=1&components=12367614&priority=10200&versions=12385624[Jira issue] for the most relevant documentation component. Please
-provide specific details, such as the section name and {product-title} version.
+error, submit a link:https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12332330&summary=Documentation_issue&issuetype=1&components=12367614&priority=10200&versions=12385624[Jira issue] for the most relevant documentation component. Please provide specific details, such as the section name and {product-title} version.
+endif::microshift[]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-8693

Link to docs preview:
[Getting support](https://68476--docspreview.netlify.app/microshift/latest/microshift_support/microshift-getting-support)
[OCP Getting support](https://68476--docspreview.netlify.app/openshift-enterprise/latest/support/getting-support)

Support review:
- [x] Support has approved this change.

Additional information:
Also replaces DDF with module that links to creating a Jira

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
