### PR TITLE
OSDOCS-8923: adds RHEL 9.3 to MicroShift V4.15 relnotes

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -30,8 +30,8 @@ This release adds improvements related to the following components and concepts.
 
 //L3 major categories with features in each as L4s, for example:
 [id="microshift-4-15-rhel"]
-=== {op-system-base-full} {op-system-version}
-* {microshift-short} runs on {op-system-base-full} versions 9.2 and 9.3.
+=== {op-system-base-full}
+* {microshift-short} now runs on {op-system-base-full} versions 9.2 and 9.3. Compatibility with {op-system} 9.3 is an enhancement for {microshift-short} version 4.15.
 
 // Some details of the next note are adapted from https://kubernetes.io/blog/2022/08/31/cgroupv2-ga-1-25/
 * {microshift-short} uses crun and Control Group v2 (cgroup v2). If workloads rely on the cgroup file system layout, they might need to be updated to be compatible with cgroup v2.


### PR DESCRIPTION
Version(s):
4.15 only

Issue:
[OSDOCS-8923](https://issues.redhat.com/browse/OSDOCS-8923)

Link to docs preview:
[Release notes RHEL](https://69919--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes#microshift-4-15-rhel)

QE review:
- N/A

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
