### PR TITLE
OSDOCS#9205: Removed reference to CNS not being supported.

### DIFF
--- a/modules/available-persistent-storage-options.adoc
+++ b/modules/available-persistent-storage-options.adoc
@@ -42,8 +42,3 @@ a| * Accessible through a REST API endpoint
 --
 1. NetApp NFS supports dynamic PV provisioning when using the Trident plugin.
 --
-
-[IMPORTANT]
-====
-Currently, CNS is not supported in {product-title} {product-version}.
-====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
CNS is an ambiguous acronym. 

– We once had a product called CNS, then OCS, that is now ODF.
– VMware now has a CNS offering as part of their latest CSI storage driver. 

Regardless, both of the above are now fully supported.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14
4.13
4.12
4.11 

https://docs.openshift.com/container-platform/4.11/storage/container_storage_interface/persistent-storage-csi-vsphere.html

Looks like vmware CSI was supported as of 4.10.

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-9205

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
