### PR TITLE
OBSDOCS-78: Update eventrouter docs

### DIFF
--- a/modules/cluster-logging-eventrouter-deploy.adoc
+++ b/modules/cluster-logging-eventrouter-deploy.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * logging/cluster-logging-eventrouter.adoc
+// * logging/log_collection_forwarding/cluster-logging-eventrouter.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="cluster-logging-eventrouter-deploy_{context}"]
@@ -8,7 +8,7 @@
 
 Use the following steps to deploy the Event Router into your cluster. You should always deploy the Event Router to the `openshift-logging` project to ensure it collects events from across the cluster.
 
-The following Template object creates the service account, cluster role, and cluster role binding required for the Event Router. The template also configures and deploys the Event Router pod. You can use this template without making changes, or change the deployment object CPU and memory requests.
+The following `Template` object creates the service account, cluster role, and cluster role binding required for the Event Router. The template also configures and deploys the Event Router pod. You can either use this template without making changes or edit the template to change the deployment object CPU and memory requests.
 
 .Prerequisites
 
@@ -22,8 +22,8 @@ The following Template object creates the service account, cluster role, and clu
 +
 [source,yaml]
 ----
-kind: Template
 apiVersion: template.openshift.io/v1
+kind: Template
 metadata:
   name: eventrouter-template
   annotations:
@@ -102,17 +102,16 @@ objects:
                 mountPath: /etc/eventrouter
               securityContext:
                 allowPrivilegeEscalation: false
-                seccompProfile:
-                  type: RuntimeDefault
                 capabilities:
-                  drop:
-                  - ALL
-          volumes:
-            - name: config-volume
-              configMap:
-                name: eventrouter
+                  drop: ["ALL"]
           securityContext:
             runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          volumes:
+          - name: config-volume
+            configMap:
+              name: eventrouter
 parameters:
   - name: IMAGE <6>
     displayName: Image


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OBSDOCS-78

Link to docs preview:
https://69647--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_collection_forwarding/cluster-logging-eventrouter#cluster-logging-eventrouter-deploy_cluster-logging-eventrouter

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
