### PR TITLE
OBSDOCS-289: Added Logging 5.8.0 release notes to ROSA and OSD

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -1027,8 +1027,8 @@ Topics:
 - Name: Release notes
   Dir: logging_release_notes
   Topics:
-#  - Name: Logging 5.8
-#    File: logging-5-8-release-notes
+  - Name: Logging 5.8
+    File: logging-5-8-release-notes
   - Name: Logging 5.7
     File: logging-5-7-release-notes
 - Name: Support

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1209,8 +1209,8 @@ Topics:
 - Name: Release notes
   Dir: logging_release_notes
   Topics:
-#  - Name: Logging 5.8
-#    File: logging-5-8-release-notes
+  - Name: Logging 5.8
+    File: logging-5-8-release-notes
   - Name: Logging 5.7
     File: logging-5-7-release-notes
 - Name: Support


### PR DESCRIPTION
Change type: Doc update; Add Logging 5.8.0 Release Notes to ROSA & OSD

Note: This PR is to include the Logging 5.8.0 Release Notes in OSD & ROSA. The Release Notes is already merged in OCP.
PR Link: https://github.com/openshift/openshift-docs/pull/66871 

Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-289

Fix Version: 4.12+

Doc Preview: 
ROSA: https://68510--docspreview.netlify.app/openshift-rosa/latest/logging/logging_release_notes/logging-5-8-release-notes 
OSD: https://68510--docspreview.netlify.app/openshift-dedicated/latest/logging/logging_release_notes/logging-5-8-release-notes 

QE review:
N/A - content has already been reviewed