### PR TITLE
[enterprise-4.12] Manual CP DOCS OBSDOCS-660 - 5.7.9 Release Notes

### DIFF
--- a/logging/logging_release_notes/logging-5-7-release-notes.adoc
+++ b/logging/logging_release_notes/logging-5-7-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-7-9.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-7-8.adoc[leveloffset=+1]
 
 include::modules/logging-rn-5.7.7.adoc[leveloffset=+1]

--- a/modules/logging-release-notes-5-7-9.adoc
+++ b/modules/logging-release-notes-5-7-9.adoc
@@ -1,0 +1,92 @@
+// Module included in the following assemblies:
+// cluster-logging-release-notes.adoc
+// logging-5-7-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-5-7-9_{context}"]
+= Logging 5.7.9
+This release includes link:https://access.redhat.com/errata/RHBA-2023:7718[OpenShift Logging Bug Fix Release 5.7.9].
+
+[id="logging-release-notes-5-7-9-bug-fixes"]
+== Bug fixes
+
+* Before this fix, IPv6 addresses would not be parsed correctly after evaluating a host or multiple hosts for placeholders. With this update, IPv6 addresses are correctly parsed. (link:https://issues.redhat.com/browse/LOG-4281[LOG-4281])
+
+* Before this update, the Vector failed to start on IPv4-only nodes. As a result, it failed to create a listener for its metrics endpoint with the following error: `Failed to start Prometheus exporter: TCP bind failed: Address family not supported by protocol (os error 97)`. With this update, the Vector operates normally on IPv4-only nodes. (link:https://issues.redhat.com/browse/LOG-4589[LOG-4589])
+
+* Before this update, during the process of creating index patterns, the default alias was missing from the initial index in each log output. As a result, Kibana users were unable to create index patterns by using {es-op}. This update adds the missing aliases to {es-op}, resolving the issue. Kibana users can now create index patterns that include the `{app,infra,audit}-000001` indexes. (link:https://issues.redhat.com/browse/LOG-4806[LOG-4806])
+
+* Before this update, the {loki-op} did not mount a custom CA bundle to the ruler pods. As a result, during the process to evaluate alerting or recording rules, object storage access failed. With this update, the {loki-op} mounts the custom CA bundle to all ruler pods. The ruler pods can download logs from object storage to evaluate alerting or recording rules. (link:https://issues.redhat.com/browse/LOG-4837[LOG-4837])
+
+* Before this update, changing a LogQL query using controls such as time range or severity changed the label matcher operator as though it was defined like a regular expression. With this update, regular expression operators remain unchanged when updating the query. (link:https://issues.redhat.com/browse/LOG-4842[LOG-4842])
+
+* Before this update, the Vector collector deployments relied upon the default retry and buffering behavior. As a result, the delivery pipeline backed up trying to deliver every message when the availability of an output was unstable. With this update, the Vector collector deployments limit the number of message retries and drop messages after the threshold has been exceeded. (link:https://issues.redhat.com/browse/LOG-4536[LOG-4536])
+
+[id="logging-release-notes-5-7-9-CVEs"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2007-4559[CVE-2007-4559]
+* link:https://access.redhat.com/security/cve/CVE-2021-43975[CVE-2021-43975]
+* link:https://access.redhat.com/security/cve/CVE-2022-3594[CVE-2022-3594]
+* link:https://access.redhat.com/security/cve/CVE-2022-3640[CVE-2022-3640]
+* link:https://access.redhat.com/security/cve/CVE-2022-4744[CVE-2022-4744]
+* link:https://access.redhat.com/security/cve/CVE-2022-28388[CVE-2022-28388]
+* link:https://access.redhat.com/security/cve/CVE-2022-38457[CVE-2022-38457]
+* link:https://access.redhat.com/security/cve/CVE-2022-40133[CVE-2022-40133]
+* link:https://access.redhat.com/security/cve/CVE-2022-40982[CVE-2022-40982]
+* link:https://access.redhat.com/security/cve/CVE-2022-41862[CVE-2022-41862]
+* link:https://access.redhat.com/security/cve/CVE-2022-42895[CVE-2022-42895]
+* link:https://access.redhat.com/security/cve/CVE-2022-45869[CVE-2022-45869]
+* link:https://access.redhat.com/security/cve/CVE-2022-45887[CVE-2022-45887]
+* link:https://access.redhat.com/security/cve/CVE-2022-48337[CVE-2022-48337]
+* link:https://access.redhat.com/security/cve/CVE-2022-48339[CVE-2022-48339]
+* link:https://access.redhat.com/security/cve/CVE-2023-0458[CVE-2023-0458]
+* link:https://access.redhat.com/security/cve/CVE-2023-0590[CVE-2023-0590]
+* link:https://access.redhat.com/security/cve/CVE-2023-0597[CVE-2023-0597]
+* link:https://access.redhat.com/security/cve/CVE-2023-1073[CVE-2023-1073]
+* link:https://access.redhat.com/security/cve/CVE-2023-1074[CVE-2023-1074]
+* link:https://access.redhat.com/security/cve/CVE-2023-1075[CVE-2023-1075]
+* link:https://access.redhat.com/security/cve/CVE-2023-1079[CVE-2023-1079]
+* link:https://access.redhat.com/security/cve/CVE-2023-1118[CVE-2023-1118]
+* link:https://access.redhat.com/security/cve/CVE-2023-1206[CVE-2023-1206]
+* link:https://access.redhat.com/security/cve/CVE-2023-1252[CVE-2023-1252]
+* link:https://access.redhat.com/security/cve/CVE-2023-1382[CVE-2023-1382]
+* link:https://access.redhat.com/security/cve/CVE-2023-1855[CVE-2023-1855]
+* link:https://access.redhat.com/security/cve/CVE-2023-1981[CVE-2023-1981]
+* link:https://access.redhat.com/security/cve/CVE-2023-1989[CVE-2023-1989]
+* link:https://access.redhat.com/security/cve/CVE-2023-1998[CVE-2023-1998]
+* link:https://access.redhat.com/security/cve/CVE-2023-2513[CVE-2023-2513]
+* link:https://access.redhat.com/security/cve/CVE-2023-3138[CVE-2023-3138]
+* link:https://access.redhat.com/security/cve/CVE-2023-3141[CVE-2023-3141]
+* link:https://access.redhat.com/security/cve/CVE-2023-3161[CVE-2023-3161]
+* link:https://access.redhat.com/security/cve/CVE-2023-3212[CVE-2023-3212]
+* link:https://access.redhat.com/security/cve/CVE-2023-3268[CVE-2023-3268]
+* link:https://access.redhat.com/security/cve/CVE-2023-3609[CVE-2023-3609]
+* link:https://access.redhat.com/security/cve/CVE-2023-3611[CVE-2023-3611]
+* link:https://access.redhat.com/security/cve/CVE-2023-3772[CVE-2023-3772]
+* link:https://access.redhat.com/security/cve/CVE-2023-4016[CVE-2023-4016]
+* link:https://access.redhat.com/security/cve/CVE-2023-4128[CVE-2023-4128]
+* link:https://access.redhat.com/security/cve/CVE-2023-4132[CVE-2023-4132]
+* link:https://access.redhat.com/security/cve/CVE-2023-4155[CVE-2023-4155]
+* link:https://access.redhat.com/security/cve/CVE-2023-4206[CVE-2023-4206]
+* link:https://access.redhat.com/security/cve/CVE-2023-4207[CVE-2023-4207]
+* link:https://access.redhat.com/security/cve/CVE-2023-4208[CVE-2023-4208]
+* link:https://access.redhat.com/security/cve/CVE-2023-4641[CVE-2023-4641]
+* link:https://access.redhat.com/security/cve/CVE-2023-4732[CVE-2023-4732]
+* link:https://access.redhat.com/security/cve/CVE-2023-22745[CVE-2023-22745]
+* link:https://access.redhat.com/security/cve/CVE-2023-23455[CVE-2023-23455]
+* link:https://access.redhat.com/security/cve/CVE-2023-26545[CVE-2023-26545]
+* link:https://access.redhat.com/security/cve/CVE-2023-28328[CVE-2023-28328]
+* link:https://access.redhat.com/security/cve/CVE-2023-28772[CVE-2023-28772]
+* link:https://access.redhat.com/security/cve/CVE-2023-30456[CVE-2023-30456]
+* link:https://access.redhat.com/security/cve/CVE-2023-31084[CVE-2023-31084]
+* link:https://access.redhat.com/security/cve/CVE-2023-31436[CVE-2023-31436]
+* link:https://access.redhat.com/security/cve/CVE-2023-31486[CVE-2023-31486]
+* link:https://access.redhat.com/security/cve/CVE-2023-32324[CVE-2023-32324]
+* link:https://access.redhat.com/security/cve/CVE-2023-33203[CVE-2023-33203]
+* link:https://access.redhat.com/security/cve/CVE-2023-33951[CVE-2023-33951]
+* link:https://access.redhat.com/security/cve/CVE-2023-33952[CVE-2023-33952]
+* link:https://access.redhat.com/security/cve/CVE-2023-34241[CVE-2023-34241]
+* link:https://access.redhat.com/security/cve/CVE-2023-35823[CVE-2023-35823]
+* link:https://access.redhat.com/security/cve/CVE-2023-35824[CVE-2023-35824]
+* link:https://access.redhat.com/security/cve/CVE-2023-35825[CVE-2023-35825]


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/openshift-docs/pull/69236

Fix version: 4.12

Doc Preview: [Logging 5.7.9](https://69367--docspreview.netlify.app/openshift-enterprise/latest/logging/logging_release_notes/logging-5-7-release-notes#logging-release-notes-5-7-9_logging-5-7-release-notes)

cherry picked from: https://github.com/openshift/openshift-docs/commit/cc4047ae9acc884399e43bf7b6214c4d357bf5da