### PR TITLE
OSDOCS#24488: Changed example values for cert-manager

### DIFF
--- a/modules/cert-manager-configure-cpu-memory.adoc
+++ b/modules/cert-manager-configure-cpu-memory.adoc
@@ -90,24 +90,24 @@ spec:
         cpu: 200m <2>
         memory: 64Mi <3>
       requests: <4>
-        cpu: 200m <2>
-        memory: 64Mi <3>
+        cpu: 10m <2>
+        memory: 16Mi <3>
   webhookConfig:
     overrideResources:
       limits: <5>
         cpu: 200m <6>
         memory: 64Mi <7>
       requests: <8>
-        cpu: 200m <6>
-        memory: 64Mi <7>
+        cpu: 10m <6>
+        memory: 16Mi <7>
   cainjectorConfig:
     overrideResources:
       limits: <9>
         cpu: 200m <10>
         memory: 64Mi <11>
       requests: <12>
-        cpu: 200m <10>
-        memory: 64Mi <11>
+        cpu: 10m <10>
+        memory: 16Mi <11>
 "
 ----
 <1> Defines the maximum amount of CPU and memory that a single container in a cert-manager controller pod can request.


### PR DESCRIPTION
Version(s): 4.12+

Issue: https://issues.redhat.com/browse/OCPBUGS-24488

Link to docs preview: https://69897--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-customizing-api-fields#cert-manager-configure-cpu-memory_cert-manager-customizing-api-fields

QE review:
- [x] QE has approved this change.