### PR TITLE
fix yaml errors

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -54,18 +54,18 @@ Topics:
 - Name: OpenShift Container Platform 4.15 release notes
   File: ocp-4-15-release-notes
 ---
- Name: Getting started
- Dir: getting_started
- Distros: openshift-enterprise
- Topics:
- - Name: Kubernetes overview
-   File: kubernetes-overview
- - Name: OpenShift Container Platform overview
-   File: openshift-overview
- - Name: Web console walkthrough
-   File: openshift-web-console
- - Name: Command-line walkthrough
-   File: openshift-cli
+Name: Getting started
+Dir: getting_started
+Distros: openshift-enterprise
+Topics:
+- Name: Kubernetes overview
+  File: kubernetes-overview
+- Name: OpenShift Container Platform overview
+  File: openshift-overview
+- Name: Web console walkthrough
+  File: openshift-web-console
+- Name: Command-line walkthrough
+  File: openshift-cli
 ---
 Name: Architecture
 Dir: architecture
@@ -135,22 +135,22 @@ Topics:
   Dir: installing_alibaba
   Distros: openshift-origin,openshift-enterprise
   Topics:
-    - Name: Preparing to install on Alibaba Cloud
-      File: preparing-to-install-on-alibaba
-    - Name: Creating the required Alibaba Cloud resources
-      File: manually-creating-alibaba-ram
-    - Name: Installing a cluster quickly on Alibaba Cloud
-      File: installing-alibaba-default
-    - Name: Installing a cluster on Alibaba Cloud with customizations
-      File: installing-alibaba-customizations
-    - Name: Installing a cluster on Alibaba Cloud with network customizations
-      File: installing-alibaba-network-customizations
-    - Name: Installing a cluster on Alibaba Cloud into an existing VPC
-      File: installing-alibaba-vpc
-    - Name: Installation configuration parameters for Alibaba Cloud
-      File: installation-config-parameters-alibaba
-    - Name: Uninstalling a cluster on Alibaba Cloud
-      File: uninstall-cluster-alibaba
+  - Name: Preparing to install on Alibaba Cloud
+    File: preparing-to-install-on-alibaba
+  - Name: Creating the required Alibaba Cloud resources
+    File: manually-creating-alibaba-ram
+  - Name: Installing a cluster quickly on Alibaba Cloud
+    File: installing-alibaba-default
+  - Name: Installing a cluster on Alibaba Cloud with customizations
+    File: installing-alibaba-customizations
+  - Name: Installing a cluster on Alibaba Cloud with network customizations
+    File: installing-alibaba-network-customizations
+  - Name: Installing a cluster on Alibaba Cloud into an existing VPC
+    File: installing-alibaba-vpc
+  - Name: Installation configuration parameters for Alibaba Cloud
+    File: installation-config-parameters-alibaba
+  - Name: Uninstalling a cluster on Alibaba Cloud
+    File: uninstall-cluster-alibaba
 - Name: Installing on AWS
   Dir: installing_aws
   Distros: openshift-origin,openshift-enterprise
@@ -599,16 +599,16 @@ Topics:
 - Name: Understanding OpenShift updates
   Dir: understanding_updates
   Topics:
-    - Name: Introduction to OpenShift updates
-      File: intro-to-updates
-    - Name: How cluster updates work
-      File: how-updates-work
-      Distros: openshift-enterprise
-    - Name: Understanding update channels and releases
-      File: understanding-update-channels-release
-      Distros: openshift-enterprise
-    - Name: Understanding OpenShift update duration
-      File: understanding-openshift-update-duration
+  - Name: Introduction to OpenShift updates
+    File: intro-to-updates
+  - Name: How cluster updates work
+    File: how-updates-work
+    Distros: openshift-enterprise
+  - Name: Understanding update channels and releases
+    File: understanding-update-channels-release
+    Distros: openshift-enterprise
+  - Name: Understanding OpenShift update duration
+    File: understanding-openshift-update-duration
 - Name: Preparing to update a cluster
   Dir: preparing_for_updates
   Topics:
@@ -1037,7 +1037,7 @@ Topics:
   - Name: Configuring and managing Tang servers using the NBDE Tang Server Operator
     File: nbde-tang-server-operator-configuring-managing
   - Name: Identifying URL of a Tang server deployed with the NBDE Tang Server Operator
-    File: nbde-tang-server-operator-identifying-url    
+    File: nbde-tang-server-operator-identifying-url
 - Name: cert-manager Operator for Red Hat OpenShift
   Dir: cert_manager_operator
   Distros: openshift-enterprise
@@ -2701,14 +2701,14 @@ Topics:
   Dir: optimization
   Distros: openshift-origin,openshift-enterprise
   Topics:
-    - Name: Optimizing storage
-      File: optimizing-storage
-    - Name: Optimizing routing
-      File: routing-optimization
-    - Name: Optimizing networking
-      File: optimizing-networking
-    - Name: Optimizing CPU usage
-      File: optimizing-cpu-usage
+  - Name: Optimizing storage
+    File: optimizing-storage
+  - Name: Optimizing routing
+    File: routing-optimization
+  - Name: Optimizing networking
+    File: optimizing-networking
+  - Name: Optimizing CPU usage
+    File: optimizing-cpu-usage
 - Name: Managing bare metal hosts
   File: managing-bare-metal-hosts
   Distros: openshift-origin,openshift-enterprise
@@ -2735,35 +2735,35 @@ Topics:
   Dir: ztp_far_edge
   Distros: openshift-origin,openshift-enterprise
   Topics:
-    - Name: Challenges of the network far edge
-      File: ztp-deploying-far-edge-clusters-at-scale
-    - Name: Preparing the hub cluster for ZTP
-      File: ztp-preparing-the-hub-cluster
-    - Name: Installing managed clusters with RHACM and SiteConfig resources
-      File: ztp-deploying-far-edge-sites
-    - Name: Configuring managed clusters with policies and PolicyGenTemplate resources
-      File: ztp-configuring-managed-clusters-policies
-    - Name: Manually installing a single-node OpenShift cluster with ZTP
-      File: ztp-manual-install
-    - Name: Recommended single-node OpenShift cluster configuration for vDU application workloads
-      File: ztp-reference-cluster-configuration-for-vdu
-    - Name: Validating cluster tuning for vDU application workloads
-      File: ztp-vdu-validating-cluster-tuning
-    - Name: Advanced managed cluster configuration with SiteConfig resources
-      File: ztp-advanced-install-ztp
-    - Name: Advanced managed cluster configuration with PolicyGenTemplate resources
-      File: ztp-advanced-policy-config
-    - Name: Updating managed clusters with the Topology Aware Lifecycle Manager
-      File: cnf-talm-for-cluster-upgrades
-      Distros: openshift-origin,openshift-enterprise
-    - Name: Updating managed clusters in a disconnected environment with the Topology Aware Lifecycle Manager
-      File: ztp-talm-updating-managed-policies
-    - Name: Updating GitOps ZTP
-      File: ztp-updating-gitops
-    - Name: Expanding single-node OpenShift clusters with GitOps ZTP
-      File: ztp-sno-additional-worker-node
-    - Name: Pre-caching images for single-node OpenShift deployments
-      File: ztp-precaching-tool
+  - Name: Challenges of the network far edge
+    File: ztp-deploying-far-edge-clusters-at-scale
+  - Name: Preparing the hub cluster for ZTP
+    File: ztp-preparing-the-hub-cluster
+  - Name: Installing managed clusters with RHACM and SiteConfig resources
+    File: ztp-deploying-far-edge-sites
+  - Name: Configuring managed clusters with policies and PolicyGenTemplate resources
+    File: ztp-configuring-managed-clusters-policies
+  - Name: Manually installing a single-node OpenShift cluster with ZTP
+    File: ztp-manual-install
+  - Name: Recommended single-node OpenShift cluster configuration for vDU application workloads
+    File: ztp-reference-cluster-configuration-for-vdu
+  - Name: Validating cluster tuning for vDU application workloads
+    File: ztp-vdu-validating-cluster-tuning
+  - Name: Advanced managed cluster configuration with SiteConfig resources
+    File: ztp-advanced-install-ztp
+  - Name: Advanced managed cluster configuration with PolicyGenTemplate resources
+    File: ztp-advanced-policy-config
+  - Name: Updating managed clusters with the Topology Aware Lifecycle Manager
+    File: cnf-talm-for-cluster-upgrades
+    Distros: openshift-origin,openshift-enterprise
+  - Name: Updating managed clusters in a disconnected environment with the Topology Aware Lifecycle Manager
+    File: ztp-talm-updating-managed-policies
+  - Name: Updating GitOps ZTP
+    File: ztp-updating-gitops
+  - Name: Expanding single-node OpenShift clusters with GitOps ZTP
+    File: ztp-sno-additional-worker-node
+  - Name: Pre-caching images for single-node OpenShift deployments
+    File: ztp-precaching-tool
 ---
 Name: Reference design specifications
 Dir: telco_ref_design_specs
@@ -3670,40 +3670,40 @@ Topics:
 - Name: Distributed tracing platform (Jaeger)
   Dir: distr_tracing_jaeger
   Topics:
-    - Name: Installation
-      File: distr-tracing-jaeger-installing
-    - Name: Configuration
-      File: distr-tracing-jaeger-configuring
-    - Name: Updating
-      File: distr-tracing-jaeger-updating
-    - Name: Removal
-      File: distr-tracing-jaeger-removing
+  - Name: Installation
+    File: distr-tracing-jaeger-installing
+  - Name: Configuration
+    File: distr-tracing-jaeger-configuring
+  - Name: Updating
+    File: distr-tracing-jaeger-updating
+  - Name: Removal
+    File: distr-tracing-jaeger-removing
 - Name: Distributed tracing platform (Tempo)
   Dir: distr_tracing_tempo
   Topics:
-    - Name: Installation
-      File: distr-tracing-tempo-installing
-    - Name: Configuration
-      File: distr-tracing-tempo-configuring
-    - Name: Updating
-      File: distr-tracing-tempo-updating
-    - Name: Removal
-      File: distr-tracing-tempo-removing
+  - Name: Installation
+    File: distr-tracing-tempo-installing
+  - Name: Configuration
+    File: distr-tracing-tempo-configuring
+  - Name: Updating
+    File: distr-tracing-tempo-updating
+  - Name: Removal
+    File: distr-tracing-tempo-removing
 - Name: Distributed tracing data collection (OpenTelemetry)
   Dir: distr_tracing_otel
   Topics:
-    - Name: Installation
-      File: distr-tracing-otel-installing
-    - Name: Configuration
-      File: distr-tracing-otel-configuring
-    - Name: Use
-      File: distr-tracing-otel-using
-    - Name: Troubleshooting
-      File: distr-tracing-otel-troubleshooting
-    - Name: Migration
-      File: distr-tracing-otel-migrating
-    - Name: Removal
-      File: distr-tracing-otel-removing
+  - Name: Installation
+    File: distr-tracing-otel-installing
+  - Name: Configuration
+    File: distr-tracing-otel-configuring
+  - Name: Use
+    File: distr-tracing-otel-using
+  - Name: Troubleshooting
+    File: distr-tracing-otel-troubleshooting
+  - Name: Migration
+    File: distr-tracing-otel-migrating
+  - Name: Removal
+    File: distr-tracing-otel-removing
 ---
 Name: Virtualization
 Dir: virt

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -44,18 +44,18 @@ Topics:
   Dir: osd_policy
   Distros: openshift-dedicated
   Topics:
-    - Name: OpenShift Dedicated service definition
-      File: osd-service-definition
-    - Name: Responsibility assignment matrix
-      File: policy-responsibility-matrix
-    - Name: Understanding process and security for OpenShift Dedicated
-      File: policy-process-security
-    - Name: SRE and service account access
-      File: osd-sre-access
-    - Name: About availability for OpenShift Dedicated
-      File: policy-understand-availability
-    - Name: Update life cycle
-      File: osd-life-cycle
+  - Name: OpenShift Dedicated service definition
+    File: osd-service-definition
+  - Name: Responsibility assignment matrix
+    File: policy-responsibility-matrix
+  - Name: Understanding process and security for OpenShift Dedicated
+    File: policy-process-security
+  - Name: SRE and service account access
+    File: osd-sre-access
+  - Name: About availability for OpenShift Dedicated
+    File: policy-understand-availability
+  - Name: Update life cycle
+    File: osd-life-cycle
 # Created a new assembly in ROSA/OSD. In OCP, the assembly is in a book that is not in ROSA/OSD
 - Name: About admission plugins
   File: osd-admission-plug-ins
@@ -229,9 +229,9 @@ Topics:
   Topics:
   - Name: Installing the web terminal
     File: installing-web-terminal
-# Do not have sufficient permissions to read any cluster configuration. 
-#  - Name: Configuring the web terminal
-#    File: configuring-web-terminal
+  # Do not have sufficient permissions to read any cluster configuration.
+  #  - Name: Configuring the web terminal
+  #    File: configuring-web-terminal
   - Name: Using the web terminal
     File: odc-using-web-terminal
   - Name: Troubleshooting the web terminal
@@ -325,22 +325,22 @@ Topics:
   Dir: osd_private_connections
   Distros: openshift-dedicated
   Topics:
-    - Name: Configuring private connections for AWS
-      File: aws-private-connections
-    - Name: Configuring a private cluster
-      File: private-cluster
+  - Name: Configuring private connections for AWS
+    File: aws-private-connections
+  - Name: Configuring a private cluster
+    File: private-cluster
 - Name: Cluster autoscaling
   File: osd-cluster-autoscaling
 - Name: Nodes
   Dir: osd_nodes
   Distros: openshift-dedicated
   Topics:
-    - Name: About machine pools
-      File: osd-nodes-machinepools-about
-    - Name: Managing compute nodes
-      File: osd-managing-worker-nodes
-    - Name: About autoscaling nodes on a cluster
-      File: osd-nodes-about-autoscaling-nodes
+  - Name: About machine pools
+    File: osd-nodes-machinepools-about
+  - Name: Managing compute nodes
+    File: osd-managing-worker-nodes
+  - Name: About autoscaling nodes on a cluster
+    File: osd-nodes-about-autoscaling-nodes
 - Name: Logging
   Dir: osd_logging
   Distros: openshift-dedicated
@@ -348,12 +348,12 @@ Topics:
   - Name: Accessing the service logs
     File: osd-accessing-the-service-logs
 ---
- Name: Security and compliance
- Dir: security
- Distros: openshift-dedicated
- Topics:
- - Name: Audit logs
-   File: audit-log-view
+Name: Security and compliance
+Dir: security
+Distros: openshift-dedicated
+Topics:
+- Name: Audit logs
+  File: audit-log-view
 ---
 Name: Authentication and authorization
 Dir: authentication
@@ -789,8 +789,8 @@ Topics:
   Dir: deployments
   Distros: openshift-dedicated
   Topics:
-    - Name: Custom domains for applications
-      File: osd-config-custom-domains-applications
+  - Name: Custom domains for applications
+    File: osd-config-custom-domains-applications
 ---
 Name: Nodes
 Dir: nodes

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -444,16 +444,16 @@ Topics:
   Dir: rosa_cli
   Distros: openshift-rosa
   Topics:
-    # - Name: CLI and web console
-    #   File: rosa-cli-openshift-console
-    - Name: Getting started with the ROSA CLI
-      File: rosa-get-started-cli
-    - Name: Managing objects with the ROSA CLI
-      File: rosa-manage-objects-cli
-    - Name: Checking account and version information with the ROSA CLI
-      File: rosa-checking-acct-version-cli
-    - Name: Checking logs with the ROSA CLI
-      File: rosa-checking-logs-cli
+  # - Name: CLI and web console
+  #   File: rosa-cli-openshift-console
+  - Name: Getting started with the ROSA CLI
+    File: rosa-get-started-cli
+  - Name: Managing objects with the ROSA CLI
+    File: rosa-manage-objects-cli
+  - Name: Checking account and version information with the ROSA CLI
+    File: rosa-checking-acct-version-cli
+  - Name: Checking logs with the ROSA CLI
+    File: rosa-checking-logs-cli
 ---
 Name: Red Hat OpenShift Cluster Manager
 Dir: ocm
@@ -677,14 +677,14 @@ Topics:
   - Name: Customizing source-to-image images
     File: customizing-s2i-images
 ---
-  Name: Add-on services
-  Dir: adding_service_cluster
-  Distros: openshift-rosa
-  Topics:
-  - Name: Adding services to a cluster
-    File: adding-service
-  - Name: Available services
-    File: rosa-available-services
+Name: Add-on services
+Dir: adding_service_cluster
+Distros: openshift-rosa
+Topics:
+- Name: Adding services to a cluster
+  File: adding-service
+- Name: Available services
+  File: rosa-available-services
 ---
 Name: Storage
 Dir: storage
@@ -951,8 +951,8 @@ Topics:
   Dir: deployments
   Distros: openshift-rosa
   Topics:
-    - Name: Custom domains for applications
-      File: osd-config-custom-domains-applications
+  - Name: Custom domains for applications
+    File: osd-config-custom-domains-applications
 # - Name: Application GitOps workflows
 #   File: rosa-app-gitops-workflows
 # - Name: Application logging


### PR DESCRIPTION
Cleans up the topic_maps using `.yamllint` config.

Merge to main, CP to enterprise-4.14+

Docs guidelines state we should strip trailing spaces. Wrong indentation can break the build.

QE review:
- [x] not required.