### PR TITLE
TELCODOCS#1645: Removed tech preview notice

### DIFF
--- a/scalability_and_performance/enabling-workload-partitioning.adoc
+++ b/scalability_and_performance/enabling-workload-partitioning.adoc
@@ -6,9 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: Workload partitioning
-include::snippets/technology-preview.adoc[]
-
 In resource-constrained environments, you can use workload partitioning to isolate {product-title} services, cluster management workloads, and infrastructure pods to run on a reserved set of CPUs.
 
 The minimum number of reserved CPUs required for the cluster management is four CPU Hyper-Threads (HTs).


### PR DESCRIPTION
Version(s): 4.14+

Issue: [TELCODOCS-1645](https://issues.redhat.com/browse/TELCODOCS-1645)

Preview link: 
https://68705--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/enabling-workload-partitioning

QE review:
- [x] QE has approved this change.