### PR TITLE
OCPBUGS#25659: Add OLM API tier support mapping

### DIFF
--- a/modules/api-support-tiers-mapping.adoc
+++ b/modules/api-support-tiers-mapping.adoc
@@ -125,3 +125,26 @@ API groups that end with the suffix `monitoring.coreos.com` have the following m
 
 |===
 endif::microshift[]
+
+ifndef::microshift[]
+[id="mapping-support-tiers-to-olm-api-groups_{context}"]
+== Support for Operator Lifecycle Manager API groups
+
+Operator Lifecycle Manager (OLM) provides APIs that include API groups with the suffix `operators.coreos.com`. These APIs have the following mapping:
+
+[cols="2",options="header"]
+|===
+|API version example
+|API tier
+
+|`v2`
+|Tier 1
+
+|`v1`
+|Tier 1
+
+|`v1alpha1`
+|Tier 1
+
+|===
+endif::microshift[]


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-25659

4.11+

Going through CM process for this addition to the API tier / support documentation.

Preview: https://69585--ocpdocs-pr.netlify.app/openshift-enterprise/latest/rest_api/understanding-api-support-tiers#mapping-support-tiers-to-olm-api-groups_understanding-api-tiers