### PR TITLE
OCPBUGS-16954-RN413: Updated Installation Technology Preview tracker table with AWS Outpost platform entry

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -2314,6 +2314,11 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |General Availability
 
+|AWS Outposts platform
+|Not Available
+|Technology Preview
+|Technology Preview
+
 |Enabling NIC partitioning for SR-IOV devices
 |Not Available
 |Not Available


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-16954 AWS Outposts documentation doesn't reflect the correct support status

PR https://github.com/openshift/openshift-docs/pull/67464 deals with the TP note being added to the module text. 

This PR ONLY deals with the update to the 'Installation Technology Preview tracker' table in the 4.13 Release Notes.

Applies to OpenShift version : 4.13

Preview: [Table 18. Installation Technology Preview tracker](https://69617--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes#ocp-4-13-technology-preview)

Reporter review completed by @dfitzmau
Peer review completed by @StephenJamesSmith

Thank you.