### PR TITLE
OSDOCS-9004 Adding 4.15 operator not available

### DIFF
--- a/nodes/pods/run_once_duration_override/index.adoc
+++ b/nodes/pods/run_once_duration_override/index.adoc
@@ -8,5 +8,8 @@ toc::[]
 
 You can use the {run-once-operator} to specify a maximum time limit that run-once pods can be active for.
 
+:operator-name: The {run-once-operator}
+include::snippets/operator-not-available.adoc[]
+
 // About the {run-once-operator}
 include::modules/rodoo-about.adoc[leveloffset=+1]

--- a/nodes/pods/run_once_duration_override/run-once-duration-override-install.adoc
+++ b/nodes/pods/run_once_duration_override/run-once-duration-override-install.adoc
@@ -8,10 +8,13 @@ toc::[]
 
 You can use the {run-once-operator} to specify a maximum time limit that run-once pods can be active for. By enabling the run-once duration override on a namespace, all future run-once pods created or updated in that namespace have their `activeDeadlineSeconds` field set to the value specified by the {run-once-operator}.
 
-[NOTE]
-====
-If both the run-once pod and the {run-once-operator} have their `activeDeadlineSeconds` value set, the lower of the two values is used.
-====
+:operator-name: The {run-once-operator}
+include::snippets/operator-not-available.adoc[]
+
+//[NOTE]
+//====
+//If both the run-once pod and the {run-once-operator} have their `activeDeadlineSeconds` value set, the lower of the two values is used.
+//====
 
 // Installing the {run-once-operator}
 include::modules/rodoo-install-operator.adoc[leveloffset=+1]

--- a/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
+++ b/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
@@ -12,34 +12,5 @@ To apply the run-once duration override from the {run-once-operator} to run-once
 
 These release notes track the development of the {run-once-operator} for {product-title}.
 
-For an overview of the {run-once-operator}, see xref:../../../nodes/pods/run_once_duration_override/index.adoc#run-once-about_run-once-duration-override-about[About the {run-once-operator}].
-
-[id="run-once-duration-override-operator-release-notes-1-0-1"]
-== {run-once-operator} 1.0.1
-
-Issued: 2023-10-26
-
-The following advisory is available for the {run-once-operator} 1.0.1:
-
-* link:https://access.redhat.com/errata/RHSA-2023:5947[RHSA-2023:5947]
-
-[id="run-once-duration-override-operator-1.0.1-bug-fixes"]
-=== Bug fixes
-
-* This release of the {run-once-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
-
-[id="run-once-duration-override-operator-release-notes-1-0-0"]
-== {run-once-operator} 1.0.0
-
-Issued: 2023-05-18
-
-The following advisory is available for the {run-once-operator} 1.0.0:
-
-* link:https://access.redhat.com/errata/RHEA-2023:2035[RHEA-2023:2035]
-
-[id="run-once-duration-override-operator-1-0-0-new-features-and-enhancements"]
-=== New features and enhancements
-
-* This is the initial, generally available release of the {run-once-operator}. For installation information, see xref:../../../nodes/pods/run_once_duration_override/run-once-duration-override-install.adoc#run-once-duration-override-install[Installing the {run-once-operator}].
-
-// No bug fixes or known issues to list
+:operator-name: The {run-once-operator}
+include::snippets/operator-not-available.adoc[]

--- a/nodes/pods/run_once_duration_override/run-once-duration-override-uninstall.adoc
+++ b/nodes/pods/run_once_duration_override/run-once-duration-override-uninstall.adoc
@@ -8,6 +8,9 @@ toc::[]
 
 You can remove the {run-once-operator} from {product-title} by uninstalling the Operator and removing its related resources.
 
+:operator-name: The {run-once-operator}
+include::snippets/operator-not-available.adoc[]
+
 // Uninstalling the {run-once-operator}
 include::modules/rodoo-uninstall-operator.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-9004](https://issues.redhat.com/browse/OSDOCS-9004)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

-  [Run Once Duration Override Operator overview ](https://69986--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/)
- [RODOO release notes](https://69986--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes)
- [Overriding the active deadline for run-once pods](https://69986--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/run-once-duration-override-install)
- [Uninstalling RODOO](https://69986--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/run-once-duration-override-uninstall)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: RODOO won't be available on GA, it has an async release post-GA. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
