### PR TITLE
OSDOCS-8618 Applied 2 new security group IDs Infra and control plane to be consistent with Compute security ID content

### DIFF
--- a/modules/rosa-create-objects.adoc
+++ b/modules/rosa-create-objects.adoc
@@ -117,7 +117,13 @@ $ rosa create cluster --cluster-name=<cluster_name> [arguments]
 |Option |Definition
 
 |--additional-compute-security-group-ids <sec_group_id>
-|The identifier of one or more additional security groups to use in addition to the default security groups. For more information on additional security groups, see the requirements for _Security groups_ under _Additional resources_.
+|The identifier of one or more additional security groups to use along with the default security groups that are used with the standard machine pool created alongside the cluster. For more information on additional security groups, see the requirements for _Security groups_ under _Additional resources_.
+
+|--additional-infra-security-group-ids <sec_group_id>
+|The identifier of one or more additional security groups to use along with the default security groups that are used with the infra nodes created alongside the cluster. For more information on additional security groups, see the requirements for _Security groups_ under _Additional resources_.
+
+|--additional-control-plane-security-group-ids <sec_group_id>
+|The identifier of one or more additional security groups to use along with the default security groups that are used with the control plane nodes created alongside the cluster. For more information on additional security groups, see the requirements for _Security groups_ under _Additional resources_.
 
 a|--cluster-name <cluster_name>
 |Required. The name of the cluster. When used with the `create cluster` command, this argument is used to set the cluster name and to generate a sub-domain for your cluster on `openshiftapps.com`. The value for this argument must be unique within your organization.
@@ -161,7 +167,7 @@ OVN-Kubernetes, the default network provider in ROSA 4.11 and later, uses the `1
 |Deploys to multiple data centers.
 
 |--operator-roles-prefix <string>
-|Prefix to use for all IAM roles used by the operators needed in the OpenShift installer. A prefix is generated automatically if you do not specify one.
+|Prefix that are used for all IAM roles used by the operators needed in the OpenShift installer. A prefix is generated automatically if you do not specify one.
 
 |--pod-cidr <address_block>
 a|Block of IP addresses (ipNet) from which pod IP addresses are allocated, for example, `10.128.0.0/14`.
@@ -198,7 +204,7 @@ a|--sts \| --non-sts
 |Specifies whether to use AWS Security Token Service (STS) or IAM credentials (non-STS) to deploy your cluster.
 
 |--subnet-ids <aws_subnet_id>
-|The AWS subnet IDs to use when installing the cluster, for example, `subnet-01abc234d5678ef9a`. Subnet IDs must be in pairs with one private subnet ID and one public subnet ID per availability zone. Subnets are comma-delimited, for example, `--subnet-ids=subnet-1,subnet-2`. Leave the value empty for installer-provisioned subnet IDs.
+|The AWS subnet IDs that are used when installing the cluster, for example, `subnet-01abc234d5678ef9a`. Subnet IDs must be in pairs with one private subnet ID and one public subnet ID per availability zone. Subnets are comma-delimited, for example, `--subnet-ids=subnet-1,subnet-2`. Leave the value empty for installer-provisioned subnet IDs.
 
 When using `--private-link`, the `--subnet-ids` argument is required and only one private subnet is allowed per zone.
 
@@ -216,7 +222,7 @@ Tags that are added by Red Hat are required for clusters to stay in compliance w
 ====
 
 |--version string
-|The version of ROSA that will be used to install the cluster or cluster resources. For `cluster` use an `X.Y.Z` format, for example, `4.12.9`. For `account-role` use an `X.Y` format, for example, `4.12`.
+|The version of ROSA that will be used to install the cluster or cluster resources. For `cluster` use an `X.Y.Z` format, for example, `4.14.0`. For `account-role` use an `X.Y` format, for example, `4.14`.
 
 |--worker-iam-role string
 |The ARN of the IAM role that will be attached to compute instances.
@@ -307,7 +313,7 @@ a|--cluster <cluster_name>\|<cluster_id>
 |Option |Definition
 
 |--hostname
-|The optional domain (string) to use with a hosted instance of GitHub Enterprise.
+|The optional domain (string) that are used with a hosted instance of GitHub Enterprise.
 
 |--organizations
 |Specifies the organizations for login access. Only users that are members of at least one of the listed organizations (string) are allowed to log in.
@@ -358,7 +364,7 @@ a|--cluster <cluster_name>\|<cluster_id>
 |The list (string) of attributes whose values should be used as the display name. Default: `cn`
 
 |--url
-|An RFC 2255 URL (string) which specifies the LDAP search parameters to use.
+|An RFC 2255 URL (string) which specifies the LDAP search parameters that are used.
 
 |--username-attributes
 |The list (string) of attributes whose values should be used as the preferred username. Default: `uid`
@@ -370,7 +376,7 @@ a|--cluster <cluster_name>\|<cluster_id>
 |Option |Definition
 
 |--email-claims
-|The list (string) of claims to use as the email address.
+|The list (string) of claims that are used as the email address.
 
 |--extra-scopes
 |The list (string) of scopes to request, in addition to the `openid` scope, during the authorization token request.
@@ -379,13 +385,13 @@ a|--cluster <cluster_name>\|<cluster_id>
 |The URL (string) that the OpenID provider asserts as the issuer identifier. It must use the HTTPS scheme with no URL query parameters or fragment.
 
 |--name-claims
-|The list (string) of claims to use as the display name.
+|The list (string) of claims that are used as the display name.
 
 |--username-claims
-|The list (string) of claims to use as the preferred username when provisioning a user.
+|The list (string) of claims that are used as the preferred username when provisioning a user.
 
 |--groups-claims
-|The list (string) of claims to use as the groups names.
+|The list (string) of claims that are used as the groups names.
 |===
 
 .Optional arguments inherited from parent commands
@@ -505,7 +511,7 @@ $ rosa create machinepool --cluster=<cluster_name> | <cluster_id> --replicas=<nu
 
 // Note for writers: This command works the same way as rosa create --additional-compute-security-group-ids but all subsequent machinepools are compute only so we don't specify compute here yet; consistency across commands to come in OCM-3111.
 |--additional-security-group-ids <sec_group_id>
-|The identifier of one or more additional security groups to use in addition to the default security groups for this machine pool. For more information on additional security groups, see the requirements for _Security groups_ under _Additional resources_.
+|The identifier of one or more additional security groups to use along with the default security groups for this machine pool. For more information on additional security groups, see the requirements for _Security groups_ under _Additional resources_.
 
 a|--cluster <cluster_name>\|<cluster_id>
 |Required: The name or ID of the cluster to which the machine pool will be added.

--- a/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
@@ -219,7 +219,7 @@ Deploy cluster with Hosted Control Plane (optional): No
 ? Create cluster admin user: Yes <1>
 ? Username: user-admin <1>
 ? Password: [? for help] *************** <1>
-? OpenShift version: 4.13.4 <2>
+? OpenShift version: 4.14.0 <2>
 ? Configure the use of IMDSv2 for ec2 instances optional/required (optional): <3>
 I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role for the Installer role <4>
 I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-ControlPlane-Role for the ControlPlane role
@@ -249,14 +249,14 @@ I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role for th
 ? Disable Workload monitoring (optional): No
 I: Creating cluster '<cluster_name>'
 I: To create this cluster again in the future, you can run:
-   rosa create cluster --cluster-name <cluster_name> --role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role --master-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Worker-Role --operator-roles-prefix <cluster_name>-<random_string> --region us-east-1 --version 4.8.9 --additional-compute-security-group-ids sg-0e375ff0ec4a6cfa2 --replicas 2 --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23 <12>
+   rosa create cluster --cluster-name <cluster_name> --role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role --master-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Worker-Role --operator-roles-prefix <cluster_name>-<random_string> --region us-east-1 --version 4.14.0 --additional-compute-security-group-ids sg-0e375ff0ec4a6cfa2 --additional-infra-security-group-ids sg-0e375ff0ec4a6cfa2 --additional-control-plane-security-group-ids sg-0e375ff0ec4a6cfa2 --replicas 2 --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23 <12>
 I: To view a list of clusters and their status, run 'rosa list clusters'
 I: Cluster '<cluster_name>' has been created.
 I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.
 ...
 ----
 <1> When creating your cluster, you can create a local administrator user for your cluster. Selecting `Yes` then prompts you to create a user name and password for the cluster admin. The user name must not contain `/`, `:`, or `%`. The password must be at least 14 characters (ASCII-standard) without whitespaces. This process automatically configures an htpasswd identity provider.
-<2> When creating the cluster, the listed `OpenShift version` options include the major, minor, and patch versions, for example `4.13.4`.
+<2> When creating the cluster, the listed `OpenShift version` options include the major, minor, and patch versions, for example `4.14.0`.
 <3> Optional: Specify 'optional' to configure all EC2 instances to use both v1 and v2 endpoints of EC2 Instance Metadata Service (IMDS). This is the default value. Specify 'required' to configure all EC2 instances to use IMDSv2 only.
 +
 [IMPORTANT]
@@ -297,7 +297,7 @@ Only persistent volumes (PVs) created from the default storage class are encrypt
 PVs created by using any other storage class are still encrypted, but the PVs are not encrypted with this key unless the storage class is specifically configured to use this key.
 ====
 
-<10> Optional: You can select additional custom security groups to use in your cluster. You must have already created the security groups and associated them with the VPC you selected for this cluster. You cannot add or edit security groups for the default machine pools after you create the machine pool. For more information, see the requirements for _Security groups_ under _Additional resources_.
+<10> Optional: You can select additional custom security groups to use in each of the cluster nodes, compute, infra and control plane. You must have already created the security groups and associated them with the VPC you selected for this cluster. You cannot add or edit security groups for the default machine pools after you create the machine pool. For more information, see the requirements for _Security groups_ under _Additional resources_.
 <11> Optional: Enable this option only if your use case requires etcd key value encryption in addition to the control plane storage encryption that encrypts the etcd volumes by default. With this option, the etcd key values are encrypted but not the keys.
 +
 [IMPORTANT]

--- a/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
@@ -303,12 +303,11 @@ If you opted to use private API endpoints, you must use an existing VPC and Priv
 ====
 You must ensure that your VPC is configured with a public and a private subnet for each availability zone that you want the cluster installed into. If you opted to use PrivateLink, only private subnets are required.
 ====
-// Commented out until OCMUI-302 and OCMUI-1039 are complete
-//.. Optional: Expand *Additional security groups* and select additional custom security groups to apply to nodes in the machine pools created by default. You must have already created the security groups and associated them with the VPC you selected for this cluster. You cannot add or edit security groups to the default machine pools after you create the cluster.
-//+
-//By default, the security groups you specify will be added for all node types. Uncheck the *Apply the same security groups to all node types* checkbox to apply different security groups for each node type.
-//+
-//For more information, see the requirements for _Security groups_ under _Additional resources_.
+.. Optional: Expand *Additional security groups* and select additional custom security groups to apply to nodes in the machine pools created by default. You must have already created the security groups and associated them with the VPC you selected for this cluster. You cannot add or edit security groups to the default machine pools after you create the cluster.
++
+By default, the security groups you specify will be added for all node types. Uncheck the *Apply the same security groups to all node types (control plane, infrastructure and worker)* checkbox to select different security groups for each node type.
++
+For more information, see the requirements for _Security groups_ under _Additional resources_.
 
 . If you opted to configure a cluster-wide proxy, provide your proxy configuration details on the *Cluster-wide proxy* page:
 +

--- a/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
+++ b/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
@@ -82,7 +82,7 @@ Tags that are added by Red Hat are required for clusters to stay in compliance w
 |Install a cluster into an existing AWS VPC. To use this option, your VPC must have 2 subnets for each availability zone that you are installing the cluster into. The default is `No`.
 
 |`Select availability zones (optional)`
-|Specify the availability zones to use when installing into an existing AWS VPC. Use a comma-separated list to provide the availability zones. If you specify `No`, the installer selects the availability zones automatically.
+|Specify the availability zones that are used when installing into an existing AWS VPC. Use a comma-separated list to provide the availability zones. If you specify `No`, the installer selects the availability zones automatically.
 
 |`Enable customer managed key (optional)`
 |Enable this option to use a specific AWS Key Management Service (KMS) key as the encryption key for persistent data. This key functions as the encryption key for control plane, infrastructure, and worker node root volumes. The key is also configured on the default storage class to ensure that persistent volumes created with the default storage class will be encrypted with the specific KMS key. When disabled, the account KMS key for the specified region is used by default to ensure persistent data is always encrypted. The default is `No`.
@@ -94,7 +94,13 @@ Tags that are added by Red Hat are required for clusters to stay in compliance w
 |Enable compute node autoscaling. The autoscaler adjusts the size of the cluster to meet your deployment demands. The default is `No`.
 
 |`Additional Compute Security Group IDs (optional)`
-|Select the additional custom security group IDs to use with this cluster. The default is none selected. Only security groups associated with the selected VPC are displayed. You can select a maximum of 5 additional security groups.
+|Select the additional custom security group IDs that are used with the standard machine pool created along side the cluster. The default is none selected. Only security groups associated with the selected VPC are displayed. You can select a maximum of 5 additional security groups.
+
+|`Additional Infra Security Group IDs (optional)`
+|Select the additional custom security group IDs that are used with the infra nodes created along side the cluster. The default is none selected. Only security groups associated with the selected VPC are displayed. You can select a maximum of 5 additional security groups.
+
+|`Additional Control Plane Security Group IDs (optional)`
+|Select the additional custom security group IDs that are used with the control plane nodes created along side the cluster. The default is none selected. Only security groups associated with the selected VPC are displayed. You can select a maximum of 5 additional security groups.
 
 |`Compute nodes`
 |Specify the number of compute nodes to provision into each availability zone. Clusters deployed in a single availability zone require at least 2 nodes. Clusters deployed in multiple zones must have at least 3 nodes. The maximum number of worker nodes is 180 nodes. The default value is `2`.


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-8618

Link to docs preview:
https://69248--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations#rosa-sts-creating-cluster-customizations-cli_rosa-sts-creating-a-cluster-with-customizations

https://69248--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-interactive-mode-reference

https://69248--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli#rosa-create-objects_rosa-managing-objects-cli

QE review:
- [x] QE has approved this change.

