### PR TITLE
OSDOCS-9018: Added a link to the AWS docs for ROSA with HCP

### DIFF
--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
@@ -25,6 +25,9 @@ Since it is not possible to upgrade or convert existing ROSA clusters to a {hcp}
 {hcp-title} clusters only support AWS Security Token Service (STS) authentication.
 ====
 
+.Further reading
+* See the AWS documentation for information about link:https://docs.aws.amazon.com/rosa/latest/userguide/getting-started-hcp.html[Getting started with ROSA with HCP using the ROSA CLI in auto mode].
+
 include::modules/rosa-hcp-classic-comparison.adoc[leveloffset=+1]
 
 .Additional resources


### PR DESCRIPTION
Version(s):
`enterprise-4.14+`

Issue:
[OSDOCS-9018](https://issues.redhat.com/browse/OSDOCS-9018)

Link to docs preview:
- [Creating ROSA with HCP clusters using the default options](https://file.rdu.redhat.com/eponvell/OSDOCS-9018_AWS-HCP-Link/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html)
    ![image](https://github.com/openshift/openshift-docs/assets/16167833/7b38316f-4169-40b2-a451-4a3e401ed8fb)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added a link to the AWS documentation about getting started with ROSA with HCP.