### PR TITLE
OSDOCS-8911: Fix typo

### DIFF
--- a/modules/rosa-sdpolicy-am-local-zones.adoc
+++ b/modules/rosa-sdpolicy-am-local-zones.adoc
@@ -19,7 +19,7 @@ endif::rosa-with-hcp[]
 ifndef::rosa-with-hcp[]
 {product-title} supports the use of AWS Local Zones, which are metropolis-centralized availability zones where customers can place latency-sensitive application workloads. Local Zones are extensions of AWS Regions that have their own internet connection. For more information about AWS Local Zones, see the AWS documentation link:https://docs.aws.amazon.com/local-zones/latest/ug/how-local-zones-work.html[How Local Zones work].
 
-For steps to enable AWS Local Zones and add a Local Zone to a machine pool, see xref:../../rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-configuring.adoc#rosa-nodes-machine-pools-local-zones[Configuring Local Zones for machine pulls].
+For steps to enable AWS Local Zones and to add a Local Zone to a machine pool, see xref:../../rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-configuring.adoc#rosa-nodes-machine-pools-local-zones[Configuring Local Zones for machine pools].
 endif::rosa-with-hcp[]
 
 ifeval::["{context}" == "rosa-hcp-service-definition"]


### PR DESCRIPTION
Version(s):
4.14+ 

Issue:
https://issues.redhat.com/browse/OSDOCS-8911

Link to docs preview:
https://68850--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition#rosa-sdpolicy-am-local-zones_rosa-service-definition

QE review:
No QE review required. 
