### PR TITLE
OSDOCS-8701: Update resource considerations table

### DIFF
--- a/modules/network-observability-resources-table.adoc
+++ b/modules/network-observability-resources-table.adoc
@@ -17,10 +17,10 @@ The examples outlined in the table demonstrate scenarios that are tailored to sp
 |                                     | Extra small (10 nodes) | Small (25 nodes)  | Medium (65 nodes) ^[2]^ | Large (120 nodes) ^[2]^
 | *Worker Node vCPU and memory*       | 4 vCPUs\| 16GiB mem ^[1]^ | 16 vCPUs\| 64GiB mem ^[1]^ | 16 vCPUs\| 64GiB mem  ^[1]^  |16 vCPUs\| 64GiB Mem ^[1]^
 | *LokiStack size*                    | `1x.extra-small`         | `1x.small`          | `1x.small`           | `1x.medium`
-| *Network Observability controller memory limit* | 400Mi (default)        | 400Mi (default)   | 400Mi (default)    | 800Mi
+| *Network Observability controller memory limit* | 400Mi (default)        | 400Mi (default)   | 400Mi (default)    | 400Mi (default)
 | *eBPF sampling rate*                | 50 (default)           | 50 (default)      | 50 (default)       | 50 (default)
-| *eBPF memory limit*                 | 800Mi (default)        | 800Mi (default)   | 2000Mi             | 800Mi (default)
-| *FLP memory limit*                     | 800Mi (default)        | 800Mi (default)   | 800Mi (default)    | 800Mi (default)
+| *eBPF memory limit*                 | 800Mi (default)        | 800Mi (default)   | 800Mi (default)    | 1600Mi
+| *FLP memory limit*                  | 800Mi (default)        | 800Mi (default)   | 800Mi (default)    | 800Mi (default)
 | *FLP Kafka partitions*              | N/A                    | 48                | 48                 | 48
 | *Kafka consumer replicas*           | N/A                    | 24                | 24                 | 24
 | *Kafka brokers*                     | N/A                    | 3 (default)       | 3 (default)        | 3 (default)


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->
For peer review/merge review:
Merge to only the no-1.5 branch - no cherrypicks are required.
This PR is part of an experiment for simplifying merges for asynchronous content, and I will open one PR against main to incorporate all of the Network Observability 1.5 content just before its GA.

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.11+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-8701
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://69821--docspreview.netlify.app/openshift-enterprise/latest/network_observability/configuring-operator#network-observability-resources-table_network_observability
QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
