### PR TITLE
Fixing typos in PTP config ref tables

### DIFF
--- a/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
@@ -89,13 +89,15 @@ include::snippets/ptp_PtpConfigBoundary.yaml[]
 |Specify the `priority` with an integer value between `0` and `99`. A larger number gets lower priority, so a priority of `99` is lower than a priority of `10`. If a node can be matched with multiple profiles according to rules defined in the `match` field, the profile with the higher priority is applied to that node.
 
 |`.recommend.match`
-|Specify `.recommend.match` rules with `nodeLabel` or `nodeName`.
+|Specify `.recommend.match` rules with `nodeLabel` or `nodeName` values.
 
 |`.recommend.match.nodeLabel`
-|Update `nodeLabel` with the `key` of `node.Labels` from the node object by using the `oc get nodes --show-labels` command. For example: `node-role.kubernetes.io/worker`.
+|Set `nodeLabel` with the `key` of the `node.Labels` field from the node object by using the `oc get nodes --show-labels` command.
+For example, `node-role.kubernetes.io/worker`.
 
-|`.recommend.match.nodeLabel`
-|Update `nodeName` with value of `node.Name` from the node object by using the `oc get nodes` command. For example: `compute-0.example.com`.
+|`.recommend.match.nodeName`
+|Set `nodeName` with the value of the `node.Name` field from the node object by using the `oc get nodes` command.
+For example, `compute-1.example.com`.
 |====
 
 . Create the CR by running the following command:

--- a/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
@@ -82,13 +82,15 @@ include::snippets/ptp_PtpConfigOrdinaryClock.yaml[]
 |Set `.recommend.priority` to `0` for ordinary clock.
 
 |`.recommend.match`
-|Specify `.recommend.match` rules with `nodeLabel` or `nodeName`.
+|Specify `.recommend.match` rules with `nodeLabel` or `nodeName` values.
 
 |`.recommend.match.nodeLabel`
-|Update `nodeLabel` with the `key` of `node.Labels` from the node object by using the `oc get nodes --show-labels` command. For example: `node-role.kubernetes.io/worker`.
+|Set `nodeLabel` with the `key` of the `node.Labels` field from the node object by using the `oc get nodes --show-labels` command.
+For example, `node-role.kubernetes.io/worker`.
 
-|`.recommend.match.nodeLabel`
-|Update `nodeName` with value of `node.Name` from the node object by using the `oc get nodes` command. For example: `compute-0.example.com`.
+|`.recommend.match.nodeName`
+|Set `nodeName` with the value of the `node.Name` field from the node object by using the `oc get nodes` command.
+For example, `compute-1.example.com`.
 |====
 
 . Create the `PtpConfig` CR by running the following command:


### PR DESCRIPTION
manual 4.11 CP for https://github.com/openshift/openshift-docs/pull/69815