### PR TITLE
Virtualization docs fixes during ROSA review

### DIFF
--- a/modules/virt-adding-container-disk-as-cd.adoc
+++ b/modules/virt-adding-container-disk-as-cd.adoc
@@ -46,7 +46,7 @@ volumes:
 +
 [source,terminal]
 ----
-$ virtctl start <vm>
+$ virtctl start <vm> -n <namespace>
 ----
 
 * If the VM is running, reboot the VM or run the following command:

--- a/modules/virt-adding-public-key-cli.adoc
+++ b/modules/virt-adding-public-key-cli.adoc
@@ -152,8 +152,8 @@ $ oc create -f <manifest_file>.yaml
 +
 [source,terminal]
 ----
-$ virtctl start vm example-vm
-----
+$ virtctl start vm example-vm -n example-namespace
+---- 
 
 .Verification
 . Get the VM configuration:
@@ -187,6 +187,7 @@ endif::[]
             source:
               secret:
                 secretName: authorized-keys
+# ...
 ----
 
 ifeval::["{context}" == "static-key"]

--- a/modules/virt-adding-vm-to-service-mesh.adoc
+++ b/modules/virt-adding-vm-to-service-mesh.adoc
@@ -83,17 +83,17 @@ $ oc apply -f <vm_name>.yaml <1>
 +
 [source,yaml]
 ----
-  apiVersion: v1
-  kind: Service
-  metadata:
-    name: vm-istio
-  spec:
-    selector:
-      app: vm-istio <1>
-    ports:
-      - port: 8080
-        name: http
-        protocol: TCP
+apiVersion: v1
+kind: Service
+metadata:
+  name: vm-istio
+spec:
+  selector:
+    app: vm-istio <1>
+  ports:
+    - port: 8080
+      name: http
+      protocol: TCP
 ----
 <1> The service selector that determines the set of pods targeted by a service. This attribute corresponds to the `spec.metadata.labels` field in the VM configuration file. In the above example, the `Service` object named `vm-istio` targets TCP port 8080 on any pod with the label `app=vm-istio`.
 

--- a/modules/virt-adding-vtpm-to-vm.adoc
+++ b/modules/virt-adding-vtpm-to-vm.adoc
@@ -20,7 +20,7 @@ TPM device. A vTPM device also stores secrets for that VM.
 +
 [source,terminal]
 ----
-$ oc edit vm <vm_name>
+$ oc edit vm <vm_name> -n <namespace>
 ----
 
 . Edit the VM specification to add the vTPM device. For example:

--- a/modules/virt-configuring-storage-class-bootsource-update.adoc
+++ b/modules/virt-configuring-storage-class-bootsource-update.adoc
@@ -7,7 +7,7 @@
 [id="virt-configuring-storage-class-bootsource-update_{context}"]
 = Configuring a storage class for custom boot source updates
 
-Specify a new default storage class in the `HyperConverged` custom resource (CR).
+You can override the default storage class by editing the `HyperConverged` custom resource (CR).
 
 [IMPORTANT]
 ====
@@ -39,9 +39,20 @@ spec:
       template:
         spec:
           storageClassName: <new_storage_class> <1>
-#...
+      schedule: "0 */12 * * *" <2>
+      managedDataSource: <data_source> <3>
+# ...
 ----
 <1> Define the storage class.
+<2> Required: Schedule for the job specified in cron format.
+<3> Required: The data source to use.
++
+--
+[NOTE]
+----
+For the custom image to be detected as an available boot source, the value of the `spec.dataVolumeTemplates.spec.sourceRef.name` parameter in the VM template must match this value.
+----
+--
 
 . Remove the `storageclass.kubernetes.io/is-default-class` annotation from the current default storage class.
 .. Retrieve the name of the current default storage class by running the following command:
@@ -54,10 +65,9 @@ $ oc get storageclass
 .Example output
 [source,text]
 ----
-NAME PROVISIONER RECLAIMPOLICY VOLUMEBINDINGMODE ALLOWVOLUMEEXPANSION AGE
-csi-manila-ceph manila.csi.openstack.org Delete Immediate false 11d
-hostpath-csi-basic (default) kubevirt.io.hostpath-provisioner Delete WaitForFirstConsumer false 11d <1>
-...
+NAME                          PROVISIONER                      RECLAIMPOLICY  VOLUMEBINDINGMODE    ALLOWVOLUMEEXPANSION  AGE
+csi-manila-ceph               manila.csi.openstack.org         Delete         Immediate            false                 11d
+hostpath-csi-basic (default)  kubevirt.io.hostpath-provisioner Delete         WaitForFirstConsumer false                 11d <1>
 ----
 +
 <1> In this example, the current default storage class is named `hostpath-csi-basic`.

--- a/modules/virt-connecting-secondary-network-ssh.adoc
+++ b/modules/virt-connecting-secondary-network-ssh.adoc
@@ -19,7 +19,7 @@ You can connect to a virtual machine (VM) attached to a secondary network by usi
 +
 [source,terminal]
 ----
-$ oc describe vm <vm_name>
+$ oc describe vm <vm_name> -n <namespace>
 ----
 +
 .Example output

--- a/modules/virt-creating-linux-bridge-nad-cli.adoc
+++ b/modules/virt-creating-linux-bridge-nad-cli.adoc
@@ -34,9 +34,9 @@ metadata:
 spec:
   config: '{
     "cniVersion": "0.3.1",
-    "name": bridge-network, <3>
-    "type": cnv-bridge, <4>
-    "bridge": bridge-interface, <5>
+    "name": "bridge-network", <3>
+    "type": "cnv-bridge", <4>
+    "bridge": "bridge-interface", <5>
     "macspoofchk": true, <6>
     "vlan": 100, <7>
     "preserveDefaultVlan": false <8>

--- a/modules/virt-creating-service-cli.adoc
+++ b/modules/virt-creating-service-cli.adoc
@@ -55,9 +55,15 @@ spec:
   selector:
     special: key <1>
   type: NodePort <2>
+  ports: <3>
+    protocol: TCP
+    port: 80
+    targetPort: 9376
+    nodePort: 30000
 ----
 <1> Specify the label that you added to the `spec.template.metadata.labels` stanza of the `VirtualMachine` manifest.
 <2> Specify `ClusterIP`, `NodePort`, or `LoadBalancer`.
+<3> Specifies a collection of network ports and protocols that you want to expose from the virtual machine.
 
 . Save the `Service` manifest file.
 . Create the service by running the following command:

--- a/modules/virt-creating-vm-cli.adoc
+++ b/modules/virt-creating-vm-cli.adoc
@@ -32,7 +32,7 @@ spec:
     spec:
       sourceRef:
         kind: DataSource
-        name: rhel9
+        name: rhel9 <2>
         namespace: openshift-virtualization-os-images
       storage:
         resources:
@@ -82,12 +82,13 @@ spec:
           userData: |-
             #cloud-config
             user: cloud-user
-            password: '<password>' <2>
+            password: '<password>' <3>
             chpasswd: { expire: False }
         name: cloudinitdisk
 ----
 <1> Specify the name of the virtual machine.
-<2> Specify the password for cloud-user.
+<2> Specify the name in the `spec.dataImportCronTemplate.spec.managedDataSource` field in the `Hyperconvered` CR.
+<3> Specify the password for cloud-user.
 ====
 
 . Create a virtual machine by using the manifest file:
@@ -101,5 +102,5 @@ $ oc create -f <vm_manifest_file>.yaml
 +
 [source,terminal]
 ----
-$ virtctl start <vm_name>
+$ virtctl start <vm_name> -n <namespace>
 ----

--- a/modules/virt-creating-vm-custom-image-web.adoc
+++ b/modules/virt-creating-vm-custom-image-web.adoc
@@ -62,7 +62,7 @@ ifdef::clone[]
 . Select the PVC project and the PVC name.
 endif::[]
 . Set the disk size.
-. Click *Customize VirtualMachine*.
+. Click *Next*.
 . Click *Create VirtualMachine*.
 
 ifeval::["{context}" == "virt-creating-vms-from-web-images"]

--- a/modules/virt-customizing-storage-profile.adoc
+++ b/modules/virt-customizing-storage-profile.adoc
@@ -24,11 +24,11 @@ If you create a data volume and omit YAML attributes and these attributes are no
 
 .Procedure
 
-. Edit the storage profile. In this example, the provisioner is not recognized by CDI:
+. Edit the storage profile. In this example, the provisioner is not recognized by CDI.
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit -n {CNVNamespace} storageprofile <storage_class>
+$ oc edit storageprofile <storage_class>
 ----
 +
 .Example storage profile

--- a/modules/virt-disabling-tls-for-registry.adoc
+++ b/modules/virt-disabling-tls-for-registry.adoc
@@ -10,12 +10,16 @@ You can disable TLS (transport layer security) for one or more container registr
 
 .Prerequisites
 
-* Log in to the cluster as a user with the `cluster-admin` role.
-
-.Procedure
-
-* Edit the `HyperConverged` custom resource and add a list of insecure registries to the `spec.storageImport.insecureRegistries` field.
+. Open the `HyperConverged` CR in your default editor by running the following command:
 +
+[source,terminal,subs="attributes+"]
+----
+$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+----
+
+. Add a list of insecure registries to the `spec.storageImport.insecureRegistries` field.
++
+.Example `HyperConverged` custom resource
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: hco.kubevirt.io/v1beta1

--- a/modules/virt-edit-boot-order-yaml-web.adoc
+++ b/modules/virt-edit-boot-order-yaml-web.adoc
@@ -15,11 +15,10 @@ Edit the boot order list in a YAML configuration file by using the CLI.
 +
 [source,terminal]
 ----
-$ oc edit vm example
+$ oc edit vm <vm_name> -n <namespace>
 ----
 
 . Edit the YAML file and modify the values for the boot order associated with a disk or network interface controller (NIC). For example:
-
 +
 [source,yaml]
 ----
@@ -44,6 +43,3 @@ interfaces:
 <2> The boot order value specified for the network interface controller.
 
 . Save the YAML file.
-
-
-. Click *reload the content* to apply the updated boot order values from the YAML file to the boot order list in the web console.

--- a/modules/virt-editing-vm-cli.adoc
+++ b/modules/virt-editing-vm-cli.adoc
@@ -28,5 +28,5 @@ $ oc edit vm <vm_name>
 +
 [source,terminal]
 ----
-$ oc apply vm <vm_name>
+$ oc apply vm <vm_name> -n <namespace>
 ----

--- a/modules/virt-editing-vm-dynamic-key-injection.adoc
+++ b/modules/virt-editing-vm-dynamic-key-injection.adoc
@@ -18,7 +18,7 @@ The key is added to the VM by the QEMU guest agent, which is installed with {op-
 
 . Navigate to *Virtualization* -> *VirtualMachines* in the web console.
 . Select a VM to open the *VirtualMachine details* page.
-. On the *Configure* tab, click *Scripts*.
+. On the *Configuration* tab, click *Scripts*.
 . If you have not already added a public SSH key to your project, click the edit icon beside *Authorized SSH key* and select one of the following options:
 
 * *Use existing*: Select a secret from the secrets list.

--- a/modules/virt-enabling-preallocation-for-dv.adoc
+++ b/modules/virt-enabling-preallocation-for-dv.adoc
@@ -22,9 +22,13 @@ metadata:
   name: preallocated-datavolume
 spec:
   source: <1>
-    pvc:
-      preallocation: true <2>
+    registry:
+      url: <image_url> <2>
+  storage:
+    resources:
+      requests:
+        storage: 1Gi
 # ...
 ----
 <1> All CDI source types support preallocation. However, preallocation is ignored for cloning operations.
-<2> The default value is `false`.
+<2> Specify the URL of the data source in your registry.

--- a/modules/virt-hot-plugging-bridge-network-interface-cli.adoc
+++ b/modules/virt-hot-plugging-bridge-network-interface-cli.adoc
@@ -20,7 +20,7 @@ Hot plug a secondary network interface to a virtual machine (VM) while the VM is
 +
 [source,terminal]
 ----
-$ virtctl start <vm_name>
+$ virtctl start <vm_name> -n <namespace>
 ----
 
 . Use the following command to add the new network interface to the running VM. Editing the VM specification adds the new network interface to the VM and virtual machine instance (VMI) configuration but does not attach it to the running VM.

--- a/modules/virt-initiating-vm-migration-cli.adoc
+++ b/modules/virt-initiating-vm-migration-cli.adoc
@@ -37,7 +37,7 @@ The `VirtualMachineInstanceMigration` object triggers a live migration of the VM
 +
 [source,terminal]
 ----
-$ oc describe vmi <vm_name>
+$ oc describe vmi <vm_name> -n <namespace>
 ----
 +
 .Example output

--- a/modules/virt-pausing-vm-web.adoc
+++ b/modules/virt-pausing-vm-web.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virt-controlling-vm-states.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-pausing-vm-web_{context}"]
+= Pausing a virtual machine
+
+You can pause a virtual machine from the web console.
+
+.Procedure
+
+. Click *Virtualization* -> *VirtualMachines* from the side menu.
+
+. Find the row that contains the virtual machine that you want to pause.
+
+. Navigate to the appropriate menu for your use case:
+
+* To stay on this page, where you can perform actions on multiple virtual machines:
+
+.. Click the Options menu {kebab} located at the far right end of the row and click *Pause VirtualMachine*.
+
+* To view comprehensive information about the selected virtual machine before you pause it:
+
+.. Access the *VirtualMachine details* page by clicking the name of the virtual machine.
+
+.. Click *Actions* -> *Pause*.

--- a/modules/virt-pxe-booting-with-mac-address.adoc
+++ b/modules/virt-pxe-booting-with-mac-address.adoc
@@ -117,7 +117,7 @@ networks:
 ----
 $ oc create -f vmi-pxe-boot.yaml
 ----
-
++
 .Example output
 [source,terminal]
 ----
@@ -148,6 +148,8 @@ $ virtctl vnc vmi-pxe-boot
 $ virtctl console vmi-pxe-boot
 ----
 
+.Verification
+
 . Verify the interfaces and MAC address on the virtual machine and that the interface connected to the bridge has the specified MAC address.
 In this case, we used `eth1` for the PXE boot, without an IP address. The other interface, `eth0`, got an IP address from {product-title}.
 +
@@ -155,7 +157,7 @@ In this case, we used `eth1` for the PXE boot, without an IP address. The other 
 ----
 $ ip addr
 ----
-
++
 .Example output
 [source,terminal]
 ----

--- a/modules/virt-restarting-vm-web.adoc
+++ b/modules/virt-restarting-vm-web.adoc
@@ -23,7 +23,7 @@ To avoid errors, do not restart a virtual machine while it has a status of *Impo
 
 * To stay on this page, where you can perform actions on multiple virtual machines:
 
-.. Click the Options menu {kebab} located at the far right end of the row.
+.. Click the Options menu {kebab} located at the far right end of the row and click *Restart*.
 
 * To view comprehensive information about the selected virtual machine before
 you restart it:
@@ -32,5 +32,3 @@ you restart it:
 machine.
 
 .. Click *Actions* -> *Restart*.
-
-. In the confirmation window, click *Restart* to restart the virtual machine.

--- a/modules/virt-runbook-cdistorageprofilesincomplete.adoc
+++ b/modules/virt-runbook-cdistorageprofilesincomplete.adoc
@@ -49,7 +49,7 @@ $ oc patch storageprofile local --type=merge -p '{"spec": \
   {"claimPropertySets": [{"accessModes": ["ReadWriteOnce"], \
   "volumeMode": "Filesystem"}]}}'
 ----
-
+ 
 If you cannot resolve the issue, log in to the
 link:https://access.redhat.com[Customer Portal] and open a support case,
 attaching the artifacts gathered during the diagnosis procedure.

--- a/modules/virt-starting-vm-web.adoc
+++ b/modules/virt-starting-vm-web.adoc
@@ -18,17 +18,13 @@ You can start a virtual machine from the web console.
 
 * To stay on this page, where you can perform actions on multiple virtual machines:
 
-.. Click the Options menu {kebab} located at the far right end of the row.
+.. Click the Options menu {kebab} located at the far right end of the row and click *Start VirtualMachine*.
 
 * To view comprehensive information about the selected virtual machine before you start it:
 
 .. Access the *VirtualMachine details* page by clicking the name of the virtual machine.
 
-.. Click *Actions*.
-
-. Select *Restart*.
-
-. In the confirmation window, click *Start* to start the virtual machine.
+.. Click *Actions* -> *Start*.
 
 [NOTE]
 ====

--- a/modules/virt-stopping-vm-web.adoc
+++ b/modules/virt-stopping-vm-web.adoc
@@ -18,12 +18,10 @@ You can stop a virtual machine from the web console.
 
 * To stay on this page, where you can perform actions on multiple virtual machines:
 
-.. Click the Options menu {kebab} located at the far right end of the row.
+.. Click the Options menu {kebab} located at the far right end of the row and click *Stop VirtualMachine*.
 
 * To view comprehensive information about the selected virtual machine before you stop it:
 
 .. Access the *VirtualMachine details* page by clicking the name of the virtual machine.
 
 .. Click *Actions* → *Stop*.
-
-. In the confirmation window, click *Stop* to stop the virtual machine.

--- a/modules/virt-unpausing-vm-web.adoc
+++ b/modules/virt-unpausing-vm-web.adoc
@@ -11,11 +11,6 @@ You can unpause a paused virtual machine from the web console.
 .Prerequisites
 
 * At least one of your virtual machines must have a status of *Paused*.
-+
-[NOTE]
-====
-You can pause virtual machines by using the `virtctl` client.
-====
 
 .Procedure
 
@@ -27,7 +22,7 @@ You can pause virtual machines by using the `virtctl` client.
 
 * To stay on this page, where you can perform actions on multiple virtual machines:
 
-.. In the *Status* column, click *Paused*.
+.. Click the Options menu {kebab} located at the far right end of the row and click *Unpause VirtualMachine*.
 
 * To view comprehensive information about the selected virtual machine before
 you unpause it:
@@ -35,6 +30,4 @@ you unpause it:
 .. Access the *VirtualMachine details* page by clicking the name of the virtual
 machine.
 
-.. Click the pencil icon that is located on the right side of *Status*.
-
-. In the confirmation window, click *Unpause* to unpause the virtual machine.
+.. Click *Actions* → *Unpause*.

--- a/virt/post_installation_configuration/virt-post-install-network-config.adoc
+++ b/virt/post_installation_configuration/virt-post-install-network-config.adoc
@@ -45,8 +45,7 @@ include::modules/virt-creating-linux-bridge-nncp.adoc[leveloffset=+2]
 
 include::modules/virt-creating-linux-bridge-nad-web.adoc[leveloffset=+2]
 
-[id="next-steps_configuring-linux-bridge-network"]
-=== Next steps
+.Next steps
 * xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-attaching-vm-secondary-network-cli_virt-connecting-vm-to-linux-bridge[Attaching a virtual machine (VM) to a Linux bridge network]
 
 [id="configuring-network-live-migration"]
@@ -70,8 +69,8 @@ include::modules/nw-sriov-configuring-device.adoc[leveloffset=+2]
 
 include::modules/nw-sriov-network-attachment.adoc[leveloffset=+2]
 
-[id="next-steps_configuring-sriov-network"]
-=== Next steps
+.Next steps
+
 * xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#virt-attaching-vm-to-sriov-network_virt-connecting-vm-to-sriov[Attaching a virtual machine (VM) to an SR-IOV network]
 endif::openshift-rosa,openshift-dedicated[]
 

--- a/virt/virtual_machines/virt-controlling-vm-states.adoc
+++ b/virt/virtual_machines/virt-controlling-vm-states.adoc
@@ -12,8 +12,10 @@ You can use xref:../../virt/getting_started/virt-using-the-cli-tools.adoc#virt-u
 
 include::modules/virt-starting-vm-web.adoc[leveloffset=+1]
 
+include::modules/virt-stopping-vm-web.adoc[leveloffset=+1]
+
 include::modules/virt-restarting-vm-web.adoc[leveloffset=+1]
 
-include::modules/virt-stopping-vm-web.adoc[leveloffset=+1]
+include::modules/virt-pausing-vm-web.adoc[leveloffset=+1]
 
 include::modules/virt-unpausing-vm-web.adoc[leveloffset=+1]


### PR DESCRIPTION
Fixing various errors in the Applications docs as I find them during the ROSA content port. Mostly formatting, wording, and such.

Previews:
[Installing VirtIO drivers from a container disk added as a SATA CD drive](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/creating_vms_custom/virt-installing-qemu-guest-agent#virt-adding-container-disk-as-cd_virt-installing-qemu-guest-agent) -- Added `-n namespace` to command.
[Adding a key when creating a VM by using the command line](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-accessing-vm-ssh#virt-adding-public-key-cli_static-key) and [Enabling dynamic key injection by using the command line](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-accessing-vm-ssh#virt-adding-public-key-cli_static-key) -- Added namespace to code example in step 3 to match namespace in step 1 code block.
[Adding a virtual machine to a service mesh](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-service-mesh#virt-adding-vm-to-service-mesh_virt-connecting-vm-to-service-mesh) -- Fixed YAML spacing in the code example in step 3.
[Adding a vTPM device to a virtual machine](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-using-vtpm-devices#virt-adding-vtpm-to-vm_virt-using-vtpm-devices) -- Added `-n namespace` to command in step 1.
[Configuring a storage class for custom boot source updates](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-automatic-bootsource-updates#virt-configuring-storage-class-bootsource-update_virt-automatic-bootsource-updates) -- Added required parameters to code example. [ ] QE has approved this change.  Fixed spacing in code block in step 3a.
[Connecting to a VM attached to a secondary network by using SSH](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-accessing-vm-ssh#virt-connecting-secondary-network-ssh_virt-accessing-vm-ssh) -- Added `-n namespace` to command.
[Creating a Linux bridge NAD by using the command line](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-linux-bridge#virt-creating-linux-bridge-nad-cli_virt-connecting-vm-to-linux-bridge) -- Added required quotes to values. [ ] QE has approved this change.
[Creating a service by using the command line](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-accessing-vm-ssh#virt-creating-service-cli_virt-accessing-vm-ssh) -- Added required parameters to step 3. [ ] QE has approved this change.
[Creating a VM from a VirtualMachine manifest](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/creating_vms_rh/virt-creating-vms-from-cli#virt-creating-vm-cli_virt-creating-vms-cli) -- Added `-n <namespace>` to code example in step 3
[Creating a VM from a container disk by using the web console](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/creating_vms_custom/virt-creating-vms-from-container-disks#virt-creating-vm-custom-image-web_virt-creating-vms-from-container-disks) -- Corrected the web console steps.
[Customizing the storage profile](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-configuring-storage-profile#virt-customizing-storage-profile_virt-configuring-storage-profile) -- Fixed punctuation in step 1.
[Disabling TLS for a container registry](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/creating_vms_custom/virt-creating-vms-from-container-disks#virt-disabling-tls-for-registry_virt-creating-vms-from-container-disks) -- Added example of how to edit the file in Step 1.
[Editing a boot order list in the YAML configuration file](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-edit-boot-order#virt-edit-boot-order-yaml-web_virt-edit-boot-order) -- Added `-n namespace` to command.
[Editing a virtual machine by using the command line](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-edit-vms#virt-editing-vm-cli_virt-edit-vms) -- Added `-n namespace` to command.
[Enabling dynamic SSH key injection by using the web console](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-accessing-vm-ssh#virt-editing-vm-dynamic-key-injection_dynamic-key) -- Updated procedure step 3 to match what is in console.
[Enabling preallocation for a data volume](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-using-preallocation-for-datavolumes#virt-enabling-preallocation-for-dv_virt-using-preallocation-for-datavolumes) -- Added required parameters to code block. [ ] QE has approved this change.
[Hot plugging a bridge network interface using the CLI](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-hot-plugging-network-interfaces#virt-hot-plugging-bridge-network-interface_virt-hot-plugging-network-interfaces) -- Added `-n namespace` to command in step 1.
[Initiating live migration by using the command line](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-initiating-live-migration#virt-initiating-vm-migration-cli_virt-initiating-live-migration) -- Added `-n namespace` to command.
[Pause a virtual machine](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-controlling-vm-states#virt-pausing-vm-web_virt-controlling-vm-states) -- New file copied from [virt-starting-vm-web.adoc](https://github.com/openshift/openshift-docs/pull/69051/files#diff-8cb9d109052efd28a6ee8492466998313d6ed6fd2138f268473f8d79c924d581) and changed start to pause.
Initiating live migration by using the command line -- Added `-n namespace` to command in verification.
[PXE booting with a specified MAC address](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-configuring-pxe-booting#virt-pxe-booting-with-mac-address_pxe-booting) -- Added verification heading.
[Restarting a virtual machine](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-controlling-vm-states#virt-restarting-vm-web_virt-controlling-vm-states) --  Updated substeps under step 3 to match web console.
[Starting a virtual machine](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-controlling-vm-states#virt-starting-vm-web_virt-controlling-vm-states) -- Updated substeps under step 3 to match web console.
[Stopping a virtual machine](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-controlling-vm-states#virt-stopping-vm-web_virt-controlling-vm-states) --  Updated substeps under step 3 to match web console.
[Unpausing a virtual machine](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-controlling-vm-states#virt-unpausing-vm-web_virt-controlling-vm-states) -- Updated substeps under step 3 to match web console.
Post-install ->Network configuration  -> Demoted assembly-level next step to module level in [Creating a Linux bridge NAD by using the web console](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-post-install-network-config#virt-creating-linux-bridge-nad-web_virt-post-install-network-config) and [Configuring SR-IOV network devices](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-post-install-network-config#nw-sriov-configuring-device_virt-post-install-network-config).
[Controlling virtual machine states](https://69051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-controlling-vm-states) -- Reordered modules and added new module for pausing. [Current docs](https://docs.openshift.com/container-platform/4.14/virt/virtual_machines/virt-controlling-vm-states.html).