### PR TITLE
[virt] DPDK cluster config: Enable AlignCPUs

### DIFF
--- a/modules/virt-configuring-cluster-dpdk.adoc
+++ b/modules/virt-configuring-cluster-dpdk.adoc
@@ -100,6 +100,20 @@ $ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
 Editing the `HyperConverged` CR changes a global setting that affects all VMs that are created after the change is applied.
 ====
 
+. If your DPDK-enabled compute nodes use Simultaneous multithreading (SMT), enable the `AlignCPUs` enabler by editing the `HyperConverged` CR:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
+    --type='json' -p='[{"op": "replace", "path": "/spec/featureGates/alignCPUs", "value": true}]'
+----
++
+[NOTE]
+====
+Enabling `AlignCPUs` allows {VirtProductName} to request up to two additional dedicated CPUs to bring the total CPU count to an even parity when using
+emulator thread isolation.
+====
+
 . Create an `SriovNetworkNodePolicy` object with the `spec.deviceType` field set to `vfio-pci`:
 +
 .Example `SriovNetworkNodePolicy` manifest


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
In case the user's worker nodes have SMT [1] enabled, they will probably encounter [CNV-31584](https://issues.redhat.com//browse/CNV-31584) [2].

Add an instruction to enable the `AlignCPUs` enabler in HCO [3], so it will enable [4] KubeVirt to request up to two additional dedicated CPUs in order to complete the total CPU count to an even parity when using
emulator thread isolation.

[1] https://en.wikipedia.org/wiki/Simultaneous_multithreading
[2] https://issues.redhat.com/browse/CNV-31584
[3] https://github.com/kubevirt/hyperconverged-cluster-operator/pull/2695
[4] https://github.com/kubevirt/kubevirt/pull/10872

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.15+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/CNV-31584

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://69713--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-using-dpdk-with-sriov#virt-configuring-cluster-dpdk_virt-using-dpdk-with-sriov

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
