### PR TITLE
TELCODOCS-999  Support MultiNetworkPolicies in IPv6 networks

### DIFF
--- a/modules/nw-multi-network-policy-ipv6-suppport.adoc
+++ b/modules/nw-multi-network-policy-ipv6-suppport.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/configuring-multi-network-policy.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nw-multi-network-policy-ipv6-support_{context}"]
+= Supporting multi-network policies in IPv6 networks
+
+The ICMPv6 Neighbor Discovery Protocol (NDP) is a set of messages and processes that enable devices to discover and maintain information about neighboring nodes. NDP plays a crucial role in IPv6 networks, facilitating the interaction between devices on the same link.
+
+The Cluster Network Operator (CNO) deploys the iptables implementation of multi-network policy when the `useMultiNetworkPolicy` parameter is set to `true`.
+
+To support multi-network policies in IPv6 networks the Cluster Network Operator deploys the following set of rules in every pod affected by a multi-network policy:
+
+.Multi-network policy custom rules
+
+[source,yaml]
+----
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: multi-networkpolicy-custom-rules
+  namespace: openshift-multus
+data:
+
+  custom-v6-rules.txt: |
+    # accept NDP
+    -p icmpv6 --icmpv6-type neighbor-solicitation -j ACCEPT <1>
+    -p icmpv6 --icmpv6-type neighbor-advertisement -j ACCEPT <2>
+    # accept RA/RS
+    -p icmpv6 --icmpv6-type router-solicitation -j ACCEPT <3>
+    -p icmpv6 --icmpv6-type router-advertisement -j ACCEPT <4>
+----
+
+<1> This rule allows incoming ICMPv6 neighbor solicitation messages, which are part of the neighbor discovery protocol (NDP). These messages help determine the link-layer addresses of neighboring nodes.
+<2> This rule allows incoming ICMPv6 neighbor advertisement messages, which are part of NDP and provide information about the link-layer address of the sender.
+<3> This rule permits incoming ICMPv6 router solicitation messages. Hosts use these messages to request router configuration information.
+<4> This rule allows incoming ICMPv6 router advertisement messages, which give configuration information to hosts.
+
+[NOTE]
+====
+You cannot edit these predefined rules.
+====
+
+These rules collectively enable essential ICMPv6 traffic for correct network functioning, including address resolution and router communication in an IPv6 environment. With these rules in place and a multi-network policy denying traffic, applications are not expected to experience connectivity issues.

--- a/networking/multiple_networks/configuring-multi-network-policy.adoc
+++ b/networking/multiple_networks/configuring-multi-network-policy.adoc
@@ -15,14 +15,9 @@ Support for configuring multi-network policies for SR-IOV additional networks is
 For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 ====
 
-[NOTE]
-====
-Configured network policies are ignored in IPv6 networks.
-====
-
-
 include::modules/nw-multi-network-policy-differences.adoc[leveloffset=+1]
 include::modules/nw-multi-network-policy-enable.adoc[leveloffset=+1]
+include::modules/nw-multi-network-policy-ipv6-suppport.adoc[leveloffset=+1]
 
 [id="{context}_working-with-multi-network-policy"]
 == Working with multi-network policy


### PR DESCRIPTION
[TELCODOCS-999]: Support MultiNetworkPolicies in IPv6 networks
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15, main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-999
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://69719--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-multi-network-policy#nw-multi-network-policy-ipv6-support_configuring-multi-network-policy
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
