### PR TITLE
OSDOCS#6518: 64k pages in the RHCOS kernal support on multi-arch compute

### DIFF
--- a/modules/multi-architecture-enabling-64k-pages.adoc
+++ b/modules/multi-architecture-enabling-64k-pages.adoc
@@ -1,0 +1,101 @@
+//Module included in the following assemblies
+//
+//post_installation_configuration/multi-architecture-configuration.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="multi-architecture-enabling-64k-pages_{context}"]
+
+= Enabling 64k pages on the {op-system-first} kernel 
+
+You can enable the 64k memory page in the {op-system-first} kernel on the 64-bit ARM compute machines in your cluster. The 64k page size kernel specification can be used for large GPU or high memory workloads. This is done using the Machine Config Operator (MCO) which uses a machine config pool to update the kernel. To enable 64k page sizes, you must dedicate a machine config pool for ARM64 to enable on the kernel.
+
+[IMPORTANT]
+====
+Using 64k pages is exclusive to 64-bit ARM architecture compute nodes or clusters installed on 64-bit ARM machines. If you configure the 64k pages kernel on a machine config pool using 64-bit x86 machines, the machine config pool and MCO will degrade.
+====
+
+.Prerequisites: 
+* You installed the OpenShift CLI (`oc`).
+* You created a cluster with compute nodes of different architecture on one of the supported platforms.
+
+.Procedure: 
+
+. Label the nodes where you want to run the 64k page size kernel:
+[source,terminal]
++
+----
+$ oc label node <node_name> <label>
+----
++
+.Example command 
+[source,terminal]
+----
+$ oc label node worker-arm64-01 node-role.kubernetes.io/worker-64k-pages=
+----
+
+. Create a machine config pool that contains the worker role that uses the ARM64 architecture and the `worker-64k-pages` role:
+[source,yaml]
++
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-64k-pages
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values:
+        - worker
+        - worker-64k-pages
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-64k-pages: ""
+      kubernetes.io/arch: arm64
+----
+
+. Create a machine config on your compute node to enable `64k-pages` with the `64k-pages` parameter. 
++
+[source,terminal]
+----
+$ oc create -f <filename>.yaml
+----
++
+.Example MachineConfig
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: "worker-64k-pages" <1>
+  name: 99-worker-64kpages  
+spec:
+  kernelType: 64k-pages <2>
+----
+<1> Specify the value of the `machineconfiguration.openshift.io/role` label in the custom machine config pool. The example MachineConfig uses the `worker-64k-pages` label to enable 64k pages in the `worker-64k-pages` pool. 
+<2> Specify your desired kernel type. Valid values are `64k-pages` and `default`
++
+[NOTE]
+====
+The `64k-pages` type is supported on only 64-bit ARM architecture based compute nodes. The `realtime` type is supported on only 64-bit x86 architecture based compute nodes.
+====
+
+.Verification 
+
+* To view your new `worker-64k-pages` machine config pool, run the following command:
++
+[source,terminal]
+----
+$ oc get mcp
+----
++
+.Example output 
+[source,terminal]
+----
+NAME     CONFIG                                                                UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
+master   rendered-master-9d55ac9a91127c36314e1efe7d77fbf8                      True      False      False      3              3                   3                     0                      361d
+worker   rendered-worker-e7b61751c4a5b7ff995d64b967c421ff                      True      False      False      7              7                   7                     0                      361d
+worker-64k-pages  rendered-worker-64k-pages-e7b61751c4a5b7ff995d64b967c421ff   True      False      False      2              2                   2                     0                      35m
+----

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-compute-managing.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-compute-managing.adoc
@@ -24,4 +24,6 @@ include::modules/multi-architecture-scheduling-examples.adoc[leveloffset=+2]
 
 * xref:../../machine_management/modifying-machineset.adoc#machineset-modifying_modifying-machineset[Modifying a compute machine set]
 
+include::modules/multi-architecture-enabling-64k-pages.adoc[leveloffset=+1]
+
 include::modules/multi-architecture-import-imagestreams.adoc[leveloffset=+1]


### PR DESCRIPTION
**Version(s):** 4.15+ 
**Issue:** [OSDOCS-6518](https://issues.redhat.com/browse/OSDOCS-6518)

**Link to docs preview:**

- [Managing your cluster with multi-architecture compute machines -> Enabling 64k pages on the RHEL kernal](https://69212--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-compute-managing#multi-architecture-enabling-64k-pages_multi-architecture-compute-managing)

**QE review:**
- [x] QE has approved this change.