### PR TITLE
OSDOCS-8898: Added notes to Compliance Operator

### DIFF
--- a/modules/compliance-applying.adoc
+++ b/modules/compliance-applying.adoc
@@ -24,3 +24,8 @@ The Compliance Operator can apply remediations automatically. Set `autoApplyReme
 ====
 Applying remediations automatically should only be done with careful consideration.
 ====
+
+[IMPORTANT]
+====
+The Compliance Operator does not automatically resolve dependency issues that can occur between remediations. Users should perform a rescan after remediations are applied to ensure accurate results.
+====

--- a/modules/compliance-review.adoc
+++ b/modules/compliance-review.adoc
@@ -53,3 +53,8 @@ $ echo "net.ipv4.conf.all.accept_redirects%3D0" | python3 -c "import sys, urllib
 ----
 net.ipv4.conf.all.accept_redirects=0
 ----
+
+[IMPORTANT]
+====
+The Compliance Operator does not automatically resolve dependency issues that can occur between remediations. Users should perform a rescan after remediations are applied to ensure accurate results.
+====

--- a/modules/compliance-unapplying.adoc
+++ b/modules/compliance-unapplying.adoc
@@ -23,3 +23,8 @@ patch complianceremediations/rhcos4-moderate-worker-sysctl-net-ipv4-conf-all-acc
 ====
 All affected nodes with the remediation will be rebooted.
 ====
+
+[IMPORTANT]
+====
+The Compliance Operator does not automatically resolve dependency issues that can occur between remediations. Users should perform a rescan after remediations are applied to ensure accurate results.
+====

--- a/modules/compliance-updating.adoc
+++ b/modules/compliance-updating.adoc
@@ -52,3 +52,8 @@ workers-scan-no-empty-passwords   Applied
 ----
 
 . The nodes will apply the newer remediation version and reboot.
+
+[IMPORTANT]
+====
+The Compliance Operator does not automatically resolve dependency issues that can occur between remediations. Users should perform a rescan after remediations are applied to ensure accurate results.
+====


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OSDOCS-8898

Link to docs preview (VPN required):
[Applying remediation when using customized machine config pools](https://file.rdu.redhat.com/antaylor/OSDOCS-8898/security/compliance_operator/co-scans/compliance-operator-remediation.html#compliance-operator-apply-remediation-for-customized-mcp)
[Applying a remediation](https://file.rdu.redhat.com/antaylor/OSDOCS-8898/security/compliance_operator/co-scans/compliance-operator-remediation.html#compliance-applying_compliance-remediation)
[Updating remediations](https://file.rdu.redhat.com/antaylor/OSDOCS-8898/security/compliance_operator/co-scans/compliance-operator-remediation.html#compliance-updating_compliance-remediation)
[Unapplying a remediation](https://file.rdu.redhat.com/antaylor/OSDOCS-8898/security/compliance_operator/co-scans/compliance-operator-remediation.html#compliance-unapplying_compliance-remediation)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
None