### PR TITLE
Updates release notes to call out macvlan ipv6 support

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -364,6 +364,11 @@ This release adds improvements related to the following components and concepts.
 [id="ocp-4-15-networking"]
 === Networking
 
+[id="ocp-4-15-ipv6-default-macvlan"]
+==== IPv6 unsolicited neighbor advertisements now default on macvlan CNI plugin
+
+Pods created using the macvlan CNI plugin, where the IP address management CNI plug-in has assigned IPs, now send IPv6 unsolicited neighbor advertisements by default onto the network. This enhancement notifies hosts of the new pod's MAC address for a particular IP to refresh IPv6 neighbor caches.
+
 [id="ocp-4-15-registry"]
 === Registry
 


### PR DESCRIPTION
Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-8734

Link to docs preview:
https://69150--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-ipv6-default-macvlan

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
