### PR TITLE
PR for SRVCOM-2868: Updated the incorrect "Enabling monitoring for user-defined projects" link. 

### DIFF
--- a/observability/developer-metrics/serverless-developer-metrics.adoc
+++ b/observability/developer-metrics/serverless-developer-metrics.adoc
@@ -23,5 +23,5 @@ Scraping the metrics does not affect autoscaling of a Knative service, because s
 [role="_additional-resources"]
 == Additional resources for {ocp-product-title}
 * link:https://docs.openshift.com/container-platform/latest/monitoring/monitoring-overview.html#monitoring-overview[Monitoring overview]
-* link:https://docs.openshift.com/container-platform/latest/monitoring/managing-metrics.html#specifying-how-a-service-is-monitored[Enabling monitoring for user-defined projects]
+* link:https://docs.openshift.com/container-platform/latest/monitoring/enabling-monitoring-for-user-defined-projects.html[Enabling monitoring for user-defined projects]
 * link:https://docs.openshift.com/container-platform/latest/monitoring/enabling-monitoring-for-user-defined-projects.html#enabling-monitoring-for-user-defined-projects[Specifying how a service is monitored]


### PR DESCRIPTION
**Affected versions for cherry-picking:**
- Serverless 1.31
- Serverless 1.30

**Tracking JIRA:** https://issues.redhat.com/browse/SRVCOM-2868

**Doc preview & description:**
In the [Serverless developer metrics overview](https://68519--docspreview.netlify.app/openshift-serverless/latest/observability/developer-metrics/serverless-developer-metrics) docs page, the "**Enabling monitoring for user-defined projects**" link is now pointing to the correct location. 
