### PR TITLE
[enterprise-4.12] OCPBUGS#22483: Expanded on general vmotion statement in vSphere doc

### DIFF
--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -405,15 +405,15 @@ For more information about creating an account with only the required privileges
 
 If you intend on using vMotion in your vSphere environment, consider the following before installing an {product-title} cluster.
 
-* {product-title} generally supports compute-only vMotion. Using Storage vMotion can cause issues and is not supported.
+* {product-title} generally supports compute-only vMotion, where _generally_ implies that you meet all VMware best practices for vMotion.
 +
 --
-To help ensure the uptime of your compute and control plane nodes, it is recommended that you follow the VMware best practices for vMotion. It is also recommended to use VMware anti-affinity rules to improve the availability of {product-title} during maintenance or hardware issues.
+To help ensure the uptime of your compute and control plane nodes, ensure that you follow the VMware best practices for vMotion, and use VMware anti-affinity rules to improve the availability of {product-title} during maintenance or hardware issues.
 
 For more information about vMotion and anti-affinity rules, see the VMware vSphere documentation for  link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vcenterhost.doc/GUID-3B41119A-1276-404B-8BFB-A32409052449.html[vMotion networking requirements] and link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.resmgmt.doc/GUID-FBE46165-065C-48C2-B775-7ADA87FF9A20.html[VM anti-affinity rules].
 --
-* If you are using vSphere volumes in your pods, migrating a VM across datastores either manually or through Storage vMotion causes, invalid references within {product-title} persistent volume (PV) objects. These references prevent affected pods from starting up and can result in data loss.
-* Similarly, {product-title} does not support selective migration of VMDKs across datastores, using datastore clusters for VM provisioning or for dynamic or static provisioning of PVs, or using a datastore that is part of a datastore cluster for dynamic or static provisioning of PVs.
+* Using Storage vMotion can cause issues and is not supported. If you are using vSphere volumes in your pods, migrating a VM across datastores, either manually or through Storage vMotion, causes invalid references within {product-title} persistent volume (PV) objects that can result in data loss.
+* {product-title} does not support selective migration of VMDKs across datastores, using datastore clusters for VM provisioning or for dynamic or static provisioning of PVs, or using a datastore that is part of a datastore cluster for dynamic or static provisioning of PVs.
 
 [discrete]
 [id="installation-vsphere-installer-infra-requirements-resources_{context}"]


### PR DESCRIPTION
Issue cherry picked from #22483 through commit # 6ddd92049e53f6b4d7f22f775c5265a295303d05

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OCPBUGS-22483

Link to docs preview:
[Using OpenShift Container Platform with vMotion](https://69093--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations#:~:text=Using%20OpenShift%20Container%20Platform%20with%20vMotion)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
