### PR TITLE
CNV#35107: bugfix in VM memory overhead section

### DIFF
--- a/modules/virt-cluster-resource-requirements.adoc
+++ b/modules/virt-cluster-resource-requirements.adoc
@@ -34,14 +34,19 @@ Additionally, {VirtProductName} environment resources require a total of 2179 Mi
 .Virtual machine memory overhead
 
 ----
-Memory overhead per virtual machine ≈ (1.002 * requested memory) + 146 MiB  \
-              + 8 MiB * (number of vCPUs) \ <1>
-              + 16 MiB * (number of graphics devices) <2>
+Memory overhead per virtual machine ≈ (1.002 × requested memory) \
+              + 218 MiB \ <1>
+              + 8 MiB × (number of vCPUs) \ <2>
+              + 16 MiB × (number of graphics devices) \ <3>
+              + (additional memory overhead) <4>
 ----
-<1> Number of virtual CPUs requested by the virtual machine
-<2> Number of virtual graphics cards requested by the virtual machine
-
-If your environment includes a Single Root I/O Virtualization (SR-IOV) network device or a Graphics Processing Unit (GPU), allocate 1 GiB additional memory overhead for each device.
+<1> Required for the processes that run in the `virt-launcher` pod.
+<2> Number of virtual CPUs requested by the virtual machine.
+<3> Number of virtual graphics cards requested by the virtual machine.
+<4> Additional memory overhead:
+* If your environment includes a Single Root I/O Virtualization (SR-IOV) network device or a Graphics Processing Unit (GPU), allocate 1 GiB additional memory overhead for each device.
+* If Secure Encrypted Virtualization (SEV) is enabled, add 256 MiB.
+* If Trusted Platform Module (TPM) is enabled, add 53 MiB.
 
 [discrete]
 [id="CPU-overhead_{context}"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+ for this PR; opening other PRs for 4.11-4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-35107](https://issues.redhat.com//browse/CNV-35107)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://69225--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/install/preparing-cluster-for-virt#virt-cluster-resource-requirements_preparing-cluster-for-virt
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: 
- Not married to my "(additional memory overhead)" solution; open to suggestions if this comes off as too lazy. :) 
- Also changing the `*`s to the multiplication symbol as [per IBM Style](https://www.ibm.com/docs/en/ibm-style?topic=measurement-mathematical-equations).
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
