### PR TITLE
[OCPBUGS-25121] Updating ccoctl details in 4.14+

### DIFF
--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -345,7 +345,6 @@ endif::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 ifdef::aws-sts,google-cloud-platform,azure-workload-id[]
 .Verification
 
-
 * To verify that the {product-title} secrets are created, list the files in the `<path_to_ccoctl_output_dir>/manifests` directory:
 +
 [source,terminal]
@@ -360,6 +359,8 @@ ifdef::aws-sts[]
 ----
 cluster-authentication-02-config.yaml
 openshift-cloud-credential-operator-cloud-credential-operator-iam-ro-creds-credentials.yaml
+openshift-cloud-network-config-controller-cloud-credentials-credentials.yaml
+openshift-cluster-api-capa-manager-bootstrap-credentials-credentials.yaml
 openshift-cluster-csi-drivers-ebs-cloud-credentials-credentials.yaml
 openshift-image-registry-installer-cloud-credentials-credentials.yaml
 openshift-ingress-operator-cloud-credentials-credentials.yaml
@@ -377,6 +378,7 @@ cluster-authentication-02-config.yaml
 openshift-cloud-controller-manager-gcp-ccm-cloud-credentials-credentials.yaml
 openshift-cloud-credential-operator-cloud-credential-operator-gcp-ro-creds-credentials.yaml
 openshift-cloud-network-config-controller-cloud-credentials-credentials.yaml
+openshift-cluster-api-capg-manager-bootstrap-credentials-credentials.yaml
 openshift-cluster-csi-drivers-gcp-pd-cloud-credentials-credentials.yaml
 openshift-image-registry-installer-cloud-credentials-credentials.yaml
 openshift-ingress-operator-cloud-credentials-credentials.yaml

--- a/modules/cco-ccoctl-creating-individually.adoc
+++ b/modules/cco-ccoctl-creating-individually.adoc
@@ -130,19 +130,20 @@ For each `CredentialsRequest` object, `ccoctl` creates an IAM role with a trust 
 +
 [source,terminal]
 ----
-$ ll <path_to_ccoctl_output_dir>/manifests
+$ ls <path_to_ccoctl_output_dir>/manifests
 ----
 +
 .Example output
 [source,text]
 ----
-total 24
--rw-------. 1 <user> <user> 161 Apr 13 11:42 cluster-authentication-02-config.yaml
--rw-------. 1 <user> <user> 379 Apr 13 11:59 openshift-cloud-credential-operator-cloud-credential-operator-iam-ro-creds-credentials.yaml
--rw-------. 1 <user> <user> 353 Apr 13 11:59 openshift-cluster-csi-drivers-ebs-cloud-credentials-credentials.yaml
--rw-------. 1 <user> <user> 355 Apr 13 11:59 openshift-image-registry-installer-cloud-credentials-credentials.yaml
--rw-------. 1 <user> <user> 339 Apr 13 11:59 openshift-ingress-operator-cloud-credentials-credentials.yaml
--rw-------. 1 <user> <user> 337 Apr 13 11:59 openshift-machine-api-aws-cloud-credentials-credentials.yaml
+cluster-authentication-02-config.yaml
+openshift-cloud-credential-operator-cloud-credential-operator-iam-ro-creds-credentials.yaml
+openshift-cloud-network-config-controller-cloud-credentials-credentials.yaml
+openshift-cluster-api-capa-manager-bootstrap-credentials-credentials.yaml
+openshift-cluster-csi-drivers-ebs-cloud-credentials-credentials.yaml
+openshift-image-registry-installer-cloud-credentials-credentials.yaml
+openshift-ingress-operator-cloud-credentials-credentials.yaml
+openshift-machine-api-aws-cloud-credentials-credentials.yaml
 ----
-
++
 You can verify that the IAM roles are created by querying AWS. For more information, refer to AWS documentation on listing IAM roles.

--- a/modules/manually-configure-iam-nutanix.adoc
+++ b/modules/manually-configure-iam-nutanix.adoc
@@ -133,19 +133,19 @@ $ ls ./<installation_directory>/manifests
 .Example output
 [source,text]
 ----
-total 64
--rw-r----- 1 <user> <user> 2335 Jul  8 12:22 cluster-config.yaml
--rw-r----- 1 <user> <user>  161 Jul  8 12:22 cluster-dns-02-config.yml
--rw-r----- 1 <user> <user>  864 Jul  8 12:22 cluster-infrastructure-02-config.yml
--rw-r----- 1 <user> <user>  191 Jul  8 12:22 cluster-ingress-02-config.yml
--rw-r----- 1 <user> <user> 9607 Jul  8 12:22 cluster-network-01-crd.yml
--rw-r----- 1 <user> <user>  272 Jul  8 12:22 cluster-network-02-config.yml
--rw-r----- 1 <user> <user>  142 Jul  8 12:22 cluster-proxy-01-config.yaml
--rw-r----- 1 <user> <user>  171 Jul  8 12:22 cluster-scheduler-02-config.yml
--rw-r----- 1 <user> <user>  200 Jul  8 12:22 cvo-overrides.yaml
--rw-r----- 1 <user> <user>  118 Jul  8 12:22 kube-cloud-config.yaml
--rw-r----- 1 <user> <user> 1304 Jul  8 12:22 kube-system-configmap-root-ca.yaml
--rw-r----- 1 <user> <user> 4090 Jul  8 12:22 machine-config-server-tls-secret.yaml
--rw-r----- 1 <user> <user> 3961 Jul  8 12:22 openshift-config-secret-pull-secret.yaml
--rw------- 1 <user> <user>  283 Jul  8 12:24 openshift-machine-api-nutanix-credentials-credentials.yaml
+cluster-config.yaml
+cluster-dns-02-config.yml
+cluster-infrastructure-02-config.yml
+cluster-ingress-02-config.yml
+cluster-network-01-crd.yml
+cluster-network-02-config.yml
+cluster-proxy-01-config.yaml
+cluster-scheduler-02-config.yml
+cvo-overrides.yaml
+kube-cloud-config.yaml
+kube-system-configmap-root-ca.yaml
+machine-config-server-tls-secret.yaml
+openshift-config-secret-pull-secret.yaml
+openshift-cloud-controller-manager-nutanix-credentials-credentials.yaml
+openshift-machine-api-nutanix-credentials-credentials.yaml
 ----


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OCPBUGS-25121](https://issues.redhat.com/browse/OCPBUGS-25121)

Link to docs preview:
- [Creating AWS resources with the Cloud Credential Operator utility](https://69353--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations#sts-mode-create-aws-resources-ccoctl_installing-aws-customizations)
- [Creating GCP resources with the Cloud Credential Operator utility](https://69353--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations#cco-ccoctl-creating-at-once_installing-gcp-customizations)
- [Configuring IAM for Nutanix](https://69353--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned#manually-create-iam-nutanix_installing-nutanix-installer-provisioned)

QE review:
- [x] QE has approved this change.

Additional information: