### PR TITLE
Reformatting Nutanix and Alibaba install config parameters

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -2188,91 +2188,148 @@ If defined, the parameters `compute.platform.alibabacloud` and `controlPlane.pla
 ====
 
 .Optional {alibaba} parameters
-[cols=".^2,.^3,.^5a",options="header"]
+[cols=".^2l,.^3,.^5a",options="header"]
 |====
 |Parameter|Description|Values
 
-|`compute.platform.alibabacloud.imageID`
+|compute:
+  platform:
+    alibabacloud:
+      imageID:
 |The imageID used to create the ECS instance. ImageID must belong to the same region as the cluster.
 |String.
 
-|`compute.platform.alibabacloud.instanceType`
+|compute:
+  platform:
+    alibabacloud:
+      instanceType:
 |InstanceType defines the ECS instance type. Example: `ecs.g6.large`
 |String.
 
-|`compute.platform.alibabacloud.systemDiskCategory`
+|compute:
+  platform:
+    alibabacloud:
+      systemDiskCategory:
 |Defines the category of the system disk. Examples: `cloud_efficiency`,`cloud_essd`
 |String.
 
-|`compute.platform.alibabacloud.systemDisksize`
+|compute:
+  platform:
+    alibabacloud:
+      systemDisksize:
 |Defines the size of the system disk in gibibytes (GiB).
 |Integer.
 
-|`compute.platform.alibabacloud.zones`
+|compute:
+  platform:
+    alibabacloud:
+      zones:
 |The list of availability zones that can be used. Examples: `cn-hangzhou-h`, `cn-hangzhou-j`
 |String list.
 
-|`controlPlane.platform.alibabacloud.imageID`
+|controlPlane:
+  platform:
+    alibabacloud:
+      imageID:
 |The imageID used to create the ECS instance. ImageID must belong to the same region as the cluster.
 |String.
 
-|`controlPlane.platform.alibabacloud.instanceType`
+|controlPlane:
+  platform:
+    alibabacloud:
+      instanceType:
 |InstanceType defines the ECS instance type. Example: `ecs.g6.xlarge`
 |String.
 
-|`controlPlane.platform.alibabacloud.systemDiskCategory`
+|controlPlane:
+  platform:
+    alibabacloud:
+      systemDiskCategory:
 |Defines the category of the system disk. Examples: `cloud_efficiency`,`cloud_essd`
 |String.
 
-|`controlPlane.platform.alibabacloud.systemDisksize`
+|controlPlane:
+  platform:
+    alibabacloud:
+      systemDisksize:
 |Defines the size of the system disk in gibibytes (GiB).
 |Integer.
 
-|`controlPlane.platform.alibabacloud.zones`
+|controlPlane:
+  platform:
+    alibabacloud:
+      zones:
 |The list of availability zones that can be used. Examples: `cn-hangzhou-h`, `cn-hangzhou-j`
 |String list.
 
-|`platform.alibabacloud.region`
+|platform:
+  alibabacloud:
+    region:
 |Required. The Alibaba Cloud region where the cluster will be created.
 |String.
 
-|`platform.alibabacloud.resourceGroupID`
+|platform:
+  alibabacloud:
+    resourceGroupID:
 |The ID of an already existing resource group where the cluster will be installed. If empty, the installation program will create a new resource group for the cluster.
 |String.
 
-|`platform.alibabacloud.tags`
+|platform:
+  alibabacloud:
+    tags:
 |Additional keys and values to apply to all Alibaba Cloud resources created for the cluster.
 |Object.
 
-|`platform.alibabacloud.vpcID`
+|platform:
+  alibabacloud:
+    vpcID:
 |The ID of an already existing VPC where the cluster should be installed. If empty, the installation program will create a new VPC for the cluster.
 |String.
 
-|`platform.alibabacloud.vswitchIDs`
+|platform:
+  alibabacloud:
+    vswitchIDs:
 |The ID list of already existing VSwitches where cluster resources will be created. The existing VSwitches can only be used when also using existing VPC. If empty, the installation program will create new VSwitches for the cluster.
 |String list.
 
-|`platform.alibabacloud.defaultMachinePlatform.imageID`
+|platform:
+  alibabacloud:
+    defaultMachinePlatform:
+      imageID:
 |For both compute machines and control plane machines, the image ID that should be used to create ECS instance. If set, the image ID should belong to the same region as the cluster.
 |String.
 
-|`platform.alibabacloud.defaultMachinePlatform.instanceType`
+|platform:
+  alibabacloud:
+    defaultMachinePlatform:
+      instanceType:
 |For both compute machines and control plane machines, the ECS instance type used to create the ECS instance. Example: `ecs.g6.xlarge`
 |String.
 
-|`platform.alibabacloud.defaultMachinePlatform.systemDiskCategory`
+|platform:
+  alibabacloud:
+    defaultMachinePlatform:
+      systemDiskCategory:
 |For both compute machines and control plane machines, the category of the system disk. Examples: `cloud_efficiency`, `cloud_essd`.
 |String, for example "", `cloud_efficiency`, `cloud_essd`.
 
-|`platform.alibabacloud.defaultMachinePlatform.systemDiskSize`
+|platform:
+  alibabacloud:
+    defaultMachinePlatform:
+      systemDiskSize:
 |For both compute machines and control plane machines, the size of the system disk in gibibytes (GiB). The minimum is `120`.
 |Integer.
 
-|`platform.alibabacloud.defaultMachinePlatform.zones`
+|platform:
+  alibabacloud:
+    defaultMachinePlatform:
+      zones:
 |For both compute machines and control plane machines, the list of availability zones that can be used. Examples: `cn-hangzhou-h`, `cn-hangzhou-j`
 |String list.
 
-|`platform.alibabacloud.privateZoneID`
+|platform:
+  alibabacloud:
+    privateZoneID:
 |The ID of an existing private zone into which to add DNS records for the cluster's internal API. An existing private zone can only be used when also using existing VPC. The private zone must be associated with the VPC containing the subnets. Leave the private zone unset to have the installation program create the private zone on your behalf.
 |String.
 
@@ -2287,107 +2344,194 @@ ifdef::nutanix[]
 Additional Nutanix configuration parameters are described in the following table:
 
 .Additional Nutanix cluster parameters
-[cols=".^2,.^3a,.^3a",options="header"]
+[cols=".^2l,.^3a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
-|`compute.platform.nutanix.categories.key`
+|compute:
+  platform:
+    nutanix:
+      categories:
+        key:
 |The name of a prism category key to apply to compute VMs. This parameter must be accompanied by the `value` parameter, and both `key` and `value` parameters must exist in Prism Central. For more information on categories, see link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_2022_6:ssp-ssp-categories-manage-pc-c.html[Category management].
 |String
 
-|`compute.platform.nutanix.categories.value`
+|compute:
+  platform:
+    nutanix:
+      categories:
+        value:
 |The value of a prism category key-value pair to apply to compute VMs. This parameter must be accompanied by the `key` parameter, and both `key` and `value` parameters must exist in Prism Central.
 |String
 
-|`compute.platform.nutanix.project.type`
+|compute:
+  platform:
+    nutanix:
+      project:
+        type:
 |The type of identifier you use to select a project for compute VMs.  Projects define logical groups of user roles for managing permissions, networks, and other parameters. For more information on projects, see link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_2022_9:ssp-app-mgmt-project-env-c.html[Projects Overview].
 |`name` or `uuid`
 
-|`compute.platform.nutanix.project.name` or `compute.platform.nutanix.project.uuid`
+|compute:
+  platform:
+    nutanix:
+      project:
+        name: or uuid:
 |The name or UUID of a project with which compute VMs are associated. This parameter must be accompanied by the `type` parameter.
 |String
 
-|`compute.platform.nutanix.bootType`
+|compute:
+  platform:
+    nutanix:
+      bootType:
 |The boot type that the compute machines use. You must use the `Legacy` boot type in {product-title} {product-version}. For more information on boot types, see link:https://portal.nutanix.com/page/documents/kbs/details?targetId=kA07V000000H3K9SAK[Understanding UEFI, Secure Boot, and TPM in the Virtualized Environment].
 |`Legacy`, `SecureBoot` or `UEFI`. The default is `Legacy`.
 
-|`controlPlane.platform.nutanix.categories.key`
+|controlPlane:
+  platform:
+    nutanix:
+      categories:
+        key:
 |The name of a prism category key to apply to control plane VMs. This parameter must be accompanied by the `value` parameter, and both `key` and `value` parameters must exist in Prism Central. For more information on categories, see link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_2022_6:ssp-ssp-categories-manage-pc-c.html[Category management].
 |String
 
-|`controlPlane.platform.nutanix.categories.value`
+|controlPlane:
+  platform:
+    nutanix:
+      categories:
+        value:
 |The value of a prism category key-value pair to apply to control plane VMs. This parameter must be accompanied by the `key` parameter, and both `key` and `value` parameters must exist in Prism Central.
 |String
 
-|`controlPlane.platform.nutanix.project.type`
+|controlPlane:
+  platform:
+    nutanix:
+      project:
+        type:
 |The type of identifier you use to select a project for control plane VMs.  Projects define logical groups of user roles for managing permissions, networks, and other parameters. For more information on projects, see link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_2022_9:ssp-app-mgmt-project-env-c.html[Projects Overview].
 |`name` or `uuid`
 
-|`controlPlane.platform.nutanix.project.name` or `controlPlane.platform.nutanix.project.uuid`
+|controlPlane:
+  platform:
+    nutanix:
+      project:
+        name: or uuid:
 |The name or UUID of a project with which control plane VMs are associated. This parameter must be accompanied by the `type` parameter.
 |String
 
-|`platform.nutanix.defaultMachinePlatform.categories.key`
+|platform:
+  nutanix:
+    defaultMachinePlatform:
+      categories:
+        key:
 |The name of a prism category key to apply to all VMs. This parameter must be accompanied by the `value` parameter, and both `key` and `value` parameters must exist in Prism Central. For more information on categories, see link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_2022_6:ssp-ssp-categories-manage-pc-c.html[Category management].
 |String
 
-|`platform.nutanix.defaultMachinePlatform.categories.value`
+|platform:
+  nutanix:
+    defaultMachinePlatform:
+      categories:
+        value:
 |The value of a prism category key-value pair to apply to all VMs. This parameter must be accompanied by the `key` parameter, and both `key` and `value` parameters must exist in Prism Central.
 |String
 
-|`platform.nutanix.defaultMachinePlatform.project.type`
+|platform:
+  nutanix:
+    defaultMachinePlatform:
+      project:
+        type:
 |The type of identifier you use to select a project for all VMs. Projects define logical groups of user roles for managing permissions, networks, and other parameters. For more information on projects, see link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_2022_9:ssp-app-mgmt-project-env-c.html[Projects Overview].
 |`name` or `uuid`.
 
-|`platform.nutanix.defaultMachinePlatform.project.name` or `platform.nutanix.defaultMachinePlatform.project.uuid`
+|platform:
+  nutanix:
+    defaultMachinePlatform:
+      project:
+        name: or uuid:
 |The name or UUID of a project with which all VMs are associated. This parameter must be accompanied by the `type` parameter.
 |String
 
-|`platform.nutanix.defaultMachinePlatform.bootType`
+|platform:
+  nutanix:
+    defaultMachinePlatform:
+      bootType:
 |The boot type for all machines. You must use the `Legacy` boot type in {product-title} {product-version}. For more information on boot types, see link:https://portal.nutanix.com/page/documents/kbs/details?targetId=kA07V000000H3K9SAK[Understanding UEFI, Secure Boot, and TPM in the Virtualized Environment].
 |`Legacy`, `SecureBoot` or `UEFI`. The default is `Legacy`.
 
-|`platform.nutanix.apiVIP`
+|platform:
+  nutanix:
+    apiVIP:
 |The virtual IP (VIP) address that you configured for control plane API access.
 |IP address
 
-|`platform.nutanix.ingressVIP`
+|platform:
+  nutanix:
+    ingressVIP:
 |The virtual IP (VIP) address that you configured for cluster ingress.
 |IP address
 
-|`platform.nutanix.prismCentral.endpoint.address`
+|platform:
+  nutanix:
+    prismCentral:
+      endpoint:
+        address:
 |The Prism Central domain name or IP address.
 |String
 
-|`platform.nutanix.prismCentral.endpoint.port`
+|platform:
+  nutanix:
+    prismCentral:
+      endpoint:
+        port:
 |The port that is used to log into Prism Central.
 |String
 
-|`platform.nutanix.prismCentral.password`
+|platform:
+  nutanix:
+    prismCentral:
+      password:
 |The password for the Prism Central user name.
 |String
 
-|`platform.nutanix.prismCentral.username`
+|platform:
+  nutanix:
+    prismCentral:
+      username:
 |The user name that is used to log into Prism Central.
 |String
 
-|`platform.nutanix.prismElments.endpoint.address`
+|platform:
+  nutanix:
+    prismElements:
+      endpoint:
+        address:
 |The Prism Element domain name or IP address. [^1^]
 |String
 
-|`platform.nutanix.prismElments.endpoint.port`
+|platform:
+  nutanix:
+    prismElements:
+      endpoint:
+        port:
 |The port that is used to log into Prism Element.
 |String
 
-|`platform.nutanix.prismElements.uuid`
+|platform:
+  nutanix:
+    prismElements:
+      uuid:
 |The universally unique identifier (UUID) for Prism Element.
 |String
 
-|`platform.nutanix.subnetUUIDs`
+|platform:
+  nutanix:
+    subnetUUIDs:
 |The UUID of the Prism Element network that contains the virtual IP addresses and DNS records that you configured. [^2^]
 |String
 
-|`platform.nutanix.clusterOSImage`
+|platform:
+  nutanix:
+    clusterOSImage:
 |Optional: By default, the installation program downloads and installs the {op-system-first} image. If Prism Central does not have internet access, you can override the default behavior by hosting the {op-system} image on any HTTP server and pointing the installation program to the image.
 |An HTTP or HTTPS URL, optionally with a SHA-256 checksum. For example, \http://example.com/images/rhcos-47.83.202103221318-0-nutanix.x86_64.qcow2
 |====


### PR DESCRIPTION
Version: 4.14+

Reformatting the Alibaba and Nutanix installation configuration parameter tables into stacked format.

Previous format:
`controlPlane.alibaba.region`

New format:
```
controlPlane:
  alibaba:
    region:
```
Preview:
[Alibaba](https://68695--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_alibaba/installation-config-parameters-alibaba#installation-configuration-parameters-additional-alibaba_installation-config-parameters-alibaba)
[Nutanix](https://68695--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installation-config-parameters-nutanix#installation-configuration-parameters-additional-vsphere_installation-config-parameters-nutanix)

No QE required because this only affects docs formatting.