### PR TITLE
OBSDOCS-112: Update event router template

### DIFF
--- a/logging/log_collection_forwarding/cluster-logging-eventrouter.adoc
+++ b/logging/log_collection_forwarding/cluster-logging-eventrouter.adoc
@@ -15,9 +15,4 @@ The Event Router collects events from all projects and writes them to `STDOUT`. 
 The Event Router adds additional load to Fluentd and can impact the number of other log messages that can be processed.
 ====
 
-// The following include statements pull in the module files that comprise
-// the assembly. Include any combination of concept, procedure, or reference
-// modules required to cover the user story. You can also include other
-// assemblies.
-
 include::modules/cluster-logging-eventrouter-deploy.adoc[leveloffset=+1]

--- a/modules/cluster-logging-eventrouter-deploy.adoc
+++ b/modules/cluster-logging-eventrouter-deploy.adoc
@@ -43,7 +43,7 @@ objects:
     - apiGroups: [""]
       resources: ["events"]
       verbs: ["get", "watch", "list"]
-  - kind: ClusterRoleBinding  <3>
+  - kind: ClusterRoleBinding <3>
     apiVersion: rbac.authorization.k8s.io/v1
     metadata:
       name: event-reader-binding
@@ -100,15 +100,24 @@ objects:
               volumeMounts:
               - name: config-volume
                 mountPath: /etc/eventrouter
+              securityContext:
+                allowPrivilegeEscalation: false
+                seccompProfile:
+                  type: RuntimeDefault
+                capabilities:
+                  drop:
+                  - ALL
           volumes:
             - name: config-volume
               configMap:
                 name: eventrouter
+          securityContext:
+            runAsNonRoot: true
 parameters:
   - name: IMAGE <6>
     displayName: Image
     value: "registry.redhat.io/openshift-logging/eventrouter-rhel8:v0.4"
-  - name: CPU  <7>
+  - name: CPU <7>
     displayName: CPU
     value: "100m"
   - name: MEMORY <8>
@@ -146,8 +155,8 @@ $ oc process -f eventrouter.yaml | oc apply -n openshift-logging -f -
 [source,terminal]
 ----
 serviceaccount/eventrouter created
-clusterrole.authorization.openshift.io/event-reader created
-clusterrolebinding.authorization.openshift.io/event-reader-binding created
+clusterrole.rbac.authorization.k8s.io/event-reader created
+clusterrolebinding.rbac.authorization.k8s.io/event-reader-binding created
 configmap/eventrouter created
 deployment.apps/eventrouter created
 ----


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OBSDOCS-112

Link to docs preview:
https://68493--docspreview.netlify.app/openshift-enterprise/latest/logging/log_collection_forwarding/cluster-logging-eventrouter#cluster-logging-eventrouter-deploy_cluster-logging-eventrouter

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
