### PR TITLE
OSDOCS-8988: adds FIPS release note MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -6,14 +6,14 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-{product-title} provides developers and IT organizations with small-form-factor and edge computing, delivered as an application that customers can deploy on top of their managed {op-system-base-full} devices at the edge. Built on {OCP} and Kubernetes, {microshift-short} provides an efficient way to operate single-node clusters in low-resource edge environments.
+{product-title-first} provides developers and IT organizations with small-form-factor and edge computing, delivered as an application that customers can deploy on top of their managed {op-system-base-full} devices at the edge. Built on {OCP} and Kubernetes, {microshift-short} provides an efficient way to operate single-node clusters in low-resource edge environments.
 
 {microshift-short} is designed to make control plane restarts economical and be lifecycle-managed as a single unit by the operating system. Updates, roll-backs, and configuration changes consist of simply staging another version in parallel and then - without relying on a network - flipping to and from that version and restarting.
 
 [id="microshift-4-15-about-this-release"]
 == About this release
 // TODO: Update with the relevant information closer to release.
-Version 4.15 of {microshift-short} includes new features and enhancements. {microshift-short} was introduced as Generally Available with {microshift-short} 4.14. You should plan to update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md[Kubernetes 1.27] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {microshift-short} are included in this topic.
+Version 4.15 of {microshift-short} includes new features and enhancements. {microshift-short} was introduced as Generally Available with {microshift-short} 4.14. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md[Kubernetes 1.27] with the CRI-O container runtime. New features, changes, and known issues that pertain to {product-title} {microshift-short} are included in this topic.
 
 You can deploy {microshift-short} clusters to either on-premise, cloud, or disconnected environments.
 
@@ -21,7 +21,7 @@ You can deploy {microshift-short} clusters to either on-premise, cloud, or disco
 {microshift-short} {product-version} is supported on {op-system-ostree-first} and {op-system-base-full} 9.2 and 9.3.
 
 //TODO: update link after GA; KCS article will not be live until then
-//For lifecycle information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
+//For lifecycle information, see the link:https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle Policy].
 
 [id="microshift-4-15-new-features-and-enhancements"]
 == New features and enhancements
@@ -34,11 +34,19 @@ This release adds improvements related to the following components and concepts.
 * {microshift-short} runs on {op-system-base-full} versions 9.2 and 9.3.
 
 // Some details of the next note are adapted from https://kubernetes.io/blog/2022/08/31/cgroupv2-ga-1-25/
-* {microshift-short} uses crun and Control Group v2 (cgroup v2). {OCP} {ocp-version} defaults to Control Group v1. The divergence of control group versions is not anticipated to have a noticeable behavior difference on most workloads. If workloads rely on the cgroup file system layout, they may need to be updated to be compatible with cgroup v2.
+* {microshift-short} uses crun and Control Group v2 (cgroup v2). If workloads rely on the cgroup file system layout, they might need to be updated to be compatible with cgroup v2.
 
 ** If you run third-party monitoring and security agents that depend on the cgroup file system, update the agents to versions that support cgroup v2.
 ** If you run cAdvisor as a standalone DaemonSet for monitoring pods and containers, update it to v0.43.0 or later.
-** If you deploy Java applications with the JDK, ensure you are using JDK 11.0.16 and later or JDK 15 and later, which fully support cgroup v2.
+** If you deploy Java applications with JDK, ensure you are using JDK 11.0.16 and later or JDK 15 and later, which fully support cgroup v2.
+
+[id="microshift-4-15-security"]
+=== Security and compliance
+
+[id="microshift-4-15-rhel-fips"]
+==== FIPS compliance
+* When {op-system-base-full} is installed and started with FIPS enabled, {microshift-short} containers are automatically enabled to run in FIPS-compliant mode.
+//TODO add link to section once merged
 
 [id="microshift-4-15-updating"]
 === Updating
@@ -140,43 +148,38 @@ In the following tables, features are marked with the following statuses:
 
 |====
 
-[id="microshift-4-15-bug-fixes"]
-== Bug fixes
+//[id="microshift-4-15-bug-fixes"]
+//== Bug fixes
 
 
-[discrete]
-[id="microshift-4-15-installation-bug-fixes"]
-==== Installation
+//[discrete]
+//[id="microshift-4-15-installation-bug-fixes"]
+//==== Installation
 
 
-
-[discrete]
-[id="microshift-4-15-storage-bug-fixes"]
-==== Storage
-
+//[discrete]
+//[id="microshift-4-15-storage-bug-fixes"]
+//==== Storage
 
 
-[discrete]
-[id="microshift-4-15-running-applications-bug-fixes"]
-==== Running applications
+//[discrete]
+//[id="microshift-4-15-running-applications-bug-fixes"]
+//==== Running applications
 
 
-
-[discrete]
-[id="microshift-4-15-support-bug-fixes"]
-==== Support
-
+//[discrete]
+//[id="microshift-4-15-support-bug-fixes"]
+//==== Support
 
 
-[discrete]
-[id="microshift-4-15-configuring-bug-fixes"]
-==== Configuring
+//[discrete]
+//[id="microshift-4-15-configuring-bug-fixes"]
+//==== Configuring
 
 
-
-[discrete]
-[id="microshift-4-15-networking-bug-fixes"]
-==== Networking
+//[discrete]
+//[id="microshift-4-15-networking-bug-fixes"]
+//==== Networking
 
 
 //[id="microshift-4-15-known-issues"]
@@ -225,15 +228,15 @@ Red Hat Customer Portal users can enable errata notifications in the account set
 Red Hat Customer Portal user accounts must have systems registered and consuming {microshift-short} entitlements for {microshift-short} errata notification emails to generate.
 ====
 
-This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {ocp-version}. Versioned asynchronous releases, for example with the form {microshift-short} {ocp-version}.z, will be detailed in the following subsections.
+This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, will be detailed in the following subsections.
 
 //FIXME-TODO
-[id="microshift-4-15-0-dp"]
-=== RHSA-2024:XXXX - {microshift-short} 4.15.0 bug fix and security update advisory
+//[id="microshift-4-15-0-dp"]
+//=== RHSA-2024:XXXX - {microshift-short} 4.15.0 bug fix and security update advisory
 
-Issued: 2024-02-28
+//Issued: 2024-02-28
 
-{product-title} release 4.15.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:XXXX[RHSA-2024:XXXX] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:XXXX[RHSA-2024:XXXX] advisory.
+//{product-title} release 4.15.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:XXXX[RHSA-2024:XXXX] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:XXXX[RHSA-2024:XXXX] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+//For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
 //check the lvms version


### PR DESCRIPTION
Version(s):
4.15 only

Issue:
https://issues.redhat.com/browse/OSDOCS-8988

Link to docs preview:
[FIPS release note](https://69381--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes#microshift-4-15-security)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
