### PR TITLE
CNV-33431: Storage profile must be reapplied if storage class changes

### DIFF
--- a/modules/virt-customizing-storage-profile.adoc
+++ b/modules/virt-customizing-storage-profile.adoc
@@ -9,6 +9,8 @@
 
 You can specify default parameters by editing the `StorageProfile` object for the provisioner's storage class. These default parameters only apply to the persistent volume claim (PVC) if they are not configured in the `DataVolume` object.
 
+You cannot modify storage class parameters. To make changes, delete and re-create the storage class. You must then reapply any customizations that were previously made to the storage profile.
+
 An empty `status` section in a storage profile indicates that a storage provisioner is not recognized by the Containerized Data Interface (CDI). Customizing a storage profile is necessary if you have a storage provisioner that is not recognized by CDI. In this case, the administrator sets appropriate values in the storage profile to ensure successful allocations.
 
 [WARNING]

--- a/virt/storage/virt-configuring-storage-profile.adoc
+++ b/virt/storage/virt-configuring-storage-profile.adoc
@@ -6,9 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You must configure storage profiles if your storage provider is not recognized by the Containerized Data Importer (CDI)
-
 A storage profile provides recommended storage settings based on the associated storage class. A storage profile is allocated for each storage class.
+
+If the Containerized Data Importer (CDI) does not recognize your storage provider, you must configure storage profiles.
 
 For recognized storage types, CDI provides values that optimize the creation of PVCs.  However, you can configure automatic settings for a storage class if you customize the storage profile.
 


### PR DESCRIPTION
Version(s): 4.15+

Issue: [CNV-33431](https://issues.redhat.com/browse/CNV-33431)

Links to docs previews: 
- [Customizing the storage profile](https://69785--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-configuring-storage-profile#virt-customizing-storage-profile_virt-configuring-storage-profile)
- [Configuring storage profiles](https://69785--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-configuring-storage-profile)

QE review:
- [x] QE has approved this change.



