### PR TITLE
CNV-35286: fix bandwidthPerMigration documentation

### DIFF
--- a/modules/virt-configuring-live-migration-limits.adoc
+++ b/modules/virt-configuring-live-migration-limits.adoc
@@ -35,7 +35,7 @@ spec:
     parallelOutboundMigrationsPerNode: 2 <4>
     progressTimeout: 150 <5>
 ----
-<1> Bandwidth limit of each migration, in MiB/s or GiB/s. Default: `0`, which is unlimited.
+<1> Bandwidth limit of each migration, where the value is the quantity of bytes per second. For example, a value of `2048Mi` means 2048 MiB/s. Default: `0`, which is unlimited.
 <2> The migration is canceled if it has not completed in this time, in seconds per GiB of memory. For example, a VM with 6GiB memory times out if it has not completed migration in 4800 seconds. If the `Migration Method` is `BlockMigration`, the size of the migrating disks is included in the calculation.
 <3> Number of migrations running in parallel in the cluster. Default: `5`.
 <4> Maximum number of outbound migrations per node. Default: `2`.


### PR DESCRIPTION
Version(s):
v4.11+

Issue:
https://issues.redhat.com/browse/CNV-35286

Link to docs preview:
https://69254--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-configuring-live-migration#virt-configuring-live-migration-limits_virt-configuring-live-migration

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
