### PR TITLE
[manual CP] Add Serverless 1.31 release notes

### DIFF
--- a/about/serverless-release-notes.adoc
+++ b/about/serverless-release-notes.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 [NOTE]
 ====
-For additional information about the {ServerlessProductName} life cycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift#ossrvless[Platform Life Cycle Policy].
+For additional information about the {ServerlessProductName} life cycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles].
 ====
 
 Release notes contain information about new and deprecated features, breaking changes, and known issues. The following release notes apply for the most recent {ServerlessProductName} releases on {ocp-product-title}.
@@ -28,6 +28,11 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 
 // Release notes included, most to least recent
 // OCP + OSD + ROSA
+include::modules/serverless-rn-1-31-0.adoc[leveloffset=+1]
+
+
+// OCP + OSD + ROSA
+include::modules/serverless-rn-1-30-2.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-30-1.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-30-0.adoc[leveloffset=+1]
 // 1.30.0 additional resources

--- a/modules/release-notes-template.adoc
+++ b/modules/release-notes-template.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies
 //
-// * /serverless/serverless-release-notes.adoc
+// * about/serverless-release-notes.adoc
 
 :_content-type: REFERENCE
 [id="serverless-rn-X-YY-Z_{context}"]
@@ -23,7 +23,7 @@
 * {ServerlessProductName} now uses Knative Eventing 0.x.
 * {ServerlessProductName} now uses Kourier 0.x.
 * {ServerlessProductName} now uses Knative (`kn`) CLI 0.x.
-* {ServerlessProductName} now uses Knative Kafka 0.x.
+* {ServerlessProductName} now uses Knative for Apache Kafka 0.x.
 * The `kn func` CLI plug-in now uses `func` 0.x.
 
 [id="fixed-issues-X-YY-Z_{context}"]

--- a/modules/serverless-deprecated-removed-features.adoc
+++ b/modules/serverless-deprecated-removed-features.adoc
@@ -13,29 +13,29 @@ For the most recent list of major functionality deprecated and removed within {S
 .Deprecated and removed features tracker
 [cols="3,1,1,1,1,1,1",options="header"]
 |====
-|Feature |1.21|1.22 to 1.26|1.27|1.28|1.29|1.30
+|Feature |1.22 to 1.26|1.27|1.28|1.29|1.30|1.31
 
 |`NamespacedKafka` annotation
 |-
 |-
 |-
 |-
-|-
+|Deprecated
 |Deprecated
 
 |`enable-secret-informer-filtering` annotation
 |-
 |-
-|-
+|Deprecated
 |Deprecated
 |Deprecated
 |Deprecated
 
 |Serving and Eventing `v1alpha1` API
 |-
-|-
 |Deprecated
 |Deprecated
+|Removed
 |Removed
 |Removed
 
@@ -48,7 +48,7 @@ For the most recent list of major functionality deprecated and removed within {S
 |Removed
 
 |`KafkaBinding` API
-|Deprecated
+|Removed
 |Removed
 |Removed
 |Removed

--- a/modules/serverless-rn-1-30-2.adoc
+++ b/modules/serverless-rn-1-30-2.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies
+//
+// * /serverless/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-30-2_{context}"]
+= Red Hat {ServerlessProductName} 1.30.2
+
+{ServerlessProductName} 1.30.2 is now available. New features, updates, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes.
+
+This release of {ServerlessProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on OpenShift Container Platform 4.11 and later versions. Notably, this update addresses CVE-2023-44487 - HTTP/2 Rapid Stream Reset by disabling HTTP/2 transport on Serving, Eventing webhooks, and RBAC proxy containers.

--- a/modules/serverless-rn-1-31-0.adoc
+++ b/modules/serverless-rn-1-31-0.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies
+//
+// * about/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-31-0_{context}"]
+= Red Hat {ServerlessProductName} 1.31
+
+{ServerlessProductName} 1.31 is now available. New features, updates, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes.
+
+[id="new-features-1-31-0_{context}"]
+== New features
+
+* {ServerlessProductName} now uses Knative Serving 1.10.
+* {ServerlessProductName} now uses Knative Eventing 1.10.
+* {ServerlessProductName} now uses Kourier 1.10.
+* {ServerlessProductName} now uses Knative (`kn`) CLI 1.10.
+* {ServerlessProductName} now uses Knative for Apache Kafka 1.10.
+* The `kn func` CLI plug-in now uses `func` 1.11.
+
+* {ServerlessProductName} multi-tenancy with {SMProductShortName} is now available as a Technology Preview (TP) feature.
+
+* {FunctionsProductName} now supports the Go runtime as a Technology Preview (TP) feature.
+
+* Serverless Logic, which is available as a Technology Preview (TP) feature, has been updated.
++
+See link:https://openshift-knative.github.io/docs/docs/latest/serverless-logic/about.html[the Serverless Logic documentation] for usage instructions.
+
+* You can now configure a persistent volume claim (PVC) for an existing `PersistentVolume` object to use with a Serverless function.
+
+* When specifying Kourier for Ingress and using `DomainMapping`, the TLS for OpenShift Route is set to passthrough, and TLS is handled by the Kourier Gateway. Beginning with {ServerlessProductShortName} 1.31, it is possible to specify the enabled cipher suites on the side of the Kourier Gateway.
+
+* Integrating {SMProductName} with {ServerlessProductShortName} when Kourier is enabled is now deprecated. Use `net-istio` instead of `net-kourier` for Service Mesh integration.
++
+See the "Integrating {SMProductName} with {ServerlessProductShortName}" section for details.
+
+* The `PodDistruptionBudget` and `HorizontalPodAutoscaler` objects have been added for the `3scale-kourier-gateway` deployment.
+** `PodDistruptionBudget` is used to define the minimum availability requirements for pods in a deployment.
+** `HorizontalPodAutoscaler` is used to automatically scale the number of pods in the deployment based on demand or on your custom metrics.
+
+* Now you can change the pattern for Apache Kafka topic names used by Knative brokers and channels for Apache Kafka.
+
+* The `DomainMapping` `v1alpha1` custom resource definition (CRD) is now deprecated. Use `v1beta1` CRD instead.
+
+* The `NamespacedKafka` annotation, which was a Technology Preview (TP) feature, is now deprecated in favor of the standard Kafka broker with no data plane isolation.
+
+[id="fixed-issues-1-31-0_{context}"]
+== Fixed issues
+
+* Previously, when deploying Knative Eventing with full {SMProductName} integration and with `STRICT` peer authentication, the `PingSource` adapter metrics were unavailable.
++
+This has been fixed, and the `PingSource` adapter metrics are now collected using a different `job` and `service` label value. The previous value was `pingsource-mt-adapter`, the new value is `pingsource-mt-adapter-sm-service`.

--- a/modules/serverless-tech-preview-features.adoc
+++ b/modules/serverless-tech-preview-features.adoc
@@ -6,24 +6,34 @@
 [id="serverless-tech-preview-features_{context}"]
 = Generally Available and Technology Preview features
 
-Features which are Generally Available (GA) are fully supported and are suitable for production use. Technology Preview (TP) features are experimental features and are not intended for production use. See the link:https://access.redhat.com/support/offerings/techpreview[Technology Preview scope of support on the Red Hat Customer Portal] for more information about TP features.
+Features that are Generally Available (GA) are fully supported and are suitable for production use. Technology Preview (TP) features are experimental features and are not intended for production use. See the link:https://access.redhat.com/support/offerings/techpreview[Technology Preview scope of support on the Red Hat Customer Portal] for more information about TP features.
 
 The following table provides information about which {ServerlessProductName} features are GA and which are TP:
 
 .Generally Available and Technology Preview features tracker
 [cols="2,1,1,1",options="header"]
 |====
-|Feature |1.28|1.29|1.30
+|Feature |1.29|1.30|1.31
 
-|Overriding `liveness` and `readiness` in functions
-|-
-|-
-|GA
-
-|Eventing integration with {SMProductName}
+|Using Service Mesh to isolate network traffic with OpenShift Serverless
 |-
 |-
 |TP
+
+|Golang functions
+|-
+|-
+|TP
+
+|Serverless Logic
+|-
+|TP
+|TP
+
+|Overriding `liveness` and `readiness` in functions
+|-
+|GA
+|GA
 
 |`kn func`
 |GA
@@ -51,8 +61,8 @@ The following table provides information about which {ServerlessProductName} fea
 |TP
 
 |Service Mesh mTLS
-|GA
-|GA
+|-
+|TP
 |GA
 
 |`emptyDir` volumes
@@ -96,7 +106,7 @@ The following table provides information about which {ServerlessProductName} fea
 |TP
 
 |`multi-container support`
-|TP
+|GA
 |GA
 |GA
 


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/68620 into `serverless-docs-1.31`.