### PR TITLE
Revert "OBSDOCS-650: Update structure of collector docs"

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2550,6 +2550,8 @@ Topics:
     File: cluster-logging-memory
   - Name: Using tolerations to control Logging pod placement
     File: cluster-logging-tolerations
+  - Name: Moving logging subsystem resources with node selectors
+    File: cluster-logging-moving-nodes
   - Name: Configuring systemd-journald for Logging
     File: cluster-logging-systemd
 - Name: Log collection and forwarding

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -1059,6 +1059,8 @@ Topics:
     File: cluster-logging-memory
   - Name: Using tolerations to control Logging pod placement
     File: cluster-logging-tolerations
+  - Name: Moving logging subsystem resources with node selectors
+    File: cluster-logging-moving-nodes
   #- Name: Configuring systemd-journald and Fluentd
   #  File: cluster-logging-systemd
 - Name: Log collection and forwarding

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1257,6 +1257,8 @@ Topics:
     File: cluster-logging-memory
   - Name: Using tolerations to control Logging pod placement
     File: cluster-logging-tolerations
+  - Name: Moving logging subsystem resources with node selectors
+    File: cluster-logging-moving-nodes
   #- Name: Configuring systemd-journald and Fluentd
   #  File: cluster-logging-systemd
 - Name: Log collection and forwarding

--- a/logging/config/cluster-logging-moving-nodes.adoc
+++ b/logging/config/cluster-logging-moving-nodes.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: ASSEMBLY
+:context: cluster-logging-moving
+[id="cluster-logging-moving"]
+= Moving {logging} resources with node selectors
+include::_attributes/common-attributes.adoc[]
+
+toc::[]
+
+You can use node selectors to deploy the Elasticsearch and Kibana pods to different nodes.
+
+include::modules/infrastructure-moving-logging.adoc[leveloffset=+1]

--- a/logging/log_collection_forwarding/cluster-logging-collector.adoc
+++ b/logging/log_collection_forwarding/cluster-logging-collector.adoc
@@ -8,11 +8,10 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 {logging-title-uc} collects operations and application logs from your cluster and enriches the data with Kubernetes pod and project metadata.
-All supported modifications to the log collector can be performed though the `spec.collection` stanza in the `ClusterLogging` custom resource (CR).
+
+You can configure the CPU and memory limits for the log collector and xref:../../logging/config/cluster-logging-moving-nodes.adoc#cluster-logging-moving[move the log collector pods to specific nodes]. All supported modifications to the log collector can be performed though the `spec.collection.log.fluentd` stanza in the `ClusterLogging` custom resource (CR).
 
 include::modules/configuring-logging-collector.adoc[leveloffset=+1]
-
-include::modules/infrastructure-moving-logging.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-collector-pod-location.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Reverts openshift/openshift-docs#68921

Preview: https://68946--docspreview.netlify.app/openshift-enterprise/latest/logging/config/cluster-logging-moving-nodes

`main` branch only - original PR was never cherrypicked