### PR TITLE
Updates macvlan release note

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -367,7 +367,9 @@ This release adds improvements related to the following components and concepts.
 [id="ocp-4-15-ipv6-default-macvlan"]
 ==== IPv6 unsolicited neighbor advertisements now default on macvlan CNI plugin
 
-Pods created using the macvlan CNI plugin, where the IP address management CNI plug-in has assigned IPs, now send IPv6 unsolicited neighbor advertisements by default onto the network. This enhancement notifies hosts of the new pod's MAC address for a particular IP to refresh IPv6 neighbor caches.
+Previously, if one pod (`Pod X`) was deleted, and a second pod (`Pod Y`) was created with a similar configuration, `Pod Y` might have had the same IPv6 address as `Pod X`, but it would have a different MAC address.  In this scenario, the router was unaware of the MAC address address change, and it would continue sending traffic to the MAC address for `Pod X`.
+
+With this update, pods created using the macvlan CNI plugin, where the IP address management CNI plugin has assigned IPs, now send IPv6 unsolicited neighbor advertisements by default onto the network. This enhancement notifies the network fabric of the new pod's MAC address for a particular IP to refresh IPv6 neighbor caches.
 
 [id="ocp-4-15-registry"]
 === Registry


### PR DESCRIPTION
Version(s):
4.15

Issue:
Follow up to https://github.com/openshift/openshift-docs/pull/69150

Link to docs preview:
https://69859--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-ipv6-default-macvlan

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
