### PR TITLE
OSDOCS#9216:Corrected typo in first step of creating ROSA cluster with Terraform procedure

### DIFF
--- a/modules/rosa-sts-cluster-terraform.adoc
+++ b/modules/rosa-sts-cluster-terraform.adoc
@@ -13,9 +13,7 @@ endif::[]
 The following Terraform cluster example shows how to create your account-wide IAM roles and a ROSA cluster with a managed OIDC configuration.
 
 .Procedure
-. Optional: Because the Terraform files that are created in your current directory during this procedure, you can create a new directory to store these files.
-
-.. To create and navigate into a new directory, run the following command:
+. Optional: Because the Terraform files get created in your current directory during this procedure, you can create a new directory to store these files and navigate into it by running the following command:
 +
 [source,terminal]
 ----
@@ -100,7 +98,7 @@ terraform {
       version = ">= 4.20.0"
     }
     rhcs = {
-      version = ">= 1.4.1"
+      version = ">= 1.5"
       source  = "terraform-redhat/rhcs"
     }
   }
@@ -396,10 +394,10 @@ $ rosa list account-roles
 ----
 I: Fetching account roles
 ROLE NAME                                   ROLE TYPE      ROLE ARN                                                           OPENSHIFT VERSION  AWS Managed
-ROSA-demo-ControlPlane-Role                 Control plane  arn:aws:iam::<ID>:role/ROSA-demo-ControlPlane-Role                 4.13               No
-ROSA-demo-Installer-Role                    Installer      arn:aws:iam::<ID>:role/ROSA-demo-Installer-Role                    4.13               No
-ROSA-demo-Support-Role                      Support        arn:aws:iam::<ID>:role/ROSA-demo-Support-Role                      4.13               No
-ROSA-demo-Worker-Role                       Worker         arn:aws:iam::<ID>:role/ROSA-demo-Worker-Role                       4.13               No
+ROSA-demo-ControlPlane-Role                 Control plane  arn:aws:iam::<ID>:role/ROSA-demo-ControlPlane-Role                 4.14               No
+ROSA-demo-Installer-Role                    Installer      arn:aws:iam::<ID>:role/ROSA-demo-Installer-Role                    4.14               No
+ROSA-demo-Support-Role                      Support        arn:aws:iam::<ID>:role/ROSA-demo-Support-Role                      4.14               No
+ROSA-demo-Worker-Role                       Worker         arn:aws:iam::<ID>:role/ROSA-demo-Worker-Role                       4.14               No
 ----
 
 . Verify that your Operator roles were created by running the following command:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+

Issue:
[OSDOCS-9216](https://issues.redhat.com/browse/OSDOCS-9216)

- Corrected typo
- Updated Terraform version from 1.4.1 to 1.5

Link to docs preview:
[Creating your ROSA cluster with Terraform](https://69820--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly-terraform#rosa-sts-cluster-terraform_rosa-sts-creating-a-cluster-quickly-terraform)

QE review:

- [x] QE has approved this change.
