### PR TITLE
HCIDOCS-133: [enterprise-4.13] Issue in file installing/installing_bare_metal_ipi/ipi-install-prerequisites.adoc

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -14,7 +14,7 @@
 :op-system-lowercase: rhcos
 :op-system-base: RHEL
 :op-system-base-full: Red Hat Enterprise Linux (RHEL)
-:op-system-version: 8.x
+:op-system-version: 9.x
 ifdef::openshift-origin[]
 :op-system-first: Fedora CoreOS (FCOS)
 :op-system: FCOS

--- a/installing/installing_bare_metal_ipi/ipi-install-prerequisites.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-prerequisites.adoc
@@ -9,7 +9,7 @@ toc::[]
 Installer-provisioned installation of {product-title} requires:
 
 ifdef::openshift-origin[. One provisioner node with {op-system-first} installed. The provisioner can be removed after installation.]
-ifndef::openshift-origin[. One provisioner node with {op-system-base-full} 8.x installed. The provisioner can be removed after installation.]
+ifndef::openshift-origin[. One provisioner node with {op-system-base-full} {op-system-version} installed. The provisioner can be removed after installation.]
 . Three control plane nodes
 . Baseboard management controller (BMC) access to each node
 . At least one network:

--- a/modules/ipi-install-configuring-nodes.adoc
+++ b/modules/ipi-install-configuring-nodes.adoc
@@ -25,7 +25,7 @@ While the cluster nodes can contain more than two NICs, the installation process
 | NIC2 | `baremetal` | `<baremetal_vlan>`
 |===
 
-ifndef::openshift-origin[The {op-system-base-full} 8.x installation process on the provisioner node might vary. To install {op-system-base-full} 8.x using a local Satellite server or a PXE server, PXE-enable NIC2.]
+ifndef::openshift-origin[The {op-system-base-full} {op-system-version} installation process on the provisioner node might vary. To install {op-system-base-full} {op-system-version} using a local Satellite server or a PXE server, PXE-enable NIC2.]
 ifdef::openshift-origin[The {op-system-first} installation process on the provisioner node might vary. To install {op-system} using a local Satellite server or a PXE server, PXE-enable NIC2.]
 
 [options="header"]

--- a/modules/ipi-install-node-requirements.adoc
+++ b/modules/ipi-install-node-requirements.adoc
@@ -18,7 +18,7 @@ CPU architecture.
 * *Baseboard Management Controller:* The `provisioner` node must be able to access the baseboard management controller (BMC) of each {product-title} cluster node. You may use IPMI, Redfish, or a proprietary protocol.
 
 ifndef::openshift-origin[]
-* *Latest generation:* Nodes must be of the most recent generation. Installer-provisioned installation relies on BMC protocols, which must be compatible across nodes. Additionally, {op-system-base} 8 ships with the most recent drivers for RAID controllers. Ensure that the nodes are recent enough to support {op-system-base} 8 for the `provisioner` node and {op-system} 8 for the control plane and worker nodes.
+* *Latest generation:* Nodes must be of the most recent generation. Installer-provisioned installation relies on BMC protocols, which must be compatible across nodes. Additionally, {op-system-base} {op-system-version} ships with the most recent drivers for RAID controllers. Ensure that the nodes are recent enough to support {op-system-base} {op-system-version} for the `provisioner` node and {op-system} {op-system-version} for the control plane and worker nodes.
 endif::[]
 ifdef::openshift-origin[]
 * *Latest generation:* Nodes must be of the most recent generation. Installer-provisioned installation relies on BMC protocols, which must be compatible across nodes. Additionally, {op-system-first} ships with the most recent drivers for RAID controllers. Ensure that the nodes are recent enough to support {op-system} for the `provisioner` node and {op-system} for the control plane and worker nodes.

--- a/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
+++ b/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
@@ -54,7 +54,11 @@ ifndef::openshift-origin[]
 [source,terminal]
 ----
 $ sudo subscription-manager register --username=<user> --password=<pass> --auto-attach
-$ sudo subscription-manager repos --enable=rhel-8-for-<architecture>-appstream-rpms --enable=rhel-8-for-<architecture>-baseos-rpms
+----
++
+[source,terminal]
+----
+$ sudo subscription-manager repos --enable=rhel-9-for-<architecture>-appstream-rpms --enable=rhel-9-for-<architecture>-baseos-rpms
 ----
 +
 [NOTE]


### PR DESCRIPTION
Updated operating system version from RHEL 8.x to RHEL 9.x.

Fixes: [HCIDOCS-133](https://issues.redhat.com//browse/HCIDOCS-133)

See https://issues.redhat.com/browse/HCIDOCS-133 for additional details.

Preview URL: http://jowilkin.com:8080/HCIDOCS-133/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html and http://jowilkin.com:8080/HCIDOCS-133/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html

For release(s): 4.15, 4.14, 4.13
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
