### PR TITLE
Removed the tech preview notice

### DIFF
--- a/scalability_and_performance/enabling-workload-partitioning.adoc
+++ b/scalability_and_performance/enabling-workload-partitioning.adoc
@@ -6,8 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: Workload partitioning
-include::snippets/technology-preview.adoc[]
 
 In resource-constrained environments, you can use workload partitioning to isolate {product-title} services, cluster management workloads, and infrastructure pods to run on a reserved set of CPUs.
 


### PR DESCRIPTION
 Removed the tech preview notice at the beginning of this section:
 https://docs.openshift.com/container-platform/4.14/scalability_and_performance/enabling-workload-partitioning.html
 
This applies to main, and enterprise-4.14.

This relates to: [TELCODOCS-1645](https://issues.redhat.com/browse/TELCODOCS-1645)