### PR TITLE
DOCS OBSDOCS-659 -Logging 5.8.1 Release Notes

### DIFF
--- a/logging/logging_release_notes/logging-5-8-release-notes.adoc
+++ b/logging/logging_release_notes/logging-5-8-release-notes.adoc
@@ -10,4 +10,6 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-8-1.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-8-0.adoc[leveloffset=+1]

--- a/modules/logging-release-notes-5-8-1.adoc
+++ b/modules/logging-release-notes-5-8-1.adoc
@@ -1,0 +1,126 @@
+//module included in logging-5-8-release-notes.adoc
+:content-type: REFERENCE
+[id="logging-release-notes-5-8-1_{context}"]
+= Logging 5.8.1
+This release includes link:https://access.redhat.com/errata/RHBA-2023:7720[OpenShift Logging Bug Fix Release 5.8.1] and link:https://access.redhat.com/errata/RHBA-2023:7717[OpenShift Logging Bug Fix Release 5.8.1 Kibana].
+
+[id="logging-release-notes-5-8-1-enhancements"]
+== Enhancements
+
+[id="logging-release-notes-5-8-1-log-collection"]
+=== Log Collection
+
+* With this update, while configuring Vector as a collector, you can add logic to the {clo} to use a token specified in the secret in place of the token associated with the service account. (link:https://issues.redhat.com/browse/LOG-4780[LOG-4780])
+
+* With this update, the *BoltDB Shipper* Loki dashboards are now renamed to *Index* dashboards. (link:https://issues.redhat.com/browse/LOG-4828[LOG-4828])
+
+[id="logging-release-notes-5-8-1-bug-fixes"]
+== Bug fixes
+
+* Before this update, the `ClusterLogForwarder` created empty indices after enabling the parsing of JSON logs, even when the rollover conditions were not met. With this update, the `ClusterLogForwarder` skips the rollover when the `write-index` is empty. (link:https://issues.redhat.com/browse/LOG-4452[LOG-4452])
+
+* Before this update, the Vector set the `default` log level incorrectly. With this update, the correct log level is set by improving the enhancement of regular expression, or `regexp`, for log level detection. (link:https://issues.redhat.com/browse/LOG-4480[LOG-4480])
+
+* Before this update, during the process of creating index patterns, the default alias was missing from the initial index in each log output. As a result, Kibana users were unable to create index patterns by using {es-op}. This update adds the missing aliases to {es-op}, resolving the issue. Kibana users can now create index patterns that include the `{app,infra,audit}-000001` indexes. (link:https://issues.redhat.com/browse/LOG-4683[LOG-4683])
+
+* Before this update, Fluentd collector pods were in a `CrashLoopBackOff` state due to binding of the Prometheus server on IPv6 clusters. With this update, the collectors work properly on IPv6 clusters. (link:https://issues.redhat.com/browse/LOG-4706[LOG-4706])
+
+* Before this update, the {clo} would undergo numerous reconciliations whenever there was a change in the `ClusterLogForwarder`. With this update, the {clo} disregards the status changes in the collector daemonsets that triggered the reconciliations. (link:https://issues.redhat.com/browse/LOG-4741[LOG-4741])
+
+* Before this update, the Vector log collector pods were stuck in the `CrashLoopBackOff` state on {ibm-power-title} machines. With this update, the Vector log collector pods start successfully on {ibm-power-title} architecture machines. (link:https://issues.redhat.com/browse/LOG-4768[LOG-4768])
+
+* Before this update, forwarding with a legacy forwarder to an internal LokiStack would produce SSL certificate errors using Fluentd collector pods. With this update, the log collector service account is used by default for authentication, using the associated token and `ca.crt`. (link:https://issues.redhat.com/browse/LOG-4791[LOG-4791])
+
+* Before this update, forwarding with a legacy forwarder to an internal LokiStack would produce SSL certificate errors using Vector collector pods. With this update, the log collector service account is used by default for authentication and also using the associated token and `ca.crt`. (link:https://issues.redhat.com/browse/LOG-4852[LOG-4852])
+
+* Before this fix, IPv6 addresses would not be parsed correctly after evaluating a host or multiple hosts for placeholders. With this update, IPv6 addresses are correctly parsed. (link:https://issues.redhat.com/browse/LOG-4811[LOG-4811])
+
+* Before this update, it was necessary to create a `ClusterRoleBinding` to collect audit permissions for HTTP receiver inputs. With this update, it is not necessary to create the `ClusterRoleBinding` because the endpoint already depends upon the cluster certificate authority. (link:https://issues.redhat.com/browse/LOG-4815[LOG-4815])
+
+* Before this update, the {loki-op} did not mount a custom CA bundle to the ruler pods. As a result, during the process to evaluate alerting or recording rules, object storage access failed. With this update, the {loki-op} mounts the custom CA bundle to all ruler pods. The ruler pods can download logs from object storage to evaluate alerting or recording rules. (link:https://issues.redhat.com/browse/LOG-4836[LOG-4836])
+
+* Before this update, while removing the `inputs.receiver` section in the `ClusterLogForwarder`, the HTTP input services and its associated secrets were not deleted. With this update, the HTTP input resources are deleted when not needed. (link:https://issues.redhat.com/browse/LOG-4612[LOG-4612])
+
+* Before this update, the `ClusterLogForwarder` indicated validation errors in the status, but the outputs and the pipeline status did not accurately reflect the specific issues. With this update, the pipeline status displays the validation failure reasons correctly in case of misconfigured outputs, inputs, or filters. (link:https://issues.redhat.com/browse/LOG-4821[LOG-4821])
+
+* Before this update, changing a `LogQL` query that used controls such as time range or severity changed the label matcher operator defining it like a regular expression. With this update, regular expression operators remain unchanged when updating the query. (link:https://issues.redhat.com/browse/LOG-4841[LOG-4841])
+
+[id="logging-release-notes-5-8-1-CVEs"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2007-4559[CVE-2007-4559]
+* link:https://access.redhat.com/security/cve/CVE-2021-3468[CVE-2021-3468]
+* link:https://access.redhat.com/security/cve/CVE-2021-3502[CVE-2021-3502]
+* link:https://access.redhat.com/security/cve/CVE-2021-3826[CVE-2021-3826]
+* link:https://access.redhat.com/security/cve/CVE-2021-43618[CVE-2021-43618]
+* link:https://access.redhat.com/security/cve/CVE-2022-3523[CVE-2022-3523]
+* link:https://access.redhat.com/security/cve/CVE-2022-3565[CVE-2022-3565]
+* link:https://access.redhat.com/security/cve/CVE-2022-3594[CVE-2022-3594]
+* link:https://access.redhat.com/security/cve/CVE-2022-4285[CVE-2022-4285]
+* link:https://access.redhat.com/security/cve/CVE-2022-38457[CVE-2022-38457]
+* link:https://access.redhat.com/security/cve/CVE-2022-40133[CVE-2022-40133]
+* link:https://access.redhat.com/security/cve/CVE-2022-40982[CVE-2022-40982]
+* link:https://access.redhat.com/security/cve/CVE-2022-41862[CVE-2022-41862]
+* link:https://access.redhat.com/security/cve/CVE-2022-42895[CVE-2022-42895]
+* link:https://access.redhat.com/security/cve/CVE-2023-0597[CVE-2023-0597]
+* link:https://access.redhat.com/security/cve/CVE-2023-1073[CVE-2023-1073]
+* link:https://access.redhat.com/security/cve/CVE-2023-1074[CVE-2023-1074]
+* link:https://access.redhat.com/security/cve/CVE-2023-1075[CVE-2023-1075]
+* link:https://access.redhat.com/security/cve/CVE-2023-1076[CVE-2023-1076]
+* link:https://access.redhat.com/security/cve/CVE-2023-1079[CVE-2023-1079]
+* link:https://access.redhat.com/security/cve/CVE-2023-1206[CVE-2023-1206]
+* link:https://access.redhat.com/security/cve/CVE-2023-1249[CVE-2023-1249]
+* link:https://access.redhat.com/security/cve/CVE-2023-1252[CVE-2023-1252]
+* link:https://access.redhat.com/security/cve/CVE-2023-1652[CVE-2023-1652]
+* link:https://access.redhat.com/security/cve/CVE-2023-1855[CVE-2023-1855]
+* link:https://access.redhat.com/security/cve/CVE-2023-1981[CVE-2023-1981]
+* link:https://access.redhat.com/security/cve/CVE-2023-1989[CVE-2023-1989]
+* link:https://access.redhat.com/security/cve/CVE-2023-2731[CVE-2023-2731]
+* link:https://access.redhat.com/security/cve/CVE-2023-3138[CVE-2023-3138]
+* link:https://access.redhat.com/security/cve/CVE-2023-3141[CVE-2023-3141]
+* link:https://access.redhat.com/security/cve/CVE-2023-3161[CVE-2023-3161]
+* link:https://access.redhat.com/security/cve/CVE-2023-3212[CVE-2023-3212]
+* link:https://access.redhat.com/security/cve/CVE-2023-3268[CVE-2023-3268]
+* link:https://access.redhat.com/security/cve/CVE-2023-3316[CVE-2023-3316]
+* link:https://access.redhat.com/security/cve/CVE-2023-3358[CVE-2023-3358]
+* link:https://access.redhat.com/security/cve/CVE-2023-3576[CVE-2023-3576]
+* link:https://access.redhat.com/security/cve/CVE-2023-3609[CVE-2023-3609]
+* link:https://access.redhat.com/security/cve/CVE-2023-3772[CVE-2023-3772]
+* link:https://access.redhat.com/security/cve/CVE-2023-3773[CVE-2023-3773]
+* link:https://access.redhat.com/security/cve/CVE-2023-4016[CVE-2023-4016]
+* link:https://access.redhat.com/security/cve/CVE-2023-4128[CVE-2023-4128]
+* link:https://access.redhat.com/security/cve/CVE-2023-4155[CVE-2023-4155]
+* link:https://access.redhat.com/security/cve/CVE-2023-4194[CVE-2023-4194]
+* link:https://access.redhat.com/security/cve/CVE-2023-4206[CVE-2023-4206]
+* link:https://access.redhat.com/security/cve/CVE-2023-4207[CVE-2023-4207]
+* link:https://access.redhat.com/security/cve/CVE-2023-4208[CVE-2023-4208]
+* link:https://access.redhat.com/security/cve/CVE-2023-4273[CVE-2023-4273]
+* link:https://access.redhat.com/security/cve/CVE-2023-4641[CVE-2023-4641]
+* link:https://access.redhat.com/security/cve/CVE-2023-22745[CVE-2023-22745]
+* link:https://access.redhat.com/security/cve/CVE-2023-26545[CVE-2023-26545]
+* link:https://access.redhat.com/security/cve/CVE-2023-26965[CVE-2023-26965]
+* link:https://access.redhat.com/security/cve/CVE-2023-26966[CVE-2023-26966]
+* link:https://access.redhat.com/security/cve/CVE-2023-27522[CVE-2023-27522]
+* link:https://access.redhat.com/security/cve/CVE-2023-29491[CVE-2023-29491]
+* link:https://access.redhat.com/security/cve/CVE-2023-29499[CVE-2023-29499]
+* link:https://access.redhat.com/security/cve/CVE-2023-30456[CVE-2023-30456]
+* link:https://access.redhat.com/security/cve/CVE-2023-31486[CVE-2023-31486]
+* link:https://access.redhat.com/security/cve/CVE-2023-32324[CVE-2023-32324]
+* link:https://access.redhat.com/security/cve/CVE-2023-32573[CVE-2023-32573]
+* link:https://access.redhat.com/security/cve/CVE-2023-32611[CVE-2023-32611]
+* link:https://access.redhat.com/security/cve/CVE-2023-32665[CVE-2023-32665]
+* link:https://access.redhat.com/security/cve/CVE-2023-33203[CVE-2023-33203]
+* link:https://access.redhat.com/security/cve/CVE-2023-33285[CVE-2023-33285]
+* link:https://access.redhat.com/security/cve/CVE-2023-33951[CVE-2023-33951]
+* link:https://access.redhat.com/security/cve/CVE-2023-33952[CVE-2023-33952]
+* link:https://access.redhat.com/security/cve/CVE-2023-34241[CVE-2023-34241]
+* link:https://access.redhat.com/security/cve/CVE-2023-34410[CVE-2023-34410]
+* link:https://access.redhat.com/security/cve/CVE-2023-35825[CVE-2023-35825]
+* link:https://access.redhat.com/security/cve/CVE-2023-36054[CVE-2023-36054]
+* link:https://access.redhat.com/security/cve/CVE-2023-37369[CVE-2023-37369]
+* link:https://access.redhat.com/security/cve/CVE-2023-38197[CVE-2023-38197]
+* link:https://access.redhat.com/security/cve/CVE-2023-38545[CVE-2023-38545]
+* link:https://access.redhat.com/security/cve/CVE-2023-38546[CVE-2023-38546]
+* link:https://access.redhat.com/security/cve/CVE-2023-39191[CVE-2023-39191]
+* link:https://access.redhat.com/security/cve/CVE-2023-39975[CVE-2023-39975]
+* link:https://access.redhat.com/security/cve/CVE-2023-44487[CVE-2023-44487]


### PR DESCRIPTION
Change type: Doc update; Logging Z-Stream Release Notes - 5.8.1
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-659 

Fix Version: 4.12+

Doc Preview: [Logging 5.8.1](https://69187--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/logging_release_notes/logging-5-8-release-notes#logging-release-notes-5-8-1_logging-5-8-release-notes)

SME Review: @xperimental @anpingli 
QE Review: @anpingli 
Peer Review: @kcarmichael08 