### PR TITLE
OCPBUGS-9089: Disabling TLS for SuperMicro servers as it causes install problems in ZTP

### DIFF
--- a/modules/ztp-troubleshooting-ztp-gitops-supermicro-tls.adoc
+++ b/modules/ztp-troubleshooting-ztp-gitops-supermicro-tls.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ztp-troubleshooting-ztp-gitops-supermicro-tls_{context}"]
+= Troubleshooting {ztp} virtual media booting on Supermicro servers
+
+SuperMicro X11 servers do not support virtual media installations when the image is served using the `https` protocol. As a result, {sno} deployments for this environment fail to boot on the target node. To avoid this issue, log in to the hub cluster and disable Transport Layer Security (TLS) in the `Provisioning` resource. This ensures the image is not served with TLS even though the image address uses the `https` scheme. 
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+
+* You have logged in to the hub cluster as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Disable TLS in the `Provisioning` resource by running the following command: 
++
+[source,terminal]
+----
+$ oc patch provisioning provisioning-configuration --type merge -p '{"spec":{"disableVirtualMediaTLS": true}}'
+----
+
+. Continue the steps to deploy your {sno} cluster.

--- a/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc
@@ -51,6 +51,8 @@ include::modules/ztp-monitoring-installation-progress.adoc[leveloffset=+1]
 
 include::modules/ztp-troubleshooting-ztp-gitops-installation-crs.adoc[leveloffset=+1]
 
+include::modules/ztp-troubleshooting-ztp-gitops-supermicro-tls.adoc[leveloffset=+1]
+
 include::modules/ztp-site-cleanup.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
OCPBUGS-9089: SuperMicro X11 servers do not support vMedia-based installations where the image is served via https:// and need TLS to be disabled for the installation to succeed. Further information is provided in https://issues.redhat.com/browse/OCPBUGS-9089?focusedId=21874476&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-21874476

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1425

Link to docs preview:
https://69261--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites#ztp-troubleshooting-ztp-gitops-supermicro-tls_ztp-deploying-far-edge-sites

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
