### PR TITLE
OSDOCS#8721: Refactor of vSphere install reqs for IPI

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -469,6 +469,8 @@ Topics:
     Dir: ipi
     Distros: openshift-origin,openshift-enterprise
     Topics:
+    - Name: vSphere installation requirements
+      File: ipi-vsphere-installation-reqs
     - Name: Installing a cluster
       File: installing-vsphere-installer-provisioned
     - Name: Installing a cluster with customizations

--- a/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc
+++ b/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc
@@ -35,29 +35,6 @@ include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
-include::modules/installation-vsphere-infrastructure.adoc[leveloffset=+1]
-
-include::modules/installation-vsphere-installer-network-requirements.adoc[leveloffset=+1]
-
-include::modules/vmware-csi-driver-reqs.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* To remove a third-party vSphere CSI driver, see xref:../../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-install-issues_persistent-storage-csi-vsphere[Removing a third-party vSphere CSI Driver].
-* To update the hardware version for your vSphere nodes, see xref:../../../updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on nodes running in vSphere].
-
-include::modules/installation-vsphere-installer-infra-requirements.adoc[leveloffset=+1]
-
-include::modules/installation-vsphere-installer-infra-static-ip-nodes.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../../post_installation_configuration/node-tasks.html#nodes-vsphere-scaling-machines-static-ip_post-install-node-tasks[Scaling machines to use static IP addresses]
-* xref:../../../post_installation_configuration/node-tasks.html#nodes-vsphere-machine-set-scaling-static-ip_post-install-node-tasks[Using a machine set to scale machines with configured static IP addresses]
-
-
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-adding-vcenter-root-certificates.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.adoc
+++ b/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.adoc
@@ -28,25 +28,6 @@ Be sure to also review this site list if you are configuring a proxy.
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
-include::modules/installation-vsphere-infrastructure.adoc[leveloffset=+1]
-
-include::modules/installation-vsphere-installer-network-requirements.adoc[leveloffset=+1]
-
-include::modules/vmware-csi-driver-reqs.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* To remove a third-party vSphere CSI driver, see xref:../../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-install-issues_persistent-storage-csi-vsphere[Removing a third-party vSphere CSI Driver].
-* To update the hardware version for your vSphere nodes, see xref:../../../updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on nodes running in vSphere].
-
-include::modules/installation-vsphere-installer-infra-requirements.adoc[leveloffset=+1]
-
-include::modules/installation-vsphere-installer-infra-static-ip-nodes.adoc[leveloffset=+2]
-
-* xref:../../../post_installation_configuration/node-tasks.html#nodes-vsphere-scaling-machines-static-ip_post-install-node-tasks[Scaling machines to use static IP addresses]
-* xref:../../../post_installation_configuration/node-tasks.html#nodes-vsphere-machine-set-scaling-static-ip_post-install-node-tasks[Using a machine set to scale machines with configured static IP addresses]
-
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations.adoc
+++ b/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations.adoc
@@ -30,25 +30,6 @@ Be sure to also review this site list if you are configuring a proxy.
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
-include::modules/installation-vsphere-infrastructure.adoc[leveloffset=+1]
-
-include::modules/installation-vsphere-installer-network-requirements.adoc[leveloffset=+1]
-
-include::modules/vmware-csi-driver-reqs.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* To remove a third-party vSphere CSI driver, see xref:../../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-install-issues_persistent-storage-csi-vsphere[Removing a third-party vSphere CSI Driver].
-* To update the hardware version for your vSphere nodes, see xref:../../../updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on nodes running in vSphere].
-
-include::modules/installation-vsphere-installer-infra-requirements.adoc[leveloffset=+1]
-
-include::modules/installation-vsphere-installer-infra-static-ip-nodes.adoc[leveloffset=+2]
-
-* xref:../../../post_installation_configuration/node-tasks.html#nodes-vsphere-scaling-machines-static-ip_post-install-node-tasks[Scaling machines to use static IP addresses]
-* xref:../../../post_installation_configuration/node-tasks.html#nodes-vsphere-machine-set-scaling-static-ip_post-install-node-tasks[Using a machine set to scale machines with configured static IP addresses]
-
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned.adoc
+++ b/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned.adoc
@@ -28,25 +28,6 @@ Be sure to also review this site list if you are configuring a proxy.
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
-include::modules/installation-vsphere-infrastructure.adoc[leveloffset=+1]
-
-include::modules/installation-vsphere-installer-network-requirements.adoc[leveloffset=+1]
-
-include::modules/vmware-csi-driver-reqs.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* To remove a third-party vSphere CSI driver, see xref:../../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-install-issues_persistent-storage-csi-vsphere[Removing a third-party vSphere CSI Driver].
-* To update the hardware version for your vSphere nodes, see xref:../../../updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on nodes running in vSphere].
-
-include::modules/installation-vsphere-installer-infra-requirements.adoc[leveloffset=+1]
-
-include::modules/installation-vsphere-installer-infra-static-ip-nodes.adoc[leveloffset=+2]
-
-* xref:../../../post_installation_configuration/node-tasks.html#nodes-vsphere-scaling-machines-static-ip_post-install-node-tasks[Scaling machines to use static IP addresses]
-* xref:../../../post_installation_configuration/node-tasks.html#nodes-vsphere-machine-set-scaling-static-ip_post-install-node-tasks[Using a machine set to scale machines with configured static IP addresses]
-
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.adoc
+++ b/installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.adoc
@@ -1,0 +1,28 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="ipi-vsphere-installation-reqs"]
+= vSphere installation requirements
+include::_attributes/common-attributes.adoc[]
+:context: ipi-vsphere-installation-reqs
+
+toc::[]
+
+Before you begin an installation using installer-provisioned infrastructure, be sure that your vSphere environment meets the following installation requirements.
+
+include::modules/installation-vsphere-infrastructure.adoc[leveloffset=+1]
+include::modules/installation-vsphere-installer-network-requirements.adoc[leveloffset=+1]
+include::modules/vmware-csi-driver-reqs.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* To remove a third-party vSphere CSI driver, see xref:../../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-install-issues_persistent-storage-csi-vsphere[Removing a third-party vSphere CSI Driver].
+* To update the hardware version for your vSphere nodes, see xref:../../../updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on nodes running in vSphere].
+
+include::modules/installation-vsphere-installer-infra-requirements.adoc[leveloffset=+1]
+include::modules/installation-vsphere-installer-infra-static-ip-nodes.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../post_installation_configuration/node-tasks.html#nodes-vsphere-scaling-machines-static-ip_post-install-node-tasks[Scaling machines to use static IP addresses]
+* xref:../../../post_installation_configuration/node-tasks.html#nodes-vsphere-machine-set-scaling-static-ip_post-install-node-tasks[Using a machine set to scale machines with configured static IP addresses]

--- a/installing/installing_vsphere/preparing-to-install-on-vsphere.adoc
+++ b/installing/installing_vsphere/preparing-to-install-on-vsphere.adoc
@@ -57,15 +57,6 @@ User-provisioned infrastructure requires the user to provision all resources req
 
 * **xref:../../installing/installing_vsphere/upi/installing-restricted-networks-vsphere.adoc#installing-restricted-networks-vsphere[Installing a cluster on vSphere in a restricted network with user-provisioned infrastructure]**: {product-title} can be installed on VMware vSphere infrastructure that you provision in a restricted network.
 
-include::modules/installation-vsphere-infrastructure.adoc[leveloffset=+1]
-
-include::modules/vmware-csi-driver-reqs.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* To remove a third-party vSphere CSI driver, see xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-install-issues_persistent-storage-csi-vsphere[Removing a third-party vSphere CSI Driver].
-
 == Configuring the vSphere connection settings
 
 * **xref:../../installing/installing_vsphere/installing-vsphere-post-installation-configuration.adoc#installing-vsphere-post-installation-configuration[Updating the vSphere connection settings following an installation]**: For installations on vSphere using the Assisted Installer, you must manually update the vSphere connection settings to complete the installation. For installer-provisioned or user-provisioned infrastructure installations on vSphere, you can optionally validate or modify the vSphere connection settings at any time.

--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -1,12 +1,9 @@
 // Module included in the following assemblies:
 //
+// * installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.adoc
 // * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
 // * installing/installing_vsphere/installing-vsphere.adoc
 // * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
-// * installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
 
 [id="installation-vsphere-infrastructure_{context}"]
 = VMware vSphere infrastructure requirements

--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -1,16 +1,9 @@
 // Module included in the following assemblies for vSphere:
 //
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+// * installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.adoc
 // * installing/installing_vsphere/installing-vsphere.adoc
 // * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
-// * installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
 // * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
-
-ifeval::["{context}" == "installing-restricted-networks-installer-provisioned-vsphere"]
-:restricted:
-endif::[]
 
 ifeval::["{context}" == "installing-vsphere"]
 :vsphere:
@@ -446,9 +439,9 @@ Configure the default gateway to use the DHCP server. All nodes must be in the s
 
 You must use the Dynamic Host Configuration Protocol (DHCP) for the network and ensure that the DHCP server is configured to provide persistent IP addresses to the cluster machines. In the DHCP lease, you must configure the DHCP to use the default gateway. All nodes must be in the same VLAN. You cannot scale the cluster using a second VLAN as a Day 2 operation.
 
-ifdef::restricted[]
-The VM in your restricted network must have access to vCenter so that it can provision and manage nodes, persistent volume claims (PVCs), and other resources.
-endif::restricted[]
+
+If you are installing to a restricted environment, the VM in your restricted network must have access to vCenter so that it can provision and manage nodes, persistent volume claims (PVCs), and other resources.
+
 Additionally, you must create the following networking resources before you install the {product-title} cluster:
 
 [NOTE]
@@ -494,10 +487,6 @@ machines that run the Ingress router pods, which are the worker nodes by
 default. This record must be resolvable by both clients external to the cluster
 and from all the nodes within the cluster.
 |===
-
-ifeval::["{context}" == "installing-restricted-networks-installer-provisioned-vsphere"]
-:!restricted:
-endif::[]
 
 ifeval::["{context}" == "installing-vsphere"]
 :!vsphere:

--- a/modules/installation-vsphere-installer-infra-static-ip-nodes.adoc
+++ b/modules/installation-vsphere-installer-infra-static-ip-nodes.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.adoc
+
 :_mod-docs-content-type: CONCEPT
 [discrete]
 [id="installation-vsphere-installer-infra-static-ip-nodes_{context}"]

--- a/modules/installation-vsphere-installer-network-requirements.adoc
+++ b/modules/installation-vsphere-installer-network-requirements.adoc
@@ -1,8 +1,6 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+// * installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="installation-vsphere-installer-network-requirements_{context}"]

--- a/modules/vmware-csi-driver-reqs.adoc
+++ b/modules/vmware-csi-driver-reqs.adoc
@@ -1,13 +1,9 @@
 // Module included in the following assemblies:
 //
+// * installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.adoc
 // * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
 // * installing/installing_vsphere/installing-vsphere.adoc
 // * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
-// * installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
-// * installing/installing_vsphere/preparing-to-install-on-vsphere.adoc
 // * storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
 
 :_mod-docs-content-type: CONCEPT

--- a/post_installation_configuration/node-tasks.adoc
+++ b/post_installation_configuration/node-tasks.adoc
@@ -167,7 +167,7 @@ After you deployed your cluster to run nodes with static IP addresses, you can s
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned.adoc#installation-vsphere-installer-infra-requirements_installing-vsphere-installer-provisioned[Static IP addresses for vSphere nodes]
+* xref:../installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.adoc#installation-vsphere-installer-infra-requirements_ipi-vsphere-installation-reqs[Static IP addresses for vSphere nodes]
 
 // Scaling machines to use static IP addresses
 include::modules/nodes-vsphere-scaling-machines-static-ip.adoc[leveloffset=+2]

--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.adoc
@@ -28,7 +28,7 @@ include::modules/creating-the-vsphere-windows-vm-golden-image.adoc[leveloffset=+
 ==== Additional resources
 
 * xref:../../windows_containers/enabling-windows-container-workloads.adoc#configuring-secret-for-wmco_enabling-windows-container-workloads[Configuring a secret for the Windows Machine Config Operator]
-* xref:../../installing/installing_vsphere/preparing-to-install-on-vsphere.adoc#installation-vsphere-infrastructure_preparing-to-install-on-vsphere[VMware vSphere infrastructure requirements]
+* xref:../../installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.adoc#installation-vsphere-infrastructure_ipi-vsphere-installation-reqs[VMware vSphere infrastructure requirements]
 
 include::modules/enabling-internal-api-server-vsphere.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.15+

Issue:

This PR addresses [osdocs-8721](https://issues.redhat.com/browse/OSDOCS-8721) and implements refactored vSphere installation requirements for an IPI installation, which is detailed in this Miro [board](https://miro.com/app/board/uXjVNbUhuKQ=/). This refactor has been approved by Stephanie Stout (CS) and Ju Lim (Senior Manager, Product Management).

Link to docs preview:

[vSphere installation requirements](https://69675--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs)

QE review:
[N/A] QE has approved this change.
QE approval is not required for this change. This PR represents a refactor of existing content.
