### PR TITLE
[Osdocs 8065]/[OSDOCS-8893]:Relax GCP organizational policy constraint/Document additional GCP API service requirement

### DIFF
--- a/modules/ccs-gcp-customer-procedure.adoc
+++ b/modules/ccs-gcp-customer-procedure.adoc
@@ -16,8 +16,8 @@ To use {product-title} in your GCP project, the following GCP organizational pol
 
 * `constraints/iam.allowedPolicyMemberDomains`
 * `constraints/compute.restrictLoadBalancerCreationForTypes`
-* `constraints/compute.requireShieldedVm`
-* `constraints/compute.vmExternalIpAccess` (This policy constraint is unsupported only during installation. You can re-enable the policy constraint after installation.)
+* `constraints/compute.requireShieldedVm` (This policy constraint is supported only if the cluster is installed with "Enable Secure Boot support for Shielded VMs" selected during the initial cluster creation).
+* `constraints/compute.vmExternalIpAccess` (This policy constraint is supported only after installation).
 ====
 
 .Procedure
@@ -73,6 +73,9 @@ The project name must be 10 characters or less.
 
 |link:https://console.cloud.google.com/apis/library/storage-component.googleapis.com?project=openshift-gce-devel&folder=&organizationId=[Cloud Storage]
 |`storage-component.googleapis.com`
+//Additional Org Policy going live TBD. See https://issues.redhat.com/browse/OSDOCS-8893 for more info.
+// |link:https://console.cloud.google.com/apis/library/orgpolicy.googleapis.com?project=openshift-gce-devel&folder=&organizationId=[Google Cloud Organization Policy API]
+// |`orgpolicy.googleapis.com`
 
 |===
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
**This PR is for the Shielded VMs constraint policy setting for GCP OSD release that is scheduled for 12/15/23. Do not merge until this date.**
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-8065 and 

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://68506--docspreview.netlify.app/openshift-dedicated/latest/osd_planning/gcp-ccs#ccs-gcp-customer-procedure_gcp-ccs
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

<!--- Optional: Include additional context or expand the description here.--->




<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
