### PR TITLE
OCPBUGS-13794: Added NodeFeatureRule to the docs

### DIFF
--- a/hardware_enablement/psap-node-feature-discovery-operator.adoc
+++ b/hardware_enablement/psap-node-feature-discovery-operator.adoc
@@ -16,6 +16,10 @@ include::modules/psap-using-node-feature-discovery-operator.adoc[leveloffset=+1]
 
 include::modules/psap-configuring-node-feature-discovery.adoc[leveloffset=+1]
 
+include::modules/nfd-rules-about.adoc[leveloffset=+1]
+
+include::modules/nfd-rules-using.adoc[leveloffset=+1]
+
 include::modules/psap-node-feature-discovery-using-topology-updater.adoc[leveloffset=+1]
 
 include::modules/psap-node-feature-discovery-topology-updater-command-reference.adoc[leveloffset=+2]

--- a/modules/nfd-rules-about.adoc
+++ b/modules/nfd-rules-about.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/psap-node-feature-discovery-operator.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nfd-rules-about_{context}"]
+= About the NodeFeatureRule custom resource
+
+`NodeFeatureRule` objects are a `NodeFeatureDiscovery` custom resource designed for rule-based custom labeling of nodes. Some use cases include application-specific labeling or distribution by hardware vendors to create specific labels for their devices.
+
+`NodeFeatureRule` objects provide a method to create vendor- or application-specific labels and taints. It uses a flexible rule-based mechanism for creating labels and optionally taints based on node features.

--- a/modules/nfd-rules-using.adoc
+++ b/modules/nfd-rules-using.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/psap-node-feature-discovery-operator.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nfd-rules-using_{context}"]
+= Using the NodeFeatureRule custom resource
+
+Create a `NodeFeatureRule` object to label nodes if a set of rules match the conditions.
+
+.Procedure
+
+. Create a custom resource file named `nodefeaturerule.yaml` that contains the following text:
++
+[source,yaml]
+----
+apiVersion: nfd.openshift.io/v1
+kind: NodeFeatureRule
+metadata:
+  name: example-rule
+spec:
+  rules:
+    - name: "example rule"
+      labels:
+        "example-custom-feature": "true"
+      # Label is created if all of the rules below match
+      matchFeatures:
+        # Match if "veth" kernel module is loaded
+        - feature: kernel.loadedmodule
+          matchExpressions:
+            veth: {op: Exists}
+        # Match if any PCI device with vendor 8086 exists in the system
+        - feature: pci.device
+          matchExpressions:
+            vendor: {op: In, value: ["8086"]}
+----
++
+This custom resource specifies that labelling occurs when the `veth` module is loaded and any PCI device with vendor code `8086` exists in the cluster.
+
+. Apply the `nodefeaturerule.yaml` file to your cluster by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/v0.13.6/examples/nodefeaturerule.yaml
+----
+The example applies the feature label on nodes with the `veth` module loaded and any PCI device with vendor code `8086` exists.
++
+[NOTE]
+====
+A relabeling delay of up to 1 minute might occur.
+====


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-13794

Link to docs preview (VPN required):
[About the NodeFeatureRule custom resource](https://file.rdu.redhat.com/antaylor/OCPBUGS-13794/hardware_enablement/psap-node-feature-discovery-operator.html#nfd-rules-about_node-feature-discovery-operator)
[Using the NodeFeatureRule custom resource](https://file.rdu.redhat.com/antaylor/OCPBUGS-13794/hardware_enablement/psap-node-feature-discovery-operator.html#nfd-rules-using_node-feature-discovery-operator)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
None