### PR TITLE
OSDOCS-9284: adds RHEL 9.3 to MicroShift 4.15 docs

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -72,7 +72,7 @@ Topics:
   File: microshift-about-updates
 - Name: Update options
   File: microshift-update-options
-- Name: Updates with rom-ostree systems
+- Name: Updates with rpm-ostree systems
   File: microshift-update-rpms-ostree
 - Name: Manual updates with RPMs
   File: microshift-update-rpms-manually

--- a/microshift_updating/microshift-about-updates.adoc
+++ b/microshift_updating/microshift-about-updates.adoc
@@ -6,7 +6,7 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-Upgrades are supported on {product-title} beginning with the General Availability version 4.14. Supported upgrades include those from one minor version to the next in sequence, for example, from 4.14 to 4.15. Patch updates are also supported from z-stream to z-stream, for example 4.14.1 to 4.14.2.
+Updates are supported on {product-title} beginning with the General Availability version 4.14. Supported updates include those from one minor version to the next in sequence, for example, from 4.14 to 4.15. Patch updates are also supported from z-stream to z-stream, for example 4.14.1 to 4.14.2.
 
 [id="microshift-about-updates-understanding-microshift-updates_{context}"]
 == Understanding {microshift-short} updates
@@ -32,11 +32,4 @@ include::snippets/microshift-rhde-compatibility-table-snip.adoc[leveloffset=+1]
 === Manual RPM updates
 You can use the manual RPM update path to replace your existing version of {microshift-short}. The versions of {op-system} and {microshift-short} must be compatible. Ensuring system health and completing additional system backups are manual processes.
 
-[id="microshift-about-updates-checking-version-update-path_{context}"]
-== Checking version update path
-Before attempting an update of either {op-system-bundle} component, determine which versions of {microshift-short} and {op-system-ostree} or {op-system} you have installed. Plan for the versions of each that you intend to use.
-
-*{product-title} update paths*
-
-* Generally Available Version 4.14 to 4.14.z on {op-system-ostree} 9.2
-* Generally Available Version 4.14 to 4.14.z on {op-system} 9.2
+include::snippets/microshift-update-paths-snip.adoc[leveloffset=+2]

--- a/microshift_updating/microshift-update-options.adoc
+++ b/microshift_updating/microshift-update-options.adoc
@@ -6,26 +6,23 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-You can update {op-system-ostree-first} or {op-system-base-full} with or without updating {product-title} as long as the two versions are compatible. See the following table for details:
+You can update {op-system-ostree-first} images or {op-system-base-full} with or without updating the {product-title} version if the version combination is supported. See the following table for details:
 
 include::snippets/microshift-rhde-compatibility-table-snip.adoc[leveloffset=+1]
 
-*{product-title} update paths*
-
-* Generally Available Version 4.14.0 to 4.14.z on {op-system-ostree} 9.2
-* Generally Available Version 4.14.0 to 4.14.z on {op-system} 9.2
+include::snippets/microshift-update-paths-snip.adoc[leveloffset=+1]
 
 [IMPORTANT]
 ====
-Updates of {microshift-short} from one minor version to the next must be in sequence. For example, you cannot update from 4.14 to 4.16. You must update 4.14 to 4.15.
+Updates of {microshift-short} from one minor version to the next must be in sequence. For example, you cannot update from 4.14 to 4.16. You must update 4.14 to 4.15 and so on.
 ====
 
 [id="microshift-update-options-standalone-updates_{context}"]
 == Standalone {microshift-short} updates
 
-You can update {microshift-short} without reinstalling the applications you created. {op-system} or {op-system-ostree} updates are also not required to update {microshift-short}, as long as the existing operating system is compatible with the new version of {microshift-short} that you want to use.
+You can update {microshift-short} without reinstalling your applications. {op-system} or {op-system-ostree} updates are also not required to update {microshift-short}, as long as the existing operating system is compatible with the new version of {microshift-short} that you want to use.
 
-{product-title} operates as an in-place update and does not require removal of the previous version. Data backups beyond those required for the usual functioning of your applications are also not required.
+{microshift-short} operates as an in-place update and does not require removal of the previous version. Data backups beyond those required for the usual functioning of your applications are also not required.
 
 [id="microshift-update-options-rpm-ostree-updates_{context}"]
 === RPM-OSTree updates
@@ -64,12 +61,13 @@ You can update {op-system-ostree} or {op-system} without updating {microshift-sh
 
 [id="microshift-update-options-simultaneous-microshift-rhel-updates_{context}"]
 == Simultaneous {microshift-short} and operating system updates
-You can update {op-system-ostree} or {op-system} and update {microshift-short} at the same time, on the condition that the versions are compatible. Check for compatibility before beginning an update. First use the {op-system-ostree} documentation specific to your update path to plan and update the operating system. Then use the {microshift-short} update type specific to your update path.
+You can update {op-system-ostree} or {op-system} and update {microshift-short} at the same time, on the condition that the versions are compatible. Check for compatibility before beginning an update. First use the {op-system-ostree} and {op-system} documentation specific to your update path to plan and update the operating system. Then use the {microshift-short} update type specific to your update path.
 
 //additional resources for updating RHEL and MicroShift
 [role="_additional-resources"]
 .Additional resources
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/index[Managing RHEL for Edge images]
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_a_customized_rhel_system_image/index[Composing a customized RHEL system image]
 * xref:../microshift_updating/microshift-update-rpms-ostree.adoc#microshift-update-rpms-ostree[Applying updates on an OSTree system]
 * xref:../microshift_updating/microshift-update-rpms-manually.adoc#microshift-update-rpms-manually[Applying updates manually with RPMs]
 * xref:../microshift_install/microshift-greenboot.adoc#microshift-greenboot[The Greenboot system health check]

--- a/microshift_updating/microshift-update-rpms-manually.adoc
+++ b/microshift_updating/microshift-update-rpms-manually.adoc
@@ -6,7 +6,7 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-Updating {product-title} for non-OSTree systems such as {op-system-base-full} requires downloading then updating the RPMs. For patch releases, such as 4.14.1 to 4.14.2, download and update the RPMs. For minor-version release updates, add the step of enabling the update repository using your subscription manager.
+Updating {product-title} for non-OSTree systems such as {op-system-base-full} requires downloading then updating the RPMs. For patch releases, such as 4.15.1 to 4.15.2, download and update the RPMs. For minor-version release updates, add the step of enabling the update repository using your subscription manager.
 
 [IMPORTANT]
 ====
@@ -19,6 +19,7 @@ include::modules/microshift-updating-rpms-z.adoc[leveloffset=+1]
 
 include::modules/microshift-updating-rpms-y.adoc[leveloffset=+1]
 
-//[role="_additional-resources"]
-//.Additional resources
-//TODO: cross reference to backup and restore when merged
+//additional resources for backup and restore
+[role="_additional-resources"]
+.Additional resources
+* xref:../microshift_backup_and_restore/microshift-backup-and-restore.adoc#microshift-backup-and-restore[Backup and restore]

--- a/microshift_updating/microshift-update-rpms-ostree.adoc
+++ b/microshift_updating/microshift-update-rpms-ostree.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 Updating {product-title} on an `rpm-ostree` system such as {op-system-ostree-first} requires building a new operating system image containing the new version of {product-title}. After you have the `rpm-ostree` image with {product-title} embedded, direct your system to boot into that operating system image.
 
-The procedures are the same for patches and minor-version updates. For example, use the same steps to upgrade from 4.14.0 to 4.14.1 or from 4.14 to 4.15.
+The procedures are the same for minor-version and patch updates. For example, use the same steps to upgrade from 4.14 to 4.15 or from 4.15.0 to 4.15.1.
 
 include::snippets/microshift-rhde-compatibility-table-snip.adoc[leveloffset=+1]
 

--- a/snippets/microshift-rhde-compatibility-table-snip.adoc
+++ b/snippets/microshift-rhde-compatibility-table-snip.adoc
@@ -11,12 +11,17 @@ The two products of {op-system-bundle} work together as a single solution for de
 
 [cols="4",%autowidth]
 |===
-^|*{op-system-ostree} Version*
+^|*{op-system-ostree} Version(s)*
 ^|*{microshift-short} Version*
 ^|*{microshift-short} Release Status*
 ^|*{microshift-short} Supported Updates*
 
-^|9.2
+^|9.2, 9.3
+^|4.15
+^|Generally Available
+^|4.15.0&#8594;4.15.z and 4.15&#8594;future minor version
+
+^|9.2, 9.3
 ^|4.14
 ^|Generally Available
 ^|4.14.0&#8594;4.14.z and 4.14&#8594;4.15

--- a/snippets/microshift-update-paths-snip.adoc
+++ b/snippets/microshift-update-paths-snip.adoc
@@ -1,0 +1,19 @@
+//Snippet included in the following assemblies:
+//
+//* microshift_updating/microshift-about-updates.adoc
+//* microshift_updating/microshift-update-options.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+[id="microshift-about-updates-checking-version-update-path_{context}"]
+= Checking version update path
+
+Before attempting an update of either {op-system-bundle} component, determine which versions of {microshift-short} and {op-system-ostree} or {op-system} are installed. Plan for the versions of each that you intend to use.
+
+*{product-title} update paths*
+
+* Generally Available Version 4.14 to 4.14.z or 4.15 on {op-system-ostree} 9.2 or 9.3
+* Generally Available Version 4.14 to 4.14.z or 4.15 on {op-system} 9.2 or 9.3
+
+* Generally Available Version 4.15 to 4.15.z on {op-system-ostree} 9.2 or 9.3
+* Generally Available Version 4.15 to 4.15.z on {op-system} 9.2 or 9.3


### PR DESCRIPTION
Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-9284

Link to docs preview:
[Compatibility table, 4.15 docs](https://69960--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-about-updates#microshift-about-updates-rpm-ostree-updates_microshift-about-updates)
[Update paths](https://69960--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-about-updates#microshift-about-updates-checking-version-update-path_microshift-about-updates)
[Update options--same modules used here](https://69960--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-options)
[Adds link to backup and restore](https://69960--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-rpms-manually)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
