### PR TITLE
OADP-814: OADP: running must-gather with two flags

### DIFF
--- a/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
@@ -94,6 +94,7 @@ include::modules/oadp-restic-issues.adoc[leveloffset=+1]
 include::modules/oadp-restic-restore-failing-psa-policy.adoc[leveloffset=+2]
 
 include::modules/migration-using-must-gather.adoc[leveloffset=+1]
+include::modules/migration-combining-must-gather.adoc[leveloffset=+2]
 include::modules/oadp-monitoring.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources

--- a/modules/migration-combining-must-gather.adoc
+++ b/modules/migration-combining-must-gather.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+// * backup_and_restore/application_backup_and_restore/troubleshooting.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="migration-combining-must-gather_{context}"]
+= Combining options when using the must-gather tool
+
+Currently, it is not possible to combine must-gather scripts, for example specifying a timeout threshold while permitting insecure TLS connections. In some situations, you can get around this limitation by setting up internal variables on the must-gather command line, such as the following example:
+
+[source,terminal]
+----
+$ oc adm must-gather --image=brew.registry.redhat.io/rh-osbs/oadp-oadp-mustgather-rhel8:1.1.1-8  -- skip_tls=true /usr/bin/gather_with_timeout <timeout_value_in_seconds>
+----
+
+In this example, set the `skip_tls` variable before running the `gather_with_timeout` script. The result is a combination of `gather_with_timeout` and `gather_without_tls`.
+
+The only other variables that you can specify this way are the following:
+
+* `logs_since`, with a default value of `72h`
+* `request_timeout`, with a default value of `0s`


### PR DESCRIPTION
### Jira

* [OADP-814](https://issues.redhat.com/browse/OADP-814)

### Versions

* Affects version: OADP 1.1.0
* Fix Version: OADP 1.3.0

#### OpenShift versions

* OCP 4.11 → branch/enterprise-4.11
* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15

### Link to docs preview

* [Combining options when using the must-gather tool](https://68711--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting#migration-combining-must-gather_oadp-troubleshooting)

### QE review:
- [X] [QE has approved this change](https://github.com/openshift/openshift-docs/pull/68711#issuecomment-1840777056).
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
