### PR TITLE
OBSDOCS-200: Fix typo in command for logging 5.7 (4.11)

### DIFF
--- a/modules/cluster-logging-collector-tuning.adoc
+++ b/modules/cluster-logging-collector-tuning.adoc
@@ -149,7 +149,7 @@ $ oc get pods -l component=collector -n openshift-logging
 +
 [source,terminal]
 ----
-$ oc extract configmap/fluentd --confirm
+$ oc extract configmap/collector --confirm
 ----
 +
 .Example fluentd.conf


### PR DESCRIPTION
Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OBSDOCS-200

Link to docs preview:
Step 4 in the procedure: https://68531--docspreview.netlify.app/openshift-enterprise/latest/logging/log_collection_forwarding/cluster-logging-collector#cluster-logging-collector-tuning_cluster-logging-collector

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
