### PR TITLE
[INTERNAL-FIX] vsphere-static-nodes-xrefs

### DIFF
--- a/modules/installation-vsphere-installer-infra-static-ip-nodes.adoc
+++ b/modules/installation-vsphere-installer-infra-static-ip-nodes.adoc
@@ -1,9 +1,9 @@
 ////
 Module included in the following assemblies:
-* xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc[Installing a cluster on vSphere]
-* xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc[Installing a cluster on vSphere with customizations]
-* xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc[Installing a cluster on vSphere with network customizations]
-* xref:../installing/installing_vsphere/installing-restricted-networks-vsphere.adoc[Installing a cluster on vSphere in a restricted network]
+* installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc[Installing a cluster on vSphere]
+* installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc[Installing a cluster on vSphere with customizations]
+* installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc[Installing a cluster on vSphere with network customizations]
+* installing/installing_vsphere/installing-restricted-networks-vsphere.adoc[Installing a cluster on vSphere in a restricted network]
 ////
 
 :_mod-docs-content-type: CONCEPT


### PR DESCRIPTION
NO JIRA

Version(s):
4.14 only (4.15 corrected as part of a refactoring effort)

Preview links:
Check that the Static IP addresses for vSphere nodes module in the following assemblies does not include any commented out file references:

* [Installing a cluster on vSphere](https://69750--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned#:~:text=within%20the%20cluster.-,Static%20IP%20addresses%20for%20vSphere%20nodes,-You%20can%20provision)
* [Installing a cluster on vSphere with customizations](https://69750--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations#:~:text=within%20the%20cluster.-,Static%20IP%20addresses%20for%20vSphere%20nodes,-You%20can%20provision)
* [Installing a cluster on vSphere with network customizations](https://69750--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations#:~:text=within%20the%20cluster.-,Static%20IP%20addresses%20for%20vSphere%20nodes,-You%20can%20provision)
* [Installing a cluster on vSphere in a restricted network](https://69750--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere#:~:text=within%20the%20cluster.-,Static%20IP%20addresses%20for%20vSphere%20nodes,-You%20can%20provision)

QE review:
- [x] QE not required

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
