### PR TITLE
OCPBUGS#24561: fix typo busybox yaml

### DIFF
--- a/modules/microshift-applying-manifests-example.adoc
+++ b/modules/microshift-applying-manifests-example.adoc
@@ -38,8 +38,8 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: busybox-deployment
-  namespace:busybox
+  name: busybox
+  namespace: busybox-deployment
 spec:
   selector:
     matchLabels:
@@ -52,9 +52,7 @@ spec:
       containers:
       - name: busybox
         image: BUSYBOX_IMAGE
-        command:
-          - sleep
-          - "3600"
+        command: [ "/bin/sh", "-c", "while true ; do date; sleep 3600; done;" ]
 EOF
 ----
 


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OCPBUGS-24561

Link to docs preview:
[Using manifests example](https://69121--docspreview.netlify.app/microshift/latest/microshift_running_apps/microshift-applications#microshift-applying-manifests-example_applications-microshift)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
