### PR TITLE
ROX-18752: Fix typo in example

### DIFF
--- a/modules/declarative-configuration-examples.adoc
+++ b/modules/declarative-configuration-examples.adoc
@@ -24,7 +24,7 @@ groups: <4>
     - key: email <5>
       value: example@example.com
       role: Admin <6>
-    - key: group
+    - key: groups
       value: reviewers
       role: Analyst
 requiredAttributes: <7>


### PR DESCRIPTION
Version(s):
- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-4.3`
- Cherry pick to `rhacs-docs-4.2`
- Cherry pick to `rhacs-docs-4.1`

[Issue](https://issues.redhat.com/browse/ROX-18752)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

[Link to docs preview
](https://68556--docspreview.netlify.app/openshift-acs/latest/configuration/declarative-configuration-using#declarative-config-example-auth-provider)

QE review: (**Not required**)
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
