### PR TITLE
CNV- 36864: CDIDefaultStorageClassDegraded runbook

### DIFF
--- a/modules/virt-runbook-cdidefaultstorageclassdegraded.adoc
+++ b/modules/virt-runbook-cdidefaultstorageclassdegraded.adoc
@@ -1,0 +1,79 @@
+// Do not edit this module. It is generated with a script.
+// Do not reuse this module. The anchor IDs do not contain a context statement.
+// Module included in the following assemblies:
+//
+// * virt/monitoring/virt-runbooks.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="virt-runbook-CDIDefaultStorageClassDegraded"]
+= CDIDefaultStorageClassDegraded
+
+[discrete]
+[id="meaning-cdidefaultstorageclassdegraded"]
+== Meaning
+
+This alert fires when there is no default storage class that supports smart cloning
+(CSI or snapshot-based) or the ReadWriteMany access mode.
+
+[discrete]
+[id="impact-cdidefaultstorageclassdegraded"]
+== Impact
+
+If the default storage class does not support smart cloning, the default cloning
+method is host-assisted cloning, which is much less efficient.
+
+If the default storage class does not support ReadWriteMany, virtual machines (VMs)
+cannot be live migrated.
+
+NOTE: A default {VirtProductName} storage class has precedence over a
+default {product-title} storage class when creating a
+VM disk.
+
+[discrete]
+[id="diagnosis-cdidefaultstorageclassdegraded"]
+== Diagnosis
+
+. Get the default {VirtProductName} storage class by running the following
+command:
++
+[source,terminal]
+----
+$ oc get sc -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubevirt\.io/is-default-virt-class=="true")].metadata.name}'
+----
+
+. If a default {VirtProductName} storage class exists, check that it
+supports ReadWriteMany by running the following command:
++
+[source,terminal]
+----
+$ oc get storageprofile <storage_class> -o json | jq '.status.claimPropertySets'| grep ReadWriteMany
+----
+
+. If there is no default {VirtProductName} storage class, get the
+default {product-title} storage class by running the following
+command:
++
+[source,terminal]
+----
+$ oc get sc -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubevirt\.io/is-default-class=="true")].metadata.name}'
+----
+
+. If a default {product-title} storage class exists, check that it
+supports ReadWriteMany by running the following command:
++
+[source,terminal]
+----
+$ oc get storageprofile <storage_class> -o json | jq '.status.claimPropertySets'| grep ReadWriteMany
+----
+
+[discrete]
+[id="mitigation-cdidefaultstorageclassdegraded"]
+== Mitigation
+
+Ensure that you have a default storage class, either {product-title}
+or {VirtProductName}, and that the default storage class supports
+smart cloning and ReadWriteMany.
+
+If you cannot resolve the issue, log in to the
+link:https://access.redhat.com[Customer Portal] and open a support case, attaching
+the artifacts gathered during the diagnosis procedure.

--- a/virt/monitoring/virt-runbooks.adoc
+++ b/virt/monitoring/virt-runbooks.adoc
@@ -17,6 +17,8 @@ include::modules/virt-runbook-cdidataimportcronoutdated.adoc[leveloffset=+1]
 
 include::modules/virt-runbook-cdidatavolumeunusualrestartcount.adoc[leveloffset=+1]
 
+include::modules/virt-runbook-cdidefaultstorageclassdegraded.adoc[leveloffset=+1]
+
 include::modules/virt-runbook-cdimultipledefaultvirtstorageclasses.adoc[leveloffset=+1]
 
 include::modules/virt-runbook-cdinodefaultstorageclass.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-36864](https://issues.redhat.com//browse/CNV-36864)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [CDIDefaultStorageClassDegraded](https://70017--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-runbooks#virt-runbook-CDIDefaultStorageClassDegraded)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
