### PR TITLE
OBSDOCS-698: Update rhel8 to rhel9

### DIFF
--- a/modules/cluster-logging-eventrouter-deploy.adoc
+++ b/modules/cluster-logging-eventrouter-deploy.adoc
@@ -115,7 +115,7 @@ objects:
 parameters:
   - name: IMAGE <6>
     displayName: Image
-    value: "registry.redhat.io/openshift-logging/eventrouter-rhel8:v0.4"
+    value: "registry.redhat.io/openshift-logging/eventrouter-rhel9:v0.4"
   - name: CPU <7>
     displayName: CPU
     value: "100m"


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OBSDOCS-698

Link to docs preview:
https://69831--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_collection_forwarding/cluster-logging-eventrouter#cluster-logging-eventrouter-deploy_cluster-logging-eventrouter

QE review:
- [x] QE has approved this change.
