### PR TITLE
fixed a typo in the machine set YAML

### DIFF
--- a/modules/machineset-yaml-nutanix.adoc
+++ b/modules/machineset-yaml-nutanix.adoc
@@ -99,7 +99,7 @@ endif::infra[]
             type: uuid
             uuid: <cluster_uuid>
           credentialsSecret:
-            name: nutanix-creds-secret
+            name: nutanix-credentials
           image:
             name: <infrastructure_id>-rhcos <8>
             type: name


### PR DESCRIPTION
Version(s):
4.11+

Issue:
N/A

Link to docs preview:
[Sample YAML for a compute machine set custom resource on Nutanix](https://68697--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-nutanix#machineset-yaml-nutanix_creating-machineset-nutanix)

QE review:
- [x] QE has approved this change.

Additional information:
From https://github.com/openshift/cloud-credential-operator/blob/e295bb23acb96b0902d8c14cf05b9eb0a77ca19f/docs/ccoctl.md?plain=1#L519 and https://github.com/openshift/machine-api-operator/blob/master/pkg/webhooks/machine_webhook.go#L173