### PR TITLE
Fix closing parenthesis in CRI-O support docs

### DIFF
--- a/modules/gathering-crio-logs.adoc
+++ b/modules/gathering-crio-logs.adoc
@@ -22,7 +22,7 @@ endif::openshift-rosa,openshift-dedicated[]
 
 .Procedure
 
-. Gather CRI-O journald unit logs. The following example collects logs from all control plane nodes (within the cluster:
+. Gather CRI-O journald unit logs. The following example collects logs from all control plane nodes within the cluster:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
All supported versions.

Issue:

None - I only stumbled across this reading the documentation:

https://docs.openshift.com/container-platform/4.14/support/troubleshooting/troubleshooting-crio-issues.html#gathering-crio-logs_troubleshooting-crio-issues

Link to docs preview:

QE review:
- [ ] QE has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
