### PR TITLE
OSDOCS-9002: Note about default host config values

### DIFF
--- a/modules/installing-ocp-agent-inputs.adoc
+++ b/modules/installing-ocp-agent-inputs.adoc
@@ -44,6 +44,7 @@ This is the preferred method for the Agent-based installation. Using {ztp} manif
 
 . Create the `install-config.yaml` file:
 +
+--
 [source,terminal]
 ----
 $ cat << EOF > ./my-cluster/install-config.yaml
@@ -70,19 +71,24 @@ networking:
   networkType: OVNKubernetes <3>
   serviceNetwork:
   - 172.30.0.0/16
-platform:
+platform: <4>
   none: {}
-pullSecret: '<pull_secret>' <4>
-sshKey: '<ssh_pub_key>' <5>
+pullSecret: '<pull_secret>' <5>
+sshKey: '<ssh_pub_key>' <6>
 EOF
 ----
-+
 <1> Specify the system architecture, valid values are `amd64` and `arm64`.
 <2> Required. Specify your cluster name.
 <3> Specify the cluster network plugin to install. The supported values are `OVNKubernetes` and `OpenShiftSDN`. The default value is `OVNKubernetes`.
-<4> Specify your pull secret.
-<5> Specify your SSH public key.
-
+<4> Specify your platform.
++
+[NOTE]
+====
+For bare metal platforms, host settings made in the platform section of the `install-config.yaml` file are used by default, unless they are overridden by configurations made in the `agent-config.yaml` file.
+====
+<5> Specify your pull secret.
+<6> Specify your SSH public key.
+--
 +
 [NOTE]
 ====


### PR DESCRIPTION
[OSDOCS-9002](https://issues.redhat.com/browse/OSDOCS-9002)

Version(s): 4.15+

This PR adds a note to the Agent install procedure explaining which configuration values will be used by default in the `install-config.yaml` unless they are overridden in the `agent-config.yaml`

QE review:
- [x] QE has approved this change.

Preview: [Creating the preferred configuration inputs](https://69882--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer#installing-ocp-agent-inputs_installing-with-agent-based-installer)