### PR TITLE
Adds vSphere to ipv6/v6 conversion note

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -186,7 +186,7 @@ endif::ibm-cloud[]
 ifdef::vsphere[]
 [NOTE]
 ====
-On VMware vSphere, dual-stack networking must specify IPv4 as the primary address family.
+On VMware vSphere, dual-stack networking can specify either IPv4 or IPv6 as the primary address family.
 ====
 endif::vsphere[]
 

--- a/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.adoc
+++ b/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.adoc
@@ -11,12 +11,8 @@ After converting to dual-stack, all newly created pods are dual-stack enabled.
 
 [NOTE]
 ====
-A dual-stack network is supported on clusters provisioned on bare metal, {ibm-power-name}, {ibm-z-name} infrastructure, and single node OpenShift clusters.
-====
-
-[NOTE]
-====
-While using dual-stack networking, you cannot use IPv4-mapped IPv6 addresses, such as `::FFFF:198.51.100.1`, where IPv6 is required.
+* While using dual-stack networking, you cannot use IPv4-mapped IPv6 addresses, such as `::FFFF:198.51.100.1`, where IPv6 is required.
+* A dual-stack network is supported on clusters provisioned on bare metal, {ibm-power-name}, {ibm-z-name} infrastructure, {sno}, and VMware vSphere.
 ====
 
 include::modules/nw-dual-stack-convert.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OCPBUGS-24709

Link to docs preview:
https://69348--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/converting-to-dual-stack

https://69348--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere#installation-configuration-parameters-network_installation-config-parameters-vsphere

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
