### PR TITLE
OSDOCS-3462-re: Removed port 80 reference from AWS firewall pre in RO…

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -45,7 +45,7 @@ This section provides the necessary details that enable you to control egress tr
 |Provides core container images.
 
 |`sso.redhat.com`
-|443, 80
+|443
 |Required. The `https://console.redhat.com/openshift` site uses authentication from `sso.redhat.com` to download the pull secret and use Red Hat SaaS solutions to facilitate monitoring of your subscriptions, cluster inventory, chargeback reporting, and so on.
 
 |`quay-registry.s3.amazonaws.com`
@@ -73,11 +73,11 @@ This section provides the necessary details that enable you to control egress tr
 |Hosts all the container images that are stored on the Red Hat Ecosytem Catalog. Additionally, the registry provides access to the `odo` CLI tool that helps developers build on OpenShift and Kubernetes.
 
 |`registry.connect.redhat.com`
-|443, 80
+|443
 |Required for all third-party images and certified Operators.
 
 |`console.redhat.com`
-|443, 80
+|443
 |Required. Allows interactions between the cluster and OpenShift Console Manager to enable functionality, such as scheduling upgrades.
 
 |`sso.redhat.com`
@@ -97,7 +97,7 @@ This section provides the necessary details that enable you to control egress tr
 |The `openshift.org` site redirects through `www.okd.io`.
 
 |`www.redhat.com`
-|443, 80
+|443
 |The `sso.redhat.com` site redirects through `www.redhat.com`.
 
 |`aws.amazon.com`
@@ -232,11 +232,11 @@ Alternatively, if you choose to not use a wildcard for Amazon Web Services (AWS)
 |Used to install and manage clusters in an AWS environment.
 
 |`servicequotas.<aws_region>.amazonaws.com`
-|443, 80
+|443
 |Required. Used to confirm quotas for deploying the service.
 
 |`tagging.<aws_region>.amazonaws.com`
-|443, 80
+|443
 |Allows the assignment of metadata about AWS resources in the form of tags.
 |===
 


### PR DESCRIPTION
Jira: [OSDOCS-3462](https://issues.redhat.com/browse/OSDOCS-3462)

Version(s):
ROSA (4.15, 4.14)

Link to docs preview:
[AWS firewall prerequisites](https://69896--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs)

SME review:
- [X] SME has approved this change.

QE review:
- [x] QE has approved this change.

