### PR TITLE
TELCODOCS-1675 - Adding updated T-GM config to 4.13+

### DIFF
--- a/modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock.adoc
@@ -6,7 +6,7 @@
 [id="configuring-linuxptp-services-as-grandmaster-clock_{context}"]
 = Configuring linuxptp services as a grandmaster clock
 
-You can configure the `linuxptp` services (`ptp4l`, `phc2sys`, `ts2phc`) as grandmaster clock by creating a `PtpConfig` custom resource (CR) that configures the host NIC.
+You can configure the `linuxptp` services (`ptp4l`, `phc2sys`, `ts2phc`) as a grandmaster clock (T-GM) by creating a `PtpConfig` custom resource (CR) that configures the host NIC.
 
 The `ts2phc` utility allows you to synchronize the system clock with the PTP grandmaster clock so that the node can stream precision clock signal to downstream PTP ordinary clocks and boundary clocks.
 
@@ -20,7 +20,7 @@ See "Configuring the PTP fast event notifications publisher" for more informatio
 
 .Prerequisites
 
-* Install an Intel Westport Channel network interface in the bare-metal cluster host.
+* For T-GM clocks in production environments, install an Intel E810 Westport Channel NIC in the bare-metal cluster host.
 
 * Install the OpenShift CLI (`oc`).
 
@@ -32,13 +32,31 @@ See "Configuring the PTP fast event notifications publisher" for more informatio
 
 . Create the `PtpConfig` resource. For example:
 
-.. Save the following YAML in the `grandmaster-clock-ptp-config.yaml` file:
+.. Depending on your requirements, use one of the following T-GM configurations for your deployment.
+Save the YAML in the `grandmaster-clock-ptp-config.yaml` file:
 +
 .Example PTP grandmaster clock configuration
+[%collapsible]
+=====
 [source,yaml]
 ----
 include::snippets/ptp_PtpConfigMaster.yaml[]
 ----
+
+[NOTE]
+====
+The example PTP grandmaster clock configuration is for test purposes only and is not intended for production.
+====
+=====
++
+.PTP grandmaster clock configuration for E810 NIC
+[%collapsible]
+====
+[source,yaml]
+----
+include::snippets/ptp_PtpConfigGmWpc.yaml[]
+----
+====
 
 .. Create the CR by running the following command:
 +

--- a/modules/nw-ptp-grandmaster-clock-configuration-reference.adoc
+++ b/modules/nw-ptp-grandmaster-clock-configuration-reference.adoc
@@ -6,7 +6,7 @@
 [id="nw-ptp-grandmaster-clock-configuration-reference_{context}"]
 = Grandmaster clock PtpConfig configuration reference
 
-The following reference information describes the configuration options for the `PtpConfig` custom resource (CR) that configures the `linuxptp` services (`ptp4l`, `phc2sys`, `ts2phc`) as grandmaster clock.
+The following reference information describes the configuration options for the `PtpConfig` custom resource (CR) that configures the `linuxptp` services (`ptp4l`, `phc2sys`, `ts2phc`) as a grandmaster clock.
 
 .PtpConfig configuration options for PTP Grandmaster clock
 [cols="1,3" options="header"]
@@ -25,7 +25,7 @@ For the Intel Westport Channel NIC, when `enableDefaultConfig` is true, The PTP 
 The options should not include the network interface name `-i <interface>` and service config file `-f /etc/ptp4l.conf` because the network interface name and the service config file are automatically appended.
 
 |`ptp4lConf`
-|Specify the required configuration to start `ptp4l` as grandmaster clock.
+|Specify the required configuration to start `ptp4l` as a grandmaster clock.
 For example, the `ens2f1` interface synchronizes downstream connected devices.
 For grandmaster clocks, set `clockClass` to `6` and set `clockAccuracy` to `0x27`.
 Set `timeSource` to `0x20` for when receiving the timing signal from a Global navigation satellite system (GNSS).

--- a/snippets/ptp_PtpConfigGmWpc.yaml
+++ b/snippets/ptp_PtpConfigGmWpc.yaml
@@ -1,0 +1,146 @@
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: grandmaster
+  namespace: openshift-ptp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+spec:
+  profile:
+  - name: "grandmaster"
+    ptp4lOpts: "-2 --summary_interval -4"
+    phc2sysOpts: -r -u 0 -m -O -37 -N 8 -R 16 -s $iface_master -n 24
+    ptpSchedulingPolicy: SCHED_FIFO
+    ptpSchedulingPriority: 10
+    ptpSettings:
+      logReduce: "true"
+    plugins:
+      e810:
+        enableDefaultConfig: true
+    ts2phcOpts: " "
+    ts2phcConf: |
+      [nmea]
+      ts2phc.master 1
+      [global]
+      use_syslog  0
+      verbose 1
+      logging_level 7
+      ts2phc.pulsewidth 100000000
+      ts2phc.nmea_serialport $gnss_serialport
+      leapfile  /usr/share/zoneinfo/leap-seconds.list
+      [$iface_master]
+      ts2phc.extts_polarity rising
+      ts2phc.extts_correction 0
+    ptp4lConf: |
+      [$iface_master]
+      masterOnly 1
+      [$iface_master_1]
+      masterOnly 1
+      [$iface_master_2]
+      masterOnly 1
+      [$iface_master_3]
+      masterOnly 1
+      [global]
+      #
+      # Default Data Set
+      #
+      twoStepFlag 1
+      priority1 128
+      priority2 128
+      domainNumber 24
+      #utc_offset 37
+      clockClass 6
+      clockAccuracy 0x27
+      offsetScaledLogVariance 0xFFFF
+      free_running 0
+      freq_est_interval 1
+      dscp_event 0
+      dscp_general 0
+      dataset_comparison G.8275.x
+      G.8275.defaultDS.localPriority 128
+      #
+      # Port Data Set
+      #
+      logAnnounceInterval -3
+      logSyncInterval -4
+      logMinDelayReqInterval -4
+      logMinPdelayReqInterval 0
+      announceReceiptTimeout 3
+      syncReceiptTimeout 0
+      delayAsymmetry 0
+      fault_reset_interval -4
+      neighborPropDelayThresh 20000000
+      masterOnly 0
+      G.8275.portDS.localPriority 128
+      #
+      # Run time options
+      #
+      assume_two_step 0
+      logging_level 6
+      path_trace_enabled 0
+      follow_up_info 0
+      hybrid_e2e 0
+      inhibit_multicast_service 0
+      net_sync_monitor 0
+      tc_spanning_tree 0
+      tx_timestamp_timeout 50
+      unicast_listen 0
+      unicast_master_table 0
+      unicast_req_duration 3600
+      use_syslog 1
+      verbose 0
+      summary_interval -4
+      kernel_leap 1
+      check_fup_sync 0
+      clock_class_threshold 7
+      #
+      # Servo Options
+      #
+      pi_proportional_const 0.0
+      pi_integral_const 0.0
+      pi_proportional_scale 0.0
+      pi_proportional_exponent -0.3
+      pi_proportional_norm_max 0.7
+      pi_integral_scale 0.0
+      pi_integral_exponent 0.4
+      pi_integral_norm_max 0.3
+      step_threshold 2.0
+      first_step_threshold 0.00002
+      clock_servo pi
+      sanity_freq_limit  200000000
+      ntpshm_segment 0
+      #
+      # Transport options
+      #
+      transportSpecific 0x0
+      ptp_dst_mac 01:1B:19:00:00:00
+      p2p_dst_mac 01:80:C2:00:00:0E
+      udp_ttl 1
+      udp6_scope 0x0E
+      uds_address /var/run/ptp4l
+      #
+      # Default interface options
+      #
+      clock_type BC
+      network_transport L2
+      delay_mechanism E2E
+      time_stamping hardware
+      tsproc_mode filter
+      delay_filter moving_median
+      delay_filter_length 10
+      egressLatency 0
+      ingressLatency 0
+      boundary_clock_jbod 0
+      #
+      # Clock description
+      #
+      productDescription ;;
+      revisionData ;;
+      manufacturerIdentity 00:00:00
+      userDescription ;
+      timeSource 0x20
+  recommend:
+  - profile: "grandmaster"
+    priority: 4
+    match:
+    - nodeLabel: "node-role.kubernetes.io/$mcp"


### PR DESCRIPTION
Adding updated T-GM config to PTP docs

Version(s):
4.13+

Issue:
* https://issues.redhat.com/browse/TELCODOCS-1675

Link to docs previews:
* https://file.emea.redhat.com/aireilly/TELCODOCS-1675/networking/using-ptp.html#configuring-linuxptp-services-as-grandmaster-clock_using-ptp

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
