### PR TITLE
OSDOCS-6090: GCP CCM is GA (RNs)

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -430,6 +430,19 @@ The Network Observability Operator releases updates independently from the {prod
 
 With this release, the ports that serve metrics for the Cluster Machine Approver Operator and Cluster Cloud Controller Manager Operator use the Transport Layer Security (TLS) protocol for additional security. (link:https://issues.redhat.com/browse/OCPCLOUD-2272[*OCPCLOUD-2272*], link:https://issues.redhat.com/browse/OCPCLOUD-2271[*OCPCLOUD-2271*])
 
+[id="ocp-4-15-cluster-cloud-controller-manager-operator"]
+=== Cloud controller manager for Google Cloud Platform
+
+The Kubernetes community plans to deprecate the use of the Kubernetes controller manager to interact with underlying cloud platforms in favor of using cloud controller managers. As a result, there is no plan to add Kubernetes controller manager support for any new cloud platforms.
+
+This release introduces the General Availability of using a cloud controller manager for Google Cloud Platform.
+
+To learn more about the cloud controller manager, see the link:https://kubernetes.io/docs/concepts/architecture/cloud-controller/[Kubernetes Cloud Controller Manager documentation].
+
+To manage the cloud controller manager and cloud node manager deployments and lifecycles, use the Cluster Cloud Controller Manager Operator.
+
+For more information, see the xref:../operators/operator-reference.adoc#cluster-cloud-controller-manager-operator_cluster-operators-ref[Cluster Cloud Controller Manager Operator] entry in the _Cluster Operators reference_.
+
 [id="ocp-4-15-deprecated-removed-features"]
 == Deprecated and removed features
 
@@ -1265,7 +1278,7 @@ In the following tables, features are marked with the following statuses:
 |Cloud controller manager for Google Cloud Platform
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|General Availability
 
 |Cloud controller manager for {ibm-power-name} VS
 |Technology Preview


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-6090](https://issues.redhat.com//browse/OSDOCS-6090) > [OSDOCS-6091](https://issues.redhat.com//browse/OSDOCS-6091)

Link to docs preview:
* [Cloud controller managers for additional cloud providers](https://69888--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-cluster-cloud-controller-manager-operator)
* [Machine management Technology Preview features](https://69888--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#machine-management-technology-preview-features)

QE review:
- [x] QE has approved this change.

Additional information: