### PR TITLE
OBSDOCS-83: Removed JSON message field

### DIFF
--- a/modules/cluster-logging-json-log-forwarding.adoc
+++ b/modules/cluster-logging-json-log-forwarding.adoc
@@ -1,9 +1,9 @@
 [id="cluster-logging-json-log-forwarding_{context}"]
 = Parsing JSON logs
 
-Logs including JSON logs are usually represented as a string inside the `message` field. That makes it hard for users to query specific fields inside a JSON document. OpenShift Logging's Log Forwarding API enables you to parse JSON logs into a structured object and forward them to either OpenShift Logging-managed Elasticsearch or any other third-party system supported by the Log Forwarding API.
+You can use a `ClusterLogForwarder` object to parse JSON logs into a structured object and forward them to a supported output.
 
-To illustrate how this works, suppose that you have the following structured JSON log entry.
+To illustrate how this works, suppose that you have the following structured JSON log entry:
 
 .Example structured JSON log entry
 [source,yaml]
@@ -11,16 +11,7 @@ To illustrate how this works, suppose that you have the following structured JSO
 {"level":"info","name":"fred","home":"bedrock"}
 ----
 
-Normally, the `ClusterLogForwarder` custom resource (CR) forwards that log entry in the `message` field. The `message` field contains the JSON-quoted string equivalent of the JSON log entry, as shown in the following example.
-
-.Example `message` field
-[source,yaml]
-----
-{"message":"{\"level\":\"info\",\"name\":\"fred\",\"home\":\"bedrock\"",
- "more fields..."}
-----
-
-To enable parsing JSON log, you add `parse: json` to a pipeline in the `ClusterLogForwarder` CR, as shown in the following example.
+To enable parsing JSON log, you add `parse: json` to a pipeline in the `ClusterLogForwarder` CR, as shown in the following example:
 
 .Example snippet showing `parse: json`
 [source,yaml]
@@ -31,7 +22,7 @@ pipelines:
   parse: json
 ----
 
-When you enable parsing JSON logs by using `parse: json`, the CR copies the JSON-structured log entry in a `structured` field, as shown in the following example. This does not modify the original `message` field.
+When you enable parsing JSON logs by using `parse: json`, the CR copies the JSON-structured log entry in a `structured` field, as shown in the following example:
 
 .Example `structured` output containing the structured JSON log entry
 [source,yaml]
@@ -42,5 +33,5 @@ When you enable parsing JSON logs by using `parse: json`, the CR copies the JSON
 
 [IMPORTANT]
 ====
-If the log entry does not contain valid structured JSON, the `structured` field will be absent.
+If the log entry does not contain valid structured JSON, the `structured` field is absent.
 ====


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OBSDOCS-83

Link to docs preview:
https://69829--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_collection_forwarding/cluster-logging-enabling-json-logging#cluster-logging-json-log-forwarding_cluster-logging-enabling-json-logging

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
