### PR TITLE
OBSDOCS-650: Add docs for CLF supporting clusterlogging

### DIFF
--- a/logging/config/cluster-logging-moving-nodes.adoc
+++ b/logging/config/cluster-logging-moving-nodes.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 :context: cluster-logging-moving
-[id="cluster-logging-moving"]
+[id="cluster-logging-moving-nodes"]
 = Moving {logging} resources with node selectors
 include::_attributes/common-attributes.adoc[]
 

--- a/logging/log_collection_forwarding/cluster-logging-collector.adoc
+++ b/logging/log_collection_forwarding/cluster-logging-collector.adoc
@@ -8,10 +8,11 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 {logging-title-uc} collects operations and application logs from your cluster and enriches the data with Kubernetes pod and project metadata.
-
-You can configure the CPU and memory limits for the log collector and xref:../../logging/config/cluster-logging-moving-nodes.adoc#cluster-logging-moving[move the log collector pods to specific nodes]. All supported modifications to the log collector can be performed though the `spec.collection.log.fluentd` stanza in the `ClusterLogging` custom resource (CR).
+All supported modifications to the log collector can be performed though the `spec.collection` stanza in the `ClusterLogging` custom resource (CR).
 
 include::modules/configuring-logging-collector.adoc[leveloffset=+1]
+
+include::modules/log-collector-resources-scheduling.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-collector-pod-location.adoc[leveloffset=+1]
 

--- a/modules/log-collector-resources-scheduling.adoc
+++ b/modules/log-collector-resources-scheduling.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+//
+// * logging/log_collection_forwarding/log-forwarding.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="log-collector-resources-scheduling_{context}"]
+= Configuring resources and scheduling for logging collectors
+
+Administrators can modify the resources or scheduling of the collector by creating a `ClusterLogging` custom resource (CR) that is in the same namespace and has the same name as the `ClusterLogForwarder` CR that it supports.
+
+The applicable stanzas for the `ClusterLogging` CR when using multiple log forwarders in a deployment are `managmentState` and `collection`. All other stanzas are ignored.
+
+.Prerequisites
+
+* You have administrator permissions.
+* You have installed the {clo} version 5.8 or newer.
+* You have created a `ClusterLogForwarder` CR.
+
+.Procedure
+
+. Create a `ClusterLogging` CR that supports your existing `ClusterLogForwarder` CR:
++
+.Example `ClusterLogging` CR YAML
+[source,yaml]
+----
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogging
+metadata:
+  name:  <name> # <1>
+  namespace: <namespace> # <2>
+spec:
+  managementState: "Managed"
+  collection:
+    type: "vector"
+    tolerations:
+    - key: "logging"
+      operator: "Exists"
+      effect: "NoExecute"
+      tolerationSeconds: 6000
+    resources:
+      limits:
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 1Gi
+    nodeSelector:
+      collector: needed
+# ...
+----
+<1> The name must be the same name as the `ClusterLogForwarder` CR.
+<2> The namespace must be the same namespace as the `ClusterLogForwarder` CR.
+
+. Apply the `ClusterLogging` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OBSDOCS-650

Link to docs preview:
- https://68919--docspreview.netlify.app/openshift-enterprise/latest/logging/log_collection_forwarding/cluster-logging-collector#log-collector-resources-scheduling_cluster-logging-collector

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
