### PR TITLE
OADP-3305 adding open shift operator life cycles to docs

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
@@ -16,6 +16,11 @@ include::modules/oadp-configuring-velero-plugins.adoc[leveloffset=+1]
 include::modules/oadp-plugins-receiving-eof-message.adoc[leveloffset=+2]
 include::modules/oadp-supported-architecture.adoc[leveloffset=+1]
 
+[openshift-operator-life-cycles]
+== OpenShift Operator Life Cycles
+
+For more information about the software maintenance Life Cycle classifications for Operators, such as OADP, shipped by Red Hat for use with OpenShift Container Platform, see link:https://access.redhat.com/support/policy/updates/openshift_operators#platform-agnostic[OpenShift Operator Life Cycles].
+
 [id="oadp-support-for-ibm-power-and-ibm-z"]
 == OADP support for {ibm-power-title} and {ibm-z-title}
 

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
@@ -13,9 +13,11 @@ include::modules/oadp-release-notes-1-3-0.adoc[leveloffset=+1]
 include::modules/oadp-upgrade-from-oadp-data-mover-1-2-0.adoc[leveloffset=+3]
 include::modules/oadp-backing-up-dpa-configuration-1-3-0.adoc[leveloffset=+3]
 include::modules/oadp-upgrading-oadp-operator-1-3-0.adoc[leveloffset=+3]
+
 [role="_additional-resources"]
 .Additional resources
 * xref:../../../operators/admin/olm-upgrading-operators.adoc#olm-changing-update-channel_olm-upgrading-operators[Updating installed Operators]
 
 include::modules/oadp-converting-dpa-to-new-version-1-3-0.adoc[leveloffset=+3]
 include::modules/oadp-verifying-upgrade-1-3-0.adoc[leveloffset=+3]
+include::modules/oadp-operator-lifecycle-1-3-0.adoc[leveloffset=+2]

--- a/modules/oadp-operator-lifecycle-1-3-0.adoc
+++ b/modules/oadp-operator-lifecycle-1-3-0.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-release-notes-1-3.adoc
+
+:_mod-docs-content-type: CONCEPT
+
+[id="oadp-operator-lifecycle-rn-1-3-0_{context}"]
+== OADP operator lifecycle
+
+.OADP operator lifecycle
+[width="99%",cols="20%,16%,16%,16%,16%",options="header",]
+|===
+|*Version* |*OpenShift Version* |*General availability* |*Full
+support ends* |*Maintenance ends*
+|1.3 |4.12, 4.13, 4.14 |29 Nov 2023 |Release of 1.4
+|Release of 1.5
+|===
+


### PR DESCRIPTION
### Jira

* [OADP-3305](https://issues.redhat.com/browse/OADP-3305)

### Version(s):

* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15

### Link to docs preview:

1. [OADP 1.3.0 release notes](https://69839--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3)
2. [OpenShift Operator Life Cycles](https://69839--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-features-plugins#openshift-operator-life-cycles)

