### PR TITLE
OSDOCS#9040: Adding note warning of future PSA restricted enforcement

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -565,6 +565,25 @@ To manage the cloud controller manager and cloud node manager deployments and li
 
 For more information, see the xref:../operators/operator-reference.adoc#cluster-cloud-controller-manager-operator_cluster-operators-ref[Cluster Cloud Controller Manager Operator] entry in the _Cluster Operators reference_.
 
+[id="ocp-4-15-planned-psa-restricted-enforcement"]
+=== Future restricted enforcement for pod security admission
+
+Currently, pod security violations are shown as warnings in the audit logs without resulting in the rejection of the pod.
+
+Global restricted enforcement for pod security admission is currently planned for the next minor release of {product-title}. When this restricted enforcement is enabled, pods with pod security violations will be rejected.
+
+To prepare for this upcoming change, ensure that your workloads match the pod security admission profile that applies to them. Workloads that are not configured according to the enforced security standards defined globally or at the namespace level will be rejected. The `restricted-v2` SCC admits workloads according to the link:https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted[Restricted] Kubernetes definition.
+
+If you are receiving pod security violations, see the following resources:
+
+* See xref:../authentication/understanding-and-managing-pod-security-admission.adoc#security-context-constraints-psa-alert-eval_understanding-and-managing-pod-security-admission[Identifying pod security violations] for information about how to find which workloads are causing pod security violations.
+
+* See xref:../authentication/understanding-and-managing-pod-security-admission.adoc#security-context-constraints-psa-synchronization_understanding-and-managing-pod-security-admission[About pod security admission synchronization] to understand when pod security admission label synchronization is performed. Pod security admission labels are not synchronized in certain situations, such as the following situations:
+** The workload is running in a system-created namespace that is prefixed with `openshift-`.
+** The workload is running on a pod that was created directly without a pod controller.
+
+* If necessary, you can set a custom admission profile on the namespace or pod by setting the `pod-security.kubernetes.io/enforce` label.
+
 [id="ocp-4-15-deprecated-removed-features"]
 == Deprecated and removed features
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-9040

Link to docs preview:
https://69218--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-planned-psa-restricted-enforcement

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This is _almost_ word-for-word the same as has already been used in 4.14, 4.13, etc. here: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-planned-psa-restricted-enforcement

The only change is the link text changed from "Security context constraint synchronization with pod security standards" to "About pod security admission synchronization".
