### PR TITLE
OSDOCS#8828: Adding the RN for IBM Cloud user-managed encryption (BYOK)

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -58,7 +58,14 @@ This release adds improvements related to the following components and concepts.
 [id="ocp-4-15-installation-and-update"]
 === Installation and update
 
-The Cluster API Provider for OpenStack (CAPO) is now deployed by default when the `TechPreviewNoUpgrade` feature flag is enabled. The lifecycle of this component is managed by the CAPI Operator. When the `TechPreviewNoUpgrade` feature flag is enabled, an OpenStack cluster and additional OpenShift cluster are automatically created for the current OpenShift cluster. It is now possible to configure the CAPI machine and OpenStack machine resources in a similar fashion to how the Mail Application Programming Interface (MAPI) resources are configured. It is important to note that these resources are equivalent but not identical. 
+The Cluster API Provider for OpenStack (CAPO) is now deployed by default when the `TechPreviewNoUpgrade` feature flag is enabled. The lifecycle of this component is managed by the CAPI Operator. When the `TechPreviewNoUpgrade` feature flag is enabled, an OpenStack cluster and additional OpenShift cluster are automatically created for the current OpenShift cluster. It is now possible to configure the CAPI machine and OpenStack machine resources in a similar fashion to how the Mail Application Programming Interface (MAPI) resources are configured. It is important to note that these resources are equivalent but not identical.
+
+[id="ocp-4-15-installation-and-update-ibm-cloud-user-managed-encryption"]
+==== IBM Cloud and user-managed encryption
+
+You can now specify your own {ibm-name} Key Protect for {ibm-cloud-name} or {ibm-name} Hyper Protect Crypto Services root key as part of the installation process. This root key is used to encrypt the root (boot) volume of control plane and compute machines, as well as the persistent volumes (data volumes) that are provisioned after the cluster is deployed.
+
+For more information, see xref:../installing/installing_ibm_cloud_public/user-managed-encryption-ibm-cloud.adoc#user-managed-encryption-ibm-cloud[User-managed encryption for IBM Cloud].
 
 [id="ocp-4-15-web-console"]
 === Web console


### PR DESCRIPTION
Version(s):
4.15

Issue:
This PR adds the release note for IBM Cloud user-managed encryption ([osdocs-8828](https://issues.redhat.com/browse/OSDOCS-8828)).

Link to docs preview:

[IBM Cloud and user-managed encryption](https://70010--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-installation-and-update-ibm-cloud-user-managed-encryption)

QE review:
- [x] QE has approved this change.