### PR TITLE
OSDOCS-9123: Documented the 4.12.46 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -4361,3 +4361,28 @@ $ oc adm release info 4.12.45 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-12-46"]
+=== RHSA-2023:7823 - {product-title} 4.12.46 bug fix and security update
+
+Issued: 2024-01-04
+
+{product-title} release 4.12.46, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:7823[RHSA-2023:7823] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:7825[RHBA-2023:7825] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.46 --pullspecs
+----
+
+[id="ocp-4-12-46-bug-fixes"]
+==== Bug fixes
+
+* Previously, the Image Registry Operator made API calls to the Storage Account List endpoint as part of obtaining access keys every 5 minutes. In projects with several {product-title} clusters, this could lead to API rate limits being reached, which could result in several HTTP errors when attempting to create new clusters. With this release, the time between calls is increased from 5 minutes to 20 minutes. (link:https://issues.redhat.com/browse/OCPBUGS-22125[*OCPBUGS-22125*])  
+
+
+[id="ocp-4-12-46-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-9123](https://issues.redhat.com/browse/OSDOCS-9123)

Link to docs preview:
[OCP 4.12.46 z-stream release notes](https://69767--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes#ocp-4-12-46)

QE review:
- [X] Not required for z-stream release notes. See the peer-reviewer checklist. 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
