### PR TITLE
[OSDOCS-8706] Cloud credential as a cluster capability

### DIFF
--- a/installing/cluster-capabilities.adoc
+++ b/installing/cluster-capabilities.adoc
@@ -28,6 +28,7 @@ include::modules/explanation-of-capabilities.adoc[leveloffset=+1]
 .Additional resources
 * xref:../operators/operator-reference.adoc#cluster-operator-reference[Cluster Operators reference]
 
+// Bare-metal capability
 include::modules/cluster-bare-metal-operator.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -39,14 +40,24 @@ include::modules/cluster-bare-metal-operator.adoc[leveloffset=+2]
 // Build capability
 include::modules/build-config-capability.adoc[leveloffset=+2]
 
+// Cloud credential capability
+include::modules/cloud-credential-operator.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc#about-cloud-credential-operator[About the Cloud Credential Operator]
+
+// Cluster storage capability
 include::modules/cluster-storage-operator.adoc[leveloffset=+2]
 
+// Console capability
 include::modules/console-operator.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../web_console/web-console-overview.adoc#web-console-overview[Web console overview]
 
+// CSI snapshot controller capability
 include::modules/cluster-csi-snapshot-controller-operator.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -56,12 +67,14 @@ include::modules/cluster-csi-snapshot-controller-operator.adoc[leveloffset=+2]
 // DeploymentConfig capability
 include::modules/deployment-config-capability.adoc[leveloffset=+2]
 
+// Insights capability
 include::modules/insights-operator.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../support/remote_health_monitoring/using-insights-operator.adoc#using-insights-operator[Using Insights Operator]
 
+// Machine API capability
 include::modules/machine-api-capability.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -71,24 +84,28 @@ include::modules/machine-api-capability.adoc[leveloffset=+2]
 * xref:../operators/operator-reference.html#cluster-autoscaler-operator_cluster-operators-ref[Cluster Autoscaler Operator]
 * xref:../operators/operator-reference.html#control-plane-machine-set-operator_cluster-operators-ref[Control Plane Machine Set Operator]
 
+// Marketplace capability
 include::modules/operator-marketplace.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../operators/understanding/olm-rh-catalogs.adoc#olm-rh-catalogs[Red Hat-provided Operator catalogs]
 
+// Node Tuning capability
 include::modules/node-tuning-operator.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../scalability_and_performance/using-node-tuning-operator.adoc#using-node-tuning-operator[Using the Node Tuning Operator]
 
+// OpenShift samples capability
 include::modules/cluster-samples-operator.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../openshift_images/configuring-samples-operator.adoc#configuring-samples-operator[Configuring the Cluster Samples Operator]
 
+// Cluster Image Registry capability
 include::modules/cluster-image-registry-operator.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/modules/cloud-credential-operator.adoc
+++ b/modules/cloud-credential-operator.adoc
@@ -1,17 +1,37 @@
 // Module included in the following assemblies:
 //
 // * operators/operator-reference.adoc
+// * installing/modules/node-tuning-operator.adoc
 
+ifeval::["{context}" == "cluster-operators-ref"]
+:operators:
+endif::[]
+ifeval::["{context}" == "cluster-capabilities"]
+:cluster-caps:
+endif::[]
+
+:_mod-docs-content-type: REFERENCE
 [id="cloud-credential-operator_{context}"]
-= Cloud Credential Operator
+ifdef::operators[= Cloud Credential Operator]
+ifdef::cluster-caps[= Cloud credential capability]
 
 [discrete]
 == Purpose
+
+ifdef::cluster-caps[]
+The Cloud Credential Operator provides features for the `CloudCredential` capability.
+
+[NOTE]
+====
+Currently, disabling the `CloudCredential` capability is only supported for bare-metal clusters.
+====
+endif::cluster-caps[]
 
 The Cloud Credential Operator (CCO) manages cloud provider credentials as Kubernetes custom resource definitions (CRDs). The CCO syncs on `CredentialsRequest` custom resources (CRs) to allow {product-title} components to request cloud provider credentials with the specific permissions that are required for the cluster to run.
 
 By setting different values for the `credentialsMode` parameter in the `install-config.yaml` file, the CCO can be configured to operate in several different modes. If no mode is specified, or the `credentialsMode` parameter is set to an empty string (`""`), the CCO operates in its default mode.
 
+ifdef::operators[]
 [discrete]
 == Project
 
@@ -29,3 +49,11 @@ link:https://github.com/openshift/cloud-credential-operator[openshift-cloud-cred
 == Configuration objects
 
 No configuration required.
+endif::operators[]
+
+ifeval::["{context}" == "cluster-operators-ref"]
+:!operators:
+endif::[]
+ifeval::["{context}" == "cluster-capabilities"]
+:!cluster-caps:
+endif::[]


### PR DESCRIPTION
Version(s):
4.15+

Issue:
[OSDOCS-8706](https://issues.redhat.com//browse/OSDOCS-8706)

Link to docs preview:
- [Cloud credential capability](https://69624--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/cluster-capabilities#cloud-credential-operator_cluster-capabilities) module added to _Cluster capabilities_ assembly
- [Cloud Credential Operator](https://69624--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator-reference#cloud-credential-operator_cluster-operators-ref) original use of module in _Cluster Operators reference_ assembly; preview link to verify no accidental changes

QE review:
- [ ] QE has approved this change.

Additional information: