### PR TITLE
OADP-2029: Data mover , Restore - CephFS PV create time is long or PV not created

### DIFF
--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc
@@ -12,3 +12,8 @@ You can create restore hooks to run commands in a container in a pod while resto
 
 include::modules/oadp-creating-restore-cr.adoc[leveloffset=+1]
 include::modules/oadp-creating-restore-hooks.adoc[leveloffset=+1]
+
+[id="known-issues-restoring-applications"]
+== Known issues
+
+If Data Mover is used to back up and restore CephFS persistent volumes (PVs), the restoring might take a long time, up to 40 minutes. For more information, see link:https://issues.redhat.com/browse/OADP-2029[OADP-2029].

--- a/modules/oadp-release-notes-1-3-0.adoc
+++ b/modules/oadp-release-notes-1-3-0.adoc
@@ -91,6 +91,10 @@ Due to the asynchronous nature of the Data Mover operation, a post-hook might be
 .GCP-Workload Identity Federation VSL backup PartiallyFailed
 VSL backup `PartiallyFailed` when GCP workload identity is configured on GCP.
 
+.Restoring CephFS PVs with Data Mover takes longer than expected
+
+If Data Mover is used to back up and restore CephFS PVs, the restoring might take a long time, up to 40 minutes. link:https://issues.redhat.com/browse/OADP-2029[OADP-2029]
+
 
 For a complete list of all known issues in this release, see the list of link:https://issues.redhat.com/issues/?filter=12422838[OADP 1.3.0 known issues] in Jira.
 

--- a/rosa_backing_up_and_restoring_applications/backing-up-applications.adoc
+++ b/rosa_backing_up_and_restoring_applications/backing-up-applications.adoc
@@ -25,7 +25,7 @@ include::modules/oadp-installing-oadp-rosa-sts.adoc[leveloffset=+1]
 
 [id="rosa-backing-up-applications-known-issues"]
 == Known issues
-.Restic, Kopia, and DataMover are not supported or recommended
+.Restic, Kopia, and Data Mover are not supported or recommended
 
 * link:https://issues.redhat.com/browse/OADP-1054[CloudStorage: openshift-adp-controller-manager crashloop seg fault with Restic enabled]
 * link:https://issues.redhat.com/browse/OADP-1057[Cloudstorage API: CSI Backup of an app with internal images partially fails with plugin panicked error]


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/OADP-2029
OCP 4.12+
OADP 1.3.0
Preview: 