### PR TITLE
OSDOCS-8805: Adds etcd version query to MicroShift

### DIFF
--- a/microshift_support/microshift-etcd.adoc
+++ b/microshift_support/microshift-etcd.adoc
@@ -7,8 +7,10 @@ include::_attributes/attributes-microshift.adoc[]
 toc::[]
 
 [role="_abstract"]
-The etcd service is delivered as part of the {product-title} RPM. The etcd service is run as a separate process and the lifecycle is managed automatically by {product-title}.
+The etcd service is delivered as part of the {product-title} RPM. The etcd service is run as a separate process and the etcd lifecycle is managed automatically by {microshift-short}.
 
 include::modules/microshift-observe-debug-etcd-server.adoc[leveloffset=+1]
 
 include::modules/microshift-config-etcd.adoc[leveloffset=+1]
+
+include::modules/microshift-etcd-version.adoc[leveloffset=+1]

--- a/microshift_support/microshift-getting-support.adoc
+++ b/microshift_support/microshift-getting-support.adoc
@@ -6,10 +6,14 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-// Getting support; note these modules are OCP
+Use the following information to get more help with {op-system-bundle}, including {product-title} or {op-system-ostree-first}.
 
 include::modules/support.adoc[leveloffset=+1]
+
 include::modules/microshift-provide-feedback-jira-link.adoc[leveloffset=+1]
+
 include::modules/support-knowledgebase-about.adoc[leveloffset=+1]
+
 include::modules/support-knowledgebase-search.adoc[leveloffset=+1]
+
 include::modules/microshift-submitting-a-case.adoc[leveloffset=+1]

--- a/microshift_troubleshooting/microshift-version.adoc
+++ b/microshift_troubleshooting/microshift-version.adoc
@@ -11,3 +11,5 @@ To begin troubleshooting, determine which version of {product-title} you have in
 include::modules/microshift-version-cli.adoc[leveloffset=+1]
 
 include::modules/microshift-version-api.adoc[leveloffset=+1]
+
+include::modules/microshift-etcd-version.adoc[leveloffset=+1]

--- a/modules/microshift-etcd-version.adoc
+++ b/modules/microshift-etcd-version.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// * microshift_troubleshooting/microshift-version.adoc
+// * microshift_support/microshift-etcd.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-version-etcd_{context}"]
+= Checking the etcd version
+
+You can get the version information for the etcd database included with your {microshift-short}.
+
+.Procedure
+
+* To display the base database version information, run the following command:
++
+[source,terminal]
+----
+$ microshift-etcd version
+----
++
+.Example output
+[source,terminal,subs="attributes+"]
+----
+microshift-etcd Version: 4.15.1
+Base etcd Version: 3.5.10
+----
+
+* To display the full database version information, run the following command:
++
+[source,terminal]
+----
+$ microshift-etcd version -o json
+----
++
+.Example output
+[source,terminal,subs="attributes+"]
+----
+{
+  "major": "4",
+  "minor": "15",
+  "gitVersion": "4.15.1",
+  "gitCommit": "2e182312718cc9d267ec71f37dc2fbe2eed01ee2",
+  "gitTreeState": "clean",
+  "buildDate": "2024-01-09T06:51:40Z",
+  "goVersion": "go1.20.10",
+  "compiler": "gc",
+  "platform": "linux/amd64",
+  "patch": "",
+  "etcdVersion": "3.5.10"
+}
+----


### PR DESCRIPTION
Version(s):
4.15+

Issue:
[OSDOCS-8805](https://issues.redhat.com/browse/OSDOCS-8805)

Link to docs preview:
[Support book](https://69917--ocpdocs-pr.netlify.app/microshift/latest/microshift_support/microshift-etcd#microshift-version-etcd_microshift-etcd)
[Troubleshooting book](https://69917--ocpdocs-pr.netlify.app/microshift/latest/microshift_troubleshooting/microshift-version#microshift-version-etcd_microshift-version)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
