### PR TITLE
RHDEVDOCS-4220: Doc: Openshift pipelines should only run on Linux nod…

### DIFF
--- a/install_config/installing-pipelines.adoc
+++ b/install_config/installing-pipelines.adoc
@@ -18,6 +18,11 @@ This guide walks cluster administrators through the process of installing the {p
 * You have installed xref:../tkn_cli/installing-tkn.adoc#installing-tkn[{pipelines-shortname} (`tkn`) CLI] on your local system.
 * Your cluster has the link:https://docs.openshift.com/container-platform/latest/installing/cluster-capabilities.html#marketplace-operator_cluster-capabilities[Marketplace capability] enabled or the Red Hat Operator catalog source configured manually.
 
+[NOTE]
+====
+In a cluster with both Windows and Linux nodes, {pipelines-title} can run on only Linux nodes.
+====
+
 //Installing pipelines Operator using web console
 
 include::modules/op-installing-pipelines-operator-in-web-console.adoc[leveloffset=+1]


### PR DESCRIPTION
**Version(s)**: CP to `pipelines-docs-1.10`, `pipelines-docs-1.11`, `pipelines-docs-1.12`, `pipelines-docs-1.13`

**Issue**: [RHDEVDOCS-4220](https://issues.redhat.com/browse/RHDEVDOCS-4220)

**Preview link**:  [Installing OpenShift Pipelines](https://69178--docspreview.netlify.app/openshift-pipelines/latest/install_config/installing-pipelines)

**SME review**: @concaf 

**QE review**: @ppitonak 

**Peer review**: @lahinson 