### PR TITLE
Fix cgroup v1 and v2 descriptions reversed

### DIFF
--- a/modules/nodes-clusters-cgroups-2.adoc
+++ b/modules/nodes-clusters-cgroups-2.adoc
@@ -148,7 +148,7 @@ $ oc describe mc <name>
 ----
 +
 ifdef::nodes[]
-.Example output for cgroup v2
+.Example output for cgroup v1
 [source,terminal]
 ----
 apiVersion: machineconfiguration.openshift.io/v2
@@ -162,11 +162,11 @@ spec:
     systemd.unified_cgroup_hierarchy=0 <1>
     systemd.legacy_systemd_cgroup_controller=1 <2>
 ----
-<1> Enables cgroup v2 in systemd.
-<2> Disables cgroup v1.
+<1> Disable cgroup v2 in systemd.
+<2> Enable cgroup v1.
 +
 endif::nodes[]
-.Example output for cgroup v1
+.Example output for cgroup v2
 [source,terminal]
 ----
 apiVersion: machineconfiguration.openshift.io/v2
@@ -181,8 +181,8 @@ spec:
   - cgroup_no_v1="all" <2>
   - psi=1 <3>
 ----
-<1> Enables cgroup v1 in systemd.
-<2> Disables cgroup v2.
+<1> Enables cgroup v2 in systemd.
+<2> Disables cgroup v1.
 <3> Enables the Linux Pressure Stall Information (PSI) feature.
 
 . Check the nodes to see that scheduling on the nodes is disabled. This indicates that the change is being applied:
@@ -240,16 +240,16 @@ ifdef::nodes[]
 $ stat -c %T -f /sys/fs/cgroup
 ----
 +
-.Example output for cgroup v2
-[source,terminal]
-----
-tmp2fs
-----
-+
 .Example output for cgroup v1
 [source,terminal]
 ----
-cgroup1fs
+tmpfs
+----
++
+.Example output for cgroup v2
+[source,terminal]
+----
+cgroup2fs
 ----
 endif::nodes[]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
v4.14 (and main branch also)

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
Cgroups v1 and v2 descriptions are reversed.

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
