### PR TITLE
[virt] DPDK: Remove nodeSelector from VM def

### DIFF
--- a/modules/virt-configuring-vm-dpdk.adoc
+++ b/modules/virt-configuring-vm-dpdk.adoc
@@ -31,12 +31,10 @@ spec:
         cpu-quota.crio.io: disable <2>
         irq-load-balancing.crio.io: disable <3>
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/worker-dpdk: "" <4>
       domain:
         cpu:
-          sockets: 1 <5>
-          cores: 5 <6>
+          sockets: 1 <4>
+          cores: 5 <5>
           threads: 2
           dedicatedCpuPlacement: true
           isolateEmulatorThread: true
@@ -51,24 +49,23 @@ spec:
           rng: {}
       memory:
         hugepages:
-          pageSize: 1Gi <7>
+          pageSize: 1Gi <6>
           guest: 8Gi
       networks:
         - name: default
           pod: {}
         - multus:
-            networkName: dpdk-net <8>
+            networkName: dpdk-net <7>
           name: nic-east
 # ...
 ----
 <1> This annotation specifies that load balancing is disabled for CPUs that are used by the container.
 <2> This annotation specifies that the CPU quota is disabled for CPUs that are used by the container.
 <3> This annotation specifies that Interrupt Request (IRQ) load balancing is disabled for CPUs that are used by the container.
-<4> The label that is used in the `MachineConfigPool` and `PerformanceProfile` manifests that were created when configuring the cluster for DPDK workloads.
-<5> The number of sockets inside the VM. This field must be set to `1` for the CPUs to be scheduled from the same Non-Uniform Memory Access (NUMA) node.
-<6> The number of cores inside the VM. This must be a value greater than or equal to `1`. In this example, the VM is scheduled with 5 hyper-threads or 10 CPUs.
-<7> The size of the huge pages. The possible values for x86-64 architecture are 1Gi and 2Mi. In this example, the request is for 8 huge pages of size 1Gi.
-<8> The name of the SR-IOV `NetworkAttachmentDefinition` object.
+<4> The number of sockets inside the VM. This field must be set to `1` for the CPUs to be scheduled from the same Non-Uniform Memory Access (NUMA) node.
+<5> The number of cores inside the VM. This must be a value greater than or equal to `1`. In this example, the VM is scheduled with 5 hyper-threads or 10 CPUs.
+<6> The size of the huge pages. The possible values for x86-64 architecture are 1Gi and 2Mi. In this example, the request is for 8 huge pages of size 1Gi.
+<7> The name of the SR-IOV `NetworkAttachmentDefinition` object.
 
 . Save and exit the editor.
 . Apply the `VirtualMachine` manifest:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Currently, the DPDK VM definition contains a node selector with a label that will not necessarily be present in the cluster.

kube-scheduler probably has enough constraints to schedule the virt-launcher pod to a node configured for DPDK:
1. runtimeClass defined in KubeVirt CR `defaultRuntimeClass`.
2. HugePages.
3. Resource associated with the SR-IOV network.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.13+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://69944--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-using-dpdk-with-sriov#virt-configuring-vm-dpdk_virt-using-dpdk-with-sriov

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
