### PR TITLE
OSDOCS-9236: adds 4.14.8 release note to MicroShift docs

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -394,3 +394,12 @@ Issued: 2024-01-03
 {product-title} release 4.14.7, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:7833[RHBA-2023:7833] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7831[RHSA-2023:7831] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-14-8-dp"]
+=== RHBA-2024:0052 - {microshift-short} 4.14.8 bug fix update advisory
+
+Issued: 2024-01-09
+
+{product-title} release 4.14.8, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0052[RHBA-2024:0052] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0050[RHSA-2024:0050] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
Version(s):
4.14 only

Issue:
https://issues.redhat.com/browse/OSDOCS-9236

Link to docs preview:
[4.14.8 release note](https://69902--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes#microshift-4-14-8-dp)

QE review:
- N/A no bugs attached to this release note; no technical language

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
