### PR TITLE
OSDOCS-8889: Documented the 4.13.25 z-stream release notes]

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -3543,3 +3543,28 @@ $ oc adm release info 4.13.24 --pullspecs
 [id="ocp-4-13-24-updating"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-13-25"]
+=== RHSA-2023:7604 - {product-title} 4.13.25 bug fix and security update
+
+Issued: 2023-12-06
+
+{product-title} release 4.13.25, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:7604[RHSA-2023:7604] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7606[RHSA-2023:7606] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.25 --pullspecs
+----
+
+[id="ocp-4-13-25-bug-fixes"]
+==== Bug fixes
+
+* Previously, the Image Registry Operator made API calls to the Storage Account List endpoint as part of obtaining access keys every 5 minutes. In projects with many {product-title} clusters, this could lead to API limits being reached causing 429 errors when attempting to create new clusters. With this release, the time between calls is increased from 5 minutes to 20 minutes. (link:https://issues.redhat.com/browse/OCPBUGS-22126[*OCPBUGS-22126*])
+
+[id="ocp-4-13-25-updating"]
+==== Updating
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
[OSDOCS-8889](https://issues.redhat.com/browse/OSDOCS-8889)

Version(s):
4.13

Link to docs preview:
[4.13.25](https://68924--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes#ocp-4-13-25)

QE review:
- [x] QE not required for z-stream releases. See the peer-reivew checklist. 
