### PR TITLE
Updating imageSpec in Deploying the NUMA-aware secondary pod scheduler

### DIFF
--- a/modules/cnf-deploying-the-numa-aware-scheduler.adoc
+++ b/modules/cnf-deploying-the-numa-aware-scheduler.adoc
@@ -8,7 +8,7 @@
 
 After you install the NUMA Resources Operator, do the following to deploy the NUMA-aware secondary pod scheduler:
 
-* Configure the performance profile. 
+* Configure the performance profile.
 
 * Deploy the NUMA-aware secondary scheduler.
 
@@ -36,8 +36,8 @@ metadata:
   name: perfprof-nrop
 spec:
   cpu: <1>
-    isolated: "4-51,56-103" 
-    reserved: "0,1,2,3,52,53,54,55" 
+    isolated: "4-51,56-103"
+    reserved: "0,1,2,3,52,53,54,55"
   nodeSelector:
     node-role.kubernetes.io/worker: ""
   numa:
@@ -69,8 +69,8 @@ kind: NUMAResourcesScheduler
 metadata:
   name: numaresourcesscheduler
 spec:
-  imageSpec: "registry.redhat.io/openshift4/noderesourcetopology-scheduler-container-rhel8:v{product-version}"
-  cacheResyncPeriod: "5s" <1> 
+  imageSpec: "registry.redhat.io/openshift4/noderesourcetopology-scheduler-rhel9:v{product-version}"
+  cacheResyncPeriod: "5s" <1>
 ----
 <1> Enter an interval value in seconds for synchronization of the scheduler cache. A value of `5s` is typical for most implementations.
 +


### PR DESCRIPTION
[OCPBUGS-25811]: Error in https://docs.openshift.com/container-platform/4.14//scalability_and_performance/cnf-numa-aware-scheduling.html

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-25811
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://69679--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-numa-aware-scheduling.html#cnf-deploying-the-numa-aware-scheduler_numa-aware
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
