### PR TITLE
OSDOCS-9287: revise install books RHEL versions MicroShift

### DIFF
--- a/microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc
+++ b/microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc
@@ -8,6 +8,15 @@ toc::[]
 
 Embedding {microshift-short} containers in an `rpm-ostree` commit means that you can run a cluster in air-gapped, disconnected, or offline environments. You can embed {product-title} containers in a {op-system-ostree-first} image so that container engines do not need to pull images over a network from a container registry. Workloads can start up immediately without network connectivity.
 
+include::modules/microshift-install-system-requirements.adoc[leveloffset=+1]
+
+[id="embed-offline-rhde-compatibility-table"]
+== Compatibility table
+
+Plan to pair a supported version of {op-system-ostree} with the {microshift-short} version you are using as described in the following compatibility table:
+
+include::snippets/microshift-rhde-compatibility-table-snip.adoc[leveloffset=+1]
+
 include::modules/microshift-embed-microshift-image-offline-deploy.adoc[leveloffset=+1]
 
 include::modules/microshift-embed-microshift-update-osbuilder-worker.adoc[leveloffset=+1]

--- a/microshift_install/microshift-embed-in-rpm-ostree.adoc
+++ b/microshift_install/microshift-embed-in-rpm-ostree.adoc
@@ -6,7 +6,18 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-You can embed {microshift-short} into a {op-system-ostree-first} {op-system-version} image. Use this guide to build a {op-system} image containing {microshift-short}.
+You can embed {microshift-short} into a {op-system-ostree-first} image. Use this guide to build a {op-system} image containing {microshift-short}.
+
+include::modules/microshift-install-system-requirements.adoc[leveloffset=+1]
+
+Plan to use a supported version of {op-system} paired with your version of {microshift-short} as described in the following table.
+
+[id="embed-ostree-rhde-compatibility-table"]
+== Compatibility table
+
+Plan to pair a supported version of {op-system-ostree} with the {microshift-short} version you are using as described in the following compatibility table:
+
+include::snippets/microshift-rhde-compatibility-table-snip.adoc[leveloffset=+1]
 
 include::modules/microshift-preparing-for-image-building.adoc[leveloffset=+1]
 

--- a/microshift_install/microshift-install-rpm.adoc
+++ b/microshift_install/microshift-install-rpm.adoc
@@ -6,9 +6,16 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-You can install {microshift-short} from an RPM package on a machine with {op-system-base-full} {op-system-version}.
+You can install {microshift-short} from an RPM package on a machine with a supported version of {op-system-base-full}.
 
 include::modules/microshift-install-system-requirements.adoc[leveloffset=+1]
+
+[id="install-rpm-rhde-compatibility-table"]
+== Compatibility table
+
+Plan to pair a supported version of {op-system-ostree} with the {microshift-short} version you are using as described in the following compatibility table:
+
+include::snippets/microshift-rhde-compatibility-table-snip.adoc[leveloffset=+1]
 
 include::modules/microshift-install-rpm-before.adoc[leveloffset=+1]
 

--- a/modules/microshift-install-system-requirements.adoc
+++ b/modules/microshift-install-system-requirements.adoc
@@ -8,9 +8,9 @@
 
 The following conditions must be met prior to installing {microshift-short}:
 
-* {op-system} {op-system-version}
-* 2 CPU cores
-* 2 GB RAM for {microshift-short} or 3 GB RAM, required by {op-system} for networked-based HTTPs or FTP installations
-* 10 GB of storage
+* A supported version of {op-system} or {op-system-ostree}.
+* 2 CPU cores.
+* 2 GB RAM for {microshift-short} or 3 GB RAM, required by {op-system} for networked-based HTTPs or FTP installations.
+* 10 GB of storage.
 * You have an active {microshift-short} subscription on your Red Hat account. If you do not have a subscription, contact your sales representative for more information.
 * You have a Logical Volume Manager (LVM) Volume Group (VG) with sufficient capacity for the Persistent Volumes (PVs) of your workload.

--- a/modules/microshift-preparing-for-image-building.adoc
+++ b/modules/microshift-preparing-for-image-building.adoc
@@ -8,11 +8,6 @@
 
 Read link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images[Composing, installing, and managing RHEL for Edge images].
 
-[IMPORTANT]
-====
-{microshift-short} {ocp-version} deployments have only been tested with {op-system-ostree-first} {op-system-version}. Other versions of {op-system} are not supported.
-====
-
 To build an {op-system-ostree-first} {op-system-version} image for a given CPU architecture, you need a {op-system} {op-system-version} build host of the same CPU architecture that meets the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/setting-up-image-builder_composing-installing-managing-rhel-for-edge-images#edge-image-builder-system-requirements_setting-up-image-builder[Image Builder system requirements].
 
 Follow the instructions in link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/setting-up-image-builder_composing-installing-managing-rhel-for-edge-images#edge-installing-image-builder_setting-up-image-builder[Installing Image Builder] to install Image Builder and the `composer-cli` tool.


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-9287

Link to docs preview:
[Install from RPM](https://69980--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-install-rpm)
[RPM OSTree install](https://69980--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree)
[Offline use install](https://69980--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree-offline-use)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
