### PR TITLE
OSDOCS-8999: Documented the 4.14.6 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3144,6 +3144,32 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+[id="ocp-4-14-6"]
+=== RHSA-2023:7682 - {product-title} 4.14.6 bug fix and security update
+
+Issued: 2023-12-12
+
+{product-title} release 4.14.6, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:7682[RHSA-2023:7682] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:7685[RHBA-2023:7685] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.6 --pullspecs
+----
+
+[id="ocp-4-14-6-bug-fixes"]
+==== Bug fixes
+
+* Previously, when you deployed IPv6-only hosts from a dual-stack cluster, an issue prevented the Baseboard Management Controller (BMC) from receiving the correct callback URL. Instead, the BMC received an IPv4 URL. With this update, the issue no longer occurs because the IP version of the URL depends on the IP version of the BMC address.(link:https://issues.redhat.com/browse/OCPBUGS-23903[*OCPBUGS-23903*])
+
+[id="ocp-4-14-6-updating"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 [id="ocp-4-14-5"]
 === RHSA-2023:7599 - {product-title} 4.14.5 bug fix and security update
 


### PR DESCRIPTION
[OSDOCS-8999](https://issues.redhat.com/browse/OSDOCS-8999)

Version(s):
4.14

Link to docs preview:
[4.14.6 z-stream release notes](https://file.emea.redhat.com/dfitzmau/OSDOCS-8999/ocp-4-14-release-notes.html#ocp-4-14-6)

QE review:
- [ ] QE not required. See the peer-review checklist. 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
