### PR TITLE
[OCPBUGS-17076]: Updating unhealthy etcd member docs

### DIFF
--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -129,6 +129,13 @@ $ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides":
 +
 This command ensures that you can successfully re-create secrets and roll out the static pods.
 
+. Delete the affected node by running the following command:
++
+[source,terminal]
+----
+$ oc delete node <node_name>
+---- 
+
 . Remove the old secrets for the unhealthy etcd member that was removed.
 
 .. List the secrets for the unhealthy etcd member that was removed.
@@ -172,7 +179,7 @@ $ oc delete secret -n openshift-etcd etcd-serving-ip-10-0-131-183.ec2.internal
 $ oc delete secret -n openshift-etcd etcd-serving-metrics-ip-10-0-131-183.ec2.internal
 ----
 
-. Delete and recreate the control plane machine. After this machine is recreated, a new revision is forced and etcd scales up automatically.
+. Delete and re-create the control plane machine. After this machine is re-created, a new revision is forced and etcd scales up automatically.
 +
 If you are running installer-provisioned infrastructure, or you used the Machine API to create your machines, follow these steps. Otherwise, you must create the new master using the same method that was used to originally create it.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-17076
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://69162--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member#restore-replace-stopped-etcd-member_replacing-unhealthy-etcd-member
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

![Screenshot 2023-12-08 at 2 09 56 PM](https://github.com/openshift/openshift-docs/assets/102675557/83c1f634-44f9-4144-bf92-78fef5967fbb)


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
