### PR TITLE
OSDOCS-8382: Migrate "Getting Started with ROSA: Autoscaling" from rosaworkshop.io into product documentation

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -149,6 +149,8 @@ Topics:
     File: cloud-experts-getting-started-accessing
   - Name: Managing worker nodes
     File: cloud-experts-getting-started-managing-worker-nodes
+  - Name: Autoscaling
+    File: cloud-experts-getting-started-autoscaling
 - Name: Deploying an application
   Dir: cloud-experts-deploying-application
   Distros: openshift-rosa

--- a/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-autoscaling.adoc
+++ b/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-autoscaling.adoc
@@ -1,0 +1,85 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="cloud-experts-getting-started-autoscaling"]
+= Tutorial: Autoscaling
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: cloud-experts-getting-started-autoscaling
+
+toc::[]
+
+//rosaworkshop.io content metadata
+//Brought into ROSA product docs 2024-01-04
+
+The xref:../../rosa_cluster_admin/rosa_nodes/rosa-nodes-about-autoscaling-nodes.adoc#rosa-nodes-about-autoscaling-nodes[cluster autoscaler] adds or removes worker nodes from a cluster based on pod resources.
+
+The cluster autoscaler increases the size of the cluster when:
+
+* Pods fail to schedule on the current nodes due to insufficient resources.
+* Another node is necessary to meet deployment needs.
+
+The cluster autoscaler does not increase the cluster resources beyond the limits that you specify. 
+
+The cluster autoscaler decreases the size of the cluster when:
+
+* Some nodes are consistently not needed for a significant period. For example, when a node has low resource use and all of its important pods can fit on other nodes.
+
+== Enabling autoscaling for an existing machine pool using the CLI
+
+[NOTE]
+====
+Cluster autoscaling can be enabled at cluster creation and when creating a new machine pool by using the `--enable-autoscaling` option.
+====
+
+. Autoscaling is set based on machine pool availability. To find out which machine pools are available for autoscaling, run the following command:
++
+[source,terminal]
+----
+$ rosa list machinepools -c <cluster-name>
+----
++
+.Example output
++
+[source,terminal]
+----
+ID         AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS     TAINTS    AVAILABILITY ZONES
+Default    No           2         m5.xlarge                           us-east-1a
+----
+
+. Run the following command to add autoscaling to an available machine pool:
++
+[source,terminal]
+----
+$ rosa edit machinepool -c <cluster-name> --enable-autoscaling <machinepool-name> --min-replicas=<num> --max-replicas=<num>
+----
++
+.Example input
++
+[source,terminal]
+----
+$ rosa edit machinepool -c my-rosa-cluster --enable-autoscaling Default --min-replicas=2 --max-replicas=4
+----
++
+The above command creates an autoscaler for the worker nodes that scales between 2 and 4 nodes depending on the resources.
+
+== Enabling autoscaling for an existing machine pool using the UI
+
+[NOTE]
+====
+Cluster autoscaling can be enabled at cluster creation by checking the *Enable autoscaling* checkbox when creating machine pools.
+====
+
+. Go to the *Machine pools* tab and click the three dots in the right..
+. Click *Scale*, then *Enable autoscaling*.
+. Run the following command to confirm that autoscaling was added:
++
+[source,terminal]
+----
+$ rosa list machinepools -c <cluster-name>
+----
++
+.Example output
++
+[source,terminal]
+----
+ID         AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS     TAINTS    AVAILABILITY ZONES
+Default    Yes          2-4       m5.xlarge                           us-east-1a
+----


### PR DESCRIPTION
[OSDOCS-8382](https://issues.redhat.com//browse/OSDOCS-8382): Migrate "Getting Started with ROSA: Autoscaling" from rosaworkshop.io into product documentation
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-8382

Link to docs preview:
https://69847--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-autoscaling

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
