### PR TITLE
About Amazon Simple Storage Service, Identity and Access Management, and GovCloud

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
@@ -17,6 +17,7 @@ You configure AWS for Velero, create a default `Secret`, and then install the Da
 
 To install the OADP Operator in a restricted network environment, you must first disable the default OperatorHub sources and mirror the Operator catalog. See xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments] for details.
 
+include::modules/oadp-s3-and-gov-cloud.adoc[leveloffset=+1]
 
 //include::modules/oadp-installing-operator.adoc[leveloffset=+1]
 include::modules/migration-configuring-aws-s3.adoc[leveloffset=+1]

--- a/modules/oadp-s3-and-gov-cloud.adoc
+++ b/modules/oadp-s3-and-gov-cloud.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="oadp-s3-and-gov-cloud_{context}"]
+= About Amazon Simple Storage Service, Identity and Access Management, and GovCloud
+
+Amazon Simple Storage Service (Amazon S3) is a storage solution of Amazon for the internet. As an authorized user, you can use this service to store and retrieve any amount of data whenever you want, from anywhere on the web.
+
+You securely control access to Amazon S3 and other Amazon services by using the AWS Identity and Access Management (IAM) web service.
+
+You can use IAM to manage permissions that control which AWS resources users can access. You use IAM to both authenticate, or verify that a user is who they claim to be, and to authorize, or grant permissions to use resources.
+
+AWS GovCloud (US) is an Amazon storage solution developed to meet the stringent and specific data security requirements of the United States Federal Government. AWS GovCloud (US) works the same as Amazon S3 except for the following:
+
+* You cannot copy the contents of an Amazon S3 bucket in the AWS GovCloud (US) regions directly to or from another AWS region.
+* If you use Amazon S3 policies, use the AWS GovCloud (US) Amazon Resource Name (ARN) identifier to unambiguously specify a resource  across all of AWS, such as in IAM policies, Amazon S3 bucket names, and API calls.
+
+** IIn AWS GovCloud (US) regions, ARNs have an identifier that is different from the one in other standard AWS regions, `arn:aws-us-gov`. If you need to specify the US-West or US-East region, use one the following ARNs:
+
+*** For US-West, use `us-gov-west-1`.
+*** For US-East, use `us-gov-east-1`.
+
+
+** For all other standard regions, ARNs begin with: `arn:aws`.
+
+* In AWS GovCloud (US) regions, use the endpoints listed in the *AWS GovCloud (US-East)* and *AWS GovCloud (US-West)* rows of the "Amazon S3 endpoints" table on link:https://docs.aws.amazon.com/general/latest/gr/s3.html[Amazon Simple Storage Service endpoints and quotas]. If you are processing export-controlled data, use one of the SSL/TLS endpoints. If you have FIPS requirements, use a FIPS 140-2 endpoint such as https://s3-fips.us-gov-west-1.amazonaws.com or https://s3-fips.us-gov-east-1.amazonaws.com.
+* To find the other AWS-imposed restrictions, see https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-s3.html#govcloud-S3-diffs[How Amazon Simple Storage Service Differs for AWS GovCloud (US)].
+


### PR DESCRIPTION
OADP 1.4, OCP 4.14+

Resolves https://issues.redhat.com/browse/OADP-2428 by adding a new section, "About Amazon Simple Storage Service, Identity and Access Management, and GovCloud" to the instructions for installing OADP on AWS.

Preview:https://68995--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html