### PR TITLE
CNV- 36240: CDINoDefaultStorageClass added

### DIFF
--- a/modules/virt-runbook-cdinodefaultstorageclass.adoc
+++ b/modules/virt-runbook-cdinodefaultstorageclass.adoc
@@ -1,0 +1,74 @@
+// Do not edit this module. It is generated with a script.
+// Do not reuse this module. The anchor IDs do not contain a context statement.
+// Module included in the following assemblies:
+//
+// * virt/monitoring/virt-runbooks.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="virt-runbook-CDINoDefaultStorageClass"]
+= CDINoDefaultStorageClass
+
+[discrete]
+[id="meaning-cdinodefaultstorageclass"]
+== Meaning
+
+This alert fires when no default {product-title} or
+{VirtProductName} storage class is defined.
+
+[discrete]
+[id="impact-cdinodefaultstorageclass"]
+== Impact
+
+If no default {product-title} or {VirtProductName} storage
+class is defined, a data volume requesting a default storage class (the storage
+class is not specified), remains in a "pending" state.
+
+[discrete]
+[id="diagnosis-cdinodefaultstorageclass"]
+== Diagnosis
+
+. Check for a default {product-title} storage class by running
+the following command:
++
+[source,terminal]
+----
+$ oc get sc -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubevirt\.io/is-default-class=="true")].metadata.name}'
+----
+
+. Check for a default {VirtProductName} storage class by running
+the following command:
++
+[source,terminal]
+----
+$ oc get sc -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubevirt\.io/is-default-virt-class=="true")].metadata.name}'
+----
+
+[discrete]
+[id="mitigation-cdinodefaultstorageclass"]
+== Mitigation
+
+Create a default storage class for either {product-title} or
+{VirtProductName} or for both.
+
+A default {VirtProductName} storage class has precedence over a default
+{product-title} storage class for creating a virtual machine disk image.
+
+* Create a default {product-title} storage class by running
+the following command:
++
+[source,terminal]
+----
+$ oc patch storageclass <storage-class-name> -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+----
+
+* Create a default {VirtProductName} storage class by running
+the following command:
++
+[source,terminal]
+----
+$ oc patch storageclass <storage-class-name> -p '{"metadata": {"annotations":{"storageclass.kubevirt.io/is-default-virt-class":"true"}}}'
+----
+
+If you cannot resolve the issue, log in to the
+link:https://access.redhat.com[Customer Portal] and open a support case,
+attaching the artifacts gathered during the diagnosis procedure.

--- a/virt/monitoring/virt-runbooks.adoc
+++ b/virt/monitoring/virt-runbooks.adoc
@@ -19,6 +19,8 @@ include::modules/virt-runbook-cdidatavolumeunusualrestartcount.adoc[leveloffset=
 
 include::modules/virt-runbook-cdimultipledefaultvirtstorageclasses.adoc[leveloffset=+1]
 
+include::modules/virt-runbook-cdinodefaultstorageclass.adoc[leveloffset=+1]
+
 include::modules/virt-runbook-cdinotready.adoc[leveloffset=+1]
 
 include::modules/virt-runbook-cdioperatordown.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-36240](https://issues.redhat.com//browse/CNV-36240)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [CDINoDefaultStorageClass](https://69674--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-runbooks#virt-runbook-CDINoDefaultStorageClass)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
