### PR TITLE
[OSDOCS-6893]Field presentation mistake in example, string instead of list of strings

### DIFF
--- a/modules/nodes-cma-autoscaling-custom-install.adoc
+++ b/modules/nodes-cma-autoscaling-custom-install.adoc
@@ -104,7 +104,7 @@ spec:
       policy:
         rules:
         - level: Metadata
-        omitStages: "RequestReceived"
+        omitStages: ["RequestReceived"]
         omitManagedFields: false
       lifetime:
         maxAge: "2"

--- a/modules/sd-nodes-cma-autoscaling-custom-install.adoc
+++ b/modules/sd-nodes-cma-autoscaling-custom-install.adoc
@@ -118,7 +118,7 @@ spec:
       policy:
         rules:
         - level: Metadata
-        omitStages: "RequestReceived"
+        omitStages: ["RequestReceived"]
         omitManagedFields: false
       lifetime:
         maxAge: "2"


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-6893
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://69952--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/cma/nodes-cma-autoscaling-custom-install#sd-nodes-cma-autoscaling-custom-install_nodes-cma-autoscaling-custom-install
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
![image](https://github.com/openshift/openshift-docs/assets/122639474/ded19a72-c507-4298-a3b8-2ed689269748)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
