### PR TITLE
OADP-844: updating release notes for 4.11 following failed cherry pick

### DIFF
--- a/modules/oadp-release-notes-1-2-0.adoc
+++ b/modules/oadp-release-notes-1-2-0.adoc
@@ -15,13 +15,13 @@ The OADP 1.2.0 release notes include information about new features, bug fixes, 
 The new `resourceTimeout` option specifies the timeout duration in minutes for waiting on various Velero resources. This option applies to resources such as Velero CRD availability, `volumeSnapshot` deletion, and backup repository availability. The default duration is 10 minutes.
 
 .AWS S3 compatible backup storage providers
-You can back up objects and snapshots on AWS S3 compatible providers.
+You can back up objects and snapshots on AWS S3 compatible providers. For more details, see xref:../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc#migration-configuring-aws-s3_installing-oadp-aws[Configuring Amazon Web Services].
 
 [id="new-features-tech-preview-1-2-0_{context}"]
 === Technical preview features
 
 .Data Mover
-The OADP Data Mover enables you to back up Container Storage Interface (CSI) volume snapshots to a remote object store. When you enable Data Mover, you can restore stateful applications using CSI volume snapshots pulled from the object store in case of accidental cluster deletion, cluster failure, or data corruption.
+The OADP Data Mover enables you to back up Container Storage Interface (CSI) volume snapshots to a remote object store. When you enable Data Mover, you can restore stateful applications using CSI volume snapshots pulled from the object store in case of accidental cluster deletion, cluster failure, or data corruption. For more information, see xref:../../backup_and_restore/application_backup_and_restore/installing/oadp-using-data-mover-for-csi-snapshots-doc.adoc#oadp-using-data-mover-for-csi-snapshots-doc[Using Data Mover for CSI snapshots].
 
 :FeatureName: OADP Data Mover
 include::snippets/technology-preview.adoc[]


### PR DESCRIPTION
### Jira 
* [OADP-844](https://issues.redhat.com/browse/OADP-844)

* PR to resolve [cherry pick issue for 4.11](https://github.com/openshift/openshift-docs/pull/68867)

### Version(s):

* Enterprise 4.11 → branch/enterprise-4.11

#### Issue:
https://issues.redhat.com/browse/OADP-844

### Link to docs preview:
* [OADP 1.2.0 release notes](https://68867--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-release-notes#oadp-release-notes-1-2-0_oadp-release-notes)

### QE review:
* [X ] QE has approved this change.
* QE approved by Sachin in previous [PR#65626 - QE LGTM ](https://github.com/openshift/openshift-docs/pull/65626#pullrequestreview-1661213263)
* Peer review approved in previous PR = [LGTM](https://github.com/openshift/openshift-docs/pull/65626#pullrequestreview-1664832364)

