### PR TITLE
Virtualization docs fixes during ROSA review 2

### DIFF
--- a/modules/oadp-creating-backup-hooks.adoc
+++ b/modules/oadp-creating-backup-hooks.adoc
@@ -29,7 +29,7 @@ spec:
         - <namespace> <1>
         excludedNamespaces: <2>
         - <namespace>
-        includedResources: []
+        includedResources:
         - pods <3>
         excludedResources: [] <4>
         labelSelector: <5>

--- a/modules/oadp-installing-dpa-1-2-and-earlier.adoc
+++ b/modules/oadp-installing-dpa-1-2-and-earlier.adoc
@@ -345,7 +345,7 @@ endif::[]
 . Click *Create*.
 
 [id="verifying-oadp-installation-1-2_{context}"]
-== Verifying the installation
+.Verification
 
 . Verify the installation by viewing the {oadp-first} resources by running the following command:
 +
@@ -400,9 +400,9 @@ $ oc get dpa dpa-sample -n openshift-adp -o jsonpath='{.status}'
 ----
 $ oc get backupStorageLocation -n openshift-adp
 ----
-.Example output
-[source,yaml]
 +
+.Example output
+[source,terminal]
 ----
 NAME           PHASE       LAST VALIDATED   AGE     DEFAULT
 dpa-sample-1   Available   1s               3d16h   true

--- a/modules/oadp-installing-dpa-1-3.adoc
+++ b/modules/oadp-installing-dpa-1-3.adoc
@@ -359,10 +359,9 @@ endif::[]
 
 . Click *Create*.
 
-[id="verifying-oadp-installation-1-3_{context}"]
-== Verifying the installation
+.Verification
 
-. . Verify the installation by viewing the {oadp-first} resources by running the following command:
+. Verify the installation by viewing the {oadp-first} resources by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/oadp-self-signed-certificate.adoc
+++ b/modules/oadp-self-signed-certificate.adoc
@@ -23,7 +23,7 @@ kind: DataProtectionApplication
 metadata:
   name: <dpa_sample>
 spec:
-...
+# ...
   backupLocations:
     - name: default
       velero:
@@ -35,7 +35,7 @@ spec:
           caCert: <base64_encoded_cert_string> <1>
         config:
           insecureSkipTLSVerify: "false" <2>
-...
+# ...
 ----
 <1> Specify the Base64-encoded CA certificate string.
 <2> The `insecureSkipTLSVerify` configuration can be set to either `"true"` or `"false"`. If set to `"true"`, SSL/TLS security is disabled. If set to `"false"`, SSL/TLS security is enabled.

--- a/modules/oadp-setting-resource-limits-and-requests.adoc
+++ b/modules/oadp-setting-resource-limits-and-requests.adoc
@@ -24,7 +24,7 @@ kind: DataProtectionApplication
 metadata:
   name: <dpa_sample>
 spec:
-...
+# ...
   configuration:
     velero:
       podConfig:

--- a/modules/virt-adding-key-creating-vm-template.adoc
+++ b/modules/virt-adding-key-creating-vm-template.adoc
@@ -65,7 +65,7 @@ endif::[]
 The *VirtualMachine details* page displays the progress of the VM creation.
 
 .Verification
-. Click the *Scripts* tab on the *Configuration* tab.
+* Click the *Scripts* tab on the *Configuration* tab.
 +
 The secret name is displayed in the *Authorized SSH key* section.
 

--- a/modules/virt-adding-public-key-cli.adoc
+++ b/modules/virt-adding-public-key-cli.adoc
@@ -156,7 +156,7 @@ $ virtctl start vm example-vm
 ----
 
 .Verification
-. Get the VM configuration:
+* Get the VM configuration:
 +
 [source,terminal]
 ----

--- a/modules/virt-creating-vm-snapshot-cli.adoc
+++ b/modules/virt-creating-vm-snapshot-cli.adoc
@@ -20,7 +20,7 @@ You can create a virtual machine (VM) snapshot for an offline or online VM by cr
 +
 [source,yaml]
 ----
-apiVersion: snapshot.kubevirt.io/v1beta1
+apiVersion: snapshot.kubevirt.io/v1alpha1
 kind: VirtualMachineSnapshot
 metadata:
   name: <snapshot_name>
@@ -76,7 +76,7 @@ $ oc describe vmsnapshot <snapshot_name>
 .Example output
 [source,yaml]
 ----
-apiVersion: snapshot.kubevirt.io/v1beta1
+apiVersion: snapshot.kubevirt.io/v1alpha1
 kind: VirtualMachineSnapshot
 metadata:
   creationTimestamp: "2020-09-30T14:41:51Z"
@@ -86,7 +86,7 @@ metadata:
   name: mysnap
   namespace: default
   resourceVersion: "3897"
-  selfLink: /apis/snapshot.kubevirt.io/v1beta1/namespaces/default/virtualmachinesnapshots/my-vmsnapshot
+  selfLink: /apis/snapshot.kubevirt.io/v1alpha1/namespaces/default/virtualmachinesnapshots/my-vmsnapshot
   uid: 28eedf08-5d6a-42c1-969c-2eda58e2a78d
 spec:
   source:

--- a/modules/virt-define-guest-agent-ping-probe.adoc
+++ b/modules/virt-define-guest-agent-ping-probe.adoc
@@ -24,15 +24,23 @@ include::snippets/technology-preview.adoc[]
 .Sample guest agent ping probe
 [source,yaml]
 ----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  annotations:
+  name: fedora-vm
+  namespace: example-namespace
 # ...
 spec:
-  readinessProbe:
-    guestAgentPing: {} <1>
-    initialDelaySeconds: 120 <2>
-    periodSeconds: 20 <3>
-    timeoutSeconds: 10 <4>
-    failureThreshold: 3 <5>
-    successThreshold: 3 <6>
+  template:
+    spec:
+      readinessProbe:
+        guestAgentPing: {} <1>
+        initialDelaySeconds: 120 <2>
+        periodSeconds: 20 <3>
+        timeoutSeconds: 10 <4>
+        failureThreshold: 3 <5>
+        successThreshold: 3 <6>
 # ...
 ----
 <1> The guest agent ping probe to connect to the VM.

--- a/modules/virt-define-http-liveness-probe.adoc
+++ b/modules/virt-define-http-liveness-probe.adoc
@@ -18,18 +18,26 @@ Define an HTTP liveness probe by setting the `spec.livenessProbe.httpGet` field 
 .Sample liveness probe with an HTTP GET test
 [source,yaml]
 ----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  annotations:
+  name: fedora-vm
+  namespace: example-namespace
 # ...
 spec:
-  livenessProbe:
-    initialDelaySeconds: 120 <1>
-    periodSeconds: 20 <2>
-    httpGet: <3>
-      port: 1500 <4>
-      path: /healthz <5>
-      httpHeaders:
-      - name: Custom-Header
-        value: Awesome
-    timeoutSeconds: 10 <6>
+  template:
+    spec:
+      livenessProbe:
+        initialDelaySeconds: 120 <1>
+        periodSeconds: 20 <2>
+        httpGet: <3>
+          port: 1500 <4>
+          path: /healthz <5>
+          httpHeaders:
+          - name: Custom-Header
+            value: Awesome
+        timeoutSeconds: 10 <6>
 # ...
 ----
 <1> The time, in seconds, after the VM starts before the liveness probe is initiated.

--- a/modules/virt-define-http-readiness-probe.adoc
+++ b/modules/virt-define-http-readiness-probe.adoc
@@ -17,20 +17,28 @@ Define an HTTP readiness probe by setting the `spec.readinessProbe.httpGet` fiel
 .Sample readiness probe with an HTTP GET test
 [source,yaml]
 ----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  annotations:
+  name: fedora-vm
+  namespace: example-namespace
 # ...
 spec:
-  readinessProbe:
-    httpGet: <1>
-      port: 1500 <2>
-      path: /healthz <3>
-      httpHeaders:
-      - name: Custom-Header
-        value: Awesome
-    initialDelaySeconds: 120 <4>
-    periodSeconds: 20 <5>
-    timeoutSeconds: 10 <6>
-    failureThreshold: 3 <7>
-    successThreshold: 3 <8>
+  template:
+    spec:
+      readinessProbe:
+        httpGet: <1>
+          port: 1500 <2>
+          path: /healthz <3>
+          httpHeaders:
+          - name: Custom-Header
+            value: Awesome
+        initialDelaySeconds: 120 <4>
+        periodSeconds: 20 <5>
+        timeoutSeconds: 10 <6>
+        failureThreshold: 3 <7>
+        successThreshold: 3 <8>
 # ...
 ----
 <1> The HTTP GET request to perform to connect to the VM.

--- a/modules/virt-define-tcp-readiness-probe.adoc
+++ b/modules/virt-define-tcp-readiness-probe.adoc
@@ -18,14 +18,22 @@ Define a TCP readiness probe by setting the `spec.readinessProbe.tcpSocket` fiel
 .Sample readiness probe with a TCP socket test
 [source,yaml]
 ----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  annotations:
+  name: fedora-vm
+  namespace: example-namespace
 # ...
 spec:
-  readinessProbe:
-    initialDelaySeconds: 120 <1>
-    periodSeconds: 20 <2>
-    tcpSocket: <3>
-      port: 1500 <4>
-    timeoutSeconds: 10 <5>
+  template:
+    spec:
+      readinessProbe:
+        initialDelaySeconds: 120 <1>
+        periodSeconds: 20 <2>
+        tcpSocket: <3>
+          port: 1500 <4>
+        timeoutSeconds: 10 <5>
 # ...
 ----
 <1> The time, in seconds, after the VM starts before the readiness probe is initiated.

--- a/modules/virt-pxe-booting-with-mac-address.adoc
+++ b/modules/virt-pxe-booting-with-mac-address.adoc
@@ -115,7 +115,7 @@ networks:
 ----
 $ oc create -f vmi-pxe-boot.yaml
 ----
-
++
 .Example output
 [source,terminal]
 ----
@@ -153,7 +153,7 @@ In this case, we used `eth1` for the PXE boot, without an IP address. The other 
 ----
 $ ip addr
 ----
-
++
 .Example output
 [source,terminal]
 ----
@@ -161,3 +161,4 @@ $ ip addr
 3. eth1: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
    link/ether de:00:00:00:00:de brd ff:ff:ff:ff:ff:ff
 ----
+

--- a/modules/virt-restarting-vm-web.adoc
+++ b/modules/virt-restarting-vm-web.adoc
@@ -23,7 +23,7 @@ To avoid errors, do not restart a virtual machine while it has a status of *Impo
 
 * To stay on this page, where you can perform actions on multiple virtual machines:
 
-.. Click the Options menu {kebab} located at the far right end of the row.
+.. Click the Options menu {kebab} located at the far right end of the row and click *Restart*.
 
 * To view comprehensive information about the selected virtual machine before
 you restart it:

--- a/modules/virt-restoring-vm-from-snapshot-cli.adoc
+++ b/modules/virt-restoring-vm-from-snapshot-cli.adoc
@@ -51,7 +51,7 @@ $ oc get vmrestore <vm_restore>
 .Example output
 [source, yaml]
 ----
-apiVersion: snapshot.kubevirt.io/v1beta1
+apiVersion: snapshot.kubevirt.io/v1alpha1
 kind: VirtualMachineRestore
 metadata:
 creationTimestamp: "2020-09-30T14:46:27Z"
@@ -66,7 +66,7 @@ ownerReferences:
   name: my-vm
   uid: 355897f3-73a0-4ec4-83d3-3c2df9486f4f
   resourceVersion: "5512"
-  selfLink: /apis/snapshot.kubevirt.io/v1beta1/namespaces/default/virtualmachinerestores/my-vmrestore
+  selfLink: /apis/snapshot.kubevirt.io/v1alpha1/namespaces/default/virtualmachinerestores/my-vmrestore
   uid: 71c679a8-136e-46b0-b9b5-f57175a6a041
   spec:
     target:

--- a/modules/virt-runbook-cdistorageprofilesincomplete.adoc
+++ b/modules/virt-runbook-cdistorageprofilesincomplete.adoc
@@ -45,9 +45,7 @@ example:
 +
 [source,terminal]
 ----
-$ oc patch storageprofile local --type=merge -p '{"spec": \
-  {"claimPropertySets": [{"accessModes": ["ReadWriteOnce"], \
-  "volumeMode": "Filesystem"}]}}'
+$ oc patch storageprofile <storage_class> --type=merge -p '{"spec": {"claimPropertySets": [{"accessModes": ["ReadWriteOnce"], "volumeMode": "Filesystem"}]}}'
 ----
 
 If you cannot resolve the issue, log in to the

--- a/modules/virt-temporary-token-VNC.adoc
+++ b/modules/virt-temporary-token-VNC.adoc
@@ -24,7 +24,6 @@ Kubernetes also supports authentication using client certificates, instead of a 
 [source,terminal,subs="attributes+"]
 ----
 $ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} --type json -p '[{"op": "replace", "path": "/spec/featureGates/deployVmConsoleProxy", "value": true}]'
-# ...
 ----
 
 . Generate a token by running the following command:

--- a/modules/virt-verifying-online-snapshot-creation-with-snapshot-indications.adoc
+++ b/modules/virt-verifying-online-snapshot-creation-with-snapshot-indications.adoc
@@ -14,10 +14,11 @@ Snapshot indications are contextual information about online virtual machine (VM
 
 .Procedure
 
-. Display the output from the snapshot indications by doing one of the following:
-* For snapshots created by using the command line, view indicator output in the `status` stanza of the `VirtualMachineSnapshot` object YAML.
-* For snapshots created by using the web console, click *VirtualMachineSnapshot* -> *Status* in the *Snapshot details* screen.
+. Display the output from the snapshot indications by performing one of the following actions:
+* Use the command line to view indicator output in the `status` stanza of the `VirtualMachineSnapshot` object YAML.
+* In the web console, click *VirtualMachineSnapshot* -> *Status* in the *Snapshot details* screen.
 
-. Verify the status of your online VM snapshot:
+. Verify the status of your online VM snapshot by viewing the values of the `status.indications` parameter:
 * `Online` indicates that the VM was running during online snapshot creation.
+* `GuestAgent` indicates that the QEMU guest agent was running during online snapshot creation.
 * `NoGuestAgent` indicates that the QEMU guest agent was not running during online snapshot creation. The QEMU guest agent could not be used to freeze and thaw the file system, either because the QEMU guest agent was not installed or running or due to another error.

--- a/modules/virt-vm-custom-scheduler.adoc
+++ b/modules/virt-vm-custom-scheduler.adoc
@@ -38,7 +38,9 @@ spec:
 
 
 .Verification
+
 * Verify that the VM is using the custom scheduler specified in the `VirtualMachine` manifest by checking the `virt-launcher` pod events:
+
 .. View the list of pods in your cluster by entering the following command:
 +
 [source,terminal]


### PR DESCRIPTION
Fixing various errors in the Applications docs as I find them during the ROSA content port. Mostly formatting, wording, and such.

Previews:
[Creating backup hooks](https://69687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-hooks-doc) -- Removed stray `[]` from code example.
[Installing the Data Protection Application 1.2 and earlier](https://69687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws#oadp-installing-dpa-1-2-and-earlier_installing-oadp-aws) -- Changed the verification header type.
[Installing the Data Protection Application 1.3](https://69687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws#oadp-installing-dpa-1-3_installing-oadp-aws) -- Changed the verification header type.
[Enabling self-signed CA certificates](https://69687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-installing-configuring-oadp#oadp-self-signed-certificate_virt-installing-configuring-oadp) -- Changed `...` to `# ...`
[Setting Velero CPU and memory resource allocations](https://69687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-installing-configuring-oadp#oadp-setting-resource-limits-and-requests_virt-installing-configuring-oadp) -- Changed `...` to `# ...`
[Adding a key when creating a VM from a template](https://65125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-accessing-vm-ssh#virt-adding-key-creating-vm-template_static-key) -- Changed single step Verification to a bullet
[Adding a key when creating a VM by using the command line](https://65125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-accessing-vm-ssh#virt-adding-public-key-cli_static-key) -- Changed single step Verification to a bullet
[Enabling dynamic key injection when creating a VM from a template](https://69687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-accessing-vm-ssh#virt-adding-key-creating-vm-template_dynamic-key) -- Changed single step Verification to a bullet
[Enabling dynamic key injection by using the command line](https://65125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-accessing-vm-ssh#virt-adding-public-key-cli_dynamic-key) -- Changed single step Verification to a bullet
[Creating a snapshot by using the command line](https://69687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-backup-restore-snapshots#virt-creating-vm-snapshot-cli_virt-backup-restore-snapshots) -- s/v1alpha1/v1alpha1   [ ] QE has approved this change.
[Defining a guest agent ping probe](https://69687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-monitoring-vm-health#virt-define-guest-agent-ping-probe_virt-monitoring-vm-health) -- Added code example metadata and fixed YAML spacing.
[Defining an HTTP liveness probe](https://69687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-monitoring-vm-health#virt-define-http-liveness-probe_virt-monitoring-vm-health) -- Added code example metadata and fixed YAML spacing.
[Defining an HTTP readiness probe](https://69687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-monitoring-vm-health#virt-define-http-readiness-probe_virt-monitoring-vm-health) -- Added code example metadata and fixed YAML spacing.
[Defining a TCP readiness probe](https://69687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-monitoring-vm-health#virt-define-tcp-readiness-probe_virt-monitoring-vm-health) -- Added code example metadata and fixed YAML spacing.
[PXE booting with a specified MAC address](https://69687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-configuring-pxe-booting#virt-pxe-booting-with-mac-address_pxe-booting) -- Fix formatting in Step 4. [Current docs](https://docs.openshift.com/container-platform/4.15/virt/virtual_machines/advanced_vm_management/virt-configuring-pxe-booting.html#virt-pxe-booting-with-mac-address_pxe-booting)
[Restoring a VM from a snapshot by using the command line](https://69687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-backup-restore-snapshots#virt-restoring-vm-from-snapshot-cli_virt-backup-restore-snapshots) -- s/v1alpha1/v1alpha1   [ ] QE has approved this change.
[CDIStorageProfilesIncomplete -> Mitigation](https://69687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-runbooks#virt-runbook-CDIStorageProfilesIncomplete) -- Switched specific object name in code example to generic, in order to match the previous command.
[Generating a temporary token for the VNC console](https://69687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-accessing-vm-consoles#virt-temporary-token-VNC_vnc-console) -- Removed a stray `# ...` from a command example. 
[Verifying online snapshots by using snapshot indications](https://69687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-backup-restore-snapshots#virt-verifying-online-snapshot-creation-with-snapshot-indications_virt-backup-restore-snapshots) -- Changed sub-bullets in step 1. It doesn't matter how the snapshots were created. [Current docs](https://docs.openshift.com/container-platform/4.14/virt/backup_restore/virt-backup-restore-snapshots.html#virt-verifying-online-snapshot-creation-with-snapshot-indications_virt-backup-restore-snapshots).  
[Scheduling virtual machines with a custom scheduler](https://69687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-schedule-vms#virt-vm-custom-scheduler_virt-schedule-vms) -- Changed formatting to Verification to avoid an odd a numbered substep under a bullet. [Current docs](https://docs.openshift.com/container-platform/4.15/virt/virtual_machines/advanced_vm_management/virt-schedule-vms.html#virt-vm-custom-scheduler_virt-schedule-vms).