### PR TITLE
OADP-3234: Fix Broken-Link Creating a Restore CR in index.adoc - cher…

### DIFF
--- a/backup_and_restore/index.adoc
+++ b/backup_and_restore/index.adoc
@@ -74,7 +74,7 @@ If you do not want to back up PVs by using snapshots, you can use link:https://r
 [id="backing-up-and-restoring-applications"]
 === Backing up and restoring applications
 
-You back up applications by creating a `Backup` custom resource (CR). See xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr.adoc#backing-up-applications[Creating a Backup CR].You can configure the following backup options:
+You back up applications by creating a `Backup` custom resource (CR). See xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr.adoc#backing-up-applications[Creating a Backup CR]. You can configure the following backup options:
 
 * xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-hooks-doc.adoc#backing-up-applications[Creating backup hooks] to run commands before or after the backup operation
 * xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-scheduling-backups-doc.adoc#backing-up-applications[Scheduling backups]


### PR DESCRIPTION
#### Cherrypick for 4.11

* See [PR#69202](https://github.com/openshift/openshift-docs/pull/69202)

The only link is the missing space at the end of line 77

### JIra

* [OADP-3234](https://issues.redhat.com/browse/OADP-3234)

Fixing broken link in [Backing up and restoring applications](https://docs.openshift.com/container-platform/4.14/backup_and_restore/index.html#backing-up-and-restoring-applications): `You restore application backups by creating a Restore (CR). See [Creating a Restore CR](https://docs.openshift.com/container-platform/4.11/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr-doc.html#backing-up-applications).`

### OCP version

* OCP 4.11 → branch/enterprise-4.11



#### Error from cherrypick

```
Applying: OADP-3234: Fix Broken-Link Creating a Restore CR in index.adoc
Using index info to reconstruct a base tree...
M	backup_and_restore/index.adoc
Falling back to patching base and 3-way merge...
Auto-merging backup_and_restore/index.adoc
CONFLICT (content): Merge conflict in backup_and_restore/index.adoc
error: Failed to merge in the changes.
hint: Use 'git am --show-current-patch=diff' to see the failed patch
Patch failed at 0001 OADP-3234: Fix Broken-Link Creating a Restore CR in index.adoc
When you have resolved this problem, run "git am --continue".
If you prefer to skip this patch, run "git am --skip" instead.
To restore the original branch and stop patching, run "git am --abort".
```