### PR TITLE
Reformatting remaining install config parameters

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -887,54 +887,92 @@ ifdef::osp[]
 Additional {rh-openstack} configuration parameters are described in the following table:
 
 .Additional {rh-openstack} parameters
-[cols=".^2m,.^3a,^5a",options="header"]
+[cols=".^2l,.^3a,^5a",options="header"]
 |====
 |Parameter|Description|Values
 
-|`compute.platform.openstack.rootVolume.size`
+|compute:
+  platform:
+    openstack:
+      rootVolume:
+        size:
 |For compute machines, the size in gigabytes of the root volume. If you do not set this value, machines use ephemeral storage.
 |Integer, for example `30`.
 
-|`compute.platform.openstack.rootVolume.types`
+|compute:
+  platform:
+    openstack:
+      rootVolume:
+        types:
 |For compute machines, the root volume types.
 |A list of strings, for example, {`performance-host1`, `performance-host2`, `performance-host3`}. ^[1]^
 
-|`compute.platform.openstack.rootVolume.type`
+|compute:
+  platform:
+    openstack:
+      rootVolume:
+        type:
 |For compute machines, the root volume's type. This property is deprecated and is replaced by `compute.platform.openstack.rootVolume.types`.
 |String, for example, `performance`. ^[2]^
 
-|`compute.platform.openstack.rootVolume.zones`
+|compute:
+  platform:
+    openstack:
+      rootVolume:
+        zones:
 |For compute machines, the Cinder availability zone to install root volumes on. If you do not set a value for this parameter, the installation program selects the default availability zone. This parameter is mandatory when `compute.platform.openstack.zones` is defined.
 |A list of strings, for example `["zone-1", "zone-2"]`.
 
-|`controlPlane.platform.openstack.rootVolume.size`
+|controlPlane:
+  platform:
+    openstack:
+      rootVolume:
+        size:
 |For control plane machines, the size in gigabytes of the root volume. If you do not set this value, machines use ephemeral storage.
 |Integer, for example `30`.
 
-|`controlPlane.platform.openstack.rootVolume.types`
+|controlPlane:
+  platform:
+    openstack:
+      rootVolume:
+        types:
 |For control plane machines, the root volume types.
 |A list of strings, for example, {`performance-host1`, `performance-host2`, `performance-host3`}. ^[1]^
 
-|`controlPlane.platform.openstack.rootVolume.type`
+|controlPlane:
+  platform:
+    openstack:
+      rootVolume:
+        type:
 |For control plane machines, the root volume's type. This property is deprecated and is replaced by `compute.platform.openstack.rootVolume.types`.
 |String, for example, `performance`. ^[2]^
 
-|`controlPlane.platform.openstack.rootVolume.zones`
+|controlPlane:
+  platform:
+    openstack:
+      rootVolume:
+        zones:
 |For control plane machines, the Cinder availability zone to install root volumes on. If you do not set this value, the installation program selects the default availability zone. This parameter is mandatory when `controlPlane.platform.openstack.zones` is defined.
 |A list of strings, for example `["zone-1", "zone-2"]`.
 
-|`platform.openstack.cloud`
+|platform:
+  openstack:
+    cloud:
 |The name of the {rh-openstack} cloud to use from the list of clouds in the `clouds.yaml` file.
 
 In the cloud configuration in the `clouds.yaml` file, if possible, use application credentials rather than a user name and password combination. Using application credentials avoids disruptions from secret propogation that follow user name and password rotation.
 
 |String, for example `MyCloud`.
 
-|`platform.openstack.externalNetwork`
+|platform:
+  openstack:
+    externalNetwork:
 |The {rh-openstack} external network name to be used for installation.
 |String, for example `external`.
 
-|`platform.openstack.computeFlavor`
+|platform:
+  openstack:
+    computeFlavor:
 |The {rh-openstack} flavor to use for control plane and compute machines.
 
 This property is deprecated. To use a flavor as the default for all machine pools, add it as the value of the `type` key in the `platform.openstack.defaultMachinePlatform` property. You can also set a flavor value for each machine pool individually.
@@ -953,25 +991,37 @@ This property is deprecated. To use a flavor as the default for all machine pool
 Optional {rh-openstack} configuration parameters are described in the following table:
 
 .Optional {rh-openstack} parameters
-[%header, cols=".^2,.^3,.^5a"]
+[%header, cols=".^2l,.^3,.^5a"]
 |====
 |Parameter|Description|Values
 
-|`compute.platform.openstack.additionalNetworkIDs`
+|compute:
+  platform:
+    openstack:
+      additionalNetworkIDs:
 |Additional networks that are associated with compute machines. Allowed address pairs are not created for additional networks.
 |A list of one or more UUIDs as strings. For example, `fa806b2f-ac49-4bce-b9db-124bc64209bf`.
 
-|`compute.platform.openstack.additionalSecurityGroupIDs`
+|compute:
+  platform:
+    openstack:
+      additionalSecurityGroupIDs:
 |Additional security groups that are associated with compute machines.
 |A list of one or more UUIDs as strings. For example, `7ee219f3-d2e9-48a1-96c2-e7429f1b0da7`.
 
-|`compute.platform.openstack.zones`
+|compute:
+  platform:
+    openstack:
+      zones:
 |{rh-openstack} Compute (Nova) availability zones (AZs) to install machines on. If this parameter is not set, the installation program relies on the default settings for Nova that the {rh-openstack} administrator configured.
 
 On clusters that use Kuryr, {rh-openstack} Octavia does not support availability zones. Load balancers and, if you are using the Amphora provider driver, {product-title} services that rely on Amphora VMs, are not created according to the value of this property.
 |A list of strings. For example, `["zone-1", "zone-2"]`.
 
-|`compute.platform.openstack.serverGroupPolicy`
+|compute:
+  platform:
+    openstack:
+      serverGroupPolicy:
 |Server group policy to apply to the group that will contain the compute machines in the pool. You cannot change server group policies or affiliations after creation. Supported options include `anti-affinity`, `soft-affinity`, and `soft-anti-affinity`. The default value is `soft-anti-affinity`.
 
 An `affinity` policy prevents migrations and therefore affects {rh-openstack} upgrades. The `affinity` policy is not supported.
@@ -979,23 +1029,35 @@ An `affinity` policy prevents migrations and therefore affects {rh-openstack} up
 If you use a strict `anti-affinity` policy, an additional {rh-openstack} host is required during instance migration.
 |A server group policy to apply to the machine pool. For example, `soft-affinity`.
 
-|`controlPlane.platform.openstack.additionalNetworkIDs`
+|controlPlane:
+  platform:
+    openstack:
+      additionalNetworkIDs:
 |Additional networks that are associated with control plane machines. Allowed address pairs are not created for additional networks.
 
 Additional networks that are attached to a control plane machine are also attached to the bootstrap node.
 |A list of one or more UUIDs as strings. For example, `fa806b2f-ac49-4bce-b9db-124bc64209bf`.
 
-|`controlPlane.platform.openstack.additionalSecurityGroupIDs`
+|controlPlane:
+  platform:
+    openstack:
+      additionalSecurityGroupIDs:
 |Additional security groups that are associated with control plane machines.
 |A list of one or more UUIDs as strings. For example, `7ee219f3-d2e9-48a1-96c2-e7429f1b0da7`.
 
-|`controlPlane.platform.openstack.zones`
+|controlPlane:
+  platform:
+    openstack:
+      zones:
 |{rh-openstack} Compute (Nova) availability zones (AZs) to install machines on. If this parameter is not set, the installation program relies on the default settings for Nova that the {rh-openstack} administrator configured.
 
 On clusters that use Kuryr, {rh-openstack} Octavia does not support availability zones. Load balancers and, if you are using the Amphora provider driver, {product-title} services that rely on Amphora VMs, are not created according to the value of this property.
 |A list of strings. For example, `["zone-1", "zone-2"]`.
 
-|`controlPlane.platform.openstack.serverGroupPolicy`
+|controlPlane:
+  platform:
+    openstack:
+      serverGroupPolicy:
 |Server group policy to apply to the group that will contain the control plane machines in the pool. You cannot change server group policies or affiliations after creation. Supported options include `anti-affinity`, `soft-affinity`, and `soft-anti-affinity`. The default value is `soft-anti-affinity`.
 
 An `affinity` policy prevents migrations, and therefore affects {rh-openstack} upgrades. The `affinity` policy is not supported.
@@ -1003,7 +1065,9 @@ An `affinity` policy prevents migrations, and therefore affects {rh-openstack} u
 If you use a strict `anti-affinity` policy, an additional {rh-openstack} host is required during instance migration.
 |A server group policy to apply to the machine pool. For example, `soft-affinity`.
 
-|`platform.openstack.clusterOSImage`
+|platform:
+  openstack:
+    clusterOSImage:
 |The location from which the installation program downloads the {op-system} image.
 
 You must set this parameter to perform an installation in a restricted network.
@@ -1012,7 +1076,9 @@ You must set this parameter to perform an installation in a restricted network.
 For example, `\http://mirror.example.com/images/rhcos-43.81.201912131630.0-openstack.x86_64.qcow2.gz?sha256=ffebbd68e8a1f2a245ca19522c16c86f67f9ac8e4e0c1f0a812b068b16f7265d`.
 The value can also be the name of an existing Glance image, for example `my-rhcos`.
 
-|`platform.openstack.clusterOSImageProperties`
+|platform:
+  openstack:
+    clusterOSImageProperties:
 |Properties to add to the installer-uploaded ClusterOSImage in Glance. This property is ignored if `platform.openstack.clusterOSImage` is set to an existing Glance image.
 
 You can use this property to exceed the default persistent volume (PV) limit for {rh-openstack} of 26 PVs per node. To exceed the limit, set the `hw_scsi_model` property value to `virtio-scsi` and the `hw_disk_bus` value to  `scsi`.
@@ -1020,7 +1086,9 @@ You can use this property to exceed the default persistent volume (PV) limit for
 You can also use this property to enable the QEMU guest agent by including the `hw_qemu_guest_agent` property with a value of `yes`.
 |A list of key-value string pairs. For example, `["hw_scsi_model": "virtio-scsi", "hw_disk_bus": "scsi"]`.
 
-|`platform.openstack.defaultMachinePlatform`
+|platform:
+  openstack:
+    defaultMachinePlatform:
 |The default machine pool platform configuration.
 |
 [source,json]
@@ -1034,23 +1102,33 @@ You can also use this property to enable the QEMU guest agent by including the `
 }
 ----
 
-|`platform.openstack.ingressFloatingIP`
+|platform:
+  openstack:
+    ingressFloatingIP:
 |An existing floating IP address to associate with the Ingress port. To use this property, you must also define the `platform.openstack.externalNetwork` property.
 |An IP address, for example `128.0.0.1`.
 
-|`platform.openstack.apiFloatingIP`
+|platform:
+  openstack:
+    apiFloatingIP:
 |An existing floating IP address to associate with the API load balancer. To use this property, you must also define the `platform.openstack.externalNetwork` property.
 |An IP address, for example `128.0.0.1`.
 
-|`platform.openstack.externalDNS`
+|platform:
+  openstack:
+    externalDNS:
 |IP addresses for external DNS servers that cluster instances use for DNS resolution.
 |A list of IP addresses as strings. For example, `["8.8.8.8", "192.168.1.12"]`.
 
-|`platform.openstack.loadbalancer`
+|platform:
+  openstack:
+    loadbalancer:
 |Whether or not to use the default, internal load balancer. If the value is set to `UserManaged`, this default load balancer is disabled so that you can deploy a cluster that uses an external, user-managed load balancer. If the parameter is not set, or if the value is `OpenShiftManagedDefault`, the cluster uses the default load balancer.
 |`UserManaged` or `OpenShiftManagedDefault`.
 
-|`platform.openstack.machinesSubnet`
+|platform:
+  openstack:
+    machinesSubnet:
 |The UUID of a {rh-openstack} subnet that the cluster's nodes use. Nodes and virtual IP (VIP) ports are created on this subnet.
 
 The first item in `networking.machineNetwork` must match the value of `machinesSubnet`.
@@ -2107,42 +2185,60 @@ ifdef::ibm-cloud[]
 Additional {ibm-cloud-name} configuration parameters are described in the following table:
 
 .Additional {ibm-cloud-name} parameters
-[cols=".^1,.^6a,.^3a",options="header"]
+[cols=".^1l,.^6a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
-|`platform.ibmcloud.resourceGroupName`
+|platform:
+  ibmcloud:
+    resourceGroupName:
 |The name of an existing resource group.
 By default, an installer-provisioned VPC and cluster resources are placed in this resource group. When not specified, the installation program creates the resource group for the cluster.
 If you are deploying the cluster into an existing VPC, the installer-provisioned cluster resources are placed in this resource group. When not specified, the installation program creates the resource group for the cluster. The VPC resources that you have provisioned must exist in a resource group that you specify using the `networkResourceGroupName` parameter.
 In either case, this resource group must only be used for a single cluster installation, as the cluster components assume ownership of all of the resources in the resource group. [^1^]
 |String, for example `existing_resource_group`.
 
-|`platform.ibmcloud.networkResourceGroupName`
+|platform:
+  ibmcloud:
+    networkResourceGroupName:
 |The name of an existing resource group. This resource contains the existing VPC and subnets to which the cluster will be deployed. This parameter is required when deploying the cluster to a VPC that you have provisioned.
 |String, for example `existing_network_resource_group`.
 
-|`platform.ibmcloud.dedicatedHosts.profile`
+|platform:
+  ibmcloud:
+    dedicatedHosts:
+      profile:
 |The new dedicated host to create. If you specify a value for `platform.ibmcloud.dedicatedHosts.name`, this parameter is not required.
 |Valid {ibm-cloud-name} dedicated host profile, such as `cx2-host-152x304`. [^2^]
 
-|`platform.ibmcloud.dedicatedHosts.name`
+|platform:
+  ibmcloud:
+    dedicatedHosts:
+      name:
 |An existing dedicated host. If you specify a value for `platform.ibmcloud.dedicatedHosts.profile`, this parameter is not required.
 |String, for example `my-dedicated-host-name`.
 
-|`platform.ibmcloud.type`
+|platform:
+  ibmcloud:
+    type:
 |The instance type for all {ibm-cloud-name} machines.
 |Valid {ibm-cloud-name} instance type, such as `bx2-8x32`. [^2^]
 
-|`platform.ibmcloud.vpcName`
+|platform:
+  ibmcloud:
+    vpcName:
 | The name of the existing VPC that you want to deploy your cluster to.
 | String.
 
-|`platform.ibmcloud.controlPlaneSubnets`
+|platform:
+  ibmcloud:
+    controlPlaneSubnets:
 | The name(s) of the existing subnet(s) in your VPC that you want to deploy your control plane machines to. Specify a subnet for each availability zone.
 | String array
 
-|`platform.ibmcloud.computeSubnets`
+|platform:
+  ibmcloud:
+    computeSubnets:
 | The name(s) of the existing subnet(s) in your VPC that you want to deploy your compute machines to. Specify a subnet for each availability zone. Subnet IDs are not supported.
 | String array
 
@@ -2378,63 +2474,106 @@ ifdef::ash[]
 Additional Azure configuration parameters are described in the following table:
 
 .Additional Azure Stack Hub parameters
-[cols=".^2,.^3a,.^3a",options="header"]
+[cols=".^2l,.^3a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
-|`compute.platform.azure.osDisk.diskSizeGB`
+|compute:
+  platform:
+    azure:
+      osDisk:
+        diskSizeGB:
 |The Azure disk size for the VM.
 |Integer that represents the size of the disk in GB. The default is `128`.
 
-|`compute.platform.azure.osDisk.diskType`
+|compute:
+  platform:
+    azure:
+      osDisk:
+        diskType:
 |Defines the type of disk.
 |`standard_LRS` or `premium_LRS`. The default is `premium_LRS`.
 
-|`compute.platform.azure.type`
+|compute:
+  platform:
+    azure:
+      type:
 |Defines the azure instance type for compute machines.
 |String
 
-|`controlPlane.platform.azure.osDisk.diskSizeGB`
+|controlPlane:
+  platform:
+    azure:
+      osDisk:
+        diskSizeGB:
 |The Azure disk size for the VM.
 |Integer that represents the size of the disk in GB. The default is `1024`.
 
-|`controlPlane.platform.azure.osDisk.diskType`
+|controlPlane:
+  platform:
+    azure:
+      osDisk:
+        diskType:
 |Defines the type of disk.
 |`premium_LRS`.
 
-|`controlPlane.platform.azure.type`
+|controlPlane:
+  platform:
+    azure:
+      type:
 |Defines the azure instance type for control plane machines.
 |String
 
-|`platform.azure.defaultMachinePlatform.osDisk.diskSizeGB`
+|platform:
+  azure:
+    defaultMachinePlatform:
+      osDisk:
+        diskSizeGB:
 |The Azure disk size for the VM.
 |Integer that represents the size of the disk in GB. The default is `128`.
 
-|`platform.azure.defaultMachinePlatform.osDisk.diskType`
+|platform:
+  azure:
+    defaultMachinePlatform:
+      osDisk:
+        diskType:
 |Defines the type of disk.
 |`standard_LRS` or `premium_LRS`. The default is `premium_LRS`.
 
-|`platform.azure.defaultMachinePlatform.type`
+|platform:
+  azure:
+    defaultMachinePlatform:
+      type:
 |The Azure instance type for control plane and compute machines.
 |The Azure instance type.
 
-|`platform.azure.armEndpoint`
+|platform:
+  azure:
+    armEndpoint:
 |The URL of the Azure Resource Manager endpoint that your Azure Stack Hub operator provides.
 |String
 
-|`platform.azure.baseDomainResourceGroupName`
+|platform:
+  azure:
+    baseDomainResourceGroupName:
 |The name of the resource group that contains the DNS zone for your base domain.
 |String, for example `production_cluster`.
 
-|`platform.azure.region`
+|platform:
+  azure:
+    region:
 |The name of your Azure Stack Hub local region.
 |String
 
-|`platform.azure.resourceGroupName`
+|platform:
+  azure:
+    resourceGroupName:
 |The name of an already existing resource group to install your cluster to. This resource group must be empty and only used for this specific cluster; the cluster components assume ownership of all resources in the resource group. If you limit the service principal scope of the installation program to this resource group, you must ensure all other resources used by the installation program in your environment have the necessary permissions, such as the public DNS zone and virtual network. Destroying the cluster by using the installation program deletes this resource group.
 |String, for example `existing_resource_group`.
 
-|`platform.azure.outboundType`
+|platform:
+  azure:
+    outboundType:
 |The outbound routing strategy used to connect your cluster to the internet. If
 you are using user-defined routing, you must have pre-existing networking
 available where the outbound routing has already been configured prior to
@@ -2442,11 +2581,13 @@ installing a cluster. The installation program is not responsible for
 configuring user-defined routing.
 |`LoadBalancer` or `UserDefinedRouting`. The default is `LoadBalancer`.
 
-|`platform.azure.cloudName`
+|platform:
+  azure:
+    cloudName:
 |The name of the Azure cloud environment that is used to configure the Azure SDK with the appropriate Azure API endpoints.
 |`AzureStackCloud`
 
-|`clusterOSImage`
+|clusterOSImage:
 |The URL of a storage blob in the Azure Stack environment that contains an {op-system} VHD.
 |String, for example, \https://vhdsa.blob.example.example.com/vhd/rhcos-410.84.202112040202-0-azurestack.x86_64.vhd
 


### PR DESCRIPTION
ersion: 4.14+

Reformatting the Openstack, ibmcloud and azure stack hub installation configuration parameter tables into stacked format.

Previous format:
`controlPlane.aws.region`

New format:
```
controlPlane:
  aws:
    region:
```
Preview: 
[Azure Stack Hub](https://68794--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installation-config-parameters-ash#installation-configuration-parameters-additional-azure-stack-hub_installation-config-parameters-ash)
[IBM Cloud](https://68794--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installation-config-parameters-ibm-cloud-vpc#installation-configuration-parameters-additional-ibm-cloud_installation-config-parameters-ibm-cloud-vpc)
[Openstack](https://68794--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installation-config-parameters-openstack#installation-configuration-parameters-additional-osp_installation-config-parameters-openstack)

No QE required because this only affects docs formatting.