### PR TITLE
Documentation for the GitOps 1.11.0 release notes.

### DIFF
--- a/modules/gitops-release-notes-1-11-0.adoc
+++ b/modules/gitops-release-notes-1-11-0.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assembly:
+//
+// * release_notes/gitops-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="gitops-release-notes-1-11-0_{context}"]
+= Release notes for {gitops-title} 1.11.0
+
+{gitops-title} 1.11.0 is now available on {OCP} 4.12, 4.13, and 4.14.
+
+[id="new-features-1-11-0_{context}"]
+== New features
+
+The current release adds the following improvement:
+
+* With this update, you can selectively disable the `redis` and `application-controller` components for an Argo CD instance in a specified namespace. These components are enabled by default.
+To disable a component, set the `enabled` flag to `false` in the `.spec.<component>.enabled` field of the Argo CD Custom Resource (CR). link:https://issues.redhat.com/browse/GITOPS-3723[GITOPS-3723]
++
+For example:
++
+[source,yaml]
+----
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+spec:
+  controller:
+    enabled: false
+  redis:
+    enabled: false
+----
++
+[NOTE]
+====
+This feature is currently limited to the `redis` and `application-controller` components. It is expected that support for other components will be included in a future {gitops-title} release.
+====
+
+[id="fixed-issues-1-11-0_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* Before this update, the Argo CD Notifications Controller did not support custom certificates added to the `argocd-tls-certs-cm` config map. As a result, notification services with custom certificates did not receive notifications due to the `x509: certificate signed by unknown authority` error message. This update fixes the issue by correctly initializing the cert resolver function in the Argo CD Notifications Controller to load all certificates stored in the `argocd-tls-certs-cm` config map. Now, notification services with custom certificates can successfully receive notifications. link:https://issues.redhat.com/browse/GITOPS-2809[GITOPS-2809]
+
+* Before this update, users would face `PrometheusOperatorRejectedResources` alerts when the {gitops-title} Operator was not installed in the `openshift-gitops-operator` namespace. The problem affected users who upgraded from earlier versions of the {gitops-title} Operator to v1.10. This update fixes the issue by updating the Operator's `serverName` metrics service to reflect the correct installation namespace. Now, users who upgrade or install the {gitops-title} Operator in namespaces other than `openshift-gitops-operator` should not see these alerts. link:https://issues.redhat.com/browse/GITOPS-3424[GITOPS-3424]

--- a/modules/gitops-release-notes-1-9-0.adoc
+++ b/modules/gitops-release-notes-1-9-0.adoc
@@ -32,11 +32,6 @@ $ oc describe deployment gitops-operator-controller-manager -n openshift-operato
 The current release adds the following improvements:
 
 * With this update, you can use a custom `must-gather` tool to collect diagnostic information for project-level resources, cluster-level resources, and {gitops-title} components. This tool provides the debugging information about the cluster associated with {gitops-title}, which you can share with the Red Hat Support team for analysis. link:https://issues.redhat.com/browse/GITOPS-2797[GITOPS-2797]
-+
-[IMPORTANT]
-====
-The custom `must-gather` tool is a Technology Preview feature.
-====
 
 * With this update, you can add support to progressive delivery using Argo Rollouts. Currently, the supported traffic manager is only {SMProductName}. link:https://issues.redhat.com/browse/GITOPS-959[GITOPS-959]
 +

--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -24,6 +24,8 @@ In {OCP} 4.13, the `stable` channel has been removed. Before upgrading to {OCP} 
 
 |*Version* |*`kam`*    |*Helm*  |*Kustomize* |*Argo CD*|*Argo Rollouts*|*ApplicationSet* |*Dex*     |*RH SSO* |
 
+|1.11.0 |0.0.51 TP |3.13.2 GA |5.2.1 GA |2.9.2 GA |1.6.0 TP |NA |2.36.0 GA |7.6.0 GA |4.12-4.14
+
 |1.10.0 |0.0.50 TP |3.12.1 GA |5.1.0 GA |2.8.3 GA |1.5.0 TP |NA |2.35.1 GA |7.5.1 GA |4.12-4.14
 
 |1.9.0    |0.0.49 TP |3.11.2 GA|5.0.1 GA   |2.7.2 GA |1.5.0 TP |NA     |2.35.1 GA |7.5.1 GA |4.12-4.14
@@ -45,10 +47,6 @@ The features mentioned in the following table are currently in Technology Previe
 [cols="4,1,1",options="header"]
 |====
 |Feature |TP in {gitops-title} versions|GA in {gitops-title} versions
-
-|The custom `must-gather` tool
-|1.9.0
-|NA
 
 |Argo Rollouts
 |1.9.0

--- a/release_notes/gitops-release-notes.adoc
+++ b/release_notes/gitops-release-notes.adoc
@@ -22,6 +22,8 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+include::modules/gitops-release-notes-1-11-0.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-10-1.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-10-0.adoc[leveloffset=+1]


### PR DESCRIPTION
- Jira issue: [RHDEVDOC-5680](https://issues.redhat.com/browse/RHDEVDOCS-5680)
- Cherry-pick branches: gitops-docs-1.11
- OCP  team: Devtools outerloop
- Doc preview: [GitOps 1.11.0 Release Notes](https://68509--docspreview.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes#gitops-release-notes-1-11-0_gitops-release-notes)
- SME reviews by: @svghadi , @reginapizza , @jaideepr97 
- QE reviews by: @varshab1210 
- Peer reviews by: @Srivaralakshmi 
