### PR TITLE
OSDOCS-8996: Add CDO deprecation note to Tutorial: Deploying the Exte…

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-external-dns.adoc
+++ b/cloud_experts_tutorials/cloud-experts-external-dns.adoc
@@ -18,6 +18,11 @@ toc::[]
 //  - Dustin Scott
 //---
 
+[NOTE]
+====
+Starting with {product-title} 4.14, the Custom Domain Operator is deprecated. To manage Ingress in {product-title} 4.14, use the Ingress Operator. The functionality is unchanged for {product-title} 4.13 and earlier versions.
+====
+
 Configuring the xref:../applications/deployments/osd-config-custom-domains-applications.adoc[Custom Domain Operator] requires a wildcard CNAME DNS record in your Amazon Route 53 hosted zone. If you do not want to use a wildcard record, you can use the `External DNS` Operator to create individual entries for routes.
 
 Use this tutorial to deploy and configure the `External DNS` Operator with a custom domain in {product-title} (ROSA).


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-8996

Link to docs preview:
https://69091--docspreview.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-external-dns

QE review:
Adding existing note to tutorial. No new technical information. No QE review required. 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
