### PR TITLE
OSDOCS-8910

### DIFF
--- a/modules/oadp-preparing-aws-credentials.adoc
+++ b/modules/oadp-preparing-aws-credentials.adoc
@@ -9,7 +9,7 @@
 An AWS account must be ready to accept an OADP installation.
 
 .Procedure
-. Create the following environment variables by running the following commands:
+. Create the following environment variables by running the following commands: 
 +
 [NOTE]
 ====
@@ -117,7 +117,7 @@ $ echo ${POLICY_ARN}
 ----
 $ cat <<EOF > ${SCRATCH}/trust-policy.json
 {
-    "Version":2012-10-17",
+    "Version": "2012-10-17",
     "Statement": [{
       "Effect": "Allow",
       "Principal": {


### PR DESCRIPTION
[OSDOCS-8910](https://issues.redhat.com/browse/OSDOCS-8910): [rosa-] Issue in file rosa_backing_up_and_restoring_applications/backing-up-applications.adoc

Aligned team: Service Delivery
OCP version for cherry-picking: enterprise-4.14+
JIRA issues: [OSDOCS-8910](https://issues.redhat.com/browse/OSDOCS-8910)
Preview pages: [Click to see the build preview in your browser for ROSA](https://68615--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_backing_up_and_restoring_applications/backing-up-applications#oadp-preparing-aws-credentials_rosa-backing-up-applications)
SME review : **Not Applicable**
QE review **completed**: @xueli181114  ([Approval in Jira comment](https://issues.redhat.com/browse/OSDOCS-8910?focusedId=23619901&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-23619901))
Peer review **completed**: @bburt-rh and @shipsing

PS: Here Jira number is changed from OCPBUGS-18824 to [OSDOCS-8910](https://issues.redhat.com//browse/OSDOCS-8910). I have updated the title and description in PR accordingly.