### PR TITLE
[enterprise-4.13] OCPBUGS-21939: fixing to-image update command in disconnected doc

### DIFF
--- a/modules/update-restricted.adoc
+++ b/modules/update-restricted.adoc
@@ -34,13 +34,25 @@ The release image signature config map allows the Cluster Version Operator (CVO)
 +
 [source,terminal]
 ----
-$ oc adm upgrade --allow-explicit-upgrade --to-image ${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}@<digest> <1>
+$ oc adm upgrade --allow-explicit-upgrade --to-image <defined_registry>/<defined_repository>@<digest>
 ----
-<1> The `<digest>` value is the sha256 digest for the targeted release image, for example, `sha256:81154f5c03294534e1eaf0319bef7a601134f891689ccede5d705ef659aa8c92`
 +
-If you use an `ImageContentSourcePolicy` for the mirror registry, you can use the canonical registry name instead of `LOCAL_REGISTRY`.
+--
+Where:
+
+`<defined_registry>`:: Specifies the name of the mirror registry you mirrored your images to.
+
+`<defined_repository>`:: Specifies the name of the image repository you want to use on the mirror registry.
+
+`<digest>`:: Specifies the sha256 digest for the targeted release image, for example, `sha256:81154f5c03294534e1eaf0319bef7a601134f891689ccede5d705ef659aa8c92`.
+--
 +
 [NOTE]
 ====
-You can only configure global pull secrets for clusters that have an `ImageContentSourcePolicy` object. You cannot add a pull secret to a project.
+* See "Mirroring {product-title} images" to review how your mirror registry and repository names are defined.
+
+* If you used an `ImageContentSourcePolicy` or `ImageDigestMirrorSet`, you can use the canonical registry and repository names instead of the names you defined.
+The canonical registry name is `quay.io` and the canonical repository name is `openshift-release-dev/ocp-release`.
+
+* You can only configure global pull secrets for clusters that have an `ImageContentSourcePolicy` object. You cannot add a pull secret to a project.
 ====

--- a/updating/updating-restricted-network-cluster/restricted-network-update.adoc
+++ b/updating/updating-restricted-network-cluster/restricted-network-update.adoc
@@ -36,6 +36,11 @@ include::modules/update-restricted-image-digests.adoc[leveloffset=+1]
 
 include::modules/update-restricted.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../updating/updating-restricted-network-cluster/mirroring-image-repository.adoc#mirroring-ocp-image-repository[Mirroring {product-title} images]
+
 include::modules/images-configuration-registry-mirror.adoc[leveloffset=+1]
 
 include::modules/images-configuration-registry-mirror-convert.adoc[leveloffset=+2]


### PR DESCRIPTION
Cherry picked from 2e952d1fe02f05f6495f2e9b8a3612d19d11ec9b

#68593 