### PR TITLE
ROX-20706: Add pull secret info

### DIFF
--- a/modules/acs-quick-install-secured-cluster-using-helm.adoc
+++ b/modules/acs-quick-install-secured-cluster-using-helm.adoc
@@ -12,6 +12,13 @@ ifeval::["{context}" == "install-secured-cluster-cloud-other"]
 :cloud-svc:
 endif::[]
 
+ifeval::["{context}" == "install-secured-cluster-other"]
+:k8:
+endif::[]
+
+ifeval::["{context}" == "install-secured-cluster-ocp"]
+:ocp:
+endif::[]
 
 [role="_abstract"]
 Use the following instructions to install the `secured-cluster-services` Helm chart to deploy the per-cluster and per-node components (Sensor, Admission controller, Collector, and Scanner-slim).
@@ -22,7 +29,8 @@ To install Collector on systems that have Unified Extensible Firmware Interface 
 ====
 
 .Prerequisites
-* You must have generated {product-title-short} init bundle for your cluster.
+* You must have generated an {product-title-short} init bundle for your cluster.
+* You must have access to the Red Hat Container Registry and a pull secret for authentication. For information about downloading images from `registry.redhat.io`, see link:https://access.redhat.com/RegistryAuthentication[Red Hat Container Registry Authentication].
 ifndef::cloud-svc[]
 * You must have the address and the port number that you are exposing the Central service on.
 endif::cloud-svc[]
@@ -31,6 +39,7 @@ ifdef::cloud-svc[]
 endif::[]
 
 .Procedure
+ifndef::ocp[]
 * Run the following command on your Kubernetes based clusters:
 +
 [source,terminal]
@@ -38,22 +47,25 @@ endif::[]
 $ helm install -n stackrox --create-namespace \
     stackrox-secured-cluster-services rhacs/secured-cluster-services \
     -f <path_to_cluster_init_bundle.yaml> \ <1>
+    -f <path_to_pull_secret.yaml> \ <2>
     --set clusterName=<name_of_the_secured_cluster> \
-    --set centralEndpoint=<endpoint_of_central_service> <2>
+    --set centralEndpoint=<endpoint_of_central_service> <3>
 ifdef::cloud-svc[]
 --set imagePullSecrets.username=<your redhat.com username> \
 --set imagePullSecrets.password=<your redhat.com password>
 endif::[]
 ----
 <1> Use the `-f` option to specify the path for the init bundle.
+<2> Use the -f option to specify the path for the pull secret for Red Hat Container Registry authentication.
 ifndef::cloud-svc[]
-<2> Specify the address and port number for Central. For example, `acs.domain.com:443`.
+<3> Specify the address and port number for Central. For example, `acs.domain.com:443`.
 endif::[]
 ifdef::cloud-svc[]
-<2> Enter the Central API Endpoint, including the address and the port number. You can view this information again in the Red Hat Hybrid Cloud Console console by choosing Advanced Cluster Security → ACS Instances, and then clicking the ACS instance you created.
+<3> Enter the Central API Endpoint, including the address and the port number. You can view this information again in the Red Hat Hybrid Cloud Console console by choosing Advanced Cluster Security → ACS Instances, and then clicking the ACS instance you created.
+endif::[]
 endif::[]
 
-ifndef::cloud-svc[]
+ifndef::cloud-svc,k8[]
 * Run the following command on {ocp} clusters:
 +
 [source,terminal]
@@ -61,11 +73,13 @@ ifndef::cloud-svc[]
 $ helm install -n stackrox --create-namespace \
     stackrox-secured-cluster-services rhacs/secured-cluster-services \
     -f <path_to_cluster_init_bundle.yaml> \ <1>
+    -f <path_to_pull_secret.yaml> \ <2>
     --set clusterName=<name_of_the_secured_cluster> \
-    --set centralEndpoint=<endpoint_of_central_service> <2>
-    --set scanner.disable=false <3>
+    --set centralEndpoint=<endpoint_of_central_service> <3>
+    --set scanner.disable=false <4>
 ----
 <1> Use the `-f` option to specify the path for the init bundle.
-<2> Specify the address and port number for Central. For example, `acs.domain.com:443`.
-<3> Set the value of the `scanner.disable` parameter to `false`, which means that Scanner-slim will be enabled during the installation. In Kubernetes, the secured cluster services now include Scanner-slim as an optional component.
+<2> Use the -f option to specify the path for the pull secret for Red Hat Container Registry authentication.
+<3> Specify the address and port number for Central. For example, `acs.domain.com:443`.
+<4> Set the value of the `scanner.disable` parameter to `false`, which means that Scanner-slim will be enabled during the installation. In Kubernetes, the secured cluster services now include Scanner-slim as an optional component.
 endif::[]

--- a/modules/acs-quick-install-using-helm.adoc
+++ b/modules/acs-quick-install-using-helm.adoc
@@ -19,10 +19,12 @@ Use the following instructions to install the `central-services` Helm chart to d
 ----
 $ helm install -n stackrox \
   --create-namespace stackrox-central-services rhacs/central-services \
-  --set imagePullSecrets.username=<username> \
-  --set imagePullSecrets.password=<password> \
+  --set imagePullSecrets.username=<username> \ <1>
+  --set imagePullSecrets.password=<password> \ <2>
   --set central.exposure.route.enabled=true
 ----
+<1> Include the user name for your pull secret for Red Hat Container Registry authentication.
+<2> Include the password for your pull secret for Red Hat Container Registry authentication.
 
 * Or, run the following command to install Central services and expose Central using a load balancer:
 +
@@ -30,10 +32,12 @@ $ helm install -n stackrox \
 ----
 $ helm install -n stackrox \
   --create-namespace stackrox-central-services rhacs/central-services \
-  --set imagePullSecrets.username=<username> \
-  --set imagePullSecrets.password=<password> \
+  --set imagePullSecrets.username=<username> \ <1>
+  --set imagePullSecrets.password=<password> \ <2>
   --set central.exposure.loadBalancer.enabled=true
 ----
+<1> Include the user name for your pull secret for Red Hat Container Registry authentication.
+<2> Include the password for your pull secret for Red Hat Container Registry authentication.
 
 * Or, run the following command to install Central services and expose Central using port forward:
 +
@@ -41,9 +45,11 @@ $ helm install -n stackrox \
 ----
 $ helm install -n stackrox \
   --create-namespace stackrox-central-services rhacs/central-services \
-    --set imagePullSecrets.username=<username> \
-  --set imagePullSecrets.password=<password>
+  --set imagePullSecrets.username=<username> \ <1>
+  --set imagePullSecrets.password=<password>  <2>
 ----
+<1> Include the user name for your pull secret for Red Hat Container Registry authentication.
+<2> Include the password for your pull secret for Red Hat Container Registry authentication.
 
 [IMPORTANT]
 ====

--- a/modules/install-secured-cluster-services-helm-chart.adoc
+++ b/modules/install-secured-cluster-services-helm-chart.adoc
@@ -13,7 +13,8 @@ To install Collector on systems that have Unified Extensible Firmware Interface 
 ====
 
 .Prerequisites
-* You must have generated {product-title-short} init bundle for your cluster.
+* You must have generated an {product-title-short} init bundle for your cluster.
+* You must have access to the Red Hat Container Registry and a pull secret for authentication. For information about downloading images from `registry.redhat.io`, see link:https://access.redhat.com/RegistryAuthentication[Red Hat Container Registry Authentication].
 ifndef::cloud-svc[]
 * You must have the address and the port number that you are exposing the Central service on.
 endif::cloud-svc[]
@@ -27,12 +28,16 @@ endif::[]
 +
 [source,terminal]
 ----
-$ helm install -n stackrox --create-namespace \
-  stackrox-secured-cluster-services rhacs/secured-cluster-services \
+$ helm install -n stackrox \
+  --create-namespace stackrox-secured-cluster-services rhacs/secured-cluster-services \
   -f <name_of_cluster_init_bundle.yaml> \
-  -f <path_to_values_public.yaml> -f <path_to_values_private.yaml> <1>
+  -f <path_to_values_public.yaml> -f <path_to_values_private.yaml> \ <1>
+  --set imagePullSecrets.username=<username> \ <2>
+  --set imagePullSecrets.password=<password> <3>
 ----
 <1> Use the `-f` option to specify the paths for your YAML configuration files.
+<2> Include the user name for your pull secret for Red Hat Container Registry authentication.
+<3> Include the password for your pull secret for Red Hat Container Registry authentication.
 
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):

4.1+

[Issue](https://issues.redhat.com/browse/ROX-20706)

Links to docs preview:

- non-OCP, Helm w/o customization: https://68724--docspreview.netlify.app/openshift-acs/latest/installing/installing_other/install-secured-cluster-other#installing-secured-cluster-services-quickly_install-secured-cluster-other
- non-OCP, Helm w/ customization: https://68724--docspreview.netlify.app/openshift-acs/latest/installing/installing_other/install-secured-cluster-other#install-secured-cluster-services-helm-chart_install-secured-cluster-other
- OCP, Helm w/o customizations: https://68724--docspreview.netlify.app/openshift-acs/latest/installing/installing_other/install-secured-cluster-other#install-secured-cluster-services-helm-chart_install-secured-cluster-other
- OCP, Helm w/ customizations: https://68724--docspreview.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-ocp#install-secured-cluster-services-helm-chart_install-secured-cluster-ocp

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Also added conditionals so that OCP info doesn't appear on non-OCP pages, and Kubernetes info doesn't appear on OCP pages.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
