### PR TITLE
RHDEVDOCS-5856: Add the round-robin cluster sharding algorithm and dy…

### DIFF
--- a/modules/gitops-release-notes-1-10-0.adoc
+++ b/modules/gitops-release-notes-1-10-0.adoc
@@ -72,8 +72,18 @@ You need to install the {gitops-title} Operator in the default `openshift-gitops
 ====
 
 * Before this update, there was no option for choosing an algorithm for distributing the destination clusters equally across the different application controller shards. Now, you can set the sharding algorithm to the `round-robin` parameter, which distributes clusters equally across the different application controller shards so that the synchronization load is spread equally among the shards. link:https://issues.redhat.com/browse/GITOPS-3288[GITOPS-3288]
++
+[IMPORTANT]
+====
+The `round-robin` sharding algorithm is a Technology Preview feature. 
+====
 
 * Before this update, there was no option for scaling the application controller replicas dynamically. Now, you can dynamically scale the number of application controllers based on the number of clusters managed by each application controller. link:https://issues.redhat.com/browse/GITOPS-3287[GITOPS-3287]
++
+[IMPORTANT]
+====
+Dynamic scaling of shards is a Technology Preview feature.
+====
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -46,6 +46,14 @@ The features mentioned in the following table are currently in Technology Previe
 |====
 |Feature |TP in {gitops-title} versions|GA in {gitops-title} versions
 
+|The `round-robin` cluster sharding algorithm
+|1.10.0
+|NA
+
+|Dynamic scaling of shards
+|1.10.0
+|NA
+
 |Argo Rollouts
 |1.9.0
 |NA


### PR DESCRIPTION
**Aligned team**: Dev Tools

**Version(s)**: CP to `gitops-docs-1.10`, `gitops-docs-1.11`

**Issue**: [RHDEVDOCS-5856](https://issues.redhat.com/browse/RHDEVDOCS-5856)

**Preview links**:
- [Technology Preview features](https://69691--docspreview.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes#GitOps-technology-preview_gitops-release-notes)
- [New features](https://69691--docspreview.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes#new-features-1-10-0_gitops-release-notes)

**Change Management**

- [x] ACK from Eng: @iam-veeramalla @jannfis 
- [x] ACK from PM: @harrietgrace 
- [x] ACK from Product experience: @RickJWagner 
- [x] ACK from QE: @varshab1210
- [x] ACK from CS: @Preeticp 
- [x]  **Peer review**: @kcarmichael08 

**Additional information**: 

- This issue adds the missing TP notices to the round-robin sharding algorithm and dynamic scaling of shards and also adds them to the TP feature table.
- Both the features went TP in 1.10 release.