### PR TITLE
Add hyperlink to the Node Tuning Operator documentation in nodes-namespaced-nodelevel-sysctls.adoc

### DIFF
--- a/modules/nodes-namespaced-nodelevel-sysctls.adoc
+++ b/modules/nodes-namespaced-nodelevel-sysctls.adoc
@@ -21,7 +21,11 @@ Additionally, most of the sysctls in the `net.*` group are known to be namespace
 Sysctls that are not namespaced are called _node-level_ and must be set
 manually by the cluster administrator, either by means of the underlying Linux
 distribution of the nodes, such as by modifying the `_/etc/sysctls.conf_` file,
-or by using a daemon set with privileged containers. You can use the Node Tuning Operator to set _node-level_ sysctls.
+or by using a daemon set with privileged containers. You can use the Node Tuning Operator to set _node-level_ sysctls. For more information, see "Node Tuning Operator."
+[NOTE]
+====
+This information can be found in the "Scalability and performance" section of the {product-title} documentation. Reference the sub-section titled "Using the Node Tuning Operator".
+==== 
 
 
 [NOTE]


### PR DESCRIPTION
Add hyperlink to the Node Tuning Operator documentation in nodes-namespaced-nodelevel-sysctls.adoc for easy access.

Version(s): 4.12+

Issue: [OCPBUGS-25817](https://issues.redhat.com/browse/OCPBUGS-25817) Hyperlink to the Node Tuning Operator in the doc is missing 

Link to docs preview: https://docs.openshift.com/container-platform/4.12/nodes/containers/nodes-containers-sysctls.html#namespaced-and-node-level-sysctls

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
