### PR TITLE
OCPBUGS#25249:Corrected typo in Frankfurt region in HCP classic comparison doc

### DIFF
--- a/modules/rosa-hcp-classic-comparison.adoc
+++ b/modules/rosa-hcp-classic-comparison.adoc
@@ -54,7 +54,7 @@
 
 | *Regional Availability*
 |
-* Europe - Frankfort (eu-central-1)
+* Europe - Frankfurt (eu-central-1)
 * Europe - Ireland (eu-west-1)
 * US East - N. Virginia (us-east-1)
 * US East - Ohio (us-east-2)


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OCPBUGS-25249

Link to docs preview:
https://69942--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly#rosa-hcp-classic-comparison_rosa-hcp-sts-creating-a-cluster-quickly


