### PR TITLE
Warning for values in the Loki sizing table is static and cannot be changed

### DIFF
--- a/modules/loki-deployment-sizing.adoc
+++ b/modules/loki-deployment-sizing.adoc
@@ -12,6 +12,11 @@ endif::[]
 
 Sizing for Loki follows the format of `<N>x.<size>` where the value `<N>` is number of instances and `<size>` specifies performance capabilities.
 
+[NOTE]
+====
+The values mentioned in the below table are static and cannot be modified.
+====
+
 .Loki sizing
 [cols="1h,3*",options="header"]
 |===


### PR DESCRIPTION
The loki sizing table values are fixed and hardcoded and cannot be modified

Version(s):

4.12 and above

Issue:

https://issues.redhat.com/browse/OBSDOCS-718

Link to docs preview:


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
