### PR TITLE
Updates eSwitch mode in SRIOV docs

### DIFF
--- a/modules/nw-sriov-networknodepolicy-object.adoc
+++ b/modules/nw-sriov-networknodepolicy-object.adoc
@@ -34,7 +34,7 @@ spec:
   deviceType: <device_type> <15>
   isRdma: false <16>
   linkType: <link_type> <17>
-  eSwitchMode: "switchdev" <18>
+  eSwitchMode: <mode> <18>
   excludeTopology: false <19>
 ----
 <1> The name for the custom resource object.
@@ -97,7 +97,11 @@ When `linkType` is set to `ib`, `isRdma` is automatically set to `true` by the S
 +
 Do not set linkType to 'eth' for SriovNetworkNodePolicy, because this can lead to an incorrect number of available devices reported by the device plugin.
 
-<18> Optional: To enable hardware offloading, the 'eSwitchMode' field must be set to `"switchdev"`.
+<18> Optional: The NIC device mode. The only allowed values are `legacy` or `switchdev`.
++
+When `eSwitchMode` is set to `legacy`, the default SR-IOV behavior is enabled.
++
+When `eSwitchMode` is set to `switchdev`, hardware offloading is enabled. 
 
 <19> Optional: To exclude advertising an SR-IOV network resource's NUMA node to the Topology Manager, set the value to `true`. The default value is `false`.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-24050

Link to docs preview:
https://68504--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-device#nw-sriov-networknodepolicy-object_configuring-sriov-device

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
