### PR TITLE
OSDOCS-9220 z-stream RNs for 4.13.28

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -3626,3 +3626,28 @@ $ oc adm release info 4.13.27 --pullspecs
 [id="ocp-4-13-27-updating"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-13-28"]
+=== RHBA-2024:0055 - {product-title} 4.13.28 bug fix and security update
+
+Issued: 2024-01-10
+
+{product-title} release 4.13.28 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0055[RHBA-2024:0055] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:0057[RHBA-2024:0057] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.28 --pullspecs
+----
+
+[id="ocp-4-13-28-bug-fixes"]
+==== Bug fixes
+
+* Previously, due to a different DNS suffix, `ccoctl` failed to create AWS security token service (STS) resources in China. With this release, `ccoctl` can be used to create STS resources in China regions and the cluster can be installed successfully. (link:https://issues.redhat.com/browse/OCPBUGS-25369[*OCPBUGS-25369*])
+
+[id="ocp-4-13-28-updating"]
+==== Updating
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-9220](https://issues.redhat.com/browse/OSDOCS-9220)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Preview](https://69885--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes#ocp-4-13-28)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Not needed
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Expected merge date Jan. 10th. Errata links will not work until then. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
