### PR TITLE
[OSDOCS-8251]Add note to ROSA HCP docs that specify enforced AWS managed policies for HCP clusters

### DIFF
--- a/modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc
+++ b/modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc
@@ -5,6 +5,11 @@
 
 Before using the {product-title} (ROSA) CLI, `rosa`, to create {hcp-title-first} clusters, create the required account-wide roles and policies, including the Operator policies.
 
+[NOTE]
+====
+{hcp-title} clusters require account and operator roles with AWS managed policies attached. Customer managed policies are not supported. For more information regarding AWS managed policies for {hcp-title} clusters, see link:https://docs.aws.amazon.com/ROSA/latest/userguide/security-iam-awsmanpol-account-policies.html[AWS managed policies for ROSA account roles].
+====
+
 .Prerequisites
 
 * You have completed the AWS prerequisites for {hcp-title}.
@@ -21,4 +26,3 @@ Before using the {product-title} (ROSA) CLI, `rosa`, to create {hcp-title-first}
 ----
 $ rosa create account-roles --hosted-cp
 ----
-For more information regarding AWS managed IAM policies for ROSA, see link:https://docs.aws.amazon.com/ROSA/latest/userguide/security-iam-awsmanpol.html[AWS managed IAM policies for ROSA].


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-8251
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://68899--docspreview.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly#rosa-sts-creating-account-wide-sts-roles-and-policies_rosa-hcp-sts-creating-a-cluster-quickly
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
Based on duplicate ticket https://github.com/openshift/openshift-docs/pull/59437 which was delayed due to delay in GA . 
Additional information:
<!--- Optional: Include additional context or expand the description here.--->
![image](https://github.com/openshift/openshift-docs/assets/122639474/a26f72aa-9ee9-42e0-acaf-ead22bc34fb8)


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
