### PR TITLE
OCPBUGS-17499: Adding reset step to Booting from an HTTP-hosted ISO image using the Redfish API

### DIFF
--- a/modules/install-booting-from-an-iso-over-http-redfish.adoc
+++ b/modules/install-booting-from-an-iso-over-http-redfish.adoc
@@ -8,9 +8,19 @@
 
 You can provision hosts in your network using ISOs that you install using the Redfish Baseboard Management Controller (BMC) API.
 
+[NOTE]
+====
+This example procedure demonstrates the steps on a Dell server.
+====
+
+[IMPORTANT]
+====
+Ensure that you have the latest firmware version of iDRAC that is compatible with your hardware. If you have any issues with the hardware or firmware, you must contact the provider.
+====
+
 .Prerequisites
 
-. Download the installation {op-system-first} ISO.
+* Download the installation {op-system-first} ISO.
 
 .Procedure
 
@@ -18,7 +28,7 @@ You can provision hosts in your network using ISOs that you install using the Re
 
 . Boot the host from the hosted ISO file, for example:
 
-.. Call the redfish API to set the hosted ISO as the `VirtualMedia` boot media by running the following command:
+.. Call the Redfish API to set the hosted ISO as the `VirtualMedia` boot media by running the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13, 4.14, 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-17499
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://69874--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-installing-sno#install-booting-from-an-iso-over-http-redfish_install-sno-installing-sno-with-the-assisted-installer
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
