### PR TITLE
Fix distr_tracing xrefs for 4.14 customer portal build

### DIFF
--- a/distr_tracing/distr_tracing_jaeger/distr-tracing-jaeger-installing.adoc
+++ b/distr_tracing/distr_tracing_jaeger/distr-tracing-jaeger-installing.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 [WARNING]
 ====
-Jaeger is deprecated in Red Hat OpenShift distributed tracing 3.0. See the xref:../distr_tracing_rn/distr-tracing-rn-3-0.adoc[release notes] for more information.
+Jaeger is deprecated in Red Hat OpenShift distributed tracing 3.0. See the xref:../../distr_tracing/distr_tracing_rn/distr-tracing-rn-3-0.adoc[release notes] for more information.
 ====
 
 You can install {DTProductName} on {product-title} in either of two ways:

--- a/distr_tracing/distr_tracing_jaeger/distr-tracing-jaeger-updating.adoc
+++ b/distr_tracing/distr_tracing_jaeger/distr-tracing-jaeger-updating.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 [WARNING]
 ====
-Jaeger is deprecated in Red Hat OpenShift distributed tracing 3.0. See the xref:../distr_tracing_rn/distr-tracing-rn-3-0.adoc[release notes] for more information.
+Jaeger is deprecated in Red Hat OpenShift distributed tracing 3.0. See the xref:../../distr_tracing/distr_tracing_rn/distr-tracing-rn-3-0.adoc[release notes] for more information.
 ====
 
 Operator Lifecycle Manager (OLM) controls the installation, upgrade, and role-based access control (RBAC) of Operators in a cluster. The OLM runs by default in {product-title}.


### PR DESCRIPTION
The Distributed tracing book is not building for 4.14 on the customer portal.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: The distributed tracing and GitOps books are not building on the customer portal. I am hoping that fixing this xref that does not back up all the way to the root project directory will fix it. 
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
* [Installation](https://69550--ocpdocs-pr.netlify.app/openshift-enterprise/latest/distr_tracing/distr_tracing_jaeger/distr-tracing-jaeger-installing)
* [Updating](https://69550--ocpdocs-pr.netlify.app/openshift-enterprise/latest/distr_tracing/distr_tracing_jaeger/distr-tracing-jaeger-updating)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
