### PR TITLE
Travis errors: put back grep changes, they are causing build failures

### DIFF
--- a/scripts/check-asciidoctor-build.sh
+++ b/scripts/check-asciidoctor-build.sh
@@ -17,7 +17,7 @@ check_updated_assemblies () {
     if [ "${MODULES}" ]
     then
         # $UPDATED_ASSEMBLIES is the list of assemblies that contains changed modules
-        UPDATED_ASSEMBLIES=$(grep -rnwl "$REPO_PATH" --exclude-dir={snippets,modules} -e "$MODULES" -- "*.adoc")
+        UPDATED_ASSEMBLIES=$(grep -rnwl "$REPO_PATH" --include=\*.adoc --exclude-dir={snippets,modules} -e "$MODULES")
         # Exit 0 if there are no modified assemblies
         if [[ -z "${UPDATED_ASSEMBLIES}" ]]
         then
@@ -38,7 +38,7 @@ check_updated_assemblies () {
         # search for files only, not folders
         PAGE="File: $(basename "$ASSEMBLY" .adoc)"
         # don't validate the assembly if it is not in a topic map
-        if grep -rq "$PAGE" _topic_maps/*.yml; then
+        if grep -rq "$PAGE" --include "*.yml" _topic_maps ; then
             # validate the assembly
             echo "Validating $ASSEMBLY ... 🚨"
             RED='\033[0;31m'

--- a/scripts/get-updated-distros.sh
+++ b/scripts/get-updated-distros.sh
@@ -15,7 +15,7 @@ MODULES=$(echo "$FILES" | awk '/modules\/(.*)\.adoc/')
 if [ "${MODULES}" ]
 then
     # $UPDATED_ASSEMBLIES is the list of assemblies that contains changed modules
-    UPDATED_ASSEMBLIES=$(grep -rnwl "$REPO_PATH" --exclude-dir={snippets,modules} -e "$MODULES" -- "*.adoc")
+    UPDATED_ASSEMBLIES=$(grep -rnwl "$REPO_PATH" --include=\*.adoc --exclude-dir={snippets,modules} -e "$MODULES")
 
     # Exit 0 if there are no modified assemblies
     if [[ -z "${UPDATED_ASSEMBLIES}" ]]
@@ -36,7 +36,7 @@ for ASSEMBLY in $ALL_ASSEMBLIES; do
     # Search for files only, not folders
     PAGE="File: $(basename "$ASSEMBLY" .adoc)"
     # Don't include the assembly if it is not in a topic map
-    if grep -rq "$PAGE" _topic_maps/*.yml; then
+    if grep -rq "$PAGE" --include "*.yml" _topic_maps ; then
         DISTROS+=("$(grep -rl "$PAGE" _topic_maps/*.yml)")
     fi
 done


### PR DESCRIPTION
Fixes errors introduced in https://github.com/openshift/openshift-docs/pull/68798 and https://github.com/openshift/openshift-docs/pull/68806

Also fixes a long-standing cause of intermittent errors in how we built lists of files.

-L (uppercase) shows files that do not contain the pattern, while -l (lowercase) shows files that do contain the pattern.

[SOURCE](https://www.gnu.org/software/grep/manual/grep.html#index-_002d_002dfiles_002dwithout_002dmatch)

This PR also corrects `grep -rnwL` to `grep -rnwl`.

Merge to enterprise-4.10+ 

