### PR TITLE
OBSDOCS-664: Add demo size for loki and update lokistack CR docs

### DIFF
--- a/logging/log_storage/installing-log-storage.adoc
+++ b/logging/log_storage/installing-log-storage.adoc
@@ -1,6 +1,5 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
-include::_attributes/attributes-openshift-dedicated.adoc[]
 [id="installing-log-storage"]
 = Installing log storage
 :context: installing-log-storage

--- a/modules/create-lokistack-cr-cli.adoc
+++ b/modules/create-lokistack-cr-cli.adoc
@@ -39,10 +39,10 @@ spec:
   tenants:
     mode: openshift-logging
 ----
-<1> Supported size options for production instances of Loki are `1x.small` and `1x.medium`.
-<2> Enter the name of your log store secret.
-<3> Enter the type of your log store secret.
-<4> Enter the name of a storage class for temporary storage. For best performance, specify a storage class that allocates block storage. Available storage classes for your cluster can be listed by using `oc get storageclasses`.
+<1> Specify the deployment size. In the {logging} 5.8 and later versions, the supported size options for production instances of Loki are `1x.extra-small`, `1x.small`, or `1x.medium`.
+<2> Specify the name of your log store secret.
+<3> Specify the type of your log store secret.
+<4> Specify the name of a storage class for temporary storage. For best performance, specify a storage class that allocates block storage. Available storage classes for your cluster can be listed by using the `oc get storageclasses` command.
 
 . Apply the `LokiStack` CR:
 +

--- a/modules/create-lokistack-cr-console.adoc
+++ b/modules/create-lokistack-cr-console.adoc
@@ -27,23 +27,23 @@ You can create a `LokiStack` custom resource (CR) by using the {product-title} w
 apiVersion: loki.grafana.com/v1
 kind: LokiStack
 metadata:
-  name: logging-loki <1>
+  name: logging-loki # <1>
   namespace: openshift-logging
 spec:
-  size: 1x.small <2>
+  size: 1x.small # <2>
   storage:
     schemas:
     - version: v12
       effectiveDate: '2022-06-01'
     secret:
-      name: logging-loki-s3 <3>
-      type: s3 <4>
-  storageClassName: <storage_class_name> <5>
+      name: logging-loki-s3 # <3>
+      type: s3 # <4>
+  storageClassName: <storage_class_name> # <5>
   tenants:
     mode: openshift-logging
 ----
 <1> Use the name `logging-loki`.
-<2> Select your Loki deployment size.
+<2> Specify the deployment size. In the {logging} 5.8 and later versions, the supported size options for production instances of Loki are `1x.extra-small`, `1x.small`, or `1x.medium`.
 <3> Specify the secret used for your log storage.
 <4> Specify the corresponding storage type.
 <5> Enter the name of a storage class for temporary storage. For best performance, specify a storage class that allocates block storage. Available storage classes for your cluster can be listed by using the `oc get storageclasses` command.

--- a/modules/loki-deployment-sizing.adoc
+++ b/modules/loki-deployment-sizing.adoc
@@ -1,8 +1,8 @@
 // Module is included in the following assemblies:
-// * logging/cluster-logging-loki.adoc
+// * logging/log_storage/installing-log-storage.adoc
 // * network_observability/installing-operators.adoc
 
-ifeval::["{context}" == "cluster-logging-loki"]
+ifeval::["{context}" == "installing-log-storage"]
 :restricted:
 endif::[]
 
@@ -13,65 +13,75 @@ endif::[]
 Sizing for Loki follows the format of `<N>x.<size>` where the value `<N>` is number of instances and `<size>` specifies performance capabilities.
 
 .Loki sizing
-[cols="1h,3*",options="header"]
+[cols="1h,4*",options="header"]
 |===
 |
+|1x.demo
 |1x.extra-small
 |1x.small
 |1x.medium
 
 |Data transfer
+|Demo use only
 |100GB/day
 |500GB/day
 |2TB/day
 
 |Queries per second (QPS)
+|Demo use only
 |1-25 QPS at 200ms
 |25-50 QPS at 200ms
 |25-75 QPS at 200ms
 
 |Replication factor
+|None
 |2
 |2
 |2
 
 |Total CPU requests
+|None
 |14 vCPUs
 |34 vCPUs
 |54 vCPUs
 
 ifdef::restricted[]
 |Total CPU requests if using the ruler
+|None
 |16 vCPUs
 |42 vCPUs
 |70 vCPUs
 endif::restricted[]
 
 |Total memory requests
+|None
 |31Gi
 |67Gi
 |139Gi
 
 ifdef::restricted[]
 |Total memory requests if using the ruler
+|None
 |35Gi
 |83Gi
 |171Gi
 endif::restricted[]
 
 |Total disk requests
+|40Gi
 |430Gi
 |430Gi
 |590Gi
 
 ifdef::restricted[]
 |Total disk requests if using the ruler
-|650Gi
-|650Gi
+|80Gi
+|750Gi
+|750Gi
 |910Gi
 endif::restricted[]
 |===
 
-ifeval::["{context}" == "cluster-logging-loki"]
+ifeval::["{context}" == "installing-log-storage"]
 :!restricted:
 endif::[]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OBSDOCS-664

Link to docs preview:
- https://69602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_storage/installing-log-storage#loki-deployment-sizing_installing-log-storage
- https://69602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_storage/installing-log-storage#create-lokistack-cr-console_installing-log-storage
- https://69602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_storage/installing-log-storage#create-lokistack-cr-cli_installing-log-storage

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
