### PR TITLE
OSSM-3159 Remove routerMode: sni-dnat from federation docs

### DIFF
--- a/modules/ossm-federation-config-smcp.adoc
+++ b/modules/ossm-federation-config-smcp.adoc
@@ -31,7 +31,6 @@ spec:
         enabled: true
         requestedNetworkView:
         - green-network
-        routerMode: sni-dnat
         service:
           metadata:
             labels:
@@ -45,7 +44,6 @@ spec:
         enabled: true
         requestedNetworkView:
         - blue-network
-        routerMode: sni-dnat
         service:
           metadata:
             labels:
@@ -58,7 +56,6 @@ spec:
     additionalIngress:
       ingress-green-mesh:
         enabled: true
-        routerMode: sni-dnat
         service:
           type: LoadBalancer
           metadata:
@@ -71,7 +68,6 @@ spec:
             name: https-discovery  #note HTTPS here
       ingress-blue-mesh:
         enabled: true
-        routerMode: sni-dnat
         service:
           type: LoadBalancer
           metadata:
@@ -146,14 +142,6 @@ To avoid naming conflicts between meshes, you must create separate egress and in
 |Networks associated with exported services.
 |Set to the value of `spec.cluster.network` in the SMCP for the mesh, otherwise use <ServiceMeshPeer-name>-network. For example, if the `ServiceMeshPeer` resource for that mesh is named `west`, then the network would be named `west-network`.
 |
-
-|spec:
-  gateways:
-    additionalEgress:
-      <egressName>:
-        routerMode:
-|The router mode to be used by the gateway.
-|`sni-dnat`
 |
 
 |spec:
@@ -194,14 +182,6 @@ To avoid naming conflicts between meshes, you must create separate egress and in
 |`true`/`false`
 |`true`
 
-|spec:
-  gateways:
-    additionalIngress:
-      <ingressName>:
-        routerMode:
-|The router mode to be used by the gateway.
-|`sni-dnat`
-|
 
 |spec:
   gateways:
@@ -266,7 +246,6 @@ In the following example, the administrator is configuring the SMCP for federati
      additionalIngress:
       ingress-green-mesh:
         enabled: true
-        routerMode: sni-dnat
         service:
           type: NodePort
           metadata:


### PR DESCRIPTION
[OSSM-3159](https://issues.redhat.com//browse/OSSM-3159) Remove "routerMode: sni-dnat" from federation docs

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+ 

Issue:
https://issues.redhat.com/browse/OSSM-3159

Link to docs preview:
https://69120--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-federation#ossm-federation-config-smcp_federation

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

OSSM 2.1 is no longer supported so "routerMode: sni-dnat" has been removed instead of adding "Required only in OSSM 2.1".

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
