### PR TITLE
NETOBSERV-1060: loki empty ring troubleshooting

### DIFF
--- a/modules/troubleshooting-network-observability-loki-empty-ring.adoc
+++ b/modules/troubleshooting-network-observability-loki-empty-ring.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+
+// * networking/network_observability/troubleshooting-network-observability.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="network-observability-troubleshooting-loki-empty-ring_{context}"]
+= Loki empty ring error
+
+The Loki "empty ring" error results in flows not being stored in Loki and not showing up in the web console. This error might happen in various situations. A single workaround to address them all does not exist. There are some actions you can take to investigate the logs in your Loki pods, and verify that the `LokiStack` is healthy and ready. 
+
+Some of the situations where this error is observed are as follows:
+
+* After a `LokiStack` is uninstalled and reinstalled in the same namespace, old PVCs are not removed, which can cause this error. 
+** *Action*: You can try removing the `LokiStack` again, removing the PVC, then reinstalling the `LokiStack`.
+* After a certificate rotation, this error can prevent communication with the `flowlogs-pipeline` and `console-plugin` pods. 
+** *Action*: You can restart the pods to restore the connectivity.

--- a/network_observability/troubleshooting-network-observability.adoc
+++ b/network_observability/troubleshooting-network-observability.adoc
@@ -18,6 +18,8 @@ include::modules/troubleshooting-network-observability-network-flow.adoc[levelof
 
 include::modules/troubleshooting-network-observability-controller-manager-pod-out-of-memory.adoc[leveloffset=+1]
 
+include::modules/troubleshooting-network-observability-loki-empty-ring.adoc[leveloffset=+1]
+
 == Resource troubleshooting
 
 include::modules/troubleshooting-network-observability-loki-tenant-rate-limit.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Merge to only the no-1.5 branch - no cherrypicks are required.
This PR is part of an experiment for simplifying merges for asynchronous content, and I will open one PR against main to incorporate all of the Network Observability 1.5 content just before its GA.
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.11+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/NETOBSERV-1060
https://issues.redhat.com/browse/OSDOCS-9019
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://69149--docspreview.netlify.app/openshift-enterprise/latest/network_observability/troubleshooting-network-observability#network-observability-troubleshooting-loki-empty-ring_network-observability-troubleshooting

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
