### PR TITLE
OSDOCS-6863: IPsec N/S GA

### DIFF
--- a/modules/nw-modifying-operator-install-config.adoc
+++ b/modules/nw-modifying-operator-install-config.adoc
@@ -81,7 +81,8 @@ metadata:
 spec:
   defaultNetwork:
     ovnKubernetesConfig:
-      ipsecConfig: {}
+      ipsecConfig:
+        mode: Full
 ----
 --
 

--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -249,10 +249,10 @@ endif::operator[]
 |`object`
 |
 ifndef::operator[]
-Specify an empty object to enable IPsec encryption.
+Specify a configuration object for customizing the IPsec configuration.
 endif::operator[]
 ifdef::operator[]
-If the field is present, IPsec is enabled for the cluster.
+An object describing the IPsec mode for the cluster.
 endif::operator[]
 
 |`policyAuditConfig`
@@ -336,6 +336,31 @@ If you set this field to `true`, you do not receive the performance benefits of 
 
 |====
 
+[id="nw-operator-cr-ipsec_{context}"]
+.`ipsecConfig` object
+[cols=".^2,.^2,.^6a",options="header"]
+|====
+|Field|Type|Description
+
+|`mode`
+|`string`
+a|Specifies the behavior of the IPsec implementation. Must be one of the following values:
+
+--
+- `Disabled`: IPsec is not enabled on cluster nodes.
+- `External`: IPsec is enabled for network traffic with external hosts.
+- `Full`: IPsec is enabled for pod traffic and network traffic with external hosts.
+--
+
+|====
+
+
+ifdef::operator[]
+[NOTE]
+====
+You can only change the configuration for your cluster network plugin during cluster installation, except for the `gatewayConfig` field that can be changed at runtime as a postinstallation activity.
+====
+endif::operator[]
 
 .Example OVN-Kubernetes configuration with IPSec enabled
 [source,yaml]
@@ -345,7 +370,8 @@ defaultNetwork:
   ovnKubernetesConfig:
     mtu: 1400
     genevePort: 6081
-    ipsecConfig: {}
+      ipsecConfig:
+        mode: Full
 ----
 [IMPORTANT]
 ====

--- a/modules/nw-ovn-ipsec-certificates.adoc
+++ b/modules/nw-ovn-ipsec-certificates.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * networking/ovn_kubernetes_network_provider/about-ipsec-ovn.adoc
+// * networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="nw-ovn-ipsec-certificates_{context}"]

--- a/modules/nw-ovn-ipsec-disable.adoc
+++ b/modules/nw-ovn-ipsec-disable.adoc
@@ -6,12 +6,7 @@
 [id="nw-ovn-ipsec-disable_{context}"]
 = Disabling IPsec encryption
 
-As a cluster administrator, you can disable IPsec encryption only if you enabled IPsec after cluster installation.
-
-[NOTE]
-====
-If you enabled IPsec when you installed your cluster, you cannot disable IPsec with this procedure.
-====
+As a cluster administrator, you can disable IPsec encryption.
 
 .Prerequisites
 
@@ -24,8 +19,14 @@ If you enabled IPsec when you installed your cluster, you cannot disable IPsec w
 +
 [source,terminal]
 ----
-$ oc patch networks.operator.openshift.io/cluster --type=json \
-  -p='[{"op":"remove", "path":"/spec/defaultNetwork/ovnKubernetesConfig/ipsecConfig"}]'
+$ oc patch networks.operator.openshift.io cluster --type=merge \
+-p '{
+  "spec":{
+    "defaultNetwork":{
+      "ovnKubernetesConfig":{
+        "ipsecConfig":{
+          "mode":"Disabled"
+        }}}}}'
 ----
 
 . Optional: You can increase the size of your cluster MTU by `46` bytes because there is no longer any overhead from the IPsec ESP header in IP packets.

--- a/modules/nw-ovn-ipsec-enable.adoc
+++ b/modules/nw-ovn-ipsec-enable.adoc
@@ -4,9 +4,16 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-ovn-ipsec-enable_{context}"]
-= Enabling pod-to-pod IPsec encryption
+= Enabling IPsec encryption
 
-As a cluster administrator, you can enable pod-to-pod IPsec encryption after cluster installation.
+As a cluster administrator, you can enable pod-to-pod IPsec encryption and IPsec encryption between the cluster and external IPsec endpoints.
+
+You can configure IPsec in either of the following modes:
+
+- `Full`: Encryption for pod-to-pod and external traffic
+- `External`: Encryption for external traffic
+
+If you need to configure encryption for external traffic in addition to pod-to-pod traffic, you must also complete the "Configuring IPsec encryption for external traffic" procedure.
 
 .Prerequisites
 
@@ -16,10 +23,24 @@ As a cluster administrator, you can enable pod-to-pod IPsec encryption after clu
 
 .Procedure
 
-* To enable IPsec encryption, enter the following command:
+. To enable IPsec encryption, enter the following command:
 +
 [source,terminal]
 ----
 $ oc patch networks.operator.openshift.io cluster --type=merge \
--p '{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"ipsecConfig":{ }}}}}'
+-p '{
+  "spec":{
+    "defaultNetwork":{
+      "ovnKubernetesConfig":{
+        "ipsecConfig":{
+          "mode":<mode>
+        }}}}}'
 ----
++
+where:
++
+--
+`mode`:: Specify `External` to encrypt only traffic to external hosts or specify `Full` to encrypt pod to pod traffic and optionally traffic to external hosts. By default, IPsec is disabled.
+--
+
+. Optional: If you need to encrypt traffic to external hosts, complete the "Configuring IPsec encryption for external traffic" procedure.

--- a/modules/nw-ovn-ipsec-encryption.adoc
+++ b/modules/nw-ovn-ipsec-encryption.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * networking/ovn_kubernetes_network_provider/about-ipsec-ovn.adoc
+// * networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="nw-ovn-ipsec-encryption_{context}"]

--- a/modules/nw-ovn-ipsec-external.adoc
+++ b/modules/nw-ovn-ipsec-external.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nw-ovn-ipsec-external_{context}"]
+= IPsec encryption for external traffic
+
+{product-title} supports IPsec encryption for traffic to external hosts with TLS certificates that you must supply.
+
+[id="supported-platforms_{context}"]
+== Supported platforms
+
+This feature is supported on the following platforms:
+
+- Bare metal
+- {gcp-first}
+- {rh-openstack-first}
+- {vmw-full}
+
+[IMPORTANT]
+====
+If you have {op-system-base-full} worker nodes, these do not support IPsec encryption for external traffic.
+====
+
+If your cluster uses hosted control planes for Red Hat {product-title}, configuring IPsec for encrypting traffic to external hosts is not supported.
+
+[id="ipsec-external-limitations_{context}"]
+== Limitations
+
+Ensure that the following prohibitions are observed:
+
+* Certificate common names (CN) in the provided certificate bundle must not begin with the `ovs_` prefix, because this naming can conflict with pod-to-pod IPsec CN names in the Network Security Services (NSS) database of each node.

--- a/modules/nw-ovn-ipsec-north-south-disable.adoc
+++ b/modules/nw-ovn-ipsec-north-south-disable.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-ovn-ipsec-north-south-disable_{context}"]
+= Disabling IPsec encryption for an external IPsec endpoint
+
+As a cluster administrator, you can remove an existing IPsec tunnel to an external host.
+
+.Prerequisites
+
+* Install the {oc-first}.
+* You are logged in to the cluster as a user with `cluster-admin` privileges.
+* You enabled IPsec in either `Full` or `External` mode on your cluster.
+
+.Procedure
+
+. Create a file named `remove-ipsec-tunnel.yaml` with the following YAML:
++
+[source,yaml]
+----
+kind: NodeNetworkConfigurationPolicy
+apiVersion: nmstate.io/v1
+metadata:
+  name: <name>
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: <node_name>
+  desiredState:
+    interfaces:
+    - name: <tunnel_name>
+      type: ipsec
+      state: absent
+----
++
+--
+where:
+
+`name`:: Specifies a name for the node network configuration policy.
+`node_name`:: Specifies the name of the node where the IPsec tunnel that you want to remove exists.
+`tunnel_name`:: Specifies the interface name for the existing IPsec tunnel.
+--
+
+. To remove the IPsec tunnel, enter the following command:
++
+[source,terminal]
+----
+$ oc apply -f remove-ipsec-tunnel.yaml
+----

--- a/modules/nw-ovn-ipsec-north-south-enable.adoc
+++ b/modules/nw-ovn-ipsec-north-south-enable.adoc
@@ -4,11 +4,9 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-ovn-ipsec-north-south-enable_{context}"]
-= Enabling IPsec encryption for external IPsec endpoints
+= Configuring IPsec encryption for external traffic
 
-// This procedure requests installing Butane to prepare the machine config
-
-As a cluster administrator, you can enable IPsec encryption between the cluster and external IPsec endpoints. Because this procedure uses Butane to create machine configs, you must have the `butane` command installed.
+As a cluster administrator, to encrypt external traffic with IPsec you must configure IPsec for your network infrastructure, including providing PKCS#12 certificates. Because this procedure uses Butane to create machine configs, you must have the `butane` command installed.
 
 [NOTE]
 ====
@@ -18,16 +16,99 @@ After you apply the machine config, the Machine Config Operator reboots affected
 .Prerequisites
 
 * Install the {oc-first}.
+* You have installed the `butane` utility on your local computer.
+* You have installed the NMState Operator on the cluster.
 * You are logged in to the cluster as a user with `cluster-admin` privileges.
-* You have reduced the size of your cluster MTU by `46` bytes to allow for the overhead of the IPsec ESP header.
-* You have installed the `butane` utility.
 * You have an existing PKCS#12 certificate for the IPsec endpoint and a CA cert in PEM format.
+* You enabled IPsec in either `Full` or `External` mode on your cluster.
+* The OVN-Kubernetes network plugin must be configured in local gateway mode, where `ovnKubernetesConfig.gatewayConfig.routingViaHost=true`.
 
 .Procedure
 
-As a cluster administrator, you can enable IPsec support for external IPsec endpoints.
+. Create an IPsec configuration with an NMState Operator node network configuration policy. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/securing_networks/configuring-a-vpn-with-ipsec_securing-networks#configuring-a-vpn-with-ipsec_securing-networks[Libreswan as an IPsec VPN implementation].
 
-. Create an IPsec configuration file named `ipsec-endpoint-config.conf`. The configuration is consumed in the next step. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/securing_networks/configuring-a-vpn-with-ipsec_securing-networks#configuring-a-vpn-with-ipsec_securing-networks[Libreswan as an IPsec VPN implementation].
+.. To identify the IP address of the cluster node that is the IPsec endpoint, enter the following command:
++
+----
+$ oc get nodes
+----
+
+.. Create a file named `ipsec-config.yaml` that contains a node network configuration policy for the NMState Operator, such as in the following examples. For an overview about `NodeNetworkConfigurationPolicy` objects, see link:https://nmstate.io/kubernetes-nmstate/[The Kubernetes NMState project].
++
+--
+.Example NMState IPsec transport configuration
+[source,yaml]
+----
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: ipsec-config
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: "<hostname>" <1>
+  desiredState:
+    interfaces:
+    - name: <interface_name> <2>
+      type: ipsec
+      libreswan:
+        left: <cluster_node> <3>
+        leftid: '%fromcert'
+        leftrsasigkey: '%cert'
+        leftcert: left_server
+        leftmodecfgclient: false
+        right: <external_host> <4>
+        rightid: '%fromcert'
+        rightrsasigkey: '%cert'
+        rightsubnet: <external_address>/32 <5>
+        ikev2: insist
+        type: transport
+----
+<1> Specifies the host name to apply the policy to. This host serves as the left side host in the IPsec configuration.
+<2> Specifies the name of the interface to create on the host.
+<3> Specifies the host name of the cluster node that terminates the IPsec tunnel on the cluster side. The name should match SAN `[Subject Alternate Name]` from your supplied PKCS#12 certificates.
+<4> Specifies the external host name, such as `host.example.com`. The name should match the SAN `[Subject Alternate Name]` from your supplied PKCS#12 certificates.
+<5> Specifies the IP address of the external host, such as `10.1.2.3.4/32`.
+
+.Example NMState IPsec tunnel configuration
+[source,yaml]
+----
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: ipsec-config
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: "<hostname>" <1>
+  desiredState:
+    interfaces:
+    - name: <interface_name> <2>
+      type: ipsec
+      libreswan:
+        left: <cluster_node> <3>
+        leftid: '%fromcert'
+        leftmodecfgclient: false
+        leftrsasigkey: '%cert'
+        leftcert: left_server
+        right: <external_host> <4>
+        rightid: '%fromcert'
+        rightrsasigkey: '%cert'
+        rightsubnet: <external_address>/32 <5>
+        ikev2: insist
+        type: tunnel
+----
+<1> Specifies the host name to apply the policy to. This host serves as the left side host in the IPsec configuration.
+<2> Specifies the name of the interface to create on the host.
+<3> Specifies the host name of the cluster node that terminates the IPsec tunnel on the cluster side. The name should match SAN `[Subject Alternate Name]` from your supplied PKCS#12 certificates.
+<4> Specifies the external host name, such as `host.example.com`. The name should match the SAN `[Subject Alternate Name]` from your supplied PKCS#12 certificates.
+<5> Specifies the IP address of the external host, such as `10.1.2.3.4/32`.
+--
+
+.. To configure the IPsec interface, enter the following command:
++
+[source,terminal]
+----
+$ oc create -f ipsec-config.yaml
+----
 
 . Provide the following certificate files to add to the Network Security Services (NSS) database on each host. These files are imported as part of the Butane configuration in subsequent steps.
 +
@@ -50,9 +131,6 @@ $ for role in master worker; do
     name: 99-$\{role}-import-certs-enable-svc-os-ext
     labels:
       machineconfiguration.openshift.io/role: $role
-  openshift:
-    extensions:
-      - ipsec
   systemd:
     units:
     - name: ipsec-import.service
@@ -67,15 +145,6 @@ $ for role in master worker; do
         ExecStart=/usr/local/bin/ipsec-addcert.sh
         RemainAfterExit=false
         StandardOutput=journal
-
-        [Install]
-        WantedBy=multi-user.target
-    - name: ipsecenabler.service
-      enabled: true
-      contents: |
-        [Service]
-        Type=oneshot
-        ExecStart=systemctl enable --now ipsec.service
 
         [Install]
         WantedBy=multi-user.target
@@ -146,3 +215,49 @@ A successfully updated node has the following status: `UPDATED=true`, `UPDATING=
 ====
 By default, the MCO updates one machine per pool at a time, causing the total time the migration takes to increase with the size of the cluster.
 ====
+
+. To confirm that IPsec machine configs rolled out successfully, enter the following commands:
+.. Confirm that the IPsec machine configs were created:
++
+[source,terminal]
+----
+$ oc get mc | grep ipsec
+----
++
+.Example output
+[source,text]
+----
+80-ipsec-master-extensions        3.2.0        6d15h
+80-ipsec-worker-extensions        3.2.0        6d15h
+----
+
+.. Confirm that the that the IPsec extension are applied to control plane nodes:
++
+[source,terminal]
+----
+$ oc get mcp master -o yaml | grep 80-ipsec-master-extensions -c
+----
++
+.Expected output
+[source,text]
+----
+2
+----
+
+.. Confirm that the that the IPsec extension are applied to worker nodes:
++
+[source,terminal]
+----
+$ oc get mcp worker -o yaml | grep 80-ipsec-worker-extensions -c
+----
++
+.Expected output
+[source,text]
+----
+2
+----
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about the nmstate IPsec API, see link:https://nmstate.io/devel/yaml_api.html#ipsec-encryption[IPsec Encryption]

--- a/modules/nw-ovn-ipsec-traffic.adoc
+++ b/modules/nw-ovn-ipsec-traffic.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * networking/ovn_kubernetes_network_provider/about-ipsec-ovn.adoc
+// * networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="nw-ovn-ipsec-traffic_{context}"]

--- a/modules/nw-ovn-ipsec-verification.adoc
+++ b/modules/nw-ovn-ipsec-verification.adoc
@@ -1,12 +1,12 @@
 // Module included in the following assemblies:
 //
-// * networking/ovn_kubernetes_network_provider/about-ipsec-ovn.adoc
+// * networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-ovn-ipsec-verification_{context}"]
-= Verifying that IPsec is enabled
+= Verifying that IPsec is enabled for pod-to-pod traffic
 
-As a cluster administrator, you can verify that IPsec is enabled.
+As a cluster administrator, you can verify that IPsec is enabled between pods on your cluster when IPsec is configured in `Full` mode. This procedure does not verify whether IPsec is working between your cluster and external hosts.
 
 .Verification
 

--- a/modules/nw-own-ipsec-modes.adoc
+++ b/modules/nw-own-ipsec-modes.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nw-ovn-ipsec-modes_{context}"]
+= Modes of operation
+
+When using IPsec on your {product-title} cluster, you can choose from the following operating modes:
+
+.IPsec modes of operation
+[cols="2,6,2",options="header"]
+|===
+
+|Mode
+|Description
+|Default
+
+|`Disabled`
+|No traffic is encrypted. This is the cluster default.
+|Yes
+
+|`Full`
+|Pod-to-pod traffic is encrypted as described in "Types of network traffic flows encrypted by pod-to-pod IPsec". Traffic to external nodes may be encrypted after you complete the required configuration steps for IPsec.
+|No
+
+|`External`
+|Traffic to external nodes may be encrypted after you complete the required configuration steps for IPsec.
+|No
+
+|===

--- a/modules/nw-own-ipsec-required-ports.adoc
+++ b/modules/nw-own-ipsec-required-ports.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * networking/ovn_kubernetes_network_provider/about-ipsec-ovn.adoc
+// * networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="network-connectivity-requirements-ipsec_{context}"]

--- a/networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc
@@ -6,9 +6,14 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-With IPsec enabled, you can encrypt both internal pod-to-pod cluster traffic between nodes and external traffic between pods and IPsec endpoints external to your cluster. All pod-to-pod network traffic between nodes on the OVN-Kubernetes cluster network is encrypted with IPsec _Transport mode_.
+With IPsec enabled, you can encrypt both internal pod-to-pod cluster traffic between nodes and external traffic between pods and IPsec endpoints external to your cluster. All pod-to-pod network traffic between nodes on the OVN-Kubernetes cluster network is encrypted with IPsec in _Transport mode_.
 
-IPsec is disabled by default. It can be enabled either during or after installing the cluster. For information about cluster installation, see xref:../../installing/index.adoc#ocp-installation-overview[{product-title} installation overview]. If you need to enable IPsec after cluster installation, you must first resize your cluster MTU to account for the overhead of the IPsec ESP IP header.
+IPsec is disabled by default. It can be enabled either during or after installing the cluster. For information about cluster installation, see xref:../../installing/index.adoc#ocp-installation-overview[{product-title} installation overview].
+
+[IMPORTANT]
+====
+If your cluster uses link:https://www.redhat.com/en/topics/containers/what-are-hosted-control-planes[hosted control planes] for Red Hat {product-title}, IPsec is not supported for IPsec encryption of either pod-to-pod or traffic to external hosts.
+====
 
 [NOTE]
 ====
@@ -18,50 +23,56 @@ IPsec on {ibm-cloud-name} supports only NAT-T. Using ESP is not supported.
 Use the procedures in the following documentation to:
 
 * Enable and disable IPSec after cluster installation
-* Configure support for external IPsec endpoints outside the cluster
+* Configure IPsec encryption for traffic between the cluster and external hosts
 * Verify that IPsec encrypts traffic between pods on different nodes
 
+include::modules/nw-own-ipsec-modes.adoc[leveloffset=+1]
+
+// Uses xrefs, so must be located here
 [id="{context}-prerequisites"]
 == Prerequisites
 
-* You have decreased the size of the cluster MTU by `46` bytes to allow for the additional overhead of the IPsec ESP header. For more information on resizing the MTU that your cluster uses, see xref:../../networking/changing-cluster-network-mtu.adoc#changing-cluster-network-mtu[Changing the MTU for the cluster network].
+For IPsec support for encrypting traffic to external hosts, ensure that the following prerequisites are met:
+
+* The OVN-Kubernetes network plugin must be configured in local gateway mode, where `ovnKubernetesConfig.gatewayConfig.routingViaHost=true`.
+* The NMState Operator is installed. This Operator is required for specifying the IPsec configuration. For more information, see xref:../../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#k8s-nmstate-about-the-k8s-nmstate-operator[About the Kubernetes NMState Operator].
++
+--
+[NOTE]
+====
+The NMState Operator is supported on {gcp-first} only for configuring IPsec.
+====
+--
+* The Butane tool (`butane`) is installed. To install Butane, see xref:../../installing/install_config/installing-customizing.adoc#installation-special-config-butane-install_installing-customizing[Installing Butane].
+
+These prerequisites are required to add certificates into the host NSS database and to configure IPsec to communicate with external hosts.
 
 include::modules/nw-own-ipsec-required-ports.adoc[leveloffset=+1]
 
 [id="{context}-pod-to-pod-ipsec"]
 == IPsec encryption for pod-to-pod traffic
 
-{product-title} supports IPsec encryption for network traffic between pods.
+For IPsec encryption of pod-to-pod traffic, the following sections describe which specific pod-to-pod traffic is encrypted, what kind of encryption protocol is used, and how X.509 certificates are handled. These sections do not apply to IPsec encryption between the cluster and external hosts, which you must configure manually for your specific external network infrastructure.
 
 include::modules/nw-ovn-ipsec-traffic.adoc[leveloffset=+2]
 include::modules/nw-ovn-ipsec-encryption.adoc[leveloffset=+2]
 include::modules/nw-ovn-ipsec-certificates.adoc[leveloffset=+2]
-include::modules/nw-ovn-ipsec-enable.adoc[leveloffset=+2]
-include::modules/nw-ovn-ipsec-verification.adoc[leveloffset=+2]
-include::modules/nw-ovn-ipsec-disable.adoc[leveloffset=+2]
 
-[id="{context}-external-traffic-ipsec"]
-== IPsec encryption for external traffic
+include::modules/nw-ovn-ipsec-external.adoc[leveloffset=+1]
+// Enable & then optionally configure IPsec for external hosts
+include::modules/nw-ovn-ipsec-enable.adoc[leveloffset=+1]
+include::modules/nw-ovn-ipsec-north-south-enable.adoc[leveloffset=+1]
 
-{product-title} supports IPsec encryption for traffic to external hosts.
+include::modules/nw-ovn-ipsec-verification.adoc[leveloffset=+1]
+include::modules/nw-ovn-ipsec-north-south-disable.adoc[leveloffset=+1]
+include::modules/nw-ovn-ipsec-disable.adoc[leveloffset=+1]
 
-You must supply a custom IPsec configuration, which includes the IPsec configuration file itself and TLS certificates.
-
-Ensure that the following prohibitions are observed:
-
-* The custom IPsec configuration must not include any connection specifications that might interfere with the cluster's pod-to-pod IPsec configuration.
-* Certificate common names (CN) in the provided certificate bundle must not begin with the `ovs_` prefix, because this naming can collide with pod-to-pod IPsec CN names in the Network Security Services (NSS) database of each node.
-
-// Tech Preview
-:FeatureName: IPsec support for external endpoints
-include::snippets/technology-preview.adoc[]
-
-include::modules/nw-ovn-ipsec-north-south-enable.adoc[leveloffset=+2]
 
 [id="{context}_additional-resources"]
 == Additional resources
 
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/securing_networks/configuring-a-vpn-with-ipsec_securing-networks#libreswan-as-an-ipsec-vpn-implementation_configuring-a-vpn-with-ipsec[Configuring a VPN with IPsec] in {op-system-base-full} 9
+* xref:../../installing/install_config/installing-customizing.adoc#installation-special-config-butane-install_installing-customizing[Installing Butane]
 * xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[About the OVN-Kubernetes Container Network Interface (CNI) network plugin]
 * xref:../../networking/changing-cluster-network-mtu.adoc#changing-cluster-network-mtu[Changing the MTU for the cluster network]
-* xref:../../installing/install_config/installing-customizing.adoc#installation-special-config-butane-install_installing-customizing[Installing Butane]
-* xref:../../rest_api/operator_apis/network-operator-openshift-io-v1.adoc#network-operator-openshift-io-v1[Network [operator.openshift.io/v1]] API
+* xref:../../rest_api/operator_apis/network-operator-openshift-io-v1.adoc#network-operator-openshift-io-v1[Network [operator.openshift.io/v1\]] API


### PR DESCRIPTION
Adds IPsec as GA, updates the documentation for new API.

- https://issues.redhat.com/browse/OSDOCS-6863
- https://issues.redhat.com/browse/OSDOCS-8133

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Configuring IPsec encryption](https://69982--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn)
- [Cluster Network Operator configuration object](https://69982--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/cluster-network-operator#nw-operator-cr-cno-object_cluster-network-operator)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
