### PR TITLE
Switching to a ubi8-based Dockerfile for Prow CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
-FROM ruby:3.1.2-alpine
+FROM registry.access.redhat.com/ubi8/ruby-30:latest
 
-RUN apk add --update --no-cache git bash jq findutils
+ENV LANG=en_US.UTF-8
+
+USER root
+
+RUN yum update -y && yum install -y jq && yum clean all
 
 WORKDIR /go/src/github.com/openshift/openshift-docs
 


### PR DESCRIPTION
Upating to an easier-to-use ubi8-based Dockerfile  