### PR TITLE
OCPBUGS-23364-RN: Updated link for Disk cleaning option after SiteConfig ref restructure

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -1276,7 +1276,7 @@ With this release, you can precache your application workload images before upgr
 [id="ocp-4-14-ztp-siteconfig-disk-cleaning"]
 ==== Disk cleaning option through SiteConfig and {ztp}
 
-With this release, you can remove the partitioning table before installation by using the `automatedCleaningMode` field in the `SiteConfig` CR. For more information, see xref:../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc#ztp-deploying-a-site_ztp-deploying-far-edge-sites[Deploying a managed cluster with SiteConfig and GitOps ZTP].
+With this release, you can remove the partitioning table before installation by using the `automatedCleaningMode` field in the `SiteConfig` CR. For more information, see xref:../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc#ztp-sno-siteconfig-config-reference_ztp-deploying-far-edge-sites[Single-node OpenShift SiteConfig CR installation reference].
 
 [id="ocp-4-14-ztp-support-custom-node-labels"]
 ==== Support for adding custom node labels in the SiteConfig CR through {ztp}


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-23364
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://68516--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-ztp-siteconfig-disk-cleaning
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Additional information: The SiteConfig ref was moved and restructured after I merged the original PR and the field was accidentally deleted. The content was reviewed and approved here: https://github.com/openshift/openshift-docs/pull/63109/files
Related PR for fix: https://github.com/openshift/openshift-docs/pull/68514

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
