### PR TITLE
OSDOCS#8773: Agent configuration reference assembly

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -353,6 +353,8 @@ Topics:
     File: prepare-pxe-assets-agent
   - Name: Preparing an Agent-based installed cluster for the multicluster engine for Kubernetes
     File: preparing-an-agent-based-installed-cluster-for-mce
+  - Name: Installation configuration parameters for the Agent-based Installer
+    File: installation-config-parameters-agent
 - Name: Installing on a single node
   Dir: installing_sno
   Distros: openshift-enterprise

--- a/installing/installing_with_agent_based_installer/installation-config-parameters-agent.adoc
+++ b/installing/installing_with_agent_based_installer/installation-config-parameters-agent.adoc
@@ -1,0 +1,19 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="installation-config-parameters-agent"]
+= Installation configuration parameters for the Agent-based Installer
+include::_attributes/common-attributes.adoc[]
+:context: installation-config-parameters-agent
+
+toc::[]
+
+Before you deploy an {product-title} cluster using the Agent-based Installer, you provide parameters to customize your cluster and the platform that hosts it.
+When you create the `install-config.yaml` and `agent-config.yaml` files, you must provide values for the required parameters, and you can use the optional parameters to customize your cluster further.
+
+include::modules/installation-configuration-parameters.adoc[leveloffset=+1]
+
+include::modules/agent-configuration-parameters.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.adoc#prepare-pxe-assets-agent[Preparing PXE assets for {product-title}]
+* xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#root-device-hints_ipi-install-installation-workflow[Root device hints]

--- a/modules/agent-configuration-parameters.adoc
+++ b/modules/agent-configuration-parameters.adoc
@@ -1,0 +1,124 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_with_agent_based_installer/installation-config-parameters-agent.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="agent-configuration-parameters_{context}"]
+= Available Agent configuration parameters
+
+The following tables specify the required and optional Agent configuration parameters that you can set as part of the Agent-based installation process.
+
+These values are specified in the `agent-config.yaml` file.
+
+[NOTE]
+====
+These settings are used for installation only, and cannot be modified after installation.
+====
+
+[id="agent-configuration-parameters-required_{context}"]
+== Required configuration parameters
+
+Required Agent configuration parameters are described in the following table:
+
+.Required parameters
+[cols=".^2l,.^3,.^5a",options="header"]
+|====
+|Parameter|Description|Values
+
+|apiVersion:
+|The API version for the `agent-config.yaml` content.
+The current version is `v1beta1`.
+The installation program might also support older API versions.
+|String
+
+|metadata:
+|Kubernetes resource `ObjectMeta`, from which only the `name` parameter is consumed.
+|Object
+
+|metadata:
+  name:
+|The name of the cluster.
+DNS records for the cluster are all subdomains of `{{.metadata.name}}.{{.baseDomain}}`.
+The value entered in the `agent-config.yaml` file is ignored, and instead the value specified in the `install-config.yaml` file is used.
+When you do not provide `metadata.name` through either the `install-config.yaml` or `agent-config.yaml` files, for example when you use only ZTP manifests, the cluster name is set to `agent-cluster`.
+|String of lowercase letters and hyphens (`-`), such as `dev`.
+|====
+
+
+[id="agent-configuration-parameters-optional_{context}"]
+== Optional configuration parameters
+
+Optional Agent configuration parameters are described in the following table:
+
+.Optional parameters
+[cols=".^2l,.^4,.^4a",options="header"]
+|====
+|Parameter|Description|Values
+
+|rendezvousIP:
+|The IP address of the node that performs the bootstrapping process as well as running the `assisted-service` component.
+You must provide the rendezvous IP address when you do not specify at least one host's IP address in the `networkConfig` parameter.
+If this address is not provided, one IP address is selected from the provided hosts' `networkConfig`.
+|IPv4 or IPv6 address.
+
+|bootArtifactsBaseURL:
+|The URL of the server to upload Preboot Execution Environment (PXE) assets to when using the Agent-based Installer to generate an iPXE script.
+For more information, see "Preparing PXE assets for {product-title}".
+|String.
+
+|additionalNTPSources:
+|A list of Network Time Protocol (NTP) sources to be added to all cluster hosts, which are added to any NTP sources that are configured through other means.
+|List of hostnames or IP addresses.
+
+|hosts:
+|Host configuration.
+An optional list of hosts.
+The number of hosts defined must not exceed the total number of hosts defined in the `install-config.yaml` file, which is the sum of the values of the `compute.replicas` and `controlPlane.replicas` parameters.
+|An array of host configuration objects.
+
+|hosts:
+  hostname:
+|Hostname.
+Overrides the hostname obtained from either the Dynamic Host Configuration Protocol (DHCP) or a reverse DNS lookup.
+Each host must have a unique hostname supplied by one of these methods, although configuring a hostname through this parameter is optional.
+|String.
+
+|hosts:
+  interfaces:
+|Provides a table of the name and MAC address mappings for the interfaces on the host.
+If a `NetworkConfig` section is provided in the `agent-config.yaml` file, this table must be included and the values must match the mappings provided in the `NetworkConfig` section.
+|An array of host configuration objects.
+
+|hosts:
+  interfaces:
+    name:
+|The name of an interface on the host.
+|String.
+
+|hosts:
+  interfaces:
+    macAddress:
+|The MAC address of an interface on the host.
+|A MAC address such as the following example: `00-B0-D0-63-C2-26`
+
+|hosts:
+  rootDeviceHints:
+|Enables provisioning of the {op-system-first} image to a particular device.
+The installation program examines the devices in the order it discovers them, and compares the discovered values with the hint values.
+It uses the first discovered device that matches the hint value.
+This is the device that the operating system is written on during installation.
+|A dictionary of key-value pairs.
+For more information, see "Root device hints" in the "Setting up the environment for an OpenShift installation" page.
+
+|hosts:
+  rootDeviceHints:
+    deviceName:
+|The name of the device the {op-system} image is provisioned to.
+|String.
+
+|hosts:
+  networkConfig:
+|The host network definition.
+The configuration must match the Host Network Management API defined in the link:https://nmstate.io/[nmstate documentation].
+|A dictionary of host network configuration objects.
+|====

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -13,6 +13,7 @@
 // * installing/installing_openstack/installation-config-parameters-openstack.adoc
 // * installing/installing_azure/installation-config-parameters-azure.adoc
 // * installing/installing_aws/installation-config-parameters-aws.adoc
+// * installing/installing_with_agent_based_installer/installation-config-parameters-agent.adoc
 
 ifeval::["{context}" == "installation-config-parameters-vsphere"]
 :vsphere:
@@ -53,9 +54,13 @@ endif::[]
 ifeval::["{context}" == "installation-config-parameters-aws"]
 :aws:
 endif::[]
+ifeval::["{context}" == "installation-config-parameters-agent"]
+:agent:
+endif::[]
 
 :_mod-docs-content-type: CONCEPT
 [id="installation-configuration-parameters_{context}"]
+ifndef::agent[]
 = Available installation configuration parameters for {platform}
 The following tables specify the required, optional, and {platform}-specific installation configuration parameters that you can set as part of the installation process.
 
@@ -63,6 +68,21 @@ The following tables specify the required, optional, and {platform}-specific ins
 ====
 After installation, you cannot modify these parameters in the `install-config.yaml` file.
 ====
+
+endif::agent[]
+
+ifdef::agent[]
+= Available installation configuration parameters
+The following tables specify the required and optional installation configuration parameters that you can set as part of the Agent-based installation process.
+
+These values are specified in the `install-config.yaml` file.
+
+[NOTE]
+====
+These settings are used for installation only, and cannot be modified after installation.
+====
+
+endif::agent[]
 
 [id="installation-configuration-parameters-required_{context}"]
 == Required configuration parameters
@@ -89,6 +109,9 @@ Required installation configuration parameters are described in the following ta
 |metadata:
   name:
 |The name of the cluster. DNS records for the cluster are all subdomains of `{{.metadata.name}}.{{.baseDomain}}`.
+ifdef::agent[]
+When you do not provide `metadata.name` through either the `install-config.yaml` or `agent-config.yaml` files, for example when you use only ZTP manifests, the cluster name is set to `agent-cluster`.
+endif::agent[]
 ifndef::bare,nutanix,vsphere[]
 |String of lowercase letters, hyphens (`-`), and periods (`.`), such as `dev`.
 endif::bare,nutanix,vsphere[]
@@ -100,7 +123,12 @@ The string must be 14 characters or fewer long.
 endif::osp[]
 
 |platform:
+ifndef::agent[]
 |The configuration for the specific platform upon which to perform the installation: `alibabacloud`, `aws`, `baremetal`, `azure`, `gcp`, `ibmcloud`, `nutanix`, `openstack`, `powervs`, `vsphere`, or `{}`. For additional information about `platform.<platform>` parameters, consult the table for your specific platform that follows.
+endif::agent[]
+ifdef::agent[]
+|The configuration for the specific platform upon which to perform the installation: `baremetal`, `external`, `none`, or `vsphere`.
+endif::agent[]
 |Object
 
 ifndef::openshift-origin[]
@@ -167,11 +195,11 @@ You can customize your installation configuration based on the requirements of y
 // https://bugzilla.redhat.com/show_bug.cgi?id=2020416
 // Once BM UPI supports dual-stack, uncomment all the following conditionals and blocks
 
-ifndef::bare,ibm-power,ibm-z,vsphere[]
+ifndef::agent,bare,ibm-power,ibm-z,vsphere[]
 Only IPv4 addresses are supported.
-endif::bare,ibm-power,ibm-z,vsphere[]
+endif::agent,bare,ibm-power,ibm-z,vsphere[]
 
-ifdef::bare,ibm-power,ibm-z,vsphere[]
+ifdef::agent,bare,ibm-power,ibm-z,vsphere[]
 * If you use the {openshift-networking} OVN-Kubernetes network plugin, both IPv4 and IPv6 address families are supported.
 
 * If you use the {openshift-networking} OpenShift SDN network plugin, only the IPv4 address family is supported.
@@ -210,7 +238,7 @@ networking:
   - 172.30.0.0/16
   - fd00:172:16::/112
 ----
-endif::bare,ibm-power,ibm-z,vsphere[]
+endif::agent,bare,ibm-power,ibm-z,vsphere[]
 
 [NOTE]
 ====
@@ -259,20 +287,20 @@ If you specify multiple IP address blocks, the blocks must not overlap.
 
 [source,yaml]
 ----
-ifndef::bare[]
+ifndef::agent,bare[]
 networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
-endif::bare[]
-ifdef::bare[]
+endif::agent,bare[]
+ifdef::agent,bare[]
 networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
   - cidr: fd01::/48
     hostPrefix: 64
-endif::bare[]
+endif::agent,bare[]
 ----
 
 |networking:
@@ -281,19 +309,19 @@ endif::bare[]
 |
 Required if you use `networking.clusterNetwork`. An IP address block.
 
-ifndef::bare[]
+ifndef::agent,bare[]
 An IPv4 network.
-endif::bare[]
+endif::agent,bare[]
 
-ifdef::bare[]
+ifdef::agent,bare[]
 If you use the OpenShift SDN network plugin, specify an IPv4 network. If you use the OVN-Kubernetes network plugin, you can specify IPv4 and IPv6 networks.
-endif::bare[]
+endif::agent,bare[]
 |
 An IP address block in Classless Inter-Domain Routing (CIDR) notation.
 The prefix length for an IPv4 block is between `0` and `32`.
-ifdef::bare[]
+ifdef::agent,bare[]
 The prefix length for an IPv6 block is between `0` and `128`. For example, `10.128.0.0/14` or `fd01::/48`.
-endif::bare[]
+endif::agent,bare[]
 
 |networking:
   clusterNetwork:
@@ -302,14 +330,14 @@ endif::bare[]
 |
 A subnet prefix.
 
-ifndef::bare[]
+ifndef::agent,bare[]
 The default value is `23`.
-endif::bare[]
+endif::agent,bare[]
 
-ifdef::bare[]
+ifdef::agent,bare[]
 For an IPv4 network the default value is `23`.
 For an IPv6 network the default value is `64`. The default value is also the minimum value for IPv6.
-endif::bare[]
+endif::agent,bare[]
 
 |networking:
   serviceNetwork:
@@ -318,26 +346,26 @@ The IP address block for services. The default value is `172.30.0.0/16`.
 
 The OpenShift SDN and OVN-Kubernetes network plugins support only a single IP address block for the service network.
 
-ifdef::bare[]
+ifdef::agent,bare[]
 If you use the OVN-Kubernetes network plugin, you can specify an IP address block for both of the IPv4 and IPv6 address families.
-endif::bare[]
+endif::agent,bare[]
 
 |
 An array with an IP address block in CIDR format. For example:
 
 [source,yaml]
 ----
-ifndef::bare[]
+ifndef::agent,bare[]
 networking:
   serviceNetwork:
    - 172.30.0.0/16
-endif::bare[]
-ifdef::bare[]
+endif::agent,bare[]
+ifdef::agent,bare[]
 networking:
   serviceNetwork:
    - 172.30.0.0/16
    - fd02::/112
-endif::bare[]
+endif::agent,bare[]
 ----
 
 |networking:
@@ -372,12 +400,12 @@ endif::ibm-cloud[]
 |
 An IP network block in CIDR notation.
 
-ifndef::bare,ibm-power-vs[]
+ifndef::agent,bare,ibm-power-vs[]
 For example, `10.0.0.0/16`.
-endif::bare,ibm-power-vs[]
-ifdef::bare[]
+endif::agent,bare,ibm-power-vs[]
+ifdef::agent,bare[]
 For example, `10.0.0.0/16` or `fd00::/48`.
-endif::bare[]
+endif::agent,bare[]
 ifdef::ibm-power-vs[]
 For example, `192.168.0.0/24`.
 endif::ibm-power-vs[]
@@ -427,12 +455,12 @@ Optional installation configuration parameters are described in the following ta
 
 ifndef::openshift-origin[]
 
-ifndef::aws,bare,gcp,ibm-power,ibm-z,azure,ibm-power-vs[]
+ifndef::agent,aws,bare,gcp,ibm-power,ibm-z,azure,ibm-power-vs[]
 |compute:
   architecture:
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` (the default).
 |String
-endif::aws,bare,gcp,ibm-power,ibm-z,azure,ibm-power-vs[]
+endif::agent,aws,bare,gcp,ibm-power,ibm-z,azure,ibm-power-vs[]
 
 ifdef::aws,azure,gcp,bare[]
 |compute:
@@ -457,6 +485,14 @@ ifdef::ibm-power,ibm-power-vs[]
 |Determines the instruction set architecture of the machines in the pool. Currently, heteregeneous clusters are not supported, so all pools must specify the same architecture. Valid values are `ppc64le` (the default).
 |String
 endif::ibm-power,ibm-power-vs[]
+
+ifdef::agent[]
+|compute:
+  architecture:
+|Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`.
+|String
+endif::agent[]
+
 endif::openshift-origin[]
 
 ifdef::openshift-origin[]
@@ -491,7 +527,12 @@ endif::vsphere[]
 ifdef::ibm-power-vs[]
 Example usage, `compute.platform.powervs.sysType`.
 endif::ibm-power-vs[]
+ifndef::agent[]
 |`alibabacloud`, `aws`, `azure`, `gcp`, `ibmcloud`, `nutanix`, `openstack`, `powervs`, `vsphere`, or `{}`
+endif::agent[]
+ifdef::agent[]
+|`baremetal`, `vsphere`, or `{}`
+endif::agent[]
 
 |compute:
   replicas:
@@ -507,12 +548,12 @@ endif::ibm-power-vs[]
 |Array of `MachinePool` objects.
 
 ifndef::openshift-origin[]
-ifndef::aws,bare,gcp,ibm-z,ibm-power,azure,ibm-power-vs[]
+ifndef::agent,aws,bare,gcp,ibm-z,ibm-power,azure,ibm-power-vs[]
 |controlPlane:
   architecture:
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` (the default).
 |String
-endif::aws,bare,gcp,ibm-z,ibm-power,azure,ibm-power-vs[]
+endif::agent,aws,bare,gcp,ibm-z,ibm-power,azure,ibm-power-vs[]
 
 ifdef::aws,azure,gcp,bare[]
 |controlPlane:
@@ -537,6 +578,14 @@ ifdef::ibm-power,ibm-power-vs[]
 |Determines the instruction set architecture of the machines in the pool. Currently, heterogeneous clusters are not supported, so all pools must specify the same architecture. Valid values are `ppc64le` (the default).
 |String
 endif::ibm-power,ibm-power-vs[]
+
+ifdef::agent[]
+|controlPlane:
+  architecture:
+|Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`.
+|String
+endif::agent[]
+
 endif::openshift-origin[]
 
 ifdef::openshift-origin[]
@@ -572,12 +621,17 @@ endif::vsphere[]
 ifdef::ibm-power-vs[]
 Example usage, `controlPlane.platform.powervs.processors`.
 endif::ibm-power-vs[]
+ifndef::agent[]
 |`alibabacloud`, `aws`, `azure`, `gcp`, `ibmcloud`, `nutanix`, `openstack`, `powervs`, `vsphere`, or `{}`
+endif::agent[]
+ifdef::agent[]
+|`baremetal`, `vsphere`, or `{}`
+endif::agent[]
 
 |controlPlane:
   replicas:
 |The number of control plane machines to provision.
-|The only supported value is `3`, which is the default value.
+|Supported values are `3`, or `1` when deploying {sno}.
 
 |credentialsMode:
 |The Cloud Credential Operator (CCO) mode. If no mode is specified, the CCO dynamically tries to determine the capabilities of the provided credentials, with a preference for mint mode on the platforms where multiple modes are supported.

--- a/modules/installing-ocp-agent-inputs.adoc
+++ b/modules/installing-ocp-agent-inputs.adoc
@@ -173,7 +173,7 @@ EOF
 You must provide the rendezvous IP address when you do not specify at least one host's IP address in the `networkConfig` parameter. If this address is not provided, one IP address is selected from the provided hosts' `networkConfig`.
 <2> Optional: Host configuration. The number of hosts defined must not exceed the total number of hosts defined in the `install-config.yaml` file, which is the sum of the values of the `compute.replicas` and `controlPlane.replicas` parameters.
 <3> Optional: Overrides the hostname obtained from either the Dynamic Host Configuration Protocol (DHCP) or a reverse DNS lookup. Each host must have a unique hostname supplied by one of these methods.
-<4> Enables provisioning of the Red Hat Enterprise Linux CoreOS (RHCOS) image to a particular device. It examines the devices in the order it discovers them, and compares the discovered values with the hint values. It uses the first discovered device that matches the hint value.
+<4> Enables provisioning of the {op-system-first} image to a particular device. The installation program examines the devices in the order it discovers them, and compares the discovered values with the hint values. It uses the first discovered device that matches the hint value.
 <5> Optional: Configures the network interface of a host in NMState format.
 
 ifdef::pxe-boot[]


### PR DESCRIPTION
[OSDOCS-8773](https://issues.redhat.com/browse/OSDOCS-8773)

Version(s):
4.14+

(content should be backported in later doc effort, I believe the main difference would be which platforms are supported)

This PR adds a new assembly containing all the available configuration parameters for the `install-config.yaml` and `agent-config.yaml` files used during an Agent-based installation.

QE review:
- [x] QE has approved this change.

Preview: [Installation configuration parameters for the Agent-based Installer](https://69292--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installation-config-parameters-agent)
