### PR TITLE
OADP-3234: Fix Broken-Link Creating a Restore CR in index.adoc

### DIFF
--- a/backup_and_restore/index.adoc
+++ b/backup_and_restore/index.adoc
@@ -82,7 +82,7 @@ You back up applications by creating a `Backup` custom resource (CR). See xref:.
 
 * xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#backing-up-applications[Backing up applications with File System Backup: Kopia or Restic]
 
-* You restore application backups by creating a `Restore` (CR). See xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr-doc#backing-up-applications[Creating a Restore CR].
+* You restore application backups by creating a `Restore` (CR). See xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc#oadp-creating-restore-cr_restoring-applications[Creating a Restore CR].
 * You can configure xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications#oadp-creating-restore-hooks_restoring-applications[restore hooks] to run commands in init containers or in the application container during the restore operation.
 
 :backup-restore-overview!:


### PR DESCRIPTION
### JIra

* [OADP-3234](https://issues.redhat.com/browse/OADP-3234)

Fixing broken link in [Backing up and restoring applications](https://docs.openshift.com/container-platform/4.14/backup_and_restore/index.html#backing-up-and-restoring-applications): `You restore application backups by creating a Restore (CR). See [Creating a Restore CR](https://docs.openshift.com/container-platform/4.11/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr-doc.html#backing-up-applications).`

### OCP version

* OCP 4.11 → branch/enterprise-4.11
* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15

### Link to docs preview:

* [Backing up and restoring applications](https://69202--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/#backing-up-and-restoring-applications)

### QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
