### PR TITLE
[OCPBUGS-24516] fixing simple typo in nsenter command

### DIFF
--- a/modules/support-collecting-network-trace.adoc
+++ b/modules/support-collecting-network-trace.adoc
@@ -96,7 +96,7 @@ $ tcpdump -nn -s 0 -i ens5 -w /host/var/tmp/my-cluster-node_$(date +%d_%m_%Y-%H_
 +
 [source,terminal]
 ----
-# nsenter -n -t 49628 -- tcpdump -nn -i ens5 -w /host/var/tmp/my-cluster-node-my-container_$(date +%d_%m_%Y-%H_%M_%S-%Z).pcap.pcap  <1>
+# nsenter -n -t 49628 -- tcpdump -nn -i ens5 -w /host/var/tmp/my-cluster-node-my-container_$(date +%d_%m_%Y-%H_%M_%S-%Z).pcap  <1>
 ----
 <1> The `tcpdump` capture file's path is outside of the `chroot` environment because the toolbox container mounts the host's root directory at `/host`.
 


### PR DESCRIPTION
Version(s):
4.11+

Issue:
[OCPBUGS-24516](https://issues.redhat.com/browse/OCPBUGS-24516)

Link to docs preview:
[Collecting a network trace from an OpenShift Container Platform node or container](https://69019--docspreview.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data.html#support-collecting-network-trace_gathering-cluster-data) step 7c.

QE review:
- [x] QE has approved this change.

Additional information:
