### PR TITLE
[RHACS] Disabled preview step, similar to main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,17 +29,17 @@ jobs:
       script:
         - python3 build.py --distro openshift-acs --product "Red Hat Advanced Cluster Security for Kubernetes" --version 4.1 --no-upstream-fetch && python3 makeBuild.py
 
-    - stage: netlify
-      name: "Create Netlify preiview"
-      env:
-        - CAN_FAIL=true
-      language: minimal
-      if: type IN (pull_request) AND branch IN (rhacs-docs, rhacs-docs-3.74, rhacs-docs-4.0, rhacs-docs-4.1, rhacs-docs-4.2)
-      script:
-        - chmod +x autopreview.sh
-        - ./autopreview.sh
+    # - stage: netlify
+    #   name: "Create Netlify preiview"
+    #   env:
+    #     - CAN_FAIL=true
+    #   language: minimal
+    #   if: type IN (pull_request) AND branch IN (rhacs-docs, rhacs-docs-3.74, rhacs-docs-4.0, rhacs-docs-4.1, rhacs-docs-4.2)
+    #   script:
+    #     - chmod +x autopreview.sh
+    #     - ./autopreview.sh
 
 stages:
   - cache-and-validate
   - build
-  - netlify
+  # - netlify


### PR DESCRIPTION
Because of a Circle CI issue, preview builds are broken. This PR disables preview step from CI.

cherrypick:
- rhacs-docs-4.1
- rhacs-docs-4.2
- rhacs-docs-4.3
- rhacs-docs-4.4