### PR TITLE
OCPBUGS#23390: Removed the root statement from RH OCP 1.3.0 registry …

### DIFF
--- a/modules/mirror-registry-localhost-update.adoc
+++ b/modules/mirror-registry-localhost-update.adoc
@@ -33,7 +33,7 @@ $ sudo ./mirror-registry upgrade -v
 * Users who upgrade _mirror registry for Red Hat OpenShift_ with the `./mirror-registry upgrade -v` flag must include the same credentials used when creating their mirror registry. For example, if you installed the _mirror registry for Red Hat OpenShift_ with `--quayHostname <host_example_com>` and `--quayRoot <example_directory_name>`, you must include that string to properly upgrade the mirror registry.
 ====
 
-* If you are upgrading the _mirror registry for Red Hat OpenShift_ from 1.2.z -> 1.3.0 and you used a specified directory in your 1.2.z deployment, you must pass in the new `--pgStorage`and `--quayStorage` flags. For example:
+* If you are upgrading the _mirror registry for Red Hat OpenShift_ from 1.2.z -> 1.3.0 and you used a specified directory in your 1.2.z deployment, you must pass in the new `--pgStorage` and `--quayStorage` flags. For example:
 +
 [source,terminal]
 ----

--- a/modules/mirror-registry-release-notes.adoc
+++ b/modules/mirror-registry-release-notes.adoc
@@ -140,9 +140,9 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 +
 IPv6 is currently unsupported on _mirror registry for Red Hat OpenShift_ remote host installations.
 
-* A new feature flag, `--quayStorage`, has been added. With this flag, users with root privileges can manually set the location of their Quay persistent storage.
+* A new feature flag, `--quayStorage`, has been added. By specifying this flag, you can manually set the location for the Quay persistent storage.
 
-* A new feature flag, `--pgStorage`, has been added. With this flag, users with root privileges can manually set the location of their Postgres persistent storage.
+* A new feature flag, `--pgStorage`, has been added. By specifying this flag, you can manually set the location for the Postgres persistent storage.
 
 * Previously, users were required to have root privileges (`sudo`) to install _mirror registry for Red Hat OpenShift_. With this update, `sudo` is no longer required to install _mirror registry for Red Hat OpenShift_.
 +


### PR DESCRIPTION
[OCPBUGS-23390](https://issues.redhat.com/browse/OCPBUGS-23390)

Version(s):
4.15 to 4.11

Link to docs preview:
[Mirror registry for Red Hat OpenShift 1.3.0](https://69083--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-creating-registry#new-features)

SME review:
- [x] SME has approved this change.

QE review:
- [x] QE has approved this change. QE review requested.
