### PR TITLE
OSDOCS#8505: Removing auth dep/rem table since there are no items

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -551,15 +551,15 @@ In the following tables, features are marked with the following statuses:
 
 |====
 
-[discrete]
-=== Authentication and authorization deprecated and removed features
-
-.Authentication and authorization deprecated and removed tracker
-[cols="4,1,1,1",options="header"]
-|====
-|Feature |4.13 |4.14 |4.15
-
-|====
+// [discrete]
+// === Authentication and authorization deprecated and removed features
+//
+// .Authentication and authorization deprecated and removed tracker
+// [cols="4,1,1,1",options="header"]
+// |====
+// |Feature |4.13 |4.14 |4.15
+//
+// |====
 [discrete]
 === Specialized hardware and driver enablement deprecated and removed features
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-8505

Link to docs preview:
https://69924--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-deprecated-removed-features

QE review:
No QE required

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
