### PR TITLE
OCPBUGS-23915: updates protocols network policy applies to

### DIFF
--- a/modules/nw-networkpolicy-about.adoc
+++ b/modules/nw-networkpolicy-about.adoc
@@ -21,7 +21,7 @@ By default, all pods in a project are accessible from other pods and network end
 
 If a pod is matched by selectors in one or more `NetworkPolicy` objects, then the pod will accept only connections that are allowed by at least one of those `NetworkPolicy` objects. A pod that is not selected by any `NetworkPolicy` objects is fully accessible.
 
-A network policy applies to only the TCP, UDP, and SCTP protocols. Other protocols are not affected.
+A network policy applies to only the TCP, UDP, ICMP, and SCTP protocols. Other protocols are not affected.
 
 The following example `NetworkPolicy` objects demonstrate supporting different scenarios:
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OCPBUGS-23915
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://68791--docspreview.netlify.app/openshift-enterprise/latest/networking/network_policy/about-network-policy#:~:text=A%20network%20policy%20applies%20to%20only%20the%20TCP%2C%20UDP%2C%20ICMP%2C%20and%20SCTP%20protocols.%20Other%20protocols%20are%20not%20affected.
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
PTAL: @weliang1 , @asood-rh , and 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
