### PR TITLE
OCPBUGS-26482 - PTP E810 T-GM tech preview typo

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -2231,6 +2231,11 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |General Availability
 
+|Intel E810 Westport Channel NIC as PTP grandmaster clock
+|Not Available
+|Technology Preview
+|Technology Preview
+
 |Ingress Node Firewall Operator
 |Technology Preview
 |Technology Preview
@@ -2606,11 +2611,6 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 
 |HTTP transport replaces AMQP for PTP and bare-metal events
-|Not Available
-|Technology Preview
-|Technology Preview
-
-|Intel E810 Westport Channel NIC as PTP grandmaster clock
 |Not Available
 |Technology Preview
 |Technology Preview


### PR DESCRIPTION
Intel E810 Westport Channel NIC as PTP grandmaster clock is in the wrong Tech Preview table.

Version(s):
enterprise-4.14

Issue:
https://issues.redhat.com/browse/OCPBUGS-26482

Link to docs preview:
https://69906--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-technology-preview

QE review:
- [x] QE review not required.
