### PR TITLE
OCPBUGS-25807: Add note to clarify node delete process

### DIFF
--- a/modules/nodes-nodes-working-deleting.adoc
+++ b/modules/nodes-nodes-working-deleting.adoc
@@ -6,60 +6,59 @@
 [id="nodes-nodes-working-deleting_{context}"]
 = Deleting nodes from a cluster
 
-When you delete a node using the CLI, the node object is deleted in Kubernetes,
-but the pods that exist on the node are not deleted. Any bare pods not
-backed by a replication controller become inaccessible to {product-title}.
-Pods backed by replication controllers are rescheduled to other available
-nodes. You must delete local manifest pods.
+To delete a node from the {product-title} cluster, scale down the appropriate `MachineSet` object.
 
-.Procedure
+[IMPORTANT]
+====
+When a cluster is integrated with a cloud provider, you must delete the corresponding machine to delete a node. Do not try to use the `oc delete node` command for this task.
+====
 
-To delete a node from the {product-title} cluster, edit the appropriate `MachineSet` object:
+When you delete a node by using the CLI, the node object is deleted in Kubernetes, but the pods that exist on the node are not deleted. Any bare pods that are not backed by a replication controller become inaccessible to {product-title}. Pods backed by replication controllers are rescheduled to other available nodes. You must delete local manifest pods.
 
 [NOTE]
 ====
-If you are running cluster on bare metal, you cannot delete a node by editing
-`MachineSet` objects. Compute machine sets are only available when a cluster is integrated with a cloud provider. Instead you must unschedule and drain the node before manually
-deleting it.
+If you are running cluster on bare metal, you cannot delete a node by editing `MachineSet` objects. Compute machine sets are only available when a cluster is integrated with a cloud provider. Instead you must unschedule and drain the node before manually deleting it.
 ====
 
-. View the compute machine sets that are in the cluster:
+.Procedure
+
+. View the compute machine sets that are in the cluster by running the following command:
 +
 [source,terminal]
 ----
 $ oc get machinesets -n openshift-machine-api
 ----
 +
-The compute machine sets are listed in the form of <clusterid>-worker-<aws-region-az>.
+The compute machine sets are listed in the form of `<cluster-id>-worker-<aws-region-az>`.
 
-. Scale the compute machine set:
+. Scale down the compute machine set by using one of the following methods:
+
+** Specify the number of replicas to scale down to by running the following command:
 +
 [source,terminal]
 ----
-$ oc scale --replicas=2 machineset <machineset> -n openshift-machine-api
+$ oc scale --replicas=2 machineset <machine-set-name> -n openshift-machine-api
 ----
-+
-Or:
+
+** Edit the compute machine set custom resource by running the following command:
 +
 [source,terminal]
 ----
-$ oc edit machineset <machineset> -n openshift-machine-api
+$ oc edit machineset <machine-set-name> -n openshift-machine-api
 ----
 +
-[TIP]
-====
-You can alternatively apply the following YAML to scale the compute machine set:
-
+.Example output
 [source,yaml]
 ----
 apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
-  name: <machineset>
+  # ...
+  name: <machine-set-name>
   namespace: openshift-machine-api
+  # ...
 spec:
-  replicas: 2
-#...
+  replicas: 2 # <1>
+  # ...
 ----
-====
-
+<1> Specify the number of replicas to scale down to.

--- a/nodes/nodes/nodes-nodes-working.adoc
+++ b/nodes/nodes/nodes-nodes-working.adoc
@@ -33,7 +33,6 @@ include::modules/nodes-nodes-working-deleting.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* For more information on scaling your cluster using a MachineSet,
-see xref:../../machine_management/manually-scaling-machineset.adoc#machineset-manually-scaling-manually-scaling-machineset[Manually scaling a MachineSet].
+* xref:../../machine_management/manually-scaling-machineset.adoc#machineset-manually-scaling-manually-scaling-machineset[Manually scaling a compute machine set]
 
 include::modules/nodes-nodes-working-deleting-bare-metal.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-25807](https://issues.redhat.com/browse/OCPBUGS-25807)

Link to docs preview:
[Deleting nodes from a cluster](https://69678--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-working.html#nodes-nodes-working-deleting_nodes-nodes-working)

QE review:
- [x] QE has approved this change.

Additional information:
Also updated the module to better align with current OCP docs practices