### PR TITLE
Update xrefs to Authentication topics

### DIFF
--- a/operators/admin/olm-managing-custom-catalogs.adoc
+++ b/operators/admin/olm-managing-custom-catalogs.adoc
@@ -78,13 +78,10 @@ include::modules/olm-pruning-index-image.adoc[leveloffset=+2]
 
 include::modules/olm-catalog-source-and-psa.adoc[leveloffset=+1]
 
-// This xref points to a topic that is not currently included in the OSD and ROSA docs.
-ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Understanding and managing pod security admission]
-endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/olm-migrating-sqlite-catalog-to-fbc.adoc[leveloffset=+2]
 

--- a/operators/operator_sdk/osdk-cli-ref.adoc
+++ b/operators/operator_sdk/osdk-cli-ref.adoc
@@ -39,10 +39,7 @@ include::modules/osdk-cli-ref-run-bundle.adoc[leveloffset=+2]
 
 * See xref:../../operators/understanding/olm/olm-understanding-operatorgroups.adoc#olm-operatorgroups-membership_olm-understanding-operatorgroups[Operator group membership] for details on possible install modes.
 * xref:../../operators/operator_sdk/osdk-complying-with-psa.adoc#osdk-complying-with-psa[Complying with pod security admission]
-// This xref points to a topic that is not currently included in the OSD/ROSA docs.
-ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Understanding and managing pod security admission]
-endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/osdk-cli-ref-run-bundle-upgrade.adoc[leveloffset=+2]
 
@@ -50,10 +47,7 @@ include::modules/osdk-cli-ref-run-bundle-upgrade.adoc[leveloffset=+2]
 .Additional resources
 
 * xref:../../operators/operator_sdk/osdk-complying-with-psa.adoc#osdk-complying-with-psa[Complying with pod security admission]
-// This xref points to a topic that is not currently included in the OSD and ROSA docs.
-ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Understanding and managing pod security admission]
-endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/osdk-cli-ref-scorecard.adoc[leveloffset=+1]
 
@@ -62,7 +56,4 @@ include::modules/osdk-cli-ref-scorecard.adoc[leveloffset=+1]
 
 * See xref:../../operators/operator_sdk/osdk-scorecard.adoc#osdk-scorecard[Validating Operators using the scorecard tool] for details about running the scorecard tool.
 * xref:../../operators/operator_sdk/osdk-complying-with-psa.adoc#osdk-complying-with-psa[Complying with pod security admission]
-// This xref points to a topic that is not currently included in the OSD and ROSA docs.
-ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Understanding and managing pod security admission]
-endif::openshift-dedicated,openshift-rosa[]

--- a/operators/operator_sdk/osdk-complying-with-psa.adoc
+++ b/operators/operator_sdk/osdk-complying-with-psa.adoc
@@ -14,10 +14,7 @@ If your Operator project does not require escalated permissions to run, you can 
 * The allowed pod security admission level for the Operator's namespace
 * The allowed security context constraints (SCC) for the workload's service account
 
-// This xref points to a topic that is not currently included in the OSD/ROSA docs.
-ifndef::openshift-dedicated,openshift-rosa[]
 For more information, see xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Understanding and managing pod security admission].
-endif::openshift-dedicated,openshift-rosa[]
 
 // About pod security admission
 include::modules/security-context-constraints-psa-about.adoc[leveloffset=+1]
@@ -36,11 +33,8 @@ include::modules/osdk-ensuring-operator-workloads-run-restricted-psa.adoc[levelo
 
 include::modules/osdk-managing-psa-for-operators-with-escalated-permissions.adoc[leveloffset=+1]
 
-// This xref points to a topic that is not included in the OSD/ROSA docs.
-ifndef::openshift-dedicated,openshift-rosa[]
 [id="osdk-complying-with-psa-additional-resources"]
 [role="_additional-resources"]
 == Additional resources
 
 * xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Understanding and managing pod security admission]
-endif::openshift-dedicated,openshift-rosa[]


### PR DESCRIPTION
When the Operators book was ported to OSD and ROSA, some of the xrefs pointed to targets in the Authentication book that were not included in the OSD/ROSA docs. These xrefs were conditioned out of OSD/ROSA. However, now that the Authentication book has been ported to OSD and ROSA, these xrefs are valid. This PR removes the conditionalization and adds the xrefs to OSD/ROSA.

Version(s):
enterprise-4.14+

Issue:
N/A

Link to docs preview:
* OSD:
  *  https://68686--docspreview.netlify.app/openshift-dedicated/latest/operators/admin/olm-managing-custom-catalogs
  * https://68686--docspreview.netlify.app/openshift-dedicated/latest/operators/operator_sdk/osdk-cli-ref
  * https://68686--docspreview.netlify.app/openshift-dedicated/latest/operators/operator_sdk/osdk-complying-with-psa
* ROSA:
  * https://68686--docspreview.netlify.app/openshift-rosa/latest/operators/admin/olm-managing-custom-catalogs
  * https://68686--docspreview.netlify.app/openshift-rosa/latest/operators/operator_sdk/osdk-cli-ref
  * https://68686--docspreview.netlify.app/openshift-rosa/latest/operators/operator_sdk/osdk-complying-with-psa

QE review:
No QE review required.