### PR TITLE
OSDOCS#6518: 64k pages in the RHCOS kernel support on ARM arches

### DIFF
--- a/modules/machine-config-overview.adoc
+++ b/modules/machine-config-overview.adoc
@@ -56,7 +56,7 @@ The kinds of components that MCO can change include:
 * Adding new users by using a machine config is not supported.
 ====
 * **kernelArguments**: Add arguments to the kernel command line when {product-title} nodes boot.
-* **kernelType**: Optionally identify a non-standard kernel to use instead of the standard kernel. Use `realtime` to use the RT kernel (for RAN). This is only supported on select platforms.
+* **kernelType**: Optionally identify a non-standard kernel to use instead of the standard kernel. Use `realtime` to use the RT kernel (for RAN). This is only supported on select platforms. Use the `64k-pages` parameter to enable the 64k page size kernel. This setting is exclusive to machines with 64-bit ARM architectures.
 ifndef::openshift-origin[]
 * **fips**: Enable link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/security_hardening/index#using-the-system-wide-cryptographic-policies_security-hardening[FIPS] mode. FIPS should be set at installation-time setting and not a postinstallation procedure.
 


### PR DESCRIPTION
**Version(s):** 4.15+ 
**Issue:** [OSDOCS-6518](https://issues.redhat.com/browse/OSDOCS-6518)

**Link to docs preview:**

- Machine configuration tasks -> [Machine config overview (The update is in the "What can you change with machine configs?" subsection) ](https://69875--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks#machine-config-overview-post-install-machine-configuration-tasks)

**QE review:**
- [x] QE has approved this change.