### PR TITLE
ROX-21227: Update docs that only central-db requires persistent storage

### DIFF
--- a/modules/default-requirements-central-services.adoc
+++ b/modules/default-requirements-central-services.adoc
@@ -20,7 +20,7 @@ Central services contain the following components:
 
 A containerized service called Central handles API interactions and {product-title-short} web portal access while a containerized service called Central DB (PostgreSQL 13) handles data persistence.
 
-Both Central and Central DB require persistent storage:
+Central DB requires persistent storage.
 
 * You can provide storage with a persistent volume claim (PVC).
 +


### PR DESCRIPTION
Version(s):

4.1+

[Issue](https://issues.redhat.com/browse/ROX-21227)

[Link to docs preview
](https://68790--docspreview.netlify.app/openshift-acs/latest/installing/acs-default-requirements#default-requirements-central-services-central_acs-default-requirements)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
