### PR TITLE
OCPBUGS- 24463: Fix broken xrefs

### DIFF
--- a/virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc
+++ b/virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc
@@ -10,9 +10,9 @@ By default, {VirtProductName} is installed with a single, internal pod network.
 
 You can create a Linux bridge network and attach a virtual machine (VM) to the network by performing the following steps:
 
-. xref:../../virt-connecting-vm-to-linux-bridge.adoc#virt-creating-linux-bridge-nncp_virt-connecting-vm-to-linux-bridge[Create a Linux bridge node network configuration policy (NNCP)].
-. Create a Linux bridge network attachment definition (NAD) by using the xref:../../virt-connecting-vm-to-linux-bridge.adoc#virt-creating-linux-bridge-nad-web_virt-connecting-vm-to-linux-bridge[web console] or the xref:../../virt-connecting-vm-to-linux-bridge.adoc#virt-creating-linux-bridge-nad-cli_virt-connecting-vm-to-linux-bridge[command line].
-. Configure the VM to recognize the NAD by using the xref:../../virt-connecting-vm-to-linux-bridge.adoc#virt-vm-creating-nic-web_virt-connecting-vm-to-linux-bridge[web console] or the xref:../../virt-connecting-vm-to-linux-bridge.adoc#virt-attaching-vm-secondary-network-cli_virt-connecting-vm-to-linux-bridge[command line].
+. xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-creating-linux-bridge-nncp_virt-connecting-vm-to-linux-bridge[Create a Linux bridge node network configuration policy (NNCP)].
+. Create a Linux bridge network attachment definition (NAD) by using the xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-creating-linux-bridge-nad-web_virt-connecting-vm-to-linux-bridge[web console] or the xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-creating-linux-bridge-nad-cli_virt-connecting-vm-to-linux-bridge[command line].
+. Configure the VM to recognize the NAD by using the xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-vm-creating-nic-web_virt-connecting-vm-to-linux-bridge[web console] or the xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-attaching-vm-secondary-network-cli_virt-connecting-vm-to-linux-bridge[command line].
 
 include::modules/virt-creating-linux-bridge-nncp.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: OCPBUGS-24463
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Connecting VM to Linux bridge network](https://68978--docspreview.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-linux-bridge)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
