### PR TITLE
Updating GitOps Operator reqs

### DIFF
--- a/modules/ztp-telco-ran-software-versions.adoc
+++ b/modules/ztp-telco-ran-software-versions.adoc
@@ -56,7 +56,7 @@ The Red Hat telco RAN DU {product-version} solution has been validated using the
 |2.8, 2.9
 
 |{gitops-title}
-|1.9
+|1.9, 1.10
 
 |{cgu-operator-first}
 |4.14


### PR DESCRIPTION
Adding GitOps Operator 1.9, 1.10 to ZTP reqs

Version(s):
enterprise-4.12+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1673

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
