### PR TITLE
[enterprise-4.13] CNV-35286: fix bandwidthPerMigration documentation

### DIFF
--- a/modules/virt-live-migration-limits-reftable.adoc
+++ b/modules/virt-live-migration-limits-reftable.adoc
@@ -21,7 +21,7 @@
 |2
 
 |`bandwidthPerMigration`
-|Bandwidth limit of each migration, in MiB/s.
+|Bandwidth limit of each migration, where the value is the quantity of bytes per second. For example, a value of `2048Mi` means 2048 MiB/s.
 |0 ^[1]^
 
 |`completionTimeoutPerGiB`


### PR DESCRIPTION
Cherry Picked from 6094f12dada0f5528612d386e771ca9e823bdc43 xref: https://github.com/openshift/openshift-docs/pull/69254

Note: This information was in a different module in 4.11-4.13, so I am updating it in that module. 

Original commit message:

> Follow-up on kubevirt/kubevirt#8208
> for bandwidthPerMigration.
> 

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): this is a 4.13 cherrypick, but it also applies to 4.11 and 4.12.
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/CNV-35286
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://69985--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-live-migration-limits#virt-configuring-live-migration-limits_virt-live-migration-limits
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
