### PR TITLE
OSDOCS#9025: Move deprecated OSDK infra anno section up

### DIFF
--- a/modules/osdk-csv-annotations-dep.adoc
+++ b/modules/osdk-csv-annotations-dep.adoc
@@ -3,12 +3,7 @@
 // * operators/operator_sdk/osdk-generating-csvs.adoc
 
 [id="osdk-csv-manual-annotations-deprecated_{context}"]
-= Deprecated annotations
-
-The following Operator annotations are deprecated.
-
-[discrete]
-== operators.openshift.io/infrastructure-features
+= Deprecated infrastructure feature annotations
 
 Starting in {product-title} 4.14, the `operators.openshift.io/infrastructure-features` group of annotations are deprecated by the group of annotations with the `features.operators.openshift.io` namespace. While you are encouraged to use the newer annotations, both groups are currently accepted when used in parallel.
 

--- a/modules/osdk-csv-annotations-infra.adoc
+++ b/modules/osdk-csv-annotations-infra.adoc
@@ -5,11 +5,11 @@
 [id="osdk-csv-annotations-infra_{context}"]
 = Infrastructure features annotations
 
-The following Operator annotations detail the infrastructure features that an Operator might support, denoted with a `true` or `false` value. Users can view and filter by these features when discovering Operators through OperatorHub in the web console or on the link:https://catalog.redhat.com/software/search?deployed_as=Operator[Red Hat Ecosystem Catalog].
+Annotations in the `features.operators.openshift.io` group detail the infrastructure features that an Operator might support, specified by setting a `true` or `false` value. Users can view and filter by these features when discovering Operators through OperatorHub in the web console or on the link:https://catalog.redhat.com/software/search?deployed_as=Operator[Red Hat Ecosystem Catalog]. These annotations are supported in {product-title} 4.10 and later.
 
-[NOTE]
+[IMPORTANT]
 ====
-The following infrastructure feature annotations are supported in {product-title} 4.10 and later.
+The `features.operators.openshift.io` infrastructure feature annotations deprecate the `operators.openshift.io/infrastructure-features` annotations used in earlier versions of {product-title}. See "Deprecated infrastructure feature annotations" for more information.
 ====
 
 .Infrastructure features annotations

--- a/operators/operator_sdk/osdk-generating-csvs.adoc
+++ b/operators/operator_sdk/osdk-generating-csvs.adoc
@@ -39,6 +39,7 @@ ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../installing/installing-fips.adoc#installing-fips[Support for FIPS cryptography]
 endif::openshift-dedicated,openshift-rosa[]
 
+include::modules/osdk-csv-annotations-dep.adoc[leveloffset=+2]
 include::modules/osdk-csv-annotations-other.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
@@ -47,9 +48,6 @@ include::modules/osdk-csv-annotations-other.adoc[leveloffset=+2]
 * xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-suggested-namespace_osdk-generating-csvs[Setting a suggested namespace]
 * xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-suggested-namespace-default-node_osdk-generating-csvs[Setting a suggested namespace with default node selector]
 * xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-hiding-internal-objects_osdk-generating-csvs[Hiding internal objects]
-
-include::modules/osdk-csv-annotations-dep.adoc[leveloffset=+2]
-
 
 include::modules/olm-enabling-operator-restricted-network.adoc[leveloffset=+1]
 include::modules/olm-enabling-operator-for-multi-arch.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-9025

OCP 4.14+

Preview: https://69441--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-generating-csvs#osdk-csv-manual-annotations_osdk-generating-csvs

Follow-up to https://github.com/openshift/openshift-docs/pull/69171 

* Moves the "Deprecated infrastructure feature annotations" section up to now directly follow the "Infrastructure feature annotations" section
* Minor tweaks to language for clarity

No QE needed.

NOTE: Will backport this (along with https://github.com/openshift/openshift-docs/pull/69171) to 4.10 - 4.13 after confirming the related web console changes have shipped in those versions.

FYI @dmesser 