### PR TITLE
[OSDOCS-9232]: Issue in file rosa_hcp/rosa-tuning-config.adoc

### DIFF
--- a/modules/custom-tuning-specification.adoc
+++ b/modules/custom-tuning-specification.adoc
@@ -146,8 +146,8 @@ ifdef::rosa-hcp-tuning[]
   ]
 }
 ----
-<1> Profile ordering priority. Lower numbers mean higher priority (`0` is the highest priority).
-<2> A TuneD profile to apply on a match. For example `tuned_profile_1`.
+<1> A TuneD profile to apply on a match. For example `tuned_profile_1`.
+<2> Profile ordering priority. Lower numbers mean higher priority (`0` is the highest priority).
 <3> Optional: A dictionary of key-value pairs `MachineConfig` labels. The keys must be unique.
 <4> If omitted, profile match is assumed unless a profile with a higher priority matches first or `machineConfigLabels` is set.
 <5> The label for the profile matched items.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-9232
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://69866--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-tuning-config#custom-tuning-specification_rosa-tuning-config
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
**Image taken from updated (preview) docs. The numbered list did not reflect what was being shown within JSON file (#1 and #2 were reversed).** 
![image](https://github.com/openshift/openshift-docs/assets/122639474/692611c7-d44a-4f82-b6ec-fc0fc8b35421)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
