### PR TITLE
OSDOCS#9085: Prompting rebuild to try to address broken render

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-rosa-osd-change-default-domain.adoc
+++ b/cloud_experts_tutorials/cloud-experts-rosa-osd-change-default-domain.adoc
@@ -13,11 +13,6 @@
 //   Hector Kemp
 //---
 
-//Footnote definitions
-:fn-supported-cli: footnote:[The example commands in this guide use the ROSA CLI, but similar commands with the same function are available in the OCM CLI version 0.1.68 and higher for OpenShift Dedicated clusters that run on Google Cloud Platform.]
-:fn-supported-versions: footnote:[Modifying these routes on ROSA and OSD versions prior to 4.14 is not typically supported. However, if you have a cluster using version 4.13, you can request for Red Hat Support to enable support for this feature on your version 4.13 cluster.]
-:fn-term-component-routes: footnote:[We use the term `component routes` to refer to the `OAuth`, `Console`, and `Downloads` routes that are provided when ROSA and OSD are first installed. The ROSA CLI also uses the term `cluster routes` to refer to these resources.]
-
 //Article text
 This guide demonstrates how to modify the Console, Downloads, OAuth domain, and TLS certificate keypair on Red Hat Openshift on AWS (ROSA) and Red Hat Openshift Dedicated (OSD) versions 4.14 and above.{fn-supported-versions}
 
@@ -184,3 +179,12 @@ r3l6  https://apps.my-example-cluster-aws.z9a9.p1.openshiftapps.com  yes      ye
 ----
 
 Add your certificate to the trust store on your local system, then confirm that you can access your components at their new routes using your local web browser.
+
+
+
+//Footnote definitions
+:fn-supported-cli: footnote:[The example commands in this guide use the ROSA CLI, but similar commands with the same function are available in the OCM CLI version 0.1.68 and higher for OpenShift Dedicated clusters that run on Google Cloud Platform.]
+:fn-supported-versions: footnote:[Modifying these routes on ROSA and OSD versions prior to 4.14 is not typically supported. However, if you have a cluster using version 4.13, you can request for Red Hat Support to enable support for this feature on your version 4.13 cluster.]
+:fn-term-component-routes: footnote:[We use the term "component routes" to refer to the OAuth, "Console", and "Downloads" routes that are provided when ROSA and OSD are first installed. The ROSA CLI also uses the term `cluster routes` to refer to these resources.]
+
+//Adding the footnotes at the end in case this has some bizarre effect on article truncation.


### PR DESCRIPTION
Rendering of this page is broken on openshift.com for some reason, truncating at the footnotes and not rendering markup in the footnotes. Moving them to the bottom of the doc and removing the markup to see if this helps.

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-9085

Link to docs preview:
TBD

QE review:
N/A