### PR TITLE
[OCPBUGS-23793] for creating azure service principle

### DIFF
--- a/modules/installation-creating-azure-service-principal.adoc
+++ b/modules/installation-creating-azure-service-principal.adoc
@@ -53,5 +53,7 @@ control. For more information, see https://aka.ms/azadsp-cli
 ----
 $ az role assignment create --role "User Access Administrator" \
   --assignee-object-id $(az ad sp show --id <appId> --query id -o tsv) <1>
+  --scope /subscriptions/<subscription_id> <2>
 ----
 <1> Specify the `appId` parameter value for your service principal.
+<2> Specifies the subscription ID.


### PR DESCRIPTION
As per bug https://issues.redhat.com/browse/OCPBUGS-23793 changing the command for adding "user administrator access" to service principle.

Verified with my own test where the existing command from doc fails. 

$ az role assignment create --role "User Access Administrator" \
  --assignee-object-id $(az ad sp show --id <omitted> --query id -o tsv)

the following arguments are required: --scope

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-23793

Link to docs preview:
https://68976--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-account#installation-creating-azure-service-principal_installing-azure-account

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
