### PR TITLE
OSDOCS-8490: TLS support for metrics ports (OCPSTRAT-970)

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -424,6 +424,12 @@ The Network Observability Operator releases updates independently from the {prod
 //[id="ocp-4-15-cluster-cloud-controller-manager-operator"]
 //=== Cloud controller managers for additional cloud providers
 
+[discrete]
+[id="ocp-4-15-ports-use-tls"]
+=== Cluster metrics ports secured
+
+With this release, the ports that serve metrics for the Cluster Machine Approver Operator and Cluster Cloud Controller Manager Operator use the Transport Layer Security (TLS) protocol for additional security. (link:https://issues.redhat.com/browse/OCPCLOUD-2272[*OCPCLOUD-2272*], link:https://issues.redhat.com/browse/OCPCLOUD-2271[*OCPCLOUD-2271*])
+
 [id="ocp-4-15-deprecated-removed-features"]
 == Deprecated and removed features
 


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-8490](https://issues.redhat.com//browse/OSDOCS-8490)

Link to docs preview:
[Cluster metrics ports secured](https://69884--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-ports-use-tls)

QE review:
- [x] QE has approved this change.

Additional information: