### PR TITLE
reformatting Azure installation configuration parameters

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1074,251 +1074,512 @@ within link:https://azure.microsoft.com/en-us/global-infrastructure/regions[a re
 ====
 
 .Additional Azure parameters
-[cols=".^2,.^3a,.^3a",options="header"]
+[cols=".^2l,.^3a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
-|`compute.platform.azure.encryptionAtHost`
+|compute:
+  platform:
+    azure:
+      encryptionAtHost:
 |Enables host-level encryption for compute machines. You can enable this encryption alongside user-managed server-side encryption. This feature encrypts temporary, ephemeral, cached and un-managed disks on the VM host. This is not a prerequisite for user-managed server-side encryption.
 |`true` or `false`. The default is `false`.
 
-|`compute.platform.azure.osDisk.diskSizeGB`
+|compute:
+  platform:
+    azure:
+      osDisk:
+        diskSizeGB:
 |The Azure disk size for the VM.
 |Integer that represents the size of the disk in GB. The default is `128`.
 
-|`compute.platform.azure.osDisk.diskType`
+|compute:
+  platform:
+    azure:
+      osDisk:
+        diskType:
 |Defines the type of disk.
 |`standard_LRS`, `premium_LRS`, or `standardSSD_LRS`. The default is `premium_LRS`.
 
-|`compute.platform.azure.ultraSSDCapability`
+|compute:
+  platform:
+    azure:
+      ultraSSDCapability:
 |Enables the use of Azure ultra disks for persistent storage on compute nodes. This requires that your Azure region and zone have ultra disks available.
 |`Enabled`, `Disabled`. The default is `Disabled`.
 
-|`compute.platform.azure.osDisk.diskEncryptionSet.resourceGroup`
+|compute:
+  platform:
+    azure:
+      osDisk:
+        diskEncryptionSet:
+          resourceGroup:
 |The name of the Azure resource group that contains the disk encryption set from the installation prerequisites. This resource group should be different from the resource group where you install the cluster to avoid deleting your Azure encryption key when the cluster is destroyed. This value is only necessary if you intend to install the cluster with user-managed disk encryption.
 |String, for example `production_encryption_resource_group`.
 
-|`compute.platform.azure.osDisk.diskEncryptionSet.name`
+|compute:
+  platform:
+    azure:
+      osDisk:
+        diskEncryptionSet:
+          name:
 |The name of the disk encryption set that contains the encryption key from the installation prerequisites.
 |String, for example `production_disk_encryption_set`.
 
-|`compute.platform.azure.osDisk.diskEncryptionSet.subscriptionId`
+|compute:
+  platform:
+    azure:
+      osDisk:
+        diskEncryptionSet:
+          subscriptionId:
 |Defines the Azure subscription of the disk encryption set where the disk encryption set resides. This secondary disk encryption set is used to encrypt compute machines.
 |String, in the format `00000000-0000-0000-0000-000000000000`.
 
-|`compute.platorm.azure.osImage.publisher`
+|compute:
+  platform:
+    azure:
+      osImage:
+        publisher:
 |Optional. By default, the installation program downloads and installs the {op-system-first} image that is used to boot compute machines. You can override the default behavior by using a custom {op-system} image that is available from the Azure Marketplace. The installation program uses this image for compute machines only.
 |String. The name of the image publisher.
 
-|`compute.platorm.azure.osImage.offer`
-|The name of Azure Marketplace offer that is associated with the custom {op-system} image. If you use `compute.platorm.azure.osImage.publisher`, this field is required.
+|compute:
+  platform:
+    azure:
+      osImage:
+        offer:
+|The name of Azure Marketplace offer that is associated with the custom {op-system} image. If you use `compute.platform.azure.osImage.publisher`, this field is required.
 |String. The name of the image offer.
 
-|`compute.platorm.azure.osImage.sku`
-|An instance of the Azure Marketplace offer. If you use `compute.platorm.azure.osImage.publisher`, this field is required.
+|compute:
+  platform:
+    azure:
+      osImage:
+        sku:
+|An instance of the Azure Marketplace offer. If you use `compute.platform.azure.osImage.publisher`, this field is required.
 |String. The SKU of the image offer.
 
-|`compute.platorm.azure.osImage.version`
-|The version number of the image SKU. If you use `compute.platorm.azure.osImage.publisher`, this field is required.
+|compute:
+  platform:
+    azure:
+      osImage:
+        version:
+|The version number of the image SKU. If you use `compute.platform.azure.osImage.publisher`, this field is required.
 |String. The version of the image to use.
 
-|`compute.platform.azure.vmNetworkingType`
+|compute:
+  platform:
+    azure:
+      vmNetworkingType:
 |Enables accelerated networking. Accelerated networking enables single root I/O virtualization (SR-IOV) to a VM, improving its networking performance. If instance type of compute machines support `Accelerated` networking, by default, the installer enables `Accelerated` networking, otherwise the default networking type is `Basic`.
 |`Accelerated` or `Basic`.
 
-|`compute.platform.azure.type`
+|compute:
+  platform:
+    azure:
+      type:
 |Defines the Azure instance type for compute machines.
 |String
 
-|`compute.platform.azure.zones`
+|compute:
+  platform:
+    azure:
+      zones:
 |The availability zones where the installation program creates compute machines.
 |String list
 
-|`compute.platform.azure.settings.securityType`
+|compute:
+  platform:
+    azure:
+      settings:
+        securityType:
 |Enables confidential VMs or trusted launch for compute nodes. This option is not enabled by default.
 |`ConfidentialVM` or `TrustedLaunch`.
 
-|`compute.platform.azure.settings.confidentialVM.uefiSettings.secureBoot`
+|compute:
+  platform:
+    azure:
+      settings:
+        confidentialVM:
+          uefiSettings:
+            secureBoot:
 |Enables secure boot on compute nodes if you are using confidential VMs.
 |`Enabled` or `Disabled`. The default is `Disabled`.
 
-|`compute.platform.azure.settings.confidentialVM.uefiSettings.virtualizedTrustedPlatformModule`
+|compute:
+  platform:
+    azure:
+      settings:
+        confidentialVM:
+          uefiSettings:
+            virtualizedTrustedPlatformModule:
 |Enables the virtualized Trusted Platform Module (vTPM) feature on compute nodes if you are using confidential VMs.
 |`Enabled` or `Disabled`. The default is `Disabled`.
 
-|`compute.platform.azure.settings.trustedLaunch.uefiSettings.secureBoot`
+|compute:
+  platform:
+    azure:
+      settings:
+        trustedLaunch:
+          uefiSettings:
+            secureBoot:
 |Enables secure boot on compute nodes if you are using trusted launch.
 |`Enabled` or `Disabled`. The default is `Disabled`.
 
-|`compute.platform.azure.settings.trustedLaunch.uefiSettings.virtualizedTrustedPlatformModule`
+|compute:
+  platform:
+    azure:
+      settings:
+        trustedLaunch:
+          uefiSettings:
+            virtualizedTrustedPlatformModule:
 |Enables the vTPM feature on compute nodes if you are using trusted launch.
 |`Enabled` or `Disabled`. The default is `Disabled`.
 
-|`compute.platform.azure.osDisk.securityProfile.securityEncryptionType`
+|compute:
+  platform:
+    azure:
+      osDisk:
+        securityProfile:
+          securityEncryptionType:
 |Enables the encryption of the virtual machine guest state for compute nodes. This parameter can only be used if you use Confidential VMs.
 |`VMGuestStateOnly` is the only supported value.
 
-|`controlPlane.platform.azure.settings.securityType`
+|controlPlane:
+  platform:
+    azure:
+      settings:
+        securityType:
 |Enables confidential VMs or trusted launch for control plane nodes. This option is not enabled by default.
 |`ConfidentialVM` or `TrustedLaunch`.
 
-|`controlPlane.platform.azure.settings.confidentialVM.uefiSettings.secureBoot`
+|controlPlane:
+  platform:
+    azure:
+      settings:
+        confidentialVM:
+          uefiSettings:
+            secureBoot:
 |Enables secure boot on control plane nodes if you are using confidential VMs.
 |`Enabled` or `Disabled`. The default is `Disabled`.
 
-|`controlPlane.platform.azure.settings.confidentialVM.uefiSettings.virtualizedTrustedPlatformModule`
+|controlPlane:
+  platform:
+    azure:
+      settings:
+        confidentialVM:
+          uefiSettings:
+            virtualizedTrustedPlatformModule:
 |Enables the vTPM feature on control plane nodes if you are using confidential VMs.
 |`Enabled` or `Disabled`. The default is `Disabled`.
 
-|`controlPlane.platform.azure.settings.trustedLaunch.uefiSettings.secureBoot`
+|controlPlane:
+  platform:
+    azure:
+      settings:
+        trustedLaunch:
+          uefiSettings:
+            secureBoot:
 |Enables secure boot on control plane nodes if you are using trusted launch.
 |`Enabled` or `Disabled`. The default is `Disabled`.
 
-|`controlPlane.platform.azure.settings.trustedLaunch.uefiSettings.virtualizedTrustedPlatformModule`
+|controlPlane:
+  platform:
+    azure:
+      settings:
+        trustedLaunch:
+          uefiSettings:
+            virtualizedTrustedPlatformModule:
 |Enables the vTPM feature on control plane nodes if you are using trusted launch.
 |`Enabled` or `Disabled`. The default is `Disabled`.
 
-|`controlPlane.platform.azure.osDisk.securityProfile.securityEncryptionType`
+|controlPlane:
+  platform:
+    azure:
+      osDisk:
+        securityProfile:
+          securityEncryptionType:
 |Enables the encryption of the virtual machine guest state for control plane nodes. This parameter can only be used if you use Confidential VMs.
 |`VMGuestStateOnly` is the only supported value.
 
-|`controlPlane.platform.azure.type`
+|controlPlane:
+  platform:
+    azure:
+      type:
 |Defines the Azure instance type for control plane machines.
 |String
 
-|`controlPlane.platform.azure.zones`
+|controlPlane:
+  platform:
+    azure:
+      zones:
 |The availability zones where the installation program creates control plane machines.
 |String list
 
-|`platform.azure.defaultMachinePlatform.settings.securityType`
+|platform:
+  azure:
+    defaultMachinePlatform:
+      settings:
+        securityType:
 |Enables confidential VMs or trusted launch for all nodes. This option is not enabled by default.
 |`ConfidentialVM` or `TrustedLaunch`.
 
-|`platform.azure.defaultMachinePlatform.settings.confidentialVM.uefiSettings.secureBoot`
+|platform:
+  azure:
+    defaultMachinePlatform:
+      settings:
+        confidentialVM:
+          uefiSettings:
+            secureBoot:
 |Enables secure boot on all nodes if you are using confidential VMs.
 |`Enabled` or `Disabled`. The default is `Disabled`.
 
-|`platform.azure.defaultMachinePlatform.settings.confidentialVM.uefiSettings.virtualizedTrustedPlatformModule`
+|platform:
+  azure:
+    defaultMachinePlatform:
+      settings:
+        confidentialVM:
+          uefiSettings:
+            virtualizedTrustedPlatformModule:
 |Enables the virtualized Trusted Platform Module (vTPM) feature on all nodes if you are using confidential VMs.
 |`Enabled` or `Disabled`. The default is `Disabled`.
 
-|`platform.azure.defaultMachinePlatform.settings.trustedLaunch.uefiSettings.secureBoot`
+|platform:
+  azure:
+    defaultMachinePlatform:
+      settings:
+        trustedLaunch:
+          uefiSettings:
+            secureBoot:
 |Enables secure boot on all nodes if you are using trusted launch.
 |`Enabled` or `Disabled`. The default is `Disabled`.
 
-|`platform.azure.defaultMachinePlatform.settings.trustedLaunch.uefiSettings.virtualizedTrustedPlatformModule`
+|platform:
+  azure:
+    defaultMachinePlatform:
+      settings:
+        trustedLaunch:
+          uefiSettings:
+            virtualizedTrustedPlatformModule:
 |Enables the vTPM feature on all nodes if you are using trusted launch.
 |`Enabled` or `Disabled`. The default is `Disabled`.
 
-|`platform.azure.defaultMachinePlatform.osDisk.securityProfile.securityEncryptionType`
+|platform:
+  azure:
+    defaultMachinePlatform:
+      osDisk:
+        securityProfile:
+          securityEncryptionType:
 |Enables the encryption of the virtual machine guest state for all nodes. This parameter can only be used if you use Confidential VMs.
 |`VMGuestStateOnly` is the only supported value.
 
-|`platform.azure.defaultMachinePlatform.encryptionAtHost`
+|platform:
+  azure:
+    defaultMachinePlatform:
+      encryptionAtHost:
 |Enables host-level encryption for compute machines. You can enable this encryption alongside user-managed server-side encryption. This feature encrypts temporary, ephemeral, cached, and un-managed disks on the VM host. This parameter is not a prerequisite for user-managed server-side encryption.
 |`true` or `false`. The default is `false`.
 
-|`platform.azure.defaultMachinePlatform.osDisk.diskEncryptionSet.name`
+|platform:
+  azure:
+    defaultMachinePlatform:
+      osDisk:
+        diskEncryptionSet:
+          name:
 |The name of the disk encryption set that contains the encryption key from the installation prerequisites.
 |String, for example, `production_disk_encryption_set`.
 
-|`platform.azure.defaultMachinePlatform.osDisk.diskEncryptionSet.resourceGroup`
+|platform:
+  azure:
+    defaultMachinePlatform:
+      osDisk:
+        diskEncryptionSet:
+          resourceGroup:
 |The name of the Azure resource group that contains the disk encryption set from the installation prerequisites. To avoid deleting your Azure encryption key when the cluster is destroyed, this resource group must be different from the resource group where you install the cluster. This value is necessary only if you intend to install the cluster with user-managed disk encryption.
 |String, for example, `production_encryption_resource_group`.
 
-|`platform.azure.defaultMachinePlatform.osDisk.diskEncryptionSet.subscriptionId`
+|platform:
+  azure:
+    defaultMachinePlatform:
+      osDisk:
+        diskEncryptionSet:
+          subscriptionId:
 |Defines the Azure subscription of the disk encryption set where the disk encryption set resides. This secondary disk encryption set is used to encrypt compute machines.
 |String, in the format `00000000-0000-0000-0000-000000000000`.
 
-|`platform.azure.defaultMachinePlatform.osDisk.diskSizeGB`
+|platform:
+  azure:
+    defaultMachinePlatform:
+      osDisk:
+        diskSizeGB:
 |The Azure disk size for the VM.
 |Integer that represents the size of the disk in GB. The default is `128`.
 
-|`platform.azure.defaultMachinePlatform.osDisk.diskType`
+|platform:
+  azure:
+    defaultMachinePlatform:
+      osDisk:
+        diskType:
 |Defines the type of disk.
 |`premium_LRS` or `standardSSD_LRS`. The default is `premium_LRS`.
 
-|`platform.azure.defaultMachinePlatform.osImage.publisher`
+|platform:
+  azure:
+    defaultMachinePlatform:
+      osImage:
+        publisher:
 |Optional. By default, the installation program downloads and installs the {op-system-first} image that is used to boot control plane and compute machines. You can override the default behavior by using a custom {op-system} image that is available from the Azure Marketplace. The installation program uses this image for both types of machines.
 |String. The name of the image publisher.
 
-|`platform.azure.defaultMachinePlatform.osImage.offer`
+|platform:
+  azure:
+    defaultMachinePlatform:
+      osImage:
+        offer:
 |The name of Azure Marketplace offer that is associated with the custom {op-system} image. If you use `platform.azure.defaultMachinePlatform.osImage.publisher`, this field is required.
 |String. The name of the image offer.
 
-|`platform.azure.defaultMachinePlatform.osImage.sku`
+|platform:
+  azure:
+    defaultMachinePlatform:
+      osImage:
+        sku:
 |An instance of the Azure Marketplace offer. If you use `platform.azure.defaultMachinePlatform.osImage.publisher`, this field is required.
 |String. The SKU of the image offer.
 
-|`platform.azure.defaultMachinePlatform.osImage.version`
+|platform:
+  azure:
+    defaultMachinePlatform:
+      osImage:
+        version:
 |The version number of the image SKU. If you use `platform.azure.defaultMachinePlatform.osImage.publisher`, this field is required.
 |String. The version of the image to use.
 
-|`platform.azure.defaultMachinePlatform.type`
+|platform:
+  azure:
+    defaultMachinePlatform:
+      type:
 |The Azure instance type for control plane and compute machines.
 |The Azure instance type.
 
-|`platform.azure.defaultMachinePlatform.zones`
+|platform:
+  azure:
+    defaultMachinePlatform:
+      zones:
 |The availability zones where the installation program creates compute and control plane machines.
 |String list.
 
-|`controlPlane.platform.azure.encryptionAtHost`
+|controlPlane:
+  platform:
+    azure:
+      encryptionAtHost:
 |Enables host-level encryption for control plane machines. You can enable this encryption alongside user-managed server-side encryption. This feature encrypts temporary, ephemeral, cached and un-managed disks on the VM host. This is not a prerequisite for user-managed server-side encryption.
 |`true` or `false`. The default is `false`.
 
-|`controlPlane.platform.azure.osDisk.diskEncryptionSet.resourceGroup`
+|controlPlane:
+  platform:
+    azure:
+      osDisk:
+        diskEncryptionSet:
+          resourceGroup:
 |The name of the Azure resource group that contains the disk encryption set from the installation prerequisites. This resource group should be different from the resource group where you install the cluster to avoid deleting your Azure encryption key when the cluster is destroyed. This value is only necessary if you intend to install the cluster with user-managed disk encryption.
 |String, for example `production_encryption_resource_group`.
 
-|`controlPlane.platform.azure.osDisk.diskEncryptionSet.name`
+|controlPlane:
+  platform:
+    azure:
+      osDisk:
+        diskEncryptionSet:
+          name:
 |The name of the disk encryption set that contains the encryption key from the installation prerequisites.
 |String, for example `production_disk_encryption_set`.
 
-|`controlPlane.platform.azure.osDisk.diskEncryptionSet.subscriptionId`
+|controlPlane:
+  platform:
+    azure:
+      osDisk:
+        diskEncryptionSet:
+          subscriptionId:
 |Defines the Azure subscription of the disk encryption set where the disk encryption set resides. This secondary disk encryption set is used to encrypt control plane machines.
 |String, in the format `00000000-0000-0000-0000-000000000000`.
 
-|`controlPlane.platform.azure.osDisk.diskSizeGB`
+|controlPlane:
+  platform:
+    azure:
+      osDisk:
+        diskSizeGB:
 |The Azure disk size for the VM.
 |Integer that represents the size of the disk in GB. The default is `1024`.
 
-|`controlPlane.platform.azure.osDisk.diskType`
+|controlPlane:
+  platform:
+    azure:
+      osDisk:
+        diskType:
 |Defines the type of disk.
 |`premium_LRS` or `standardSSD_LRS`. The default is `premium_LRS`.
 
-|`controlPlane.platorm.azure.osImage.publisher`
+|controlPlane:
+  platform:
+    azure:
+      osImage:
+        publisher:
 |Optional. By default, the installation program downloads and installs the {op-system-first} image that is used to boot control plane machines. You can override the default behavior by using a custom {op-system} image that is available from the Azure Marketplace. The installation program uses this image for control plane machines only.
 |String. The name of the image publisher.
 
-|`controlPlane.platorm.azure.osImage.offer`
-|The name of Azure Marketplace offer that is associated with the custom {op-system} image. If you use `controlPlane.platorm.azure.osImage.publisher`, this field is required.
+|controlPlane:
+  platform:
+    azure:
+      osImage:
+        offer:
+|The name of Azure Marketplace offer that is associated with the custom {op-system} image. If you use `controlPlane.platform.azure.osImage.publisher`, this field is required.
 |String. The name of the image offer.
 
-|`controlPlane.platorm.azure.osImage.sku`
-|An instance of the Azure Marketplace offer. If you use `controlPlane.platorm.azure.osImage.publisher`, this field is required.
+|controlPlane:
+  platform:
+    azure:
+      osImage:
+        sku:
+|An instance of the Azure Marketplace offer. If you use `controlPlane.platform.azure.osImage.publisher`, this field is required.
 |String. The SKU of the image offer.
 
-|`controlPlane.platorm.azure.osImage.version`
-|The version number of the image SKU. If you use `controlPlane.platorm.azure.osImage.publisher`, this field is required.
+|controlPlane:
+  platform:
+    azure:
+      osImage:
+        version:
+|The version number of the image SKU. If you use `controlPlane.platform.azure.osImage.publisher`, this field is required.
 |String. The version of the image to use.
 
-|`controlPlane.platform.azure.ultraSSDCapability`
+|controlPlane:
+  platform:
+    azure:
+      ultraSSDCapability:
 |Enables the use of Azure ultra disks for persistent storage on control plane machines. This requires that your Azure region and zone have ultra disks available.
 |`Enabled`, `Disabled`. The default is `Disabled`.
 
-|`controlPlane.platform.azure.vmNetworkingType`
+|controlPlane:
+  platform:
+    azure:
+      vmNetworkingType:
 |Enables accelerated networking. Accelerated networking enables single root I/O virtualization (SR-IOV) to a VM, improving its networking performance. If instance type of control plane machines support `Accelerated` networking, by default, the installer enables `Accelerated` networking, otherwise the default networking type is `Basic`.
 |`Accelerated` or `Basic`.
 
-|`platform.azure.baseDomainResourceGroupName`
+|platform:
+  azure:
+    baseDomainResourceGroupName:
 |The name of the resource group that contains the DNS zone for your base domain.
 |String, for example `production_cluster`.
 
-|`platform.azure.resourceGroupName`
+|platform:
+  azure:
+    resourceGroupName:
 | The name of an already existing resource group to install your cluster to. This resource group must be empty and only used for this specific cluster; the cluster components assume ownership of all resources in the resource group. If you limit the service principal scope of the installation program to this resource group, you must ensure all other resources used by the installation program in your environment have the necessary permissions, such as the public DNS zone and virtual network. Destroying the cluster by using the installation program deletes this resource group.
 |String, for example `existing_resource_group`.
 
-|`platform.azure.outboundType`
+|platform:
+  azure:
+    outboundType:
 |The outbound routing strategy used to connect your cluster to the internet. If
 you are using user-defined routing, you must have pre-existing networking
 available where the outbound routing has already been configured prior to
@@ -1336,40 +1597,60 @@ For more information about the support scope of Red Hat Technology Preview featu
 
 |`LoadBalancer`, `UserDefinedRouting`, or `NatGateway`. The default is `LoadBalancer`.
 
-|`platform.azure.region`
+|platform:
+  azure:
+    region:
 |The name of the Azure region that hosts your cluster.
 |Any valid region name, such as `centralus`.
 
-|`platform.azure.zone`
+|platform:
+  azure:
+    zone:
 |List of availability zones to place machines in. For high availability, specify
 at least two zones.
 |List of zones, for example `["1", "2", "3"]`.
 
-|`platform.azure.defaultMachinePlatform.ultraSSDCapability`
+|platform:
+  azure:
+    defaultMachinePlatform:
+      ultraSSDCapability:
 |Enables the use of Azure ultra disks for persistent storage on control plane and compute machines. This requires that your Azure region and zone have ultra disks available.
 |`Enabled`, `Disabled`. The default is `Disabled`.
 
-|`platform.azure.networkResourceGroupName`
+|platform:
+  azure:
+    networkResourceGroupName:
 |The name of the resource group that contains the existing VNet that you want to deploy your cluster to. This name cannot be the same as the `platform.azure.baseDomainResourceGroupName`.
 |String.
 
-|`platform.azure.virtualNetwork`
+|platform:
+  azure:
+    virtualNetwork:
 |The name of the existing VNet that you want to deploy your cluster to.
 |String.
 
-|`platform.azure.controlPlaneSubnet`
+|platform:
+  azure:
+    controlPlaneSubnet:
 |The name of the existing subnet in your VNet that you want to deploy your control plane machines to.
 |Valid CIDR, for example `10.0.0.0/16`.
 
-|`platform.azure.computeSubnet`
+|platform:
+  azure:
+    computeSubnet:
 |The name of the existing subnet in your VNet that you want to deploy your compute machines to.
 |Valid CIDR, for example `10.0.0.0/16`.
 
-|`platform.azure.cloudName`
+|platform:
+  azure:
+    cloudName:
 |The name of the Azure cloud environment that is used to configure the Azure SDK with the appropriate Azure API endpoints. If empty, the default value `AzurePublicCloud` is used.
 |Any valid cloud environment, such as `AzurePublicCloud` or `AzureUSGovernmentCloud`.
 
-|`platform.azure.defaultMachinePlatform.vmNetworkingType`
+|platform:
+  azure:
+    defaultMachinePlatform:
+      vmNetworkingType:
 |Enables accelerated networking. Accelerated networking enables single root I/O virtualization (SR-IOV) to a VM, improving its networking performance.
 |`Accelerated` or `Basic`. If instance type of control plane and compute machines support `Accelerated` networking, by default, the installer enables `Accelerated` networking, otherwise the default networking type is `Basic`.
 


### PR DESCRIPTION
Version: 4.14+

Reformatting the Azure installation configuration parameter tables into stacked format.

Previous format:
`controlPlane.azure.region`

New format:
```
controlPlane:
  azure:
    region:
```

Preview: [Azure configuration parameters](https://68647--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installation-config-parameters-azure#installation-configuration-parameters-additional-azure_installation-config-parameters-azure)

No QE required because this only affects docs formatting.