### PR TITLE
OCPBUGS#24683: Added Role and RoleBinding objects to enable monitoring

### DIFF
--- a/modules/cert-manager-enable-metrics.adoc
+++ b/modules/cert-manager-enable-metrics.adoc
@@ -22,15 +22,45 @@ You can enable monitoring and metrics collection for the {cert-manager-operator}
 $ oc label namespace cert-manager openshift.io/cluster-monitoring=true
 ----
 
-. Enable monitoring for user-defined projects. See _Enabling monitoring for user-defined projects_ for instructions.
-
 . Create a service monitor:
 
-.. Create a YAML file that defines the `ServiceMonitor` object:
+.. Create a YAML file that defines the `Role`, `RoleBinding`, and `ServiceMonitor` objects:
 +
-.Example `service-monitor.yaml` file
+.Example `monitoring.yaml` file
+
 [source,yaml]
 ----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: cert-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: cert-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -53,9 +83,9 @@ spec:
       app.kubernetes.io/name: cert-manager
 ----
 
-.. Create the `ServiceMonitor` object by running the following command:
+.. Create the `Role`, `RoleBinding`, and `ServiceMonitor` objects by running the following command:
 +
 [source,terminal]
 ----
-$ oc create -f service-monitor.yaml
+$ oc create -f monitoring.yaml
 ----

--- a/security/cert_manager_operator/cert-manager-monitoring.adoc
+++ b/security/cert_manager_operator/cert-manager-monitoring.adoc
@@ -14,7 +14,6 @@ include::modules/cert-manager-enable-metrics.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects_enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
 * xref:../../monitoring/managing-metrics.adoc#setting-up-metrics-collection-for-user-defined-projects_managing-metrics[Setting up metrics collection for user-defined projects]
 
 // Querying metrics for the {cert-manager-operator}


### PR DESCRIPTION
Version(s): 4.12+

Issue: https://issues.redhat.com/browse/OCPBUGS-24683

Link to docs preview: https://69893--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-monitoring#cert-manager-enable-metrics_cert-manager-monitoring

QE review:
- [x] QE has approved this change.
- [x] SME has approved this change.