### PR TITLE
[TELCODOCS-1004, TELCODOCS-1207] - 4.14.6 release notes for PTP + known issues

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3306,3 +3306,34 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.14.0 --pullspecs
 ----
 //replace 4.y.z for the correct values for the release. You do not need to update oc to run this command.
+
+[id="ocp-4-14-6"]
+=== RHSA-2023:7682 - {product-title} {product-version}.6 bug fix, and security update advisory
+
+Issued: 2023-12-12
+
+{product-title} release {product-version}.6, which includes security updates, is now available. The list of enhancements that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:7682[RHSA-2023:7682] advisory.
+
+[id="ocp-4-14.6-features"]
+==== Features
+
+The following PTP features are included in this z-stream release:
+
+[id="ocp-4-14.6-ptp-hardware-plugin"]
+===== Using hardware-specific NIC features with the PTP Operator
+
+* A new PTP Operator hardware plugin is available that allows you to use hardware-specific features for supported NICs with the PTP Operator.
+Currently the Intel Westport channel E810 NIC is supported.
+For more information see, xref:../networking/ptp/configuring-ptp.adoc#nw-ptp-wpc-hardware-pins-reference_configuring-ptp[E810 hardware configuration reference].
+
+[id="ocp-4-14.6-ptp-gnss-timing"]
+===== Using GNSS timing synchronization for PTP grandmaster clocks
+
+* The PTP Operator now supports receiving precision PTP timing from Global Navigation Satellite System (GNSS) sources connected to grandmaster clocks (T-GM).
+For more information see, xref:../networking/ptp/configuring-ptp.adoc#configuring-linuxptp-services-as-grandmaster-clock_configuring-ptp[Configuring linuxptp services as a grandmaster clock].
+
+[id="ocp-4-14.6-known-issue"]
+==== Known issues
+
+* For PTP timing syncronization, DPLL phase offset monitoring is required to fully determine the grandmaster clock (T-GM) state.
+This is currently absent in the in-tree ice driver DPLL API, which creates a blind spot for determining the grandmaster state.


### PR DESCRIPTION
Release notes and known issues for PTP 4.14.6 release.

Issues:

https://issues.redhat.com/browse/TELCODOCS-1004
https://issues.redhat.com/browse/TELCODOCS-1207
https://issues.redhat.com/browse/RHEL-15789

Version(s):
enterprise-4.14

Link to docs preview:
https://69063--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-6

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->