### PR TITLE
OCPBUGS#17371: Wipe disks before deploying LVMS on private CI

### DIFF
--- a/modules/deploying-lvms-on-sno-cluster.adoc
+++ b/modules/deploying-lvms-on-sno-cluster.adoc
@@ -25,15 +25,26 @@ You can deploy {lvms} on {sno} clusters using one of the following:
 [id="lvms-deployment-requirements-for-sno-ran_{context}"]
 == Requirements
 
-Before you begin deploying {lvms} on {sno} clusters, ensure that the following requirements are met:
+Before deploying {lvms} on {sno} clusters, ensure that the following requirements are met:
 
 * You have installed {rh-rhacm-first} on an {product-title} cluster.
 * Every managed {sno} cluster has dedicated disks that are used to provision storage.
 
-Before you deploy {lvms} on {sno} clusters, be aware of the following limitations:
+Before deploying {lvms} on {sno} clusters, be aware of the following limitations:
 
 * You can only create a single instance of the `LVMCluster` custom resource (CR) on an {product-title} cluster.
 * When a device becomes part of the `LVMCluster` CR, it cannot be removed.
+
+Before deploying {lvms} on a private CI environment, where virutal machines and storage devices can be reused, ensure that you have wiped the LVM disks. 
+[NOTE]
+====
+To wipe the LVM disks before reusing them in a new {sno} cluster, run the following command:
+[source,terminal]
+----
+$ wipefs -a <device> <1>
+----
+<1> Replace `<device>` with the full path to the disk.
+====
 
 [id="lvms-deployment-limitations-for-sno-ran_{context}"]
 == Limitations


### PR DESCRIPTION
Version(s): 4.12, 4.13

Issue: [OCPBUGS-17371](https://issues.redhat.com/browse/OCPBUGS-17371)

Link to docs preview:
https://69630--docspreview.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms#lvms-deployment-requirements-for-sno-ran_logical-volume-manager-storage

QE review:
- [ ] QE has approved this change.