### PR TITLE
OADP Datamover readthrough

### DIFF
--- a/modules/oadp-ceph-preparing-crs-additional.adoc
+++ b/modules/oadp-ceph-preparing-crs-additional.adoc
@@ -9,7 +9,7 @@
 After you redefine the default `StorageClass` and CephRBD `VolumeSnapshotClass` custom resources (CRs), you must create the following CRs:
 
 * A CephFS `StorageClass` CR defined to use the shallow copy feature
-* A Rustic `Secret` CR
+* A Restic `Secret` CR
 
 .Procedure
 

--- a/modules/oadp-ceph-prerequisites.adoc
+++ b/modules/oadp-ceph-prerequisites.adoc
@@ -13,4 +13,4 @@ The following prerequisites apply to all back up and restore operations of data 
 * You have installed the OADP Operator.
 * You have created a secret `cloud-credentials` in the namespace `openshift-adp.`
 * You have installed {rh-storage-first}.
-* You have installed the latest VolSync Operator using the Operator Lifecycle Manager.
+* You have installed the latest VolSync Operator by using Operator Lifecycle Manager.

--- a/modules/oadp-using-data-mover-for-csi-snapshots.adoc
+++ b/modules/oadp-using-data-mover-for-csi-snapshots.adoc
@@ -16,8 +16,7 @@ The Data Mover solution uses the Restic option of VolSync.
 
 Data Mover supports backup and restore of CSI volume snapshots only.
 
-In OADP 1.2 Data Mover `VolumeSnapshotBackups` (VSBs) and `VolumeSnapshotRestores` (VSRs) are queued using the VolumeSnapshotMover (VSM). The VSM's performance is improved by specifying a concurrent number of VSBs and VSRs simultaneously `InProgress`. After all async plugin operations are complete, the backup is marked as complete.
-
+In OADP 1.2 Data Mover, `VolumeSnapshotBackups` (VSBs) and `VolumeSnapshotRestores` (VSRs) are queued by using the VolumeSnapshotMover (VSM). The VSM's performance is improved by specifying a concurrent number of VSBs and VSRs simultaneously `InProgress`. After all async plugin operations are complete, the backup is marked as complete.
 
 [NOTE]
 ====
@@ -64,7 +63,7 @@ In {product-title} version 4.12 or later, verify that this is the only default `
 In OADP 1.1 the above setting is mandatory.
 ====
 
-* You have installed the VolSync Operator by using the Operator Lifecycle Manager (OLM).
+* You have installed the VolSync Operator by using Operator Lifecycle Manager (OLM).
 +
 [NOTE]
 ====
@@ -190,7 +189,7 @@ spec:
 <1> Specify the namespace where the volume snapshot exists.
 <2> Specify the namespace where the Operator is installed. The default is `openshift-adp`.
 
-. You can back up a volume snapshot by performing the following steps:
+. Back up a volume snapshot by performing the following steps:
 
 .. Create a backup CR:
 +
@@ -227,7 +226,7 @@ A snapshot is created in the object store was configured in the DPA.
 If the status of the `VolumeSnapshotBackup` CR becomes `Failed`, refer to the Velero logs for troubleshooting.
 ====
 
-. You can restore a volume snapshot by performing the following steps:
+. Restore a volume snapshot by performing the following steps:
 
 .. Delete the application namespace and the `volumeSnapshotContent` that was created by the Velero CSI plugin.
 


### PR DESCRIPTION
OADP 1.3; OCP 4.11+

Resolves https://issues.redhat.com/browse/OADP-3185 by making a number of minor changes to the discussion of the pre-OADP 1.3 DataMover in the OADP user guide.
