### PR TITLE
PR for SRVOCF-504: Reverting all the changes back in the downstream (Openshift-serverless) documents as the "Go function" is not a tech preview yet.

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -76,8 +76,8 @@ Topics:
     File: serverless-developing-typescript-functions
   - Name: Developing Python functions
     File: serverless-developing-python-functions
-  - Name: Developing Go functions
-    File: serverless-developing-go-functions
+  #- Name: Developing Go functions
+  #  File: serverless-developing-go-functions (Targetted for next release)
 - Name: Configuring functions
   Dir: configuring
   Topics:

--- a/about/about-serverless.adoc
+++ b/about/about-serverless.adoc
@@ -23,7 +23,7 @@ In addition, the {ServerlessProductName} documentation is also available on the 
 For additional information about the {ServerlessProductName} life cycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift#ossrvless[Platform Life Cycle Policy].
 ====
 
-// Add something about CLI tools?
+// Add something about CLI tools
 
 
 [id="additional-resources_about-serverless"]

--- a/about/serverless-functions-about.adoc
+++ b/about/serverless-functions-about.adoc
@@ -13,7 +13,7 @@ toc::[]
 
 {FunctionsProductName} provides templates that can be used to create basic functions for the following runtimes:
 
-// add xref links to docs once added
+// Add xref links to docs once added
 * xref:../functions/reference/serverless-developing-quarkus-functions.adoc#serverless-developing-quarkus-functions[Quarkus]
 * xref:../functions/reference/serverless-developing-nodejs-functions.adoc#serverless-developing-nodejs-functions[Node.js]
 * xref:../functions/reference/serverless-developing-typescript-functions.adoc#serverless-developing-typescript-functions[TypeScript]


### PR DESCRIPTION
**Affected versions for cherry-picking:** Serverless 1.31

**Tracking JIRAs:**
- https://issues.redhat.com/browse/SRVOCF-503
- https://issues.redhat.com/browse/SRVOCF-504

**Doc preview & Description:**
[Developing Go functions (Downstream documentation)](https://69234--docspreview.netlify.app/openshift-serverless/latest/install/serverless-kafka-admin)
The changes have been reverted as the "Go function" is not a tech preview yet.
The "Developing Go functions" section from the downstream document is not visible now. Removed from the document 