### PR TITLE
[gitops-docs-1.11] Removed GitOps v 1.8 from the docs as it has reached EOL.

### DIFF
--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -2,7 +2,7 @@
 //
 // * release_notes/gitops-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="GitOps-compatibility-support-matrix_{context}"]
 = Compatibility and support matrix
 
@@ -29,8 +29,6 @@ In {OCP} 4.13, the `stable` channel has been removed. Before upgrading to {OCP} 
 |1.10.0 |0.0.50 TP |3.12.1 GA |5.1.0 GA |2.8.3 GA |1.5.0 TP |NA |2.35.1 GA |7.5.1 GA |4.12-4.14
 
 |1.9.0    |0.0.49 TP |3.11.2 GA|5.0.1 GA   |2.7.2 GA |1.5.0 TP |NA     |2.35.1 GA |7.5.1 GA |4.12-4.14
-
-|1.8.0    |0.0.47 TP |3.10.0 GA|4.5.7 GA   |2.6.3 GA |NA     |NA     |2.35.1 GA |7.5.1 GA |4.10-4.13
 |===
 
 * `kam` is the {gitops-title} Application Manager command-line interface (CLI).

--- a/release_notes/gitops-release-notes.adoc
+++ b/release_notes/gitops-release-notes.adoc
@@ -1,5 +1,5 @@
 //OpenShift GitOps Release Notes
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="gitops-release-notes"]
 = {gitops-title} release notes
@@ -40,22 +40,3 @@ include::modules/gitops-release-notes-1-9-0.adoc[leveloffset=+1]
 .Additional resources
 * link:https://docs.openshift.com/container-platform/latest/operators/admin/olm-configuring-proxy-support.html#olm-inject-custom-ca_olm-configuring-proxy-support[Injecting a custom CA certificate]
 
-include::modules/gitops-release-notes-1-8-5.adoc[leveloffset=+1]
-
-include::modules/gitops-release-notes-1-8-4.adoc[leveloffset=+1]
-
-include::modules/gitops-release-notes-1-8-3.adoc[leveloffset=+1]
-
-include::modules/gitops-release-notes-1-8-2.adoc[leveloffset=+1]
-
-include::modules/gitops-release-notes-1-8-1.adoc[leveloffset=+1]
-
-include::modules/gitops-release-notes-1-8-0.adoc[leveloffset=+1]
-
-include::modules/gitops-release-notes-1-7-4.adoc[leveloffset=+1]
-
-include::modules/gitops-release-notes-1-7-3.adoc[leveloffset=+1]
-
-include::modules/gitops-release-notes-1-7-1.adoc[leveloffset=+1]
-
-include::modules/gitops-release-notes-1-7-0.adoc[leveloffset=+1]


### PR DESCRIPTION
**Conflict in**: release_notes/gitops-release-notes.adoc
**Manual cherry-pick of  [PR-69238](https://github.com/openshift/openshift-docs/pull/69238) to gitops-docs-1.11 branch**
