### PR TITLE
OCPBUGS#25683: Updated the errors in compute machine set sample yaml

### DIFF
--- a/modules/machineset-yaml-aws.adoc
+++ b/modules/machineset-yaml-aws.adoc
@@ -52,7 +52,9 @@ spec:
   selector:
     matchLabels:
       machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+ifdef::edge[]
       machine.openshift.io/cluster-api-machineset: <infrastructure_id>-edge-<zone>
+endif::edge[]
 ifndef::infra,edge[]
       machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> <2>
 endif::infra,edge[]
@@ -128,8 +130,8 @@ endif::edge[]
 ifdef::edge[]
               id: <value_of_PublicSubnetIds> <8>
           publicIp: true
-          tags:
 endif::edge[]
+          tags:
             - name: kubernetes.io/cluster/<infrastructure_id> <1>
               value: owned
             - name: <custom_tag_name> <5>


### PR DESCRIPTION
[OCPBUGS-25683](https://issues.redhat.com/browse/OCPBUGS-25683)

Version(s):
4.15 and 4.14

Link to docs preview:
* [Sample YAML for a compute machine set custom resource on AWS (Machine management)](https://69600--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws#machineset-yaml-aws_creating-machineset-aws)
* [Sample YAML for a compute machine set custom resource on AWS (Post install)](https://69600--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/aws-compute-edge-tasks#machineset-yaml-aws_aws-compute-edge-tasks)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
