### PR TITLE
OBSDOCS-681: Update Fluentd config docs

### DIFF
--- a/modules/cluster-logging-collector-limits.adoc
+++ b/modules/cluster-logging-collector-limits.adoc
@@ -10,7 +10,7 @@ The log collector allows for adjustments to both the CPU and memory limits.
 
 .Procedure
 
-. Edit the `ClusterLogging` custom resource (CR) in the `openshift-logging` project:
+* Edit the `ClusterLogging` custom resource (CR) in the `openshift-logging` project:
 +
 [source,terminal]
 ----
@@ -19,23 +19,20 @@ $ oc -n openshift-logging edit ClusterLogging instance
 +
 [source,yaml]
 ----
-apiVersion: "logging.openshift.io/v1"
-kind: "ClusterLogging"
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogging
 metadata:
-  name: "instance"
+  name: instance
   namespace: openshift-logging
-
-...
-
 spec:
   collection:
-    logs:
-      fluentd:
-        resources:
-          limits: <1>
-            memory: 736Mi
-          requests:
-            cpu: 100m
-            memory: 736Mi
+    type: fluentd
+    resources:
+      limits: <1>
+        memory: 736Mi
+        requests:
+          cpu: 100m
+          memory: 736Mi
+# ...
 ----
 <1> Specify the CPU and memory limits and requests as needed. The values shown are the default values.

--- a/modules/cluster-logging-collector-tuning.adoc
+++ b/modules/cluster-logging-collector-tuning.adoc
@@ -6,6 +6,8 @@
 [id="cluster-logging-collector-tuning_{context}"]
 = Advanced configuration for the Fluentd log forwarder
 
+include::snippets/logging-fluentd-dep-snip.adoc[]
+
 The {logging-title} includes multiple Fluentd parameters that you can use for tuning the performance of the Fluentd log forwarder. With these parameters, you can change the following Fluentd behaviors:
 
 * Chunk and chunk buffer sizes
@@ -114,7 +116,7 @@ metadata:
   name: instance
   namespace: openshift-logging
 spec:
-  forwarder:
+  collection:
     fluentd:
       buffer:
         chunkLimitSize: 8m <1>
@@ -126,7 +128,7 @@ spec:
         retryType: periodic <7>
         retryWait: 1s <8>
         totalLimitSize: 32m <9>
-...
+# ...
 ----
 <1> Specify the maximum size of each chunk before it is queued for flushing.
 <2> Specify the interval between chunk flushes.
@@ -156,18 +158,19 @@ $ oc extract configmap/collector-config --confirm
 [source,terminal]
 ----
 <buffer>
- @type file
- path '/var/lib/fluentd/default'
- flush_mode interval
- flush_interval 5s
- flush_thread_count 3
- retry_type periodic
- retry_wait 1s
- retry_max_interval 300s
- retry_timeout 60m
- queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
- total_limit_size 32m
- chunk_limit_size 8m
- overflow_action throw_exception
+  @type file
+  path '/var/lib/fluentd/default'
+  flush_mode interval
+  flush_interval 5s
+  flush_thread_count 3
+  retry_type periodic
+  retry_wait 1s
+  retry_max_interval 300s
+  retry_timeout 60m
+  queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+  total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+  chunk_limit_size 8m
+  overflow_action throw_exception
+  disable_chunk_backup true
 </buffer>
 ----

--- a/modules/cluster-logging-deploy-cli.adoc
+++ b/modules/cluster-logging-deploy-cli.adoc
@@ -93,6 +93,8 @@ spec:
 ----
 $ oc apply -f <filename>.yaml
 ----
++
+The {clo} is installed to the `openshift-logging` namespace.
 
 .Verification
 

--- a/modules/infrastructure-moving-logging.adoc
+++ b/modules/infrastructure-moving-logging.adoc
@@ -31,11 +31,6 @@ apiVersion: logging.openshift.io/v1
 kind: ClusterLogging
 # ...
 spec:
-  collection:
-    logs:
-      fluentd:
-        resources: null
-      type: fluentd
   logStore:
     elasticsearch:
       nodeCount: 3


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OBSDOCS-681

Link to docs preview:
- https://69107--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_collection_forwarding/cluster-logging-collector#cluster-logging-collector-tuning_cluster-logging-collector
- https://69107--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/cluster-logging-deploying#cluster-logging-deploy-cli_cluster-logging-deploying
- https://69107--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/config/cluster-logging-moving-nodes#infrastructure-moving-logging_cluster-logging-moving

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
