### PR TITLE
OADP-3234: Fix Broken-Link Creating a Restore CR in index - 4.12

### DIFF
--- a/backup_and_restore/index.adoc
+++ b/backup_and_restore/index.adoc
@@ -79,7 +79,7 @@ You back up applications by creating a `Backup` custom resource (CR). See xref:.
 * xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-hooks-doc.adoc#backing-up-applications[Creating backup hooks] to run commands before or after the backup operation
 * xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-scheduling-backups-doc.adoc#backing-up-applications[Scheduling backups]
 * xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#backing-up-applications[Restic backups]
-* You restore application backups by creating a `Restore` (CR). See xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr-doc#backing-up-applications[Creating a Restore CR].
+* You restore application backups by creating a `Restore` (CR). See xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc#oadp-creating-restore-cr_restoring-applications[Creating a Restore CR].
 * You can configure xref:../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications#oadp-creating-restore-hooks_restoring-applications[restore hooks] to run commands in init containers or in the application container during the restore operation.
 
 :backup-restore-overview!:


### PR DESCRIPTION
### JIra

* [OADP-3234](https://issues.redhat.com/browse/OADP-3234)

Fixing broken link in [Backing up and restoring applications](https://docs.openshift.com/container-platform/4.14/backup_and_restore/index.html#backing-up-and-restoring-applications): `You restore application backups by creating a Restore (CR). See [Creating a Restore CR](https://docs.openshift.com/container-platform/4.11/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr-doc.html#backing-up-applications).`

### OCP version

* OCP 4.12 → branch/enterprise-4.12

### Doc preview

* [Backing up and restoring applications](https://69347--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/#backing-up-and-restoring-applications)