### PR TITLE
Fixing OWNER and OWNER-ALIASES indents for Prow CI

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,8 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 # This file just uses aliases defined in OWNERS_ALIASES.
+# Do not change indents. Incorrect indents break the Prow CI
 
 reviewers:
-  - merge-rights
+- merge-rights
 approvers:
-  - merge-rights
+- merge-rights

--- a/OWNERS-ALIASES
+++ b/OWNERS-ALIASES
@@ -1,27 +1,28 @@
 # See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#OWNERS_ALIASES
+# Do not change indents. Incorrect indents break the Prow CI
 
 aliases:
   merge-rights:
-    - abhatt-rh
-    - abrennan89
-    - adellape
-    - aireilly
-    - apinnick
-    - bburt-rh
-    - bergerhoffer
-    - bscott-rh
-    - gabriel-rh
-    - jab-rh
-    - jeana-redhat
-    - JoeAldinger
-    - kalexand-rh
-    - kcarmichael08
-    - kelbrown20
-    - michaelryanpeter
-    - mjpytlak
-    - opayne1
-    - ousleyp
-    - rolfedh
-    - sjhala-ccs
-    - snarayan-redhat
-    - Srivaralakshmi
+  - abhatt-rh
+  - abrennan89
+  - adellape
+  - aireilly
+  - apinnick
+  - bburt-rh
+  - bergerhoffer
+  - bscott-rh
+  - gabriel-rh
+  - jab-rh
+  - jeana-redhat
+  - JoeAldinger
+  - kalexand-rh
+  - kcarmichael08
+  - kelbrown20
+  - michaelryanpeter
+  - mjpytlak
+  - opayne1
+  - ousleyp
+  - rolfedh
+  - sjhala-ccs
+  - snarayan-redhat
+  - Srivaralakshmi


### PR DESCRIPTION
The Prow CI OWNERS workfow is broken by incorrect YAML indents in the OWNERS file. See https://github.com/openshift/release/pull/46336/files#diff-0277a800035d3b98458711041d63479b871dc2061de8657d96abb8733f9608af

This PR fixes the indents to allow Prow CI to read the files.