### PR TITLE
OCPBUGS-25839: Added arch support for SPO

### DIFF
--- a/security/security_profiles_operator/spo-enabling.adoc
+++ b/security/security_profiles_operator/spo-enabling.adoc
@@ -13,6 +13,11 @@ Before you can use the Security Profiles Operator, you must ensure the Operator 
 The Security Profiles Operator supports only Red Hat Enterprise Linux CoreOS (RHCOS) worker nodes. Red Hat Enterprise Linux (RHEL) nodes are not supported.
 ====
 
+[IMPORTANT]
+====
+The Security Profiles Operator only supports `x86_64` architecture.
+====
+
 include::modules/spo-installing.adoc[leveloffset=+1]
 
 include::modules/spo-installing-cli.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-25839

Link to docs preview (VPN required):
[Enabling the Security Profiles Operator](https://file.rdu.redhat.com/antaylor/OCPBUGS-25839/security/security_profiles_operator/spo-enabling.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
None
