### PR TITLE
OSDOCS-4157: GCP Role Administrator role

### DIFF
--- a/authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc
@@ -51,10 +51,15 @@ The credential you provide for mint mode in Google Cloud Platform (GCP) must hav
 * `serviceusage.services.list`
 * `iam.serviceAccountKeys.create`
 * `iam.serviceAccountKeys.delete`
+* `iam.serviceAccountKeys.list`
 * `iam.serviceAccounts.create`
 * `iam.serviceAccounts.delete`
 * `iam.serviceAccounts.get`
+* `iam.roles.create`
 * `iam.roles.get`
+* `iam.roles.list`
+* `iam.roles.undelete`
+* `iam.roles.update`
 * `resourcemanager.projects.getIamPolicy`
 * `resourcemanager.projects.setIamPolicy`
 ====

--- a/modules/cco-ccoctl-configuring.adoc
+++ b/modules/cco-ccoctl-configuring.adoc
@@ -275,6 +275,50 @@ ifdef::azure-workload-id[]
 ====
 endif::azure-workload-id[]
 
+//GCP permissions needed when running ccoctl during install.
+ifdef::google-cloud-platform[]
+* You have added one of the following authentication options to the GCP account that the installation program uses:
+
+** The **IAM Workload Identity Pool Admin** role.
+
+** The following granular permissions:
++
+.Required GCP permissions
+[%collapsible]
+====
+* compute.projects.get
+* iam.googleapis.com/workloadIdentityPoolProviders.create
+* iam.googleapis.com/workloadIdentityPoolProviders.get
+* iam.googleapis.com/workloadIdentityPools.create
+* iam.googleapis.com/workloadIdentityPools.delete
+* iam.googleapis.com/workloadIdentityPools.get
+* iam.googleapis.com/workloadIdentityPools.undelete
+* iam.roles.create
+* iam.roles.delete
+* iam.roles.list
+* iam.roles.undelete
+* iam.roles.update
+* iam.serviceAccounts.create
+* iam.serviceAccounts.delete
+* iam.serviceAccounts.getIamPolicy
+* iam.serviceAccounts.list
+* iam.serviceAccounts.setIamPolicy
+* iam.workloadIdentityPoolProviders.get
+* iam.workloadIdentityPools.delete
+* resourcemanager.projects.get
+* resourcemanager.projects.getIamPolicy
+* resourcemanager.projects.setIamPolicy
+* storage.buckets.create
+* storage.buckets.delete
+* storage.buckets.get
+* storage.buckets.getIamPolicy
+* storage.buckets.setIamPolicy
+* storage.objects.create
+* storage.objects.delete
+* storage.objects.list
+====
+endif::google-cloud-platform[]
+
 .Procedure
 
 ifndef::update[]

--- a/modules/cco-ccoctl-deleting-sts-resources.adoc
+++ b/modules/cco-ccoctl-deleting-sts-resources.adoc
@@ -70,7 +70,8 @@ $ ccoctl {cp-name} delete \
 ifdef::aws-sts[  --region=<{cp-name}_region> <2>]
 ifdef::gcp-workload-id[]
   --project=<{cp-name}_project_id> \// <2>
-  --credentials-requests-dir=<path_to_credentials_requests_directory>
+  --credentials-requests-dir=<path_to_credentials_requests_directory> \
+  --force-delete-custom-roles <3>
 endif::gcp-workload-id[]
 ifdef::azure-workload-id[]
   --region=<{cp-name}_region> \// <2>
@@ -81,7 +82,10 @@ endif::azure-workload-id[]
 +
 <1> `<name>` matches the name that was originally used to create and tag the cloud resources.
 ifdef::aws-sts,azure-workload-id[<2> `<{cp-name}_region>` is the {cp} region in which to delete cloud resources.]
-ifdef::gcp-workload-id[<2> `<{cp-name}_project_id>` is the {cp} project ID in which to delete cloud resources.]
+ifdef::gcp-workload-id[]
+<2> `<{cp-name}_project_id>` is the {cp} project ID in which to delete cloud resources.
+<3> Optional: This parameter deletes the custom roles that the `ccoctl` utility creates during installation. GCP does not permanently delete custom roles immediately. For more information, see GCP documentation about link:https://cloud.google.com/iam/docs/creating-custom-roles#deleting-custom-role[deleting a custom role].
+endif::gcp-workload-id[]
 ifdef::azure-workload-id[<3> `<{cp-name}_subscription_id>` is the {cp} subscription ID for which to delete cloud resources.]
 ifdef::aws-sts[]
 +

--- a/modules/cco-ccoctl-install-creating-manifests.adoc
+++ b/modules/cco-ccoctl-install-creating-manifests.adoc
@@ -48,6 +48,26 @@ ifeval::["{context}" == "installing-restricted-networks-azure-installer-provisio
 :azure-workload-id:
 endif::[]
 
+//GCP install assemblies
+ifeval::["{context}" == "installing-gcp-customizations"]
+:google-cloud-platform:
+endif::[]
+ifeval::["{context}" == "installing-gcp-network-customizations"]
+:google-cloud-platform:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-gcp-installer-provisioned"]
+:google-cloud-platform:
+endif::[]
+ifeval::["{context}" == "installing-gcp-vpc"]
+:google-cloud-platform:
+endif::[]
+ifeval::["{context}" == "installing-gcp-shared-vpc"]
+:google-cloud-platform:
+endif::[]
+ifeval::["{context}" == "installing-gcp-private"]
+:google-cloud-platform:
+endif::[]
+
 :_mod-docs-content-type: PROCEDURE
 [id="cco-ccoctl-install-creating-manifests_{context}"]
 = Incorporating the Cloud Credential Operator utility manifests
@@ -61,6 +81,28 @@ To implement short-term security credentials managed outside the cluster for ind
 * You have created the cloud provider resources that are required for your cluster with the `ccoctl` utility.
 
 .Procedure
+
+ifdef::google-cloud-platform[]
+. Add the following granular permissions to the GCP account that the installation program uses:
++
+.Required GCP permissions
+[%collapsible]
+====
+* compute.machineTypes.list
+* compute.regions.list
+* compute.zones.list
+* dns.changes.create
+* dns.changes.get
+* dns.managedZones.create
+* dns.managedZones.delete
+* dns.managedZones.get
+* dns.managedZones.list
+* dns.networks.bindPrivateDNSZone
+* dns.resourceRecordSets.create
+* dns.resourceRecordSets.delete
+* dns.resourceRecordSets.list
+====
+endif::google-cloud-platform[]
 
 . If you did not set the `credentialsMode` parameter in the `install-config.yaml` configuration file to `Manual`, modify the value as shown:
 +
@@ -131,4 +173,24 @@ ifeval::["{context}" == "installing-azure-vnet"]
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-azure-installer-provisioned"]
 :!azure-workload-id:
+endif::[]
+
+//GCP install assemblies
+ifeval::["{context}" == "installing-gcp-customizations"]
+:!google-cloud-platform:
+endif::[]
+ifeval::["{context}" == "installing-gcp-network-customizations"]
+:!google-cloud-platform:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-gcp-installer-provisioned"]
+:!google-cloud-platform:
+endif::[]
+ifeval::["{context}" == "installing-gcp-vpc"]
+:!google-cloud-platform:
+endif::[]
+ifeval::["{context}" == "installing-gcp-shared-vpc"]
+:!google-cloud-platform:
+endif::[]
+ifeval::["{context}" == "installing-gcp-private"]
+:!google-cloud-platform:
 endif::[]

--- a/modules/installation-gcp-permissions.adoc
+++ b/modules/installation-gcp-permissions.adoc
@@ -21,6 +21,7 @@ When you attach the `Owner` role to the service account that you create, you gra
 
 .Required roles for the installation program
 * Compute Admin
+* IAM Role Administrator
 * IAM Security Admin
 * Service Account Admin
 * Service Account Key Admin
@@ -30,18 +31,17 @@ When you attach the `Owner` role to the service account that you create, you gra
 .Required roles for creating network resources during installation
 * DNS Administrator
 
-.Required roles for using passthrough credentials mode
+.Required roles for using the Cloud Credential Operator in passthrough mode
 * Compute Load Balancer Admin
-* IAM Role Viewer
 
 ifdef::template[]
 .Required roles for user-provisioned GCP infrastructure
 * Deployment Manager Editor
 endif::template[]
 
-The roles are applied to the service accounts that the control plane and compute machines use:
+The following roles are applied to the service accounts that the control plane and compute machines use:
 
-.GCP service account permissions
+.GCP service account roles
 [cols="2a,2a",options="header"]
 |===
 |Account

--- a/modules/manually-create-identity-access-management.adoc
+++ b/modules/manually-create-identity-access-management.adoc
@@ -160,6 +160,28 @@ endif::cco-manual-mode[]
 
 .Procedure
 
+ifdef::google-cloud-platform[]
+. Add the following granular permissions to the GCP account that the installation program uses:
++
+.Required GCP permissions
+[%collapsible]
+====
+* compute.machineTypes.list
+* compute.regions.list
+* compute.zones.list
+* dns.changes.create
+* dns.changes.get
+* dns.managedZones.create
+* dns.managedZones.delete
+* dns.managedZones.get
+* dns.managedZones.list
+* dns.networks.bindPrivateDNSZone
+* dns.resourceRecordSets.create
+* dns.resourceRecordSets.delete
+* dns.resourceRecordSets.list
+====
+endif::google-cloud-platform[]
+
 ifdef::cco-multi-mode[]
 . If you did not set the `credentialsMode` parameter in the `install-config.yaml` configuration file to `Manual`, modify the value as shown:
 +


### PR DESCRIPTION
Version(s):
4.15+

Issue:
[OSDOCS-4157](https://issues.redhat.com//browse/OSDOCS-4157)

Link to docs preview:
* [Required GCP roles](https://69886--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#installation-gcp-permissions_installing-gcp-account)
* [Configuring the Cloud Credential Operator utility](https://69886--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations#cco-ccoctl-configuring_installing-gcp-customizations)
* [Mint mode permissions requirements](https://69886--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-mint#mint-mode-permissions)
* [Deleting Google Cloud Platform resources with the Cloud Credential Operator utility](https://69886--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/uninstalling-cluster-gcp#cco-ccoctl-deleting-sts-resources_uninstalling-cluster-gcp)

QE review:
- [x] QE has approved this change.

Additional information: