### PR TITLE
OADP-3258 [DOCS] Fixing error in format

### DIFF
--- a/backup_and_restore/index.adoc
+++ b/backup_and_restore/index.adoc
@@ -74,7 +74,7 @@ If you do not want to back up PVs by using snapshots, you can use link:https://r
 [id="backing-up-and-restoring-applications"]
 === Backing up and restoring applications
 
-You back up applications by creating a `Backup` custom resource (CR). See xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr.adoc#backing-up-applications[Creating a Backup CR].You can configure the following backup options:
+You back up applications by creating a `Backup` custom resource (CR). See xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr.adoc#backing-up-applications[Creating a Backup CR]. You can configure the following backup options:
 
 * xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-hooks-doc.adoc#backing-up-applications[Creating backup hooks] to run commands before or after the backup operation
 


### PR DESCRIPTION
### Jira

* [OADP-3258](https://issues.redhat.com/browse/OADP-3258)

Missed spacing in [/backup_and_restore/index.html#backing-up-and-restoring-applications](https://docs.openshift.com/container-platform/4.14/backup_and_restore/index.html#backing-up-and-restoring-applications)

```
See *Creating a Backup CR*.You can configure the following backup options:
```

### Version(s):

* OCP 4.11 → branch/enterprise-4.11
* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15

### Link to docs preview:

* [Backing up and restoring applications](https://69328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/#backing-up-and-restoring-applications)

### QE review:
- [0] QE has approved this change. - not required formatting fix

