### PR TITLE
OSDOCS-8704: using FIPS with MicroShift

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -51,6 +51,8 @@ Distros: microshift
 Topics:
 - Name: Installing from an RPM package
   File: microshift-install-rpm
+- Name: Installing for FIPS compliance
+  File: microshift-fips
 - Name: Mirroring container images for disconnected installations
   File: microshift-deploy-with-mirror-registry
 - Name: Embedding in a RHEL for Edge image

--- a/microshift_install/microshift-fips.adoc
+++ b/microshift_install/microshift-fips.adoc
@@ -1,0 +1,23 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="microshift-fips"]
+= Running {microshift-short} containers in FIPS mode
+include::_attributes/attributes-microshift.adoc[]
+:context: microshift-fips
+
+toc::[]
+
+You can use FIPS-compliant mode with RPM-based installations of {microshift-short} on {op-system-base-full} {op-system-version-major}.
+
+* To enable FIPS mode in {microshift-short} containers, the worker machine kernel must be enabled to run in FIPS-compliant mode before the machine starts.
+* Using FIPS with {op-system-ostree-first} images is not supported.
+
+include::modules/microshift-fips-rpm-system.adoc[leveloffset=+1]
+
+[id="additional-resources_microshift-fips_{context}"]
+[role="_additional-resources"]
+== Additional resources
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/using-the-system-wide-cryptographic-policies_security-hardening#enabling-fips-mode-in-a-container_using-the-system-wide-cryptographic-policies[Enabling FIPS mode in a container]
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening#federal-information-processing-standards-140-and-fips-mode_assembly_installing-the-system-in-fips-mode[Federal Information Processing Standards 140 and FIPS mode]

--- a/microshift_install/microshift-install-rpm.adoc
+++ b/microshift_install/microshift-install-rpm.adoc
@@ -8,11 +8,14 @@ toc::[]
 
 You can install {microshift-short} from an RPM package on a machine with {op-system-base-full} {op-system-version}.
 
-//include::snippets/microshift-tech-preview-snip.adoc[leveloffset=+1]
-
 include::modules/microshift-install-system-requirements.adoc[leveloffset=+1]
 
 include::modules/microshift-install-rpm-before.adoc[leveloffset=+1]
+
+//additional resources for install rpm before module
+[role="_additional-resources"]
+.Additional resources
+* xref:../microshift_install/microshift-fips.adoc#microshift-fips[Running {microshift-short} containers in FIPS mode]
 
 include::modules/microshift-install-rpm-preparing.adoc[leveloffset=+1]
 

--- a/modules/microshift-fips-rpm-system.adoc
+++ b/modules/microshift-fips-rpm-system.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * microshift_install/microshift-fips.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-fips-rpm-system_{context}"]
+= Enabling FIPS compliance with RPM-based installations
+
+Using FIPS with {product-title-first} requires enabling the cryptographic module self-checks in your {op-system-base-full} installation. After the host operating system has been configured to start with the FIPS modules, {microshift-short} containers are automatically enabled to run in FIPS mode.
+
+* When {op-system-base} is started in FIPS mode, {microshift} core components use the {op-system} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 validation on only the x86_64 architectures.
+
+* You must enable FIPS mode when you install {op-system-base} {op-system-version-major} on the machines that you plan to use as worker machines.
++
+[IMPORTANT]
+====
+Because FIPS must be enabled before the operating system that your cluster uses starts for the first time, you cannot enable FIPS after you deploy a cluster.
+====
+
+* {microshift-short} uses a FIPS-compatible Golang compiler.
+
+* FIPS is supported in the CRI-O container runtime.
+
+[id="microshift-fips-limitations_{context}"]
+== Limitations
+
+* TLS implementation FIPS support is not complete.
+
+* The FIPS implementation does not offer a single function that both computes hash functions and validates the keys that are based on that hash. This limitation continues to be evaluated for improvement in future {microshift-short} releases.
+
+[id="microshift-fips-install_{context}"]
+== Installing {op-system-base} in FIPS mode
+
+To install {op-system-base} with FIPS, follow the guidance in the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode] of the {op-system-base} documentation.

--- a/modules/microshift-install-rpm-before.adoc
+++ b/modules/microshift-install-rpm-before.adoc
@@ -6,6 +6,16 @@
 [id="microshift-install-rpm-before_{context}"]
 = Before installing {microshift-short} from an RPM package
 
+Preparation of the host machine is recommended prior to installing {microshift-short} for memory configuration and FIPS compliance.
+
+[id="microshift-configuring-volume-groups_{context}"]
+== Configuring volume groups
+
 {microshift-short} uses the logical volume manager storage (LVMS) Container Storage Interface (CSI) plugin for providing storage to persistent volumes (PVs). LVMS relies on the Linux logical volume manager (LVM) to dynamically manage the backing logical volumes (LVs) for PVs. For this reason, your machine must have an LVM volume group (VG) with unused space in which LVMS can create the LVs for your workload's PVs.
 
 To configure a volume group (VG) that allows LVMS to create the LVs for your workload's PVs, lower the *Desired Size* of your root volume during the installation of {op-system}. Lowering the size of your root volume allows unallocated space on the disk for additional LVs created by LVMS at runtime.
+
+[id="microshift-running-containers-fips-mode_{context}"]
+== Running {microshift-short} in FIPS-compliant mode
+
+If your use case requires running {microshift-short} containers in FIPS mode, you must install {op-system-base} with FIPS enabled. After the worker machine is configured to run in FIPS mode, your {microshift-short} containers are automatically configured to also run in FIPS mode. See "Running {microshift-short} containers in FIPS mode" in the "Additional resources" of this section.


### PR DESCRIPTION
Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-8704

Link to docs preview:
[Installing for FIPS compliance](https://69379--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-fips)
[Before installing MicroShift from an RPM package, Running containers in FIPS mode](https://69379--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-install-rpm#microshift-running-containers-fips-mode_microshift-install-rpm)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
