### PR TITLE
TELCODOCS#1626: Recovering VGs from previous LVM Storage installation

### DIFF
--- a/modules/lvms-creating-logical-volume-manager-cluster.adoc
+++ b/modules/lvms-creating-logical-volume-manager-cluster.adoc
@@ -52,10 +52,10 @@ metadata:
 spec:
   storage:
     deviceClasses:  <1>
-      - name: vg1
-        fstype: ext4 <2>
-        default: true <3>
-        deviceSelector: <4>
+      - name: vg1 <2>
+        fstype: ext4 <3>
+        default: true <4>
+        deviceSelector: <5>
           paths:
           - /dev/disk/by-path/pci-0000:87:00.0-nvme-1
           - /dev/disk/by-path/pci-0000:88:00.0-nvme-1
@@ -63,12 +63,12 @@ spec:
           optionalPaths:
           - /dev/disk/by-path/pci-0000:89:00.0-nvme-1
           - /dev/disk/by-path/pci-0000:90:00.0-nvme-1
-          forceWipeDevicesAndDestroyAllData: true <5>
+          forceWipeDevicesAndDestroyAllData: true <6>
         thinPoolConfig:
           name: thin-pool-1
           sizePercent: 90
           overprovisionRatio: 10
-        nodeSelector: <6>
+        nodeSelector: <7>
           nodeSelectorTerms:
             - matchExpressions:
               - key: app
@@ -80,12 +80,14 @@ spec:
 If you add or remove a `deviceClass`, then the update reflects in the cluster only after deleting and recreating the `TopoLVM-Node` pod.
 Configure the local device paths of the disks as an array of values in the `deviceSelector` field.
 When configuring multiple device classes, you must specify the device path for each device.
-<2> Set `fstype` to `ext4` or `xfs`. By default, it is set to `xfs` if the setting is not specified.
-<3> Mandatory: The `LVMCluster` resource must contain a single default storage class. Set `default: false` for secondary device storage classes.
+<2> Specify a name for the LVM volume group (VG). To recover VGs from the previous {lvms} installation, you must set this field to the name of the VG that you want to recover. 
+You can only recover the VGs but not the logical volume associated with the VG.
+<3> Set `fstype` to `ext4` or `xfs`. By default, it is set to `xfs` if the setting is not specified.
+<4> Mandatory: The `LVMCluster` resource must contain a single default storage class. Set `default: false` for secondary device storage classes.
 If you are updating the `LVMCluster` resource from a previous version, you must specify a single default device class.
-<4> Optional. To control or restrict the volume group to your preferred devices, you can manually specify the local paths of the devices in the `deviceSelector` section of the `LVMCluster` YAML. The `paths` section refers to devices the `LVMCluster` adds, which means those paths must exist. The `optionalPaths` section refers to devices the `LVMCluster` might add. You must specify at least one of `paths` or `optionalPaths` when specifying the `deviceSelector` section. If you specify `paths`, it is not mandatory to specify `optionalPaths`. If you specify `optionalPaths`, it is not mandatory to specify `paths` but at least one optional path must be present on the node. If you do not specify any paths, then the `LVMCluster` adds the unused devices on the node. You can also add the path to the RAID arrays to integrate the RAID arrays with {lvms}. After a device is added to the `LVMCluster`, it cannot be removed.
-<5> Optional: To force wipe the selected disks, set `forceWipeDevicesAndDestroyAllData` to true. This parameter is set to `false` by default.
-<6> Optional: To control what worker nodes the `LVMCluster` CR is applied to, specify a set of node selector labels.
+<5> Optional. To control or restrict the volume group to your preferred devices, you can manually specify the local paths of the devices in the `deviceSelector` section of the `LVMCluster` YAML. The `paths` section refers to devices the `LVMCluster` adds, which means those paths must exist. The `optionalPaths` section refers to devices the `LVMCluster` might add. You must specify at least one of `paths` or `optionalPaths` when specifying the `deviceSelector` section. If you specify `paths`, it is not mandatory to specify `optionalPaths`. If you specify `optionalPaths`, it is not mandatory to specify `paths` but at least one optional path must be present on the node. If you do not specify any paths, then the `LVMCluster` adds the unused devices on the node. After a device is added to the `LVMCluster`, it cannot be removed.
+<6> Optional: To force wipe the selected disks, set `forceWipeDevicesAndDestroyAllData` to `true`. This parameter is set to `false` by default.
+<7> Optional: To control what worker nodes the `LVMCluster` CR is applied to, specify a set of node selector labels.
 The specified labels must be present on the node in order for the `LVMCluster` to be scheduled on that node.
 
 .. Create the `LVMCluster` CR:
@@ -105,6 +107,11 @@ The `LVMCluster` resource creates the following system-managed CRs:
 +
 `LVMVolumeGroup`:: Tracks individual volume groups across multiple nodes.
 `LVMVolumeGroupNodeStatus`:: Tracks the status of the volume groups on a node.
+
+To recover VGs from the previous {lvms} installation, ensure that the following conditions are met:
+
+* VGs must not be corrupted.
+* VGs must have the `lvms` tag. For more information on adding tags to LVMS objects, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_logical_volumes/grouping-lvm-objects-with-tags_configuring-and-managing-logical-volumes#doc-wrapper[Grouping LVM objects with tags].
 
 [NOTE]
 ====


### PR DESCRIPTION
Version(s): 4.15

Issue: [TELCODOCS-1626](https://issues.redhat.com/browse/TELCODOCS-1626)

Link to docs preview:
https://69629--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms#lvms-creating-lvms-cluster_logical-volume-manager-storage

QE review:
- [x] QE has approved this change.