### PR TITLE
TELCODOCS-1670: Network matrix flow

### DIFF
--- a/installing/install_config/configuring-firewall.adoc
+++ b/installing/install_config/configuring-firewall.adoc
@@ -15,3 +15,5 @@ include::modules/configuring-firewall.adoc[leveloffset=+1]
 .Additional resources
 
 * xref:../../authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc#cco-short-term-creds-auth-flow-aws-oidc_cco-short-term-creds[OpenID Connect requirements for AWS STS]
+
+include::modules/network-flow-matrix.adoc[leveloffset=+1]

--- a/modules/network-flow-matrix.adoc
+++ b/modules/network-flow-matrix.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * installing/install_config/configuring-firewall.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-flow-matrix_{context}"]
+= {product-title} network flow matrix
+
+The network flow matrix describes the ingress flows to {product-title} services.
+The network information in the matrix is accurate for both bare-metal and cloud environments.
+Use the information in the network flow matrix to help you manage ingress traffic.
+You can restrict ingress traffic to essential flows to improve network security.
+
+To view or download the raw CSV content, see link:https://raw.githubusercontent.com/openshift/openshift-docs/main/snippets/network-flow-matrix.csv[this resource].
+
+Additionally, consider the following dynamic port ranges when managing ingress traffic:
+
+* `9000-9999`: Host level services
+* `3000-32767`: Kubernetes node ports
+* `49152-65535`: Dynamic or private ports
+
+[NOTE]
+====
+The network flow matrix describes ingress traffic flows for a base {product-title} installation. It does not describe network flows for additional components, such as optional Operators available from the Red Hat Marketplace. The matrix does not apply for Hosted-Control-Plane, MicroShift, or standalone clusters.
+====
+
+.Network flow matrix
+[%header,format=csv]
+|===
+include::snippets/network-flow-matrix.csv[]
+|===

--- a/snippets/network-flow-matrix.csv
+++ b/snippets/network-flow-matrix.csv
@@ -1,0 +1,67 @@
+Direction,Protocol,Port,Namespace,Service,Pod,Container,Node Role,Optional
+Ingress,TCP,22,Host system service,sshd,,,master,TRUE
+Ingress,TCP,53,openshift-dns,dns-default,dnf-default,dns,master,FALSE
+Ingress,TCP,111,Host system service,rpcbind,,,master,TRUE
+Ingress,TCP,2379,openshift-etcd,etcd,etcd,etcdctl,master,FALSE
+Ingress,TCP,2380,openshift-etcd,healthz,etcd,etcd,master,FALSE
+Ingress,TCP,5050,openshift-machine-api,,ironic-proxy,ironic-proxy,master,FALSE
+Ingress,TCP,6080,openshift-kube-apiserver,,kube-apiserver,kube-apiserver-insecure-readyz,master,FALSE
+Ingress,TCP,6385,openshift-machine-api,,ironic-proxy,ironic-proxy,master,FALSE
+Ingress,TCP,6443,openshift-kube-apiserver,apiserver,kube-apiserver,kube-apiserver,master,FALSE
+Ingress,TCP,8080,openshift-network-operator   ,,network-operator,network-operator,master,FALSE
+Ingress,TCP,8798,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,machine-config-daemon,master,FALSE
+Ingress,TCP,9001,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,kube-rbac-proxy,master,FALSE
+Ingress,TCP,9099,openshift-cluster-version,cluster-version-operator,cluster-version-operator,cluster-version-operator,master,FALSE
+Ingress,TCP,9100,openshift-monitoring,node-exporter,node-exporter,kube-rbac-proxy,master,FALSE
+Ingress,TCP,9103,openshift-ovn-kubernetes,ovn-kubernetes-node,ovnkube-node,kube-rbac-proxy-node,master,FALSE
+Ingress,TCP,9104,openshift-network-operator,metrics,network-operator,network-operator,master,FALSE
+Ingress,TCP,9105,openshift-ovn-kubernetes,ovn-kubernetes-node,ovnkube-node,kube-rbac-proxy-ovn-metrics,master,FALSE
+Ingress,TCP,9107,openshift-ovn-kubernetes,egressip-node-healthcheck,ovnkube-node,ovnkube-controller,master,FALSE
+Ingress,TCP,9108,openshift-ovn-kubernetes,ovn-kubernetes-control-plane,ovnkube-control-plane,kube-rbac-proxy,master,FALSE
+Ingress,TCP,9192,openshift-cluster-machine-approver,machine-approver,machine-approver,kube-rbac-proxy,master,FALSE
+Ingress,TCP,9258,openshift-cloud-controller-manager-operator,machine-approver,cluster-cloud-controller-manager,cluster-cloud-controller-manager,master,FALSE
+Ingress,TCP,9444,openshift-kni-infra,,haproxy,haproxy,master,FALSE
+Ingress,TCP,9445,openshift-kni-infra,,haproxy,haproxy,master,FALSE
+Ingress,TCP,9447,openshift-machine-api,,metal3-baremetal-operator,,master,FALSE
+Ingress,TCP,9537,Host system service,crio-metrics,,,master,FALSE
+Ingress,TCP,9637,openshift-machine-config-operator,kube-rbac-proxy-crio,kube-rbac-proxy-crio,kube-rbac-proxy-crio,master,FALSE
+Ingress,TCP,9978,openshift-etcd,etcd,etcd,etcd-metrics,master,FALSE
+Ingress,TCP,9979,openshift-etcd,etcd,etcd,etcd-metrics,master,FALSE
+Ingress,TCP,9980,openshift-etcd,etcd,etcd,etcd,master,FALSE
+Ingress,TCP,10250,Host system service,kubelet,,,master,FALSE
+Ingress,TCP,10256,openshift-ovn-kubernetes,ovnkube,ovnkube,ovnkube-controller,master,FALSE
+Ingress,TCP,10257,openshift-kube-controller-manager,kube-controller-manager,kube-controller-manager,kube-controller-manager,master,FALSE
+Ingress,TCP,10258,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
+Ingress,TCP,10259,openshift-kube-scheduler,scheduler,openshift-kube-scheduler,kube-scheduler,master,FALSE
+Ingress,TCP,10260,openshift-cloud-controller-manager-operator,cloud-controller,cloud-controller-manager,cloud-controller-manager,master,FALSE
+Ingress,TCP,10300,openshift-cluster-csi-drivers,csi-livenessprobe,csi-driver-node,csi-driver,master,FALSE
+Ingress,TCP,10309,openshift-cluster-csi-drivers,csi-node-driver,csi-driver-node,csi-node-driver-registrar,master,FALSE
+Ingress,TCP,10357,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
+Ingress,TCP,17697,openshift-kube-apiserver,openshift-kube-apiserver-healthz,kube-apiserver,kube-apiserver-check-endpoints,master,FALSE
+Ingress,TCP,18080,openshift-kni-infra,,coredns,coredns,master,FALSE
+Ingress,TCP,22623,openshift-machine-config-operator,machine-config-server,machine-config-server,machine-config-server,master,FALSE
+Ingress,TCP,22624,openshift-machine-config-operator,machine-config-server,machine-config-server,machine-config-server,master,FALSE
+Ingress,UDP,53,openshift-dns,dns-default,dnf-default,dns,master,FALSE
+Ingress,UDP,111,Host system service,rpcbind,,,master,TRUE
+Ingress,UDP,6081,openshift-ovn-kubernetes,ovn-kubernetes geneve,,,master,FALSE
+Ingress,TCP,22,Host system service,sshd,,,worker,TRUE
+Ingress,TCP,53,openshift-dns,dns-default,dnf-default,dns,worker,FALSE
+Ingress,TCP,80,openshift-ingress,router-default,router-default,router,worker,FALSE
+Ingress,TCP,111,Host system service,rpcbind,,,worker,TRUE
+Ingress,TCP,443,openshift-ingress,router-default,router-default,router,worker,FALSE
+Ingress,TCP,8798,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,machine-config-daemon,worker,FALSE
+Ingress,TCP,9001,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,kube-rbac-proxy,worker,FALSE
+Ingress,TCP,9100,openshift-monitoring,node-exporter,node-exporter,kube-rbac-proxy,worker,FALSE
+Ingress,TCP,9103,openshift-ovn-kubernetes,ovn-kubernetes-node,ovnkube-node,kube-rbac-proxy-node,worker,FALSE
+Ingress,TCP,9105,openshift-ovn-kubernetes,ovn-kubernetes-node,ovnkube-node,kube-rbac-proxy-ovn-metrics,worker,FALSE
+Ingress,TCP,9107,openshift-ovn-kubernetes,egressip-node-healthcheck,ovnkube-node,ovnkube-controller,worker,FALSE
+Ingress,TCP,9537,Host system service,crio-metrics,,,worker,FALSE
+Ingress,TCP,9637,openshift-machine-config-operator,kube-rbac-proxy-crio,kube-rbac-proxy-crio,kube-rbac-proxy-crio,worker,FALSE
+Ingress,TCP,10250,Host system service,kubelet,,,worker,FALSE
+Ingress,TCP,10256,openshift-ovn-kubernetes,ovnkube,ovnkube,ovnkube-controller,worker,TRUE
+Ingress,TCP,10300,openshift-cluster-csi-drivers,csi-livenessprobe,csi-driver-node,csi-driver,worker,FALSE
+Ingress,TCP,10309,openshift-cluster-csi-drivers,csi-node-driver-registrar,csi-driver-node,csi-node-driver-registrar,worker,FALSE
+Ingress,TCP,18080,openshift-kni-infra,,coredns,coredns,worker,FALSE
+Ingress,UDP,53,openshift-dns,dns-default,dnf-default,dns,worker,FALSE
+Ingress,UDP,111,Host system service,rpcbind,,,worker,TRUE
+Ingress,UDP,6081,openshift-ovn-kubernetes,ovn-kubernetes geneve,,,worker,FALSE


### PR DESCRIPTION
[TELCODOCS-1670](https://issues.redhat.com//browse/TELCODOCS-1670): Adding ingress network flow data. 

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1670

Link to docs preview:
https://69720--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall.html#network-flow-matrix_configuring-firewall

CNF QE have confirmed that no QE is required for this doc.
