### PR TITLE
OSDOCS#8789: Remove upgrade blocks for vSphere migration

### DIFF
--- a/modules/persistent-storage-csi-migration-overview.adoc
+++ b/modules/persistent-storage-csi-migration-overview.adoc
@@ -17,7 +17,7 @@ The following in-tree to CSI drivers are automatically migrated:
 * Amazon Web Services (AWS) Elastic Block Storage (EBS)
 * Google Compute Engine Persistent Disk (GCP PD)
 * Azure File
-* VMware vSphere (see information below for specific migration behavior for vSphere)
+* VMware vSphere
 
 CSI migration for these volume types is considered generally available (GA), and requires no manual intervention.
 

--- a/storage/container_storage_interface/persistent-storage-csi-migration.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-migration.adoc
@@ -13,10 +13,3 @@ include::modules/persistent-storage-csi-migration-sc.adoc[leveloffset=+1]
 
 To change the default storage class, see xref:../../storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc#change-default-storage-class_persistent-storage-csi-sc-manage[Changing the default storage class].
 
-include::modules/persistent-storage-csi-migration-vsphere.adoc[leveloffset=+1]
-
-ifndef::openshift-origin[]
-[role="_additional-resources"]
-.Additional resources
-* xref:../../updating/updating_a_cluster/eus-eus-update.adoc#eus-eus-update[Performing an EUS-to-EUS update]
-endif::openshift-origin[]

--- a/storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
@@ -22,9 +22,11 @@ To create CSI-provisioned persistent volumes (PVs) that mount to vSphere storage
 
 //Listing the VMWare driver version here because it has a more variable set of features. The Operator version does not change independently (is parallel).
 
-[IMPORTANT]
+[NOTE]
 ====
-{product-title} defaults to using the CSI plugin to provision vSphere storage.
+For new installations, {product-title} 4.13 and later provides automatic migration for the vSphere in-tree volume plugin to its equivalent CSI driver. Updating to {product-title} 4.15 and later also provides automatic migration. For more information about updating and migration, see xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration].
+
+CSI automatic migration should be seamless. Migration does not change how you use all existing API objects, such as persistent volumes, persistent volume claims, and storage classes.
 ====
 
 [NOTE]

--- a/storage/persistent_storage/persistent-storage-vsphere.adoc
+++ b/storage/persistent_storage/persistent-storage-vsphere.adoc
@@ -26,11 +26,9 @@ requested by users.
 
 [IMPORTANT]
 ====
-{product-title} defaults to using an in-tree (non-CSI) plugin to provision vSphere storage.
+For new installations, {product-title} 4.13 and later provides automatic migration for the vSphere in-tree volume plugin to its equivalent CSI driver. Updating to {product-title} 4.15 and later also provides automatic migration. For more information about updating and migration, see xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration].
 
-In future {product-title} versions, volumes provisioned using existing in-tree plugins are planned for migration to their equivalent CSI driver. CSI automatic migration should be seamless. Migration does not change how you use all existing API objects, such as persistent volumes, persistent volume claims, and storage classes. For more information about migration, see xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration].
-
-After full migration, in-tree plugins will eventually be removed in future versions of {product-title}.
+CSI automatic migration should be seamless. Migration does not change how you use all existing API objects, such as persistent volumes, persistent volume claims, and storage classes.
 ====
 
 [role="_additional-resources"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-8789
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://68558--docspreview.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-migration
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

**PTAL**:  @gcharot, @gnufied, @duanwei33 
