### PR TITLE
[enterprise-4.13] CNV#33811 - RN for VMs that use LVM with block storage on RHCOS

### DIFF
--- a/virt/virt-4-13-release-notes.adoc
+++ b/virt/virt-4-13-release-notes.adoc
@@ -302,3 +302,7 @@ $ oc patch storageprofile <storage_profile> --type=merge -p '{"spec": {"claimPro
 
 //CNV-28577
 * If you deploy {VirtProductName} with {rh-storage-first}, you must create a dedicated storage class for Windows virtual machine disks. See link:https://access.redhat.com/articles/6978371[Optimizing ODF PersistentVolumes for Windows VMs] for details.
+
+//CNV-33811
+* VMs that use logical volume management (LVM) with block storage devices require additional configuration to avoid conflicts with {op-system-first} hosts.
+** As a workaround, you can create a VM, provision an LVM, and restart the VM. This creates an empty `system.lvmdevices` file. (link:https://issues.redhat.com/browse/OCPBUGS-5223[*OCPBUGS-5223*])


### PR DESCRIPTION
Version(s):
4.13

Issue:
https://issues.redhat.com/browse/CNV-33811

Link to docs preview:
https://69840--docspreview.netlify.app/openshift-enterprise/latest/virt/virt-4-13-release-notes#virt-4-13-known-issues

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
