### PR TITLE
OSDOCS-8330: Configure limits via Subscription, not CSV

### DIFF
--- a/modules/troubleshooting-network-observability-controller-manager-pod-out-of-memory.adoc
+++ b/modules/troubleshooting-network-observability-controller-manager-pod-out-of-memory.adoc
@@ -6,26 +6,42 @@
 [id="controller-manager-pod-runs-out-of-memory_{context}"]
 = Network Observability controller manager pod runs out of memory
 
-You can increase memory limits for the Network Observability operator by patching the Cluster Service Version (CSV), where Network Observability controller manager pod runs out of memory.
+You can increase memory limits for the Network Observability operator by editing the `spec.config.resources.limits.memory` specification in the `Subscription` object.
 
 .Procedure
 
-. Run the following command to patch the CSV:
+. In the web console, navigate to *Operators* -> *Installed Operators*
+. Click *Network Observability* and then select *Subscription*.
+. From the *Actions* menu, click *Edit Subscription*.
+.. Alternatively, you can use the CLI to open the YAML configuration for the `Subscription` object by running the following command:
 +
 [source,terminal]
 ----
-$ oc -n netobserv patch csv network-observability-operator.v1.0.0 --type='json' -p='[{"op": "replace", "path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/resources/limits/memory", value: "1Gi"}]'
+$ oc edit subscription netobserv-operator -n openshift-netobserv-operator
 ----
+. Edit the `Subscription` object to add the `config.resources.limits.memory` specification and set the value to account for your memory requirements. See the Additional resources for more information about resource considerations:
 +
-.Example output
+[source,yaml]
 ----
-clusterserviceversion.operators.coreos.com/network-observability-operator.v1.0.0 patched
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: netobserv-operator
+  namespace: openshift-netobserv-operator
+spec:
+  channel: stable
+  config:
+    resources:
+      limits:
+        memory: 800Mi     <1>
+      requests:
+        cpu: 100m
+        memory: 100Mi
+  installPlanApproval: Automatic
+  name: netobserv-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: <network_observability_operator_latest_version> <2>
 ----
-
-. Run the following command to view the updated CSV:
-+
-[source,terminal]
-----
-$ oc -n netobserv get csv network-observability-operator.v1.0.0 -o jsonpath='{.spec.install.spec.deployments[0].spec.template.spec.containers[0].resources.limits.memory}'
-1Gi
-----
+<1> For example, you can increase the memory limit to `800Mi`.
+<2> This value should not be edited, but note that it changes depending on the most current release of the Operator. 

--- a/network_observability/troubleshooting-network-observability.adoc
+++ b/network_observability/troubleshooting-network-observability.adoc
@@ -18,6 +18,10 @@ include::modules/troubleshooting-network-observability-network-flow.adoc[levelof
 
 include::modules/troubleshooting-network-observability-controller-manager-pod-out-of-memory.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../network_observability/configuring-operator.adoc#network-observability-resources-table_network_observability[Resource considerations]
+
 include::modules/troubleshooting-network-observability-loki-resource-exhausted.adoc[leveloffset=+1]
 
 == Resource troubleshooting


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.11+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-8330
https://issues.redhat.com/browse/NETOBSERV-1373
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://68486--docspreview.netlify.app/openshift-enterprise/latest/network_observability/troubleshooting-network-observability#controller-manager-pod-runs-out-of-memory_network-observability-troubleshooting
QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
