### PR TITLE
OADP-3145: OADP 1.3.0 Attributes Updates

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -61,7 +61,7 @@ endif::openshift-origin[]
 :secondary-scheduler-operator: Secondary Scheduler Operator
 // Backup and restore
 :velero-domain: velero.io
-:velero-version: 1.11
+:velero-version: 1.12
 :launch: image:app-launcher.png[title="Application Launcher"]
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers

--- a/modules/velero-oadp-version-relationship.adoc
+++ b/modules/velero-oadp-version-relationship.adoc
@@ -17,4 +17,5 @@
 | 1.2.1 | link:https://{velero-domain}/docs/v1.11/[1.11] | 4.11 and later
 | 1.2.2 | link:https://{velero-domain}/docs/v1.11/[1.11] | 4.11 and later
 | 1.2.3 | link:https://{velero-domain}/docs/v1.11/[1.11] | 4.11 and later
+| 1.3.0 | link:https://{velero-domain}/docs/v1.12/[1.12] | 4.12 and later
 |===


### PR DESCRIPTION
### Jira

* [OADP-3145](https://issues.redhat.com/browse/OADP-3145) - see [Slack discussion](https://redhat-internal.slack.com/archives/C0144ECKUJ0/p1701202173787149?thread_ts=1701200116.943819&cid=C0144ECKUJ0)

    * Velero version moves to 1.12 to OADP 1.3.0
    
     ![image](https://github.com/openshift/openshift-docs/assets/106804821/0df95935-e452-44d1-aa29-f97d120d0613)

### Version(s):

* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15

### Link to docs preview:

* [OADP-Velero-OpenShift Container Platform version relationship](https://68597--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator#velero-oadp-version-relationship_installing-oadp-operator)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
