### PR TITLE
OSDOCS-8951: Added ROSA with HCP release note

### DIFF
--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -16,6 +16,8 @@ toc::[]
 [id="rosa-q4-2023_{context}"]
 === Q4 2023
 
+* **{hcp-title-first}.** {hcp-title} is now generally available. For more information, see xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly[Creating ROSA with HCP clusters using the default options].
+
 * **Configurable process identifier (PID) limits.** With the release of ROSA CLI (`rosa`) version 1.2.31, administrators can use the `rosa create kubeletconfig` and `rosa edit kubeletconfig` commands to set the maximum PIDs for an existing cluster. For more information, see link:https://access.redhat.com/articles/7033551[Changing the maximum number of process IDs per pod (podPidsLimit) for ROSA].
 
 * **ROSA CLI update.** The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/tag/v1.2.31[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-about_rosa-getting-started-cli[About the ROSA CLI].


### PR DESCRIPTION
Version(s):
`enterprise-4.14+`

Issue:
[OSDOCS-8951](https://issues.redhat.com/browse/OSDOCS-8951)

Link to docs preview:
- [What's new](https://file.rdu.redhat.com/eponvell/OSDOCS-8951_HCP-Whats-New/rosa_release_notes/rosa-release-notes.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added a statement that ROSA with HCP is now available for use.