### PR TITLE
[enterprise-4.14] OSDOCS#9025: Add older infra feat anno to OF tracker

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -1440,6 +1440,11 @@ In the following tables, features are marked with the following statuses:
 |Deprecated
 |Deprecated
 
+|`operators.openshift.io/infrastructure-features` annotations
+|General Availability
+|General Availability
+|Deprecated
+
 |====
 
 [discrete]
@@ -1735,6 +1740,18 @@ Red Hat Virtualization (RHV) as a host platform for {product-title} was deprecat
 Using the `REGISTRY_AUTH_PREFERENCE` environment variable to specify your preferred location to obtain registry credentials for OpenShift CLI (`oc`) commands is now deprecated.
 
 OpenShift CLI (`oc`) commands now default to obtaining the credentials from Podman configuration locations first, but will fall back to checking the deprecated Docker configuration file locations.
+
+[id="ocp-4-14-dep-infra-anno"]
+==== operators.openshift.io/infrastructure-features annotations
+
+Starting in {product-title} 4.14, the `operators.openshift.io/infrastructure-features` group of annotations are deprecated by the group of annotations with the `features.operators.openshift.io` namespace.
+
+[NOTE]
+====
+Currently, the web console continues to support displaying and filtering based on the earlier annotations. However, because they are deprecated, this support will be removed from the web console in a future {product-title} release, and therefore migration to the new annotations format is advised.
+====
+
+See xref:../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-csv-manual-annotations-deprecated_osdk-generating-csvs[Deprecated infrastructure feature annotations] for the earlier group of annotations, and see xref:../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-csv-annotations-infra_osdk-generating-csvs[Infrastructure features annotations] for the latest group.
 
 [id="ocp-4-14-removed-features"]
 === Removed features


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-9025

4.14

Going through CM process for this addition to the 4.14 release notes. [New annotations](https://69579--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-generating-csvs#osdk-csv-annotations-infra_osdk-generating-csvs) have been added in a z-stream that deprecate the older set of annotations.

Preview:

* [Table 6. Operator lifecycle and development deprecated and removed tracker](https://69579--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-deprecated-removed-features)
* New [operators.openshift.io/infrastructure-features annotations](https://69579--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-dep-infra-anno) subsection under "Deprecated features"

QE not needed (reusing already-reviewed content)

NOTE: New annotations already added via https://github.com/openshift/openshift-docs/pull/69171.