### PR TITLE
Add must-gather xref for troubleshooting ovn-k8s

### DIFF
--- a/networking/ovn_kubernetes_network_provider/ovn-kubernetes-troubleshooting-sources.adoc
+++ b/networking/ovn_kubernetes_network_provider/ovn-kubernetes-troubleshooting-sources.adoc
@@ -6,8 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-OVN-Kubernetes has many sources of built-in health checks and logs.
-
+OVN-Kubernetes has many sources of built-in health checks and logs. Follow the instructions in these sections to examine your cluster. If a support case is necessary, follow the xref:../../support/gathering-cluster-data.adoc#support_gathering_data_gathering-cluster-data[support guide] to collect additional information through a `must-gather`. Only use the `-- gather_network_logs` when instructed by support.
 
 include::modules/nw-ovn-kubernetes-readiness-probes.adoc[leveloffset=+1]
 
@@ -32,7 +31,6 @@ include::modules/nw-ovn-kubernetes-pod-connectivity-checks.adoc[leveloffset=+1]
 [id="additional-resources_ovn-kubernetes-sources-of-troubleshooting-information"]
 == Additional resources
 
+* xref:../../support/gathering-cluster-data.adoc#support_gathering_data_gathering-cluster-data[Gathering data about your cluster for Red Hat Support]
 * xref:../../networking/verifying-connectivity-endpoint.adoc#nw-pod-network-connectivity-implementation_verifying-connectivity-endpoint[Implementation of connection health checks]
 * xref:../../networking/verifying-connectivity-endpoint.adoc#nw-pod-network-connectivity-verify_verifying-connectivity-endpoint[Verifying network connectivity for an endpoint]
-
-


### PR DESCRIPTION
- https://issues.redhat.com/browse/OCPBUGS-25366

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://69382--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/ovn-kubernetes-troubleshooting-sources#nw-ovn-kubernetes-readiness-probes_ovn-kubernetes-sources-of-troubleshooting-information
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
