### PR TITLE
HCCDOC-1671:  URL for allowlist is incorrect

### DIFF
--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -52,9 +52,8 @@ If your environment has a dedicated load balancer in front of your {product-titl
 |Provides core container images
 
 |`sso.redhat.com`
-|443, 80
-|The `https://console.redhat.com/openshift` site uses authentication from `sso.redhat.com`
-[.small]
+|443
+|The `https://console.redhat.com` site uses authentication from `sso.redhat.com`
 |===
 +
 [.small]
@@ -84,8 +83,8 @@ You can use the wildcards `\*.quay.io` and `*.openshiftapps.com` instead of `cdn
 |443, 80
 |Required for Telemetry
 
-|`console.redhat.com/api/ingress`
-|443, 80
+|`console.redhat.com`
+|443
 |Required for Telemetry and for `insights-operator`
 |===
 
@@ -217,8 +216,8 @@ Alternatively, if you choose to not use a wildcard for AWS APIs, you must allowl
 |443, 80
 |Required to download {op-system-first} images.
 
-|`console.redhat.com/openshift`
-|443, 80
+|`console.redhat.com`
+|443
 |Required for your cluster token.
 
 // |`registry.access.redhat.com`
@@ -226,8 +225,8 @@ Alternatively, if you choose to not use a wildcard for AWS APIs, you must allowl
 // |Required for `odo` CLI.
 
 |`sso.redhat.com`
-|443, 80
-|The `https://console.redhat.com/openshift` site uses authentication from `sso.redhat.com`
+|443
+|The `https://console.redhat.com` site uses authentication from `sso.redhat.com`
 
 |===
 Operators require route access to perform health checks. Specifically, the


### PR DESCRIPTION
Version(s):
PR applies to 4.11+

Issue:
https://issues.redhat.com/browse/HCCDOC-1671

Link to docs preview:
https://68568--docspreview.netlify.app

QE review:
@radekvokal provided QE review.
[X ] QE has approved this change.

Additional information:
- In table entries where `console.redhat.com/openshift` is referrenced, remove `/openshift`.
- Remove references to port `80` from allowlist ports for console.redhat.com

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.11+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
[HCCDOC-1671](https://issues.redhat.com//browse/HCCDOC-1671)
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
