### PR TITLE
OSDOCS#8126: cert-manager 1.13 changes

### DIFF
--- a/modules/cert-manager-override-arguments.adoc
+++ b/modules/cert-manager-override-arguments.adoc
@@ -34,7 +34,7 @@ spec:
   ...
   controllerConfig:
     overrideArgs:
-      - '--dns01-recursive-nameservers=<host>:<port>' <1>
+      - '--dns01-recursive-nameservers=<server_address>' <1>
       - '--dns01-recursive-nameservers-only' <2>
       - '--acme-http01-solver-nameservers=<host>:<port>' <3>
       - '--v=<verbosity_level>' <4>
@@ -47,12 +47,17 @@ spec:
     overrideArgs:
       - '--v=2' <4>
 ----
-<1> Provide a comma-separated list of `<host>:<port>` nameservers to query for the DNS-01 self check. For example, `--dns01-recursive-nameservers=1.1.1.1:53`.
+<1> Provide a comma-separated list of nameservers to query for the DNS-01 self check. The nameservers can be specified either as `<host>:<port>`, for example, `1.1.1.1:53`, or use DNS over HTTPS (DoH), for example, `https://1.1.1.1/dns-query`.
 <2> Specify to only use recursive nameservers instead of checking the authoritative nameservers associated with that domain.
 <3> Provide a comma-separated list of `<host>:<port>` nameservers to query for the Automated Certificate Management Environment (ACME) HTTP01 self check. For example, `--acme-http01-solver-nameservers=1.1.1.1:53`.
 <4> Specify to set the log level verbosity to determine the verbosity of log messages.
 <5> Specify the host and port for the metrics endpoint. The default value is `--metrics-listen-address=0.0.0.0:9402`.
 <6> You must use the `--issuer-ambient-credentials` argument when configuring an ACME Issuer to solve DNS-01 challenges by using ambient credentials.
++
+[NOTE]
+====
+DNS over HTTPS (DoH) is supported starting only from {cert-manager-operator} version 1.13.0 and later.
+====
 
 . Save your changes and quit the text editor to apply your changes.
 

--- a/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
@@ -12,153 +12,32 @@ These release notes track the development of {cert-manager-operator}.
 
 For more information, see xref:../../security/cert_manager_operator/index.adoc#cert-manager-operator-about[About the {cert-manager-operator}].
 
-[id="cert-manager-operator-release-notes-1.12.1"]
-== Release notes for {cert-manager-operator} 1.12.1
+[id="cert-manager-operator-release-notes-1.13"]
+== Release notes for {cert-manager-operator} 1.13.0
 
-Issued: 2023-11-15
+Issued: 2024-01-16
 
-The following advisory is available for the {cert-manager-operator} 1.12.1:
+The following advisory is available for the {cert-manager-operator} 1.13.0:
 
-* link:https://access.redhat.com/errata/RHSA-2023:6269-02[RHSA-2023:6269-02]
+* link:https://access.redhat.com/errata/RHEA-2024:0259[RHEA-2024:0259]
 
-Version `1.12.1` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.12.5`. For more information, see the link:https://cert-manager.io/docs/release-notes/release-notes-1.12/#v1125[cert-manager project release notes for v1.12.5].
+Version `1.13.0` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.13.3`. For more information, see the link:https://cert-manager.io/docs/release-notes/release-notes-1.13/#v1133[cert-manager project release notes for v1.13.0].
 
-[id="cert-manager-operator-1.12.1-bug-fixes"]
-=== Bug fixes
-
-* Previously, in a multi-architecture environment, the cert-manager Operator pods were prone to failures because of the invalid node affinity configuration. With this fix, the cert-manager Operator pods run without any failures. (link:https://issues.redhat.com/browse/OCPBUGS-19446[*OCPBUGS-19446*])
-
-[id="cert-manager-operator-1.12.1-CVEs"]
-=== CVEs
-
-* link:https://access.redhat.com/security/cve/CVE-2023-44487[CVE-2023-44487]
-* link:https://access.redhat.com/security/cve/CVE-2023-39325[CVE-2023-39325]
-* link:https://access.redhat.com/security/cve/CVE-2023-4527[CVE-2023-4527]
-* link:https://access.redhat.com/security/cve/CVE-2023-4806[CVE-2023-4806]
-* link:https://access.redhat.com/security/cve/CVE-2023-4813[CVE-2023-4813]
-* link:https://access.redhat.com/security/cve/CVE-2023-4911[CVE-2023-4911]
-* link:https://access.redhat.com/security/cve/CVE-2023-38545[CVE-2023-38545]
-* link:https://access.redhat.com/security/cve/CVE-2023-38546[CVE-2023-38546]
-
-[id="cert-manager-operator-release-notes-1.12.0"]
-== Release notes for {cert-manager-operator} 1.12.0
-
-Issued: 2023-10-02
-
-The following advisories are available for the {cert-manager-operator} 1.12.0:
-
-* link:https://access.redhat.com/errata/RHEA-2023:5339[RHEA-2023:5339]
-* link:https://access.redhat.com/errata/RHBA-2023:5412[RHBA-2023:5412]
-
-Version `1.12.0` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.12.4`. For more information, see the link:https://cert-manager.io/docs/release-notes/release-notes-1.12/#v1124[cert-manager project release notes for v1.12.4].
-
-
-[id="cert-manager-operator-1.12.0-bug-fixes"]
-=== Bug fixes
-
-* Previously, you could not configure the CPU and memory requests and limits for the cert-manager components such as cert-manager controller, CA injector, and Webhook. Now, you can configure the CPU and memory requests and limits for the cert-manager components by using the command-line interface (CLI). For more information, see xref:../../security/cert_manager_operator/cert-manager-customizing-api-fields.adoc#cert-manager-configure-cpu-memory_cert-manager-customizing-api-fields[Overriding CPU and memory limits for the cert-manager components]. (link:https://issues.redhat.com/browse/OCPBUGS-13830[*OCPBUGS-13830*])
-
-* Previously, if you updated the `ClusterIssuer` object, the {cert-manager-operator} could not verify and update the change in the cluster issuer. Now, if you modify the `ClusterIssuer` object, the {cert-manager-operator} verifies the ACME account registration and updates the change. (link:https://issues.redhat.com/browse/OCPBUGS-8210[*OCPBUGS-8210*])
-
-* Previously, the {cert-manager-operator} did not support enabling the  `--enable-certificate-owner-ref` flag. Now, the {cert-manager-operator} supports enabling the `--enable-certificate-owner-ref` flag by adding the `spec.controllerConfig.overrideArgs` field in the `cluster` object. After enabling the `--enable-certificate-owner-ref` flag, cert-manager can automatically delete the secret when the `Certificate` resource is removed from the cluster. For more information on enabling the `--enable-certificate-owner-ref` flag and deleting the TLS secret automatically, see xref:../../security/cert_manager_operator/cert-manager-customizing-api-fields.adoc#cert-manager-override-flag-controller_cert-manager-customizing-api-fields[Deleting a TLS secret automatically upon Certificate removal] (link:https://issues.redhat.com/browse/CM-98[*CM-98*])
-
-* Previously, the {cert-manager-operator} could not pull the `jetstack-cert-manager-container-v1.12.4-1` image. The cert-manager controller, CA injector, and Webhook pods were stuck in the `ImagePullBackOff` state. Now, the {cert-manager-operator} pulls the `jetstack-cert-manager-container-v1.12.4-1` image to run the cert-manager controller, CA injector, and Webhook pods successfully. (link:https://issues.redhat.com/browse/OCPBUGS-19986[*OCPBUGS-19986*])
-
-[id="cert-manager-operator-release-notes-1.11.5"]
-== Release notes for {cert-manager-operator} 1.11.5
-
-Issued: 2023-11-15
-
-The following advisory is available for the {cert-manager-operator} 1.11.5:
-
-* link:https://access.redhat.com/errata/RHSA-2023:6279-03[RHSA-2023:6279-03]
-
-The golang version is updated to the version `1.20.10` to fix Common Vulnerabilities and Exposures (CVEs). Version `1.11.5` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.11.5`. For more information, see the link:https://cert-manager.io/docs/release-notes/release-notes-1.11/#v1115[cert-manager project release notes for v1.11.5].
-
-[id="cert-manager-operator-1.11.5-bug-fixes"]
-=== Bug fixes
-
-* Previously, in a multi-architecture environment, the cert-manager Operator pods were prone to failures because of the invalid node affinity configuration. With this fix, the cert-manager Operator pods run without any failures. (link:https://issues.redhat.com/browse/OCPBUGS-19446[*OCPBUGS-19446*])
-
-[id="cert-manager-operator-1.11.5-CVEs"]
-=== CVEs
-
-* link:https://access.redhat.com/security/cve/CVE-2023-44487[CVE-2023-44487]
-* link:https://access.redhat.com/security/cve/CVE-2023-39325[CVE-2023-39325]
-* link:https://access.redhat.com/security/cve/CVE-2023-29409[CVE-2023-29409]
-* link:https://access.redhat.com/security/cve/CVE-2023-2602[CVE-2023-2602]
-* link:https://access.redhat.com/security/cve/CVE-2023-2603[CVE-2023-2603]
-* link:https://access.redhat.com/security/cve/CVE-2023-4527[CVE-2023-4527]
-* link:https://access.redhat.com/security/cve/CVE-2023-4806[CVE-2023-4806]
-* link:https://access.redhat.com/security/cve/CVE-2023-4813[CVE-2023-4813]
-* link:https://access.redhat.com/security/cve/CVE-2023-4911[CVE-2023-4911]
-* link:https://access.redhat.com/security/cve/CVE-2023-28484[CVE-2023-28484]
-* link:https://access.redhat.com/security/cve/CVE-2023-29469[CVE-2023-29469]
-* link:https://access.redhat.com/security/cve/CVE-2023-38545[CVE-2023-38545]
-* link:https://access.redhat.com/security/cve/CVE-2023-38546[CVE-2023-38546]
-
-
-
-[id="cert-manager-operator-release-notes-1.11.4"]
-== Release notes for {cert-manager-operator} 1.11.4
-
-Issued: 2023-07-26
-
-The following advisory is available for the {cert-manager-operator} 1.11.4:
-
-* link:https://access.redhat.com/errata/RHEA-2023:4081[RHEA-2023:4081]
-
-The golang version is updated to the version `1.19.10` to fix Common Vulnerabilities and Exposures (CVEs). Version `1.11.4` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.11.4`. For more information, see the link:https://cert-manager.io/docs/release-notes/release-notes-1.11/#v1114[cert-manager project release notes for v1.11.4].
-
-[id="cert-manager-operator-1.11.4-bug-fixes"]
-=== Bug fixes
-
-* Previously, the {cert-manager-operator} did not allow you to install older versions of the {cert-manager-operator}. Now, you can install older versions of the {cert-manager-operator} using the web console or the command-line interface (CLI). For more information on how to use the web console to install older versions, see xref:../../security/cert_manager_operator/cert-manager-operator-install.adoc#cert-manager-operator-install[Installing the {cert-manager-operator}]. (link:https://issues.redhat.com/browse/OCPBUGS-16393[*OCPBUGS-16393*])
-
-[id="cert-manager-operator-release-notes-1.11.1"]
-== Release notes for {cert-manager-operator} 1.11.1
-
-Issued: 2023-06-21
-
-The following advisory is available for the {cert-manager-operator} 1.11.1:
-
-* link:https://access.redhat.com/errata/RHEA-2023:3439[RHEA-2023:3439]
-
-Version `1.11.1` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.11.1`. For more information, see the link:https://cert-manager.io/docs/release-notes/release-notes-1.11/#v1111[cert-manager project release notes for v1.11.1].
-
-[id="cert-manager-operator-1.11.1-new-features-and-enhancements"]
+[id="cert-manager-operator-new-features-1.13"]
 === New features and enhancements
 
-This is the general availability (GA) release of the {cert-manager-operator}.
+* You can now manage certificates for API Server and Ingress Controller by using the {cert-manager-operator}. 
+For more information, see xref:../../security/cert_manager_operator/cert-manager-creating-certificate.adoc#cert-manager-creating-certificate[Configuring certificates with an issuer].
 
-[id="cert-manager-log-level-1.11.1"]
-==== Setting log levels for cert-manager and the {cert-manager-operator}
-* To troubleshoot issues with cert-manager and the {cert-manager-operator}, you can now configure the log level verbosity by setting a log level for cert-manager and the {cert-manager-operator}. For more information, see xref:../../security/cert_manager_operator/cert-manager-log-levels.adoc#cert-manager-log-levels[Configuring log levels for cert-manager and the {cert-manager-operator}].
+* With this release, the scope of the {cert-manager-operator}, which was previously limited to the {product-title} on AMD64 architecture, has now been expanded to include support for managing certificates on {product-title} running on {ibm-z-name} (`s390x`), {ibm-power-name} (`ppc64le`) and ARM64 architectures.
 
-[id="cert-manager-authentication-aws-1.11.1"]
-==== Authenticating the {cert-manager-operator} with AWS
-* You can now configure cloud credentials for the {cert-manager-operator} on AWS clusters with Security Token Service (STS) and without STS. For more information, see xref:../../security/cert_manager_operator/cert-manager-authenticate-aws.adoc#cert-manager-authenticate-aws[Authenticating the {cert-manager-operator} on AWS  Security Token Service] and xref:../../security/cert_manager_operator/cert-manager-authentication-non-sts.adoc#cert-manager-authentication-non-sts[Authenticating the {cert-manager-operator} on AWS].
+* With this release, you can use DNS over HTTPS (DoH) for performing the self-checks during the ACME DNS-01 challenge verification. The DNS self-check method can be controlled by using the command line flags, `--dns01-recursive-nameservers-only` and `--dns01-recursive-nameservers`.
+For more information, see xref:../../security/cert_manager_operator/cert-manager-customizing-api-fields.html#cert-manager-override-arguments_cert-manager-customizing-api-fields[Customizing cert-manager by overriding arguments from the cert-manager Operator API].
 
-[id="cert-manager-authentication-gcp-1.11.1"]
-==== Authenticating the {cert-manager-operator} with GCP
-* You can now configure cloud credentials for the {cert-manager-operator} on GCP clusters with Workload Identity and without Workload Identity. For more information, see xref:../../security/cert_manager_operator/cert-manager-authenticate-gcp.adoc#cert-manager-authenticate-gcp[Authenticating the {cert-manager-operator} with GCP Workload Identity] and xref:../../security/cert_manager_operator/cert-manager-authenticate-non-sts-gcp.adoc#cert-manager-authenticate-non-sts-gcp[Authenticating the {cert-manager-operator} with GCP]
+[id="cert-manager-operator-1.13-CVEs"]
+=== CVEs
 
-[id="cert-manager-operator-1.11.1-bug-fixes"]
-=== Bug fixes
-
-* Previously, the `cm-acme-http-solver` pod did not use the latest published Red Hat image `registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9`. With this release, the `cm-acme-http-solver` pod uses the latest published Red Hat image `registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9`. (link:https://issues.redhat.com/browse/OCPBUGS-10821[*OCPBUGS-10821*])
-
-* Previously, the {cert-manager-operator} did not support changing labels for cert-manager pods such as controller, CA injector, and Webhook pods. With this release, you can add labels to cert-manager pods. (link:https://issues.redhat.com/browse/OCPBUGS-8466[*OCPBUGS-8466*])
-
-* Previously, you could not update the log verbosity level in the {cert-manager-operator}. You can now update the log verbosity level by using an environmental variable `OPERATOR_LOG_LEVEL` in its subscription resource. (link:https://issues.redhat.com/browse/OCPBUGS-9994[*OCPBUGS-9994*])
-
-* Previously, when uninstalling the {cert-manager-operator}, if you select the *Delete all operand instances for this operator* checkbox in the {product-title} web console, the Operator was not uninstalled properly. The {cert-manager-operator} is now properly uninstalled. (link:https://issues.redhat.com/browse/OCPBUGS-9960[*OCPBUGS-9960*])
-
-* Previously, the {cert-manager-operator} did not support using Google workload identity federation. The {cert-manager-operator} now supports using Google workload identity federation. (link:https://issues.redhat.com/browse/OCPBUGS-9998[*OCPBUGS-9998*])
-
-[id="cert-manager-operator-1.11.1-known-issues"]
-=== Known issues
-
-* After installing the {cert-manager-operator}, if you navigate to *Operators → Installed Operators* and select *Operator details* in the {product-title} web console, you cannot see the cert-manager resources that are created across all namespaces. As a workaround, you can navigate to *Home -> API Explorer* to see the cert-manager resources. (link:https://issues.redhat.com/browse/OCPBUGS-11647[*OCPBUGS-11647*])
-
-* After uninstalling the {cert-manager-operator} by using the web console, the {cert-manager-operator} does not remove the cert-manager controller, CA injector, and Webhook pods automatically from the `cert-manager` namespace. As a workaround, you can manually delete the cert-manager controller, CA injector, and Webhook pod deployments present in the `cert-manager` namespace. (link:https://issues.redhat.com/browse/OCPBUGS-13679[*OCPBUGS-13679*])
+* link:https://access.redhat.com/security/cve/CVE-2023-39615[CVE-2023-39615]
+* link:https://access.redhat.com/security/cve/CVE-2023-3978[CVE-2023-3978]
+* link:https://access.redhat.com/security/cve/CVE-2023-37788[CVE-2023-37788]
+* link:https://access.redhat.com/security/cve/CVE-2023-29406[CVE-2023-29406]


### PR DESCRIPTION
Version(s): 4.13+ (for this change but will be creating manual CPs)

Issue: [OSDOCS-8126](https://issues.redhat.com/browse/OSDOCS-8126)

Link to docs preview: https://69800--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-operator-release-notes

QE review:
- [x] QE has approved this change. @lunarwhite 
- [x] SME has approved this change. @swghosh 