### PR TITLE
OCPBUGS#22183: Replaced an IP address for  parameter BM

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -365,7 +365,7 @@ networking:
   machineNetwork:
     cidr:
 |
-Required if you use `networking.machineNetwork`. An IP address block. The default value is `10.0.0.0/16` for all platforms other than libvirt and {ibm-power-server-name}. For libvirt, the default value is `192.168.126.0/24`. For {ibm-power-server-name}, the default value is `192.168.0.0/24`.
+Required if you use the `networking.machineNetwork` parameter. An IP address block. The default value is `10.0.0.0/16` for all platforms other than libvirt and {ibm-power-server-name}. For libvirt, the default value is `192.168.122.0/24`. For {ibm-power-server-name}, the default value is `192.168.0.0/24`.
 ifdef::ibm-cloud[]
 If you are deploying the cluster to an existing Virtual Private Cloud (VPC), the CIDR must contain the subnets defined in `platform.ibmcloud.controlPlaneSubnets` and `platform.ibmcloud.computeSubnets`.
 endif::ibm-cloud[]


### PR DESCRIPTION
[OCPBUGS-22183](https://issues.redhat.com/browse/OCPBUGS-22183)

Version(s):
4.15 to 4.11

Issue:
[Network configuration parameters](https://68658--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installation-config-parameters-bare-metal#installation-configuration-parameters-network_installation-config-parameters-bare-metal)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* [Link 1](https://github.com/openshift/installer/blob/e192aa1e36b4c4aefe277e42734796ea922a813d/data/data/install.openshift.io_installconfigs.yaml#L2156-L2161)
* [Link 2](https://github.com/openshift/installer/blob/master/docs/dev/libvirt/README.md#firewall)
