### PR TITLE
OCPBUGS-23364: Adding automatedCleaningMode to restructured SNO SiteConfig CR ref

### DIFF
--- a/modules/ztp-sno-siteconfig-config-reference.adoc
+++ b/modules/ztp-sno-siteconfig-config-reference.adoc
@@ -51,6 +51,9 @@ For standard deployments, define three hosts with `role: master` and two or more
 |`spec.clusters.nodes.nodeLabels`
 |Specify custom roles for your nodes in your managed clusters. These are additional roles are not used by any {product-title} components, only by the user. When you add a custom role, it can be associated with a custom machine config pool that references a specific configuration for that role. Adding custom labels or roles during installation makes the deployment process more effective and prevents the need for additional reboots after the installation is complete.
 
+|`spec.clusters.nodes.automatedCleaningMode`
+|Optional. Uncomment and set the value to `metadata` to enable the removal of the disk's partitioning table only, without fully wiping the disk. The default value is `disabled`.
+
 |`spec.clusters.nodes.bmcAddress`
 |BMC address that you use to access the host. Applies to all cluster types. {ztp} supports iPXE and virtual media booting by using Redfish or IPMI protocols. To use iPXE booting, you must use {rh-rhacm} 2.8 or later. For more information about BMC addressing, see the "Additional resources" section.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14, 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-23364
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://68514--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites#ztp-sno-siteconfig-config-reference_ztp-deploying-far-edge-sites
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: The SiteConfig ref was moved and restructured after I merged the original PR and the field was accidentally deleted. The content was reviewed and approved here: https://github.com/openshift/openshift-docs/pull/63109/files
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
