### PR TITLE
OCPBUGS#23317: Additional resource links replaced with correct RHEL v…

### DIFF
--- a/microshift_install/microshift-embed-in-rpm-ostree.adoc
+++ b/microshift_install/microshift-embed-in-rpm-ostree.adoc
@@ -29,8 +29,8 @@ include::modules/microshift-ca-adding-bundle-ostree.adoc[leveloffset=+2]
 .Additional resources
 
 * xref:../microshift_install/microshift-embed-in-rpm-ostree.adoc#microshift-creating-ostree-iso_microshift-embed-in-rpm-ostree[Creating the {op-system-ostree} image]
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/sec-shared-system-certificates[Using Shared System Certificates in{op-system-base-full} 7]
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/composing_a_customized_rhel_system_image/creating-system-images-with-composer-command-line-interface_composing-a-customized-rhel-system-image#image-customizations_creating-system-images-with-composer-command-line-interface[Creating system images using the image builder command-line interface {op-system-base-full} 8]
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/securing_networks/using-shared-system-certificates_securing-networks[Using Shared System Certificates ({op-system-base} 9)]
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_a_customized_rhel_system_image/creating-system-images-with-composer-command-line-interface_composing-a-customized-rhel-system-image#image-customizations_creating-system-images-with-composer-command-line-interface[Supported image customizations ({op-system-base} 9)]
 
 include::modules/microshift-creating-ostree-iso.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.15, 4.14

Issue:
[OCPBUGS-23317](https://issues.redhat.com/browse/OCPBUGS-23317)

Link to docs preview:
[Adding a certificate authority bundle to an rpm-ostree image:Additional resources](https://68832--docspreview.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree)

QE review:
- [x] QE approval required.
