### PR TITLE
PR for SRVKS-1092: Wrong code block format used in the document

### DIFF
--- a/modules/serverless-configuring-kube-rbac-proxy-resources-for-eventing.adoc
+++ b/modules/serverless-configuring-kube-rbac-proxy-resources-for-eventing.adoc
@@ -9,9 +9,9 @@
 You can globally override resource allocation for the `kube-rbac-proxy` container by using the {ServerlessOperatorName} CR.
 
 [NOTE]
-----
+====
 You can also override resource allocation for a specific deployment.
-----
+====
 
 The following configuration sets Knative Eventing `kube-rbac-proxy` minimum and maximum CPU and memory allocation:
 

--- a/modules/serverless-configuring-kube-rbac-proxy-resources-for-kafka.adoc
+++ b/modules/serverless-configuring-kube-rbac-proxy-resources-for-kafka.adoc
@@ -9,9 +9,9 @@
 You can globally override resource allocation for the `kube-rbac-proxy` container by using the {ServerlessOperatorName} CR.
 
 [NOTE]
-----
+====
 You can also override resource allocation for a specific deployment.
-----
+====
 
 The following configuration sets Knative Kafka `kube-rbac-proxy` minimum and maximum CPU and memory allocation:
 

--- a/modules/serverless-configuring-kube-rbac-proxy-resources-for-serving.adoc
+++ b/modules/serverless-configuring-kube-rbac-proxy-resources-for-serving.adoc
@@ -9,9 +9,10 @@
 You can globally override resource allocation for the `kube-rbac-proxy` container by using the {ServerlessOperatorName} CR.
 
 [NOTE]
-----
+====
 You can also override resource allocation for a specific deployment.
-----
+====
+
 
 The following configuration sets Knative Serving `kube-rbac-proxy` minimum and maximum CPU and memory allocation:
 


### PR DESCRIPTION
**Affected cherry-picking versions:** 

- serverless-docs 1.29
- serverless-docs 1.30
- serverless-docs 1.31
- serverless-docs 1.32

**Associated JIRA:** https://issues.redhat.com/browse/SRVKS-1092?src=confmacro

**Doc preview and description:** 

Check the following sections I have removed the unnecessary code block that was added. 

- [Configuring kube-rbac-proxy resources for Knative for Apache Kafka](https://70013--docspreview.netlify.app/openshift-serverless/latest/install/kube-rbac-proxy-kafka#serverless-configuring-kube-rbac-proxy-resources-for-kafka_kube-rbac-proxy-kafka)
- [Configuring kube-rbac-proxy resources for Serving](https://70013--docspreview.netlify.app/openshift-serverless/latest/knative-serving/kube-rbac-proxy-serving#serverless-configuring-kube-rbac-proxy-resources-for-serving_kube-rbac-proxy-serving)
- [Configuring kube-rbac-proxy resources for Eventing](https://70013--docspreview.netlify.app/openshift-serverless/latest/eventing/kube-rbac-proxy-eventing#serverless-configuring-kube-rbac-proxy-resources-for-eventing_kube-rbac-proxy-eventing)
