### PR TITLE
OCPBUGS-18377: Updated SPO documentation

### DIFF
--- a/modules/spo-applying-profiles.adoc
+++ b/modules/spo-applying-profiles.adoc
@@ -85,7 +85,7 @@ spec:
           localhostProfile: operator/my-namespace/profile1.json
 ----
 
-. Apply the profile to a `Deployment` object by running the following command:
+. Apply the profile to any other workload, such as a `Deployment` object, by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/spo-binding-workloads.adoc
+++ b/modules/spo-binding-workloads.adoc
@@ -47,12 +47,31 @@ spec:
 $ oc label ns my-namespace spo.x-k8s.io/enable-binding=true
 ----
 
-. Delete and re-create the pod to use the `ProfileBinding` object:
+. Define a pod named `test-pod.yaml`:
 +
-[source,terminal,subs="attributes+"]
+[source,yaml]
 ----
-$ oc delete pods test-pod && oc create -f pod01.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  containers:
+  - name: test-container
+    image: quay.io/security-profiles-operator/test-nginx-unprivileged:1.21
 ----
+
+. Create the pod:
++
+[source,terminal]
+----
+$ oc create -f test-pod.yaml
+----
++
+[NOTE]
+====
+If the pod already exists, you must re-create the pod for the binding to work properly.
+====
 
 .Verification
 

--- a/modules/spo-creating-profiles.adoc
+++ b/modules/spo-creating-profiles.adoc
@@ -26,7 +26,14 @@ ifdef::seccomp[]
 
 .Procedure
 
-* Create the `{kind}` object:
+. Create a project by running the following command:
++
+[source,terminal]
+----
+$ oc new-project my-namespace
+----
+
+. Create the `{kind}` object:
 +
 [source,yaml,subs="attributes+"]
 ----
@@ -53,6 +60,13 @@ The `{kind}` object has several features that allow for better security hardenin
 * Adds features for better security hardening and readability compared to writing a profile directly in the SELinux CIL language.
 
 .Procedure
+
+. Create a project by running the following command:
++
+[source,terminal]
+----
+$ oc new-project nginx-deploy
+----
 
 . Create a policy that can be used with a non-privileged workload by creating the following `{kind}` object:
 +

--- a/modules/spo-recording-profiles.adoc
+++ b/modules/spo-recording-profiles.adoc
@@ -32,6 +32,13 @@ A container with `privileged: true` security context restraints prevents log-bas
 
 .Procedure
 
+. Create a project by running the following command:
++
+[source,terminal]
+----
+$ oc new-project my-namespace
+----
+
 . Label the namespace with `enable-recording=true` by running the following command:
 +
 [source,terminal]

--- a/modules/spo-replicating-controllers.adoc
+++ b/modules/spo-replicating-controllers.adoc
@@ -10,6 +10,13 @@ When you deploy SELinux policies for replicating controllers, such as deployment
 
 .Procedure
 
+. Create a project by running the following command:
++
+[source,terminal]
+----
+$ oc new-project nginx-secure
+----
+
 . Create the following `RoleBinding` object to allow SELinux policies to be used in the `nginx-secure` namespace:
 +
 [source,yaml]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-18377

Link to docs preview (VPN required):
[Creating seccomp profiles](https://file.rdu.redhat.com/antaylor/OCPBUGS-18377.1/security/security_profiles_operator/spo-seccomp.html#spo-creating-profiles_spo-seccomp)
[Applying seccomp profiles to a pod](https://file.rdu.redhat.com/antaylor/OCPBUGS-18377.1/security/security_profiles_operator/spo-seccomp.html#spo-applying-profiles_spo-seccomp)
[Binding workloads to profiles with ProfileBindings (Seccomp)](https://file.rdu.redhat.com/antaylor/OCPBUGS-18377.1/security/security_profiles_operator/spo-seccomp.html#spo-binding-workloads_spo-seccomp)
[Creating SELinux profiles](https://file.rdu.redhat.com/antaylor/OCPBUGS-18377.1/security/security_profiles_operator/spo-selinux.html#spo-creating-profiles_spo-selinux)
[Binding workloads to profiles with ProfileBindings (SELinux)](https://file.rdu.redhat.com/antaylor/OCPBUGS-18377.1/security/security_profiles_operator/spo-selinux.html#spo-binding-workloads_spo-selinux)
[Replicating controllers and SecurityContextConstraints](https://file.rdu.redhat.com/antaylor/OCPBUGS-18377.1/security/security_profiles_operator/spo-selinux.html#spo-replicating-controllers_spo-selinux)
[Recording profiles from workloads](https://file.rdu.redhat.com/antaylor/OCPBUGS-18377.1/security/security_profiles_operator/spo-selinux.html#spo-recording-profiles_spo-selinux)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
All feedback in the bug has been addressed, however item #2 (changing the output to `Installed` from `Active`) has already been completed in another PR previously merged.