### PR TITLE
OSDOCS#6574: MicroShift Auditing exposed network settings

### DIFF
--- a/microshift_networking/microshift-networking-settings.adoc
+++ b/microshift_networking/microshift-networking-settings.adoc
@@ -38,3 +38,11 @@ include::modules/microshift-deploying-a-load-balancer.adoc[leveloffset=+1]
 include::modules/microshift-blocking-nodeport-access.adoc[leveloffset=+1]
 
 include::modules/microshift-mDNS.adoc[leveloffset=+1]
+
+include::modules/microshift-exposed-audit-ports.adoc[leveloffset=+1]
+
+include::modules/microshift-exposed-audit-ports-hostnetwork.adoc[leveloffset=+1]
+
+include::modules/microshift-exposed-audit-ports-hostport.adoc[leveloffset=+1]
+
+include::modules/microshift-exposed-audit-ports-loadbalancer.adoc[leveloffset=+1]

--- a/modules/microshift-configuring-ovn.adoc
+++ b/modules/microshift-configuring-ovn.adoc
@@ -21,7 +21,7 @@ $ sudo cp /etc/microshift/ovn.yaml.default /etc/microshift/ovn.yaml
 +
 [source, yaml]
 ----
-$ cat /etc/microshift/ovn.yaml.default
+$ cat /etc/microshift/ovn.yaml
 ----
 +
 .Example YAML file with default maximum transmission unit (MTU) value

--- a/modules/microshift-exposed-audit-ports-hostnetwork.adoc
+++ b/modules/microshift-exposed-audit-ports-hostnetwork.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * microshift_networking/microshift-networking-settings.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-exposed-audit-ports-hostnetwork_{context}"]
+
+== hostNetwork
+
+When a pod is configured with the `hostNetwork:true` setting, the pod is running in the host network namespace. This configuration can independently open host ports. {microshift-short} component logs cannot be used to track this case, the ports are subject to firewalld rules. If the port opens in firewalld, you can view the port opening in the firewalld debug log.
+
+.Prerequisites 
+
+* You have root user access to your build host.
+
+.Procedure
+
+. Optional: You can check that the `hostNetwork:true` parameter is set in your ovnkube-node pod by using the following example command:
++
+[source,terminal]
+----
+$ sudo oc get pod -n openshift-ovn-kubernetes <ovnkube-node-pod-name> -o json | jq -r '.spec.hostNetwork' true
+----
+
+. Enable debug in the firewalld log by running the following command:
++
+[source,terminal]
+----
+$ sudo vi /etc/sysconfig/firewalld
+FIREWALLD_ARGS=--debug=10
+----
+
+. Restart the firewalld service:
++
+[source,terminal]
+----
+$ sudo systemctl restart firewalld.service
+----
+
+. To verify that the debug option was added properly, run the following command:
++
+[source,terminal]
+----
+$ sudo systemd-cgls -u firewalld.service
+----
++
+The firewalld debug log is stored in the `/var/log/firewalld` path.
++
+.Example logs for when the port open rule is added:
+[source,terminal]
+----
+2023-06-28 10:46:37 DEBUG1: config.getZoneByName('public')
+2023-06-28 10:46:37 DEBUG1: config.zone.7.addPort('8080', 'tcp')
+2023-06-28 10:46:37 DEBUG1: config.zone.7.getSettings()
+2023-06-28 10:46:37 DEBUG1: config.zone.7.update('...')
+2023-06-28 10:46:37 DEBUG1: config.zone.7.Updated('public')
+----
++
+.Example logs for when the port open rule is removed:
+[source,terminal]
+----
+2023-06-28 10:47:57 DEBUG1: config.getZoneByName('public')
+2023-06-28 10:47:57 DEBUG2: config.zone.7.Introspect()
+2023-06-28 10:47:57 DEBUG1: config.zone.7.removePort('8080', 'tcp')
+2023-06-28 10:47:57 DEBUG1: config.zone.7.getSettings()
+2023-06-28 10:47:57 DEBUG1: config.zone.7.update('...')
+2023-06-28 10:47:57 DEBUG1: config.zone.7.Updated('public')
+----

--- a/modules/microshift-exposed-audit-ports-hostport.adoc
+++ b/modules/microshift-exposed-audit-ports-hostport.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * microshift_networking/microshift-networking-settings.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-exposed-audit-ports-hostport_{context}"]
+== hostPort
+
+You can access the hostPort setting logs in {microshift-short}. The following logs are examples for the hostPort setting:
+
+.Procedure
+
+* You can access the logs by running the following command: 
++
+[source,terminal]
+----
+$ journalctl -u crio | grep "local port"
+----
++
+.Example CRI-O logs when the host port is opened:
+[source,terminal]
+----
+$ Jun 25 16:27:37 rhel92 crio[77216]: time="2023-06-25 16:27:37.033003098+08:00" level=info msg="Opened local port tcp:443"
+----
++
+.Example CRI-O logs when the host port is closed:
+[source,terminal]
+----
+$ Jun 25 16:24:11 rhel92 crio[77216]: time="2023-06-25 16:24:11.342088450+08:00" level=info msg="Closing host port tcp:443"
+----

--- a/modules/microshift-exposed-audit-ports-loadbalancer.adoc
+++ b/modules/microshift-exposed-audit-ports-loadbalancer.adoc
@@ -1,0 +1,62 @@
+// Module included in the following assemblies:
+//
+// * microshift_networking/microshift-networking-settings.adoc
+
+:_mod-docs-content-type: PROCEDURE 
+[id="microshift-exposed-audit-ports-loadbalancer_{context}"]
+
+== NodePort and LoadBalancer service
+
+OVN-Kubernetes opens host ports for `NodePort` and `LoadBalancer` service types. These services add iptables rules that take the ingress traffic from the host port and forwards it to the clusterIP. Logs for the `NodePort` and `LoadBalancer` services are presented in the following examples:
+
+.Procedure 
+
+. To access the name of your `ovnkube-master` pods, run the following command: 
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ovn-kubernetes | awk '/ovnkube-master/{print $1}'
+----
++
+.Example `ovnkube-master` pod name
+[source,terminal]
+----
+ovnkube-master-n2shv
+----
+
+. You can access the `NodePort` and `LoadBalancer` services logs using your `ovnkube-master` pod and running the following example command:
++
+[source,terminal]
+----
+$ oc logs -n openshift-ovn-kubernetes <ovnkube-master-pod-name> ovnkube-master | grep -E "OVN-KUBE-NODEPORT|OVN-KUBE-EXTERNALIP"
+----
++
+--
+*NodePort service:*
+
+.Example logs in the ovnkube-master container of the ovnkube-master pod when a host port is open:
+[source,terminal]
+----
+$ I0625 09:07:00.992980 2118395 iptables.go:27] Adding rule in table: nat, chain: OVN-KUBE-NODEPORT with args: "-p TCP -m addrtype --dst-type LOCAL --dport 32718 -j DNAT --to-destination 10.96.178.142:8081" for protocol: 0
+----
+
+.Example logs in the ovnkube-master container of the ovnkube-master pod when a host port is closed:
+[source,terminal]
+----
+$ Deleting rule in table: nat, chain: OVN-KUBE-NODEPORT with args: "-p TCP -m addrtype --dst-type LOCAL --dport 32718 -j DNAT --to-destination 10.96.178.142:8081" for protocol: 0
+----
+
+*LoadBalancer service:*
+
+.Example logs in the ovnkube-master container of the ovnkube-master pod when a host port is open:
+[source,terminal]
+----
+$ I0625 09:34:10.406067  128902 iptables.go:27] Adding rule in table: nat, chain: OVN-KUBE-EXTERNALIP with args: "-p TCP -d 172.16.47.129 --dport 8081 -j DNAT --to-destination 10.43.114.94:8081" for protocol: 0
+----
+
+.Example logs in the ovnkube-master container of the ovnkube-master pod when a host port is closed:
+[source,terminal]
+----
+$ I0625 09:37:00.976953  128902 iptables.go:63] Deleting rule in table: nat, chain: OVN-KUBE-EXTERNALIP with args: "-p TCP -d 172.16.47.129 --dport 8081 -j DNAT --to-destination 10.43.114.94:8081" for protocol: 0
+----
+--

--- a/modules/microshift-exposed-audit-ports.adoc
+++ b/modules/microshift-exposed-audit-ports.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * microshift_networking/microshift-networking-settings.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-exposed-audit-ports_{context}"]
+= Auditing exposed network ports 
+
+On {microshift-short}, the host port can be opened by a workload in the following cases. You can check logs to view the network services.


### PR DESCRIPTION
**Version(s):** 4.15+

**Issue:** [OSDOCS-6574](https://issues.redhat.com//browse/OSDOCS-6574)

**Link to docs preview:**

[Networking -> Using network settings -> Auditing exposed network ports](https://68926--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-networking-settings#microshift-exposed-audit-ports_microshift-networking)

**QE review:**
- [x] QE has approved this change.

