### PR TITLE
OSDOCS-6090: GCP CCM is GA

### DIFF
--- a/modules/cluster-cloud-controller-manager-operator.adoc
+++ b/modules/cluster-cloud-controller-manager-operator.adoc
@@ -10,9 +10,9 @@
 
 [NOTE]
 ====
-The status of this Operator is General Availability for Amazon Web Services (AWS), {ibm-cloud-name}, global Microsoft Azure, Microsoft Azure Stack Hub, Nutanix, {rh-openstack-first}, and VMware vSphere.
+The status of this Operator is General Availability for {aws-first}, {gcp-first}, {ibm-cloud-name}, global {azure-full}, Microsoft Azure Stack Hub, Nutanix, {rh-openstack-first}, and {vmw-full}.
 
-The Operator is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Alibaba Cloud, Google Cloud Platform (GCP), and {ibm-cloud-name} Power VS.
+The Operator is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for {alibaba} and {ibm-power-server-name}.
 ====
 
 The Cluster Cloud Controller Manager Operator manages and updates the cloud controller managers deployed on top of {product-title}. The Operator is based on the Kubebuilder framework and `controller-runtime` libraries. It is installed via the Cluster Version Operator (CVO).


### PR DESCRIPTION
Version(s):
4.15+

Issue:
[OSDOCS-6090](https://issues.redhat.com//browse/OSDOCS-6090) > [OSDOCS-6092](https://issues.redhat.com//browse/OSDOCS-6092)

Link to docs preview:
[Cluster Cloud Controller Manager Operator](https://69887--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator-reference.html#cluster-cloud-controller-manager-operator_cluster-operators-ref)

QE review:
- [x] QE has approved this change.

Additional information: