### PR TITLE
Adds IPV6 Primary for vsphere to release notes

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -735,6 +735,15 @@ With this release, if the `noProxy` field is set and the route is reachable with
 [id="ocp-4-14-networking"]
 === Networking
 
+[id="ocp-4-14-ipv6-primary-address-family-vsphere-dual-stack-clusters"]
+==== IPv6 as primary IP address family on vSphere dual-stack clusters
+
+During cluster installation on vSphere, you can configure IPv6 as the primary IP address family on a dual-stack cluster. To enable this feature when installing a new cluster, specify an IPv6 address family before an IPv4 address family for the machine network, cluster network, service network, API VIPs, and ingress VIPs.
+
+* Installer-provisioned infrastructure: xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc#modifying-install-config-for-dual-stack-network_installing-vsphere-installer-provisioned-network-customizations[Deploying with dual-stack networking]
+* User-provisioned infrastructure: xref:../installing/installing_vsphere/installation-config-parameters-vsphere.adoc#installation-configuration-parameters-network_installation-config-parameters-vsphere[Network configuration parameters]
+
+
 [id="ocp-4-14-multiple-external-gateway-support-ovn-kubernetes-network-plugin"]
 ==== Multiple external gateway support for the OVN-Kubernetes network plugin
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OCPBUGS-24709

Link to docs preview:
https://69349--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-ipv6-primary-address-family-vsphere-dual-stack-clusters

ACKS:
* Product Experience: Eric Rich (in Slack -- short of a breadcrumb to that (lgtm)
* QE: Ross Brattain
* Engineering: Ben Nemec
* DPM: Kathryn Alexander
* Content Strategist: Ashley Hardin

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
