### PR TITLE
OBSDOCS-719: Add checkmark for PHP support

### DIFF
--- a/modules/logging-multiline-except.adoc
+++ b/modules/logging-multiline-except.adoc
@@ -55,7 +55,7 @@ When log messages appear as a consecutive sequence forming an exception stack tr
 |Ruby | ✓ | ✓
 |Python | ✓ | ✓
 |Golang | ✓ | ✓
-|PHP | ✓ |
+|PHP | ✓ | ✓
 |Dart | ✓ | ✓
 |===
 


### PR DESCRIPTION
Version(s):
4.12+ (logging 5.8+)

Issue:
https://issues.redhat.com/browse/OBSDOCS-719

Link to docs preview:
https://70001--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_collection_forwarding/log-forwarding#details

QE review:
Not required; change approved by SME and PM, and has already been announced in release notes:
https://docs.openshift.com/container-platform/4.14/logging/logging_release_notes/logging-5-7-release-notes.html#openshift-logging-5-7-2-bug-fixes_logging-5-7-release-notes
This PR / issue just fixes an oversight where this was not updated in the table.
