### PR TITLE
OBSDOCS-200: Fix typo in command

### DIFF
--- a/modules/cluster-logging-collector-tuning.adoc
+++ b/modules/cluster-logging-collector-tuning.adoc
@@ -149,7 +149,7 @@ $ oc get pods -l component=collector -n openshift-logging
 +
 [source,terminal]
 ----
-$ oc extract configmap/fluentd --confirm
+$ oc extract configmap/collector-config --confirm
 ----
 +
 .Example fluentd.conf


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OBSDOCS-200

Link to docs preview:
Step 4 in the procedure: https://68485--docspreview.netlify.app/openshift-enterprise/latest/logging/log_collection_forwarding/cluster-logging-collector#cluster-logging-collector-tuning_cluster-logging-collector

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Related PR for 4.11 with slightly different command: https://github.com/openshift/openshift-docs/pull/68531
