### PR TITLE
OSDOCS-8916

### DIFF
--- a/modules/rosa-sdpolicy-platform.adoc
+++ b/modules/rosa-sdpolicy-platform.adoc
@@ -26,7 +26,7 @@ endif::rosa-with-hcp[]
 
 [IMPORTANT]
 ====
-It is critical that customers have a backup plan for their applications and application data.
+Red Hat does not provide a backup method for ROSA clusters with STS, which is the default. It is critical that customers have a backup plan for their applications and application data. 
 ifndef::rosa-with-hcp[]
 The table below only applies to clusters created with IAM user credentials.
 endif::rosa-with-hcp[]


### PR DESCRIPTION
[OSDOCS-8916](https://issues.redhat.com/browse/OSDOCS-8916): [DDF] This is not true for STS clusters, as mentioned here:
Aligned team: Service Delivery
OCP version for cherry-picking: enterprise-4.14+
JIRA issues: [OSDOCS-8916](https://issues.redhat.com/browse/OSDOCS-8916)
Preview pages: [Click to see the build preview in your browser for ROSA](https://68823--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition#rosa-sdpolicy-backup-policy_rosa-service-definition)
SME review **completed**: @halfsquatch
QE review **completed**: @wanghaoran1988
Peer review **completed**: @skrthomas

PS: Here the Jira# is changed from OCPBUGS-11169 to [OSDOCS-8916](https://issues.redhat.com/browse/OSDOCS-8916). I have the updated the PR title and description accordingly.  