### PR TITLE
Loki table resources being predefined and cannot be changed

### DIFF
--- a/modules/loki-deployment-sizing.adoc
+++ b/modules/loki-deployment-sizing.adoc
@@ -12,6 +12,11 @@ endif::[]
 
 Sizing for Loki follows the format of `<N>x.<size>` where the value `<N>` is number of instances and `<size>` specifies performance capabilities.
 
+[NOTE]
+====
+The values defined in the below table for each component/parameter is static and cannot be modified.
+====
+
 .Loki sizing
 [cols="1h,4*",options="header"]
 |===


### PR DESCRIPTION
- Loki table resources being predefined and cannot be changed

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):

- OCP version 4.12+ 
- RHOL version 5.5+

Issue:

- https://issues.redhat.com/browse/OBSDOCS-718

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
