### PR TITLE
OSDOCS-9215: Documented the 4.11.56 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -3901,3 +3901,22 @@ $ oc adm release info 4.11.55 --pullspecs
 ==== Updating
 
 To update a {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-11-56"]
+=== RHSA-2024:0059 {product-title} 4.11.56 bug fix update and security update
+
+Issued: 2023-01-10
+
+{product-title} release 4.11.56, which includes security updates, is now available. Bug fixes included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2024:0059[RHSA-2024:0059] advisory. RPM packages included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:0061[RHBA-2024:0061] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.56 --pullspecs
+----
+
+[id="ocp-4-11-56-upgrading"]
+==== Updating
+
+To update a {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.11

Issue:
[OSDOCS-9215](https://issues.redhat.com/browse/OSDOCS-9215)

Link to docs preview:
[4.11.56 z-stream release notes](https://69900--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes#ocp-4-11-56)

QE review:
- [ ] QE not required. See the peer-review checklist.

