### PR TITLE
OCPBUGS-23237: Add missing advisory RHSA-2023:6143 to 4.14 release notes

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3286,7 +3286,7 @@ To update an existing {product-title} 4.14 cluster to this latest release, see x
 
 Issued: 2023-10-31
 
-{product-title} release {product-version}.0, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:5006[RHSA-2023:5006] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:5009[RHSA-2023:5009] advisory.
+{product-title} release {product-version}.0, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:5006[RHSA-2023:5006] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:5009[RHSA-2023:5009] advisory. The list of security updates that are included in the update are documented in the link:https://access.redhat.com/errata/RHSA-2023:6143[RHSA-2023:6143] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory.
 


### PR DESCRIPTION
Adding missing advisory RHSA-2023:6143 to release notes.

Version(s):
enterprise-4.14

Issue:
https://issues.redhat.com/browse/OCPBUGS-23237

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
