### PR TITLE
OCPBUG 12211:Added a note that tells using graph:true also enables mirroring of ubi image

### DIFF
--- a/modules/oc-mirror-creating-image-set-config.adoc
+++ b/modules/oc-mirror-creating-image-set-config.adoc
@@ -67,6 +67,11 @@ mirror:
 <8> Specify only certain channels of the Operator packages to include in the image set. You must always include the default channel for the Operator package even if you do not use the bundles in that channel. You can find the default channel by running the following command: `oc mirror list operators --catalog=<catalog_name> --package=<package_name>`.
 <9> Specify any additional images to include in image set.
 +
+[NOTE]
+====
+The `graph: true` field also mirrors the `ubi-micro` image along with other mirrored images.
+====
++
 See _Image set configuration parameters_ for the full list of parameters and _Image set configuration examples_ for various mirroring use cases.
 
 . Save the updated file.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUGS-12211](https://issues.redhat.com/browse/OCPBUGS-12211)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Doc Preview](https://69373--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-disconnected#oc-mirror-creating-image-set-config_installing-mirroring-disconnected)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] SME has approved this change.
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
QE review:
- [x] QE has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
