### PR TITLE
OSDOCS-6537: adds RHEL 9.3 to MicroShift 4.14 docs

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -18,7 +18,7 @@ toc::[]
 You can deploy {microshift-short} clusters to either on-premise, cloud, or disconnected environments.
 
 // Double check OP system versions
-{microshift-short} {product-version} is supported on {op-system-ostree-first} and {op-system-base-full} 9.2.
+{microshift-short} {product-version} is supported on {op-system-ostree-first} and {op-system-base-full} 9.2 and 9.3.
 
 //TODO: update link after GA; KCS article will not be live until then
 //For lifecycle information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
@@ -30,8 +30,8 @@ This release adds improvements related to the following components and concepts.
 
 //L3 major categories with features in each as L4s, for example:
 [id="microshift-4-14-rhel"]
-=== {op-system-base-full} {op-system-version}
-* {microshift-short} runs on {op-system-base-full} version 9.2.
+=== {op-system-base-full}
+* {microshift-short} now runs on {op-system-base} versions 9.2 and 9.3.
 
 // Some details of the next note are adapted from https://kubernetes.io/blog/2022/08/31/cgroupv2-ga-1-25/
 * {microshift-short} uses crun and Control Group v2 (cgroup v2). {OCP} {ocp-version} defaults to Control Group v1. The divergence of control group versions is not anticipated to have a noticeable behavior difference on most workloads. If workloads rely on the cgroup file system layout, they may need to be updated to be compatible with cgroup v2.

--- a/microshift_updating/microshift-about-updates.adoc
+++ b/microshift_updating/microshift-about-updates.adoc
@@ -38,5 +38,5 @@ Before attempting an update of either {op-system-bundle} component, determine wh
 
 *{product-title} update paths*
 
-* Generally Available Version 4.14 to 4.14.z on {op-system-ostree} 9.2
-* Generally Available Version 4.14 to 4.14.z on {op-system} 9.2
+* Generally Available Version 4.14 to 4.14.z on {op-system-ostree} 9.2 or 9.3
+* Generally Available Version 4.14 to 4.14.z on {op-system} 9.2 or 9.3

--- a/microshift_updating/microshift-update-options.adoc
+++ b/microshift_updating/microshift-update-options.adoc
@@ -12,8 +12,8 @@ include::snippets/microshift-rhde-compatibility-table-snip.adoc[leveloffset=+1]
 
 *{product-title} update paths*
 
-* Generally Available Version 4.14.0 to 4.14.z on {op-system-ostree} 9.2
-* Generally Available Version 4.14.0 to 4.14.z on {op-system} 9.2
+* Generally Available Version 4.14.0 to 4.14.z on {op-system-ostree} 9.2 or 9.3
+* Generally Available Version 4.14.0 to 4.14.z on {op-system} 9.2 or 9.3
 
 [IMPORTANT]
 ====

--- a/snippets/microshift-rhde-compatibility-table-snip.adoc
+++ b/snippets/microshift-rhde-compatibility-table-snip.adoc
@@ -16,7 +16,7 @@ The two products of {op-system-bundle} work together as a single solution for de
 ^|*{microshift-short} Release Status*
 ^|*{microshift-short} Supported Updates*
 
-^|9.2
+^|9.2, 9.3
 ^|4.14
 ^|Generally Available
 ^|4.14.0&#8594;4.14.z and 4.14&#8594;4.15


### PR DESCRIPTION
Version(s):
4.14 only
Change management applies; email sent 9 Jan 2024.

Issue:
https://issues.redhat.com/browse/OSDOCS-6537

Link to docs preview:
[RHEL support release note](https://69956--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes#microshift-4-14-rhel)
[Compatibility table, 4.14](https://69956--docspreview.netlify.app/microshift/latest/microshift_updating/microshift-about-updates#microshift-about-updates-rpm-ostree-updates_microshift-about-updates)
[Version update path, 4.14](https://69956--docspreview.netlify.app/microshift/latest/microshift_updating/microshift-about-updates#microshift-about-updates-checking-version-update-path_microshift-about-updates)
[Update options, same content, 4.14](https://69956--docspreview.netlify.app/microshift/latest/microshift_updating/microshift-update-options)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

