### PR TITLE
OSDOCS-8913: MicroShift release notes 4.14.6

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -376,3 +376,12 @@ For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers
 ==== Bug fixes
 
 * Previously, when {microshift-short} was installed on a non-ostree system, an error was logged during greenboot health check stating that the ostree directory did not exist. {microshift-short} still started normally. Now, the system properly logs the ostree status as “not an ostree system” and an error message is not produced.
+
+[id="microshift-4-14-6-dp"]
+=== RHBA-2023:7684 - {microshift-short} 4.14.6 bug fix update advisory
+
+Issued: 2023-12-12
+
+{product-title} release 4.14.6, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:7684[RHBA-2023:7684] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7682[RHSA-2023:7682] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-8913](https://issues.redhat.com/browse/OSDOCS-8913)

Link to docs preview:
[4.14.6 Release note](https://file.rdu.redhat.com/shdiaz/OSDOCS-8913/microshift_release_notes/microshift-4-14-release-notes.html)

QE review:
- N/A

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
