### PR TITLE
TELCODOCS#1255: Added limitations related to creating snapshots and clones in multi-node topology

### DIFF
--- a/modules/lvms-creating-volume-clones-in-single-node-openshift.adoc
+++ b/modules/lvms-creating-volume-clones-in-single-node-openshift.adoc
@@ -19,6 +19,7 @@ The cloned PVC has write access.
 * You ensured that the PVC is in `Bound` state. This is required for a consistent snapshot.
 * You ensured that the `StorageClass` is the same as that of the source PVC.
 
+
 .Procedure
 
 . Identify the storage class of the source PVC.

--- a/modules/lvms-limitations-for-creating-snapshots-and-clones.adoc
+++ b/modules/lvms-limitations-for-creating-snapshots-and-clones.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="lvms-limitations-for-creating-snapshots-and-clones_{context}"]
+= Limitations for creating volume snapshots and volume clones
+
+{lvms} has the following limitations for creating volume snapshots and volume clones in multi-node topology:
+
+* Creating volume snapshots and volume clones is based on the LVM thin pool capabilities.
+* The node must have additional storage after creating a volume snapshot and volume clone for further updating the original data source.
+* You can create volume snapshots and volume clones only on the node where you have deployed the original data source.
+* Pods relying on the persistent volume claim (PVC) that uses the snapshot data and clone data can be scheduled only on the node where you have deployed the original data source.
+* If the PVC is not present and available before creating a volume snapshot or volume clone, then the scheduler in multi-node {product-title} clusters does not provision the volume snapshots and volume clones on the node where you have deployed the original data source.

--- a/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
+++ b/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
@@ -125,6 +125,11 @@ include::modules/lvms-upgrading-lvms-on-sno.adoc[leveloffset=+1]
 //Volume snapshots
 include::modules/lvms-volume-snapshots-in-single-node-openshift.adoc[leveloffset=+1]
 
+[NOTE]
+====
+Before creating volume snapshots, you must be aware of the limitations. For information about the limitations, see xref:../../../storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc#lvms-limitations-for-creating-snapshots-and-clones_logical-volume-manager-storage[Limitations for creating volume snapshots and volume clones].
+====
+
 [role="_additional-resources"]
 .Additional resources
 
@@ -136,8 +141,17 @@ include::modules/lvms-deleting-volume-snapshots-in-single-node-openshift.adoc[le
 
 //Volume cloning
 include::modules/lvms-volume-clones-in-single-node-openshift.adoc[leveloffset=+1]
+
+[NOTE]
+====
+Before creating volume clones, you must be aware of the limitations. For information about limitations, see xref:../../../storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc#lvms-limitations-for-creating-snapshots-and-clones_logical-volume-manager-storage[Limitations for creating volume snapshots and volume clones].
+====
+
 include::modules/lvms-creating-volume-clones-in-single-node-openshift.adoc[leveloffset=+2]
 include::modules/lvms-deleting-cloned-volumes-in-single-node-openshift.adoc[leveloffset=+2]
+
+//Limitations for creating volume snapshots and volume clones
+include::modules/lvms-limitations-for-creating-snapshots-and-clones.adoc[leveloffset=+1]
 
 //Must-gather
 include::modules/lvms-download-log-files-and-diagnostics.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.15
Issue: [TELCODOCS-1255](https://issues.redhat.com/browse/TELCODOCS-1255)

Link to docs preview: https://69298--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms

QE review:
- [x] QE has approved this change.