### PR TITLE
OCPBUGS#22652: Removes incorrect CLI tools from web terminal docs

### DIFF
--- a/modules/odc-access-web-terminal.adoc
+++ b/modules/odc-access-web-terminal.adoc
@@ -6,7 +6,7 @@
 [id="odc-access-web-terminal_{context}"]
 = Accessing the web terminal
 
-After the {web-terminal-op} is installed, you can access the web terminal. After the web terminal is initialized, you can use the preinstalled CLI tools like `oc`, `kubectl`, `odo`, `kn`, `tkn`, `helm`, `kubens`, `subctl`, and `kubectx` in the web terminal.
+After the {web-terminal-op} is installed, you can access the web terminal. After the web terminal is initialized, you can use the preinstalled CLI tools like `oc`, `kubectl`, `odo`, `kn`, `tkn`, `helm`, and `subctl` in the web terminal.
 You can re-run commands by selecting them from the list of commands you have run in the terminal. These commands persist across multiple terminal sessions.
 The web terminal remains open until you close it or until you close the browser window or tab.
 
@@ -36,10 +36,10 @@ ifndef::openshift-rosa,openshift-dedicated[]
 .. From the drop-down list, select a timeout interval of *Seconds*, *Minutes*, *Hours*, or *Milliseconds*.
 
 . Optional: Select a custom image for the web terminal to use.
-.. Click Image. 
+.. Click Image.
 .. In the field that appears, enter the URL of the image that you want to use.
 endif::openshift-rosa,openshift-dedicated[]
 
-. Click *Start* to initialize the web terminal using the selected project. 
+. Click *Start* to initialize the web terminal using the selected project.
 
 . Click *+* to open multiple tabs within the web terminal in the console.

--- a/web_console/web_terminal/odc-using-web-terminal.adoc
+++ b/web_console/web_terminal/odc-using-web-terminal.adoc
@@ -6,6 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can launch an embedded command line terminal instance in the web console. This terminal instance is preinstalled with common CLI tools for interacting with the cluster, such as `oc`, `kubectl`,`odo`, `kn`, `tkn`, `helm`, `kubens`, `subctl`, and `kubectx`. It also has the context of the project you are working on and automatically logs you in using your credentials.
+You can launch an embedded command line terminal instance in the web console. This terminal instance is preinstalled with common CLI tools for interacting with the cluster, such as `oc`, `kubectl`,`odo`, `kn`, `tkn`, `helm`, and `subctl`. It also has the context of the project you are working on and automatically logs you in using your credentials.
 
 include::modules/odc-access-web-terminal.adoc[leveloffset=+1]


### PR DESCRIPTION
OCPBUGS#22652: Removes incorrect CLI tools from web terminal docs

Version(s):
Bug is for 4.12, but tested in cluster 4.11+ and bug is valid in all versions.

Issue:
https://issues.redhat.com/browse/OCPBUGS-22652

Link to docs preview:
https://68495--docspreview.netlify.app/openshift-enterprise/latest/web_console/web_terminal/odc-using-web-terminal

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
