### PR TITLE
[no issue] Remove Go function section until it goes TP

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -76,8 +76,6 @@ Topics:
     File: serverless-developing-typescript-functions
   - Name: Developing Python functions
     File: serverless-developing-python-functions
-  #- Name: Developing Go functions
-  #  File: serverless-developing-go-functions (Targetted for next release)
 - Name: Configuring functions
   Dir: configuring
   Topics:


### PR DESCRIPTION
Version(s):
`serverless-docs-1.30`+

Issue:
no issue

Link to docs preview:
FIXME

QE review:
- [ ] QE has approved this change.