### PR TITLE
Starting from Logging version 5.8 loki instance 1x.extra-small is sup…

### DIFF
--- a/modules/logging-loki-cli-install.adoc
+++ b/modules/logging-loki-cli-install.adoc
@@ -76,7 +76,13 @@ spec:
   tenants:
     mode: openshift-logging
 ----
-<1> Supported size options for production instances of Loki are `1x.small` and `1x.medium`.
+<1> Supported size options for production instances of Loki are `1x.extra-small`,`1x.small` and `1x.medium`.
++
+[NOTE]
+====
+Loki instance 1x.extra-small is supported for production starting from Red Hat Logging Operator version 5.8
+====
++
 <2> Enter the name of your log store secret.
 <3> Enter the type of your log store secret.
 <4> Enter the name of an existing storage class for temporary storage. For best performance, specify a storage class that allocates block storage. Available storage classes for your cluster can be listed using `oc get storageclasses`.


### PR DESCRIPTION
As per the current doc Loki instance 1x.extra-small is supported starting from Logging version 5.8 which was not mentioned in the updated documentation.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
-4.12
-4.13
-4.14

Issue:

- https://issues.redhat.com/browse/LOG-4329

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
