### PR TITLE
OSDOCS-6139.2: Updating ROSA with HCP docs for GA

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -65,6 +65,10 @@ Topics:
     File: rosa-service-definition
   - Name: ROSA update life cycle
     File: rosa-life-cycle
+  - Name: ROSA with HCP service definition
+    File: rosa-hcp-service-definition
+  - Name: ROSA with HCP update life cycle
+    File: rosa-hcp-life-cycle
   - Name: Understanding security for ROSA
     File: rosa-policy-process-security
   - Name: SRE and service account access
@@ -271,6 +275,8 @@ Topics:
 #    File: troubleshooting-installations
   - Name: Troubleshooting ROSA installations
     File: rosa-troubleshooting-installations
+  - Name: Troubleshooting networking
+    File: rosa-troubleshooting-networking
   - Name: Verifying node health
     File: verifying-node-health
 #  cannot create resource "namespaces", cannot patch resource "nodes"

--- a/modules/custom-tuning-specification.adoc
+++ b/modules/custom-tuning-specification.adoc
@@ -191,7 +191,7 @@ The list items `match` and `machineConfigLabels` are connected by the logical OR
 When using machine config pool based matching, it is advised to group nodes with the same hardware configuration into the same machine config pool. Not following this practice might result in TuneD operands calculating conflicting kernel parameters for two or more nodes sharing the same machine config pool.
 ====
 
-.Example: node or pod label based matching
+.Example: Node or pod label based matching
 
 ifndef::rosa-hcp-tuning[]
 [source,yaml]
@@ -263,7 +263,7 @@ Finally, the profile `openshift-node` has the lowest priority of `30`. It lacks 
 
 image::node-tuning-operator-workflow-revised.png[Decision workflow]
 
-.Example: machine config pool based matching
+.Example: Machine config pool based matching
 ifndef::rosa-hcp-tuning[]
 [source,yaml]
 ----

--- a/modules/life-cycle-dates.adoc
+++ b/modules/life-cycle-dates.adoc
@@ -1,7 +1,12 @@
 // Module included in the following assemblies:
 //
-// * osd_architecture/osd_policy/osd-life-cycle.adoc
 // * rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc
+// * rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.adoc
+// * osd_architecture/osd_policy/osd-life-cycle.adoc
+
+ifeval::["{context}" == "rosa-hcp-life-cycle"]
+:rosa-with-hcp:
+endif::[]
 
 [id="sd-life-cycle-dates_{context}"]
 = Life cycle dates
@@ -9,6 +14,10 @@
 [options="header"]
 |===
 |Version    |General availability   |End of life
+ifdef::rosa-with-hcp[]
+|4.14       |Dec 4, 2023            |Feb 28, 2025
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
 |4.14       |Oct 31, 2023           |Feb 28, 2025
 |4.13       |May 17, 2023           |Sep 17, 2024
 |4.12       |Jan 17, 2023           |May 17, 2024
@@ -16,5 +25,9 @@
 |4.10       |Mar 10, 2022           |Sep 10, 2023
 |4.9        |Oct 18, 2021           |Dec 18, 2022
 |4.8        |Jul 27, 2021           |Sep 27, 2022
-
+endif::rosa-with-hcp[]
 |===
+
+ifeval::["{context}" == "rosa-hcp-life-cycle"]
+:!rosa-with-hcp:
+endif::[]

--- a/modules/life-cycle-limited-support.adoc
+++ b/modules/life-cycle-limited-support.adoc
@@ -1,7 +1,12 @@
 // Module included in the following assemblies:
 //
 // * rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc
+// * rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.adoc
 // * osd_architecture/osd_policy/osd-life-cycle.adoc
+
+ifeval::["{context}" == "rosa-hcp-life-cycle"]
+:rosa-with-hcp:
+endif::[]
 
 [id="rosa-limited-support_{context}"]
 = Limited support status
@@ -10,10 +15,16 @@ When a cluster transitions to a _Limited Support_ status, Red Hat no longer proa
 
 A cluster might transition to a Limited Support status for many reasons, including the following scenarios:
 
+ifndef::rosa-with-hcp[]
 If you do not upgrade a cluster to a supported version before the end-of-life date:: Red Hat does not make any runtime or SLA guarantees for versions after their end-of-life date. To receive continued support, upgrade the cluster to a supported version prior to the end-of-life date. If you do not upgrade the cluster prior to the end-of-life date, the cluster transitions to a Limited Support status until it is upgraded to a supported version.
 +
 Red Hat provides commercially reasonable support to upgrade from an unsupported version to a supported version. However, if a supported upgrade path is no longer available, you might have to create a new cluster and migrate your workloads.
+endif::rosa-with-hcp[]
 
 If you remove or replace any native {product-title} components or any other component that is installed and managed by Red Hat:: If cluster administrator permissions were used, Red Hat is not responsible for any of your or your authorized users’ actions, including those that affect infrastructure services, service availability, or data loss. If Red Hat detects any such actions, the cluster might transition to a Limited Support status. Red Hat notifies you of the status change and you should either revert the action or create a support case to explore remediation steps that might require you to delete and recreate the cluster.
 
 If you have questions about a specific action that might cause a cluster to transition to a Limited Support status or need further assistance, open a support ticket.
+
+ifeval::["{context}" == "rosa-hcp-life-cycle"]
+:!rosa-with-hcp:
+endif::[]

--- a/modules/life-cycle-mandatory-upgrades.adoc
+++ b/modules/life-cycle-mandatory-upgrades.adoc
@@ -1,15 +1,27 @@
 // Module included in the following assemblies:
 // * rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc
+// * rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.adoc
 // * osd_architecture/osd_policy/osd-life-cycle.adoc
+
+ifeval::["{context}" == "rosa-hcp-life-cycle"]
+:rosa-with-hcp:
+endif::[]
 
 :_mod-docs-content-type: REFERENCE
 [id="rosa-mandatory-upgrades_{context}"]
 = Mandatory upgrades
 
-In the event that a Critical or Important CVE, or other bug identified by Red Hat, significantly
-impacts the security or stability of the cluster, the customer must upgrade to the next supported
-patch release within two link:https://access.redhat.com/articles/2623321[business days].
+If a critical or important CVE, or other bug identified by Red Hat, significantly impacts the security or stability of the cluster, the customer must upgrade to the next supported patch release within two link:https://access.redhat.com/articles/2623321[business days].
 
-In extreme circumstances and based on Red Hat's assessment of the CVE criticality to the
-environment, Red Hat will notify customers that they have two link:https://access.redhat.com/articles/2623321[business days] to schedule or manually update their cluster to the latest, secure patch release.
-In the case that an update is not performed after two link:https://access.redhat.com/articles/2623321[business days], Red Hat will automatically update the cluster to the latest, secure patch release to mitigate potential security breach(es) or instability. Red Hat may, at its own discretion, temporarily delay an automated update if requested by a customer through a link:https://access.redhat.com/support[support case].
+In extreme circumstances and based on Red Hat's assessment of the CVE criticality to the environment, Red Hat will notify customers that they have two link:https://access.redhat.com/articles/2623321[business days] to schedule or manually update their cluster to the latest, secure patch release. In the case that an update is not performed after two link:https://access.redhat.com/articles/2623321[business days], Red Hat will automatically update the
+ifdef::rosa-with-hcp[]
+cluster's control plane
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
+cluster
+endif::rosa-with-hcp[]
+to the latest, secure patch release to mitigate potential security breach(es) or instability. Red Hat might, at its own discretion, temporarily delay an automated update if requested by a customer through a link:https://access.redhat.com/support[support case].
+
+ifeval::["{context}" == "rosa-hcp-life-cycle"]
+:!rosa-with-hcp:
+endif::[]

--- a/modules/life-cycle-minor-versions.adoc
+++ b/modules/life-cycle-minor-versions.adoc
@@ -1,22 +1,36 @@
 // Module included in the following assemblies:
 // * rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc
+// * rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.adoc
 // * osd_architecture/osd_policy/osd-life-cycle.adoc
+
+ifeval::["{context}" == "rosa-hcp-life-cycle"]
+:rosa-with-hcp:
+endif::[]
 
 [id="rosa-minor-versions_{context}"]
 = Minor versions (x.Y.z)
 
-Starting with the 4.8 OpenShift Container Platform minor version, Red Hat supports all minor
-versions for at least a 16 month period following general availability of the given minor version. Patch
-versions are not affected by the support period.
+Starting with the 4.8 OpenShift Container Platform minor version, Red Hat supports all minor versions for at least a 16 month period following general availability of the given minor version. Patch versions are not affected by the support period.
 
-Customers are notified 60, 30, and 15 days prior to the end of the support period. Clusters must be upgraded to
-a supported minor version prior to the end of the support period, or the cluster will enter
-a "Limited Support" status.
+Customers are notified 60, 30, and 15 days before the end of the support period. Clusters must be upgraded to the latest patch version of the oldest supported minor version before the end of the support period, or
+ifdef::rosa-with-hcp[]
+Red Hat will automatically upgrade the control plane to the next supported minor version.
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
+the cluster will enter a "Limited Support" status.
+endif::rosa-with-hcp[]
 
 .Example
-. A customer's cluster is currently running on 4.13.8. The 4.13 minor version became generally
-  available on May 17, 2023.
-. On July 19, August 16, and September 2, 2024, the customer is notified that their cluster will enter "Limited Support" status
-  on September 17, 2024 if the cluster has not already been upgraded to a supported minor version.
+. A customer's cluster is currently running on 4.13.8. The 4.13 minor version became generally available on May 17, 2023.
+. On July 19, August 16, and September 2, 2024, the customer is notified that their cluster will enter "Limited Support" status on September 17, 2024 if the cluster has not already been upgraded to a supported minor version.
 . The cluster must be upgraded to 4.14 or later by September 17, 2024.
+ifdef::rosa-with-hcp[]
+. If the upgrade has not been performed, the cluster's control plane will be automatically upgraded to 4.14.26, and there will be no automatic upgrades to the cluster's worker nodes.
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
 . If the upgrade has not been performed, the cluster will be flagged as being in a "Limited Support" status.
+endif::rosa-with-hcp[]
+
+ifeval::["{context}" == "rosa-hcp-life-cycle"]
+:!rosa-with-hcp:
+endif::[]

--- a/modules/rosa-sdpolicy-am-compute.adoc
+++ b/modules/rosa-sdpolicy-am-compute.adoc
@@ -2,10 +2,20 @@
 // Module included in the following assemblies:
 //
 // * rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
+// * rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc
+
+ifeval::["{context}" == "rosa-hcp-service-definition"]
+:rosa-with-hcp:
+endif::[]
+
 :_mod-docs-content-type: CONCEPT
 [id="rosa-sdpolicy-instance-types_{context}"]
 = Instance types
 
+ifdef::rosa-with-hcp[]
+All {hcp-title} clusters require a minimum of 2 worker nodes. All {hcp-title} clusters support a maximum of 51 worker nodes. Shutting down the underlying infrastructure through the cloud provider console is unsupported and can lead to data loss.
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
 Single availability zone clusters require a minimum of 3 control plane nodes, 2 infrastructure nodes, and 2 worker nodes deployed to a single availability zone.
 
 Multiple availability zone clusters require a minimum of 3 control plane nodes, 3 infrastructure nodes, and 3 worker nodes. Additional nodes must be purchased in multiples of three to maintain proper node distribution.
@@ -13,6 +23,7 @@ Multiple availability zone clusters require a minimum of 3 control plane nodes, 
 All {product-title} clusters support a maximum of 180 worker nodes.
 
 Control plane and infrastructure nodes are deployed and managed by Red Hat. Shutting down the underlying infrastructure through the cloud provider console is unsupported and can lead to data loss. There are at least 3 control plane nodes that handle etcd- and API-related workloads. There are at least 2 infrastructure nodes that handle metrics, routing, the web console, and other workloads. You must not run any workloads on the control and infrastructure nodes. Any workloads you intend to run must be deployed on worker nodes. See the Red Hat Operator support section below for more information about Red Hat workloads that must be deployed on worker nodes.
+endif::rosa-with-hcp[]
 
 [NOTE]
 ====
@@ -22,3 +33,7 @@ Approximately one vCPU core and 1 GiB of memory are reserved on each worker node
 
 For additional information, see the link:https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#system-reserved[Kubernetes documentation].
 ====
+
+ifeval::["{context}" == "rosa-hcp-service-definition"]
+:!rosa-with-hcp:
+endif::[]

--- a/modules/rosa-sdpolicy-am-limited-support.adoc
+++ b/modules/rosa-sdpolicy-am-limited-support.adoc
@@ -2,6 +2,12 @@
 // Module included in the following assemblies:
 //
 // * rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
+// * rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc
+
+ifeval::["{context}" == "rosa-hcp-service-definition"]
+:rosa-with-hcp:
+endif::[]
+
 :_mod-docs-content-type: CONCEPT
 [id="rosa-limited-support_{context}"]
 = Limited support status
@@ -10,10 +16,15 @@ When a cluster transitions to a _Limited Support_ status, Red Hat no longer proa
 
 A cluster might move to a Limited Support status for many reasons, including the following scenarios:
 
+ifndef::rosa-with-hcp[]
 If you do not upgrade a cluster to a supported version before the end-of-life date:: Red Hat does not make any runtime or SLA guarantees for versions after their end-of-life date. To receive continued support, upgrade the cluster to a supported version prior to the end-of-life date. If you do not upgrade the cluster prior to the end-of-life date, the cluster transitions to a Limited Support status until it is upgraded to a supported version.
 +
 Red Hat provides commercially reasonable support to upgrade from an unsupported version to a supported version. However, if a supported upgrade path is no longer available, you might have to create a new cluster and migrate your workloads.
 
+endif::rosa-with-hcp[]
 If you remove or replace any native {product-title} components or any other component that is installed and managed by Red Hat:: If cluster administrator permissions were used, Red Hat is not responsible for any of your or your authorized users’ actions, including those that affect infrastructure services, service availability, or data loss. If Red Hat detects any such actions, the cluster might transition to a Limited Support status. Red Hat notifies you of the status change and you should either revert the action or create a support case to explore remediation steps that might require you to delete and recreate the cluster.
 
 If you have questions about a specific action that might cause a cluster to move to a Limited Support status or need further assistance, open a support ticket.
+ifeval::["{context}" == "rosa-hcp-service-definition"]
+:!rosa-with-hcp:
+endif::[]

--- a/modules/rosa-sdpolicy-am-local-zones.adoc
+++ b/modules/rosa-sdpolicy-am-local-zones.adoc
@@ -1,11 +1,27 @@
 
 // Module included in the following assemblies:
 //
-// * assemblies/rosa-service-definition.adoc
+// * rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
+// * rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc
+
 :_mod-docs-content-type: CONCEPT
+
+ifeval::["{context}" == "rosa-hcp-service-definition"]
+:rosa-with-hcp:
+endif::[]
+
 [id="rosa-sdpolicy-am-local-zones_{context}"]
 = Local Zones
 
+ifdef::rosa-with-hcp[]
+{hcp-title-first} does not support the use of AWS Local Zones.
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
 {product-title} supports the use of AWS Local Zones, which are metropolis-centralized availability zones where customers can place latency-sensitive application workloads. Local Zones are extensions of AWS Regions that have their own internet connection. For more information about AWS Local Zones, see the AWS documentation link:https://docs.aws.amazon.com/local-zones/latest/ug/how-local-zones-work.html[How Local Zones work].
 
 For steps to enable AWS Local Zones and add a Local Zone to a machine pool, see xref:../../rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-configuring.adoc#rosa-nodes-machine-pools-local-zones[Configuring Local Zones for machine pulls].
+endif::rosa-with-hcp[]
+
+ifeval::["{context}" == "rosa-hcp-service-definition"]
+:!rosa-with-hcp:
+endif::[]

--- a/modules/rosa-sdpolicy-am-regions-az.adoc
+++ b/modules/rosa-sdpolicy-am-regions-az.adoc
@@ -2,14 +2,33 @@
 // Module included in the following assemblies:
 //
 // * rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
+// * rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc
+
+ifeval::["{context}" == "rosa-hcp-service-definition"]
+:rosa-with-hcp:
+endif::[]
+
 :_mod-docs-content-type: CONCEPT
 [id="rosa-sdpolicy-regions-az_{context}"]
 = Regions and availability zones
-The following AWS regions are supported by Red Hat OpenShift 4 and are supported for {product-title}. Note: China and GovCloud (US) regions are not supported, regardless of their support on OpenShift 4.
+
+The following AWS regions are currently available
+ifdef::rosa-with-hcp[]
+for {hcp-title}.
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
+for Red Hat OpenShift 4 and are supported for {product-title}.
+endif::rosa-with-hcp[]
+
+[NOTE]
+====
+China and GovCloud (US) regions are not supported, regardless of their support on OpenShift 4.
+====
 
 .AWS Regions
 [%collapsible]
 ====
+ifndef::rosa-with-hcp[]
 * af-south-1 (Cape Town, AWS opt-in required)
 * ap-east-1 (Hong Kong, AWS opt-in required)
 * ap-northeast-1 (Tokyo)
@@ -19,32 +38,69 @@ The following AWS regions are supported by Red Hat OpenShift 4 and are supported
 * ap-south-2 (Hyderabad, AWS opt-in required)
 * ap-southeast-1 (Singapore)
 * ap-southeast-2 (Sydney)
+endif::rosa-with-hcp[]
 * ap-southeast-3 (Jakarta, AWS opt-in required)
+ifndef::rosa-with-hcp[]
 * ap-southeast-4 (Melbourne, AWS opt-in required)
 * ca-central-1 (Central Canada)
+endif::rosa-with-hcp[]
 * eu-central-1 (Frankfurt)
+ifndef::rosa-with-hcp[]
 * eu-central-2 (Zurich, AWS opt-in required)
 * eu-north-1 (Stockholm)
 * eu-south-1 (Milan, AWS opt-in required)
 * eu-south-2 (Spain, AWS opt-in required)
+endif::rosa-with-hcp[]
 * eu-west-1 (Ireland)
+ifndef::rosa-with-hcp[]
 * eu-west-2 (London)
 * eu-west-3 (Paris)
 * me-central-1 (UAE, AWS opt-in required)
 * me-south-1 (Bahrain, AWS opt-in required)
 * sa-east-1 (São Paulo)
+endif::rosa-with-hcp[]
 * us-east-1 (N. Virginia)
 * us-east-2 (Ohio)
+ifndef::rosa-with-hcp[]
 * us-west-1 (N. California)
+endif::rosa-with-hcp[]
 * us-west-2 (Oregon)
 ====
 
 Multiple availability zone clusters can only be deployed in regions with at least 3 availability zones. For more information, see the link:https://aws.amazon.com/about-aws/global-infrastructure/regions_az/[Regions and Availability Zones] section in the AWS documentation.
 
-Each new {product-title} cluster is installed within an installer-created or preexisting Virtual Private Cloud (VPC) in a single region, with the option to deploy into a single availability zone (Single-AZ) or across multiple availability zones (Multi-AZ). This provides cluster-level network and resource isolation, and enables cloud-provider VPC settings, such as VPN connections and VPC Peering. Persistent volumes (PVs) are backed by Amazon Elastic Block Storage (Amazon EBS), and are specific to the availability zone in which they are provisioned. Persistent volume claims (PVCs) do not bind to a volume until the associated pod resource is assigned into a specific availability zone to prevent unschedulable pods. Availability zone-specific resources are only usable by resources in the same availability zone.
+Each new
+ifndef::rosa-with-hcp[]
+{product-title}
+endif::rosa-with-hcp[]
+ifdef::rosa-with-hcp[]
+{hcp-title}
+endif::rosa-with-hcp[]
+cluster is installed within
+ifdef::rosa-with-hcp[]
+a
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
+an installer-created or
+endif::rosa-with-hcp[]
+preexisting Virtual Private Cloud (VPC) in a single region, with the option to deploy
+ifndef::rosa-with-hcp[]
+into a single availability zone (Single-AZ) or across multiple availability zones (Multi-AZ).
+endif::rosa-with-hcp[]
+ifdef::rosa-with-hcp[]
+up to the total number of availability zones for the given region.
+endif::rosa-with-hcp[]
+This provides cluster-level network and resource isolation, and enables cloud-provider VPC settings, such as VPN connections and VPC Peering. Persistent volumes (PVs) are backed by Amazon Elastic Block Storage (Amazon EBS), and are specific to the availability zone in which they are provisioned. Persistent volume claims (PVCs) do not bind to a volume until the associated pod resource is assigned into a specific availability zone to prevent unschedulable pods. Availability zone-specific resources are only usable by resources in the same availability zone.
 
 [WARNING]
 ====
-The region and the choice of single or multiple availability zone cannot be changed after a cluster has been deployed.
+The region
+ifndef::rosa-with-hcp[]
+and the choice of single or multiple availability zone
+endif::rosa-with-hcp[]
+cannot be changed after a cluster has been deployed.
 ====
 
+ifeval::["{context}" == "rosa-hcp-service-definition"]
+:!rosa-with-hcp:
+endif::[]

--- a/modules/rosa-sdpolicy-am-sla.adoc
+++ b/modules/rosa-sdpolicy-am-sla.adoc
@@ -6,4 +6,4 @@
 [id="rosa-sdpolicy-sla_{context}"]
 = Service Level Agreement (SLA)
 
-Any SLAs for the service itself are defined in Appendix 4 of the link:https://www.redhat.com/licenses/Appendix_4_Red_Hat_Online_Services_20220720.pdf[Red Hat Enterprise Agreement Appendix 4 (Online Subscription Services)].
+Any SLAs for the service itself are defined in Appendix 4 of the link:https://www.redhat.com/licenses/Appendix-4-Red-Hat-Online-Services-20230523.pdf[Red Hat Enterprise Agreement Appendix 4 (Online Subscription Services)].

--- a/modules/rosa-sdpolicy-networking.adoc
+++ b/modules/rosa-sdpolicy-networking.adoc
@@ -2,10 +2,14 @@
 // Module included in the following assemblies:
 //
 // * rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
+// * rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc
+
+ifeval::["{context}" == "rosa-hcp-service-definition"]
+:rosa-with-hcp:
+endif::[]
 
 [id="rosa-sdpolicy-networking_{context}"]
 = Networking
-
 
 This section provides information about the service definition for {product-title} networking.
 
@@ -28,6 +32,11 @@ Starting with {product-title} 4.14, the Custom Domain Operator is deprecated. To
 
 [id="rosa-sdpolicy-load-balancers_{context}"]
 == Load balancers
+
+ifdef::rosa-with-hcp[]
+{hcp-title-first} only deploys load balancers fro the default ingress controller. All other load balancers can be optionally deployed by a customer for secondary ingress controllers or Service load balancers.
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
 {product-title} uses up to five different load balancers:
 
 - An internal control plane load balancer that is internal to the cluster and used to balance traffic for internal cluster communications.
@@ -36,6 +45,8 @@ Starting with {product-title} 4.14, the Custom Domain Operator is deprecated. To
 - A default external router/ingress load balancer that is the default application load balancer, denoted by `apps` in the URL. The default load balancer can be configured in {cluster-manager} to be either publicly accessible over the Internet or only privately accessible over a pre-existing private connection. All application routes on the cluster are exposed on this default router load balancer, including cluster services such as the logging UI, metrics API, and registry.
 - Optional: A secondary router/ingress load balancer that is a secondary application load balancer, denoted by `apps2` in the URL. The secondary load balancer can be configured in {cluster-manager} to be either publicly accessible over the Internet or only privately accessible over a pre-existing private connection. If a `Label match` is configured for this router load balancer, then only application routes matching this label are exposed on this router load balancer; otherwise, all application routes are also exposed on this router load balancer.
 - Optional: Load balancers for services. Enable non-HTTP/SNI traffic and non-standard ports for services. These load balancers can be mapped to a service running on {product-title} to enable advanced ingress features, such as non-HTTP/SNI traffic or the use of non-standard ports. Each AWS account has a quota which link:https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-limits.html[limits the number of Classic Load Balancers] that can be used within each cluster.
+endif::rosa-with-hcp[]
+
 
 [id="rosa-sdpolicy-cluster-ingress_{context}"]
 == Cluster ingress
@@ -47,7 +58,12 @@ All cluster ingress traffic will go through the defined load balancers. Direct a
 
 [id="rosa-sdpolicy-cluster-egress_{context}"]
 == Cluster egress
-Pod egress traffic control through `EgressNetworkPolicy` objects can be used to prevent or limit outbound traffic in {product-title}.
+Pod egress traffic control through `EgressNetworkPolicy` objects can be used to prevent or limit outbound traffic in
+ifdef::rosa-with-hcp[]
+{hcp-title-first}.
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
+{product-title}.
 
 Public outbound traffic from the control plane and infrastructure nodes is required and necessary to maintain cluster image security and cluster monitoring. This requires that the `0.0.0.0/0` route belongs only to the Internet gateway; it is not possible to route this range over private connections.
 
@@ -58,10 +74,11 @@ Customers can determine their public static IP addresses by running a pod on the
 ----
 $ oc run ip-lookup --image=busybox -i -t --restart=Never --rm -- /bin/sh -c "/bin/nslookup -type=a myip.opendns.com resolver1.opendns.com | grep -E 'Address: [0-9.]+'"
 ----
+endif::rosa-with-hcp[]
 
 [id="rosa-sdpolicy-cloud-network-config_{context}"]
 == Cloud network configuration
-{Product-title} allows for the configuration of a private network connection through AWS-managed technologies:
+{Product-title} allows for the configuration of a private network connection through AWS-managed technologies, such as:
 
 - VPN connections
 - VPC peering
@@ -83,3 +100,6 @@ For {product-title} clusters that have a private cloud network configuration, a 
 Network verification checks run automatically when you deploy a {product-title} cluster into an existing Virtual Private Cloud (VPC) or create an additional machine pool with a subnet that is new to your cluster. The checks validate your network configuration and highlight errors, enabling you to resolve configuration issues prior to deployment.
 
 You can also run the network verification checks manually to validate the configuration for an existing cluster.
+ifeval::["{context}" == "rosa-hcp-service-definition"]
+:!rosa-with-hcp:
+endif::[]

--- a/modules/rosa-sdpolicy-platform.adoc
+++ b/modules/rosa-sdpolicy-platform.adoc
@@ -2,23 +2,42 @@
 // Module included in the following assemblies:
 //
 // * rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
+// * rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc
+
+ifeval::["{context}" == "rosa-hcp-service-definition"]
+:rosa-with-hcp:
+endif::[]
 
 :_mod-docs-content-type: ASSEMBLY
 [id="rosa-sdpolicy-platform_{context}"]
 = Platform
 :productwinc: Red Hat OpenShift support for Windows Containers
 
-This section provides information about the service definition for the {product-title} (ROSA) platform.
+This section provides information about the service definition for the
+ifdef::rosa-with-hcp[]
+{hcp-title-first} platform.
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
+{product-title} (ROSA) platform.
+endif::rosa-with-hcp[]
 
 [id="rosa-sdpolicy-backup-policy_{context}"]
 == Cluster backup policy
 
 [IMPORTANT]
 ====
-It is critical that customers have a backup plan for their applications and application data. The table below only applies to clusters created with IAM user credentials.
+It is critical that customers have a backup plan for their applications and application data.
+ifndef::rosa-with-hcp[]
+The table below only applies to clusters created with IAM user credentials.
+endif::rosa-with-hcp[]
 ====
 
-Application and application data backups are not a part of the {product-title} service.
+Application and application data backups are not a part of the
+ifdef::rosa-with-hcp[]
+{hcp-title-first} service.
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
+{product-title} service.
 The following table outlines the cluster backup policy.
 
 //Verify if the corresponding tables in policy-incident.adoc and rosa-policy-incident.adoc also need to be updated.
@@ -39,7 +58,6 @@ The following table outlines the cluster backup policy.
 |Weekly
 |30 days
 
-
 |Full object store backup
 |Hourly
 |24 hour
@@ -51,19 +69,31 @@ The following table outlines the cluster backup policy.
 |Nodes are considered to be short-term. Nothing critical should be stored on a node's root volume.
 
 |===
+endif::rosa-with-hcp[]
 
 [id="rosa-sdpolicy-autoscaling_{context}"]
 == Autoscaling
-Node autoscaling is available on {product-title}. You can configure the autoscaler option to automatically scale the number of machines in a cluster.
+Node autoscaling is available on
+ifdef::rosa-with-hcp[]
+{hcp-title-first}.
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
+{product-title}.
+endif::rosa-with-hcp[]
+You can configure the autoscaler option to automatically scale the number of machines in a cluster.
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../rosa_cluster_admin/rosa_nodes/rosa-nodes-about-autoscaling-nodes.adoc#rosa-nodes-about-autoscaling-nodes[About autoscaling nodes on a cluster]
 
-
 [id="rosa-sdpolicy-daemonsets_{context}"]
 == Daemonsets
-Customers can create and run daemonsets on {product-title}. To restrict daemonsets to only running on worker nodes, use the following `nodeSelector`:
+Customers can create and run daemonsets on
+ifdef::rosa-with-hcp[]
+{hcp-title-first}.
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
+{product-title}. To restrict daemonsets to only running on worker nodes, use the following `nodeSelector`:
 [source,yaml]
 ----
 ...
@@ -72,22 +102,42 @@ spec:
     role: worker
 ...
 ----
+endif::rosa-with-hcp[]
 
 [id="rosa-sdpolicy-multiple-availability-zone_{context}"]
 == Multiple availability zone
+
+ifdef::rosa-with-hcp[]
+Control plane components are always deployed across multiple availability zones, regardless of a customer's worker node configuration.
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
 In a multiple availability zone cluster, control plane nodes are distributed across availability zones and at least one worker node is required in each availability zone.
+endif::rosa-with-hcp[]
 
 [id="rosa-sdpolicy-node-labels_{context}"]
 == Node labels
-Custom node labels are created by Red Hat during node creation and cannot be changed on {product-title} clusters at this time. However, custom labels are supported when creating new machine pools.
+Custom node labels are created by Red Hat during node creation and cannot be changed on
+ifdef::rosa-with-hcp[]
+{hcp-title-first}
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
+{product-title}
+endif::rosa-with-hcp[]
+clusters at this time. However, custom labels are supported when creating new machine pools.
 
 [id="rosa-sdpolicy-openshift-version_{context}"]
 == OpenShift version
-{product-title} is run as a service and is kept up to date with the latest OpenShift Container Platform version. Upgrade scheduling to the latest version is available.
+ifdef::rosa-with-hcp[]
+{hcp-title-first}
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
+{product-title}
+endif::rosa-with-hcp[]
+is run as a service and is kept up to date with the latest OpenShift Container Platform version. Upgrade scheduling to the latest version is available.
 
 [id="rosa-sdpolicy-upgrades_{context}"]
 == Upgrades
-Upgrades can be scheduled using the {product-title} (ROSA) CLI, `rosa`, or through {cluster-manager}.
+Upgrades can be scheduled using the ROSA CLI, `rosa`, or through {cluster-manager}.
 
 See the link:https://docs.openshift.com/rosa/rosa_policy/rosa-life-cycle.html[{product-title} Life Cycle] for more information on the upgrade policy and procedures.
 
@@ -97,11 +147,23 @@ See the link:https://docs.openshift.com/rosa/rosa_policy/rosa-life-cycle.html[{p
 
 [id="rosa-sdpolicy-container-engine_{context}"]
 == Container engine
-{product-title} runs on OpenShift 4 and uses link:https://www.redhat.com/en/blog/red-hat-openshift-container-platform-4-now-defaults-cri-o-underlying-container-engine[CRI-O] as the only available container engine.
+ifdef::rosa-with-hcp[]
+{hcp-title-first}
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
+{product-title}
+endif::rosa-with-hcp[]
+runs on OpenShift 4 and uses link:https://www.redhat.com/en/blog/red-hat-openshift-container-platform-4-now-defaults-cri-o-underlying-container-engine[CRI-O] as the only available container engine.
 
 [id="rosa-sdpolicy-operating-system_{context}"]
 == Operating system
-{product-title} runs on OpenShift 4 and uses Red Hat CoreOS as the operating system for all control plane and worker nodes.
+ifdef::rosa-with-hcp[]
+{hcp-title-first}
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
+{product-title}
+endif::rosa-with-hcp[]
+runs on OpenShift 4 and uses Red Hat CoreOS as the operating system for all control plane and worker nodes.
 
 [id="rosa-sdpolicy-red-hat-operator_{context}"]
 == Red Hat Operator support
@@ -117,4 +179,8 @@ Red Hat workloads typically refer to Red Hat-provided Operators made available t
 
 [id="rosa-sdpolicy-kubernetes-operator_{context}"]
 == Kubernetes Operator support
-All Operators listed in the Operator Hub marketplace should be available for installation. These operators are considered customer workloads, and are not monitored by Red Hat SRE.
+All Operators listed in the OperatorHub marketplace should be available for installation. These Operators are considered customer workloads, and are not monitored by Red Hat SRE.
+
+ifeval::["{context}" == "rosa-hcp-service-definition"]
+:!rosa-with-hcp:
+endif::[]

--- a/modules/rosa-sdpolicy-security.adoc
+++ b/modules/rosa-sdpolicy-security.adoc
@@ -1,21 +1,34 @@
 // Module included in the following assemblies:
 //
 // * rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
+// * rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc
+
+ifeval::["{context}" == "rosa-hcp-service-definition"]
+:rosa-with-hcp:
+endif::[]
 
 [id="rosa-sdpolicy-security_{context}"]
 = Security
 
-This section provides information about the service definition for {product-title} security.
+This section provides information about the service definition for
+ifdef::rosa-with-hcp[]
+{hcp-title-first}
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
+{product-title}
+endif::rosa-with-hcp[]
+security.
 
 [id="rosa-sdpolicy-auth-provider_{context}"]
 == Authentication provider
-Authentication for the cluster can be configured using either {cluster-manager-url} or cluster creation process or using the {product-title} (ROSA) CLI, `rosa`. ROSA is not an identity provider, and all access to the cluster must be managed by the customer as part of their integrated solution. The use of multiple identity providers provisioned at the same time is supported. The following identity providers are supported:
+Authentication for the cluster can be configured using either {cluster-manager-url} or cluster creation process or using the ROSA CLI, `rosa`. ROSA is not an identity provider, and all access to the cluster must be managed by the customer as part of their integrated solution. The use of multiple identity providers provisioned at the same time is supported. The following identity providers are supported:
 
 - GitHub or GitHub Enterprise
 - GitLab
 - Google
 - LDAP
 - OpenID Connect
+- htpasswd
 
 [id="rosa-sdpolicy-privileged-containers_{context}"]
 == Privileged containers
@@ -23,7 +36,21 @@ Privileged containers are available for users with the `cluster-admin` role. Usa
 
 [id="rosa-sdpolicy-customer-admin-user_{context}"]
 == Customer administrator user
-In addition to normal users, {product-title} provides access to an {product-title}-specific group called `dedicated-admin`. Any users on the cluster that are members of the `dedicated-admin` group:
+In addition to normal users,
+ifdef::rosa-with-hcp[]
+{hcp-title-first}
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
+{product-title}
+endif::rosa-with-hcp[]
+provides access to an
+ifdef::rosa-with-hcp[]
+{hcp-title}-specific
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
+ROSA-specific
+endif::rosa-with-hcp[]
+group called `dedicated-admin`. Any users on the cluster that are members of the `dedicated-admin` group:
 
 - Have administrator access to all customer-created projects on the cluster.
 - Can manage resource quotas and limits on the cluster.
@@ -34,7 +61,14 @@ In addition to normal users, {product-title} provides access to an {product-titl
 
 [id="rosa-sdpolicy-cluster-admin-role_{context}"]
 == Cluster administration role
-The administrator of {product-title} has default access to the `cluster-admin` role for your organization's cluster. While logged into an account with the `cluster-admin` role, users have increased permissions to run privileged security contexts.
+The administrator of
+ifdef::rosa-with-hcp[]
+{hcp-title-first}
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
+{product-title}
+endif::rosa-with-hcp[]
+has default access to the `cluster-admin` role for your organization's cluster. While logged into an account with the `cluster-admin` role, users have increased permissions to run privileged security contexts.
 
 [id="rosa-sdpolicy-project-self-service_{context}"]
 == Project self-service
@@ -52,7 +86,13 @@ $ oc adm policy add-cluster-role-to-group self-provisioner system:authenticated:
 
 [id="rosa-sdpolicy-regulatory-compliance_{context}"]
 == Regulatory compliance
+
+ifdef::rosa-with-hcp[]
+{hcp-title} is currently in the process of obtaining compliance certifications.
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
 See Understanding process and security for ROSA for the latest compliance information.
+endif::rosa-with-hcp[]
 
 [id="rosa-sdpolicy-network-security_{context}"]
 == Network security
@@ -61,9 +101,23 @@ With {product-title}, AWS provides a standard DDoS protection on all load balanc
 [id="rosa-sdpolicy-etcd-encryption_{context}"]
 == etcd encryption
 
-In {product-title}, the control plane storage is encrypted at rest by default and this includes encryption of the etcd volumes. This storage-level encryption is provided through the storage layer of the cloud provider.
+In
+ifdef::rosa-with-hcp[]
+{hcp-title-first},
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
+{product-title},
+endif::rosa-with-hcp[]
+the control plane storage is encrypted at rest by default and this includes encryption of the etcd volumes. This storage-level encryption is provided through the storage layer of the cloud provider.
 
+ifdef::rosa-with-hcp[]
+The etcd database is always encrypted by default. Customers might opt to provide their own custom AWS KMS keys for the purpose of encrypting the etcd database.
+
+Etcd encryption will encrypt the following Kubernetes API server and OpenShift API server resources:
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
 You can also enable etcd encryption, which encrypts the key values in etcd, but not the keys. If you enable etcd encryption, the following Kubernetes API server and OpenShift API server resources are encrypted:
+endif::rosa-with-hcp[]
 
 * Secrets
 * Config maps
@@ -71,9 +125,15 @@ You can also enable etcd encryption, which encrypts the key values in etcd, but 
 * OAuth access tokens
 * OAuth authorize tokens
 
+ifndef::rosa-with-hcp[]
 The etcd encryption feature is not enabled by default and it can be enabled only at cluster installation time. Even with etcd encryption enabled, the etcd key values are accessible to anyone with access to the control plane nodes or `cluster-admin` privileges.
 
 [IMPORTANT]
 ====
 By enabling etcd encryption for the key values in etcd, you will incur a performance overhead of approximately 20%. The overhead is a result of introducing this second layer of encryption, in addition to the default control plane storage encryption that encrypts the etcd volumes. Red Hat recommends that you enable etcd encryption only if you specifically require it for your use case.
 ====
+endif::rosa-with-hcp[]
+
+ifeval::["{context}" == "rosa-hcp-service-definition"]
+:!rosa-with-hcp:
+endif::[]

--- a/modules/rosa-sdpolicy-storage.adoc
+++ b/modules/rosa-sdpolicy-storage.adoc
@@ -2,16 +2,34 @@
 // Module included in the following assemblies:
 //
 // * rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
+// * rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc
+
+ifeval::["{context}" == "rosa-hcp-service-definition"]
+:rosa-with-hcp:
+endif::[]
 
 [id="rosa-sdpolicy-storage_{context}"]
 = Storage
 
-
-This section provides information about the service definition for {product-title} storage.
+This section provides information about the service definition for
+ifdef::rosa-with-hcp[]
+{hcp-title-first}
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
+{product-title}
+endif::rosa-with-hcp[]
+storage.
 
 [id="rosa-sdpolicy-encrytpted-at-rest-storage_{context}"]
 == Encrypted-at-rest OS and node storage
-Control plane, infrastructure, and worker nodes use encrypted-at-rest Amazon Elastic Block Store (Amazon EBS) storage.
+
+ifdef::rosa-with-hcp[]
+Worker
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
+Control plane, infrastructure, and worker
+endif::rosa-with-hcp[]
+nodes use encrypted-at-rest Amazon Elastic Block Store (Amazon EBS) storage.
 
 [id="rosa-sdpolicy-encrytpted-at-rest-pv_{context}"]
 == Encrypted-at-rest PV
@@ -27,4 +45,15 @@ Each cloud provider has its own limits for how many PVs can be attached to a sin
 
 == Shared Storage (RWX)
 
-The AWS CSI Driver can be used to provide RWX support for {product-title}. A community Operator is provided to simplify setup. See link:https://access.redhat.com/articles/5025181[Amazon Elastic File Storage Setup for OpenShift Dedicated and Red Hat OpenShift Service on AWS] for details. 
+The AWS CSI Driver can be used to provide RWX support for
+ifdef::rosa-with-hcp[]
+{hcp-title-first}.
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
+{product-title}.
+endif::rosa-with-hcp[]
+A community Operator is provided to simplify setup. See link:https://access.redhat.com/articles/5025181[Amazon Elastic File Storage Setup for OpenShift Dedicated and Red Hat OpenShift Service on AWS] for details.
+
+ifeval::["{context}" == "rosa-hcp-service-definition"]
+:!rosa-with-hcp:
+endif::[]

--- a/modules/rosa-troubleshooting-networking-nlb.adoc
+++ b/modules/rosa-troubleshooting-networking-nlb.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * support/rosa-troubleshooting-deployments.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-troubleshooting-general-deployment-failure_{context}"]
+= Connectivity issues on clusters with private Network Load Balancers
+
+{product-title} and {hcp-title} clusters created with version 4.14 deploy AWS Network Load Balancers (NLB) by default for the `default` ingress controller. In the case of a private NLB, the NLB's client IP address preservation might cause connections to be dropped where the source and destination are the same host. See the AWS's documentation about how to link:https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-troubleshooting.html#loopback-timeout[Troubleshoot your Network Load Balancer]. This IP address preservation has the implication that any customer workloads cohabitating on the same node with the router pods, may not be able send traffic to the private NLB fronting the ingress controller router.
+
+To mitigate this impact, customer's should reschedule their workloads onto nodes separate from those where the router pods are scheduled. Alternatively, customers should rely on the internal pod and service networks for accessing other workloads co-located within the same cluster.

--- a/rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.adoc
@@ -1,0 +1,30 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: rosa-hcp-life-cycle
+[id="rosa-hcp-life-cycle"]
+= {hcp-title} update life cycle
+
+toc::[]
+
+include::modules/life-cycle-overview.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-service-definition[{product-title} service definition]
+
+include::modules/life-cycle-definitions.adoc[leveloffset=+1]
+include::modules/life-cycle-major-versions.adoc[leveloffset=+1]
+include::modules/life-cycle-minor-versions.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc#rosa-limited-support_rosa-life-cycle[{product-title} limited support status]
+
+include::modules/life-cycle-patch-versions.adoc[leveloffset=+1]
+include::modules/life-cycle-limited-support.adoc[leveloffset=+1]
+include::modules/life-cycle-supported-versions.adoc[leveloffset=+1]
+include::modules/life-cycle-install.adoc[leveloffset=+1]
+include::modules/life-cycle-mandatory-upgrades.adoc[leveloffset=+1]
+include::modules/life-cycle-dates.adoc[leveloffset=+1]

--- a/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc
@@ -1,0 +1,56 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: rosa-hcp-service-definition
+[id="rosa-hcp-service-definition"]
+= {hcp-title-first} service definition
+
+toc::[]
+
+This documentation outlines the service definition for the {hcp-title-first} managed service.
+
+[id="rosa-hcp-sdpolicy-account-management_{context}"]
+== Account management
+
+This section provides information about the service definition for {product-title} account management.
+
+include::modules/rosa-sdpolicy-am-billing.adoc[leveloffset=+2]
+include::modules/rosa-sdpolicy-am-cluster-self-service.adoc[leveloffset=+2]
+include::modules/rosa-sdpolicy-am-compute.adoc[leveloffset=+2]
+include::snippets/pid-limits.adoc[]
+
+[role="_additional-resources"]
+.Additional Resources
+
+* xref:../../rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc#rosa-sdpolicy-red-hat-operator_rosa-service-definition[Red Hat Operator Support]
+
+include::modules/rosa-sdpolicy-am-aws-compute-types.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional Resources
+
+* link:https://aws.amazon.com/ec2/instance-types[AWS Instance Types]
+
+include::modules/rosa-sdpolicy-am-regions-az.adoc[leveloffset=+2]
+include::modules/rosa-sdpolicy-am-local-zones.adoc[leveloffset=+2]
+include::modules/rosa-sdpolicy-am-sla.adoc[leveloffset=+2]
+include::modules/rosa-sdpolicy-am-limited-support.adoc[leveloffset=+2]
+include::modules/rosa-sdpolicy-am-support.adoc[leveloffset=+2]
+include::modules/rosa-sdpolicy-logging.adoc[leveloffset=+1]
+include::modules/rosa-sdpolicy-monitoring.adoc[leveloffset=+1]
+include::modules/rosa-sdpolicy-networking.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about the network verification checks, see xref:../../networking/network-verification.adoc#network-verification[Network verification].
+
+include::modules/rosa-sdpolicy-storage.adoc[leveloffset=+1]
+include::modules/rosa-sdpolicy-platform.adoc[leveloffset=+1]
+include::modules/rosa-sdpolicy-security.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_rosa-hcp-service-definition"]
+== Additional resources
+
+* See xref:../rosa_policy_service_definition/rosa-policy-process-security.adoc#rosa-policy-process-security[Understanding process and security for ROSA] for the latest compliance information.
+* See xref:../rosa_policy_service_definition/rosa-life-cycle.adoc#rosa-life-cycle[ROSA life cycle]

--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
@@ -13,9 +13,6 @@ If you are looking for a quickstart guide for ROSA Classic, see xref:../rosa_get
 
 {hcp-title-first} offers a more efficient and reliable architecture for creating {product-title} (ROSA) clusters. With {hcp-title}, each cluster has a dedicated control plane that is isolated in a ROSA service account.
 
-:FeatureName: {hcp-title-first}
-include::snippets/technology-preview.adoc[]
-
 Create a {hcp-title} cluster quickly by using the default options and automatic AWS Identity and Access Management (IAM) resource creation. You can deploy your cluster by using the ROSA CLI (`rosa`).
 
 [IMPORTANT]

--- a/rosa_hcp/rosa-tuning-config.adoc
+++ b/rosa_hcp/rosa-tuning-config.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 {hcp-title-first} supports the Node Tuning Operator to improve performance of your nodes on your {hcp-title} clusters. Prior to creating a node tuning configuration, you must create a custom tuning specification.
 
-:FeatureName: {hcp-title-first}
-include::snippets/technology-preview.adoc[]
-
 include::modules/node-tuning-operator.adoc[leveloffset=+1]
 
 include::modules/custom-tuning-specification.adoc[leveloffset=+1]

--- a/support/troubleshooting/rosa-troubleshooting-networking.adoc
+++ b/support/troubleshooting/rosa-troubleshooting-networking.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/attributes-openshift-dedicated.adoc[]
+[id="rosa-troubleshooting-networking"]
+= Troubleshooting networking
+:context: rosa-troubleshooting-networking
+
+toc::[]
+
+This document describes how to troubleshoot networking errors.
+
+include::modules/rosa-troubleshooting-networking-nlb.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
`enterprise-4.14+`

Issue:
* [OSDOCS-6139](https://issues.redhat.com/browse/OSDOCS-6139)
* [OSDOCS-8877](https://issues.redhat.com/browse/OSDOCS-8877)

Link to docs preview:
- Removed the Tech Preview warning on to cover **[OSDOCS-6139](https://issues.redhat.com/browse/OSDOCS-6139)**:
    - [Creating ROSA with HCP clusters using the default options](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html)
    - [Using the Node Tuning Operator on ROSA with HCP clusters](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_hcp/rosa-tuning-config.html)
- Created a new Service Definition topic for ROSA with HCP for **[OSDOCS-6139](https://issues.redhat.com/browse/OSDOCS-6139)**:
    - [Red Hat OpenShift Service on AWS service definition](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-instance-types_rosa-service-definition) (unchanged)
        - [Regions and availability zones](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-regions-az_rosa-service-definition)
        - [Local Zones](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-am-local-zones_rosa-service-definition)
        - [Limited support status](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-limited-support_rosa-service-definition)
        - [Load balancers](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-load-balancers_rosa-service-definition)
        - [Cluster egress](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-cluster-egress_rosa-service-definition)
        - [Encrypted-at-rest OS and node storage](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-encrytpted-at-rest-storage_rosa-service-definition)
        - [Cluster backup policy](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-backup-policy_rosa-service-definition)
        - [Daemonsets](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-daemonsets_rosa-service-definition)
        - [Multiple availability zone](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-multiple-availability-zone_rosa-service-definition)
        - [etcd encryption](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-etcd-encryption_rosa-service-definition)
    - [Red Hat OpenShift Service on AWS (ROSA) with hosted control planes (HCP) service definition](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-instance-types_rosa-hcp-service-definition)
        - [Regions and availability zones](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-regions-az_rosa-hcp-service-definition)
        - [Local Zones](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-am-local-zones_rosa-hcp-service-definition)
        - [Limited support status](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-limited-support_rosa-hcp-service-definition)
        - [Load balancers](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-load-balancers_rosa-hcp-service-definition)
        - [Cluster egress](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-cluster-egress_rosa-hcp-service-definition)
        - [Encrypted-at-rest OS and node storage](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-encrytpted-at-rest-storage_rosa-hcp-service-definition)
        - [Cluster backup policy](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-backup-policy_rosa-hcp-service-definition)
        - [Daemonsets](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-daemonsets_rosa-hcp-service-definition)
        - [Multiple availability zone](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-multiple-availability-zone_rosa-hcp-service-definition)
        - [etcd encryption](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-etcd-encryption_rosa-hcp-service-definition)
- Created a new ROSA with HCP Life Cycle topic for **[OSDOCS-6139](https://issues.redhat.com/browse/OSDOCS-6139)**:
    - [ROSA Life Cycle](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.html) (unchanged)
        - [Minor Versions (x.Y.Z)](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.html#rosa-minor-versions_rosa-life-cycle)
        - [Limited support status](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.html#rosa-limited-support_rosa-life-cycle)
        - [Life cycle dates](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.html#sd-life-cycle-dates_rosa-life-cycle)
    - [ROSA with HCP Life Cycle](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.html)
        - [Minor Versions (x.Y.Z)](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.html#rosa-minor-versions_rosa-hcp-life-cycle)
        - [Limited support status](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.html#rosa-limited-support_rosa-hcp-life-cycle)
        - [Life cycle dates](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.html#sd-life-cycle-dates_rosa-hcp-life-cycle)
- Created a troubleshooting networking assembly for **[OSDOCS-8877](https://issues.redhat.com/browse/OSDOCS-8877)**:
   - [Troubleshooting networking](https://file.rdu.redhat.com/eponvell/OSDOCS-6139-2_HCP-GA-Updates/support/troubleshooting/rosa-troubleshooting-networking.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Removed the Tech Preview warnings from the ROSA with HCP topics. Also created ROSA with HCP versions of the service definition and life cycle topics. Finally, I tried to change all instances of `Red Hat OpenShift Service on AWS` to  `Red Hat OpenShift Service on AWS (ROSA) with hosted control planes (HCP)`.
