### PR TITLE
WIP OADP-3124: Data Mover Limitations

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/about-oadp-1-3-data-mover.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/about-oadp-1-3-data-mover.adoc
@@ -19,7 +19,7 @@ include::snippets/technology-preview.adoc[]
 [id="enabling-oadp-1-3-data-mover"]
 == Enabling the built-in Data Mover
 
-To enable the built-in Data Mover, you must include the CSI plugin and enable the node agent in the `DataProtectionApplication` custom resource (CR). The node agent is a Kubernetes daemonset that hosts data movement modules. These include the Data Mover controller, uploader, and the repository. 
+To enable the built-in Data Mover, you must include the CSI plugin and enable the node agent in the `DataProtectionApplication` custom resource (CR). The node agent is a Kubernetes daemonset that hosts data movement modules. These include the Data Mover controller, uploader, and the repository.
 
 .Example `DataProtectionApplication` manifest
 [source,yaml]
@@ -53,6 +53,6 @@ The built-in Data Mover feature introduces three new API objects defined as CRDs
 
 * `DataUpload`: Represents a data upload of a volume snapshot. The CSI plugin creates one `DataUpload` object per CSI snapshot. The `DataUpload` CR includes information about the specified snapshot, the specified Data Mover, the specified backup repository, the progress of the current data upload, and the result of the current data upload after the process is complete.
 
-* `BackupRepository`: Represents and manages the lifecycle of the backup repositories. OADP creates a backup repository per namespace when the first CSI snapshot backup or restore for a namespace is requested. 
+* `BackupRepository`: Represents and manages the lifecycle of the backup repositories. OADP creates a backup repository per namespace when the first CSI snapshot backup or restore for a namespace is requested.
 
-
+include::modules/oadp-data-mover-limitations.adoc[leveloffset=+1]

--- a/modules/oadp-data-mover-limitations.adoc
+++ b/modules/oadp-data-mover-limitations.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// about-oadp-1-3-data-mover.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="oadp-limitations_{context}"]
+= OADP Data Mover limitations
+
+The built-in Data Mover has the following limitations:
+
+* Both the  Container Storage Interface (CSI) and the CSI snapshot support both the file system volume mode and the block volume mode.
+
+* For OADP 1.3.0, the Data Mover uses a static, common encryption key for all backup repositories it creates. This common encryption key means that anyone who has access to your backup storage can read your backup data.
+
+* The backup data for Data Mover, OADP 1.3.0, can be preserved incrementally. For a single file, the Data Mover utilizes deduplication to identify the difference that can be saved. This means that large files, such as those storing a database, will take a long time to scan for data deduplication.
+
+* When you use the Data Mover for OADP 1.3.0, you might need to change the resource limits to make sure that backups are successful for large big files or a large set of files. big backup sizes.
+
+* The Kopia uploader provides support for the block mode. However, it is limited to non-Windows platforms due to the block mode code triggering system calls that are not present in the Windows platform.


### PR DESCRIPTION
### Jira

* [OADP-3124](https://issues.redhat.com/browse/OADP-3124)

### Version(s):

* OADP 1.3.0

#### OpenShift

* branch/enterprise-4.12
* branch/enterprise-4.13
* branch/enterprise-4.14
* branch/enterprise-4.15

### Link to docs preview:

* [OADP Data Mover limitations](https://68768--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-oadp-1-3-data-mover#oadp-limitations_about-oadp-1-3-data-mover)

### QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
