### PR TITLE
OCPBUGS#9451: Volume mounts name and volume name matched in yaml file…

### DIFF
--- a/modules/persistent-storage-local-pod.adoc
+++ b/modules/persistent-storage-local-pod.adoc
@@ -23,15 +23,16 @@ declares the persistent volume claim inside a pod:
 apiVersion: v1
 kind: Pod
 spec:
-  ...
+# ...
   containers:
     volumeMounts:
     - name: local-disks <1>
       mountPath: /data <2>
   volumes:
-  - name: localpvc
+  - name: local-disks
     persistentVolumeClaim:
       claimName: local-pvc-name <3>
+# ...
 ----
 <1> The name of the volume to mount.
 <2> The path inside the pod where the volume is mounted. Do not mount to the container root, `/`, or any path that is the same in the host and the container. This can corrupt your host system if the container is sufficiently privileged, such as the host `/dev/pts` files. It is safe to mount the host by using `/host`.


### PR DESCRIPTION
Version(s):
4.11, 4.12, 4.13, 4.14, 4.15

Issue:
[OCPBUGS-9451](https://issues.redhat.com/browse/OCPBUGS-9451)

Link to docs preview:
[Persistent storage using local volumes: Attach the local claim](https://69062--docspreview.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-local#local-pod_persistent-storage-local)

QE review:
- [x] QE approval is required to merge a PR except for changes that do not impact the meaning of the docs.
