### PR TITLE
OCPBUGS#8290: Amended outdated reference to Configuring Fluentd

### DIFF
--- a/logging/cluster-logging-deploying.adoc
+++ b/logging/cluster-logging-deploying.adoc
@@ -26,6 +26,10 @@ include::snippets/logging-fluentd-dep-snip.adoc[]
 
 include::modules/cluster-logging-deploy-console.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../logging/log_collection_forwarding/cluster-logging-collector.adoc#cluster-logging-collector[Configuring the logging collector]
+
 include::modules/cluster-logging-deploy-cli.adoc[leveloffset=+1]
 
 [id="cluster-logging-deploying-es-operator"]

--- a/modules/cluster-logging-deploy-console.adoc
+++ b/modules/cluster-logging-deploy-console.adoc
@@ -145,7 +145,7 @@ However, an unmanaged deployment does not receive updates until OpenShift Loggin
 <7> Specify the CPU and memory requests for Elasticsearch as needed. If you leave these values blank, the OpenShift Elasticsearch Operator sets default values that should be sufficient for most deployments. The default values are `16Gi` for the memory request and `1` for the CPU request.
 <8> Specify the CPU and memory requests for the Elasticsearch proxy as needed. If you leave these values blank, the OpenShift Elasticsearch Operator sets default values that should be sufficient for most deployments. The default values are `256Mi` for the memory request and `100m` for the CPU request.
 <9> Settings for configuring Kibana. Using the CR, you can scale Kibana for redundancy and configure the CPU and memory for your Kibana nodes. For more information, see *Configuring the log visualizer*.
-<10> Settings for configuring Fluentd. Using the CR, you can configure Fluentd CPU and memory limits. For more information, see *Configuring Fluentd*.
+<10> Settings for configuring Fluentd. Using the CR, you can configure Fluentd CPU and memory limits. For more information, see the section named *Configuring the logging collector*.
 +
 [NOTE]
 +


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OCPBUGS-8290](https://issues.redhat.com/browse/OCPBUGS-8290)

Link to docs preview:
https://68616--docspreview.netlify.app/openshift-rosa/latest/logging/cluster-logging-deploying

QE review:
No QE review necessary as it is a simple text change.

