### PR TITLE
TELCODOCS-420: Adding release note for new MetalLB metrics

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -369,6 +369,11 @@ This release adds improvements related to the following components and concepts.
 
 Pods created using the macvlan CNI plugin, where the IP address management CNI plug-in has assigned IPs, now send IPv6 unsolicited neighbor advertisements by default onto the network. This enhancement notifies hosts of the new pod's MAC address for a particular IP to refresh IPv6 neighbor caches.
 
+[id="ocp-4-15-metallb-metrics"]
+==== Additional BGP metrics for MetalLB
+
+With this update, MetalLB exposes additional metrics relating to communication between MetalLB and Border Gateway Protocol (BGP) peers. For more information, see xref:../networking/metallb/metallb-troubleshoot-support.adoc#nw-metallb-metrics_metallb-troubleshoot-support[MetalLB metrics for BGP and BFD].
+
 [id="ocp-4-15-registry"]
 === Registry
 


### PR DESCRIPTION
[TELCODOCS-420](https://issues.redhat.com//browse/TELCODOCS-420): Additional MetalLB Metrics release note

Version(s):
4.15

Issue:
https://issues.redhat.com/browse/TELCODOCS-420

Link to docs preview:
https://69851--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-metallb-metrics

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


