### PR TITLE
[OSDOCS-6455] Azure AD Workload ID for OLM Operators (CCO reference)

### DIFF
--- a/authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc
@@ -93,6 +93,16 @@ include::modules/cco-short-term-creds-format-azure.adoc[leveloffset=+2]
 //Azure component secret permissions requirements
 include::modules/cco-short-term-creds-component-permissions-azure.adoc[leveloffset=+2]
 
+//OLM-managed Operator support for authentication with Azure AD Workload Identity
+include::modules/cco-short-term-creds-azure-olm.adoc[leveloffset=+2]
+
+////
+// Azure will need a link off to OLM docs like AWS when ready.
+[role="_additional-resources"]
+.Additional resources
+* xref:../../operators/operator_sdk/osdk-token-auth.adoc#osdk-cco-aws-sts_osdk-token-auth[CCO-based workflow for OLM-managed Operators with AWS STS]
+////
+
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources

--- a/modules/cco-short-term-creds-azure-olm.adoc
+++ b/modules/cco-short-term-creds-azure-olm.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="cco-short-term-creds-azure-olm_{context}"]
+= OLM-managed Operator support for authentication with Azure AD Workload Identity
+
+In addition to {product-title} cluster components, some Operators managed by the Operator Lifecycle Manager (OLM) on Azure clusters can use manual mode with Azure AD Workload Identity. These Operators authenticate with short-term credentials that are managed outside the cluster. To determine if an Operator supports authentication with Azure AD Workload Identity, see the Operator description in OperatorHub.


### PR DESCRIPTION
Version(s):
4.15+

Issue:
[OSDOCS-6455](https://issues.redhat.com//browse/OSDOCS-6455)

Link to docs preview:
[OLM-managed Operator support for authentication with Azure AD Workload Identity](https://69663--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-short-term-creds#cco-short-term-creds-azure-olm_cco-short-term-creds)

QE review:
- [x] QE has approved this change.

Additional information:
Possible 4.14.z backport later