### PR TITLE
LOG-4329: Starting from Logging version 5.8 loki instance 1x.extra-small is supported in prod env

### DIFF
--- a/modules/logging-loki-cli-install.adoc
+++ b/modules/logging-loki-cli-install.adoc
@@ -79,7 +79,7 @@ spec:
 +
 [NOTE]
 ====
-Loki instance `1x.extra-small` is `supported` for `production` use starting from Red Hat OpenShift Logging version 5.8`.
+In the {logging-title} 5.8 and later versions, the `1x.extra-small` Loki instance size is a supported option for production environments.
 ====
 +
 <1> Supported size options for production instances of Loki are `1x.extra-small`, `1x.small` and `1x.medium`.

--- a/modules/logging-loki-cli-install.adoc
+++ b/modules/logging-loki-cli-install.adoc
@@ -76,7 +76,13 @@ spec:
   tenants:
     mode: openshift-logging
 ----
-<1> Supported size options for production instances of Loki are `1x.small` and `1x.medium`.
++
+[NOTE]
+====
+Loki instance `1x.extra-small` is `supported` for `production` use starting from Red Hat OpenShift Logging version 5.8`.
+====
++
+<1> Supported size options for production instances of Loki are `1x.extra-small`, `1x.small` and `1x.medium`.
 <2> Enter the name of your log store secret.
 <3> Enter the type of your log store secret.
 <4> Enter the name of an existing storage class for temporary storage. For best performance, specify a storage class that allocates block storage. Available storage classes for your cluster can be listed using `oc get storageclasses`.


### PR DESCRIPTION
As per the current doc Loki instance 1x.extra-small is supported starting from Logging version 5.8 which was not mentioned in the updated documentation.

Version(s):
4.12+

Issue:
- https://issues.redhat.com/browse/LOG-4329

Link to docs preview:
https://68750--docspreview.netlify.app/openshift-enterprise/latest/logging/cluster-logging-loki#logging-loki-cli-install_cluster-logging-loki

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
