### PR TITLE
[enterprise-4.13] OCPBUGS-16168:provides note on race condition in ovn-k

### DIFF
--- a/modules/configuring-ovnk-additional-networks.adoc
+++ b/modules/configuring-ovnk-additional-networks.adoc
@@ -11,6 +11,11 @@ The {openshift-networking} OVN-Kubernetes network plugin allows the configuratio
 :FeatureName: Configuration for an OVN-Kubernetes additional network
 include::snippets/technology-preview.adoc[]
 
+[NOTE]
+====
+Pod and multi-network policy creation might remain in a pending state until the OVN-Kubernetes control plane agent in the nodes processes the associated `network-attachment-definition` CR.
+====
+
 The following sections provide example configurations for each of the topologies that OVN-Kubernetes currently allows for secondary networks.
 
 [NOTE]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
