### PR TITLE
OCPBUGS#17540:Removed incorrect reference to ppc64le and s390x

### DIFF
--- a/modules/rhel-compute-overview.adoc
+++ b/modules/rhel-compute-overview.adoc
@@ -8,7 +8,7 @@
 [id="rhel-compute-overview_{context}"]
 = About adding RHEL compute nodes to a cluster
 
-In {product-title} {product-version}, you have the option of using {op-system-base-full} machines as compute machines in your cluster if you use a user-provisioned or installer-provisioned infrastructure installation on the `x86_64`, `ppc64le`, and `s390x` architectures. You must use {op-system-first} machines for the control plane machines in your cluster.
+In {product-title} {product-version}, you have the option of using {op-system-base-full} machines as compute machines in your cluster if you use a user-provisioned or installer-provisioned infrastructure installation on the `x86_64` architecture. You must use {op-system-first} machines for the control plane machines in your cluster.
 
 If you choose to use {op-system-base} compute machines in your cluster, you are responsible for all operating system life cycle management and maintenance. You must perform system updates, apply patches, and complete all other required tasks.
 


### PR DESCRIPTION
Version(s):
4.12, 4.14, 4.15

Issue:
This PR addresses [ocpbugs-17540](https://issues.redhat.com/browse/OCPBUGS-17540).

Link to docs preview:

[About adding RHEL compute nodes to a cluster](https://68589--docspreview.netlify.app/openshift-enterprise/latest/machine_management/adding-rhel-compute#rhel-compute-overview_adding-rhel-compute)

QE review:
- [x] QE has approved this change.

Additional information:

This fix does not apply to 4.13, as the 4.13 docs correctly reference `x86_64` only. This discrepancy occurred first in https://github.com/openshift/openshift-docs/pull/62082 (`4.12`), which was subsequently used by https://github.com/openshift/openshift-docs/pull/65055 to cherry pick into `main` and `4.14`. As such, the 4.13 content was unaffected.
