### PR TITLE
OBSDOCS-124: Added details for ES8 in the log forwarder example

### DIFF
--- a/modules/cluster-logging-collector-log-forward-es.adoc
+++ b/modules/cluster-logging-collector-log-forward-es.adoc
@@ -1,16 +1,20 @@
+// Module included in the following assemblies:
+//
+// * logging/log_collection_forwarding/log-forwarding.adoc
+
 :_mod-docs-content-type: PROCEDURE
 [id="cluster-logging-collector-log-forward-es_{context}"]
 = Forwarding logs to an external Elasticsearch instance
 
-You can optionally forward logs to an external Elasticsearch instance in addition to, or instead of, the internal {product-title} Elasticsearch instance. You are responsible for configuring the external log aggregator to receive log data from {product-title}.
+You can forward logs to an external Elasticsearch instance in addition to, or instead of, the internal log store. You are responsible for configuring the external log aggregator to receive log data from {product-title}.
 
 To configure log forwarding to an external Elasticsearch instance, you must create a `ClusterLogForwarder` custom resource (CR) with an output to that instance, and a pipeline that uses the output. The external Elasticsearch output can use the HTTP (insecure) or HTTPS (secure HTTP) connection.
 
-To forward logs to both an external and the internal Elasticsearch instance, create outputs and pipelines to the external instance and a pipeline that uses the `default` output to forward logs to the internal instance. You do not need to create a `default` output. If you do configure a `default` output, you receive an error message because the `default` output is reserved for the {clo}.
+To forward logs to both an external and the internal Elasticsearch instance, create outputs and pipelines to the external instance and a pipeline that uses the `default` output to forward logs to the internal instance.
 
 [NOTE]
 ====
-If you want to forward logs to *only* the internal {product-title} Elasticsearch instance, you do not need to create a `ClusterLogForwarder` CR.
+If you only want to forward logs to an internal Elasticsearch instance, you do not need to create a `ClusterLogForwarder` CR.
 ====
 
 .Prerequisites
@@ -19,68 +23,57 @@ If you want to forward logs to *only* the internal {product-title} Elasticsearch
 
 .Procedure
 
-. Create or edit a YAML file that defines the `ClusterLogForwarder` CR object:
+. Create or edit a YAML file that defines the `ClusterLogForwarder` CR:
 +
+.Example `ClusterLogForwarder` CR
 [source,yaml]
 ----
 apiVersion: logging.openshift.io/v1
 kind: ClusterLogForwarder
 metadata:
-  name: <log_forwarder_name> <1>
-  namespace: <log_forwarder_namespace> <2>
+  name: <log_forwarder_name> # <1>
+  namespace: <log_forwarder_namespace> # <2>
 spec:
-  serviceAccountName: <service_account_name> <3>
+  serviceAccountName: <service_account_name> # <3>
   outputs:
-   - name: elasticsearch-insecure <4>
-     type: "elasticsearch" <5>
-     url: http://elasticsearch.insecure.com:9200 <6>
-   - name: elasticsearch-secure
-     type: "elasticsearch"
-     url: https://elasticsearch.secure.com:9200 <7>
+   - name: elasticsearch-example # <4>
+     type: elasticsearch # <5>
+     elasticsearch:
+       version: 8 # <6>
+     url: http://elasticsearch.example.com:9200 # <7>
      secret:
-        name: es-secret <8>
+       name: es-secret # <8>
   pipelines:
-   - name: application-logs <9>
-     inputRefs: <10>
+   - name: application-logs # <9>
+     inputRefs: # <10>
      - application
      - audit
      outputRefs:
-     - elasticsearch-secure <11>
-     - default <12>
+     - elasticsearch-example # <11>
+     - default # <12>
      labels:
-       myLabel: "myValue" <13>
-   - name: infrastructure-audit-logs <14>
-     inputRefs:
-     - infrastructure
-     outputRefs:
-     - elasticsearch-insecure
-     labels:
-       logs: "audit-infra"
+       myLabel: "myValue" # <13>
+# ...
 ----
 <1> In legacy implementations, the CR name must be `instance`. In multi log forwarder implementations, you can use any name.
 <2> In legacy implementations, the CR namespace must be `openshift-logging`. In multi log forwarder implementations, you can use any namespace.
 <3> The name of your service account. The service account is only required in multi log forwarder implementations if the log forwarder is not deployed in the `openshift-logging` namespace.
 <4> Specify a name for the output.
 <5> Specify the `elasticsearch` type.
-<6> Specify the URL and port of the external Elasticsearch instance as a valid absolute URL. You can use the `http` (insecure) or `https` (secure HTTP) protocol. If the cluster-wide proxy using the CIDR annotation is enabled, the output must be a server name or FQDN, not an IP Address.
-<7> For a secure connection, you can specify an `https` or `http` URL that you authenticate by specifying a `secret`.
+<6> Specify the Elasticsearch version. This can be `6`, `7`, or `8`.
+<7> Specify the URL and port of the external Elasticsearch instance as a valid absolute URL. You can use the `http` (insecure) or `https` (secure HTTP) protocol. If the cluster-wide proxy using the CIDR annotation is enabled, the output must be a server name or FQDN, not an IP Address.
 <8> For an `https` prefix, specify the name of the secret required by the endpoint for TLS communication. The secret must contain a `ca-bundle.crt` key that points to the certificate it represents. Otherwise, for `http` and `https` prefixes, you can specify a secret that contains a username and password. In legacy implementations, the secret must exist in the `openshift-logging` project. For more information, see the following "Example: Setting a secret that contains a username and password."
 <9> Optional: Specify a name for the pipeline.
 <10> Specify which log types to forward by using the pipeline: `application,` `infrastructure`, or `audit`.
 <11> Specify the name of the output to use when forwarding logs with this pipeline.
 <12> Optional: Specify the `default` output to send the logs to the internal Elasticsearch instance.
 <13> Optional: String. One or more labels to add to the logs.
-<14> Optional: Configure multiple outputs to forward logs to other external log aggregators of any supported type:
-** A name to describe the pipeline.
-** The `inputRefs` is the log type to forward by using the pipeline: `application,` `infrastructure`, or `audit`.
-** The `outputRefs` is the name of the output to use.
-** Optional: String. One or more labels to add to the logs.
 
-. Create the CR object:
+. Apply the `ClusterLogForwarder` CR:
 +
 [source,terminal]
 ----
-$ oc create -f <file-name>.yaml
+$ oc apply -f <filename>.yaml
 ----
 
 .Example: Setting a secret that contains a username and password
@@ -100,6 +93,7 @@ metadata:
 data:
   username: <username>
   password: <password>
+# ...
 ----
 
 . Create the secret:
@@ -124,6 +118,7 @@ spec:
      url: https://elasticsearch.secure.com:9200
      secret:
         name: openshift-test-secret
+# ...
 ----
 +
 [NOTE]
@@ -131,9 +126,9 @@ spec:
 In the value of the `url` field, the prefix can be `http` or `https`.
 ====
 
-. Create the CR object:
+. Apply the CR object:
 +
 [source,terminal]
 ----
-$ oc create -f <file-name>.yaml
+$ oc apply -f <filename>.yaml
 ----


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OBSDOCS-124

Link to docs preview:
https://69280--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_collection_forwarding/log-forwarding#cluster-logging-collector-log-forward-es_log-forwarding

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
