### PR TITLE
RHDEVDOCS-5618: Document for new scalability algorthim in upstream ArgoCD

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -89,6 +89,8 @@ Distros: openshift-gitops
 Topics:
 - Name: Configuring an OpenShift cluster by deploying an application with cluster configurations
   File: configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations
+- Name: Sharding clusters across Argo CD Application Controller replicas
+  File: sharding-clusters-across-argo-cd-application-controller-replicas
 ---
 Name: Argo Rollouts
 Dir: argo_rollouts

--- a/declarative_clusterconfig/sharding-clusters-across-argo-cd-application-controller-replicas.adoc
+++ b/declarative_clusterconfig/sharding-clusters-across-argo-cd-application-controller-replicas.adoc
@@ -1,0 +1,17 @@
+:_mod-docs-content-type: ASSEMBLY   
+include::_attributes/common-attributes.adoc[]
+[id="sharding-clusters-across-argo-cd-application-controller-replicas"]
+= Sharding clusters across Argo CD Application Controller replicas
+:context: sharding-clusters-across-argo-cd-application-controller-replicas
+
+toc::[]
+
+You can shard clusters across multiple Argo CD Application Controller replicas if the controller is managing too many clusters and uses too much memory.
+
+include::modules/gitops-argo-cd-round-robin-sharding-algorithm.adoc[leveloffset=+1]
+
+include::modules/gitops-enabling-the-round-robin-sharding-algorithm-in-web-console.adoc[leveloffset=+2]
+
+include::modules/gitops-enabling-the-round-robin-sharding-algorithm-using-cli.adoc[leveloffset=+2]
+
+//include the dynamic scaling here after the round-robin procedure

--- a/modules/gitops-argo-cd-round-robin-sharding-algorithm.adoc
+++ b/modules/gitops-argo-cd-round-robin-sharding-algorithm.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * declarative_clusterconfig/sharding-clusters-across-argo-cd-application-controller-replicas.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="gitops-argo-cd-round-robin-sharding-algorithm_{context}"]
+= Enabling the round-robin sharding algorithm
+
+:FeatureName: The `round-robin` sharding algorithm
+include::snippets/technology-preview.adoc[]
+
+By default, the Argo CD Application Controller uses the non-uniform `legacy` hash-based sharding algorithm to assign clusters to shards. This can result in uneven cluster distribution. You can enable the `round-robin` sharding algorithm to achieve more equal cluster distribution across all shards.
+
+Using the `round-robin` sharding algorithm in {gitops-title} provides the following benefits:
+
+* Ensure more balanced workload distribution
+* Prevent shards from being overloaded or underutilized
+* Optimize the efficiency of computing resources
+* Reduce the risk of bottlenecks
+* Improve overall performance and reliability of the Argo CD system
+
+The introduction of alternative sharding algorithms allows for further customization based on specific use cases. You can select the algorithm that best aligns with your deployment needs, which results in greater flexibility and adaptability in diverse operational scenarios.
+
+[TIP]
+====
+To leverage the benefits of alternative sharding algorithms in {gitops-shortname}, it is crucial to enable sharding during deployment.
+====

--- a/modules/gitops-enabling-the-round-robin-sharding-algorithm-in-web-console.adoc
+++ b/modules/gitops-enabling-the-round-robin-sharding-algorithm-in-web-console.adoc
@@ -1,0 +1,104 @@
+// Module included in the following assemblies:
+//
+// * declarative_clusterconfig/sharding-clusters-across-argo-cd-application-controller-replicas.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="enabling-the-round-robin-sharding-algorithm-in-web-console_{context}"]
+= Enabling the round-robin sharding algorithm in the web console
+
+You can enable the `round-robin` sharding algorithm by using the {OCP} web console.
+
+.Prerequisites
+* You have installed the {gitops-title} Operator in your cluster.
+* You have access to the {OCP} web console.
+* You have access to the cluster with `cluster-admin` privileges.
+
+.Procedure
+
+. In the *Administrator* perspective of the web console, go to *Operators* → *Installed Operators*.
+
+. Click *{gitops-title}* from the installed operators and go to the *Argo CD* tab.
+
+. Click the Argo CD instance where you want to enable the `round-robin` sharding algorithm, for example, `openshift-gitops`.
+
+. Click the *YAML* tab and edit the YAML file as shown in the following example:
++
+.Example Argo CD instance with round-robin sharding algorithm enabled
+[source,yaml]
+----
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: openshift-gitops
+  namespace: openshift-gitops
+spec:
+  controller:
+    sharding:
+      enabled: true <1>
+      replicas: 3 <2>
+    env: <3>
+      - name: ARGOCD_CONTROLLER_SHARDING_ALGORITHM 
+        value: round-robin
+    logLevel: debug <4>
+----
+<1> Set the `sharding.enabled` parameter to `true` to enable sharding.
+<2> Set the number of replicas to the wanted value, for example, `3`.
+<3> Set the sharding algorithm to `round-robin`.
+<4> Set the log level to `debug` so that you can verify to which shard each cluster is attached.
+
+. Click *Save*.
++
+A success notification alert, `openshift-gitops has been updated to version <version>`, appears.
++
+[NOTE]
+====
+If you edit the default `openshift-gitops` instance, the *Managed resource* dialog box is displayed. Click *Save* again to confirm the changes.
+====
+
+. Verify that the sharding is enabled with `round-robin` as the sharding algorithm by performing the following steps:
+
+.. Go to *Workloads* → *StatefulSets*.
+
+.. Select the namespace where you installed the Argo CD instance from the *Project* drop-down list.
+
+.. Click *<instance_name>-application-controller*, for example, *openshift-gitops-application-controller*, and go to the *Pods* tab.
+
+.. Observe the number of created application controller pods. It should correspond with the number of set replicas.
+
+.. Click on the controller pod you want to examine and go to the *Logs* tab to view the pod logs.
++
+.Example controller pod logs snippet
+[source,terminal]
+----
+time="2023-12-13T09:05:34Z" level=info msg="ArgoCD Application Controller is starting" built="2023-12-01T19:21:49Z" commit=a3vd5c3df52943a6fff6c0rg181fth3248976299 namespace=openshift-gitops version=v2.9.2+c5ea5c4
+time="2023-12-13T09:05:34Z" level=info msg="Processing clusters from shard 1"
+time="2023-12-13T09:05:34Z" level=info msg="Using filter function:  round-robin" <1>
+time="2023-12-13T09:05:34Z" level=info msg="Using filter function:  round-robin"
+time="2023-12-13T09:05:34Z" level=info msg="appResyncPeriod=3m0s, appHardResyncPeriod=0s"
+----
+<1> Look for the `"Using filter function:  round-robin"` message.
+
+.. In the log *Search* field, search for `processed by shard` to verify that the cluster distribution across shards is even, as shown in the following example.
++
+[IMPORTANT]
+====
+Ensure that you set the log level to `debug` to observe these logs.
+====
++
+.Example controller pod logs snippet
+[source,terminal]
+----
+time="2023-12-13T09:05:34Z" level=debug msg="ClustersList has 3 items"
+time="2023-12-13T09:05:34Z" level=debug msg="Adding cluster with id= and name=in-cluster to cluster's map"
+time="2023-12-13T09:05:34Z" level=debug msg="Adding cluster with id=068d8b26-6rhi-4w23-jrf6-wjjfyw833n23 and name=in-cluster2 to cluster's map"
+time="2023-12-13T09:05:34Z" level=debug msg="Adding cluster with id=836d8b53-96k4-f68r-8wq0-sh72j22kl90w and name=in-cluster3 to cluster's map"
+time="2023-12-13T09:05:34Z" level=debug msg="Cluster with id= will be processed by shard 0" <1>
+time="2023-12-13T09:05:34Z" level=debug msg="Cluster with id=068d8b26-6rhi-4w23-jrf6-wjjfyw833n23 will be processed by shard 1" <1>
+time="2023-12-13T09:05:34Z" level=debug msg="Cluster with id=836d8b53-96k4-f68r-8wq0-sh72j22kl90w will be processed by shard 2" <1>
+----
+<1> In this example, 3 clusters are attached consecutively to shard 0, shard 1, and shard 2.
++
+[NOTE]
+====
+If the number of clusters "C" is a multiple of the number of shard replicas "R", then each shard must have the same number of assigned clusters "N", which is equal to "C" divided by "R". The previous example shows 3 clusters and 3 replicas; therefore, each shard has 1 cluster assigned.
+====

--- a/modules/gitops-enabling-the-round-robin-sharding-algorithm-using-cli.adoc
+++ b/modules/gitops-enabling-the-round-robin-sharding-algorithm-using-cli.adoc
@@ -1,0 +1,111 @@
+// Module included in the following assemblies:
+//
+// * declarative_clusterconfig/sharding-clusters-across-argo-cd-application-controller-replicas.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="enabling-the-round-robin-sharding-algorithm-using-cli_{context}"]
+= Enabling the round-robin sharding algorithm by using the CLI
+
+You can enable the `round-robin` sharding algorithm by using the command-line interface.
+
+.Prerequisites
+* You have installed the {gitops-title} Operator in your cluster.
+* You have access to the cluster with `cluster-admin` privileges.
+
+.Procedure
+
+. Enable sharding and set the number of replicas to the wanted value by running the following command:
++
+[source,terminal]
+----
+$ oc patch argocd <argocd_instance> -n <namespace> --patch='{"spec":{"controller":{"sharding":{"enabled":true,"replicas":<value>}}}}' --type=merge
+----
++
+.Example output
+[source,terminal]
+----
+argocd.argoproj.io/<argocd_instance> patched
+----
+
+. Configure the sharding algorithm to `round-robin` by running the following command:
++
+[source,terminal]
+----
+$ oc patch argocd <argocd_instance> -n <namespace> --patch='{"spec":{"controller":{"env":[{"name":"ARGOCD_CONTROLLER_SHARDING_ALGORITHM","value":"round-robin"}]}}}' --type=merge
+----
++
+.Example output
+[source,terminal]
+----
+argocd.argoproj.io/<argocd_instance> patched
+----
+
+. Verify that the number of Argo CD Application Controller pods corresponds with the number of set replicas by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -l app.kubernetes.io/name=<argocd_instance>-application-controller -n <namespace>
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                        READY   STATUS    RESTARTS   AGE
+<argocd_instance>-application-controller-0   1/1     Running   0          11s
+<argocd_instance>-application-controller-1   1/1     Running   0          32s
+<argocd_instance>-application-controller-2   1/1     Running   0          22s
+----
+
+. Verify that the sharding is enabled with `round-robin` as the sharding algorithm by running the following command:
++
+[source,terminal]
+----
+$ oc logs <argocd_application_controller_pod> -n <namespace>
+----
++
+.Example output snippet
+[source,terminal]
+----
+time="2023-12-13T09:05:34Z" level=info msg="ArgoCD Application Controller is starting" built="2023-12-01T19:21:49Z" commit=a3vd5c3df52943a6fff6c0rg181fth3248976299 namespace=<namespace> version=v2.9.2+c5ea5c4
+time="2023-12-13T09:05:34Z" level=info msg="Processing clusters from shard 1"
+time="2023-12-13T09:05:34Z" level=info msg="Using filter function:  round-robin" <1>
+time="2023-12-13T09:05:34Z" level=info msg="Using filter function:  round-robin"
+time="2023-12-13T09:05:34Z" level=info msg="appResyncPeriod=3m0s, appHardResyncPeriod=0s"
+----
+<1> Look for the `"Using filter function:  round-robin"` message.
+
+. Verify that the cluster distribution across shards is even by performing the following steps:
+
+.. Set the log level to `debug` by running the following command:
++
+[source,terminal]
+----
+$ oc patch argocd <argocd_instance> -n <namespace> --patch='{"spec":{"controller":{"logLevel":"debug"}}}' --type=merge
+----
++
+.Example output
+[source,terminal]
+----
+argocd.argoproj.io/<argocd_instance> patched
+----
+
+.. View the logs and search for `processed by shard` to observe to which shard each cluster is attached by running the following command:
++
+[source,terminal]
+----
+$ oc logs <argocd_application_controller_pod> -n <namespace> | grep "processed by shard"
+----
++
+.Example output snippet
+[source,terminal]
+----
+time="2023-12-13T09:05:34Z" level=debug msg="Cluster with id= will be processed by shard 0" <1>
+time="2023-12-13T09:05:34Z" level=debug msg="Cluster with id=068d8b26-6rhi-4w23-jrf6-wjjfyw833n23 will be processed by shard 1" <1>
+time="2023-12-13T09:05:34Z" level=debug msg="Cluster with id=836d8b53-96k4-f68r-8wq0-sh72j22kl90w will be processed by shard 2" <1>
+----
+<1> In this example, 3 clusters are attached consecutively to shard 0, shard 1, and shard 2.
++
+[NOTE]
+====
+If the number of clusters "C" is a multiple of the number of shard replicas "R", then each shard must have the same number of assigned clusters "N", which is equal to "C" divided by "R". The previous example shows 3 clusters and 3 replicas; therefore, each shard has 1 cluster assigned.
+====


### PR DESCRIPTION
**Version(s)**: CP to `gitops-docs-1.10` `gitops-docs-1.11`

**Issue**: [RHDEVDOCS-5618](https://issues.redhat.com/browse/RHDEVDOCS-5618)

**Preview link**: [Sharding clusters across Argo CD Application Controller replicas](https://69199--docspreview.netlify.app/openshift-gitops/latest/declarative_clusterconfig/sharding-clusters-across-argo-cd-application-controller-replicas)

**SME review**: @akram 

**QE review**: @varshab1210 

**Peer review**:  @kcarmichael08 