### PR TITLE
OSDOCS-8777: move offline embedding to install book

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -49,11 +49,15 @@ Name: Installing
 Dir: microshift_install
 Distros: microshift
 Topics:
-- Name: Installing from RPM
+- Name: Installing from an RPM package
   File: microshift-install-rpm
+- Name: Mirroring container images for disconnected installations
+  File: microshift-deploy-with-mirror-registry
 - Name: Embedding in a RHEL for Edge image
   File: microshift-embed-in-rpm-ostree
-- Name: Greenboot health check
+- Name: Embedding in a RHEL for Edge image for offline use
+  File: microshift-embed-in-rpm-ostree-offline-use
+- Name: Understanding system health checks
   File: microshift-greenboot
 - Name: Troubleshooting installation issues
   File: microshift-installing-troubleshooting
@@ -424,8 +428,6 @@ Name: Running applications
 Dir: microshift_running_apps
 Distros: microshift
 Topics:
-- Name: Embedding MicroShift containers for offline deployments
-  File: microshift-embed-microshift-offline-deploy
 - Name: Embedding applications on RHEL for Edge
   File: microshift-embedded-apps-on-rhel-edge
 - Name: Embedding applications for offline use
@@ -440,8 +442,6 @@ Topics:
   File: microshift-greenboot-workload-scripts
 - Name: Pod security authentication and authorization
   File: microshift-authentication
-- Name: Mirror registry deployment
-  File: microshift-deploy-with-mirror-registry
 ---
 Name: Backup and restore
 Dir: microshift_backup_and_restore

--- a/microshift_install/microshift-deploy-with-mirror-registry.adoc
+++ b/microshift_install/microshift-deploy-with-mirror-registry.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="microshift-deploy-with-mirror-registry"]
-= {microshift-short} deployment with a mirror registry
+= Mirroring container images for disconnected installations
 include::_attributes/attributes-microshift.adoc[]
 :context: microshift-deployment-mirror
 

--- a/microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc
+++ b/microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="microshift-embed-microshift-offline-deployments"]
-= Running a cluster in an offline deployment
+[id="microshift-embed-in-rpm-ostree-for-offline-use"]
+= Embedding in a {op-system-ostree} image for offline use
 include::_attributes/attributes-microshift.adoc[]
-:context: microshift-embed-apps-offline-use
+:context: microshift-embed-rpm-ostree-offline-use
 
 toc::[]
 

--- a/microshift_install/microshift-embed-in-rpm-ostree.adoc
+++ b/microshift_install/microshift-embed-in-rpm-ostree.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="microshift-embed-in-rpm-ostree"]
-= Embedding {microshift-short} in a {op-system-ostree} image
+= Embedding in a {op-system-ostree} image
 include::_attributes/attributes-microshift.adoc[]
 :context: microshift-embed-in-rpm-ostree
 

--- a/microshift_install/microshift-greenboot.adoc
+++ b/microshift_install/microshift-greenboot.adoc
@@ -1,23 +1,25 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="microshift-greenboot"]
-= The Greenboot health check
+= The Greenboot health check framework
 include::_attributes/attributes-microshift.adoc[]
 :context: microshift-greenboot
 
 toc::[]
 
-Greenboot is the generic health check framework for the `systemd` service on RPM-OSTree-based systems. The `microshift-greenboot` RPM and `greenboot-default-health-checks` are RPM packages installed with {microshift-short}. Greenboot is used to assess system health and automate a rollback to the last healthy state in the event of software trouble, for example:
+Greenboot is the generic health check framework for the `systemd` service on `rpm-ostree` systems such as {op-system-ostree-first}. This framework is included in {microshift-short} installations with the `microshift-greenboot` and `greenboot-default-health-checks` RPM packages.
 
-* This health check framework is especially useful when you need to check for software problems and perform system rollbacks on edge devices where direct serviceability is either limited or non-existent.
-* When health check scripts are installed and configured, health checks run every time the system starts.
-* Using Greenboot can reduce your risk of being locked out of edge devices during updates and prevent a significant interruption of service if an update fails.
-* When a failure is detected, the system boots into the last known working configuration using the `rpm-ostree` rollback capability.
+Greenboot health checks run at various times to assess system health and automate a rollback to the last healthy state in the event of software trouble, for example:
 
-A {microshift-short} application health check script is included in the `microshift-greenboot` RPM. The `greenboot-default-health-checks` RPM also includes health check scripts verifying that DNS and `ostree` services are accessible. In addition, you can create your own health check scripts for the workloads you are running. You can write one that verifies that an application has started, for example.
+* Default health check scripts run each time the system starts.
+* In addition the to the default health checks, you can write, install, and configure application health check scripts to also run every time the system starts.
+* Greenboot can reduce your risk of being locked out of edge devices during updates and prevent a significant interruption of service if an update fails.
+* When a failure is detected, the system boots into the last known working configuration using the `rpm-ostree` rollback capability. This feature is especially useful automation for edge devices where direct serviceability is either limited or non-existent.
+
+A {microshift-short} application health check script is included in the `microshift-greenboot` RPM. The `greenboot-default-health-checks` RPM includes health check scripts verifying that DNS and `ostree` services are accessible. You can create your own health check scripts for the workloads you are running. You can write one that verifies that an application has started, for example.
 
 [NOTE]
 ====
-Rollback is not possible in the case of an update failure on a system not using OSTree. This is true even though health checks might run.
+Rollback is not possible in the case of an update failure on a system not using `rpm-ostree`. This is true even though health checks might run.
 ====
 
 include::modules/microshift-greenboot-dir-structure.adoc[leveloffset=+1]

--- a/modules/microshift-accessing-cluster-locally.adoc
+++ b/modules/microshift-accessing-cluster-locally.adoc
@@ -39,7 +39,7 @@ $ chmod go-r ~/.kube/config
 
 .Verification
 
-* Verify that {product-title} is running by entering the following command:
+* Verify that {microshift-short} is running by entering the following command:
 +
 [source,terminal]
 ----

--- a/modules/microshift-adding-repos-to-image-builder.adoc
+++ b/modules/microshift-adding-repos-to-image-builder.adoc
@@ -17,7 +17,7 @@ Use the following procedure to add the {microshift-short} repositories to Image 
 
 .Procedure
 
-. Create an Image Builder configuration file for adding the `{rpm-repo-version}` RPM repository source required to pull {product-title} RPMs by running the following command:
+. Create an Image Builder configuration file for adding the `{rpm-repo-version}` RPM repository source required to pull {microshift-short} RPMs by running the following command:
 +
 [source,text,subs="attributes+"]
 ----

--- a/modules/microshift-adding-service-to-blueprint.adoc
+++ b/modules/microshift-adding-service-to-blueprint.adoc
@@ -33,7 +33,7 @@ version = "*"
 enabled = ["microshift"]
 EOF
 ----
-
++
 [NOTE]
 ====
 The wildcard `*` in the commands uses the latest {microshift-short} RPMs. If you need a specific version, substitute the wildcard for the version you want. For example, insert `4.14.1` to download the {microshift-short} 4.14.1 RPMs.


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-8777

Link to docs preview:
[Main Install book view](https://file.rdu.redhat.com/shdiaz/OSDOCS-8777/microshift_install/microshift-install-rpm.html)
[Mirroring container images for disconnected installations](https://file.rdu.redhat.com/shdiaz/OSDOCS-8777/microshift_install/microshift-deploy-with-mirror-registry.html)
[Offline use install chapter](https://file.rdu.redhat.com/shdiaz/OSDOCS-8777/microshift_install/microshift-embed-in-rpm-ostree-offline-use.html)
[Greenboot chapter retitle and intro text tweaks](https://file.rdu.redhat.com/shdiaz/OSDOCS-8777/microshift_install/microshift-greenboot.html)

QE review:
- N/A, restructuring PR

Additional information:
1st of two PRs; see also https://github.com/openshift/openshift-docs/pull/68592

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
