### PR TITLE
OCPBUGS#25991: Removed "Create the LVMCluster resource" step in "Installing LVM Storage with the CLI" proc

### DIFF
--- a/modules/lvms-installing-logical-volume-manager-operator-using-cli.adoc
+++ b/modules/lvms-installing-logical-volume-manager-operator-using-cli.adoc
@@ -88,49 +88,6 @@ spec:
 $ oc create -f lvms-sub.yaml
 ----
 
-. Create the `LVMCluster` resource:
-
-.. Save the following YAML in the `lvmcluster.yaml` file:
-+
-[source,yaml]
-----
-apiVersion: lvm.topolvm.io/v1alpha1
-kind: LVMCluster
-metadata:
- name: my-lvmcluster
- namespace: openshift-storage
-spec:
- storage:
-   deviceClasses:
-   - name: vg1
-     deviceSelector:
-       paths:
-       - /dev/disk/by-path/pci-0000:87:00.0-nvme-1
-       - /dev/disk/by-path/pci-0000:88:00.0-nvme-1
-       optionalPaths:
-       - /dev/disk/by-path/pci-0000:89:00.0-nvme-1
-       - /dev/disk/by-path/pci-0000:90:00.0-nvme-1
-     thinPoolConfig:
-       name: thin-pool-1
-       sizePercent: 90
-       overprovisionRatio: 10
-     nodeSelector:
-       nodeSelectorTerms:
-       - matchExpressions:
-         - key: app
-           operator: In
-           values:
-           - test1
-----
-
-.. Create the `LVMCluster` CR:
-+
-[source,yaml]
-----
-$ oc create -f lvmcluster.yaml
-----
-
-
 . To verify that the Operator is installed, enter the following command:
 +
 [source,terminal]


### PR DESCRIPTION
Version(s):
4.13+

Issue:
[OCPBUGS-25991](https://issues.redhat.com/browse/OCPBUGS-25991)

Link to docs preview:
https://69742--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms#install-lvms-operator-cli_logical-volume-manager-storage


QE review:
- [x] QE has approved this change.