### PR TITLE
TELCODOCS-1686: BMER deprecation

### DIFF
--- a/monitoring/using-rfhe.adoc
+++ b/monitoring/using-rfhe.adoc
@@ -12,6 +12,11 @@ include::snippets/technology-preview.adoc[]
 [id="about-using-redfish-hardware-events"]
 == About bare-metal events
 
+[IMPORTANT]
+====
+The Bare Metal Event Relay Operator is deprecated. The ability to monitor bare-metal hosts by using the Bare Metal Event Relay Operator will be removed in a future {product-title} release.
+====
+
 Use the {redfish-operator} to subscribe applications that run in your {product-title} cluster to events that are generated on the underlying bare-metal host. The Redfish service publishes events on a node and transmits them on an advanced message queue to subscribed applications.
 
 Bare-metal events are based on the open Redfish standard that is developed under the guidance of the Distributed Management Task Force (DMTF). Redfish provides a secure industry-standard protocol with a REST API. The protocol is used for the management of distributed, converged or software-defined resources and infrastructure.

--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -663,8 +663,28 @@ In the following tables, features are marked with the following statuses:
 
 |====
 
+[discrete]
+=== Bare metal monitoring
+
+.Bare Metal Event Relay Operator tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.13 |4.14 |4.15
+
+|Bare Metal Event Relay Operator
+|Technology Preview
+|Technology Preview
+|Deprecated
+
+|====
+
 [id="ocp-4-15-deprecated-features"]
 === Deprecated features
+
+[id="ocp-4-15-bmer"]
+==== Bare Metal Event Relay Operator
+
+The Bare Metal Event Relay Operator is deprecated. The ability to monitor bare-metal hosts by using the Bare Metal Event Relay Operator will be removed in a future {product-title} release.
 
 [id="ocp-4-15-removed-features"]
 === Removed features


### PR DESCRIPTION
[TELCODOCS-1686](https://issues.redhat.com//browse/TELCODOCS-1686): Deprecation of BMER from 4.15

Version(s):
4.15

Issue:
https://issues.redhat.com/browse/TELCODOCS-1686

Link to docs preview:
https://69899--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-bmer (release note)

https://69899--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-deprecated-removed-features (updated table tracking BMER feature deprecation in release notes - scroll to bottom of this section to see the table)

https://69899--docspreview.netlify.app/openshift-enterprise/latest/monitoring/using-rfhe#about-using-redfish-hardware-events (note regarding deprecation in content)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
