### PR TITLE
OSDOCS-8983: Update Ushift docs to reflect lvmd.yaml not required

### DIFF
--- a/modules/microshift-lvms-system-requirements.adoc
+++ b/modules/microshift-lvms-system-requirements.adoc
@@ -11,15 +11,18 @@ Using LVMS in {microshift-short} requires the following system specifications.
 [id="lvms-volume-group-name_{context}"]
 == Volume group name
 
-The default integration of LVMS selects the default volume group (VG) dynamically. If there are no volume groups on the {microshift-short} host, LVMS is disabled.
+If you did not configure LVMS in an `lvmd.yaml` YAML file placed in the `/etc/microshift/` directory, {microshift-short} attempts to assign a default volume group (VG) dynamically by running the `vgs` command. 
+* {microshift-short} assigns a default VG when only one VG is found. 
+* If more than one VG is present, the VG named `microshift` is assigned as the default. 
+* If a VG named `microshift` does not exist, LVMS is not deployed.
 
-If there is only one VG on the {microshift-short} host, that VG is used. If there are multiple volume groups, the group `microshift` is used. If the `microshift` group is not found, LVMS is disabled.
+If there are no volume groups on the {microshift-short} host, LVMS is disabled.
 
 If you want to use a specific VG, LVMS must be configured to select that VG. You can change the default name of the VG in the configuration file. For details, read the "Configuring the LVMS" section of this document.
 
 You can change the default name of the VG in the configuration file. For details, read the "Configuring the LVMS" section of this document.
 
-Prior to launching, the `lvmd.yaml` configuration file must specify an existing VG on the node with sufficient capacity for workload storage. If the VG does not exist, the node controller fails to start and enters a `CrashLoopBackoff` state.
+After {microshift-short} starts, you can update the `lvmd.yaml` to include or remove VGs. To implement changes, you must restart {microshift-short}. If the `lvmd.yaml` is deleted, {microshift-short} attempts to find a default VG again.
 
 [id="lvms-volume-size-increments_{context}"]
 == Volume size increments


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
release-4.15
release-4.14

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-8983

Link to docs preview:
[MicroShift lvms-volume-group-name](https://69505--ocpdocs-pr.netlify.app/microshift/latest/microshift_storage/microshift-storage-plugin-overview#lvms-volume-group-name_microshift-storage-plugin-overview)
https://github.com/openshift/openshift-docs/commit/2ca5b2b77f57cec53bfbb9016ac8fdb437da9e2e

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
