### PR TITLE
OCPBUGS-23237: Adding RHSA-2023:3342 advisory to 4.13 release notes

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -2929,7 +2929,7 @@ For any {product-title} release, always review the instructions on xref:../updat
 
 Issued: 2023-05-17
 
-{product-title} release 4.13.0, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:1326[RHSA-2023:1326] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:1325[RHSA-2023:1325] advisory.
+{product-title} release 4.13.0, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:1326[RHSA-2023:1326] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:1325[RHSA-2023:1325] advisory. The list of security updates that are included in the update are documented in the link:https://access.redhat.com/errata/RHSA-2023:2138[RHSA-2023:2138] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory.
 
@@ -3039,7 +3039,7 @@ To update an existing {product-title} 4.13 cluster to this latest release, see x
 
 Issued: 2023-06-23
 
-{product-title} release 4.13.4, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:3614[RHSA-2023:3614] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3612[RHSA-2023:3612] advisory.
+{product-title} release 4.13.4, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:3614[RHSA-2023:3614] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3612[RHSA-2023:3612] advisory. The list of security updates that are included in the update are documented in the link:https://access.redhat.com/errata/RHSA-2023:3342[RHSA-2023:3342] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory.
 
@@ -3053,6 +3053,18 @@ $ oc adm release info 4.13.4 --pullspecs
 [id="ocp-4-13-4-bug-fixes"]
 ==== Bug fixes
 * Previously, you could not use persistent volume storage on a cluster with Confidential virtual machines (VMs) on Google Cloud Platform (GCP). This issue persists with {product-title} 4.13.3 and earlier versions. From {product-title} 4.13.4 and later versions, you can now use persistent volume storage on a cluster with Confidential VMs on GCP. (link:https://issues.redhat.com/browse/OCPBUGS-11768[*OCPBUGS-11768*])
+
+* Previously, there was a flaw in Vault and Vault Enterprise where values relied upon by Vault to validate AWS IAM identities and roles could be manipulated and bypass authentication.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2167337[*BZ#2167337*])
+
+* Previously, in {ztp}, when you provisioned a managed cluster that contained more than a single node using a `SiteConfig` CR, disk partition failed when one or more nodes had a `diskPartition` resource configured in the `SiteConfig` CR.
+(link:https://issues.redhat.com/browse/OCPBUGS-13161[*OCPBUGS-13161*])
+
+* Previously, misleading backup conditions were reported in `ClusterGroupUpgrade` (`CGU`) CRs when all clusters were already compliant.
+(link:https://issues.redhat.com/browse/OCPBUGS-13700[*OCPBUGS-13700*])
+
+* Previously, during scale upgrades of multiple clusters, a cluster upgrade `CGU` CR occasionally failed to upgrade with a `BackupTimeout` error.
+(link:https://issues.redhat.com/browse/OCPBUGS-7422[*OCPBUGS-7422*])
 
 [id="ocp-4-13-4-updating"]
 ==== Updating


### PR DESCRIPTION
Adding missing advisories RHSA-2023:3342 and RHSA-2023:2138 to release notes.

Version(s):
enterprise-4.14

Issue:
https://issues.redhat.com/browse/OCPBUGS-23237

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
