### PR TITLE
Adds additional step to changing the cluster MTU before moving to ver…

### DIFF
--- a/modules/nw-cluster-mtu-change.adoc
+++ b/modules/nw-cluster-mtu-change.adoc
@@ -345,6 +345,15 @@ where:
 `<mtu>`:: Specifies the new cluster network MTU that you specified with `<overlay_to>`.
 --
 
+. After finalizing the MTU migration, each MCP node is rebooted one by one. You must wait until all the nodes are updated. Check the machine config pool status by entering the following command:
++
+[source,terminal]
+----
+$ oc get mcp
+----
++
+A successfully updated node has the following status: `UPDATED=true`, `UPDATING=false`, `DEGRADED=false`.
+
 .Verification
 
 ifdef::localzone[]


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-23563

Link to docs preview:
https://68668--docspreview.netlify.app/openshift-enterprise/latest/networking/changing-cluster-network-mtu#nw-cluster-mtu-change_changing-cluster-network-mtu

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
