### PR TITLE
#CNV-33128: adjust tp tab section to web console overview

### DIFF
--- a/virt/getting_started/virt-web-console-overview.adoc
+++ b/virt/getting_started/virt-web-console-overview.adoc
@@ -79,13 +79,18 @@ The *Overview* page displays resources, metrics, migration progress, and cluster
 |Status of live migrations.
 
 |xref:../../virt/getting_started/virt-web-console-overview.adoc#overview-settings_virt-web-console-overview[*Settings* tab]
-|The *Settings* tab contains the *Cluster* tab and the *User* tab.
+|The *Settings* tab contains the *Cluster* tab, *User* tab, and *Preview features* tab.
 
 |*Settings* -> xref:../../virt/getting_started/virt-web-console-overview.adoc#overview-settings-cluster_virt-web-console-overview[*Cluster* tab]
 |{VirtProductName} version, update status, live migration, templates project, preview features, and load balancer service settings.
 
 |*Settings* -> xref:../../virt/getting_started/virt-web-console-overview.adoc#overview-settings-user_virt-web-console-overview[*User* tab]
 |Authorized SSH keys, user permissions, and welcome information settings.
+
+|*Settings* -> *Preview features*
+|Enable select link:https://access.redhat.com/support/offerings/techpreview/[preview features] in the UI. Features in this tab change frequently.
+
+Preview features are disabled by default and must not be enabled in production environments.
 |====
 =====
 
@@ -206,7 +211,7 @@ The *Settings* tab displays cluster-wide settings.
 |Description
 
 |xref:../../virt/getting_started/virt-web-console-overview.adoc#overview-settings-cluster_virt-web-console-overview[*Cluster* tab]
-|{VirtProductName} version and update status, live migration, templates project, preview features, and load balancer service settings.
+|{VirtProductName} version and update status, live migration, templates project, and load balancer service settings.
 
 |xref:../../virt/getting_started/virt-web-console-overview.adoc#overview-settings-user_virt-web-console-overview[*User* tab]
 |Authorized SSH key management, user permissions, and welcome information settings.
@@ -216,7 +221,7 @@ The *Settings* tab displays cluster-wide settings.
 [id="overview-settings-cluster_virt-web-console-overview"]
 ==== Cluster tab
 
-The *Cluster* tab displays the {VirtProductName} version and update status. You configure preview features, live migration, and other settings on the *Cluster* tab.
+The *Cluster* tab displays the {VirtProductName} version and update status. You configure live migration and other settings on the *Cluster* tab.
 
 .*Cluster* tab
 [%collapsible]
@@ -234,11 +239,6 @@ The *Cluster* tab displays the {VirtProductName} version and update status. You 
 
 |*Channel*
 |{VirtProductName} update channel.
-
-|*Preview features* section
-|Expand this section to manage link:https://access.redhat.com/support/offerings/techpreview/[preview features].
-
-Preview features are disabled by default and must not be enabled in production environments.
 
 |*Live Migration* section
 |Expand this section to configure live migration settings.
@@ -294,6 +294,11 @@ The keys are added automatically to all virtual machines that you subsequently c
 |Expand this section to show or hide the *Welcome information* dialog.
 |====
 =====
+
+[id="overview-settings-preview_virt-web-console-overview"]
+==== Preview features tab
+
+Enable select link:https://access.redhat.com/support/offerings/techpreview/[preview features] in the UI. Features in this tab change frequently.
 
 [id="catalog-page_virt-web-console-overview"]
 == Catalog page


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-33128](https://issues.redhat.com//browse/CNV-33128)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://69788--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/getting_started/virt-web-console-overview#overview-page_virt-web-console-overview
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: No QE review requested. Updating docs location  that will not be specific to each TP feature, but a general note of where to find the TP features in the UI.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
