### PR TITLE
OCPBUGS#22777: Updated GCP Kubernetes manifest optional clause

### DIFF
--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -193,6 +193,13 @@ ifdef::aws,azure,ash,gcp[]
 ----
 $ rm -f <installation_directory>/openshift/99_openshift-cluster-api_worker-machineset-*.yaml
 ----
+ifndef::user-infra-vpc[]
++
+[IMPORTANT]
+====
+If you disabled the `MachineAPI` capability when installing a cluster on user-provisioned infrastructure, you must remove the Kubernetes manifest files that define the worker machines. Otherwise, your cluster fails to install.
+====
+endif::user-infra-vpc[]
 +
 Because you create and manage the worker machines yourself, you do not need to initialize these machines.
 endif::aws,azure,ash,gcp[]


### PR DESCRIPTION
[OCPBUGS-22777](https://issues.redhat.com/browse/OCPBUGS-22777)

Version(s):
4.15 and 4.14

Link to docs preview:
[Creating the Kubernetes manifest and Ignition config files](https://68975--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra#installation-user-infra-generate-k8s-manifest-ignition_installing-gcp-user-infra)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
