### PR TITLE
GH#67953: fix switch in cgroup versioning

### DIFF
--- a/modules/nodes-clusters-cgroups-2.adoc
+++ b/modules/nodes-clusters-cgroups-2.adoc
@@ -148,7 +148,7 @@ $ oc describe mc <name>
 ----
 +
 ifdef::nodes[]
-.Example output for cgroup v2
+.Example output for cgroup v1
 [source,terminal]
 ----
 apiVersion: machineconfiguration.openshift.io/v2
@@ -162,11 +162,11 @@ spec:
     systemd.unified_cgroup_hierarchy=0 <1>
     systemd.legacy_systemd_cgroup_controller=1 <2>
 ----
-<1> Enables cgroup v2 in systemd.
-<2> Disables cgroup v1.
+<1> Enables cgroup v1 in systemd.
+<2> Disables cgroup v2.
 +
 endif::nodes[]
-.Example output for cgroup v1
+.Example output for cgroup v2
 [source,terminal]
 ----
 apiVersion: machineconfiguration.openshift.io/v2
@@ -181,8 +181,8 @@ spec:
   - cgroup_no_v1="all" <2>
   - psi=1 <3>
 ----
-<1> Enables cgroup v1 in systemd.
-<2> Disables cgroup v2.
+<1> Enables cgroup v2 in systemd.
+<2> Disables cgroup v1.
 <3> Enables the Linux Pressure Stall Information (PSI) feature.
 
 . Check the nodes to see that scheduling on the nodes is disabled. This indicates that the change is being applied:


### PR DESCRIPTION
Version(s):
OCP 4.14

4.13 and older versions are correct.

Issue:
GitHub #67953 
It only fixes the cgroup versioning problem.

QE review:
- [ ] QE has approved this change.