### PR TITLE
OSSM-5622: add topic for upgrade changes from service mesh 2.4 to 2.5 (2.5 Release)

### DIFF
--- a/modules/ossm-upgrade-24-25-changes.adoc
+++ b/modules/ossm-upgrade-24-25-changes.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+// * service_mesh/v2x/upgrading-ossm.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ossm-upgrade-24-25-changes_{context}"]
+= Upgrade changes from version 2.4 to version 2.5
+
+== Istio OpenShift Routing (IOR) default setting change
+
+The default setting for Istio OpenShift Routing (IOR) has changed. The setting is now disabled by default.
+
+You can use IOR by setting the `enabled` field to `true` in the `spec.gateways.openshiftRoute` specification of the `ServiceMeshControlPlane` resource.
+
+[source,yaml]
+----
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+spec:
+  gateways:
+    openshiftRoute:
+      enabled: true
+----
+
+== Istio proxy concurrency configuration enhancement
+
+For consistency across deployments, Istio now configures the `concurrency` parameter based on the CPU limit allocated to the proxy container. For example, a limit of 2500m would set the `concurrency` parameter to 3. If you set the `concurrency` parameter to a value, Istio uses that value to configure how many threads the proxy runs instead of using the CPU limit. 
+
+Previously, the default setting for the parameter was 2. 

--- a/service_mesh/v2x/upgrading-ossm.adoc
+++ b/service_mesh/v2x/upgrading-ossm.adoc
@@ -36,6 +36,8 @@ Although you can deploy multiple versions of the control plane in the same clust
 
 For more information about migrating your extensions, refer to xref:../../service_mesh/v2x/ossm-extensions.adoc#ossm-extensions-migration-overview_ossm-extensions[Migrating from ServiceMeshExtension to WasmPlugin resources].
 
+include::modules/ossm-upgrade-24-25-changes.adoc[leveloffset=+2]
+
 include::modules/ossm-upgrade-23-24-changes.adoc[leveloffset=+2]
 
 include::modules/ossm-upgrade-22-23-changes.adoc[leveloffset=+2]


### PR DESCRIPTION
**PR for Service Mesh 2.5 layered product release. Release date target March 18.**

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): OCP 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSSM-5622
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://69983--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/upgrading-ossm#ossm-upgrade-24-25-changes_ossm-upgrade
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
