### PR TITLE
Enable previews for all branches except `main`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ git:
 jobs:
   include:
     - name: "Preview, validate, and build"
-      # before_install:
-      #   - chmod +x autopreview.sh
-      #   - ./autopreview.sh
+      before_install:
+      - if [ "$TRAVIS_BRANCH" != "main" ]; then chmod +x autopreview.sh && ./autopreview.sh; fi
       install:
         - gem install --local _gemfiles/asciidoctor-2.0.20.gem _gemfiles/asciidoctor-diagram-plantuml-1.2023.10.gem _gemfiles/asciidoctor-diagram-ditaamini-1.0.3.gem _gemfiles/rexml-3.2.6.gem _gemfiles/asciidoctor-diagram-2.2.14.gem _gemfiles/rouge-4.1.3.gem
         - pip3 install pyyaml aura.tar.gz


### PR DESCRIPTION
Enables Circle CI previews for all branches except the `main` branch