### PR TITLE
OSDOCS-8962: adds etcd query feature to release notes MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -70,8 +70,12 @@ The following list provides update details:
 //==== New feature for use during installation here
 //can include a note about a change in base RHEL image
 
-//[id="microshift-4-15-support"]
-//=== Support
+[id="microshift-4-15-support"]
+=== Support
+
+[id="microshift-4-15-etcd"]
+==== Getting the etcd version
+Previously, you could not query for the etcd version included with {microshift-short}. Now, the `microshift-etcd version` command outputs the {microshift-short} version and the base version of the etcd database. See xref:../microshift_support/microshift-etcd.adoc#microshift-etcd[The etcd service] for more information.
 
 //[id="microshift-4-15-post-installation"]
 //=== Post-installation configuration


### PR DESCRIPTION
Version(s):
4.15 only

Issue:
[OSDOCS-8962](https://issues.redhat.com/browse/OSDOCS-8962)

Link to docs preview:
[etcd query release note](https://69918--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes#microshift-4-15-support)

QE review:
- [x] QE has approved this change.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
