### PR TITLE
[OSDOCS-9038]:Add new force-delete cluster flag "--best-effort" to "Managing objects with the ROSA CLI" docs

### DIFF
--- a/modules/rosa-delete-objects.adoc
+++ b/modules/rosa-delete-objects.adoc
@@ -75,6 +75,9 @@ $ rosa delete cluster --cluster=<cluster_name> | <cluster_id> [arguments]
 
 |--watch
 |Watches the cluster uninstallation logs.
+
+|--best-effort
+|Skips steps in the cluster destruction chain that are known to cause the cluster deletion process to fail. You should use this option with care and it is recommended that you manually check your AWS account for  any resources that might be left over after using `--best-effort`.
 |===
 
 .Optional arguments inherited from parent commands


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-9038
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://69211--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli#rosa-delete-cluster_rosa-managing-objects-cli
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
![image](https://github.com/openshift/openshift-docs/assets/122639474/0bd51e62-f494-47c6-bdb2-f5b7fe1b531f)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
