### PR TITLE
OSDOCS-9214: Use consistent formats for wildcard domain list in AWS firewall prerequisites

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -88,7 +88,7 @@ This section provides the necessary details that enable you to control egress tr
 |443
 |Provides core container images as a fallback when quay.io is not available.
 
-|`.q1w2.quay.rhcloud.com`
+|`*.q1w2.quay.rhcloud.com`
 |443
 |Provides core container images as a fallback when quay.io is not available.
 
@@ -185,7 +185,7 @@ For more information about how remote health monitoring data is used by Red Hat,
 |===
 |Domain | Port | Function
 
-|`.amazonaws.com`
+|`*.amazonaws.com`
 |443
 |Required to access AWS services and resources.
 |===


### PR DESCRIPTION
Use consistent notations for wildcard domains using only '\*'(asterisk) instead of both '\*' and '.' for suppressing confusion.
* Reference:
  - https://issues.redhat.com/browse/OSDOCS-9214

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
N/A

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-9214

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
