### PR TITLE
OADP-3268: small correction following merge

### DIFF
--- a/modules/oadp-release-notes-1-3-0.adoc
+++ b/modules/oadp-release-notes-1-3-0.adoc
@@ -149,7 +149,7 @@ spec:
 
 [NOTE]
 ====
-In OADP 1.4, `kopia` will become the default `uploaderType` value.
+In a future OADP release, it is planned that the `kopia` tool will become the default `uploaderType` value.
 ====
 
 [id="upgrade-steps-1-3-0_{context}"]


### PR DESCRIPTION
### Jira 

* [OADP-3268](https://issues.redhat.com/browse/OADP-3268)

* Correction coming from this [PR comment](https://github.com/openshift/openshift-docs/pull/69552#discussion_r1430625314) 

    ```
    In a future OADP release, it is planned that the `kopia` tool will become the default `uploaderType` value.
    ```

@michaelryanpeter - please can I flag this PR to you for merge-review



### Versions:

* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15

### Doc preview

* [OADP 1.3 release notes -> upgrade notes](https://69578--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3#upgrade-notes-1-3-0_oadp-release-notes)