### PR TITLE
OSDOCS#8722: Refactor of vSphere install reqs for UPI

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -483,6 +483,8 @@ Topics:
     Dir: upi
     Distros: openshift-origin,openshift-enterprise
     Topics:
+    - Name: vSphere installation requirements
+      File: upi-vsphere-installation-reqs
     - Name: Installing a cluster
       File: installing-vsphere
     - Name: Installing a cluster with network customizations

--- a/installing/installing_vsphere/upi/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/upi/installing-restricted-networks-vsphere.adoc
@@ -41,56 +41,6 @@ include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
-include::modules/installation-vsphere-infrastructure.adoc[leveloffset=+1]
-
-include::modules/vmware-csi-driver-reqs.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* To remove a third-party vSphere CSI driver, see xref:../../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-install-issues_persistent-storage-csi-vsphere[Removing a third-party vSphere CSI Driver].
-* To update the hardware version for your vSphere nodes, see xref:../../../updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on nodes running in vSphere].
-
-[id="installation-requirements-user-infra_{context}"]
-== Requirements for a cluster with user-provisioned infrastructure
-
-For a cluster that contains user-provisioned infrastructure, you must deploy all
-of the required machines.
-
-This section describes the requirements for deploying {product-title} on user-provisioned infrastructure.
-
-include::modules/installation-vsphere-installer-infra-requirements.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-* xref:../../../machine_management/creating_machinesets/creating-machineset-vsphere.adoc#creating-machineset-vsphere_creating-machineset-vsphere[Creating a compute machine set on vSphere]
-
-include::modules/installation-machine-requirements.adoc[leveloffset=+2]
-include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../../scalability_and_performance/optimization/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
-
-include::modules/installation-vsphere-encrypted-vms.adoc[leveloffset=+2]
-[role="_additional-resources"]
-.Additional resources
-* xref:../../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-encryption[Creating an encrypted storage class]
-
-include::modules/csr-management.adoc[leveloffset=+2]
-
-include::modules/installation-network-user-infra.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../../installing/install_config/installing-customizing.adoc#installation-special-config-chrony_installing-customizing[Configuring chrony time service]
-
-include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
-
-include::modules/installation-load-balancing-user-infra.adoc[leveloffset=+2]
-
 include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
 
 include::modules/installation-user-provisioned-validating-dns.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/upi/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/upi/installing-vsphere-network-customizations.adoc
@@ -33,56 +33,6 @@ The steps for performing a user-provisioned infrastructure installation are prov
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
-include::modules/installation-vsphere-infrastructure.adoc[leveloffset=+1]
-
-include::modules/vmware-csi-driver-reqs.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* To remove a third-party vSphere CSI driver, see xref:../../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-install-issues_persistent-storage-csi-vsphere[Removing a third-party vSphere CSI Driver].
-* To update the hardware version for your vSphere nodes, see xref:../../../updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on nodes running in vSphere].
-
-[id="installation-requirements-user-infra_{context}"]
-== Requirements for a cluster with user-provisioned infrastructure
-
-For a cluster that contains user-provisioned infrastructure, you must deploy all
-of the required machines.
-
-This section describes the requirements for deploying {product-title} on user-provisioned infrastructure.
-
-include::modules/installation-vsphere-installer-infra-requirements.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-* xref:../../../machine_management/creating_machinesets/creating-machineset-vsphere.adoc#creating-machineset-vsphere_creating-machineset-vsphere[Creating a compute machine set on vSphere]
-
-include::modules/installation-machine-requirements.adoc[leveloffset=+2]
-include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../../scalability_and_performance/optimization/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
-
-include::modules/installation-vsphere-encrypted-vms.adoc[leveloffset=+2]
-[role="_additional-resources"]
-.Additional resources
-* xref:../../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-pv-encryption[Creating an encrypted storage class]
-
-include::modules/csr-management.adoc[leveloffset=+2]
-
-include::modules/installation-network-user-infra.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../../<installing/install_config/installing-customizing.adoc#installation-special-config-chrony_installing-customizing[Configuring chrony time service]
-
-include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
-
-include::modules/installation-load-balancing-user-infra.adoc[leveloffset=+2]
-
 include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
 
 include::modules/installation-user-provisioned-validating-dns.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/upi/installing-vsphere.adoc
+++ b/installing/installing_vsphere/upi/installing-vsphere.adoc
@@ -33,56 +33,6 @@ Be sure to also review this site list if you are configuring a proxy.
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
-include::modules/installation-vsphere-infrastructure.adoc[leveloffset=+1]
-
-include::modules/vmware-csi-driver-reqs.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* To remove a third-party vSphere CSI driver, see xref:../../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-install-issues_persistent-storage-csi-vsphere[Removing a third-party vSphere CSI Driver].
-* To update the hardware version for your vSphere nodes, see xref:../../../updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on nodes running in vSphere].
-
-[id="installation-requirements-user-infra_{context}"]
-== Requirements for a cluster with user-provisioned infrastructure
-
-For a cluster that contains user-provisioned infrastructure, you must deploy all
-of the required machines.
-
-This section describes the requirements for deploying {product-title} on user-provisioned infrastructure.
-
-include::modules/installation-vsphere-installer-infra-requirements.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-* xref:../../../machine_management/creating_machinesets/creating-machineset-vsphere.adoc#creating-machineset-vsphere_creating-machineset-vsphere[Creating a compute machine set on vSphere]
-
-include::modules/installation-machine-requirements.adoc[leveloffset=+2]
-include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../../scalability_and_performance/optimization/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
-
-include::modules/installation-vsphere-encrypted-vms.adoc[leveloffset=+2]
-[role="_additional-resources"]
-.Additional resources
-* xref:../../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-pv-encryption[Creating an encrypted storage class]
-
-include::modules/csr-management.adoc[leveloffset=+2]
-
-include::modules/installation-network-user-infra.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../../installing/install_config/installing-customizing.adoc#installation-special-config-chrony_installing-customizing[Configuring chrony time service]
-
-include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
-
-include::modules/installation-load-balancing-user-infra.adoc[leveloffset=+2]
-
 include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
 
 include::modules/installation-user-provisioned-validating-dns.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc
+++ b/installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc
@@ -1,0 +1,55 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="upi-vsphere-installation-reqs"]
+= vSphere installation requirements for user-provisioned infrastructure
+include::_attributes/common-attributes.adoc[]
+:context: upi-vsphere-installation-reqs
+
+toc::[]
+
+Before you begin an installation on infrastructure that you provision, be sure that your vSphere environment meets the following installation requirements.
+
+include::modules/installation-vsphere-infrastructure.adoc[leveloffset=+1]
+include::modules/vmware-csi-driver-reqs.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* To remove a third-party vSphere CSI driver, see xref:../../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-install-issues_persistent-storage-csi-vsphere[Removing a third-party vSphere CSI Driver].
+* To update the hardware version for your vSphere nodes, see xref:../../../updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on nodes running in vSphere].
+
+[id="reqs-for-a-cluster-with-user-provisioned-infrastructure_upi-vsphere-installation-reqs"]
+== Requirements for a cluster with user-provisioned infrastructure
+
+For a cluster that contains user-provisioned infrastructure, you must deploy all of the required machines.
+
+This section describes the requirements for deploying {product-title} on user-provisioned infrastructure.
+
+include::modules/installation-vsphere-installer-infra-requirements.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../machine_management/creating_machinesets/creating-machineset-vsphere.adoc#creating-machineset-vsphere_creating-machineset-vsphere[Creating a compute machine set on vSphere]
+
+include::modules/installation-machine-requirements.adoc[leveloffset=+2]
+include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../scalability_and_performance/optimization/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
+include::modules/installation-vsphere-encrypted-vms.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-pv-encryption[Creating an encrypted storage class]
+
+include::modules/csr-management.adoc[leveloffset=+2]
+include::modules/installation-network-user-infra.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../installing/install_config/installing-customizing.adoc#installation-special-config-chrony_installing-customizing[Configuring chrony time service]
+
+include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
+include::modules/installation-load-balancing-user-infra.adoc[leveloffset=+2]

--- a/modules/csr-management.adoc
+++ b/modules/csr-management.adoc
@@ -17,13 +17,11 @@
 // installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
 // installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
 // installing/installing_platform_agnostic/installing-platform-agnostic.adoc
-// installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
-// installing/installing_vsphere/installing-vsphere-network-customizations.adoc
-// installing/installing_vsphere/installing-vsphere.adoc
 // machine_management/adding-rhel-compute.adoc
 // machine_management/more-rhel-compute.adoc
 // post_installation_configuration/node-tasks.adoc
 // installing/installing_azure/installing-restricted-networks-azure-user-provisioned.adoc
+// installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="csr-management_{context}"]

--- a/modules/installation-dns-user-infra.adoc
+++ b/modules/installation-dns-user-infra.adoc
@@ -13,9 +13,7 @@
 // * installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
 // * installing/installing_vmc/installing-vmc-user-infra.adoc
 // * installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc
-// * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
-// * installing/installing_vsphere/installing-vsphere.adoc
+// * installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc
 
 ifeval::["{context}" == "installing-ibm-z"]
 :ibm-z:

--- a/modules/installation-load-balancing-user-infra.adoc
+++ b/modules/installation-load-balancing-user-infra.adoc
@@ -4,9 +4,6 @@
 // * installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
 // * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
 // * installing/installing_platform_agnostic/installing-platform-agnostic.adoc
-// * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
 // * installing/installing_ibm_z/installing-ibm-z.adoc
 // * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
 // * installing/installing_ibm_z/installing-ibm-z-kvm.adoc
@@ -14,18 +11,7 @@
 // * installing/installing_ibm_z/installing-restricted-networks-ibm-power.adoc
 // * installing/installing_openstack/installing-openstack-installer-custom.adoc
 // * installing/installing_openstack/installing-openstack-installer-kuryr.adoc
-
-ifeval::["{context}" == "installing-vsphere"]
-:vsphere:
-endif::[]
-
-ifeval::["{context}" == "installing-restricted-networks-vsphere"]
-:vsphere:
-endif::[]
-
-ifeval::["{context}" == "installing-vsphere-network-customizations"]
-:vsphere:
-endif::[]
+// * installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc
 
 ifeval::["{context}" == "installing-ibm-z"]
 :ibm-z:
@@ -255,15 +241,6 @@ If you are deploying a three-node cluster with zero compute nodes, the Ingress C
 If you are using HAProxy as a load balancer, you can check that the `haproxy` process is listening on ports `6443`, `22623`, `443`, and `80` by running `netstat -nltupe` on the HAProxy node.
 ====
 
-ifeval::["{context}" == "installing-vsphere"]
-:!vsphere:
-endif::[]
-ifeval::["{context}" == "installing-restricted-networks-vsphere"]
-:!vsphere:
-endif::[]
-ifeval::["{context}" == "installing-vsphere-network-customizations"]
-:!vsphere:
-endif::[]
 ifeval::["{context}" == "installing-ibm-z"]
 :!ibm-z:
 endif::[]

--- a/modules/installation-machine-requirements.adoc
+++ b/modules/installation-machine-requirements.adoc
@@ -10,14 +10,12 @@
 // * installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
 // * installing/installing_gcp/installing-restricted-networks-gcp.adoc
 // * installing/installing_platform_agnostic/installing-platform-agnostic.adoc
-// * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
 // * installing/installing_ibm_power/installing-ibm-power.adoc
 // * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
 // * installing/installing_ibm_z/installing-ibm-z.adoc
 // * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
 // * installing/installing_azure/installing-restricted-networks-azure-user-provisioned.adoc
+// * installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc
 
 ifeval::["{context}" == "installing-bare-metal"]
 :bare-metal:

--- a/modules/installation-minimum-resource-requirements.adoc
+++ b/modules/installation-minimum-resource-requirements.adoc
@@ -28,9 +28,6 @@
 // * installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
 // * installing/installing_gcp/installing-restricted-networks-gcp.adoc
 // * installing/installing_platform_agnostic/installing-platform-agnostic.adoc
-// * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
 // * installing/installing_ibm_power/installing-ibm-power.adoc
 // * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
 // * installing/installing_ibm_powervs/installing-ibm-power-vs-private-cluster.adoc
@@ -44,6 +41,7 @@
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
 // * installing/installing-restricted-networks-azure-installer-provisioned.adoc
 // * installing/installing_azure/installing-restricted-networks-azure-user-provisioned.adoc
+// * installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc
 
 ifeval::["{context}" == "installing-azure-customizations"]
 :azure:
@@ -108,13 +106,7 @@ endif::[]
 ifeval::["{context}" == "installing-ibm-cloud-private"]
 :ibm-cloud-vpc:
 endif::[]
-ifeval::["{context}" == "installing-vsphere"]
-:vsphere:
-endif::[]
-ifeval::["{context}" == "installing-vsphere-network-customizations"]
-:vsphere:
-endif::[]
-ifeval::["{context}" == "installing-restricted-networks-vsphere"]
+ifeval::["{context}" == "upi-vsphere-installation-reqs"]
 :vsphere:
 endif::[]
 
@@ -307,12 +299,6 @@ endif::[]
 ifeval::["{context}" == "installing-ibm-cloud-private"]
 :!ibm-cloud-vpc:
 endif::[]
-ifeval::["{context}" == "installing-vsphere"]
-:!vsphere:
-endif::[]
-ifeval::["{context}" == "installing-vsphere-network-customizations"]
-:!vsphere:
-endif::[]
-ifeval::["{context}" == "installing-restricted-networks-vsphere"]
+ifeval::["{context}" == "upi-vsphere-installation-reqs"]
 :!vsphere:
 endif::[]

--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -9,9 +9,6 @@
 // * installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
 // * installing/installing_gcp/installing-restricted-networks-gcp.adoc
 // * installing/installing_platform_agnostic/installing-platform-agnostic.adoc
-// * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
 // * installing/installing_ibm_z/installing-ibm-z.adoc
 // * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
 // * installing/installing_ibm_z/installing-ibm-z-kvm.adoc
@@ -19,17 +16,8 @@
 // * installing/installing_ibm_z/installing-ibm-power.adoc
 // * installing/installing_ibm_z/installing-restricted-networks-ibm-power.adoc
 // * installing/installing_azure/installing-restricted-networks-azure-user-provisioned.adoc
+// * installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc
 
-
-ifeval::["{context}" == "installing-vsphere"]
-:vsphere:
-endif::[]
-ifeval::["{context}" == "installing-restricted-networks-vsphere"]
-:vsphere:
-endif::[]
-ifeval::["{context}" == "installing-vsphere-network-customizations"]
-:vsphere:
-endif::[]
 ifeval::["{context}" == "installing-ibm-z"]
 :ibm-z:
 endif::[]
@@ -67,6 +55,9 @@ ifeval::["{context}" == "installing-restricted-networks-gcp"]
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-azure-user-provisioned"]
 :azure:
+endif::[]
+ifeval::["{context}" == "upi-vsphere-installation-reqs"]
+:vsphere:
 endif::[]
 
 
@@ -233,10 +224,6 @@ If a MAC address outside the VMware OUI is used, the cluster installation will
 not succeed.
 endif::vsphere[]
 
-ifdef::vsphere[]
-:!vsphere:
-endif::[]
-
 ifndef::azure,gcp[]
 [discrete]
 == NTP configuration for user-provisioned infrastructure
@@ -285,4 +272,7 @@ ifeval::["{context}" == "installing-restricted-networks-gcp"]
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-azure-user-provisioned"]
 :!azure:
+endif::[]
+ifeval::["{context}" == "upi-vsphere-installation-reqs"]
+:!vsphere:
 endif::[]

--- a/modules/installation-vsphere-encrypted-vms.adoc
+++ b/modules/installation-vsphere-encrypted-vms.adoc
@@ -1,5 +1,5 @@
 // module is included in the following assemblies:
-// ../installing/installing_vsphere/installing-vsphere.adoc
+// installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="installation-vsphere-encrypted-vms_{context}"]

--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -1,9 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.adoc
-// * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+// * installing/installing_vsphere/upi/upi-vpshere-installation-reqs.adoc
 
 [id="installation-vsphere-infrastructure_{context}"]
 = VMware vSphere infrastructure requirements

--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -1,47 +1,39 @@
 // Module included in the following assemblies for vSphere:
 //
 // * installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.adoc
-// * installing/installing_vsphere/installing-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
-// * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+// * installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc
 
-ifeval::["{context}" == "installing-vsphere"]
-:vsphere:
-endif::[]
-ifeval::["{context}" == "installing-vsphere-network-customizations"]
-:vsphere:
-endif::[]
-ifeval::["{context}" == "installing-restricted-networks-vsphere"]
-:vsphere:
+ifeval::["{context}" == "upi-vsphere-installation-reqs"]
+:upi:
 endif::[]
 
 
 [id="installation-vsphere-installer-infra-requirements_{context}"]
 = vCenter requirements
 
-ifndef::vsphere[]
+ifndef::upi[]
 Before you install an {product-title} cluster on your vCenter that uses infrastructure that the installer provisions, you must prepare your environment.
-endif::vsphere[]
+endif::upi[]
 
-ifdef::vsphere[]
+ifdef::upi[]
 Before you install an {product-title} cluster on your vCenter that uses infrastructure that you provided, you must prepare your environment.
-endif::vsphere[]
+endif::upi[]
 
 [discrete]
 [id="installation-vsphere-installer-infra-requirements-account_{context}"]
 == Required vCenter account privileges
 
-ifndef::vsphere[]
+ifndef::upi[]
 To install an {product-title} cluster in a vCenter, the installation program requires access to an account with privileges to read and create the required resources. Using an account that has global administrative privileges is the simplest way to access all of the necessary permissions.
 
 If you cannot use an account with global administrative privileges, you must create roles to grant the privileges necessary for {product-title} cluster installation. While most of the privileges are always required, some are required only if you plan for the installation program to provision a folder to contain the {product-title} cluster on your vCenter instance, which is the default behavior. You must create or amend vSphere roles for the specified objects to grant the required privileges.
 
 An additional role is required if the installation program is to create a vSphere virtual machine folder.
-endif::vsphere[]
+endif::upi[]
 
-ifdef::vsphere[]
+ifdef::upi[]
 To install an {product-title} cluster in a vCenter, your vSphere account must include privileges for reading and creating the required resources. Using an account that has global administrative privileges is the simplest way to access all of the necessary permissions.
-endif::vsphere[]
+endif::upi[]
 
 
 .Roles and privileges required for installation in vSphere API
@@ -396,15 +388,15 @@ If you must specify VMs across multiple datastores, use a `datastore` object to 
 [id="installation-vsphere-installer-infra-requirements-resources_{context}"]
 == Cluster resources
 
-ifndef::vsphere[]
+ifndef::upi[]
 When you deploy an {product-title} cluster that uses installer-provisioned infrastructure, the installation program must be able to create several resources in your vCenter instance.
 
 A standard {product-title} installation creates the following vCenter resources:
-endif::vsphere[]
+endif::upi[]
 
-ifdef::vsphere[]
+ifdef::upi[]
 When you deploy an {product-title} cluster that uses infrastructure that you provided, you must create the following resources in your vCenter instance:
-endif::vsphere[]
+endif::upi[]
 
 * 1 Folder
 * 1 Tag category
@@ -452,14 +444,14 @@ It is recommended that each {product-title} node in the cluster must have access
 [discrete]
 [id="installation-vsphere-installer-infra-requirements-_{context}"]
 === Required IP Addresses
-ifndef::vsphere[]
+ifndef::upi[]
 For a network that uses DHCP, an installer-provisioned vSphere installation requires two static IP addresses:
 
 * The **API** address is used to access the cluster API.
 * The **Ingress** address is used for cluster ingress traffic.
 
 You must provide these IP addresses to the installation program when you install the {product-title} cluster.
-endif::vsphere[]
+endif::upi[]
 
 [discrete]
 [id="installation-vsphere-installer-infra-requirements-dns-records_{context}"]
@@ -488,12 +480,6 @@ default. This record must be resolvable by both clients external to the cluster
 and from all the nodes within the cluster.
 |===
 
-ifeval::["{context}" == "installing-vsphere"]
-:!vsphere:
-endif::[]
-ifeval::["{context}" == "installing-vsphere-network-customizations"]
-:!vsphere:
-endif::[]
-ifeval::["{context}" == "installing-restricted-networks-vsphere"]
-:!vsphere:
+ifeval::["{context}" == "upi-vsphere-installation-reqs"]
+:!upi:
 endif::[]

--- a/modules/vmware-csi-driver-reqs.adoc
+++ b/modules/vmware-csi-driver-reqs.adoc
@@ -1,9 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.adoc
-// * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+// * installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc
 // * storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
 
 :_mod-docs-content-type: CONCEPT

--- a/post_installation_configuration/vsphere-post-installation-encryption.adoc
+++ b/post_installation_configuration/vsphere-post-installation-encryption.adoc
@@ -15,4 +15,4 @@ include::modules/vsphere-encrypting-vms.adoc[leveloffset=+1]
 == Additional resources
 * xref:../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-evacuating_nodes-nodes-working[Working with nodes]
 * xref:../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-pv-encryption[vSphere encryption]
-* xref:../installing/installing_vsphere/upi/installing-vsphere.adoc#installation-vsphere-encrypted-vms_installing-vsphere[Installing a cluster on vSphere with user-provisioned infrastructure]
+* xref:../installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc#installation-vsphere-encrypted-vms_upi-vsphere-installation-reqs[Requirements for encrypting virtual machines]

--- a/storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
@@ -58,7 +58,7 @@ You must encrypt VMs before you can encrypt PVs, which you can do during install
 
 For information about encrypting VMs, see:
 
-* xref:../../installing/installing_vsphere/upi/installing-vsphere.adoc#installation-vsphere-encrypted-vms_installing-vsphere[Requirements for encrypting virtual machines]
+* xref:../../installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc#installation-vsphere-encrypted-vms_upi-vsphere-installation-reqs[Requirements for encrypting virtual machines]
 
 * xref:../../installing/installing_vsphere/upi/installing-vsphere.adoc#installation-vsphere-machines_installing-vsphere[During installation: Step 7 of Installing RHCOS and starting the {product-title} bootstrap process]
 


### PR DESCRIPTION
Version(s):
4.15+

Issue:
This PR addresses [osdocs-8722](https://issues.redhat.com/browse/OSDOCS-8722) and implements refactored vSphere installation requirements for a UPI installation, which is detailed in this Miro [board](https://miro.com/app/board/uXjVNbUhuKQ=/). This refactor has been approved by Stephanie Stout (CS) and Ju Lim (Senior Manager, Product Management).

Link to docs preview:

[vSphere installation requirements](https://69913--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/upi-vsphere-installation-reqs)

QE review:
[N/A] QE has approved this change.
QE approval is not required for this change. This PR represents a refactor of existing content.