### PR TITLE
OCPBUGS-15542: added a note for CA bundle updates

### DIFF
--- a/security/certificates/updating-ca-bundle.adoc
+++ b/security/certificates/updating-ca-bundle.adoc
@@ -6,6 +6,11 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[IMPORTANT]
+====
+Updating the certificate authority (CA) will cause the nodes of your cluster to reboot.
+====
+
 include::modules/ca-bundle-understanding.adoc[leveloffset=+1]
 
 include::modules/ca-bundle-replacing.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-15542

Link to docs preview (VPN required):
[Updating the CA bundle](https://file.rdu.redhat.com/antaylor/OCPBUGS-15542/security/certificates/updating-ca-bundle.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
None