### PR TITLE
[OCPBUGS-25121] Updating ccoctl details in 4.13

### DIFF
--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -62,14 +62,12 @@ endif::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 
 .Procedure
 
-ifdef::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 . Set the `$RELEASE_IMAGE` variable by running the following command:
 +
 [source,terminal]
 ----
 $ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}')
 ----
-endif::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 
 . Extract the list of `CredentialsRequest` objects from the {product-title} release image by running the following command:
 +
@@ -77,28 +75,28 @@ endif::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 ifdef::aws-sts[]
 ----
 $ oc adm release extract \
---credentials-requests \
---cloud=aws \
---to=<path_to_directory_with_list_of_credentials_requests>/credrequests \ <1>
---from=quay.io/<path_to>/ocp-release:<version>
+  --from=$RELEASE_IMAGE \
+  --credentials-requests \
+  --cloud=aws \
+  --to=<path_to_directory_with_list_of_credentials_requests>/credrequests <1>
 ----
 endif::aws-sts[]
 ifdef::google-cloud-platform[]
 ----
 $ oc adm release extract \
---credentials-requests \
---cloud=gcp \
---to=<path_to_directory_with_list_of_credentials_requests>/credrequests \ <1>
-quay.io/<path_to>/ocp-release:<version>
+  --from=$RELEASE_IMAGE \
+  --credentials-requests \
+  --cloud=gcp \
+  --to=<path_to_directory_with_list_of_credentials_requests>/credrequests <1>
 ----
 endif::google-cloud-platform[]
 ifdef::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 ----
 $ oc adm release extract \
---credentials-requests \
---cloud=alibabacloud \
---to=<path_to_directory_with_list_of_credentials_requests>/credrequests \ <1>
-$RELEASE_IMAGE
+  --from=$RELEASE_IMAGE \
+  --credentials-requests \
+  --cloud=alibabacloud \
+  --to=<path_to_directory_with_list_of_credentials_requests>/credrequests <1>
 ----
 endif::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 +
@@ -112,53 +110,57 @@ This command can take a few moments to run.
 ifdef::aws-sts[]
 . If your cluster uses cluster capabilities to disable one or more optional components, delete the `CredentialsRequest` custom resources for any disabled components.
 +
-.Example `credrequests` directory contents for {product-title} 4.12 on AWS
+.Example `credrequests` directory contents for {product-title} 4.13 on AWS
 +
 [source,terminal]
 ----
-0000_30_machine-api-operator_00_credentials-request.yaml <1>
-0000_50_cloud-credential-operator_05-iam-ro-credentialsrequest.yaml <2>
-0000_50_cluster-image-registry-operator_01-registry-credentials-request.yaml <3>
-0000_50_cluster-ingress-operator_00-ingress-credentials-request.yaml <4>
-0000_50_cluster-network-operator_02-cncc-credentials.yaml <5>
-0000_50_cluster-storage-operator_03_credentials_request_aws.yaml <6>
-----
-+
-<1> The Machine API Operator CR is required.
-<2> The Cloud Credential Operator CR is required.
-<3> The Image Registry Operator CR is required.
-<4> The Ingress Operator CR is required.
-<5> The Network Operator CR is required.
-<6> The Storage Operator CR is an optional component and might be disabled in your cluster.
-endif::aws-sts[]
-ifdef::google-cloud-platform[]
-. If your cluster uses cluster capabilities to disable one or more optional components, delete the `CredentialsRequest` custom resources for any disabled components.
-+
-.Example `credrequests` directory contents for {product-title} 4.12 on GCP
-+
-[source,terminal]
-----
-0000_26_cloud-controller-manager-operator_16_credentialsrequest-gcp.yaml <1>
+0000_30_cluster-api_00_credentials-request.yaml <1>
 0000_30_machine-api-operator_00_credentials-request.yaml <2>
-0000_50_cloud-credential-operator_05-gcp-ro-credentialsrequest.yaml <3>
-0000_50_cluster-image-registry-operator_01-registry-credentials-request-gcs.yaml <4>
+0000_50_cloud-credential-operator_05-iam-ro-credentialsrequest.yaml <3>
+0000_50_cluster-image-registry-operator_01-registry-credentials-request.yaml <4>
 0000_50_cluster-ingress-operator_00-ingress-credentials-request.yaml <5>
 0000_50_cluster-network-operator_02-cncc-credentials.yaml <6>
-0000_50_cluster-storage-operator_03_credentials_request_gcp.yaml <7>
+0000_50_cluster-storage-operator_03_credentials_request_aws.yaml <7>
 ----
 +
-<1> The Cloud Controller Manager Operator CR is required.
+<1> For clusters that use the `TechPreviewNoUpgrade` feature set, the Cluster API Operator CR is required.
 <2> The Machine API Operator CR is required.
 <3> The Cloud Credential Operator CR is required.
 <4> The Image Registry Operator CR is required.
 <5> The Ingress Operator CR is required.
 <6> The Network Operator CR is required.
 <7> The Storage Operator CR is an optional component and might be disabled in your cluster.
+endif::aws-sts[]
+ifdef::google-cloud-platform[]
+. If your cluster uses cluster capabilities to disable one or more optional components, delete the `CredentialsRequest` custom resources for any disabled components.
++
+.Example `credrequests` directory contents for {product-title} 4.13 on GCP
++
+[source,terminal]
+----
+0000_26_cloud-controller-manager-operator_16_credentialsrequest-gcp.yaml <1>
+0000_30_cluster-api_00_credentials-request.yaml <2>
+0000_30_machine-api-operator_00_credentials-request.yaml <3>
+0000_50_cloud-credential-operator_05-gcp-ro-credentialsrequest.yaml <4>
+0000_50_cluster-image-registry-operator_01-registry-credentials-request-gcs.yaml <5>
+0000_50_cluster-ingress-operator_00-ingress-credentials-request.yaml <6>
+0000_50_cluster-network-operator_02-cncc-credentials.yaml <7>
+0000_50_cluster-storage-operator_03_credentials_request_gcp.yaml <8>
+----
++
+<1> The Cloud Controller Manager Operator CR is required.
+<2> For clusters that use the `TechPreviewNoUpgrade` feature set, the Cluster API Operator CR is required.
+<3> The Machine API Operator CR is required.
+<4> The Cloud Credential Operator CR is required.
+<5> The Image Registry Operator CR is required.
+<6> The Ingress Operator CR is required.
+<7> The Network Operator CR is required.
+<8> The Storage Operator CR is an optional component and might be disabled in your cluster.
 endif::google-cloud-platform[]
 ifdef::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 . If your cluster uses cluster capabilities to disable one or more optional components, delete the `CredentialsRequest` custom resources for any disabled components.
 +
-.Example `credrequests` directory contents for {product-title} 4.12 on Alibaba Cloud
+.Example `credrequests` directory contents for {product-title} 4.13 on Alibaba Cloud
 +
 [source,terminal]
 ----
@@ -203,10 +205,10 @@ ifdef::google-cloud-platform[]
 [source,terminal]
 ----
 $ ccoctl gcp create-all \
---name=<name> \
---region=<gcp_region> \
---project=<gcp_project_id> \
---credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests
+  --name=<name> \
+  --region=<gcp_region> \
+  --project=<gcp_project_id> \
+  --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests
 ----
 +
 where:
@@ -232,10 +234,10 @@ ifdef::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 [source,terminal]
 ----
 $ ccoctl alibabacloud create-ram-users \
---name <name> \
---region=<alibaba_region> \
---credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \
---output-dir=<path_to_ccoctl_output_dir>
+  --name <name> \
+  --region=<alibaba_region> \
+  --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \
+  --output-dir=<path_to_ccoctl_output_dir>
 ----
 +
 where:
@@ -269,7 +271,6 @@ If your cluster uses Technology Preview features that are enabled by the `TechPr
 ====
 A RAM user can have up to two AccessKeys at the same time. If you run `ccoctl alibabacloud create-ram-users` more than twice, the previous generated manifests secret becomes stale and you must reapply the newly generated secrets.
 ====
-// Above output was in AWS area but I believe belongs here.
 
 .. Verify that the {product-title} secrets are created:
 +
@@ -321,16 +322,33 @@ ifdef::aws-sts[]
 ----
 cluster-authentication-02-config.yaml
 openshift-cloud-credential-operator-cloud-credential-operator-iam-ro-creds-credentials.yaml
+openshift-cloud-network-config-controller-cloud-credentials-credentials.yaml
+openshift-cluster-api-capa-manager-bootstrap-credentials-credentials.yaml
 openshift-cluster-csi-drivers-ebs-cloud-credentials-credentials.yaml
 openshift-image-registry-installer-cloud-credentials-credentials.yaml
 openshift-ingress-operator-cloud-credentials-credentials.yaml
 openshift-machine-api-aws-cloud-credentials-credentials.yaml
 ----
-//Would love a GCP version of the above output.
-
++
 You can verify that the IAM roles are created by querying AWS. For more information, refer to AWS documentation on listing IAM roles.
 endif::aws-sts[]
 ifdef::google-cloud-platform[]
++
+.Example output:
++
+[source,terminal]
+----
+cluster-authentication-02-config.yaml
+openshift-cloud-controller-manager-gcp-ccm-cloud-credentials-credentials.yaml
+openshift-cloud-credential-operator-cloud-credential-operator-gcp-ro-creds-credentials.yaml
+openshift-cloud-network-config-controller-cloud-credentials-credentials.yaml
+openshift-cluster-api-capg-manager-bootstrap-credentials-credentials.yaml
+openshift-cluster-csi-drivers-gcp-pd-cloud-credentials-credentials.yaml
+openshift-image-registry-installer-cloud-credentials-credentials.yaml
+openshift-ingress-operator-cloud-credentials-credentials.yaml
+openshift-machine-api-gcp-cloud-credentials-credentials.yaml
+----
++
 You can verify that the IAM service accounts are created by querying GCP. For more information, refer to GCP documentation on listing IAM service accounts.
 endif::google-cloud-platform[]
 

--- a/modules/cco-ccoctl-creating-individually.adoc
+++ b/modules/cco-ccoctl-creating-individually.adoc
@@ -51,9 +51,9 @@ This command also creates a private key that the cluster requires during install
 [source,terminal]
 ----
 $ ccoctl aws create-identity-provider \
---name=<name> \
---region=<aws_region> \
---public-key-file=<path_to_ccoctl_output_dir>/serviceaccount-signer.public
+  --name=<name> \
+  --region=<aws_region> \
+  --public-key-file=<path_to_ccoctl_output_dir>/serviceaccount-signer.public
 ----
 +
 where:
@@ -85,44 +85,47 @@ This command also creates a YAML configuration file in `/<path_to_ccoctl_output_
 +
 [source,terminal]
 ----
-$ oc adm release extract --credentials-requests \
---cloud=aws \
---to=<path_to_directory_with_list_of_credentials_requests>/credrequests <1>
---from=quay.io/<path_to>/ocp-release:<version>
+$ oc adm release extract \
+  --from=$RELEASE_IMAGE \
+  --credentials-requests \
+  --cloud=aws \
+  --to=<path_to_directory_with_list_of_credentials_requests>/credrequests <1>
 ----
 +
 <1> `credrequests` is the directory where the list of `CredentialsRequest` objects is stored. This command creates the directory if it does not exist.
 
 .. If your cluster uses cluster capabilities to disable one or more optional components, delete the `CredentialsRequest` custom resources for any disabled components.
 +
-.Example `credrequests` directory contents for {product-title} 4.12 on AWS
+.Example `credrequests` directory contents for {product-title} 4.13 on AWS
 +
 [source,terminal]
 ----
-0000_30_machine-api-operator_00_credentials-request.yaml <1>
-0000_50_cloud-credential-operator_05-iam-ro-credentialsrequest.yaml <2>
-0000_50_cluster-image-registry-operator_01-registry-credentials-request.yaml <3>
-0000_50_cluster-ingress-operator_00-ingress-credentials-request.yaml <4>
-0000_50_cluster-network-operator_02-cncc-credentials.yaml <5>
-0000_50_cluster-storage-operator_03_credentials_request_aws.yaml <6>
+0000_30_cluster-api_00_credentials-request.yaml <1>
+0000_30_machine-api-operator_00_credentials-request.yaml <2>
+0000_50_cloud-credential-operator_05-iam-ro-credentialsrequest.yaml <3>
+0000_50_cluster-image-registry-operator_01-registry-credentials-request.yaml <4>
+0000_50_cluster-ingress-operator_00-ingress-credentials-request.yaml <5>
+0000_50_cluster-network-operator_02-cncc-credentials.yaml <6>
+0000_50_cluster-storage-operator_03_credentials_request_aws.yaml <7>
 ----
 +
-<1> The Machine API Operator CR is required.
-<2> The Cloud Credential Operator CR is required.
-<3> The Image Registry Operator CR is required.
-<4> The Ingress Operator CR is required.
-<5> The Network Operator CR is required.
-<6> The Storage Operator CR is an optional component and might be disabled in your cluster.
+<1> For clusters that use the `TechPreviewNoUpgrade` feature set, the Cluster API Operator CR is required.
+<2> The Machine API Operator CR is required.
+<3> The Cloud Credential Operator CR is required.
+<4> The Image Registry Operator CR is required.
+<5> The Ingress Operator CR is required.
+<6> The Network Operator CR is required.
+<7> The Storage Operator CR is an optional component and might be disabled in your cluster.
 
 .. Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory:
 +
 [source,terminal]
 ----
 $ ccoctl aws create-iam-roles \
---name=<name> \
---region=<aws_region> \
---credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \
---identity-provider-arn=arn:aws:iam::<aws_account_id>:oidc-provider/<name>-oidc.s3.<aws_region>.amazonaws.com
+  --name=<name> \
+  --region=<aws_region> \
+  --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \
+  --identity-provider-arn=arn:aws:iam::<aws_account_id>:oidc-provider/<name>-oidc.s3.<aws_region>.amazonaws.com
 ----
 +
 [NOTE]
@@ -140,20 +143,21 @@ For each `CredentialsRequest` object, `ccoctl` creates an IAM role with a trust 
 +
 [source,terminal]
 ----
-$ ll <path_to_ccoctl_output_dir>/manifests
+$ ls <path_to_ccoctl_output_dir>/manifests
 ----
 +
 .Example output:
 +
 [source,terminal]
 ----
-total 24
--rw-------. 1 <user> <user> 161 Apr 13 11:42 cluster-authentication-02-config.yaml
--rw-------. 1 <user> <user> 379 Apr 13 11:59 openshift-cloud-credential-operator-cloud-credential-operator-iam-ro-creds-credentials.yaml
--rw-------. 1 <user> <user> 353 Apr 13 11:59 openshift-cluster-csi-drivers-ebs-cloud-credentials-credentials.yaml
--rw-------. 1 <user> <user> 355 Apr 13 11:59 openshift-image-registry-installer-cloud-credentials-credentials.yaml
--rw-------. 1 <user> <user> 339 Apr 13 11:59 openshift-ingress-operator-cloud-credentials-credentials.yaml
--rw-------. 1 <user> <user> 337 Apr 13 11:59 openshift-machine-api-aws-cloud-credentials-credentials.yaml
+cluster-authentication-02-config.yaml
+openshift-cloud-credential-operator-cloud-credential-operator-iam-ro-creds-credentials.yaml
+openshift-cloud-network-config-controller-cloud-credentials-credentials.yaml
+openshift-cluster-api-capa-manager-bootstrap-credentials-credentials.yaml
+openshift-cluster-csi-drivers-ebs-cloud-credentials-credentials.yaml
+openshift-image-registry-installer-cloud-credentials-credentials.yaml
+openshift-ingress-operator-cloud-credentials-credentials.yaml
+openshift-machine-api-aws-cloud-credentials-credentials.yaml
 ----
-
++
 You can verify that the IAM roles are created by querying AWS. For more information, refer to AWS documentation on listing IAM roles.

--- a/modules/manually-configure-iam-nutanix.adoc
+++ b/modules/manually-configure-iam-nutanix.adoc
@@ -37,13 +37,22 @@ credentials:
 <2> Specify the Prism Central credentials.
 <3> Optional: Specify the Prism Element credentials.
 
+. Set a `$RELEASE_IMAGE` variable with the release image from your installation file by running the following command:
++
+[source,terminal]
+----
+$ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}')
+----
+
 . Extract the list of `CredentialsRequest` custom resources (CRs) from the {product-title} release image by running the following command:
 +
 [source,terminal]
 ----
-$ oc adm release extract --credentials-requests --cloud=nutanix \//
---to=<path_to_directory_with_list_of_credentials_requests>/credrequests \ <1>
-quay.io/<path_to>/ocp-release:<version>
+$ oc adm release extract \
+  --from=$RELEASE_IMAGE \
+  --credentials-requests \
+  --cloud=nutanix \
+  --to=<path_to_directory_with_list_of_credentials_requests>/credrequests <1>
 ----
 +
 <1> Specify the path to the directory that contains the files for the component `CredentialsRequests` objects. If the specified directory does not exist, this command creates it.
@@ -71,23 +80,25 @@ quay.io/<path_to>/ocp-release:<version>
 
 . If your cluster uses cluster capabilities to disable one or more optional components, delete the `CredentialsRequest` custom resources for any disabled components.
 +
-.Example `credrequests` directory contents for {product-title} 4.12 on Nutanix
+.Example `credrequests` directory contents for {product-title} 4.13 on Nutanix
 +
 [source,terminal]
 ----
-0000_30_machine-api-operator_00_credentials-request.yaml <1>
+0000_26_cloud-controller-manager-operator_18_credentialsrequest-nutanix.yaml <1>
+0000_30_machine-api-operator_00_credentials-request.yaml <2>
 ----
 +
-<1> The Machine API Operator CR is required.
+<1> The Cloud Controller Manager Operator CR is required.
+<2> The Machine API Operator CR is required.
 
 . Use the `ccoctl` tool to process all of the `CredentialsRequest` objects in the `credrequests` directory by running the following command:
 +
 [source,terminal]
 ----
 $ ccoctl nutanix create-shared-secrets \
---credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <1>
---output-dir=<ccoctl_output_dir> \// <2>
---credentials-source-filepath=<path_to_credentials_file> <3>
+  --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <1>
+  --output-dir=<ccoctl_output_dir> \// <2>
+  --credentials-source-filepath=<path_to_credentials_file> <3>
 ----
 +
 <1> Specify the path to the directory that contains the files for the component `CredentialsRequests` objects.
@@ -134,19 +145,19 @@ $ ls ./<installation_directory>/manifests
 +
 [source,terminal]
 ----
-total 64
--rw-r----- 1 <user> <user> 2335 Jul  8 12:22 cluster-config.yaml
--rw-r----- 1 <user> <user>  161 Jul  8 12:22 cluster-dns-02-config.yml
--rw-r----- 1 <user> <user>  864 Jul  8 12:22 cluster-infrastructure-02-config.yml
--rw-r----- 1 <user> <user>  191 Jul  8 12:22 cluster-ingress-02-config.yml
--rw-r----- 1 <user> <user> 9607 Jul  8 12:22 cluster-network-01-crd.yml
--rw-r----- 1 <user> <user>  272 Jul  8 12:22 cluster-network-02-config.yml
--rw-r----- 1 <user> <user>  142 Jul  8 12:22 cluster-proxy-01-config.yaml
--rw-r----- 1 <user> <user>  171 Jul  8 12:22 cluster-scheduler-02-config.yml
--rw-r----- 1 <user> <user>  200 Jul  8 12:22 cvo-overrides.yaml
--rw-r----- 1 <user> <user>  118 Jul  8 12:22 kube-cloud-config.yaml
--rw-r----- 1 <user> <user> 1304 Jul  8 12:22 kube-system-configmap-root-ca.yaml
--rw-r----- 1 <user> <user> 4090 Jul  8 12:22 machine-config-server-tls-secret.yaml
--rw-r----- 1 <user> <user> 3961 Jul  8 12:22 openshift-config-secret-pull-secret.yaml
--rw------- 1 <user> <user>  283 Jul  8 12:24 openshift-machine-api-nutanix-credentials-credentials.yaml
+cluster-config.yaml
+cluster-dns-02-config.yml
+cluster-infrastructure-02-config.yml
+cluster-ingress-02-config.yml
+cluster-network-01-crd.yml
+cluster-network-02-config.yml
+cluster-proxy-01-config.yaml
+cluster-scheduler-02-config.yml
+cvo-overrides.yaml
+kube-cloud-config.yaml
+kube-system-configmap-root-ca.yaml
+machine-config-server-tls-secret.yaml
+openshift-config-secret-pull-secret.yaml
+openshift-cloud-controller-manager-nutanix-credentials-credentials.yaml
+openshift-machine-api-nutanix-credentials-credentials.yaml
 ----

--- a/modules/manually-create-iam-ibm-cloud.adoc
+++ b/modules/manually-create-iam-ibm-cloud.adoc
@@ -86,8 +86,11 @@ $ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}'
 +
 [source,terminal]
 ----
-$ oc adm release extract --cloud=<provider_name> --credentials-requests $RELEASE_IMAGE \ <1>
-    --to=<path_to_credential_requests_directory> <2>
+$ oc adm release extract \
+  --from=$RELEASE_IMAGE \
+  --credentials-requests \
+  --cloud=<provider_name> \// <1>
+  --to=<path_to_credential_requests_directory> <2>
 ----
 <1> The name of the provider. For example: `ibmcloud` or `powervs`.
 <2> The directory where the credential requests will be stored.
@@ -132,7 +135,7 @@ This command creates a YAML file for each `CredentialsRequest` object.
 ifndef::ibm-power-vs[]
 . If your cluster uses cluster capabilities to disable one or more optional components, delete the `CredentialsRequest` custom resources for any disabled components.
 +
-.Example `credrequests` directory contents for {product-title} 4.12 on IBM Cloud VPC
+.Example `credrequests` directory contents for {product-title} 4.13 on IBM Cloud VPC
 +
 [source,terminal]
 ----
@@ -154,8 +157,8 @@ endif::ibm-power-vs[]
 [source,terminal]
 ----
 $ ccoctl ibmcloud create-service-id \
-    --credentials-requests-dir <path_to_credential_requests_directory> \ <1>
-    --name <cluster_name> \ <2>
+    --credentials-requests-dir <path_to_credential_requests_directory> \// <1>
+    --name <cluster_name> \// <2>
     --output-dir <installation_directory> \
     --resource-group-name <resource_group_name> <3>
 ----


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OCPBUGS-25121](https://issues.redhat.com/browse/OCPBUGS-25121)

Link to docs preview:
- [Creating AWS resources with the Cloud Credential Operator utility](https://69344--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts#sts-mode-create-aws-resources-ccoctl_cco-mode-sts)
- [Creating GCP resources with the Cloud Credential Operator utility](https://69344--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity#cco-ccoctl-creating-at-once_cco-mode-gcp-workload-identity)
- [Creating credentials for OpenShift Container Platform components with the ccoctl tool](https://69344--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_alibaba/installing-alibaba-default#cco-ccoctl-creating-at-once_installing-alibaba-default) (AliCloud)
- [Manually creating IAM](https://69344--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations#manually-create-iam-ibm-cloud_installing-ibm-cloud-customizations) (IBM)
- [Configuring IAM for Nutanix](https://69344--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned#manually-create-iam-nutanix_installing-nutanix-installer-provisioned)

QE review:
- [ ] QE has approved this change.

Additional information:
Also tidied up some inconsistencies in the commands that I didn't hit in 4.13 before