### PR TITLE
WIP OADP-2911 ResticRepository CR is renamed as BackupRepository CR

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/oadp-using-data-mover-for-csi-snapshots-doc.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/oadp-using-data-mover-for-csi-snapshots-doc.adoc
@@ -198,11 +198,14 @@ spec:
     sourcePVCData:
       name: <source_pvc_name>
       size: <source_pvc_size>
-    resticrepository: <your_restic_repo>
+    resticrepository: <your_restic_repo><3>
+    BackupRepository: <your_backup_repository<4>
     volumeSnapshotClassName: <vsclass_name>
 ----
 <1> Specify the namespace where the volume snapshot exists.
 <2> Specify the namespace where the OADP Operator is installed. The default is `openshift-adp`.
+<3> For OADP 1.2 and earlier.
+<4> For OADP 1.3 and later.
 
 . You can back up a volume snapshot by performing the following steps:
 

--- a/modules/oadp-using-data-mover-for-csi-snapshots.adoc
+++ b/modules/oadp-using-data-mover-for-csi-snapshots.adoc
@@ -186,11 +186,14 @@ spec:
     sourcePVCData:
       name: <source_pvc_name>
       size: <source_pvc_size>
-    resticrepository: <your_restic_repo>
+    resticrepository: <your_restic_repo><3>
+    BackupRepository: <your_backup_repository<4>
     volumeSnapshotClassName: <vsclass_name>
 ----
 <1> Specify the namespace where the volume snapshot exists.
 <2> Specify the namespace where the Operator is installed. The default is `openshift-adp`.
+<3> For OADP 1.2 and earlier.
+<4> For OADP 1.3 and later.
 
 . You can back up a volume snapshot by performing the following steps:
 


### PR DESCRIPTION
### Jira 

* [OADP-2911](https://issues.redhat.com/browse/OADP-2911)

### Version(s):

* Version(s): 4.11+

### Link to docs preview:

* [Using Data Mover for CSI snapshots](https://68499--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/oadp-using-data-mover-for-csi-snapshots-doc.html)

### QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
