### PR TITLE
OCPBUGS#24443 - Fix multi-arch bug in migration docs

### DIFF
--- a/modules/migrating-to-multi-arch-cli.adoc
+++ b/modules/migrating-to-multi-arch-cli.adoc
@@ -14,7 +14,7 @@
 For more information on how to update your cluster version, see _Updating a cluster using the web console_ or _Updating a cluster using the CLI_.
 * You have installed the OpenShift CLI (`oc`) that matches the version for your current cluster.
 * Your `oc` client is updated to at least verion 4.13.0.
-* Your {product-title} cluster is installed on either the AWS or Azure platform.
+* Your {product-title} cluster is installed on AWS, Azure, GCP, bare metal or IBM P/Z platforms.
 +
 For more information on selecting a supported platform for your cluster installation, see _Selecting a cluster installation type_.
 


### PR DESCRIPTION
**Version(s):** 4.14+

**Issue:** [OCPBUGS-24443](https://issues.redhat.com/browse/OCPBUGS-24443)

**Link to docs preview:**

[Performing a cluster update -> Migrating to a cluster with multi-architecture compute machines](https://69020--docspreview.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/migrating-to-multi-payload)

**QE review:**
- [x] QE has approved this change.