### PR TITLE
[enterprise-4.12] CNV#33811 - RN for VMs that use LVM with block storage on RHCOS

### DIFF
--- a/virt/virt-4-12-release-notes.adoc
+++ b/virt/virt-4-12-release-notes.adoc
@@ -278,3 +278,6 @@ This step is optional if you specified a value for `spec.dataVolumeTemplates`.
 
 * If you clone more than 100 VMs using the `csi-clone` cloning strategy, then the Ceph CSI might not purge the clones. Manually deleting the clones can also fail. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2055595[*BZ#2055595*])
 ** As a workaround, you can restart the `ceph-mgr` to purge the VM clones.
+
+* VMs that use Logical volume management (LVM) with block storage devices require additional configuration to avoid conflicts with {op-system-first} hosts.
+** As a workaround, you can create a VM, provision an LVM, and restart the VM. This creates an empty `system.lvmdevices` file. (link:https://issues.redhat.com/browse/OCPBUGS-5223[*OCPBUGS-5223*])


### PR DESCRIPTION
Version(s):
4.12

Issue:
https://issues.redhat.com/browse/CNV-33811

Link to docs preview:
https://69838--docspreview.netlify.app/openshift-enterprise/latest/virt/virt-4-12-release-notes#virt-4-12-known-issues

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
