### PR TITLE
OCPBUGS#17371: Wipe disks before deploying LVMS on private CI environment

### DIFF
--- a/modules/deploying-lvms-on-sno-cluster.adoc
+++ b/modules/deploying-lvms-on-sno-cluster.adoc
@@ -25,10 +25,16 @@ You can deploy {lvms} using one of the following:
 [id="lvms-deployment-requirements-for-sno-ran_{context}"]
 == Requirements
 
-Before you begin deploying {lvms}, ensure that the following requirements are met:
+Before deploying {lvms} on {sno} clusters, ensure that the following requirements are met:
 
 * You have installed {rh-rhacm-first} on an {product-title} cluster.
 * Every managed cluster has dedicated disks that are used to provision storage.
+
+Before deploying {lvms} in a private CI environment where you can reuse the virtual machines and storage devices, ensure that you have wiped the disks that are not in use. 
+[NOTE]
+====
+You cannot wipe the disks that are in use.
+====
 
 [id="lvms-deployment-limitations-for-sno-ran_{context}"]
 == Limitations


### PR DESCRIPTION
Version(s): 4.12+

Issue: [OCPBUGS-17371](https://issues.redhat.com/browse/OCPBUGS-17371)

Link to docs preview:
https://69930--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms#lvms-deployment-requirements-for-sno-ran_logical-volume-manager-storage

QE review:
- [x] QE has approved this change.
