### PR TITLE
Reformatting vsphere installation configuration parameters table

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1881,82 +1881,82 @@ ifdef::vsphere[]
 Additional VMware vSphere configuration parameters are described in the following table:
 
 .Additional VMware vSphere cluster parameters
-[cols=".^2,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
+[cols=".^2l,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
 |====
 |Parameter|Description|Values
 
-l|platform:
-    vsphere
-      apiVIPs
+|platform:
+  vsphere:
+    apiVIPs:
 |Virtual IP (VIP) addresses that you configured for control plane API access.
 
 *Note:* This parameter applies only to installer-provisioned infrastructure.
 |Multiple IP addresses
 
-l|platform
-    vsphere
-      diskType
+|platform:
+  vsphere:
+    diskType:
 |Optional. The disk provisioning method. This value defaults to the vSphere default storage policy if not set.
 |Valid values are `thin`, `thick`, or `eagerZeroedThick`.
 
-l|platform
-    vsphere
-      failureDomains
+|platform:
+  vsphere:
+    failureDomains:
 |Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
 |String
 
-l|platform
-    vsphere
-      failureDomains
-        topology
-          networks
+|platform:
+  vsphere:
+    failureDomains:
+      topology:
+        networks:
 |Lists any network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured.
 |String
 
-l|platform
-    vsphere
-      failureDomains
-        region
+|platform:
+  vsphere:
+    failureDomains:
+      region:
 |If you define multiple failure domains for your cluster, you must attach the tag to each vCenter datacenter. To define a region, use a tag from the `openshift-region` tag category. For a single vSphere datacenter environment, you do not need to attach a tag, but you must enter an alphanumeric value, such as `datacenter`, for the parameter.
 |String
 
-l|platform
-    vsphere
-      failureDomains
-        zone
+|platform:
+  vsphere:
+    failureDomains:
+      zone:
 |If you define multiple failure domains for your cluster, you must attach the tag to each vCenter cluster. To define a zone, use a tag from the `openshift-zone` tag category. For a single vSphere datacenter environment, you do not need to attach a tag, but you must enter an alphanumeric value, such as `cluster`, for the parameter.
 |String
 
-l|platform
-    vsphere
-      failureDomains
-        template
+|platform:
+  vsphere:
+    failureDomains:
+      template:
 |Specify the absolute path to a pre-existing {op-system-first} image template or virtual machine. The installation program can use the image template or virtual machine to quickly install {op-system} on vSphere hosts. Consider using this parameter as an alternative to uploading an {op-system} image on vSphere hosts. The parameter is available for use only on installer-provisioned infrastructure.
 |String
 
-l|platform
-    vsphere
-      ingressVIPs
+|platform:
+  vsphere:
+    ingressVIPs:
 |Virtual IP (VIP) addresses that you configured for cluster Ingress.
 
 *Note:* This parameter applies only to installer-provisioned infrastructure.
 |Multiple IP addresses
 
-l|platform
-    vsphere
+|platform:
+  vsphere:
 | Describes your account on the cloud platform that hosts your cluster. You can use the parameter to customize the platform. When providing additional configuration settings for compute and control plane machines in the machine pool, the parameter is optional. You can only specify one vCenter server for your {product-title} cluster.
 |String
 
-l|platform
-    vsphere
-      vcenters
+|platform:
+  vsphere:
+    vcenters:
 |Lists any fully-qualified hostname or IP address of a vCenter server.
 |String
 
-l|platform
-    vsphere
-      vcenters
-        datacenters
+|platform:
+  vsphere:
+    vcenters:
+      datacenters:
 |Lists and defines the datacenters where {product-title} virtual machines (VMs) operate. The list of datacenters must match the list of datacenters specified in the `failureDomains` field.
 |String
 |====
@@ -1969,80 +1969,80 @@ In {product-title} 4.13, the following vSphere configuration parameters are depr
 The following table lists each deprecated vSphere configuration parameter:
 
 .Deprecated VMware vSphere cluster parameters
-[cols=".^2,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
+[cols=".^2l,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
 |====
 |Parameter|Description|Values
 
-l|platform
-    vsphere
-      apiVIP
+|platform:
+  vsphere:
+    apiVIP:
 |The virtual IP (VIP) address that you configured for control plane API access.
 
 *Note:* In {product-title} 4.12 and later, the `apiVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `apiVIPs` configuration setting.
 a|An IP address, for example `128.0.0.1`.
 
-l|platform
-    vsphere
-      cluster
+|platform:
+  vsphere:
+    cluster:
 |The vCenter cluster to install the {product-title} cluster in.
 |String
 
-l|platform
-    vsphere
-      datacenter
+|platform:
+  vsphere:
+    datacenter:
 |Defines the datacenter where {product-title} virtual machines (VMs) operate.
 |String
 
-l|platform
-    vsphere
-      defaultDatastore
+|platform:
+  vsphere:
+    defaultDatastore:
 |The name of the default datastore to use for provisioning volumes.
 |String
 
-l|platform
-    vsphere
-      folder
+|platform:
+  vsphere:
+    folder:
 |Optional. The absolute path of an existing folder where the installation program creates the virtual machines. If you do not provide this value, the installation program creates a folder that is named with the infrastructure ID in the data center virtual machine folder.
 |String, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
 
-l|platform
-    vsphere
-      ingressVIP
+|platform:
+  vsphere:
+    ingressVIP:
 |Virtual IP (VIP) addresses that you configured for cluster Ingress.
 
 *Note:* In {product-title} 4.12 and later, the `ingressVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `ingressVIPs` configuration setting.
 a|An IP address, for example `128.0.0.1`.
 
-l|platform
-    vsphere
-      network
+|platform:
+  vsphere:
+    network:
 |The network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured.
 |String
 
-l|platform
-    vsphere
-      password
+|platform:
+  vsphere:
+    password:
 |The password for the vCenter user name.
 |String
 
-l|platform
-    vsphere
-      resourcePool
+|platform:
+  vsphere:
+    resourcePool:
 |Optional. The absolute path of an existing resource pool where the installation program creates the virtual machines. If you do not specify a value, the installation program installs the resources in the root of the cluster under `/<datacenter_name>/host/<cluster_name>/Resources`.
 a|String, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
 
-l|platform
-    vsphere
-      username
+|platform:
+  vsphere:
+    username:
 |The user name to use to connect to the vCenter instance with. This user must have at least
 the roles and privileges that are required for
 link:https://github.com/vmware-archive/vsphere-storage-for-kubernetes/blob/master/documentation/vcp-roles.md[static or dynamic persistent volume provisioning]
 in vSphere.
 |String
 
-l|platform
-    vsphere
-      vCenter
+|platform:
+  vsphere:
+    vCenter:
 |The fully-qualified hostname or IP address of a vCenter server.
 |String
 |====
@@ -2053,38 +2053,38 @@ l|platform
 Optional VMware vSphere machine pool configuration parameters are described in the following table:
 
 .Optional VMware vSphere machine pool parameters
-[cols=".^2a,.^3a,.^3a",options="header"]
+[cols=".^2l,.^3a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
-l|platform
-    vsphere
-      clusterOSImage
+|platform:
+  vsphere:
+    clusterOSImage:
 |The location from which the installation program downloads the {op-system-first} image. Before setting a path value for this parameter, ensure that the default {op-system} boot image in the {product-title} release matches the {op-system} image template or virtual machine version; otherwise, cluster installation might fail.
 |An HTTP or HTTPS URL, optionally with a SHA-256 checksum. For example, `\https://mirror.openshift.com/images/rhcos-<version>-vmware.<architecture>.ova`.
 
-l|platform
-    vsphere
-      osDisk
-        diskSizeGB
+|platform:
+  vsphere:
+    osDisk:
+      diskSizeGB:
 |The size of the disk in gigabytes.
 |Integer
 
-l|platform
-    vsphere
-      cpus
+|platform:
+  vsphere:
+    cpus:
 |The total number of virtual processor cores to assign a virtual machine. The value of `platform.vsphere.cpus` must be a multiple of `platform.vsphere.coresPerSocket` value.
 |Integer
 
-l|platform
-    vsphere
-      coresPerSocket
+|platform:
+  vsphere:
+    coresPerSocket:
 |The number of cores per socket in a virtual machine. The number of virtual sockets on the virtual machine is `platform.vsphere.cpus`/`platform.vsphere.coresPerSocket`. The default value for control plane nodes and worker nodes is `4` and `2`, respectively.
 |Integer
 
-l|platform
-    vsphere
-      memoryMB
+|platform:
+  vsphere:
+    memoryMB:
 |The size of a virtual machine's memory in megabytes.
 |Integer
 |====


### PR DESCRIPTION
4.14+

Adding colons and fixing spacing for vsphere config parameters table. No QE needed as it's formatting only.

Preview: [From this table to the end of the page](https://68665--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere#installation-configuration-parameters-additional-vsphere_installation-config-parameters-vsphere)