### PR TITLE
[manual CP] Remove the Go function section, since it is not TP yet

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -76,8 +76,6 @@ Topics:
     File: serverless-developing-typescript-functions
   - Name: Developing Python functions
     File: serverless-developing-python-functions
-  - Name: Developing Go functions
-    File: serverless-developing-go-functions
 - Name: Configuring functions
   Dir: configuring
   Topics:


### PR DESCRIPTION
Manual CP of https://github.com/openshift/openshift-docs/pull/69376.