### PR TITLE
OSDOCS-9107: remove broken xref 4.15 MicroShift

### DIFF
--- a/microshift_networking/microshift-networking-settings.adoc
+++ b/microshift_networking/microshift-networking-settings.adoc
@@ -38,8 +38,3 @@ include::modules/microshift-deploying-a-load-balancer.adoc[leveloffset=+1]
 include::modules/microshift-blocking-nodeport-access.adoc[leveloffset=+1]
 
 include::modules/microshift-mDNS.adoc[leveloffset=+1]
-
-[id="additional-resources_microshift-understanding-networking-settings_{context}"]
-[role="_additional-resources"]
-== Additional resources
-* xref:../microshift_release_notes/microshift-4-15-release-notes.adoc#microshift-4-15-known-issues[{microshift-short} {product-version} release notes --> Known issues]


### PR DESCRIPTION
Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-9107

Link to docs preview:
[removed Additional resources from the bottom](https://69431--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-networking-settings#microshift-mDNS_microshift-networking)

QE review:
- N/A docs plumbing

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
