### PR TITLE
Document on secrets management using SSCSID and GitOps

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -103,6 +103,8 @@ Distros: openshift-gitops
 Topics:
 - Name: Configuring secure communication with Redis
   File: configuring-secure-communication-with-redis
+- Name: Managing secrets securely using Secrets Store CSI driver with GitOps
+  File: managing-secrets-securely-using-sscsid-with-gitops
 ---
 Name: Observability
 Dir: observability

--- a/modules/gitops-configuring-gitops-managed-resources-to-use-mounted-secrets.adoc
+++ b/modules/gitops-configuring-gitops-managed-resources-to-use-mounted-secrets.adoc
@@ -1,0 +1,106 @@
+// Module is included in the following assemblies:
+//
+// * securing_openshift_gitops/managing-secrets-securely-using-sscsid-with-gitops.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="gitops-configuring-gitops-managed-resources-to-use-mounted-secrets_{context}"]
+= Configuring {gitops-shortname} managed resources to use mounted secrets
+
+You must configure the {gitops-shortname} managed resources by adding volume mounts configuration to a deployment and configuring the container pod to use the mounted secret.
+
+.Prerequisites
+
+* You have the AWS Secrets Manager resources stored in your {gitops-shortname} repository.
+* You have the Secrets Store Container Storage Interface (SSCSI) driver configured to mount secrets from AWS Secrets Manager.
+
+.Procedure
+
+. Configure the {gitops-shortname} managed resources. For example, consider that you want to add volume mounts configuration to the deployment of `app-taxi` application and the `100-deployment.yaml` file is in the `/environments/dev/apps/app-taxi/services/taxi/base/config/` directory.
+
+.. Add the volume mounting to the deployment YAML file and configure the container pod to use the secret provider class resources and mounted secret:
++
+.Example YAML file
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: taxi                                
+  namespace: dev # <1>
+spec:
+  replicas: 1
+  template:
+    metadata:
+# ...
+    spec:
+      containers:
+        - image: nginxinc/nginx-unprivileged:latest
+          imagePullPolicy: Always
+          name: taxi
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: secrets-store-inline
+              mountPath: "/mnt/secrets-store" # <2>
+              readOnly: true
+          resources: {}
+    serviceAccountName: default
+    volumes:
+      - name: secrets-store-inline
+        csi:
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: "my-aws-provider" # <3>
+    status: {}
+# ...
+----
+<1> Namespace for the deployment. This must be the same namespace as the secret provider class.
+<2> The path to mount secrets in the volume mount.
+<3> Name of the secret provider class.
+
+.. Push the updated resource YAML file to your {gitops-shortname} repository.
+
+. In the Argo CD UI, click *REFRESH* on the target application page to apply the updated deployment manifest.
+
+. Verify that all the resources are successfully synchronized on the target application page.
+
+. Verify that you can you can access the secrets from AWS Secrets manager in the pod volume mount:
+
+.. List the secrets in the pod mount: 
++
+[source,terminal]
+----
+$ oc exec <deployment_name>-<hash> -n <namespace> -- ls /mnt/secrets-store/
+----
++
+.Example command
+[source,terminal]
+----
+$ oc exec taxi-5959644f9-t847m -n dev -- ls /mnt/secrets-store/
+----
++
+.Example output
+[source,terminal]
+----
+<secret_name>
+----
+
+.. View a secret in the pod mount:
++
+[source,terminal]
+----
+$ oc exec <deployment_name>-<hash> -n <namespace> -- cat /mnt/secrets-store/<secret_name>
+----
++
+.Example command
+[source,terminal]
+----
+$ oc exec taxi-5959644f9-t847m -n dev -- cat /mnt/secrets-store/testSecret
+----
++
+.Example output
+[source,terminal]
+----
+<secret_value>
+----

--- a/modules/gitops-configuring-sscsi-driver-to-mount-secrets-from-aws-secrets-manager.adoc
+++ b/modules/gitops-configuring-sscsi-driver-to-mount-secrets-from-aws-secrets-manager.adoc
@@ -1,0 +1,187 @@
+// Module is included in the following assemblies:
+//
+// * securing_openshift_gitops/managing-secrets-securely-using-sscsid-with-gitops.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="gitops-configuring-sscsi-driver-to-mount-secrets-from-aws-secrets-manager_{context}"]
+= Configuring SSCSI driver to mount secrets from AWS Secrets Manager
+
+To store and manage your secrets securely, use {gitops-shortname} workflows and configure the Secrets Store Container Storage Interface (SSCSI) Driver Operator to mount secrets from AWS Secrets Manager to a CSI volume in OpenShift Container Platform. For example, consider that you want to mount a secret to a deployment pod under the `dev` namespace which is in the `/environments/dev/` directory.
+
+.Prerequisites
+
+* You have the AWS Secrets Manager resources stored in your {gitops-shortname} repository.
+
+.Procedure
+
+. Grant privileged access to the `csi-secrets-store-provider-aws` service account by running the following command:
++
+[source,terminal]
+----
+$ oc adm policy add-scc-to-user privileged -z csi-secrets-store-provider-aws -n openshift-cluster-csi-drivers
+----
++
+.Example output
+[source,terminal]
+----
+clusterrole.rbac.authorization.k8s.io/system:openshift:scc:privileged added: "csi-secrets-store-provider-aws"
+----
+
+. Grant permission to allow the service account to read the AWS secret object:
+
+.. Create a `credentialsrequest-dir-aws` folder under a namespace-scoped directory in your {gitops-shortname} repository because the credentials request is namespace-scoped. For example, create a `credentialsrequest-dir-aws` folder under the `dev` namespace which is in the `/environments/dev/` directory by running the following command:
++
+[source,terminal]
+----
+$ mkdir credentialsrequest-dir-aws
+----
+
+.. Create a YAML file with the following configuration for the credentials request in the `/environments/dev/credentialsrequest-dir-aws/` path to mount a secret to the deployment pod in the `dev` namespace:
++
+.Example `credentialsrequest.yaml` file
+[source,yaml]
+----
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: aws-provider-test
+  namespace: openshift-cloud-credential-operator
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AWSProviderSpec
+    statementEntries:
+    - action:
+      - "secretsmanager:GetSecretValue"
+      - "secretsmanager:DescribeSecret"
+      effect: Allow
+      resource: "<aws_secret_arn>" # <2>
+secretRef:
+  name: aws-creds
+  namespace: dev # <1>
+serviceAccountNames:
+  - default
+----
+<1> The namespace for the secret reference. Update the value of this `namespace` field according to your project deployment setup.
+<2> The ARN of your secret in the region where your cluster is on. The `<aws_region>` of `<aws_secret_arn>` has to match the cluster region. If it does not match, create a replication of your secret in the region where your cluster is on. 
++
+[TIP]
+====
+To find your cluster region, run the command:
+
+[source,terminal]
+----
+$ oc get infrastructure cluster -o jsonpath='{.status.platformStatus.aws.region}'
+----
+
+.Example output
+[source,terminal]
+----
+us-west-2
+----
+====
+
+.. Retrieve the OIDC provider by running the following command:
++
+[source,terminal]
+----
+$ oc get --raw=/.well-known/openid-configuration | jq -r '.issuer'
+----
++
+.Example output
+[source,terminal]
+----
+https://<oidc_provider_name>
+----
+Copy the OIDC provider name `<oidc_provider_name>` from the output to use in the next step.
+
+.. Use the `ccoctl` tool to process the credentials request by running the following command:
++
+[source,terminal]
+----
+$ ccoctl aws create-iam-roles \
+    --name my-role --region=<aws_region> \
+    --credentials-requests-dir=credentialsrequest-dir-aws \
+    --identity-provider-arn arn:aws:iam::<aws_account>:oidc-provider/<oidc_provider_name> --output-dir=credrequests-ccoctl-output
+----
++
+.Example output
+[source,terminal]
+----
+2023/05/15 18:10:34 Role arn:aws:iam::<aws_account_id>:role/my-role-my-namespace-aws-creds created
+2023/05/15 18:10:34 Saved credentials configuration to: credrequests-ccoctl-output/manifests/my-namespace-aws-creds-credentials.yaml
+2023/05/15 18:10:35 Updated Role policy for Role my-role-my-namespace-aws-creds
+----
++
+Copy the `<aws_role_arn>` from the output to use in the next step. For example, `arn:aws:iam::<aws_account_id>:role/my-role-my-namespace-aws-creds`.
+
+.. Check the role policy on AWS to confirm the `<aws_region>` of `"Resource"` in the role policy matches the cluster region:
++
+.Example role policy
+[source,json]
+----
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Action": [
+				"secretsmanager:GetSecretValue",
+				"secretsmanager:DescribeSecret"
+			],
+			"Resource": "arn:aws:secretsmanager:<aws_region>:<aws_account_id>:secret:my-secret-xxxxxx"
+		}
+	]
+}
+----
+
+.. Bind the service account with the role ARN by running the following command:
++
+[source,terminal]
+----
+$ oc annotate -n <namespace> sa/<app_service_account> eks.amazonaws.com/role-arn="<aws_role_arn>"
+----
++
+.Example command
+[source,terminal]
+----
+$ oc annotate -n dev sa/default eks.amazonaws.com/role-arn="<aws_role_arn>"
+----
++
+.Example output
+[source,terminal]
+----
+serviceaccount/default annotated
+----
+
+. Create a namespace-scoped `SecretProviderClass` resource to define your secrets store provider. For example, you create a `SecretProviderClass` resource in `/environments/dev/apps/app-taxi/services/taxi/base/config` directory of your {gitops-shortname} repository.
+
+.. Create a `secret-provider-class-aws.yaml` file in the same directory where the target deployment is located in your {gitops-shortname} repository: 
++
+.Example `secret-provider-class-aws.yaml`
+[source,yaml]
+----
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: my-aws-provider # <1>
+  namespace: dev # <2>
+spec:
+  provider: aws # <3>
+  parameters: # <4>
+    objects: |
+      - objectName: "testSecret" # <5>
+        objectType: "secretsmanager"
+----
+<1> Name of the secret provider class.
+<2> Namespace for the secret provider class. The namespace must match the namespace of the resource which will use the secret.
+<3> Name of the secret store provider.
+<4> Specifies the provider-specific configuration parameters.
+<5> The secret name you created in AWS. 
+
+.. Verify that after pushing this YAML file to your {gitops-shortname} repository, the namespace-scoped `SecretProviderClass` resource is populated in the target application page in the Argo CD UI.  
++
+[NOTE]
+====
+If the Sync Policy of your application is not set to `Auto`, you can manually sync the `SecretProviderClass` resource by clicking *Sync* in the Argo CD UI.
+====

--- a/modules/gitops-managing-secrets-using-sscsid-with-gitops-overview.adoc
+++ b/modules/gitops-managing-secrets-using-sscsid-with-gitops-overview.adoc
@@ -1,0 +1,65 @@
+// Module is included in the following assemblies:
+//
+// * securing_openshift_gitops/managing-secrets-securely-using-sscsid-with-gitops.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="gitops-managing-secrets-using-sscsid-with-gitops-overview_{context}"]
+= Overview of managing secrets using Secrets Store CSI driver with {gitops-shortname}
+
+Some applications need sensitive information, such as passwords and usernames which must be concealed as good security practice. If sensitive information is exposed because role-based access control (RBAC) is not configured properly on your cluster, anyone with API or etcd access can retrieve or modify a secret. 
+
+[IMPORTANT]
+====
+Anyone who is authorized to create a pod in a namespace can use that RBAC to read any secret in that namespace. With the SSCSI Driver Operator, you can use an external secrets store to store and provide sensitive information to pods securely. 
+====
+
+The process of integrating the {OCP} SSCSI driver with the {gitops-shortname} Operator consists of the following procedures:
+
+. xref:../securing_openshift_gitops/managing-secrets-securely-using-sscsid-with-gitops.adoc#gitops-storing-aws-secret-manager-resources-in-gitops-repository_managing-secrets-securely-using-sscsid-with-gitops[Storing AWS Secrets Manager resources in {gitops-shortname} repository]
+. xref:../securing_openshift_gitops/managing-secrets-securely-using-sscsid-with-gitops.adoc#gitops-configuring-sscsi-driver-to-mount-secrets-from-aws-secrets-manager_managing-secrets-securely-using-sscsid-with-gitops[Configuring SSCSI driver to mount secrets from AWS Secrets Manager]
+. xref:../securing_openshift_gitops/managing-secrets-securely-using-sscsid-with-gitops.adoc#gitops-configuring-gitops-managed-resources-to-use-mounted-secrets_managing-secrets-securely-using-sscsid-with-gitops[Configuring {gitops-shortname} managed resources to use mounted secrets]
+
+[id="benefits_{context}"]
+== Benefits
+Integrating the SSCSI driver with the {gitops-shortname} Operator provides the following benefits:
+
+* Enhance the security and efficiency of your {gitops-shortname} workflows
+* Facilitate the secure attachment of secrets into deployment pods as a volume
+* Ensure that sensitive information is accessed securely and efficiently
+
+[id="secrets-store-providers_{context}"]
+== Secrets store providers
+The following secrets store providers are available for use with the Secrets Store CSI Driver Operator:
+
+* AWS Secrets Manager
+* AWS Systems Manager Parameter Store
+* Microsoft Azure Key Vault
+
+As an example, consider that you are using AWS Secrets Manager as your secrets store provider with the SSCSI Driver Operator. The following example shows the directory structure in {gitops-shortname} repository that is ready to use the secrets from AWS Secrets Manager:
+
+.Example directory structure in {gitops-shortname} repository
+----
+├── config
+│   ├── argocd
+│   │   ├── argo-app.yaml
+│   │   ├── secret-provider-app.yaml <3>
+│   │   ├── ...
+│   └── sscsid <1>
+│       └── aws-provider.yaml <2>
+├── environments
+│   ├── dev <4>
+│   │   ├── apps
+│   │   │   └── app-taxi <5>
+│   │   │       ├── ...
+│   │   ├── credentialsrequest-dir-aws <6>
+│   │   └── env
+│   │       ├── ...
+│   ├── new-env
+│   │   ├── ...
+----
+<1> Directory that stores the `aws-provider.yaml` file.
+<2> Configuration file that installs the AWS Secrets Manager provider and deploys resources for it.
+<3> Configuration file that creates an application and deploys resources for AWS Secrets Manager.
+<4> Directory that stores the deployment pod and credential requests.
+<5> Directory that stores the `SecretProviderClass` resources to define your secrets store provider.
+<6> Folder that stores the `credentialsrequest.yaml` file. This file contains the configuration for the credentials request to mount a secret to the deployment pod.

--- a/modules/gitops-storing-aws-secret-manager-resources-in-gitops-repository.adoc
+++ b/modules/gitops-storing-aws-secret-manager-resources-in-gitops-repository.adoc
@@ -1,0 +1,181 @@
+// Module is included in the following assemblies:
+//
+// * securing_openshift_gitops/managing-secrets-securely-using-sscsid-with-gitops.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="gitops-storing-aws-secret-manager-resources-in-gitops-repository_{context}"]
+= Storing AWS Secrets Manager resources in {gitops-shortname} repository
+
+This guide provides instructions with examples to help you use {gitops-shortname} workflows with the Secrets Store Container Storage Interface (SSCSI) Driver Operator to mount secrets from AWS Secrets Manager to a CSI volume in OpenShift Container Platform.
+
+[IMPORTANT]
+====
+Using the SSCSI Driver Operator with AWS Secrets Manager is not supported in a hosted control plane cluster.
+==== 
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have access to the {OCP} web console.
+* You have extracted and prepared the `ccoctl` binary.
+* You have installed the `jq` CLI tool.
+* Your cluster is installed on AWS and uses AWS Security Token Service (STS).
+* You have configured AWS Secrets Manager to store the required secrets.
+* link:https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-secrets-store.html#persistent-storage-csi-secrets-store-driver-install_nodes-pods-secrets-store[SSCSI Driver Operator is installed on your cluster].
+* {gitops-title} Operator is installed on your cluster.
+* You have a {gitops-shortname} repository ready to use the secrets.
+* You are logged in to the Argo CD instance by using the Argo CD admin account.
+
+.Procedure
+
+. Install the AWS Secrets Manager provider and add resources:
+
+.. In your {gitops-shortname} repository, create a directory and add `aws-provider.yaml` file in it with the following configuration to deploy resources for the AWS Secrets Manager provider:
++
+[IMPORTANT]
+====
+The AWS Secrets Manager provider for the SSCSI driver is an upstream provider.
+
+This configuration is modified from the configuration provided in the upstream link:https://github.com/aws/secrets-store-csi-driver-provider-aws#installing-the-aws-provider[AWS documentation] so that it works properly with {OCP}. Changes to this configuration might impact functionality.
+====
++
+.Example `aws-provider.yaml` file
+[source,yaml]
+----
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-secrets-store-provider-aws
+  namespace: openshift-cluster-csi-drivers
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csi-secrets-store-provider-aws-cluster-role
+rules:
+- apiGroups: [""]
+  resources: ["serviceaccounts/token"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-secrets-store-provider-aws-cluster-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: csi-secrets-store-provider-aws-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: csi-secrets-store-provider-aws
+  namespace: openshift-cluster-csi-drivers
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  namespace: openshift-cluster-csi-drivers
+  name: csi-secrets-store-provider-aws
+  labels:
+    app: csi-secrets-store-provider-aws
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: csi-secrets-store-provider-aws
+  template:
+    metadata:
+      labels:
+        app: csi-secrets-store-provider-aws
+    spec:
+      serviceAccountName: csi-secrets-store-provider-aws
+      hostNetwork: false
+      containers:
+        - name: provider-aws-installer
+          image: public.ecr.aws/aws-secrets-manager/secrets-store-csi-driver-provider-aws:1.0.r2-50-g5b4aca1-2023.06.09.21.19
+          imagePullPolicy: Always
+          args:
+              - --provider-volume=/etc/kubernetes/secrets-store-csi-providers
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
+              name: providervol
+            - name: mountpoint-dir
+              mountPath: /var/lib/kubelet/pods
+              mountPropagation: HostToContainer
+      tolerations:
+      - operator: Exists
+      volumes:
+        - name: providervol
+          hostPath:
+            path: "/etc/kubernetes/secrets-store-csi-providers"
+        - name: mountpoint-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: DirectoryOrCreate
+      nodeSelector:
+        kubernetes.io/os: linux
+----
+
+.. Add a `secret-provider-app.yaml` file in your {gitops-shortname} repository to create an application and deploy resources for AWS Secrets Manager:
++
+.Example `secret-provider-app.yaml` file
+[source,yaml]
+----
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: secret-provider-app
+  namespace: openshift-gitops
+spec:
+  destination:
+    namespace: openshift-cluster-csi-drivers
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: path/to/aws-provider/resources
+    repoURL: https://github.com/<my-domain>/<gitops>.git # <1>
+  syncPolicy:
+    automated:
+    prune: true
+    selfHeal: true
+----
+<1> Update the value of the `repoURL` field to point to your {gitops-shortname} repository.
+
+. Synchronize resources with the default Argo CD instance to deploy them in the cluster:
+
+.. Add a label to the `openshift-cluster-csi-drivers` namespace your application is deployed in so that the Argo CD instance in the `openshift-gitops` namespace can manage it:
++
+[source,terminal]
+----
+$ oc label namespace openshift-cluster-csi-drivers argocd.argoproj.io/managed-by=openshift-gitops
+----
+
+.. Apply the resources in your {gitops-shortname} repository to your cluster, including the `aws-provider.yaml` file you just pushed:
++
+.Example output
+[source,terminal]
+----
+application.argoproj.io/argo-app created
+application.argoproj.io/secret-provider-app created
+...
+----
+
+In the Argo CD UI, you can observe that the `csi-secrets-store-provider-aws` daemonset continues to synchronize resources. To resolve this issue, you must configure the SSCSI driver to mount secrets from the AWS Secrets Manager.

--- a/securing_openshift_gitops/managing-secrets-securely-using-sscsid-with-gitops.adoc
+++ b/securing_openshift_gitops/managing-secrets-securely-using-sscsid-with-gitops.adoc
@@ -1,0 +1,41 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="managing-secrets-securely-using-sscsid-with-gitops"]
+= Managing secrets securely using Secrets Store CSI driver with {gitops-shortname}
+:context: managing-secrets-securely-using-sscsid-with-gitops
+
+toc::[]
+
+This guide walks you through the process of integrating the Secrets Store Container Storage Interface (SSCSI) driver with the {gitops-shortname} Operator in {OCP} 4.14 and later.
+
+include::modules/gitops-managing-secrets-using-sscsid-with-gitops-overview.adoc[leveloffset=+1]
+
+[id="prerequisites_managing-secrets-securely-using-sscsid-with-gitops"]
+== Prerequisites
+* You have access to the cluster with `cluster-admin` privileges.
+* You have access to the {OCP} web console.
+* You have extracted and prepared the `ccoctl` binary.
+* You have installed the `jq` CLI tool.
+* Your cluster is installed on AWS and uses AWS Security Token Service (STS).
+* You have configured AWS Secrets Manager to store the required secrets.
+* link:https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-secrets-store.html#persistent-storage-csi-secrets-store-driver-install_nodes-pods-secrets-store[SSCSI Driver Operator is installed on your cluster].
+* {gitops-title} Operator is installed on your cluster.
+* You have a {gitops-shortname} repository ready to use the secrets.
+* You are logged in to the Argo CD instance by using the Argo CD admin account.
+
+include::modules/gitops-storing-aws-secret-manager-resources-in-gitops-repository.adoc[leveloffset=+1]
+
+include::modules/gitops-configuring-sscsi-driver-to-mount-secrets-from-aws-secrets-manager.adoc[leveloffset=+1]
+
+include::modules/gitops-configuring-gitops-managed-resources-to-use-mounted-secrets.adoc[leveloffset=+1]
+
+[id="additional-resources_managing-secrets-securely-using-sscsid-with-gitops"]
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://github.com/redhat-developer/gitops-operator/blob/bfdf81944ea60b1d62d7de7c223c3bea3e7363a6/docs/Integrate%20GitOps%20with%20Secrets%20Management.md#obtain-the-ccoctl-tool[Obtaining the `ccoctl` tool]
+* link:https://docs.openshift.com/container-platform/latest/installing/installing_aws/installing-aws-customizations.html#cco-ccoctl-configuring_installing-aws-customizations[Configuring the Cloud Credential Operator utility]
+* link:https://github.com/redhat-developer/gitops-operator/blob/bfdf81944ea60b1d62d7de7c223c3bea3e7363a6/docs/Integrate%20GitOps%20with%20Secrets%20Management.md#configure-your-aws-cluster-to-use-aws-security-token-service-sts[Configure your AWS cluster to use AWS STS]
+* link:https://docs.aws.amazon.com/secretsmanager/latest/userguide/create_secret.html[Configuring AWS Secrets Manager to store the required secrets]
+* link:https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-secrets-store.html#persistent-storage-csi-secrets-store-driver-overview_nodes-pods-secrets-store[About the Secrets Store CSI Driver Operator]
+* link:https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-secrets-store.html#mounting-secrets-external-secrets-store[Mounting secrets from an external secrets store to a CSI volume]


### PR DESCRIPTION
**Aligned team**: Dev Tools

**Please cherry-pick to**: `gitops-docs-1.11`

**JIRA issues**: [RHDEVDOCS-3544](https://issues.redhat.com/browse/RHDEVDOCS-3544)

**Preview pages**: 
- [Managing secrets securely using Secrets Store CSI driver with GitOps](https://69291--docspreview.netlify.app/openshift-gitops/latest/securing_openshift_gitops/managing-secrets-securely-using-sscsid-with-gitops)

**SME Review**: Completed by @ciiay, @svghadi 

**QE review**: Completed by @varshab1210 

**Peer review**: Completed by @GroceryBoyJr 

**Additional information**: This PR creates a document on secrets management using SSCSID and GitOpsfor 1.11 GitOps standalone doc.