### PR TITLE
[SRVOCF-517] Add docs on setting custom PVC size for on-cluster function builds

### DIFF
--- a/functions/serverless-functions-on-cluster-builds.adoc
+++ b/functions/serverless-functions-on-cluster-builds.adoc
@@ -10,3 +10,4 @@ Instead of building a function locally, you can build a function directly on the
 
 include::modules/serverless-functions-creating-on-cluster-builds.adoc[leveloffset=+1]
 include::modules/serverless-functions-specifying-function-revision.adoc[leveloffset=+1]
+include::modules/serverless-functions-setting-custom-volume-size.adoc[leveloffset=+1]

--- a/modules/serverless-functions-setting-custom-volume-size.adoc
+++ b/modules/serverless-functions-setting-custom-volume-size.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * serverless/functions/serverless-functions-on-cluster-builds.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-functions-setting-custom-volume-size_{context}"]
+= Setting custom volume size
+
+For projects that require a volume with a larger size to build, you might need to customize the persistent volume claim (PVC) when building on the cluster. The default PVC size is 256 mebibytes.
+
+.Prerequisites
+
+* {pipelines-title} must be installed on your cluster.
+
+* You have installed the OpenShift (`oc`) CLI.
+
+* You have installed the Knative (`kn`) CLI.
+
+.Procedure
+
+* Deploy your function with the `--pvc-size` flag and PVC size specification by running the following command:
++
+[source,terminal]
+----
+$ kn func deploy --remote --pvc-size='2Gi'
+----
++
+In this example, PVC is set to two gibibytes.


### PR DESCRIPTION
Version(s):
`serverless-docs-1.30`+

Issue:
https://issues.redhat.com/browse/SRVOCF-517

Link to docs preview:
https://68625--docspreview.netlify.app/openshift-serverless/latest/functions/serverless-functions-on-cluster-builds#serverless-functions-setting-custom-volume-size_serverless-functions-on-cluster-builds

QE review:
- [ ] QE has approved this change.