### PR TITLE
[OSDOCS-8072] OCP content port to ROSA and OSD: Virtualization

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -1269,3 +1269,282 @@ Topics:
   Topics:
   - Name: Serverless overview
     File: about-serverless
+---
+Name: Virtualization
+Dir: virt
+Distros: openshift-dedicated
+Topics:
+- Name: About
+  Dir: about_virt
+  Topics:
+  - Name: About OpenShift Virtualization
+    File: about-virt
+    Distros: openshift-dedicated
+  - Name: About OKD Virtualization
+    File: about-virt
+    Distros: openshift-origin
+  - Name: Security policies
+    File: virt-security-policies
+  - Name: Architecture
+    File: virt-architecture
+    Distros: openshift-dedicated
+#- Name: Release notes
+#  Dir: release_notes
+#  Topics:
+#  - Name: OpenShift Virtualization release notes
+#    File: virt-release-notes-placeholder
+#    Distros: openshift-rosa
+- Name: Getting started
+  Dir: getting_started
+  Topics:
+  - Name: Getting started with OpenShift Virtualization
+    File: virt-getting-started
+    Distros: openshift-dedicated
+  - Name: Getting started with OKD Virtualization
+    File: virt-getting-started
+    Distros: openshift-origin
+  - Name: virtctl and libguestfs
+    File: virt-using-the-cli-tools
+  - Name: Web console overview
+    File: virt-web-console-overview
+    Distros: openshift-dedicated
+- Name: Installing
+  Dir: install
+  Topics:
+  - Name: Preparing your cluster
+    File: preparing-cluster-for-virt
+  - Name: Installing OpenShift Virtualization
+    File: installing-virt
+  - Name: Uninstalling OpenShift Virtualization
+    File: uninstalling-virt
+- Name: Post-installation configuration
+  Dir: post_installation_configuration
+  Topics:
+  - Name: Post-installation configuration
+    File: virt-post-install-config
+  - Name: Node placement rules
+    File: virt-node-placement-virt-components
+  - Name: Network configuration
+    File: virt-post-install-network-config
+  - Name: Storage configuration
+    File: virt-post-install-storage-config
+- Name: Updating
+  Dir: updating
+  Topics:
+  - Name: Updating OpenShift Virtualization
+    File: upgrading-virt
+    Distros: openshift-dedicated
+- Name: Virtual machines
+  Dir: virtual_machines
+  Topics:
+  - Name: Creating VMs from Red Hat images
+    Dir: creating_vms_rh
+    Topics:
+    - Name: Creating VMs from Red Hat images overview
+      File: virt-creating-vms-from-rh-images-overview
+    - Name: Creating VMs from templates
+      File: virt-creating-vms-from-templates
+    - Name: Creating VMs from instance types
+      File: virt-creating-vms-from-instance-types
+    - Name: Creating VMs from the CLI
+      File: virt-creating-vms-from-cli
+  - Name: Creating VMs from custom images
+    Dir: creating_vms_custom
+    Topics:
+    - Name: Creating VMs from custom images overview
+      File: virt-creating-vms-from-custom-images-overview
+    - Name: Creating VMs by using container disks
+      File: virt-creating-vms-from-container-disks
+    - Name: Creating VMs by importing images from web pages
+      File: virt-creating-vms-from-web-images
+    - Name: Creating VMs by uploading images
+      File: virt-creating-vms-uploading-images
+    - Name: Creating VMs by cloning PVCs
+      File: virt-creating-vms-by-cloning-pvcs
+    - Name: Installing the QEMU guest agent and VirtIO drivers
+      File: virt-installing-qemu-guest-agent
+  - Name: Connecting to VM consoles
+    File: virt-accessing-vm-consoles
+  - Name: Configuring SSH access to VMs
+    File: virt-accessing-vm-ssh
+  - Name: Editing virtual machines
+    File: virt-edit-vms
+  - Name: Editing boot order
+    File: virt-edit-boot-order
+  - Name: Deleting virtual machines
+    File: virt-delete-vms
+  - Name: Exporting virtual machines
+    File: virt-exporting-vms
+  - Name: Managing virtual machine instances
+    File: virt-manage-vmis
+  - Name: Controlling virtual machine states
+    File: virt-controlling-vm-states
+  - Name: Using virtual Trusted Platform Module devices
+    File: virt-using-vtpm-devices
+  - Name: Managing virtual machines with OpenShift Pipelines
+    File: virt-managing-vms-openshift-pipelines
+  - Name: Advanced virtual machine management
+    Dir: advanced_vm_management
+    Topics:
+#Advanced virtual machine configuration
+    - Name: Working with resource quotas for virtual machines
+      File: virt-working-with-resource-quotas-for-vms
+    - Name: Specifying nodes for virtual machines
+      File: virt-specifying-nodes-for-vms
+    - Name: Configuring certificate rotation
+      File: virt-configuring-certificate-rotation
+    - Name: Configuring the default CPU model
+      File: virt-configuring-default-cpu-model
+    - Name: UEFI mode for virtual machines
+      File: virt-uefi-mode-for-vms
+    - Name: Configuring PXE booting for virtual machines
+      File: virt-configuring-pxe-booting
+# Huge pGES  not supported in OSD
+#    - Name: Using huge pages with virtual machines
+#      File: virt-using-huge-pages-with-vms
+# CPU Manager not supported in OSD
+#    - Name: Enabling dedicated resources for a virtual machine
+#      File: virt-dedicated-resources-vm
+    - Name: Scheduling virtual machines
+      File: virt-schedule-vms
+# Cannot create required machine config in OSD as required
+#    - Name: Configuring PCI passthrough
+#      File: virt-configuring-pci-passthrough
+# Cannot create required machine config in OSD as required
+#    - Name: Configuring virtual GPUs
+#      File: virt-configuring-virtual-gpus
+# Feature is TP, thus not supported in ROSA
+#    - Name: Enabling descheduler evictions on virtual machines
+#      File: virt-enabling-descheduler-evictions
+    - Name: About high availability for virtual machines
+      File: virt-high-availability-for-vms
+# invalid: spec.tuningPolicy: Unsupported value: "highBurst"
+#    - Name: Control plane tuning
+#      File: virt-vm-control-plane-tuning
+  - Name: VM disks
+    Dir: virtual_disks
+    Topics:
+    - Name: Hot-plugging VM disks
+      File: virt-hot-plugging-virtual-disks
+    - Name: Expanding VM disks
+      File: virt-expanding-vm-disks
+- Name: Networking
+  Dir: vm_networking
+  Topics:
+  - Name: Networking configuration overview
+    File: virt-networking-overview
+  - Name: Connecting a VM to the default pod network
+    File: virt-connecting-vm-to-default-pod-network
+  - Name: Exposing a VM by using a service
+    File: virt-exposing-vm-with-service
+# Not supported in ROSA/OSD
+#  - Name: Connecting a VM to a Linux bridge network
+#    File: virt-connecting-vm-to-linux-bridge
+#  - Name: Connecting a VM to an SR-IOV network
+#    File: virt-connecting-vm-to-sriov
+#  - Name: Using DPDK with SR-IOV
+#    File: virt-using-dpdk-with-sriov
+  - Name: Connecting a VM to an OVN-Kubernetes secondary network
+    File: virt-connecting-vm-to-ovn-secondary-network
+# Tecp preview not supported ROSA/OSD
+#  - Name: Hot plugging secondary network interfaces
+#    File: virt-hot-plugging-network-interfaces
+  - Name: Connecting a VM to a service mesh
+    File: virt-connecting-vm-to-service-mesh
+  - Name: Configuring a dedicated network for live migration
+    File: virt-dedicated-network-live-migration
+  - Name: Configuring and viewing IP addresses
+    File: virt-configuring-viewing-ips-for-vms
+# Tech Preview features not supported in ROSA/OSD
+#  - Name: Accessing a VM by using the cluster FQDN
+#    File: virt-accessing-vm-secondary-network-fqdn
+  - Name: Managing MAC address pools for network interfaces
+    File: virt-using-mac-address-pool-for-vms
+- Name: Storage
+  Dir: storage
+  Topics:
+  - Name: Storage configuration overview
+    File: virt-storage-config-overview
+  - Name: Configuring storage profiles
+    File: virt-configuring-storage-profile
+  - Name: Managing automatic boot source updates
+    File: virt-automatic-bootsource-updates
+  - Name: Reserving PVC space for file system overhead
+    File: virt-reserving-pvc-space-fs-overhead
+  - Name: Configuring local storage by using HPP
+    File: virt-configuring-local-storage-with-hpp
+  - Name: Enabling user permissions to clone data volumes across namespaces
+    File: virt-enabling-user-permissions-to-clone-datavolumes
+  - Name: Configuring CDI to override CPU and memory quotas
+    File: virt-configuring-cdi-for-namespace-resourcequota
+  - Name: Preparing CDI scratch space
+    File: virt-preparing-cdi-scratch-space
+  - Name: Using preallocation for data volumes
+    File: virt-using-preallocation-for-datavolumes
+  - Name: Managing data volume annotations
+    File: virt-managing-data-volume-annotations
+# Virtual machine live migration
+- Name: Live migration
+  Dir: live_migration
+  Topics:
+  - Name: About live migration
+    File: virt-about-live-migration
+  - Name: Configuring live migration
+    File: virt-configuring-live-migration
+  - Name: Initiating and canceling live migration
+    File: virt-initiating-live-migration
+# Node maintenance mode
+- Name: Nodes
+  Dir: nodes
+  Topics:
+  - Name: Node maintenance
+    File: virt-node-maintenance
+  - Name: Managing node labeling for obsolete CPU models
+    File: virt-managing-node-labeling-obsolete-cpu-models
+  - Name: Preventing node reconciliation
+    File: virt-preventing-node-reconciliation
+# Hiding in ROSA/OSD as user cannot cordon and drain nodes
+#  - Name: Deleting a failed node to trigger VM failover
+#    File: virt-triggering-vm-failover-resolving-failed-node
+- Name: Monitoring
+  Dir: monitoring
+  Topics:
+  - Name: Monitoring overview
+    File: virt-monitoring-overview
+# Hiding in ROSA/OSD as TP not supported
+#  - Name: Cluster checkup framework
+#    File: virt-running-cluster-checkups
+  - Name: Prometheus queries for virtual resources
+    File: virt-prometheus-queries
+  - Name: Virtual machine custom metrics
+    File: virt-exposing-custom-metrics-for-vms
+  - Name: Virtual machine health checks
+    File: virt-monitoring-vm-health
+  - Name: Runbooks
+    File: virt-runbooks
+- Name: Support
+  Dir: support
+  Topics:
+  - Name: Support overview
+    File: virt-support-overview
+  - Name: Collecting data for Red Hat Support
+    File: virt-collecting-virt-data
+    Distros: openshift-dedicated
+  - Name: Troubleshooting
+    File: virt-troubleshooting
+- Name: Backup and restore
+  Dir: backup_restore
+  Topics:
+  - Name: Backup and restore by using VM snapshots
+    File: virt-backup-restore-snapshots
+  - Name: Installing and configuring OADP
+    File: virt-installing-configuring-oadp
+  - Name: Backing up and restoring virtual machines
+    File: virt-backup-restore-overview
+  - Name: Backing up virtual machines
+    File: virt-backing-up-vms
+  - Name: Restoring virtual machines
+    File: virt-restoring-vms
+#  - Name: Collecting OKD Virtualization data for community report
+#    File: virt-collecting-virt-data
+#    Distros: openshift-origin

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1596,3 +1596,280 @@ Topics:
   Topics:
   - Name: Serverless overview
     File: about-serverless
+---
+Name: Virtualization
+Dir: virt
+Distros: openshift-rosa
+Topics:
+- Name: About
+  Dir: about_virt
+  Topics:
+  - Name: About OpenShift Virtualization
+    File: about-virt
+    Distros: openshift-rosa
+  - Name: About OKD Virtualization
+    File: about-virt
+    Distros: openshift-origin
+  - Name: Security policies
+    File: virt-security-policies
+  - Name: Architecture
+    File: virt-architecture
+    Distros: openshift-rosa
+#- Name: Release notes
+#  Dir: release_notes
+#  Topics:
+#  - Name: OpenShift Virtualization release notes
+#    File: virt-release-notes-placeholder
+#    Distros: openshift-rosa
+- Name: Getting started
+  Dir: getting_started
+  Topics:
+  - Name: Getting started with OpenShift Virtualization
+    File: virt-getting-started
+    Distros: openshift-rosa
+  - Name: Getting started with OKD Virtualization
+    File: virt-getting-started
+    Distros: openshift-origin
+  - Name: virtctl and libguestfs
+    File: virt-using-the-cli-tools
+  - Name: Web console overview
+    File: virt-web-console-overview
+    Distros: openshift-rosa
+- Name: Installing
+  Dir: install
+  Topics:
+  - Name: Preparing your cluster
+    File: preparing-cluster-for-virt
+  - Name: Installing OpenShift Virtualization
+    File: installing-virt
+  - Name: Uninstalling OpenShift Virtualization
+    File: uninstalling-virt
+- Name: Post-installation configuration
+  Dir: post_installation_configuration
+  Topics:
+  - Name: Post-installation configuration
+    File: virt-post-install-config
+  - Name: Node placement rules
+    File: virt-node-placement-virt-components
+  - Name: Network configuration
+    File: virt-post-install-network-config
+  - Name: Storage configuration
+    File: virt-post-install-storage-config
+- Name: Updating
+  Dir: updating
+  Topics:
+  - Name: Updating OpenShift Virtualization
+    File: upgrading-virt
+    Distros: openshift-rosa
+- Name: Virtual machines
+  Dir: virtual_machines
+  Topics:
+  - Name: Creating VMs from Red Hat images
+    Dir: creating_vms_rh
+    Topics:
+    - Name: Creating VMs from Red Hat images overview
+      File: virt-creating-vms-from-rh-images-overview
+    - Name: Creating VMs from templates
+      File: virt-creating-vms-from-templates
+    - Name: Creating VMs from instance types
+      File: virt-creating-vms-from-instance-types
+    - Name: Creating VMs from the CLI
+      File: virt-creating-vms-from-cli
+  - Name: Creating VMs from custom images
+    Dir: creating_vms_custom
+    Topics:
+    - Name: Creating VMs from custom images overview
+      File: virt-creating-vms-from-custom-images-overview
+    - Name: Creating VMs by using container disks
+      File: virt-creating-vms-from-container-disks
+    - Name: Creating VMs by importing images from web pages
+      File: virt-creating-vms-from-web-images
+    - Name: Creating VMs by uploading images
+      File: virt-creating-vms-uploading-images
+    - Name: Creating VMs by cloning PVCs
+      File: virt-creating-vms-by-cloning-pvcs
+    - Name: Installing the QEMU guest agent and VirtIO drivers
+      File: virt-installing-qemu-guest-agent
+  - Name: Connecting to VM consoles
+    File: virt-accessing-vm-consoles
+  - Name: Configuring SSH access to VMs
+    File: virt-accessing-vm-ssh
+  - Name: Editing virtual machines
+    File: virt-edit-vms
+  - Name: Editing boot order
+    File: virt-edit-boot-order
+  - Name: Deleting virtual machines
+    File: virt-delete-vms
+  - Name: Exporting virtual machines
+    File: virt-exporting-vms
+  - Name: Managing virtual machine instances
+    File: virt-manage-vmis
+  - Name: Controlling virtual machine states
+    File: virt-controlling-vm-states
+  - Name: Using virtual Trusted Platform Module devices
+    File: virt-using-vtpm-devices
+  - Name: Managing virtual machines with OpenShift Pipelines
+    File: virt-managing-vms-openshift-pipelines
+  - Name: Advanced virtual machine management
+    Dir: advanced_vm_management
+    Topics:
+#Advanced virtual machine configuration
+    - Name: Working with resource quotas for virtual machines
+      File: virt-working-with-resource-quotas-for-vms
+    - Name: Specifying nodes for virtual machines
+      File: virt-specifying-nodes-for-vms
+    - Name: Configuring certificate rotation
+      File: virt-configuring-certificate-rotation
+    - Name: Configuring the default CPU model
+      File: virt-configuring-default-cpu-model
+    - Name: UEFI mode for virtual machines
+      File: virt-uefi-mode-for-vms
+    - Name: Configuring PXE booting for virtual machines
+      File: virt-configuring-pxe-booting
+# Huge pages  not supported in ROSA
+#    - Name: Using huge pages with virtual machines
+#      File: virt-using-huge-pages-with-vms
+# CPU Manager not supported in ROSA
+#    - Name: Enabling dedicated resources for a virtual machine
+#      File: virt-dedicated-resources-vm
+    - Name: Scheduling virtual machines
+      File: virt-schedule-vms
+# Cannot create required machine config in ROSA as required
+#    - Name: Configuring PCI passthrough
+#      File: virt-configuring-pci-passthrough
+# Cannot create required machine config in ROSA as required
+#    - Name: Configuring virtual GPUs
+#      File: virt-configuring-virtual-gpus
+# Feature is TP, thus not supported in ROSA
+#    - Name: Enabling descheduler evictions on virtual machines
+#      File: virt-enabling-descheduler-evictions
+    - Name: About high availability for virtual machines
+      File: virt-high-availability-for-vms
+    - Name: Control plane tuning
+      File: virt-vm-control-plane-tuning
+  - Name: VM disks
+    Dir: virtual_disks
+    Topics:
+    - Name: Hot-plugging VM disks
+      File: virt-hot-plugging-virtual-disks
+    - Name: Expanding VM disks
+      File: virt-expanding-vm-disks
+- Name: Networking
+  Dir: vm_networking
+  Topics:
+  - Name: Networking configuration overview
+    File: virt-networking-overview
+  - Name: Connecting a VM to the default pod network
+    File: virt-connecting-vm-to-default-pod-network
+  - Name: Exposing a VM by using a service
+    File: virt-exposing-vm-with-service
+# Not supported in ROSA/OSD
+#  - Name: Connecting a VM to a Linux bridge network
+#    File: virt-connecting-vm-to-linux-bridge
+#  - Name: Connecting a VM to an SR-IOV network
+#    File: virt-connecting-vm-to-sriov
+#  - Name: Using DPDK with SR-IOV
+#    File: virt-using-dpdk-with-sriov
+  - Name: Connecting a VM to an OVN-Kubernetes secondary network
+    File: virt-connecting-vm-to-ovn-secondary-network
+#  - Name: Hot plugging secondary network interfaces
+#    File: virt-hot-plugging-network-interfaces
+  - Name: Connecting a VM to a service mesh
+    File: virt-connecting-vm-to-service-mesh
+  - Name: Configuring a dedicated network for live migration
+    File: virt-dedicated-network-live-migration
+  - Name: Configuring and viewing IP addresses
+    File: virt-configuring-viewing-ips-for-vms
+# Tech Preview features not supported in ROSA/OSD
+#  - Name: Accessing a VM by using the cluster FQDN
+#    File: virt-accessing-vm-secondary-network-fqdn
+  - Name: Managing MAC address pools for network interfaces
+    File: virt-using-mac-address-pool-for-vms
+- Name: Storage
+  Dir: storage
+  Topics:
+  - Name: Storage configuration overview
+    File: virt-storage-config-overview
+  - Name: Configuring storage profiles
+    File: virt-configuring-storage-profile
+  - Name: Managing automatic boot source updates
+    File: virt-automatic-bootsource-updates
+  - Name: Reserving PVC space for file system overhead
+    File: virt-reserving-pvc-space-fs-overhead
+  - Name: Configuring local storage by using HPP
+    File: virt-configuring-local-storage-with-hpp
+  - Name: Enabling user permissions to clone data volumes across namespaces
+    File: virt-enabling-user-permissions-to-clone-datavolumes
+  - Name: Configuring CDI to override CPU and memory quotas
+    File: virt-configuring-cdi-for-namespace-resourcequota
+  - Name: Preparing CDI scratch space
+    File: virt-preparing-cdi-scratch-space
+  - Name: Using preallocation for data volumes
+    File: virt-using-preallocation-for-datavolumes
+  - Name: Managing data volume annotations
+    File: virt-managing-data-volume-annotations
+# Virtual machine live migration
+- Name: Live migration
+  Dir: live_migration
+  Topics:
+  - Name: About live migration
+    File: virt-about-live-migration
+  - Name: Configuring live migration
+    File: virt-configuring-live-migration
+  - Name: Initiating and canceling live migration
+    File: virt-initiating-live-migration
+# Node maintenance mode
+- Name: Nodes
+  Dir: nodes
+  Topics:
+  - Name: Node maintenance
+    File: virt-node-maintenance
+  - Name: Managing node labeling for obsolete CPU models
+    File: virt-managing-node-labeling-obsolete-cpu-models
+  - Name: Preventing node reconciliation
+    File: virt-preventing-node-reconciliation
+# Hiding in ROSA as user cannot cordon and drain nodes
+#  - Name: Deleting a failed node to trigger VM failover
+#    File: virt-triggering-vm-failover-resolving-failed-node
+- Name: Monitoring
+  Dir: monitoring
+  Topics:
+  - Name: Monitoring overview
+    File: virt-monitoring-overview
+# Hiding in ROSA/OSD as TP not supported
+#  - Name: Cluster checkup framework
+#    File: virt-running-cluster-checkups
+  - Name: Prometheus queries for virtual resources
+    File: virt-prometheus-queries
+  - Name: Virtual machine custom metrics
+    File: virt-exposing-custom-metrics-for-vms
+  - Name: Virtual machine health checks
+    File: virt-monitoring-vm-health
+  - Name: Runbooks
+    File: virt-runbooks
+- Name: Support
+  Dir: support
+  Topics:
+  - Name: Support overview
+    File: virt-support-overview
+  - Name: Collecting data for Red Hat Support
+    File: virt-collecting-virt-data
+    Distros: openshift-rosa
+  - Name: Troubleshooting
+    File: virt-troubleshooting
+- Name: Backup and restore
+  Dir: backup_restore
+  Topics:
+  - Name: Backup and restore by using VM snapshots
+    File: virt-backup-restore-snapshots
+  - Name: Installing and configuring OADP
+    File: virt-installing-configuring-oadp
+  - Name: Backing up and restoring virtual machines
+    File: virt-backup-restore-overview
+  - Name: Backing up virtual machines
+    File: virt-backing-up-vms
+  - Name: Restoring virtual machines
+    File: virt-restoring-vms
+#  - Name: Collecting OKD Virtualization data for community report
+#    File: virt-collecting-virt-data
+#    Distros: openshift-origin

--- a/modules/virt-about-services.adoc
+++ b/modules/virt-about-services.adoc
@@ -15,7 +15,9 @@ NodePort:: Exposes the service on the same port of each selected node in the clu
 
 LoadBalancer:: Creates an external load balancer in the current cloud (if supported) and assigns a fixed, external IP address to the service.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [NOTE]
 ====
 For on-premise clusters, you can configure a load-balancing service by deploying the MetalLB Operator.
 ====
+endif::openshift-rosa,openshift-dedicated[]

--- a/modules/virt-about-storage-volumes-for-vm-disks.adoc
+++ b/modules/virt-about-storage-volumes-for-vm-disks.adoc
@@ -14,8 +14,10 @@ For best results, use the `ReadWriteMany` (RWX) access mode and the `Block` volu
 * `ReadWriteMany` (RWX) access mode is required for live migration.
 
 * The `Block` volume mode performs significantly better than the `Filesystem` volume mode. This is because the `Filesystem` volume mode uses more storage layers, including a file system layer and a disk image file. These layers are not necessary for VM disk storage.
+ifndef::openshift-rosa,openshift-dedicated[]
 +
 For example, if you use {rh-storage-first}, Ceph RBD volumes are preferable to CephFS volumes.
+endif::openshift-rosa,openshift-dedicated[]
 
 [IMPORTANT]
 ====

--- a/modules/virt-about-upgrading-virt.adoc
+++ b/modules/virt-about-upgrading-virt.adoc
@@ -23,9 +23,19 @@ connection. Most automatic updates complete within fifteen minutes.
 
 * Data volumes and their associated persistent volume claims are preserved during update.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [IMPORTANT]
 ====
 If you have virtual machines running that use hostpath provisioner storage, they cannot be live migrated and might block an {product-title} cluster update.
 
 As a workaround, you can reconfigure the virtual machines so that they can be powered off automatically during a cluster update. Remove the `evictionStrategy: LiveMigrate` field and set the `runStrategy` field to `Always`.
 ====
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[IMPORTANT]
+====
+If you have virtual machines running that use AWS Elastic Block Store (EBS) storage, they cannot be live migrated and might block an {product-title} cluster update.
+
+As a workaround, you can reconfigure the virtual machines so that they can be powered off automatically during a cluster update. Remove the `evictionStrategy: LiveMigrate` field and set the `runStrategy` field to `Always`.
+====
+endif::openshift-rosa,openshift-dedicated[]

--- a/modules/virt-applying-node-placement-rules.adoc
+++ b/modules/virt-applying-node-placement-rules.adoc
@@ -6,7 +6,12 @@
 [id="virt-applying-node-place-rules_{context}"]
 = Applying node placement rules
 
+ifndef::openshift-rosa,openshift-dedicated[]
 You can apply node placement rules by editing a `Subscription`, `HyperConverged`, or `HostPathProvisioner` object using the command line.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+You can apply node placement rules by editing a `HyperConverged` or `HostPathProvisioner` object using the command line.
+endif::openshift-rosa,openshift-dedicated[]
 
 .Prerequisites
 

--- a/modules/virt-aws-bm.adoc
+++ b/modules/virt-aws-bm.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * virt/install/preparing-cluster-for-virt.adoc
-
+ifndef::openshift-rosa,openshift-dedicated[]
 :_mod-docs-content-type: CONCEPT
 [id="virt-aws-bm_{context}"]
 = {VirtProductName} on AWS bare metal
@@ -12,6 +12,20 @@ You can run {VirtProductName} on an Amazon Web Services (AWS) bare-metal {produc
 ====
 {VirtProductName} is also supported on {product-rosa} (ROSA) Classic clusters, which have the same configuration requirements as AWS bare-metal clusters.
 ====
+endif::openshift-rosa,openshift-dedicated[]
+
+ifdef::openshift-rosa,openshift-dedicated[]
+:_mod-docs-content-type: CONCEPT
+[id="virt-aws-bm_{context}"]
+= {VirtProductName} on {product-title}
+
+ifdef::openshift-rosa[]
+You can run {VirtProductName} on a {product-rosa} (ROSA) Classic cluster.
+endif::openshift-rosa[]
+ifdef::openshift-dedicated[]
+You can run {VirtProductName} on a {product-dedicated} cluster.
+endif::openshift-dedicated[]
+endif::openshift-rosa,openshift-dedicated[]
 
 Before you set up your cluster, review the following summary of supported features and limitations:
 
@@ -25,14 +39,22 @@ For more information, see the {product-title} documentation about installing on 
 Accessing virtual machines (VMs)::
 --
 * There is no change to how you access VMs by using the `virtctl` CLI tool or the {product-title} web console.
-* You can expose VMs by using a `NodePort` or `LoadBalancer` service. 
+* You can expose VMs by using a `NodePort` or `LoadBalancer` service.
 ** The load balancer approach is preferable because {product-title} automatically creates the load balancer in AWS and manages its lifecycle. A security group is also created for the load balancer, and you can use annotations to attach existing security groups. When you remove the service, {product-title} removes the load balancer and its associated resources.
 --
 
 Networking::
+// Hiding the following in ROSA/OSD because SR-IOV is not supported.
+ifndef::openshift-rosa,openshift-dedicated[]
 --
 * You cannot use Single Root I/O Virtualization (SR-IOV) or bridge Container Network Interface (CNI) networks, including virtual LAN (VLAN). If your application requires a flat layer 2 network or control over the IP pool, consider using OVN-Kubernetes secondary overlay networks.
 --
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+--
+* If your application requires a flat layer 2 network or control over the IP pool, consider using OVN-Kubernetes secondary overlay networks.
+--
+endif::openshift-rosa,openshift-dedicated[]
 
 Storage::
 --
@@ -42,5 +64,7 @@ Storage::
 ====
 AWS bare-metal and ROSA clusters might have different supported storage solutions. Ensure that you confirm support with your storage vendor.
 ====
-* Amazon Elastic File System (EFS) and Amazon Elastic Block Store (EBS) are not supported for use with {VirtProductName} due to performance and functionality limitations.
+
+// Changed from "not supported" to "not recommeded" and added "shatred storage" per Ronen Sde-Or 1/31/24 Rosa Virtualization review meeting.
+* Amazon Elastic File System (EFS) and Amazon Elastic Block Store (EBS) are not recommended for use with {VirtProductName} due to performance and functionality limitations. Use shared storage instead.
 --

--- a/modules/virt-cloning-pvc-to-dv-cli.adoc
+++ b/modules/virt-cloning-pvc-to-dv-cli.adoc
@@ -12,12 +12,14 @@ You create a data volume that references the original source PVC. The lifecycle 
 
 Cloning between different volume modes is supported for host-assisted cloning, such as cloning from a block persistent volume (PV) to a file system PV, as long as the source and target PVs belong to the `kubevirt` content type.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [NOTE]
 ====
 Smart-cloning is faster and more efficient than host-assisted cloning because it uses snapshots to clone PVCs. Smart-cloning is supported by storage providers that support snapshots, such as {rh-storage-first}.
 
 Cloning between different volume modes is not supported for smart-cloning.
 ====
+endif::openshift-rosa,openshift-dedicated[]
 
 .Prerequisites
 

--- a/modules/virt-configuring-cluster-dpdk.adoc
+++ b/modules/virt-configuring-cluster-dpdk.adoc
@@ -15,13 +15,23 @@ You can configure an {product-title} cluster to run Data Plane Development Kit (
 * You have installed the Node Tuning Operator.
 
 .Procedure
+// Cannot label nodes in ROSA/OSD, but can edit machine pools
 . Map your compute nodes topology to determine which Non-Uniform Memory Access (NUMA) CPUs are isolated for DPDK applications and which ones are reserved for the operating system (OS).
 . Label a subset of the compute nodes with a custom role; for example, `worker-dpdk`:
 +
+ifndef::openshift-rosa[]
 [source,terminal]
 ----
 $ oc label node <node_name> node-role.kubernetes.io/worker-dpdk=""
 ----
+endif::openshift-rosa[]
++
+ifdef::openshift-rosa[]
+[source,terminal]
+----
+$ rosa edit machinepool --cluster=<cluster_name> <machinepool_ID> node-role.kubernetes.io/worker-dpdk=""
+----
+endif::openshift-rosa[]
 
 . Create a new `MachineConfigPool` manifest that contains the `worker-dpdk` label in the `spec.machineConfigSelector` object:
 +

--- a/modules/virt-creating-storage-class-csi-driver.adoc
+++ b/modules/virt-creating-storage-class-csi-driver.adoc
@@ -18,6 +18,12 @@ Virtual machines use data volumes that are based on local PVs. Local PVs are bou
 To solve this problem, use the Kubernetes pod scheduler to bind the persistent volume claim (PVC) to a PV on the correct node. By using the `StorageClass` value with `volumeBindingMode` parameter set to `WaitForFirstConsumer`, the binding and provisioning of the PV is delayed until a pod is created using the PVC.
 ====
 
+ifdef::openshift-rosa,openshift-dedicated[]
+.Prerequisites
+
+* Log in as a user with `cluster-admin` privileges.
+endif::openshift-rosa,openshift-dedicated[]
+
 .Procedure
 
 . Create a `storageclass_csi.yaml` file to define the storage class:

--- a/modules/virt-deploying-operator-cli.adoc
+++ b/modules/virt-deploying-operator-cli.adoc
@@ -10,7 +10,12 @@ You can deploy the {VirtProductName} Operator by using the `oc` CLI.
 
 .Prerequisites
 
-* An active subscription to the {VirtProductName} catalog in the `{CNVNamespace}` namespace.
+* Subscribe to the {VirtProductName} catalog in the `{CNVNamespace}` namespace.
+* Log in as a user with `cluster-admin` privileges.
+// required for ROSA/OSD
+ifdef::openshift-rosa,openshift-dedicated[]
+* Create a machine pool based on a bare metal compute node instance type.
+endif::openshift-rosa,openshift-dedicated[]
 
 .Procedure
 
@@ -50,3 +55,4 @@ The following output displays if deployment was successful:
 NAME                                      DISPLAY                    VERSION   REPLACES   PHASE
 kubevirt-hyperconverged-operator.v{HCOVersion}   {VirtProductName}   {HCOVersion}                Succeeded
 ----
+

--- a/modules/virt-installing-virt-operator.adoc
+++ b/modules/virt-installing-virt-operator.adoc
@@ -12,6 +12,10 @@ You can deploy the {VirtProductName} Operator by using the {product-title} web c
 
 * Install {product-title} {product-version} on your cluster.
 * Log in to the {product-title} web console as a user with `cluster-admin` permissions.
+// required for ROSA/OSD
+ifdef::openshift-rosa,openshift-dedicated[]
+* Create a machine pool based on a bare metal compute node instance type. For more information, see "Creating a machine pool" in the Additional resources of this section.
+endif::openshift-rosa,openshift-dedicated[]
 
 .Procedure
 

--- a/modules/virt-node-placement-rule-examples.adoc
+++ b/modules/virt-node-placement-rule-examples.adoc
@@ -6,8 +6,14 @@
 [id="virt-node-placement-rule-examples_{context}"]
 = Node placement rule examples
 
+ifndef::openshift-rosa,openshift-dedicated[]
 You can specify node placement rules for a {VirtProductName} component by editing a `Subscription`, `HyperConverged`, or `HostPathProvisioner` object.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+You can specify node placement rules for a {VirtProductName} component by editing a `HyperConverged` or `HostPathProvisioner` object.
+endif::openshift-rosa,openshift-dedicated[]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [id="subscription-object-node-placement-rules_{context}"]
 == Subscription object node placement rule examples
 
@@ -59,6 +65,7 @@ spec:
       effect: "NoSchedule"
 ----
 <1> OLM deploys {VirtProductName} Operators on nodes labeled `key = virtualization:NoSchedule` taint. Only pods with the matching tolerations are scheduled on these nodes.
+endif::openshift-rosa,openshift-dedicated[]
 
 [id="hyperconverged-object-node-placement-rules_{context}"]
 == HyperConverged object node placement rule example

--- a/modules/virt-preventing-nvidia-gpu-operands-from-deploying-on-nodes.adoc
+++ b/modules/virt-preventing-nvidia-gpu-operands-from-deploying-on-nodes.adoc
@@ -14,13 +14,22 @@ If you use the link:https://docs.nvidia.com/datacenter/cloud-native/gpu-operator
 * The OpenShift CLI (`oc`) is installed.
 
 .Procedure
-
+// Cannot label nodes in ROSA/OSD, but can edit machine pools
 * Label the node by running the following command:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,terminal]
 ----
 $ oc label node <node_name> nvidia.com/gpu.deploy.operands=false <1>
 ----
+endif::openshift-rosa,openshift-dedicated[]
++
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,terminal]
+----
+$ rosa edit machinepool --cluster=<cluster_name> <machinepool_ID> nvidia.com/gpu.deploy.operands=false <1>
+----
+endif::openshift-rosa,openshift-dedicated[]
 <1> Replace `<node_name>` with the name of a node where you do not want to install the NVIDIA GPU operands.
 
 .Verification

--- a/modules/virt-pxe-booting-with-mac-address.adoc
+++ b/modules/virt-pxe-booting-with-mac-address.adoc
@@ -12,7 +12,9 @@ You can also specify a MAC address in the virtual machine instance configuration
 
 .Prerequisites
 
+ifndef::openshift-rosa,openshift-dedicated[]
 * A Linux bridge must be connected.
+endif::openshift-rosa,openshift-dedicated[]
 * The PXE server must be connected to the same VLAN as the bridge.
 
 .Procedure

--- a/modules/virt-querying-metrics.adoc
+++ b/modules/virt-querying-metrics.adoc
@@ -12,6 +12,8 @@ The following metric descriptions include example Prometheus Query Language (Pro
 The following examples use `topk` queries that specify a time period. If virtual machines are deleted during that time period, they can still appear in the query output.
 ====
 
+// Hiding in ROSA/OSD as user cannot edit MCO
+ifndef::openshift-rosa,openshift-dedicated[]
 [id="virt-promql-vcpu-metrics_{context}"]
 == vCPU metrics
 
@@ -33,6 +35,7 @@ To query the vCPU metric, the `schedstats=enable` kernel argument must first be 
 topk(3, sum by (name, namespace) (rate(kubevirt_vmi_vcpu_wait_seconds_total[6m]))) > 0 <1>
 ----
 <1> This query returns the top 3 VMs waiting for I/O at every given moment over a six-minute time period.
+endif::openshift-rosa,openshift-dedicated[]
 
 [id="virt-promql-network-metrics_{context}"]
 == Network metrics

--- a/modules/virt-runbook-virtualmachinecrcerrors.adoc
+++ b/modules/virt-runbook-virtualmachinecrcerrors.adoc
@@ -78,8 +78,10 @@ The `krbd:rxbounce` option creates a bounce buffer to receive data. The default
 behavior is for the destination buffer to receive data directly. A bounce buffer
 is required if the stability of the destination buffer cannot be guaranteed.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 See link:https://access.redhat.com/articles/6978371[Optimizing ODF PersistentVolumes for Windows VMs]
 for details.
+endif::openshift-rosa,openshift-dedicated[]
 
 If you cannot resolve the issue, log in to the
 link:https://access.redhat.com[Customer Portal] and open a support case,

--- a/modules/virt-storage-wizard-fields-web.adoc
+++ b/modules/virt-storage-wizard-fields-web.adoc
@@ -24,8 +24,10 @@
 |Import via Registry (creates PVC)
 |Import content via container registry.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 |Container (ephemeral)
 |Upload content from a container located in a registry accessible from the cluster. The container disk should be used only for read-only filesystems such as CD-ROMs or temporary virtual machines.
+endif::openshift-rosa,openshift-dedicated[]
 
 |Name
 |Name of the disk. The name can contain lowercase letters (`a-z`), numbers (`0-9`), hyphens (`-`), and periods (`.`), up to a maximum of 253 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, or special characters.

--- a/modules/virt-what-you-can-do-with-virt.adoc
+++ b/modules/virt-what-you-can-do-with-virt.adoc
@@ -19,12 +19,14 @@
 
 An enhanced web console provides a graphical portal to manage these virtualized resources alongside the {product-title} cluster containers and infrastructure.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 {VirtProductName} is designed and tested to work well with {rh-storage-first} features.
 
 [IMPORTANT]
 ====
 When you deploy {VirtProductName} with {rh-storage}, you must create a dedicated storage class for Windows virtual machine disks. See link:https://access.redhat.com/articles/6978371[Optimizing ODF PersistentVolumes for Windows VMs] for details.
 ====
+endif::openshift-rosa,openshift-dedicated[]
 
 // A line about support for OVN and OpenShiftSDN network providers has been moved to the `about-virt` assembly due to xrefs.
 // If you are re-using this module, you might also want to include that line in your assembly.

--- a/virt/about_virt/about-virt.adoc
+++ b/virt/about_virt/about-virt.adoc
@@ -13,22 +13,40 @@ include::modules/virt-what-you-can-do-with-virt.adoc[leveloffset=+1]
 // This line is attached to the above `virt-what-you-can-do-with-virt` module.
 // It is included here in the assembly because of the xref ban.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 You can use {VirtProductName} with xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes], xref:../../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[OpenShift SDN], or one of the other certified network plugins listed in link:https://access.redhat.com/articles/5436171[Certified OpenShift CNI Plug-ins].
+endif::openshift-rosa,openshift-dedicated[]
 
+ifdef::openshift-rosa,openshift-dedicated[]
+You can use {VirtProductName} with OVN-Kubernetes or OpenShift SDN.
+endif::openshift-rosa,openshift-dedicated[]
+
+// Hiding links in ROSA/OSD until PR 62384 merges
+ifndef::openshift-rosa,openshift-dedicated[]
 You can check your {VirtProductName} cluster for compliance issues by installing the xref:../../security/compliance_operator/co-concepts/compliance-operator-understanding.adoc#understanding-compliance[Compliance Operator] and running a scan with the `ocp4-moderate` and `ocp4-moderate-node` xref:../../security/compliance_operator/co-scans/compliance-operator-supported-profiles.adoc#compliance-operator-supported-profiles[profiles]. The Compliance Operator uses OpenSCAP, a link:https://www.nist.gov/[NIST-certified tool], to scan and enforce security policies.
+endif::openshift-rosa,openshift-dedicated[]
+
+ifdef::openshift-rosa,openshift-dedicated[]
+You can check your {VirtProductName} cluster for compliance issues by installing the Compliance Operator and running a scan with the `ocp4-moderate` and `ocp4-moderate-node` profiles. The Compliance Operator uses OpenSCAP, a link:https://www.nist.gov/[NIST-certified tool], to scan and enforce security policies.
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/virt-supported-cluster-version.adoc[leveloffset=+2]
 
 include::modules/virt-about-storage-volumes-for-vm-disks.adoc[leveloffset=+1]
 
+// removing from OSD/ROSA, as SNO is not supported
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/virt-sno-differences.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-dedicated[]
 
 [role="_additional-resources"]
 [id="additional-resources_about-virt"]
 == Additional resources
 
 * xref:../../storage/index.adoc#openshift-storage-common-terms_storage-overview[Glossary of common terms for {product-title} storage]
+ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../../installing/installing_sno/install-sno-preparing-to-install-sno.adoc#install-sno-about-installing-on-a-single-node_install-sno-preparing[About {sno}]
+endif::openshift-rosa,openshift-dedicated[]
 * link:https://cloud.redhat.com/blog/using-the-openshift-assisted-installer-service-to-deploy-an-openshift-cluster-on-metal-and-vsphere[Assisted installer]
 * xref:../../nodes/pods/nodes-pods-priority.adoc#priority-preemption-other_nodes-pods-priority[Pod disruption budgets]
 * xref:../../virt/live_migration/virt-about-live-migration.adoc#virt-about-live-migration[About live migration]

--- a/virt/backup_restore/virt-backing-up-vms.adoc
+++ b/virt/backup_restore/virt-backing-up-vms.adoc
@@ -10,11 +10,27 @@ You back up virtual machines (VMs) by creating an OpenShift API for Data Protect
 
 The `Backup` CR performs the following actions:
 
+// Hiding MOG from ROSA/OSD as not supported
+ifndef::openshift-rosa,openshift-dedicated[]
 * Backs up {VirtProductName} resources by creating an archive file on S3-compatible object storage, such as xref:../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc#installing-oadp-mcg[Multicloud Object Gateway], Noobaa, or Minio.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* Backs up {VirtProductName} resources by creating an archive file on S3-compatible object storage, such as Noobaa or Minio.
+endif::openshift-rosa,openshift-dedicated[]
+
+// Hiding Backup/Restore link until 68901 is merged
+ifndef::openshift-rosa,openshift-dedicated[]
 * Backs up VM disks by using one of the following options:
 
 ** xref:../../virt/backup_restore/virt-backing-up-vms.adoc#oadp-backing-up-pvs-csi_virt-backing-up-vms[Container Storage Interface (CSI) snapshots] on CSI-enabled cloud storage, such as Ceph RBD or Ceph FS.
 ** xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#backing-up-applications[Backing up applications with File System Backup: Kopia or Restic] on object storage.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* Backs up VM disks by using one of the following options:
+
+** xref:../../virt/backup_restore/virt-backing-up-vms.adoc#oadp-backing-up-pvs-csi_virt-backing-up-vms[Container Storage Interface (CSI) snapshots] on CSI-enabled cloud storage, such as Ceph RBD or Ceph FS.
+** Backing up applications with File System Backup: Kopia or Restic on object storage.
+endif::openshift-rosa,openshift-dedicated[]
 
 [NOTE]
 ====
@@ -25,16 +41,25 @@ The `kubevirt-controller` creates the `virt-launcher` pods with annotations that
 The `freeze` and `unfreeze` APIs are subresources of the VM snapshot API. See xref:../../virt/backup_restore/virt-backup-restore-snapshots.adoc#virt-about-vm-snapshots_virt-backup-restore-snapshots[About virtual machine snapshots] for details.
 ====
 
+ifndef::openshift-rosa,openshift-dedicated[]
 You can add xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-hooks-doc.adoc#backing-up-applications[hooks] to the `Backup` CR to run commands on specific VMs before or after the backup operation.
 
 You schedule a backup by creating a xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-scheduling-backups-doc.adoc#backing-up-applications[`Schedule` CR] instead of a `Backup` CR.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+You can add hooks to the `Backup` CR to run commands on specific VMs before or after the backup operation.
+
+You schedule a backup by creating a `Schedule` CR instead of a `Backup` CR.
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/oadp-creating-backup-cr.adoc[leveloffset=+1]
 include::modules/oadp-backing-up-pvs-csi.adoc[leveloffset=+2]
 include::modules/oadp-backing-up-applications-restic.adoc[leveloffset=+2]
 include::modules/oadp-creating-backup-hooks.adoc[leveloffset=+2]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [id="additional-resources_virt-backing-up-vms"]
 == Additional resources
 
 * xref:../../storage/container_storage_interface/persistent-storage-csi-snapshots.adoc#persistent-storage-csi-snapshots-overview_persistent-storage-csi-snapshots[Overview of CSI volume snapshots]
+endif::openshift-rosa,openshift-dedicated[]

--- a/virt/backup_restore/virt-backup-restore-overview.adoc
+++ b/virt/backup_restore/virt-backup-restore-overview.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+//Hiding all links until PR 68901 merges
+ifndef::openshift-rosa,openshift-dedicated[]
 Back up and restore virtual machines by using the xref:../../backup_and_restore/index.adoc#application-backup-restore-operations-overview[OpenShift API for Data Protection (OADP)].
 
 .Prerequisites
@@ -26,3 +28,20 @@ Back up and restore virtual machines by using the xref:../../backup_and_restore/
 
 * xref:../../backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc#oadp-features-plugins[OADP features and plugins]
 * xref:../../backup_and_restore/application_backup_and_restore/troubleshooting.adoc#troubleshooting[Troubleshooting]
+endif::openshift-rosa,openshift-dedicated[]
+
+ifdef::openshift-rosa,openshift-dedicated[]
+Back up and restore virtual machines by using the OpenShift API for Data Protection (OADP).
+
+.Prerequisites
+
+* Access to the cluster as a user with the `cluster-admin` role.
+// Non-admin user [https://issues.redhat.com/browse/OADP-203] is targeted for OADP 1.2.
+
+.Procedure
+
+. Install the OADP Operator according to the instructions for your storage provider.
+. Install the Data Protection Application with the `kubevirt` and `openshift` plugins.
+. Back up virtual machines by creating a `Backup` custom resource (CR).
+. Restore the `Backup` CR by creating a `Restore` CR.
+endif::openshift-rosa,openshift-dedicated[]

--- a/virt/backup_restore/virt-backup-restore-snapshots.adoc
+++ b/virt/backup_restore/virt-backup-restore-snapshots.adoc
@@ -8,8 +8,14 @@ toc::[]
 
 You can back up and restore virtual machines (VMs) by using snapshots. Snapshots are supported by the following storage providers:
 
+// Hiding in ROSA/OSD as not supported
+ifndef::openshift-rosa,openshift-dedicated[]
 * {rh-storage-first}
 * Any other cloud storage provider with the Container Storage Interface (CSI) driver that supports the Kubernetes Volume Snapshot API
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* Any cloud storage provider with the Container Storage Interface (CSI) driver that supports the Kubernetes Volume Snapshot API
+endif::openshift-rosa,openshift-dedicated[]
 
 Online snapshots have a default time deadline of five minutes (`5m`) that can be changed, if needed.
 
@@ -53,7 +59,10 @@ include::modules/virt-deleting-vm-snapshot-web.adoc[leveloffset=+2]
 
 include::modules/virt-deleting-vm-snapshot-cli.adoc[leveloffset=+2]
 
+// Hiding in ROSA/OSD as not supported
+ifndef::openshift-rosa,openshift-dedicated[]
 [role="_additional-resources-snapshots"]
 == Additional resources
 
 * xref:../../storage/container_storage_interface/persistent-storage-csi-snapshots.adoc#persistent-storage-csi-snapshots[CSI Volume Snapshots]
+endif::openshift-rosa,openshift-dedicated[]

--- a/virt/getting_started/virt-getting-started.adoc
+++ b/virt/getting_started/virt-getting-started.adoc
@@ -18,7 +18,10 @@ Cluster configuration procedures require `cluster-admin` privileges.
 
 Plan and install {VirtProductName} on an {product-title} cluster:
 
+// Hiding in ROSA/OSD, not supported
+ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../../installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc#virt-planning-bare-metal-cluster-for-ocp-virt_preparing-to-install-on-bare-metal[Plan your bare metal cluster for {VirtProductName}].
+endif::openshift-rosa,openshift-dedicated[]
 * xref:../../virt/install/preparing-cluster-for-virt.adoc#preparing-cluster-for-virt[Prepare your cluster for {VirtProductName}].
 * xref:../../virt/install/installing-virt.adoc#virt-installing-virt-operator_installing-virt[Install the {VirtProductName} Operator].
 * xref:../../virt/getting_started/virt-using-the-cli-tools.adoc#installing-virtctl_virt-using-the-cli-tools[Install the `virtctl` command line interface (CLI) tool].
@@ -31,7 +34,10 @@ Plan and install {VirtProductName} on an {product-title} cluster:
 * xref:../../virt/install/preparing-cluster-for-virt.adoc#virt-about-storage-volumes-for-vm-disks_preparing-cluster-for-virt[About storage volumes for virtual machine disks].
 * xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[Using a CSI-enabled storage provider].
 * xref:../../virt/storage/virt-configuring-local-storage-with-hpp.adoc#virt-configuring-local-storage-with-hpp[Configuring local storage for virtual machines].
+// Hiding in ROSA/OSD, as feature is TP
+ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#installing-the-kubernetes-nmstate-operator-cli[Installing the Kubernetes NMState Operator].
+endif::openshift-rosa,openshift-dedicated[]
 * xref:../../virt/virtual_machines/advanced_vm_management/virt-specifying-nodes-for-vms.adoc#virt-specifying-nodes-for-vms[Specifying nodes for virtual machines].
 * xref:../../virt/getting_started/virt-using-the-cli-tools.adoc#virt-virtctl-commands_virt-using-the-cli-tools[`Virtctl` commands].
 
@@ -41,11 +47,17 @@ Plan and install {VirtProductName} on an {product-title} cluster:
 Create a virtual machine (VM):
 
 * xref:../../virt/virtual_machines/creating_vms_rh/virt-creating-vms-from-rh-images-overview.adoc#virt-creating-vms-from-rh-images-overview[Create a VM from a Red Hat image].
+ifndef::openshift-rosa,openshift-dedicated[]
 +
 You can create a VM by using a Red Hat template or an instance type.
 +
 :FeatureName: Creating a VM from an instance type
 include::snippets/technology-preview.adoc[]
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
++
+You can create a VM by using a Red Hat template.
+endif::openshift-rosa,openshift-dedicated[]
 
 * xref:../../virt/virtual_machines/creating_vms_custom/virt-creating-vms-from-custom-images-overview.adoc#virt-creating-vms-from-custom-images-overview[Create a VM from a custom image].
 +
@@ -53,6 +65,8 @@ You can create a VM by importing a custom image from a container registry or a w
 
 Connect a VM to a secondary network:
 
+// Linux bridge and SR-IOV not supported in ROSA/OSD
+ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-connecting-vm-to-linux-bridge[Linux bridge network].
 * xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#virt-connecting-vm-to-ovn-secondary-network[Open Virtual Network (OVN)-Kubernetes secondary network].
 * xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#virt-connecting-vm-to-sriov[Single Root I/O Virtualization (SR-IOV) network].
@@ -61,6 +75,15 @@ Connect a VM to a secondary network:
 ====
 VMs are connected to the pod network by default.
 ====
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#virt-connecting-vm-to-ovn-secondary-network[Open Virtual Network (OVN)-Kubernetes secondary network].
++
+[NOTE]
+====
+VMs are connected to the pod network by default.
+====
+endif::openshift-rosa,openshift-dedicated[]
 
 Connect to a VM:
 

--- a/virt/getting_started/virt-web-console-overview.adoc
+++ b/virt/getting_started/virt-web-console-overview.adoc
@@ -128,7 +128,12 @@ The *Overview* tab displays resources, usage, alerts, and status.
 |*Getting started resources* card
 |* *Quick Starts* tile: Learn how to create, import, and run virtual machines with step-by-step instructions and tasks.
 * *Feature highlights* tile: Read the latest information about key virtualization features.
+ifndef::openshift-rosa,openshift-dedicated[]
 * *Related operators* tile: Install Operators such as the Kubernetes NMState Operator or the {rh-storage} Operator.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* *Related operators* tile: Install Operators such as the Kubernetes NMState Operator.
+endif::openshift-rosa,openshift-dedicated[]
 
 |*Memory* tile
 |Memory usage, with a chart showing the last 1 day's trend.

--- a/virt/install/installing-virt.adoc
+++ b/virt/install/installing-virt.adoc
@@ -8,12 +8,14 @@ toc::[]
 
 Install {VirtProductName} to add virtualization functionality to your {product-title} cluster.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [IMPORTANT]
 ====
 If you install {VirtProductName} in a restricted environment with no internet connectivity, you must xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[configure Operator Lifecycle Manager (OLM) for restricted networks].
 
 If you have limited internet connectivity, you can xref:../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[configure proxy support in OLM] to access the OperatorHub.
 ====
+endif::openshift-rosa,openshift-dedicated[]
 
 [id="installing-virt-operator_installing-virt"]
 == Installing the {VirtProductName} Operator
@@ -21,6 +23,20 @@ If you have limited internet connectivity, you can xref:../../operators/admin/ol
 Install the {VirtProductName} Operator by using the {product-title} web console or the command line.
 
 include::modules/virt-installing-virt-operator.adoc[leveloffset=+2]
+
+ifdef::openshift-rosa[]
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html#creating_a_machine_pool_rosa-managing-worker-nodes[Creating a machine pool]
+endif::openshift-rosa[]
+
+ifdef::openshift-dedicated[]
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../osd_cluster_admin/osd_nodes/osd-managing-worker-nodes.html#creating_machine_pools_ocm_osd-managing-worker-nodes[Creating a machine pool]
+endif::openshift-dedicated[]
 
 [id="installing-virt-operator-cli_installing-virt"]
 === Installing the {VirtProductName} Operator by using the command line
@@ -35,6 +51,20 @@ You can xref:../../virt/virtual_machines/advanced_vm_management/virt-configuring
 ====
 
 include::modules/virt-deploying-operator-cli.adoc[leveloffset=+3]
+
+ifdef::openshift-rosa[]
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html#creating_a_machine_pool_rosa-managing-worker-nodes[Creating a machine pool]
+endif::openshift-rosa[]
+
+ifdef::openshift-dedicated[]
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../osd_cluster_admin/osd_nodes/osd-managing-worker-nodes.html#creating_machine_pools_ocm_osd-managing-worker-nodes[Creating a machine pool]
+endif::openshift-dedicated[]
 
 [id="installing-virt-web-next-steps"]
 == Next steps

--- a/virt/install/preparing-cluster-for-virt.adoc
+++ b/virt/install/preparing-cluster-for-virt.adoc
@@ -9,6 +9,8 @@ toc::[]
 
 Review this section before you install {VirtProductName} to ensure that your cluster meets the requirements.
 
+// Hiding in ROSA/OSD as not supported
+ifndef::openshift-rosa,openshift-dedicated[]
 [IMPORTANT]
 ====
 Installation method considerations::
@@ -20,16 +22,22 @@ If you deploy {VirtProductName} with {rh-storage-first}, you must create a dedic
 IPv6::
 You cannot run {VirtProductName} on a single-stack IPv6 cluster.
 ====
+endif::openshift-rosa,openshift-dedicated[]
 
+// Hiding in ROSA/OSD as FIPS not supported
+ifndef::openshift-rosa,openshift-dedicated[]
 .FIPS mode
 
 If you install your cluster in xref:../../installing/installing-fips.adoc#installing-fips-mode_installing-fips[FIPS mode], no additional setup is required for {VirtProductName}.
+endif::openshift-rosa,openshift-dedicated[]
 
 [id="supported-platforms_preparing-cluster-for-virt"]
 == Supported platforms
 
 You can use the following platforms with {VirtProductName}:
 
+// Hiding in ROSA/OSD, as bare metal not supported
+ifndef::openshift-rosa,openshift-dedicated[]
 * On-premise bare metal servers. See xref:../../installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc#virt-planning-bare-metal-cluster-for-ocp-virt_preparing-to-install-on-bare-metal[Planning a bare metal cluster for {VirtProductName}].
 
 * Amazon Web Services bare metal instances. See xref:../../installing/installing_aws/installing-aws-customizations.html#installing-aws-customizations[Installing a cluster on AWS with customizations].
@@ -44,8 +52,16 @@ include::snippets/technology-preview.adoc[]
 :!FeatureName:
 endif::[]
 --
+endif::openshift-rosa,openshift-dedicated[]
 
+ifdef::openshift-rosa,openshift-dedicated[]
+* Amazon Web Services bare metal instances.
+endif::openshift-rosa,openshift-dedicated[]
+
+// Hiding in ROSA/OSD, as bare metal not supported
+ifndef::openshift-rosa,openshift-dedicated[]
 Bare metal instances or servers offered by other cloud providers are not supported.
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/virt-aws-bm.adoc[leveloffset=+2]
 
@@ -83,6 +99,7 @@ See xref:../../nodes/scheduling/nodes-scheduler-node-affinity.adoc#nodes-schedul
 === Operating system requirements
 
 * {op-system-first} installed on worker nodes.
+ifndef::openshift-rosa,openshift-dedicated[]
 +
 See xref:../../architecture/architecture-rhcos.adoc#rhcos-about_architecture-rhcos[About RHCOS] for details.
 +
@@ -90,18 +107,26 @@ See xref:../../architecture/architecture-rhcos.adoc#rhcos-about_architecture-rhc
 ====
 {op-system-base} worker nodes are not supported.
 ====
+endif::openshift-rosa,openshift-dedicated[]
 
 [id="storage-requirements_preparing-cluster-for-virt"]
 === Storage requirements
 
+// Hiding link until PR 65079 merges
+ifndef::openshift-rosa,openshift-dedicated[]
 * Supported by {product-title}. See xref:../../scalability_and_performance/optimization/optimizing-storage.adoc#_optimizing-storage[Optimizing storage].
-
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* Supported by {product-title}.
+endif::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-dedicated[]
 * You must create a default {VirtProductName} or {product-title} storage class. The purpose of this is to address the unique storage needs of VM workloads and offer optimized performance, reliability, and user experience. If both {VirtProductName} and {product-title} default storage classes exist, the {VirtProductName} class takes precedence when creating VM disks.
-+
+
 [NOTE]
 ====
 To mark a storage class as the default for virtualization workloads, set the annotation `storageclass.kubevirt.io/is-default-virt-class` to `"true"`.
 ====
+endif::openshift-rosa,openshift-dedicated[]
 
 * If the storage provisioner supports snapshots, you must associate a `VolumeSnapshotClass` object with the default storage class.
 
@@ -129,13 +154,17 @@ The default xref:../../virt/live_migration/virt-configuring-live-migration#virt-
 
 include::modules/virt-cluster-resource-requirements.adoc[leveloffset=+1]
 
+// Hiding in ROSA/OSD as not supported
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/virt-sno-differences.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-dedicated[]
 
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../storage/index.adoc#openshift-storage-common-terms_storage-overview[Glossary of common terms for {product-title} storage]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [id="object-maximums_preparing-cluster-for-virt"]
 == Object maximums
 
@@ -165,3 +194,4 @@ In {product-title} clusters installed using installer-provisioned infrastructure
 ====
 Without an external monitoring system or a qualified human monitoring node health, virtual machines lose high availability.
 ====
+endif::openshift-rosa,openshift-dedicated[]

--- a/virt/monitoring/virt-exposing-custom-metrics-for-vms.adoc
+++ b/virt/monitoring/virt-exposing-custom-metrics-for-vms.adoc
@@ -20,6 +20,8 @@ include::modules/virt-accessing-node-exporter-outside-cluster.adoc[leveloffset=+
 [role="_additional-resources"]
 [id="additional-resources_virt-exposing-custom-metrics-for-vms"]
 == Additional resources
+// Hiding in ROSA/OSD as not supported
+ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../../monitoring/configuring-the-monitoring-stack.adoc#configuring-the-monitoring-stack[Configuring the monitoring stack]
 
 * xref:../../monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
@@ -29,6 +31,7 @@ include::modules/virt-accessing-node-exporter-outside-cluster.adoc[leveloffset=+
 * xref:../../monitoring/reviewing-monitoring-dashboards.adoc#reviewing-monitoring-dashboards[Reviewing monitoring dashboards]
 
 * xref:../../applications/application-health.adoc#application-health[Monitoring application health by using health checks]
+endif::openshift-rosa,openshift-dedicated[]
 
 * xref:../../nodes/pods/nodes-pods-configmaps.adoc#nodes-pods-configmaps[Creating and using config maps]
 

--- a/virt/monitoring/virt-monitoring-overview.adoc
+++ b/virt/monitoring/virt-monitoring-overview.adoc
@@ -11,10 +11,12 @@ You can monitor the health of your cluster and virtual machines (VMs) with the f
 Monitoring OpenShift Virtualization VMs health status::
 View the overall health of your OpenShift Virtualization environment in the web console by navigating to the *Home* -> *Overview* page in the {product-title} web console. The *Status* card displays the overall health of OpenShift Virtualization based on the alerts and conditions.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 xref:../../virt/monitoring/virt-running-cluster-checkups.adoc#virt-running-cluster-checkups[{product-title} cluster checkup framework]::
 Run automated tests on your cluster with the {product-title} cluster checkup framework to check the following conditions:
 * Network connectivity and latency between two VMs attached to a secondary network interface
 * VM running a Data Plane Development Kit (DPDK) workload with zero packet loss
+endif::openshift-rosa,openshift-dedicated[]
 
 //:FeatureName: The {product-title} cluster checkup framework
 //include::snippets/technology-preview.adoc[]

--- a/virt/monitoring/virt-monitoring-vm-health.adoc
+++ b/virt/monitoring/virt-monitoring-vm-health.adoc
@@ -45,10 +45,16 @@ include::modules/virt-defining-watchdog-device-vm.adoc[leveloffset=+2]
 
 include::modules/virt-installing-watchdog-agent.adoc[leveloffset=+2]
 
+// Hiding in ROSA/OSD as TP not supported
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/virt-define-guest-agent-ping-probe.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-dedicated[]
 
+// Hiding in ROSA/OSD as not supported
+ifndef::openshift-rosa,openshift-dedicated[]
 [id="additional-resources_monitoring-vm-health"]
 [role="_additional-resources"]
 == Additional resources
 
 * xref:../../applications/application-health.adoc#application-health[Monitoring application health by using health checks]
+endif::openshift-rosa,openshift-dedicated[]

--- a/virt/monitoring/virt-prometheus-queries.adoc
+++ b/virt/monitoring/virt-prometheus-queries.adoc
@@ -7,14 +7,21 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 {VirtProductName} provides metrics that you can use to monitor the consumption of cluster infrastructure resources, including vCPU, network, storage, and guest memory swapping. You can also use metrics to query live migration status.
-
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
 Use the {product-title} monitoring dashboard to query virtualization metrics.
+{VirtProductName} provides metrics that you can use to monitor the consumption of cluster infrastructure resources, including network, storage, and guest memory swapping. You can also use metrics to query live migration status.
+endif::openshift-rosa,openshift-dedicated[]
 
 [id="prerequisites_{context}"]
 == Prerequisites
 
+// Hiding in ROSA/OSD as user cannot edit MCO
+ifndef::openshift-rosa,openshift-dedicated[]
 * To use the vCPU metric, the `schedstats=enable` kernel argument must be applied to the `MachineConfig` object. This kernel argument enables scheduler statistics used for debugging and performance tuning and adds a minor additional load to the scheduler. For more information, see xref:../../post_installation_configuration/machine-configuration-tasks.adoc#nodes-nodes-kernel-arguments_post-install-machine-configuration-tasks[Adding kernel arguments to nodes].
+endif::openshift-rosa,openshift-dedicated[]
 
 * For guest memory swapping queries to return data, memory swapping must be enabled on the virtual guests.
 

--- a/virt/monitoring/virt-running-cluster-checkups.adoc
+++ b/virt/monitoring/virt-running-cluster-checkups.adoc
@@ -26,11 +26,20 @@ include::modules/virt-dpdk-config-map-parameters.adoc[leveloffset=+3]
 
 include::modules/virt-building-vm-containerdisk-image.adoc[leveloffset=+3]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [role="_additional-resources"]
 [id="additional-resources_running-cluster-checkups"]
 == Additional resources
+endif::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-connecting-vm-to-linux-bridge[Attaching a virtual machine to multiple networks]
+endif::openshift-rosa,openshift-dedicated[]
+// Hiding pending resolution of	OSDOCS-3691
+ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../../networking/hardware_networks/using-dpdk-and-rdma.adoc#example-vf-use-in-dpdk-mode-intel_using-dpdk-and-rdma[Using a virtual function in DPDK mode with an Intel NIC]
 * xref:../../networking/hardware_networks/using-dpdk-and-rdma.adoc#nw-example-dpdk-line-rate_using-dpdk-and-rdma[Using SR-IOV and the Node Tuning Operator to achieve a DPDK line rate]
+endif::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-dedicated[]
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/composing_a_customized_rhel_system_image/installing-composer_composing-a-customized-rhel-system-image[Installing image builder]
 * link:https://access.redhat.com/solutions/253273[How to register and subscribe a RHEL system to the Red Hat Customer Portal using Red Hat Subscription Manager]
+endif::openshift-rosa,openshift-dedicated[]

--- a/virt/nodes/virt-node-maintenance.adoc
+++ b/virt/nodes/virt-node-maintenance.adoc
@@ -47,6 +47,8 @@ The default eviction strategy is `LiveMigrate`. A non-migratable VM with a `Live
 You must set the eviction strategy of non-migratable VMs to `LiveMigrateIfPossible`, which does not block an upgrade, or to `None`, for VMs that should not be migrated.
 ====
 
+// Hiding in ROSA/OSD as TP not supported
+ifndef::openshift-rosa,openshift-dedicated[]
 Cluster eviction strategy::
 
 You can configure an eviction strategy for the cluster to prioritize workload continuity or infrastructure upgrade.
@@ -71,10 +73,14 @@ include::snippets/technology-preview.adoc[]
 2. If a VM blocks an upgrade, you must shut down the VM manually.
 3. Default eviction strategy for {sno}.
 --
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/virt-configuring-vm-eviction-strategy-cli.adoc[leveloffset=+2]
 
+// Hiding in ROSA/OSD as Tech Preview features are not suppotred
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/virt-configuring-cluster-eviction-strategy-cli.adoc[leveloffset=+2]
+endif::openshift-rosa,openshift-dedicated[]
 
 [id="run-strategies"]
 == Run strategies

--- a/virt/post_installation_configuration/virt-post-install-config.adoc
+++ b/virt/post_installation_configuration/virt-post-install-config.adoc
@@ -14,12 +14,16 @@ The following procedures are typically performed after {VirtProductName} is inst
 
 * xref:../../virt/post_installation_configuration/virt-post-install-network-config.adoc#virt-post-install-network-config[Network configuration]:
 
+ifndef::openshift-rosa,openshift-dedicated[]
 ** Installing the Kubernetes NMState and SR-IOV Operators
 ** Configuring a Linux bridge network for external access to virtual machines (VMs)
 ** Configuring a dedicated secondary network for live migration
 ** Configuring an SR-IOV network
-
 ** Enabling the creation of load balancer services by using the {product-title} web console
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+** Enabling the creation of load balancer services by using the {product-title} web console
+endif::openshift-rosa,openshift-dedicated[]
 
 * xref:../../virt/post_installation_configuration/virt-post-install-storage-config.adoc#virt-post-install-storage-config[Storage configuration]:
 ** Defining a default storage class for the Container Storage Interface (CSI)

--- a/virt/post_installation_configuration/virt-post-install-network-config.adoc
+++ b/virt/post_installation_configuration/virt-post-install-network-config.adoc
@@ -8,19 +8,34 @@ toc::[]
 
 By default, {VirtProductName} is installed with a single, internal pod network.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 After you install {VirtProductName}, you can install networking Operators and configure additional networks.
+endif::openshift-rosa,openshift-dedicated[]
 
 [id="installing-operators"]
 == Installing networking Operators
 
+ifndef::openshift-rosa,openshift-dedicated[]
 You must install the xref:../../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#k8s-nmstate-about-the-k8s-nmstate-operator[Kubernetes NMState Operator] to configure a Linux bridge network for live migration or external access to virtual machines (VMs).
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+// hide link until Networking docs are ported: xref:  ../../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#k8s-nmstate-about-the-k8s-nmstate-operator
+You must install the Kubernetes NMState Operator for live migration or external access to virtual machines (VMs).
+endif::openshift-rosa,openshift-dedicated[]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 You can install the xref:../../networking/hardware_networks/about-sriov.adoc#about-sriov[SR-IOV Operator] to manage SR-IOV network devices and network attachments.
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/k8s-nmstate-installing-the-kubernetes-nmstate-operator.adoc[leveloffset=+2]
 
+// Hiding in ROSA/OSD as dedicated-admin user cannot create the required namespace
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/nw-sriov-installing-operator.adoc[leveloffset=+2]
+endif::openshift-rosa,openshift-dedicated[]
 
+// Hiding in ROSA/OSD as dedicated-admin user cannot create the required "nodenetworkconfigurationpolicies" resource
+ifndef::openshift-rosa,openshift-dedicated[]
 [id="configuring-linux-bridge-network"]
 == Configuring a Linux bridge network
 
@@ -42,7 +57,10 @@ After you have configured a Linux bridge network, you can configure a dedicated 
 include::modules/virt-configuring-secondary-network-vm-live-migration.adoc[leveloffset=+2]
 
 include::modules/virt-selecting-migration-network-ui.adoc[leveloffset=+2]
+endif::openshift-rosa,openshift-dedicated[]
 
+// Hiding in ROSA/OSD as dedicated-admin user cannot create the required namespace
+ifndef::openshift-rosa,openshift-dedicated[]
 [id="configuring-sriov-network"]
 == Configuring an SR-IOV network
 
@@ -55,5 +73,7 @@ include::modules/nw-sriov-network-attachment.adoc[leveloffset=+2]
 [id="next-steps_configuring-sriov-network"]
 === Next steps
 * xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#virt-attaching-vm-to-sriov-network_virt-connecting-vm-to-sriov[Attaching a virtual machine (VM) to an SR-IOV network]
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/virt-enabling-load-balancer-service-web.adoc[leveloffset=+1]
+

--- a/virt/post_installation_configuration/virt-post-install-storage-config.adoc
+++ b/virt/post_installation_configuration/virt-post-install-storage-config.adoc
@@ -8,7 +8,9 @@ toc::[]
 
 The following storage configuration tasks are mandatory:
 
+ifndef::openshift-rosa,openshift-dedicated[]
 * You must configure a xref:../../post_installation_configuration/storage-configuration.adoc#defining-storage-classes_post-install-storage-configuration[default storage class] for your cluster. Otherwise, the cluster cannot receive automated boot source updates.
+endif::openshift-rosa,openshift-dedicated[]
 * You must configure xref:../../virt/storage/virt-configuring-storage-profile.adoc#virt-configuring-storage-profile[storage profiles] if your storage provider is not recognized by CDI. A storage profile provides recommended storage settings based on the associated storage class.
 
 Optional: You can configure local storage by using the hostpath provisioner (HPP).

--- a/virt/storage/virt-automatic-bootsource-updates.adoc
+++ b/virt/storage/virt-automatic-bootsource-updates.adoc
@@ -28,10 +28,18 @@ include::modules/virt-managing-auto-update-all-system-boot-sources.adoc[leveloff
 
 _Custom_ boot sources that are not provided by {VirtProductName} are not controlled by the feature gate. You must manage them individually by editing the `HyperConverged` custom resource (CR).
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [IMPORTANT]
 ====
-You must configure a storage class. Otherwise, the cluster cannot receive automated updates for custom boot sources. See xref:../../post_installation_configuration/storage-configuration.adoc#defining-storage-classes_post-install-storage-configuration[Defining a storage class] for details.
+You must configure a storage class. Otherwise, the cluster cannot receive automated updates for custom boot sources. See xref:../../post_installation_configuration/storage-configuration.adoc#defining-storage-classes_post-install-storage-configuration[Defining a storage class] for details. 
 ====
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[IMPORTANT]
+====
+You must configure a storage profile. Otherwise, the cluster cannot receive automated updates for custom boot sources. See xref:../../virt/storage/virt-configuring-storage-profile.adoc#virt-configuring-storage-profile[Configure storage profiles] for details. 
+====
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/virt-configuring-storage-class-bootsource-update.adoc[leveloffset=+2]
 

--- a/virt/storage/virt-configuring-storage-profile.adoc
+++ b/virt/storage/virt-configuring-storage-profile.adoc
@@ -12,14 +12,13 @@ If the Containerized Data Importer (CDI) does not recognize your storage provide
 
 For recognized storage types, CDI provides values that optimize the creation of PVCs.  However, you can configure automatic settings for a storage class if you customize the storage profile.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [IMPORTANT]
 ====
 When using {VirtProductName} with {rh-storage-first}, specify RBD block mode persistent volume claims (PVCs) when creating virtual machine disks. RBD block mode volumes are more efficient and provide better performance than Ceph FS or RBD filesystem-mode PVCs.
 
 To specify RBD block mode PVCs, use the 'ocs-storagecluster-ceph-rbd' storage class and `VolumeMode: Block`.
 ====
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/virt-customizing-storage-profile.adoc[leveloffset=+1]
-
-
-

--- a/virt/storage/virt-storage-config-overview.adoc
+++ b/virt/storage/virt-storage-config-overview.adoc
@@ -13,9 +13,11 @@ You can configure a default storage class, storage profiles, Containerized Data 
 
 The following storage configuration tasks are mandatory:
 
+ifndef::openshift-rosa,openshift-dedicated[]
 xref:../../post_installation_configuration/storage-configuration.adoc#defining-storage-classes_post-install-storage-configuration[Configure a default storage class]::
 
 You must configure a default storage class for your cluster. Otherwise, the cluster cannot receive automated boot source updates.
+endif::openshift-rosa,openshift-dedicated[]
 
 xref:../../virt/storage/virt-configuring-storage-profile.adoc#virt-configuring-storage-profile[Configure storage profiles]::
 

--- a/virt/support/virt-collecting-virt-data.adoc
+++ b/virt/support/virt-collecting-virt-data.adoc
@@ -8,8 +8,11 @@ toc::[]
 
 When you submit a xref:../../support/getting-support.adoc#support-submitting-a-case_getting-support[support case] to Red Hat Support, it is helpful to provide debugging information for {product-title} and {VirtProductName} by using the following tools:
 
+// must-gather not supported for ROSA/OSD, per Dustin Row
+ifndef::openshift-rosa,openshift-dedicated[]
 must-gather tool::
 The `must-gather` tool collects diagnostic information, including resource definitions and service logs.
+endif::openshift-rosa,openshift-dedicated[]
 
 Prometheus::
 Prometheus is a time-series database and a rule evaluation engine for metrics. Prometheus sends alerts to Alertmanager for processing.
@@ -33,10 +36,16 @@ Collecting data about your environment minimizes the time required to analyze an
 
 .Procedure
 
+// must-gather not supported for ROSA/OSD, per Dustin Row
+ifndef::openshift-rosa,openshift-dedicated[]
 . xref:../../support/gathering-cluster-data.adoc#support_gathering_data_gathering-cluster-data[Collect must-gather data for the cluster].
 . link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.15/html-single/troubleshooting_openshift_data_foundation/index#downloading-log-files-and-diagnostic-information_rhodf[Collect must-gather data for {rh-storage-first}], if necessary.
 . xref:../../virt/support/virt-collecting-virt-data.adoc#virt-using-virt-must-gather_virt-collecting-virt-data[Collect must-gather data for {VirtProductName}].
 . xref:../../monitoring/managing-metrics.adoc#querying-metrics-for-all-projects-as-an-administrator_managing-metrics[Collect Prometheus metrics for the cluster].
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* xref:../../monitoring/managing-metrics.adoc#querying-metrics-for-all-projects-as-an-administrator_managing-metrics[Collect Prometheus metrics for the cluster].
+endif::openshift-rosa,openshift-dedicated[]
 
 [id="virt-collecting-data-about-vms_{context}"]
 == Collecting data about virtual machines
@@ -54,11 +63,17 @@ Collecting data about malfunctioning virtual machines (VMs) minimizes the time r
 
 .Procedure
 
+// must-gather not supported for ROSA/OSD, per Dustin Row
+ifndef::openshift-rosa,openshift-dedicated[]
 . xref:../../virt/support/virt-collecting-virt-data.adoc#virt-must-gather-options_virt-collecting-virt-data[Collect must-gather data for the VMs] using the `/usr/bin/gather` script.
+endif::openshift-rosa,openshift-dedicated[]
 . Collect screenshots of VMs that have crashed _before_ you restart them.
 . xref:../../virt/getting_started/virt-using-the-cli-tools.adoc#vm-memory-dump-commands_virt-using-the-cli-tools[Collect memory dumps from VMs] _before_ remediation attempts.
 . Record factors that the malfunctioning VMs have in common. For example, the VMs have the same host or network.
 
+// must-gather not supported for ROSA/OSD, per Dustin Row
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/virt-using-virt-must-gather.adoc[leveloffset=+1]
 
 include::modules/virt-must-gather-options.adoc[leveloffset=+2]
+endif::openshift-rosa,openshift-dedicated[]

--- a/virt/support/virt-support-overview.adoc
+++ b/virt/support/virt-support-overview.adoc
@@ -51,8 +51,11 @@ Configure Prometheus and Alertmanager and collect `must-gather` data for {produc
 xref:../../virt/support/virt-collecting-virt-data.adoc#virt-collecting-data-about-vms_virt-collecting-virt-data[Collecting data about VMs]::
 Collect `must-gather` data and memory dumps from VMs.
 
+// must-gather not supported for ROSA/OSD, per Dustin Row
+ifndef::openshift-rosa,openshift-dedicated[]
 xref:../../virt/support/virt-collecting-virt-data.adoc#virt-using-virt-must-gather_virt-collecting-virt-data[`must-gather` tool for {VirtProductName}]::
 Configure and use the `must-gather` tool.
+endif::openshift-rosa,openshift-dedicated[]
 
 [id="troubleshooting_{context}"]
 == Troubleshooting

--- a/virt/updating/upgrading-virt.adoc
+++ b/virt/updating/upgrading-virt.adoc
@@ -14,13 +14,13 @@ include::modules/virt-about-upgrading-virt.adoc[leveloffset=+1]
 
 include::modules/virt-about-workload-updates.adoc[leveloffset=+2]
 
-ifndef::openshift-origin[]
+ifndef::openshift-rosa,openshift-dedicated,openshift-origin[]
 include::modules/virt-about-eus-updates.adoc[leveloffset=+2]
 
 Learn more about xref:../../updating/updating_a_cluster/eus-eus-update.adoc#eus-eus-update[performing an EUS-to-EUS update].
 
 include::modules/virt-preventing-workload-updates-during-eus-update.adoc[leveloffset=+1]
-endif::openshift-origin[]
+endif::openshift-rosa,openshift-dedicated,openshift-origin[]
 
 include::modules/virt-configuring-workload-update-methods.adoc[leveloffset=+1]
 
@@ -44,9 +44,9 @@ Configure workload updates to ensure that VMIs update automatically.
 [id="additional-resources_upgrading-virt"]
 [role="_additional-resources"]
 == Additional resources
-ifndef::openshift-origin[]
+ifndef::openshift-rosa,openshift-dedicated,openshift-origin[]
 * xref:../../updating/updating_a_cluster/eus-eus-update.adoc#eus-eus-update[Performing an EUS-to-EUS update]
-endif::openshift-origin[]
+endif::openshift-rosa,openshift-dedicated,openshift-origin[]
 * xref:../../operators/understanding/olm-what-operators-are.adoc#olm-what-operators-are[What are Operators?]
 * xref:../../operators/understanding/olm/olm-understanding-olm.adoc#olm-understanding-olm[Operator Lifecycle Manager concepts and resources]
 * xref:../../operators/understanding/olm/olm-understanding-olm.adoc#olm-csv_olm-understanding-olm[Cluster service versions (CSVs)]

--- a/virt/virtual_machines/advanced_vm_management/virt-configuring-pxe-booting.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-configuring-pxe-booting.adoc
@@ -12,11 +12,13 @@ operating system or other program without requiring a locally attached
 storage device. For example, you can use it to choose your desired OS
 image from a PXE server when deploying a new host.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 == Prerequisites
 
 * A Linux bridge must be xref:../../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-connecting-vm-to-linux-bridge[connected].
 
 * The PXE server must be connected to the same VLAN as the bridge.
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/virt-pxe-booting-with-mac-address.adoc[leveloffset=+1]
 

--- a/virt/virtual_machines/advanced_vm_management/virt-high-availability-for-vms.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-high-availability-for-vms.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+// Hiding manual delete item as not supported
+ifndef::openshift-rosa,openshift-dedicated[]
 You can enable high availability for virtual machines (VMs) by manually deleting a failed node to trigger VM failover or by configuring remediating nodes.
 
 .Manually deleting a failed node
@@ -15,6 +17,10 @@ If a node fails and machine health checks are not deployed on your cluster, virt
 See xref:../../../virt/nodes/virt-triggering-vm-failover-resolving-failed-node.adoc#virt-triggering-vm-failover-resolving-failed-node[Deleting a failed node to trigger virtual machine failover].
 
 .Configuring remediating nodes
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+You can enable high availability for virtual machines (VMs) by configuring remediating nodes.
+endif::openshift-rosa,openshift-dedicated[]
 
 You can configure remediating nodes by installing the Self Node Remediation Operator from the OperatorHub and enabling machine health checks or node remediation checks.
 

--- a/virt/virtual_machines/advanced_vm_management/virt-schedule-vms.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-schedule-vms.adoc
@@ -18,6 +18,9 @@ include::modules/virt-schedule-cpu-host-model-vms.adoc[leveloffset=+1]
 
 include::modules/virt-vm-custom-scheduler.adoc[leveloffset=+1]
 
+// Hiding in ROSA/OSD, not supported
+ifndef::openshift-rosa,openshift-dedicated[]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../../nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.adoc#nodes-secondary-scheduler-configuring-console_secondary-scheduler-configuring[Deploying a secondary scheduler]
+endif::openshift-rosa,openshift-dedicated[]

--- a/virt/virtual_machines/creating_vms_custom/virt-creating-vms-from-container-disks.adoc
+++ b/virt/virtual_machines/creating_vms_custom/virt-creating-vms-from-container-disks.adoc
@@ -10,6 +10,8 @@ You can create virtual machines (VMs) by using container disks built from operat
 
 You can enable auto updates for your container disks. See xref:../../../virt/storage/virt-automatic-bootsource-updates.adoc#virt-automatic-bootsource-updates[Managing automatic boot source updates] for details.
 
+// Hiding links in ROSA/OSD
+ifndef::openshift-rosa,openshift-dedicated[]
 [IMPORTANT]
 ====
 If the container disks are large, the I/O traffic might increase and cause worker nodes to be unavailable. You can perform the following tasks to resolve this issue:
@@ -17,6 +19,13 @@ If the container disks are large, the I/O traffic might increase and cause worke
 * xref:../../../applications/pruning-objects.adoc#pruning-deployments_pruning-objects[Pruning `DeploymentConfig` objects].
 * xref:../../../nodes/nodes/nodes-nodes-garbage-collection.adoc#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring[Configuring garbage collection].
 ====
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[IMPORTANT]
+====
+If the container disks are large, the I/O traffic might increase and cause worker nodes to be unavailable. You can prune `DeploymentConfig` objects to resolve this issue:
+====
+endif::openshift-rosa,openshift-dedicated[]
 
 You create a VM from a container disk by performing the following steps:
 

--- a/virt/virtual_machines/creating_vms_rh/virt-creating-vms-from-instance-types.adoc
+++ b/virt/virtual_machines/creating_vms_rh/virt-creating-vms-from-instance-types.adoc
@@ -8,6 +8,13 @@ toc::[]
 
 You can create virtual machines (VMs) from instance types by using the {product-title} web console.
 
+ifdef::openshift-rosa,openshift-dedicated[]
+[NOTE]
+====
+Creating a VM from an instance type in {VirtProductName} 4.15 and higher is supported for use on {product-title} clusters. In {VirtProductName} 4.14, Creating a VM from an instance type is a Technology Preview feature, and is not supported for use on {product-title} clusters
+====
+endif::openshift-rosa,openshift-dedicated[]
+
 include::modules/virt-creating-vm-instancetype.adoc[leveloffset=+1]
 
 include::modules/virt-creating-vm-from-snapshot-web.adoc[leveloffset=+1]

--- a/virt/virtual_machines/creating_vms_rh/virt-creating-vms-from-rh-images-overview.adoc
+++ b/virt/virtual_machines/creating_vms_rh/virt-creating-vms-from-rh-images-overview.adoc
@@ -15,7 +15,9 @@ Cluster administrators can enable automatic subscription for {op-system-base-ful
 You can create virtual machines (VMs) from operating system images provided by Red Hat by using one of the following methods:
 
 * xref:../../../virt/virtual_machines/creating_vms_rh/virt-creating-vms-from-templates.adoc#virt-creating-vms-from-templates[Creating a VM from a template by using the web console]
+
 * xref:../../../virt/virtual_machines/creating_vms_rh/virt-creating-vms-from-instance-types.adoc#virt-creating-vms-from-instance-types[Creating a VM from an instance type by using the web console]
+
 * xref:../../../virt/virtual_machines/creating_vms_rh/virt-creating-vms-from-cli.adoc#virt-creating-vms-from-cli[Creating a VM from a `VirtualMachine` manifest by using the command line]
 
 [IMPORTANT]

--- a/virt/virtual_machines/virt-accessing-vm-ssh.adoc
+++ b/virt/virtual_machines/virt-accessing-vm-ssh.adoc
@@ -136,14 +136,22 @@ See the link:https://access.redhat.com/articles/6994974#networking-multus[Multus
 
 .Prerequisites
 
+ifndef::openshift-rosa,openshift-dedicated[]
 * You configured a secondary network such as xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-connecting-vm-to-linux-bridge[Linux bridge] or xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#virt-connecting-vm-to-sriov[SR-IOV].
 * You created a network attachment definition for a xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-creating-linux-bridge-nad-web_virt-connecting-vm-to-linux-bridge[Linux bridge network] or the SR-IOV Network Operator created a xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#nw-sriov-network-attachment_virt-connecting-vm-to-sriov[network attachment definition] when you created an `SriovNetwork` object.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You configured a xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#virt-connecting-vm-to-ovn-secondary-network[secondary network].
+* You created a xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#creating-ovn-nad_virt-connecting-vm-to-ovn-secondary-network[network attachment definition].
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/virt-vm-creating-nic-web.adoc[leveloffset=+2]
 
 include::modules/virt-connecting-secondary-network-ssh.adoc[leveloffset=+2]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [NOTE]
 ====
 You can also xref:../../virt/vm_networking/virt-accessing-vm-secondary-network-fqdn.adoc#virt-accessing-vm-secondary-network-fqdn[access a VM attached to a secondary network interface by using the cluster FQDN].
 ====
+endif::openshift-rosa,openshift-dedicated[]

--- a/virt/virtual_machines/virt-edit-vms.adoc
+++ b/virt/virtual_machines/virt-edit-vms.adoc
@@ -10,7 +10,9 @@ You can update a virtual machine (VM) configuration by using the {product-title}
 
 You can also edit a VM by using the command line.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 To edit a VM to configure disk sharing by using virtual disks or LUN, see xref:../../virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc#virt-configuring-shared-volumes-for-vms[Configuring shared volumes for virtual machines].
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/virt-editing-vm-cli.adoc[leveloffset=+1]
 

--- a/virt/vm_networking/virt-accessing-vm-secondary-network-fqdn.adoc
+++ b/virt/vm_networking/virt-accessing-vm-secondary-network-fqdn.adoc
@@ -18,6 +18,9 @@ include::modules/virt-connecting-vm-secondarynw-using-fqdn.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources_accessing-vm-secondary-network-fqdn"]
 == Additional resources
+// Hiding until OSDOCS-3691 is merged
+ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../../networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer.adoc#configuring-ingress-cluster-traffic-load-balancer[Configuring ingress cluster traffic using a load balancer]
 * xref:../../networking/metallb/about-metallb.adoc#about-metallb[Load balancing with MetalLB]
+endif::openshift-rosa,openshift-dedicated[]
 * xref:../../virt/vm_networking/virt-configuring-viewing-ips-for-vms.adoc#configuring-ips_virt-configuring-viewing-ips-for-vms[Configuring IP addresses for virtual machines]

--- a/virt/vm_networking/virt-connecting-vm-to-default-pod-network.adoc
+++ b/virt/vm_networking/virt-connecting-vm-to-default-pod-network.adoc
@@ -20,8 +20,11 @@ include::modules/virt-configuring-masquerade-mode-dual-stack.adoc[leveloffset=+1
 // TO DO: This should be moved to an optimization section
 include::modules/virt-jumbo-frames-vm-pod-nw.adoc[leveloffset=+1]
 
+// Hiding from ROSA/OSD as not supported
+ifndef::openshift-rosa,openshift-dedicated[]
 [role="_additional-resources"]
 [id="additional-resources_virt-connecting-vm-to-default-pod-network"]
 == Additional resources
 * xref:../../networking/changing-cluster-network-mtu.adoc#changing-cluster-network-mtu[Changing the MTU for the cluster network]
 * xref:../../scalability_and_performance/optimization/optimizing-networking.adoc#optimizing-mtu_optimizing-networking[Optimizing the MTU for your network]
+endif::openshift-rosa,openshift-dedicated[]

--- a/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc
+++ b/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc
@@ -12,23 +12,27 @@ You can connect a virtual machine (VM) to an Open Virtual Network (OVN)-Kubernet
 
 * A localnet topology connects the secondary network to the physical underlay. This enables both east-west cluster traffic and access to services running outside the cluster, but it requires additional configuration of the underlying Open vSwitch (OVS) system on cluster nodes.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [NOTE]
 ====
 An OVN-Kubernetes secondary network is compatible with the xref:../../networking/multiple_networks/configuring-additional-network.adoc#compatibility-with-multi-network-policy_configuring-additional-network[multi-network policy API] which provides the `MultiNetworkPolicy` custom resource definition (CRD) to control traffic flow to and from VMs. You can use the `ipBlock` attribute to define network policy ingress and egress rules for specific CIDR blocks.
 ====
+endif::openshift-rosa,openshift-dedicated[]
 
 To configure an OVN-Kubernetes secondary network and attach a VM to that network, perform the following steps:
 
-. xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#creating-ovn-nad[Configure an OVN-Kubernetes secondary network] by creating a network attachment definition (NAD).
+. xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#virt-connecting-vm-to-ovn-secondary-network[Configure an OVN-Kubernetes secondary network] by creating a network attachment definition (NAD).
+ifndef::openshift-rosa,openshift-dedicated[]
 +
 [NOTE]
 ====
 For localnet topology, you must xref:../../networking/multiple_networks/configuring-additional-network.adoc#configuring-additional-network_ovn-kubernetes-configuration-for-a-localnet-topology[configure an OVS bridge] by creating a `NodeNetworkConfigurationPolicy` object before creating the NAD.
 ====
+endif::openshift-rosa,openshift-dedicated[]
 
 . xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#attaching-vm-to-ovn-secondary-nw[Connect the VM to the OVN-Kubernetes secondary network] by adding the network details to the VM specification.
 
-[id="creating-ovn-nad"]
+[id="creating-ovn-nad_{context}"]
 == Creating an OVN-Kubernetes NAD
 
 You can create an OVN-Kubernetes layer 2 or localnet network attachment definition (NAD) by using the {product-title} web console or the CLI.
@@ -51,6 +55,7 @@ include::modules/virt-attaching-vm-to-ovn-secondary-nw-cli.adoc[leveloffset=+2]
 include::modules/virt-creating-nad-l2-overlay-console.adoc[leveloffset=+2]
 include::modules/virt-creating-nad-localnet-console.adoc[leveloffset=+2]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [role="_additional-resources"]
 [id="additional-resources_virt-connecting-vm-to-ovn-secondary-network"]
 == Additional resources
@@ -58,3 +63,4 @@ include::modules/virt-creating-nad-localnet-console.adoc[leveloffset=+2]
 * xref:../../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#k8s-nmstate-about-the-k8s-nmstate-operator[About the Kubernetes NMState Operator]
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#configuring-additional-network_configuration-additional-network-interface[Configuration for an OVN-Kubernetes additional network mapping]
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#configuring-additional-network_configuration-additional-network-attachment[Configuration for an additional network attachment]
+endif::openshift-rosa,openshift-dedicated[]

--- a/virt/vm_networking/virt-connecting-vm-to-service-mesh.adoc
+++ b/virt/vm_networking/virt-connecting-vm-to-service-mesh.adoc
@@ -10,9 +10,12 @@ toc::[]
 
 include::modules/virt-adding-vm-to-service-mesh.adoc[leveloffset=+1]
 
+// Hiding in OSD until PR 67901 merges
+ifndef::openshift-dedicated[]
 [role="_additional-resources"]
 [id="additional-resources_virt-connecting-vm-to-service-mesh"]
 == Additional resources
 * xref:../../service_mesh/v2x/installing-ossm.adoc#installing-ossm[Installing the Service Mesh Operators]
 * xref:../../service_mesh/v2x/ossm-create-smcp.adoc#ossm-create-smcp[Creating the Service Mesh control plane]
 * xref:../../service_mesh/v2x/ossm-create-mesh.adoc#ossm-create-mesh[Adding projects to the Service Mesh member roll]
+endif::openshift-dedicated[]

--- a/virt/vm_networking/virt-dedicated-network-live-migration.adoc
+++ b/virt/vm_networking/virt-dedicated-network-live-migration.adoc
@@ -6,7 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 You can configure a dedicated xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-connecting-vm-to-linux-bridge[Multus network] for live migration. A dedicated network minimizes the effects of network saturation on tenant workloads during live migration.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+You can configure a dedicated xref:../../virt/vm_networking/virt-dedicated-network-live-migration.adoc#virt-configuring-secondary-network-vm-live-migration_virt-dedicated-network-live-migration[secondary network] for live migration. A dedicated network minimizes the effects of network saturation on tenant workloads during live migration.
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/virt-configuring-secondary-network-vm-live-migration.adoc[leveloffset=+1]
 

--- a/virt/vm_networking/virt-exposing-vm-with-service.adoc
+++ b/virt/vm_networking/virt-exposing-vm-with-service.adoc
@@ -10,18 +10,22 @@ You can expose a virtual machine within the cluster or outside the cluster by cr
 
 include::modules/virt-about-services.adoc[leveloffset=+1]
 
+// Hiding in ROSA/OSD as not supported
+ifndef::openshift-rosa,openshift-dedicated[]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../networking/metallb/metallb-operator-install.adoc#metallb-operator-install[Installing the MetalLB Operator]
 * xref:../../networking/metallb/metallb-configure-services.adoc#metallb-configure-services[Configuring services to use MetalLB]
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/virt-dual-stack-support-services.adoc[leveloffset=+1]
 
 include::modules/virt-creating-service-cli.adoc[leveloffset=+1]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [role="_additional-resources"]
 [id="additional-resources_creating-service-vm"]
 == Additional resources
 * xref:../../networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-nodeport.adoc#configuring-ingress-cluster-traffic-nodeport[Configuring ingress cluster traffic using a NodePort]
 * xref:../../networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer.adoc#configuring-ingress-cluster-traffic-load-balancer[Configuring ingress cluster traffic using a load balancer]
-
+endif::openshift-rosa,openshift-dedicated[]

--- a/virt/vm_networking/virt-networking-overview.adoc
+++ b/virt/vm_networking/virt-networking-overview.adoc
@@ -1,10 +1,10 @@
-:_mod-docs-content-type: ASSEMBLY                                        
-[id="virt-networking"]                            
-= Networking overview                                                
-include::_attributes/common-attributes.adoc[]                   
-:context: virt-networking-overview                         
-                                                                
-toc::[]    
+:_mod-docs-content-type: ASSEMBLY
+[id="virt-networking"]
+= Networking overview
+include::_attributes/common-attributes.adoc[]
+:context: virt-networking-overview
+
+toc::[]
 
 {VirtProductName} provides advanced networking functionality by using custom resources and plugins. Virtual machines (VMs) are integrated with {product-title} networking and its ecosystem.
 
@@ -20,11 +20,20 @@ Each VM is connected by default to the default internal pod network. You can add
 
 xref:../../virt/vm_networking/virt-exposing-vm-with-service.adoc#virt-exposing-vm-with-service[Exposing a virtual machine as a service]::
 
+// Hiding from ROSA/OSD until OSDOCS-3691 is merged
+ifndef::openshift-rosa,openshift-dedicated[]
 You can expose a VM within the cluster or outside the cluster by creating a `Service` object. For on-premise clusters, you can configure a load balancing service by using the MetalLB Operator. You can xref:../../networking/metallb/metallb-operator-install.adoc#metallb-operator-install[install the MetalLB Operator] by using the {product-title} web console or the CLI.
+endif::openshift-rosa,openshift-dedicated[]
+// Hiding from ROSA/OSD until OSDOCS-3691 is merged
+ifdef::openshift-rosa,openshift-dedicated[]
+You can expose a VM within the cluster or outside the cluster by creating a `Service` object. 
+endif::openshift-rosa,openshift-dedicated[]
 
 [id="secondary-network-config"]
 == Configuring VM secondary network interfaces
 
+// Hiding from ROSA/OSD as Linux Bridge not supported
+ifndef::openshift-rosa,openshift-dedicated[]
 xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-connecting-vm-to-linux-bridge[Connecting a virtual machine to a Linux bridge network]::
 
 xref:../../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#k8s-nmstate-about-the-k8s-nmstate-operator[Install the Kubernetes NMState Operator] to configure Linux bridges, VLANs, and bondings for your secondary networks.
@@ -34,7 +43,10 @@ You can create a Linux bridge network and attach a VM to the network by performi
 . xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-creating-linux-bridge-nncp_virt-connecting-vm-to-linux-bridge[Configure a Linux bridge network device] by creating a `NodeNetworkConfigurationPolicy` custom resource definition (CRD).
 . xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#creating-linux-bridge-nad[Configure a Linux bridge network] by creating a `NetworkAttachmentDefinition` CRD.
 . xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#configuring-vm-network-interface[Connect the VM to the Linux bridge network] by including the network details in the VM configuration.
+endif::openshift-rosa,openshift-dedicated[]
 
+// Hiding from ROSA/OSD as SR-IOV not supported
+ifndef::openshift-rosa,openshift-dedicated[]
 xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#virt-connecting-vm-to-sriov[Connecting a virtual machine to an SR-IOV network]::
 
 You can use Single Root I/O Virtualization (SR-IOV) network devices with additional networks on your {product-title} cluster installed on bare metal or Red Hat OpenStack Platform (RHOSP) infrastructure for applications that require high bandwidth or low latency.
@@ -46,7 +58,7 @@ You can connect a VM to an SR-IOV network by performing the following steps:
 . xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#nw-sriov-configuring-device_virt-connecting-vm-to-sriov[Configure an SR-IOV network device] by creating a `SriovNetworkNodePolicy` CRD.
 . xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#nw-sriov-network-attachment_virt-connecting-vm-to-sriov[Configure an SR-IOV network] by creating an `SriovNetwork` object.
 . xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#virt-attaching-vm-to-sriov-network_virt-connecting-vm-to-sriov[Connect the VM to the SR-IOV network] by including the network details in the VM configuration.
-
+endif::openshift-rosa,openshift-dedicated[]
 
 xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#virt-connecting-vm-to-ovn-secondary-network[Connecting a virtual machine to an OVN-Kubernetes secondary network]::
 
@@ -57,33 +69,48 @@ You can connect a VM to an Open Virtual Network (OVN)-Kubernetes secondary netwo
 
 * A localnet topology connects the secondary network to the physical underlay. This enables both east-west cluster traffic and access to services running outside the cluster, but it requires additional configuration of the underlying Open vSwitch (OVS) system on cluster nodes.
 --
-+
+
+// Updated the xref to the correct ID
+
 To configure an OVN-Kubernetes secondary network and attach a VM to that network, perform the following steps:
 
-. xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#creating-ovn-nad[Configure an OVN-Kubernetes secondary network] by creating a network attachment definition (NAD).
+. xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#virt-connecting-vm-to-ovn-secondary-network[Configure an OVN-Kubernetes secondary network] by creating a network attachment definition (NAD).
+ifndef::openshift-rosa,openshift-dedicated[]
 +
 [NOTE]
 ====
 For localnet topology, you must xref:../../networking/multiple_networks/configuring-additional-network.adoc#configuring-additional-network_ovn-kubernetes-configuration-for-a-localnet-topology[configure an OVS bridge] by creating a `NodeNetworkConfigurationPolicy` object before creating the NAD.
 ====
+endif::openshift-rosa,openshift-dedicated[]
 
 . xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#attaching-vm-to-ovn-secondary-nw[Connect the VM to the OVN-Kubernetes secondary network] by adding the network details to the VM specification.
 
+// Hiding in ROSA/OSD as not supported
+ifndef::openshift-rosa,openshift-dedicated[]
 xref:../../virt/vm_networking/virt-hot-plugging-network-interfaces.adoc#virt-hot-plugging-network-interfaces[Hot plugging secondary network interfaces]::
 
 You can add or remove secondary network interfaces without stopping your VM. {VirtProductName} supports hot plugging and hot unplugging for Linux bridge interfaces that use the VirtIO device driver.
+endif::openshift-rosa,openshift-dedicated[]
 
+// Hiding in ROSA/OSD as not supported
+ifndef::openshift-rosa,openshift-dedicated[]
 xref:../../virt/vm_networking/virt-using-dpdk-with-sriov.adoc#virt-using-dpdk-with-sriov[Using DPDK with SR-IOV]::
 
 The Data Plane Development Kit (DPDK) provides a set of libraries and drivers for fast packet processing. You can configure clusters and VMs to run DPDK workloads over SR-IOV networks.
+endif::openshift-rosa,openshift-dedicated[]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 xref:../../virt/vm_networking/virt-dedicated-network-live-migration.adoc#virt-dedicated-network-live-migration[Configuring a dedicated network for live migration]::
 
 You can configure a dedicated xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-connecting-vm-to-linux-bridge[Multus network] for live migration. A dedicated network minimizes the effects of network saturation on tenant workloads during live migration.
+endif::openshift-rosa,openshift-dedicated[]
 
+// Hiding in ROSA/OSD as not supported Tech Preview
+ifndef::openshift-rosa,openshift-dedicated[]
 xref:../../virt/vm_networking/virt-accessing-vm-secondary-network-fqdn.adoc#virt-accessing-vm-secondary-network-fqdn[Accessing a virtual machine by using the cluster FQDN]::
 
 You can access a VM that is attached to a secondary network interface from outside the cluster by using its fully qualified domain name (FQDN).
+endif::openshift-rosa,openshift-dedicated[]
 
 xref:../../virt/vm_networking/virt-configuring-viewing-ips-for-vms.adoc#virt-configuring-viewing-ips-for-vms[Configuring and viewing IP addresses]::
 

--- a/virt/vm_networking/virt-using-dpdk-with-sriov.adoc
+++ b/virt/vm_networking/virt-using-dpdk-with-sriov.adoc
@@ -12,17 +12,23 @@ You can configure clusters and virtual machines (VMs) to run DPDK workloads over
 
 include::modules/virt-configuring-cluster-dpdk.adoc[leveloffset=+1]
 
+// Hiding until PR 65079 is merged
+ifndef::openshift-rosa,openshift-dedicated[]
 [role="_additional-resources_configuring-cluster-dpdk"]
 .Additional resources
 * xref:../../scalability_and_performance/using-cpu-manager.adoc#using-cpu-manager[Using CPU Manager and Topology Manager]
 * xref:../../scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc#configuring-huge-pages_huge-pages[Configuring huge pages]
+endif::openshift-rosa,openshift-dedicated[]
+// Hiding as not supported
+ifndef::openshift-rosa,openshift-dedicated[]
 * link:https://access.redhat.com/solutions/5688941[Creating a custom machine config pool]
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/virt-configuring-vm-project-dpdk.adoc[leveloffset=+1]
 
 [role="_additional-resources_configuring-project-dpdk"]
 .Additional resources
-* xref:../../applications/projects/working-with-projects.adoc#working-with-projects[Working with projects]
+* xref:../../applications/projects/working-with-projects.adoc#working-with-projects[Working with projects] 
 * xref:../../virt/monitoring/virt-running-cluster-checkups.adoc#virt-measuring-latency-vm-secondary-network_virt-running-cluster-checkups[Virtual machine latency checkup]
 * xref:../../virt/monitoring/virt-running-cluster-checkups.adoc#virt-checking-cluster-dpdk-readiness_virt-running-cluster-checkups[DPDK checkup]
 


### PR DESCRIPTION
The pull request ports the "Virtualization" book from OCP to the OSD and ROSA libraries using single sourcing.

PEER REVIEWER
This PR is to add the "Virtualization" book to OSD and ROSA. There is little or no new text. Most of the changes are hiding assemblies, adding ifdefs, updating links, etc. The peer review principally just needs a sanity-level review to make sure everything looks OK.

https://issues.redhat.com/browse/OSDOCS-8072

OCP: [About OpenShift Virtualization](https://68906--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/about_virt/about-virt)
ROSA: [About OpenShift Virtualization](https://68906--ocpdocs-pr.netlify.app/openshift-rosa/latest/virt/about_virt/about-virt)
OSD: [About OpenShift Virtualization](https://68906--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/about_virt/about-virt)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

