### PR TITLE
OCPBUGS-8494 update install-config.yaml

### DIFF
--- a/modules/install-sno-generating-the-install-iso-manually.adoc
+++ b/modules/install-sno-generating-the-install-iso-manually.adoc
@@ -86,39 +86,42 @@ $ curl -L $ISO_URL -o rhcos-live.iso
 apiVersion: v1
 baseDomain: <domain> <1>
 compute:
+- architecture: amd64 <2>
 - name: worker
-  replicas: 0 <2>
+  replicas: 0 <3>
 controlPlane:
+  architecture: amd64
   name: master
-  replicas: 1 <3>
+  replicas: 1 <4>
 metadata:
-  name: <name> <4>
-networking: <5>
+  name: <name> <5>
+networking: <6>
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
   machineNetwork:
-  - cidr: 10.0.0.0/16 <6>
+  - cidr: 10.0.0.0/16 <7>
   networkType: OVNKubernetes
   serviceNetwork:
   - 172.30.0.0/16
 platform:
   none: {}
 bootstrapInPlace:
-  installationDisk: /dev/disk/by-id/<disk_id> <7>
-pullSecret: '<pull_secret>' <8>
+  installationDisk: /dev/disk/by-id/<disk_id> <8>
+pullSecret: '<pull_secret>' <9>
 sshKey: |
-  <ssh_key> <9>
+  <ssh_key> <10>
 ----
 <1> Add the cluster domain name.
-<2> Set the `compute` replicas to `0`. This makes the control plane node schedulable.
-<3> Set the `controlPlane` replicas to `1`. In conjunction with the previous `compute` setting, this setting ensures the cluster runs on a single node.
-<4> Set the `metadata` name to the cluster name.
-<5> Set the `networking` details. OVN-Kubernetes is the only allowed network plugin type for single-node clusters.
-<6> Set the `cidr` value to match the subnet of the {sno} cluster.
-<7> Set the path to the installation disk drive, for example, `/dev/disk/by-id/wwn-0x64cd98f04fde100024684cf3034da5c2`.
-<8> Copy the {cluster-manager-url-pull} and add the contents to this configuration setting.
-<9> Add the public SSH key from the administration host so that you can log in to the cluster after installation.
+<2> Set the architecture to `arm64` for 64-bit ARM or `amd64` for 64-bit x86 architectures. This needs to be set explicitly to the target host architecture.
+<3> Set the `compute` replicas to `0`. This makes the control plane node schedulable.
+<4> Set the `controlPlane` replicas to `1`. In conjunction with the previous `compute` setting, this setting ensures the cluster runs on a single node.
+<5> Set the `metadata` name to the cluster name.
+<6> Set the `networking` details. OVN-Kubernetes is the only allowed network plugin type for single-node clusters.
+<7> Set the `cidr` value to match the subnet of the {sno} cluster.
+<8> Set the path to the installation disk drive, for example, `/dev/disk/by-id/wwn-0x64cd98f04fde100024684cf3034da5c2`.
+<9> Copy the {cluster-manager-url-pull} and add the contents to this configuration setting.
+<10> Add the public SSH key from the administration host so that you can log in to the cluster after installation.
 
 . Generate {product-title} assets by running the following commands:
 +


### PR DESCRIPTION
[OCPBUGS-8494]: OpenShift command picks up the openshift-install binary architecture when not specified in install-config.yaml

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-8494
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://69769--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-installing-sno.html#generating-the-install-iso-manually_install-sno-installing-sno-with-the-assisted-installer
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
