### PR TITLE
[OSDOCS-7743]: ROSA Operator, Invalid IAM Policy

### DIFF
--- a/modules/oadp-preparing-aws-credentials.adoc
+++ b/modules/oadp-preparing-aws-credentials.adoc
@@ -9,7 +9,7 @@
 An AWS account must be ready to accept an OADP installation.
 
 .Procedure
-. Create the following environment variables by running the following commands: 
+. Create the following environment variables by running the following commands:
 +
 [NOTE]
 ====
@@ -75,9 +75,9 @@ cat << EOF > ${SCRATCH}/policy.json <1>
       "s3:PutObject",
       "s3:DeleteObject",
       "s3:ListBucketMultipartUploads",
-      "s3:AbortMultipartUploads",
+      "s3:AbortMultipartUpload",
       "s3:ListMultipartUploadParts",
-      "s3:DescribeSnapshots",
+      "ec2:DescribeSnapshots",
       "ec2:DescribeVolumes",
       "ec2:DescribeVolumeAttribute",
       "ec2:DescribeVolumesModifications",


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-7743
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://69773--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_backing_up_and_restoring_applications/backing-up-applications#oadp-preparing-aws-credentials_rosa-backing-up-applications
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
![image](https://github.com/openshift/openshift-docs/assets/122639474/0cc4ae57-03fa-4fc7-9e70-451669f8fe1d)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
