### PR TITLE
OBSDOCS#256: document UWM overrideHonorLabels behavior

### DIFF
--- a/modules/monitoring-creating-cluster-id-labels-for-metrics.adoc
+++ b/modules/monitoring-creating-cluster-id-labels-for-metrics.adoc
@@ -12,6 +12,14 @@ You can create cluster ID labels for metrics for default platform monitoring and
 For default platform monitoring, you add cluster ID labels for metrics in the `write_relabel` settings for remote write storage in the `cluster-monitoring-config` config map in the `openshift-monitoring` namespace.
 
 For user workload monitoring, you edit the settings in the `user-workload-monitoring-config` config map in the `openshift-user-workload-monitoring` namespace.
+
+[NOTE]
+====
+When Prometheus scrapes user workload targets that expose a `namespace` label, the system stores this label as `exported_namespace`. 
+This behavior ensures that the final namespace label value is equal to the namespace of the target pod.
+You cannot override this default configuration by setting the value of the `honorLabels` field to `true` for `PodMonitor` or `ServiceMonitor` objects.
+====
+
 endif::openshift-dedicated,openshift-rosa[]
 
 ifdef::openshift-dedicated,openshift-rosa[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-256
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://70004--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack#creating-cluster-id-labels-for-metrics_configuring-the-monitoring-stack
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR adds a note explaining how the `overrideHonorLabels` setting works for user workload monitoring.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
