### PR TITLE
Doc guidelines: Correcting the order of the callout description

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -82,13 +82,13 @@ Every module should be placed in the modules folder and should contain the follo
 //
 // * list of assemblies where this module is included              <1>
 
-:_mod-docs-content-type: <TYPE>                                             <2>
+:_mod-docs-content-type: <TYPE>                                    <2>
 [id="<module-anchor>_{context}"]                                   <3>
 = Module title                                                     <4>
 ----
 
-<1> The content type for the file. Replace `<TYPE>` with the actual type of the module, `CONCEPT`, `REFERENCE`, or `PROCEDURE`. Place this attribute before the anchor ID or, if present, the conditional that contains the anchor ID.
-<2> List of assemblies in which this module is included.
+<1> List of assemblies in which this module is included.
+<2> The content type for the file. Replace `<TYPE>` with the actual type of the module, `CONCEPT`, `REFERENCE`, or `PROCEDURE`. Place this attribute before the anchor ID or, if present, the conditional that contains the anchor ID.
 <3> A module anchor with {context} that must be lowercase and must match the module's file name.
 <4> Human readable title. To ensure consistency in the results of the
 leveloffset values in include statements, you must use a level one heading
@@ -555,7 +555,7 @@ Other common attribute values are defined in the `_attributes/common-attributes.
 
 Red Hat integrates with many third-party vendor products. For certain integrated products, third-party vendor staff might have access to certain Red Hat resources and be contactable within Red Hat. On other occasions, common open-source products might be widely used across IT infrastructure providers, so Red Hat might not have direct contacts to organizations that own these products.
 
-Depending on the third-party vendor's requirements, you might need to add a registered trademark symbol to all of the vendor's product names or only on the first occurence of referencing the product name in an assembly, a module, or a document.  
+Depending on the third-party vendor's requirements, you might need to add a registered trademark symbol to all of the vendor's product names or only on the first occurence of referencing the product name in an assembly, a module, or a document.
 
 Choose any of the following sources for clarification on using the symbol for a specific third-party vendor product name:
 


### PR DESCRIPTION
This PR corrects the order of the callout description for the [Module file metadata](https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#module-file-metadata) section.

Version(s):
`main`

Issue:
N/A

Link to docs preview: https://github.com/abhatt-rh/openshift-docs/blob/module-metadata/contributing_to_docs/doc_guidelines.adoc#module-file-metadata

QE review:
N/A