### PR TITLE
TRACING-3808: Add missing OTLP exporter to OTELcol config for span RED metrics

### DIFF
--- a/modules/distr-tracing-tempo-config-spanmetrics.adoc
+++ b/modules/distr-tracing-tempo-config-spanmetrics.adoc
@@ -43,8 +43,14 @@ spec:
     exporters:
       prometheus: # <4>
         endpoint: 0.0.0.0:8889
+        add_metric_suffixes: false
         resource_to_telemetry_conversion:
           enabled: true # by default resource attributes are dropped
+
+      otlp:
+        endpoint: "tempo-simplest-distributor:4317"
+        tls:
+          insecure: true
 
     service:
       pipelines:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.11, 4.12, 4.13, 4.14, 4.15

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/TRACING-3808

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://69673--ocpdocs-pr.netlify.app/openshift-enterprise/latest/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-configuring#opentelemetry-collector-configuration

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
