### PR TITLE
CNV- 36233: Fix runbook command

### DIFF
--- a/modules/virt-runbook-outdatedvirtualmachineinstanceworkloads.adoc
+++ b/modules/virt-runbook-outdatedvirtualmachineinstanceworkloads.adoc
@@ -43,7 +43,7 @@ stanza:
 +
 [source,terminal]
 ----
-$ oc get kubevirt kubevirt --all-namespaces -o yaml
+$ oc get kubevirt --all-namespaces -o yaml
 ----
 
 . Check each outdated VMI to determine whether it is live-migratable:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-36233](https://issues.redhat.com//browse/CNV-36233)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [OutdatedVirtualMachineInstanceWorkloads](https://69643--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-runbooks#virt-runbook-OutdatedVirtualMachineInstanceWorkloads)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
