### PR TITLE
OSDOCS#9222: Agent installer on multi-arch

### DIFF
--- a/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
@@ -70,6 +70,9 @@ include::modules/installing-ocp-agent-verify.adoc[leveloffset=+2]
 * See xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#root-device-hints_preparing-to-install-with-agent-based-installer[About root device hints].
 * See link:https://nmstate.io/examples.html[NMState state examples].
 
+//Verifying architectures 
+include::modules/agent-installer-architectures.adoc[leveloffset=+2]
+
 include::modules/sample-ztp-custom-resources.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/modules/agent-installer-architectures.adoc
+++ b/modules/agent-installer-architectures.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// * installing/installing-with-agent-based-installer/preparing-to-install-with-agent-based-installer.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="agent-install-networking_{context}"]
+= Optional: Verifying architectures on the Agent-based installer 
+
+You can check which architecture your {product-title} agent installer cluster is using by viewing the version binary.
+
+.Prerequisites: 
+
+* You installed the OpenShift CLI (oc)
+* You have the openshift-installer binary
+
+.Procedure: 
+
+. Check your release payload by running the following command: 
+[source,terminal]
++
+----
+$ ./openshift-install version
+----
++
+.Example output 
+[source,terminal]
+----
+./openshfit-install 4.15.z
+built from commit e80d50ac8c9ab65833045d648a01eb1a0a3a6d7d
+release image quay.io/openshift-release-dev/ocp-release@sha256:27d41f99e0784a2f596e773799983147b794df48d1f7536d51a95a60945b1931
+release architecture amd64
+----
++
+If you are using the `multi` installer payload, the `release architecture` output of this command displays the architecture of the host where the installer is running. 
+
+. To verify that you are using your preferred architecture, run the following example command:
+[source,terminal]
++
+----
+$ oc adm release info <release-image> -o jsonpath="{ .metadata.metadata}"
+----
++
+.Example command that uses a release-image
+[source,terminal]
+----
+$ oc adm release info quay.io/openshift-release-dev/ocp-release@sha256:27d41f99e0784a2f596e773799983147b794df48d1f7536d51a95a60945b1931 -o jsonpath="{ .metadata.metadata}"
+----
++
+.Example output when the release-image uses the `multi` payload:
+[source,terminal]
+----
+{"release.openshift.io architecture":"multi"}
+----
++
+The release image is found in the content digest and you can access your release image by running the `./openshift-install version` command. With the `multi` installer binary, your cluster supports `arm64`, `amd64`, `s390x`, and `ppc64le`. Otherwise, you can only install the architecture defined in the `release architecture` output from the `openshift-install version` command. 


### PR DESCRIPTION
**Version(s):** 4.16+ 
[feature is being pushed to 4.16]
**Issue:** [OSDOCS-9222](https://issues.redhat.com//browse/OSDOCS-9222)

**Link to docs preview:**

- [Installing an OpenShift Container Platform cluster with the Agent-based Installer -> Optional: Verifying architectures on the Agent-based installer](https://69883--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer#agent-install-networking_installing-with-agent-based-installer)

**QE review:**
- [ ] QE has approved this change
