### PR TITLE
[internal-update] release-note-tp-heading

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -27,7 +27,7 @@ You must use {op-system} machines for the control plane, and you can use either 
 //TODO: Add this for 4.14
 Starting with {product-title} 4.12, an additional six months is added to the Extended Update Support (EUS) phase on even numbered releases from 18 months to two years. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
 
-Starting with {product-title} {product-version}, Extended Update Support (EUS) is extended to 64-bit ARM, {ibmpowerProductName} (ppc64le), and {ibmzProductName} (s390x) platforms.  For more information, see the link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
+Starting with {product-title} {product-version}, Extended Update Support (EUS) is extended to 64-bit ARM, {ibm-power-name} (ppc64le), and {ibm-z-name} (s390x) platforms. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
 
 //TODO: Add the line below for EUS releases.
 {product-title} {product-version} is an Extended Update Support (EUS) release. More information on Red Hat OpenShift EUS is available in link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[OpenShift Life Cycle] and link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
@@ -65,21 +65,21 @@ This release adds improvements related to the following components and concepts.
 === OpenShift CLI (oc)
 
 [id="ocp-4-15-ibm-z"]
-=== {ibmzProductName}(R) and {linuxoneProductName}
+=== {ibm-z-title} and {ibm-linuxone-title}
 
 [id="ocp-4-15-ibm-power"]
-=== {ibmpowerRegProductName}
+=== {ibm-power-title}
 
 [discrete]
-==== {ibmpowerRegProductName} notable enhancements
+==== {ibm-power-title} notable enhancements
 
 [discrete]
-=== {ibmpowerRegProductName}, {ibmzRegProductName}, and {linuxoneProductName} support matrix
+=== {ibm-power-title}, {ibm-z-title}, and {ibm-linuxone-title} support matrix
 
 .{product-title} features
 [cols="3,1,1",options="header"]
 |====
-|Feature |{ibmpowerRegProductName} |{ibmzRegProductName} and {linuxoneProductName}
+|Feature |{ibm-power-name} |{ibm-z-name} and {ibm-linuxone-name}
 
 |Alternate authentication providers
 |Supported
@@ -93,7 +93,7 @@ This release adds improvements related to the following components and concepts.
 |Unsupported
 |Unsupported
 
-|Cloud controller manager for IBM Cloud
+|Cloud controller manager for {ibm-cloud-name}
 |Supported
 |Unsupported
 
@@ -133,11 +133,11 @@ This release adds improvements related to the following components and concepts.
 |Unsupported
 |Supported
 
-|{ibmpowerProductName} Virtual Server Block CSI Driver Operator (Technology Preview)
+|{ibm-power-server-name} Block CSI Driver Operator (Technology Preview)
 |Supported
 |Unsupported
 
-|Installer-provisioned Infrastructure Enablement for {ibmpowerProductName} Virtual Server (Technology Preview)
+|Installer-provisioned Infrastructure Enablement for {ibm-power-server-name} (Technology Preview)
 |Supported
 |Unsupported
 
@@ -233,7 +233,7 @@ This release adds improvements related to the following components and concepts.
 .Persistent storage options
 [cols="2,1,1",options="header"]
 |====
-|Feature |{ibmpowerProductName} |{ibmzProductName} and {linuxoneProductName}
+|Feature |{ibm-power-name} |{ibm-z-name} and {ibm-linuxone-name}
 |Persistent storage using iSCSI
 |Supported ^[1]^
 |Supported ^[1]^,^[2]^
@@ -267,7 +267,7 @@ This release adds improvements related to the following components and concepts.
 .Operators
 [cols="2,1,1",options="header"]
 |====
-|Feature |{ibmpowerRegProductName} |{ibmzRegProductName} and {linuxoneProductName}
+|Feature |{ibm-power-name} |{ibm-z-name} and {ibm-linuxone-name}
 
 |Cluster Logging Operator
 |Supported
@@ -321,7 +321,7 @@ This release adds improvements related to the following components and concepts.
 .Multus CNI plugins
 [cols="2,1,1",options="header"]
 |====
-|Feature |{ibmpowerRegProductName} |{ibmzRegProductName} and {linuxoneProductName}
+|Feature |{ibm-power-name} |{ibm-z-name} and {ibm-linuxone-name}
 
 |Bridge
 |Supported
@@ -343,7 +343,7 @@ This release adds improvements related to the following components and concepts.
 .CSI Volumes
 [cols="2,1,1",options="header"]
 |====
-|Feature |{ibmpowerRegProductName} |{ibmzRegProductName} and {linuxoneProductName}
+|Feature |{ibm-power-name} |{ibm-z-name} and {ibm-linuxone-name}
 
 |Cloning
 |Supported
@@ -813,8 +813,8 @@ In the following tables, features are marked with the following statuses:
 ==== Windows containers
 // Added after OCP GA
 
-[id="ocp-4-15-technology-preview"]
-== Technology Preview features
+[id="ocp-4-15-technology-preview-tables"]
+== Technology Preview support in recent releases
 
 Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red Hat Customer Portal for these features:
 
@@ -905,7 +905,7 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |General Availability
 
-|{ibmpowerProductName} Virtual Server Block CSI Driver Operator
+|{ibm-power-server-name} Block CSI Driver Operator
 |Technology Preview
 |Technology Preview
 |Technology Preview
@@ -1020,7 +1020,7 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.13 |4.14 |4.15
 
-|{ibmpowerProductName} Virtual Server using installer-provisioned infrastructure
+|{ibm-power-server-name} using installer-provisioned infrastructure
 |Technology Preview
 |Technology Preview
 |Technology Preview
@@ -1246,7 +1246,7 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
-|Cloud controller manager for IBM Cloud Power VS
+|Cloud controller manager for {ibm-power-name} VS
 |Technology Preview
 |Technology Preview
 |Technology Preview


### PR DESCRIPTION
INTERNAL UPDATE. NO JIRA

Purpose:

* Provided a clearer title for the Tech preview table section based on a [Slack conversation](https://redhat-internal.slack.com/archives/C04DLQNN7B9/p1701248366042939). Also replaced old IBM name attributes with newer attributes. 

Version(s):
4.15

Link to docs preview:
[Technology Preview support in recent releases](https://68540--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-technology-preview-tables)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
