### PR TITLE
CNV- 36956: VirtualMachineCRCErrors update

### DIFF
--- a/modules/virt-runbook-virtualmachinecrcerrors.adoc
+++ b/modules/virt-runbook-virtualmachinecrcerrors.adoc
@@ -78,6 +78,9 @@ The `krbd:rxbounce` option creates a bounce buffer to receive data. The default
 behavior is for the destination buffer to receive data directly. A bounce buffer
 is required if the stability of the destination buffer cannot be guaranteed.
 
+See link:https://access.redhat.com/articles/6978371[Optimizing ODF PersistentVolumes for Windows VMs]
+for details.
+
 If you cannot resolve the issue, log in to the
 link:https://access.redhat.com[Customer Portal] and open a support case,
 attaching the artifacts gathered during the diagnosis procedure.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-36956](https://issues.redhat.com//browse/CNV-36956)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [VirtualMachineCRCErrors](https://69892--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-runbooks#virt-runbook-VirtualMachineCRCErrors)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
