### PR TITLE
OBSDOCS-674: Split LokiStack CR into own modules, move object storage docs

### DIFF
--- a/logging/cluster-logging-deploying.adoc
+++ b/logging/cluster-logging-deploying.adoc
@@ -7,7 +7,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-You can install the {logging-title} by deploying the Red Hat OpenShift Logging Operator. The {logging} Operator creates and manages the components of the logging stack.
+You can install the {logging-title} by deploying the {clo}. The {clo} creates and manages the components of the logging stack.
 
 [IMPORTANT]
 ====

--- a/logging/log_storage/cluster-logging-loki.adoc
+++ b/logging/log_storage/cluster-logging-loki.adoc
@@ -10,20 +10,6 @@ In {logging} documentation, _LokiStack_ refers to the {logging} supported combin
 
 include::modules/logging-creating-new-group-cluster-admin-user-role.adoc[leveloffset=+1]
 
-include::modules/logging-loki-storage.adoc[leveloffset=+1]
-
-include::modules/logging-loki-storage-aws.adoc[leveloffset=+2]
-
-include::modules/logging-loki-storage-azure.adoc[leveloffset=+2]
-
-include::modules/logging-loki-storage-gcp.adoc[leveloffset=+2]
-
-include::modules/logging-loki-storage-minio.adoc[leveloffset=+2]
-
-include::modules/logging-loki-storage-odf.adoc[leveloffset=+2]
-
-include::modules/logging-loki-storage-swift.adoc[leveloffset=+2]
-
 include::modules/logging-loki-restart-hardening.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/logging/log_storage/installing-log-storage.adoc
+++ b/logging/log_storage/installing-log-storage.adoc
@@ -7,23 +7,52 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-You can use the {oc-first} or the {product-title} web console to install a log store on your {product-title} cluster.
+You can use the {oc-first} or the {product-title} web console to deploy a log store on your {product-title} cluster.
 
 include::snippets/logging-elastic-dep-snip.adoc[]
 
 [id="installing-log-storage-loki"]
-== Installing a Loki log store
+== Deploying a Loki log store
 
-You can use the {loki-op} to install an internal Loki log store on your {product-title} cluster.
+You can use the {loki-op} to deploy an internal Loki log store on your {product-title} cluster.
+After install the {loki-op}, you must configure Loki object storage by creating a secret, and create a `LokiStack` custom resource (CR).
 
 include::modules/loki-deployment-sizing.adoc[leveloffset=+2]
+
+// Loki console install
 include::modules/logging-loki-gui-install.adoc[leveloffset=+2]
+include::modules/loki-create-object-storage-secret-console.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../logging/log_storage/installing-log-storage.adoc#logging-loki-storage_installing-log-storage[Loki object storage]
+
+include::modules/create-lokistack-cr-console.adoc[leveloffset=+2]
+
+// Loki CLI install
 include::modules/logging-loki-cli-install.adoc[leveloffset=+2]
+include::modules/loki-create-object-storage-secret-cli.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../logging/log_storage/installing-log-storage.adoc#logging-loki-storage_installing-log-storage[Loki object storage]
+
+include::modules/create-lokistack-cr-cli.adoc[leveloffset=+2]
+
+// Loki object storage
+include::modules/logging-loki-storage.adoc[leveloffset=+1]
+// create object storage
+include::modules/logging-loki-storage-aws.adoc[leveloffset=+2]
+include::modules/logging-loki-storage-azure.adoc[leveloffset=+2]
+include::modules/logging-loki-storage-gcp.adoc[leveloffset=+2]
+include::modules/logging-loki-storage-minio.adoc[leveloffset=+2]
+include::modules/logging-loki-storage-odf.adoc[leveloffset=+2]
+include::modules/logging-loki-storage-swift.adoc[leveloffset=+2]
 
 [id="installing-log-storage-es"]
-== Installing an Elasticsearch log store
+== Deploying an Elasticsearch log store
 
-You can use the {es-op} to install an internal Elasticsearch log store on your {product-title} cluster.
+You can use the {es-op} to deploy an internal Elasticsearch log store on your {product-title} cluster.
 
 include::snippets/logging-elastic-dep-snip.adoc[]
 include::modules/logging-es-storage-considerations.adoc[leveloffset=+2]

--- a/modules/cluster-logging-about-crd.adoc
+++ b/modules/cluster-logging-about-crd.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// * logging/cluster-logging.adoc
+// * logging/cluster-logging-deploying.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="cluster-logging-about-crd_{context}"]
 = About the ClusterLogging custom resource
 
@@ -11,15 +11,15 @@ To make changes to your {logging} environment, create and modify the `ClusterLog
 .Sample `ClusterLogging` custom resource (CR)
 [source,yaml]
 ----
-apiVersion: "logging.openshift.io/v1"
-kind: "ClusterLogging"
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogging
 metadata:
-  name: "instance" <1>
-  namespace: "openshift-logging" <2>
+  name: instance <1>
+  namespace: openshift-logging <2>
 spec:
-  managementState: "Managed" <3>
+  managementState: Managed <3>
 # ...
 ----
 <1> The CR name must be `instance`.
 <2> The CR must be installed to the `openshift-logging` namespace.
-<3> The Red Hat OpenShift Logging Operator management state. When set to `unmanaged` the operator is in an unsupported state and will not get updates.
+<3> The {clo} management state. When the state is set to `unmanaged`, the Operator is in an unsupported state and does not receive updates.

--- a/modules/configuring-log-storage-cr.adoc
+++ b/modules/configuring-log-storage-cr.adoc
@@ -46,6 +46,23 @@ spec:
 <2> Optional configuration options for the Elasticsearch log store.
 <3> Specify the redundancy type. This value can be `ZeroRedundancy`, `SingleRedundancy`, `MultipleRedundancy`, or `FullRedundancy`.
 <4> Optional configuration options for LokiStack.
++
+.Example `ClusterLogging` CR to specify LokiStack as the log store
+[source,yaml]
+----
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogging
+metadata:
+  name: instance
+  namespace: openshift-logging
+spec:
+  managementState: Managed
+  logStore:
+    type: lokistack
+    lokistack:
+      name: logging-loki
+# ...
+----
 
 . Apply the `ClusterLogging` CR by running the following command:
 +

--- a/modules/create-lokistack-cr-cli.adoc
+++ b/modules/create-lokistack-cr-cli.adoc
@@ -1,0 +1,90 @@
+// Module included in the following assemblies:
+//
+// * logging/log_storage/installing-log-storage.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="create-lokistack-cr-cli_{context}"]
+= Creating a LokiStack custom resource by using the CLI
+
+You can create a `LokiStack` custom resource (CR) by using the {oc-first}.
+
+.Prerequisites
+
+* You have administrator permissions.
+* You installed the {loki-op}.
+* You installed the {oc-first}.
+
+.Procedure
+
+. Create a `LokiStack` CR:
++
+.Example `LokiStack` CR
+[source,yaml]
+----
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: logging-loki
+  namespace: openshift-logging
+spec:
+  size: 1x.small # <1>
+  storage:
+    schemas:
+    - version: v12
+      effectiveDate: "2022-06-01"
+    secret:
+      name: logging-loki-s3 # <2>
+      type: s3 # <3>
+  storageClassName: <storage_class_name> # <4>
+  tenants:
+    mode: openshift-logging
+----
+<1> Supported size options for production instances of Loki are `1x.small` and `1x.medium`.
+<2> Enter the name of your log store secret.
+<3> Enter the type of your log store secret.
+<4> Enter the name of a storage class for temporary storage. For best performance, specify a storage class that allocates block storage. Available storage classes for your cluster can be listed by using `oc get storageclasses`.
+
+. Apply the `LokiStack` CR:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
+
+.Verification
+
+* Verify the installation by listing the pods in the `openshift-logging` project by running the following command and observing the output:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-logging
+----
++
+Confirm that you see several pods for components of the {logging}, similar to the following list:
++
+.Example output
+[source,terminal]
+----
+NAME                                           READY   STATUS    RESTARTS   AGE
+cluster-logging-operator-78fddc697-mnl82       1/1     Running   0          14m
+collector-6cglq                                2/2     Running   0          45s
+collector-8r664                                2/2     Running   0          45s
+collector-8z7px                                2/2     Running   0          45s
+collector-pdxl9                                2/2     Running   0          45s
+collector-tc9dx                                2/2     Running   0          45s
+collector-xkd76                                2/2     Running   0          45s
+logging-loki-compactor-0                       1/1     Running   0          8m2s
+logging-loki-distributor-b85b7d9fd-25j9g       1/1     Running   0          8m2s
+logging-loki-distributor-b85b7d9fd-xwjs6       1/1     Running   0          8m2s
+logging-loki-gateway-7bb86fd855-hjhl4          2/2     Running   0          8m2s
+logging-loki-gateway-7bb86fd855-qjtlb          2/2     Running   0          8m2s
+logging-loki-index-gateway-0                   1/1     Running   0          8m2s
+logging-loki-index-gateway-1                   1/1     Running   0          7m29s
+logging-loki-ingester-0                        1/1     Running   0          8m2s
+logging-loki-ingester-1                        1/1     Running   0          6m46s
+logging-loki-querier-f5cf9cb87-9fdjd           1/1     Running   0          8m2s
+logging-loki-querier-f5cf9cb87-fp9v5           1/1     Running   0          8m2s
+logging-loki-query-frontend-58c579fcb7-lfvbc   1/1     Running   0          8m2s
+logging-loki-query-frontend-58c579fcb7-tjf9k   1/1     Running   0          8m2s
+logging-view-plugin-79448d8df6-ckgmx           1/1     Running   0          46s
+----

--- a/modules/create-lokistack-cr-console.adoc
+++ b/modules/create-lokistack-cr-console.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// * logging/log_storage/installing-log-storage.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="create-lokistack-cr-console_{context}"]
+= Creating a LokiStack custom resource by using the web console
+
+You can create a `LokiStack` custom resource (CR) by using the {product-title} web console.
+
+.Prerequisites
+
+* You have administrator permissions.
+* You have access to the {product-title} web console.
+* You installed the {loki-op}.
+
+.Procedure
+
+. Go to the *Operators* -> *Installed Operators* page. Click the *All instances* tab.
+
+. From the *Create new* drop-down list, select *LokiStack*.
+
+. Select *YAML view*, and then use the following template to create a `LokiStack` CR:
++
+[source,yaml]
+----
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: logging-loki <1>
+  namespace: openshift-logging
+spec:
+  size: 1x.small <2>
+  storage:
+    schemas:
+    - version: v12
+      effectiveDate: '2022-06-01'
+    secret:
+      name: logging-loki-s3 <3>
+      type: s3 <4>
+  storageClassName: <storage_class_name> <5>
+  tenants:
+    mode: openshift-logging
+----
+<1> Use the name `logging-loki`.
+<2> Select your Loki deployment size.
+<3> Specify the secret used for your log storage.
+<4> Specify the corresponding storage type.
+<5> Enter the name of a storage class for temporary storage. For best performance, specify a storage class that allocates block storage. Available storage classes for your cluster can be listed by using the `oc get storageclasses` command.

--- a/modules/logging-loki-cli-install.adoc
+++ b/modules/logging-loki-cli-install.adoc
@@ -1,8 +1,9 @@
 // Module is included in the following assemblies:
-// logging/cluster-logging-loki.adoc
+// logging/log_storage/installing-log-storage.adoc
+
 :_mod-docs-content-type: PROCEDURE
 [id="logging-loki-cli-install_{context}"]
-= Installing {loki-op} using the {product-title} CLI
+= Installing {loki-op} by using the CLI
 
 To install and configure logging on your {product-title} cluster, additional Operators must be installed. This can be done from the {product-title} CLI.
 
@@ -10,19 +11,13 @@ To install and configure logging on your {product-title} cluster, additional Ope
 
 .Prerequisites
 
-* Supported object store (AWS S3, Google Cloud Storage, Azure, Swift, Minio, OpenShift Data Foundation)
+* You have administrator permissions.
+* You installed the {oc-first}.
+* You have access to a supported object store. For example: AWS S3, Google Cloud Storage, Azure, Swift, Minio, or {rh-storage}.
 
 .Procedure
 
-. Install the {loki-op} by creating the following objects:
-
-.. Create a `Subscription` object YAML file (for example, `olo-sub.yaml`) to
-subscribe a namespace to the Loki Operator using the template below:
-+
-[source,terminal]
-----
-$ oc create -f <file-name>.yaml
-----
+. Create a `Subscription` object:
 +
 [source,yaml]
 ----
@@ -47,70 +42,9 @@ spec:
 <2> Specify `stable`, or `stable-5.<y>` as the channel.
 <3> Specify `redhat-operators`. If your {product-title} cluster is installed on a restricted network, also known as a disconnected cluster, specify the name of the `CatalogSource` object you created when you configured the Operator Lifecycle Manager (OLM).
 
-. Create a LokiStack instance:
-
-.. Create an `instance` object YAML file (for example, `logging-loki.yaml`) using the template below:
+. Apply the `Subscription` object:
 +
 [source,terminal]
 ----
-$ oc create -f <file-name>.yaml
-----
-+
-[source,yaml]
-----
-apiVersion: loki.grafana.com/v1
-kind: LokiStack
-metadata:
-  name: logging-loki
-  namespace: openshift-logging
-spec:
-  size: 1x.small # <1>
-  storage:
-    schemas:
-    - version: v12
-      effectiveDate: "2022-06-01"
-    secret:
-      name: logging-loki-s3 # <2>
-      type: s3 # <3>
-  storageClassName: <storage_class_name> # <4>
-  tenants:
-    mode: openshift-logging
-----
-<1> Supported size options for production instances of Loki are `1x.small` and `1x.medium`.
-<2> Enter the name of your log store secret.
-<3> Enter the type of your log store secret.
-<4> Enter the name of an existing storage class for temporary storage. For best performance, specify a storage class that allocates block storage. Available storage classes for your cluster can be listed using `oc get storageclasses`.
-
-.Verification
-
-Verify the installation by listing the pods in the *openshift-logging* project by running the following command:
-
-[source,terminal]
-----
-$ oc get pods -n openshift-logging
-----
-
-You should see several pods for components of the Logging subsystem, similar to the following list:
-
-.Example output
-[source,terminal]
-----
-$ oc get pods -n openshift-logging
-NAME                                               READY   STATUS    RESTARTS   AGE
-cluster-logging-operator-fb7f7cf69-8jsbq           1/1     Running   0          98m
-collector-222js                                    2/2     Running   0          18m
-collector-g9ddv                                    2/2     Running   0          18m
-collector-hfqq8                                    2/2     Running   0          18m
-collector-sphwg                                    2/2     Running   0          18m
-collector-vv7zn                                    2/2     Running   0          18m
-collector-wk5zz                                    2/2     Running   0          18m
-logging-view-plugin-6f76fbb78f-n2n4n               1/1     Running   0          18m
-lokistack-sample-compactor-0                       1/1     Running   0          42m
-lokistack-sample-distributor-7d7688bcb9-dvcj8      1/1     Running   0          42m
-lokistack-sample-gateway-5f6c75f879-bl7k9          2/2     Running   0          42m
-lokistack-sample-gateway-5f6c75f879-xhq98          2/2     Running   0          42m
-lokistack-sample-index-gateway-0                   1/1     Running   0          42m
-lokistack-sample-ingester-0                        1/1     Running   0          42m
-lokistack-sample-querier-6b7b56bccc-2v9q4          1/1     Running   0          42m
-lokistack-sample-query-frontend-84fb57c578-gq2f7   1/1     Running   0          42m
+$ oc apply -f <filename>.yaml
 ----

--- a/modules/logging-loki-gui-install.adoc
+++ b/modules/logging-loki-gui-install.adoc
@@ -1,8 +1,10 @@
 // Module is included in the following assemblies:
 //
+// logging/log_storage/installing-log-storage.adoc
+
 :_mod-docs-content-type: PROCEDURE
 [id="logging-loki-gui-install_{context}"]
-= Installing {loki-op} using the {product-title} web console
+= Installing the {loki-op} by using the {product-title} web console
 
 To install and configure logging on your {product-title} cluster, additional Operators must be installed. This can be done from the Operator Hub within the web console.
 
@@ -10,16 +12,17 @@ To install and configure logging on your {product-title} cluster, additional Ope
 
 .Prerequisites
 
-* You have access to a supported object store (AWS S3, Google Cloud Storage, Azure, Swift, Minio, OpenShift Data Foundation).
+* You have access to a supported object store (AWS S3, Google Cloud Storage, Azure, Swift, Minio, {rh-storage}).
 * You have administrator permissions.
+* You have access to the {product-title} web console.
 
 .Procedure
 
-. In the {product-title} web console *Administrator* perspective, navigate to *Operators* -> *OperatorHub*.
+. In the {product-title} web console *Administrator* perspective, go to *Operators* -> *OperatorHub*.
 
-. Type {loki-op} in the *Filter by keyword* box. Click *Loki Operator* in the list of available Operators, then click *Install*.
+. Type {loki-op} in the *Filter by keyword* field. Click *{loki-op}* in the list of available Operators, and then click *Install*.
 +
-[NOTE]
+[IMPORTANT]
 ====
 The Community Loki Operator is not supported by Red Hat.
 ====
@@ -34,84 +37,15 @@ The {loki-op} must be deployed to the global operator group namespace `openshift
 
 . Select *Enable operator-recommended cluster monitoring on this namespace.*
 +
-This option sets the `openshift.io/cluster-monitoring: "true"` label in the Namespace object. You must select this option to ensure that cluster monitoring scrapes the `openshift-operators-redhat` namespace.
+This option sets the `openshift.io/cluster-monitoring: "true"` label in the `Namespace` object. You must select this option to ensure that cluster monitoring scrapes the `openshift-operators-redhat` namespace.
 
 . For *Update approval* select *Automatic*, then click *Install*.
 +
 If the approval strategy in the subscription is set to *Automatic*, the update process initiates as soon as a new Operator version is available in the selected channel. If the approval strategy is set to *Manual*, you must manually approve pending updates.
 
-. Create a secret.
-.. Navigate to *Workloads* -> *Secrets* in the *Administrator* perspective of the {product-title} web console.
-.. In the *Create* drop-down menu, select *From YAML*.
-.. Create a secret that uses the `access_key_id` and `access_key_secret` fields to specify your credentials and the `bucketnames`, `endpoint`, and `region` fields to define the object storage location. AWS is used in the following example:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: logging-loki-s3
-  namespace: openshift-logging
-stringData:
-  access_key_id: AKIAIOSFODNN7EXAMPLE
-  access_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-  bucketnames: s3-bucket-name
-  endpoint: https://s3.eu-central-1.amazonaws.com
-  region: eu-central-1
-----
-
-. Create a `LokiStack` custom resource (CR).
-.. Navigate to *Operators* -> *Installed Operators*. Click the *All instances* tab.
-.. Use the *Create new* drop-down menu to select *LokiStack*.
-.. Select *YAML view*, then use the following template to create a `LokiStack` CR:
-+
-[source,yaml]
-----
-apiVersion: loki.grafana.com/v1
-kind: LokiStack
-metadata:
-  name: logging-loki <1>
-  namespace: openshift-logging
-spec:
-  size: 1x.small <2>
-  storage:
-    schemas:
-    - version: v12
-      effectiveDate: '2022-06-01'
-    secret:
-      name: logging-loki-s3 <3>
-      type: s3 <4>
-  storageClassName: <storage_class_name> <5>
-  tenants:
-    mode: openshift-logging
-----
-<1> Use the name `logging-loki`.
-<2> Select your Loki deployment size.
-<3> Specify the secret used for your log storage.
-<4> Specify the corresponding storage type.
-<5> Enter the name of an existing storage class for temporary storage. For best performance, specify a storage class that allocates block storage. Available storage classes for your cluster can be listed by using the `oc get storageclasses` command.
-
-. Create or edit the `ClusterLogging` CR to specify using the Loki log store:
-+
-[source,yaml]
-----
-apiVersion: logging.openshift.io/v1
-kind: ClusterLogging
-metadata:
-  name: instance
-  namespace: openshift-logging
-spec:
-  managementState: Managed
-  logStore:
-    type: lokistack
-    lokistack:
-      name: logging-loki
-# ...
-----
-
 .Verification
 
-. Navigate to *Operators* -> *Installed Operators*.
+. Go to *Operators* -> *Installed Operators*.
 . Make sure the *openshift-logging* project is selected.
 . In the *Status* column, verify that you see green checkmarks with *InstallSucceeded* and the text *Up to date*.
 

--- a/modules/logging-loki-storage-aws.adoc
+++ b/modules/logging-loki-storage-aws.adoc
@@ -1,18 +1,21 @@
 // Module is included in the following assemblies:
-// logging/cluster-logging-loki.adoc
+// logging/log_storage/installing-log-storage.adoc
 //
 :_mod-docs-content-type: PROCEDURE
 [id="logging-loki-storage-aws_{context}"]
 = AWS storage
 
 .Prerequisites
-* You have deployed Loki Operator.
-* You have created a link:https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html[bucket] on AWS.
-* You have created an link:https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_resource-based[AWS IAM Policy and IAM User].
+
+* You installed the {loki-op}.
+* You installed the {oc-first}.
+* You created a link:https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html[bucket] on AWS.
+* You created an link:https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#policies_resource-based[AWS IAM Policy and IAM User].
 
 .Procedure
-* Create an object storage secret with the name `logging-loki-aws` by running the following command:
 
+* Create an object storage secret with the name `logging-loki-aws` by running the following command:
++
 [source,terminal,subs="+quotes"]
 ----
 $ oc create secret generic logging-loki-aws \

--- a/modules/logging-loki-storage-azure.adoc
+++ b/modules/logging-loki-storage-azure.adoc
@@ -1,17 +1,20 @@
 // Module is included in the following assemblies:
-// logging/cluster-logging-loki.adoc
+// logging/log_storage/installing-log-storage.adoc
 //
 :_mod-docs-content-type: PROCEDURE
 [id="logging-loki-storage-azure_{context}"]
 = Azure storage
 
 .Prerequisites
-* You have deployed Loki Operator.
-* You have created a link:https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction[bucket] on Azure.
+
+* You installed the {loki-op}.
+* You installed the {oc-first}.
+* You created a link:https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction[bucket] on Azure.
 
 .Procedure
-* Create an object storage secret with the name `logging-loki-azure` by running the following command:
 
+* Create an object storage secret with the name `logging-loki-azure` by running the following command:
++
 [source,terminal,subs="+quotes"]
 ----
 $ oc create secret generic logging-loki-azure \
@@ -20,4 +23,4 @@ $ oc create secret generic logging-loki-azure \
   --from-literal=account_name="<azure_account_name>" \
   --from-literal=account_key="<azure_account_key>"
 ----
-<1> Supported environment values are: `AzureGlobal`, `AzureChinaCloud`, `AzureGermanCloud`, `AzureUSGovernment`.
+<1> Supported environment values are `AzureGlobal`, `AzureChinaCloud`, `AzureGermanCloud`, or `AzureUSGovernment`.

--- a/modules/logging-loki-storage-gcp.adoc
+++ b/modules/logging-loki-storage-gcp.adoc
@@ -1,26 +1,23 @@
 // Module is included in the following assemblies:
-// logging/cluster-logging-loki.adoc
+// logging/log_storage/installing-log-storage.adoc
 //
 :_mod-docs-content-type: PROCEDURE
 [id="logging-loki-storage-gcp_{context}"]
-= GCP storage
+= Google Cloud Platform storage
 
 .Prerequisites
 
-* You have deployed Loki Operator.
-
-* You have created a link:https://cloud.google.com/resource-manager/docs/creating-managing-projects[project] on Google Cloud Platform.
-
-* You have created a link:https://cloud.google.com/storage/docs/creating-buckets[bucket] in the same project.
-
-* You have created a link:https://cloud.google.com/docs/authentication/getting-started#creating_a_service_account[service account] in the same project for GCP authentication.
+* You installed the {loki-op}.
+* You installed the {oc-first}.
+* You created a link:https://cloud.google.com/resource-manager/docs/creating-managing-projects[project] on Google Cloud Platform (GCP).
+* You created a link:https://cloud.google.com/storage/docs/creating-buckets[bucket] in the same project.
+* You created a link:https://cloud.google.com/docs/authentication/getting-started#creating_a_service_account[service account] in the same project for GCP authentication.
 
 .Procedure
 
 . Copy the service account credentials received from GCP into a file called `key.json`.
 
 . Create an object storage secret with the name `logging-loki-gcs` by running the following command:
-
 +
 [source,terminal,subs="+quotes"]
 ----

--- a/modules/logging-loki-storage-minio.adoc
+++ b/modules/logging-loki-storage-minio.adoc
@@ -1,5 +1,5 @@
 // Module is included in the following assemblies:
-// logging/cluster-logging-loki.adoc
+// logging/log_storage/installing-log-storage.adoc
 //
 :_mod-docs-content-type: PROCEDURE
 [id="logging-loki-storage-minio_{context}"]
@@ -7,16 +7,15 @@
 
 .Prerequisites
 
-* You have deployed Loki Operator.
-
-* You have link:https://operator.min.io/[Minio] deployed on your Cluster.
-
-* You have created a link:https://docs.min.io/docs/minio-client-complete-guide.html[bucket] on Minio.
+* You installed the {loki-op}.
+* You installed the {oc-first}.
+* You have link:https://operator.min.io/[Minio] deployed on your cluster.
+* You created a link:https://docs.min.io/docs/minio-client-complete-guide.html[bucket] on Minio.
 
 .Procedure
 
 * Create an object storage secret with the name `logging-loki-minio` by running the following command:
-
++
 [source,terminal,subs="+quotes"]
 ----
 $ oc create secret generic logging-loki-minio \

--- a/modules/logging-loki-storage-odf.adoc
+++ b/modules/logging-loki-storage-odf.adoc
@@ -3,16 +3,14 @@
 //
 :_mod-docs-content-type: PROCEDURE
 [id="logging-loki-storage-odf_{context}"]
-
-= ODF storage
+= {rh-storage} storage
 
 .Prerequisites
 
-* You have deployed Loki Operator.
-
-* You have deployed link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/[OpenShift Data Foundation].
-
-* You have configured your OpenShift Data Foundation cluster https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.14/html/managing_and_allocating_storage_resources/adding-file-and-object-storage-to-an-existing-external-ocs-cluster[for object storage].
+* You installed the {loki-op}.
+* You installed the {oc-first}.
+* You deployed link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/[{rh-storage}].
+* You configured your {rh-storage} cluster https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.14/html/managing_and_allocating_storage_resources/adding-file-and-object-storage-to-an-existing-external-ocs-cluster[for object storage].
 
 .Procedure
 
@@ -47,7 +45,7 @@ ACCESS_KEY_ID=$(oc get -n openshift-logging secret loki-bucket-odf -o jsonpath='
 SECRET_ACCESS_KEY=$(oc get -n openshift-logging secret loki-bucket-odf -o jsonpath='{.data.AWS_SECRET_ACCESS_KEY}' | base64 -d)
 ----
 
-.. Create an object storage secret with the name `logging-loki-odf` by running the following command:
+. Create an object storage secret with the name `logging-loki-odf` by running the following command:
 +
 [source,terminal,subs="+quotes"]
 ----

--- a/modules/logging-loki-storage-swift.adoc
+++ b/modules/logging-loki-storage-swift.adoc
@@ -1,21 +1,20 @@
 // Module is included in the following assemblies:
-// logging/cluster-logging-loki.adoc
+// logging/log_storage/installing-log-storage.adoc
 //
 :_mod-docs-content-type: PROCEDURE
 [id="logging-loki-storage-swift_{context}"]
 = Swift storage
 
-
 .Prerequisites
 
-* You have deployed Loki Operator.
-
-* You have created a https://docs.openstack.org/newton/user-guide/cli-swift-create-containers.html[bucket] on Swift.
+* You installed the {loki-op}.
+* You installed the {oc-first}.
+* You created a https://docs.openstack.org/newton/user-guide/cli-swift-create-containers.html[bucket] on Swift.
 
 .Procedure
 
 * Create an object storage secret with the name `logging-loki-swift` by running the following command:
-
++
 [source,terminal,subs="+quotes"]
 ----
 $ oc create secret generic logging-loki-swift \
@@ -31,7 +30,7 @@ $ oc create secret generic logging-loki-swift \
 ----
 
 * You can optionally provide project-specific data, region, or both by running the following command:
-
++
 [source,terminal,subs="+quotes"]
 ----
 $ oc create secret generic logging-loki-swift \

--- a/modules/logging-loki-storage.adoc
+++ b/modules/logging-loki-storage.adoc
@@ -1,37 +1,13 @@
 // Module is included in the following assemblies:
-// logging/cluster-logging-loki.adoc
+// logging/log_storage/installing-log-storage.adoc
 //
 :_mod-docs-content-type: CONCEPT
 [id="logging-loki-storage_{context}"]
 = Loki object storage
 
-The Loki Operator supports link:https://aws.amazon.com/[AWS S3], as well as other S3 compatible object stores such as link:https://min.io/[Minio] and link:https://www.redhat.com/en/technologies/cloud-computing/openshift-data-foundation[OpenShift Data Foundation]. link:https://azure.microsoft.com[Azure], link:https://cloud.google.com/[GCS], and link:https://docs.openstack.org/swift/latest/[Swift] are also supported.
+The {loki-op} supports link:https://aws.amazon.com/[AWS S3], as well as other S3 compatible object stores such as link:https://min.io/[Minio] and link:https://www.redhat.com/en/technologies/cloud-computing/openshift-data-foundation[{rh-storage}]. link:https://azure.microsoft.com[Azure], link:https://cloud.google.com/[GCS], and link:https://docs.openstack.org/swift/latest/[Swift] are also supported.
 
 The recommended nomenclature for Loki storage is `logging-loki-_<your_storage_provider>_`.
-
-You can create a secret in the directory that contains your certificate and key files by using the following command:
-
-[source,terminal]
-----
-$ oc create secret generic -n openshift-logging <your_secret_name> \
- --from-file=tls.key=<your_key_file>
- --from-file=tls.crt=<your_crt_file>
- --from-file=ca-bundle.crt=<your_bundle_file>
- --from-literal=username=<your_username>
- --from-literal=password=<your_password>
-----
-
-[NOTE]
-====
-Use generic or opaque secrets for best results.
-====
-
-You can verify a secret has been created by running the following command:
-
-[source,terminal]
-----
-$ oc get secrets
-----
 
 The following table shows the `type` values within the `LokiStack` custom resource (CR) for each storage provider. For more information, see the section on your storage provider.
 

--- a/modules/loki-create-object-storage-secret-cli.adoc
+++ b/modules/loki-create-object-storage-secret-cli.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * list assemblies
+
+:_mod-docs-content-type: PROCEDURE
+[id="loki-create-object-storage-secret-cli_{context}"]
+= Creating a secret for Loki object storage by using the CLI
+
+To configure Loki object storage, you must create a secret. You can do this by using the {oc-first}.
+
+.Prerequisites
+
+* You have administrator permissions.
+* You installed the {loki-op}.
+* You installed the {oc-first}.
+
+.Procedure
+
+* Create a secret in the directory that contains your certificate and key files by running the following command:
++
+[source,terminal]
+----
+$ oc create secret generic -n openshift-logging <your_secret_name> \
+ --from-file=tls.key=<your_key_file>
+ --from-file=tls.crt=<your_crt_file>
+ --from-file=ca-bundle.crt=<your_bundle_file>
+ --from-literal=username=<your_username>
+ --from-literal=password=<your_password>
+----
+
+[NOTE]
+====
+Use generic or opaque secrets for best results.
+====
+
+.Verification
+
+* Verify that a secret was created by running the following command:
++
+[source,terminal]
+----
+$ oc get secrets
+----

--- a/modules/loki-create-object-storage-secret-console.adoc
+++ b/modules/loki-create-object-storage-secret-console.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * list assemblies
+
+:_mod-docs-content-type: PROCEDURE
+[id="loki-create-object-storage-secret-console_{context}"]
+= Creating a secret for Loki object storage by using the web console
+
+To configure Loki object storage, you must create a secret. You can create a secret by using the {product-title} web console.
+
+.Prerequisites
+
+* You have administrator permissions.
+* You have access to the {product-title} web console.
+* You installed the {loki-op}.
+
+.Procedure
+
+. Go to *Workloads* -> *Secrets* in the *Administrator* perspective of the {product-title} web console.
+
+. From the *Create* drop-down list, select *From YAML*.
+
+. Create a secret that uses the `access_key_id` and `access_key_secret` fields to specify your credentials and the `bucketnames`, `endpoint`, and `region` fields to define the object storage location. AWS is used in the following example:
++
+.Example `Secret` object
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: logging-loki-s3
+  namespace: openshift-logging
+stringData:
+  access_key_id: AKIAIOSFODNN7EXAMPLE
+  access_key_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+  bucketnames: s3-bucket-name
+  endpoint: https://s3.eu-central-1.amazonaws.com
+  region: eu-central-1
+----


### PR DESCRIPTION
Version(s):
4.11+

Issue:
- https://issues.redhat.com/browse/OBSDOCS-674
- https://issues.redhat.com/browse/OBSDOCS-144 (related, follow up)

Link to docs preview:
https://68952--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_storage/installing-log-storage

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
