### PR TITLE
OSDOCS-6888-new: Created the agent-based installer book for OCI

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -254,6 +254,10 @@ endif::[]
 //Oracle
 :oci-first: Oracle(R) Cloud Infrastructure (OCI)
 :oci: OCI
+:oci-ccm-full: Oracle Cloud Controller Manager (CCM)
+:oci-ccm: Oracle CCM
+:oci-csi-full: Oracle Container Storage Interface (CSI)
+:oci-csi: Oracle CSI
 :ocid-first: Oracle(R) Cloud Identifier (OCID)
 :ocid: OCID
 :ocvs-first: Oracle(R) Cloud VMware Solution (OCVS)

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -481,6 +481,8 @@ Topics:
   Topics:
   - Name: Using the Assisted Installer to install a cluster on OCI
     File: installing-oci-assisted-installer
+  - Name: Using the Agent-based Installer to install a cluster on OCI
+    File: installing-oci-agent-based-installer
 - Name: Installing on vSphere
   Dir: installing_vsphere
   Distros: openshift-origin,openshift-enterprise

--- a/installing/installing_oci/installing-oci-agent-based-installer.adoc
+++ b/installing/installing_oci/installing-oci-agent-based-installer.adoc
@@ -1,0 +1,56 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="installing-oci-agent-based-installer"]
+= Installing a cluster OCI by using the Agent-based Installer 
+include::_attributes/common-attributes.adoc[]
+:context: installing-oci-agent-based-installer
+
+toc::[]
+
+In {product-title} {product-version}, you can use the Agent-based Installer to install a cluster on {oci-first}, so that you can run cluster workloads on infrastructure that supports dedicated, hybrid, public, and multiple cloud environments.
+
+// The Agent-based Installer and OCI overview
+include::modules/installing-oci-about-agent-based-installer.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../architecture/architecture-installation.html#installation-process_architecture-installation[Installation process]
+* xref:../../installing/installing_platform_agnostic/installing-platform-agnostic.html#cluster-entitlements_installing-platform-agnostic[Internet access for {product-title}]
+* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#understanding-agent-install_preparing-to-install-with-agent-based-installer[Understanding the Agent-based Installer]
+* See link:https://docs.oracle.com/en-us/iaas/Content/Compute/Concepts/computeoverview.htm[Overview of the Compute Service] in the Oracle documentation.
+* See link:https://docs.oracle.com/en-us/iaas/Content/Block/Concepts/blockvolumeperformance.htm#vpus[Volume Performance Units] in the Oracle documentation.
+
+// Creating OCI infrastructure resources and services
+include::modules/creating-oci-infra-resources-services.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+See the following Oracle documentation resources: 
+
+* link:https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingcompartments.htm#ariaid-title5[Creating compartments] 
+* link:https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/create_vcn.htm[Creating a VCN]
+* link:https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/create-nsg.htm[Creating an NSG]
+* link:https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengdynamicgrouppolicyforselfmanagednodes.htm[Creating a dynamic group and a policy for self-managed nodes]
+* link:https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingpolicies.htm[Managing policies]
+* link:https://docs.oracle.com/en-us/iaas/Content/Balance/Tasks/managingloadbalancer_topic-Creating_Load_Balancers.htm[Creating a load balancer]
+* link:https://docs.oracle.com/en-us/iaas/Content/DNS/Tasks/record-add.htm[Adding a record to a DNS zone]
+
+// Creating configuration files for installing a cluster on OCI
+include::modules/creating-config-files-cluster-install-oci.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html#installing-ocp-agent-ztp_installing-with-agent-based-installer[Optional: Using ZTP manifests]
+
+// Running your cluster on OCI
+include::modules/running-cluster-oci-agent-based.adoc[leveloffset=+1]
+
+// Verifying a succesful cluster installation on OCI
+include::modules/verifying-cluster-install-oci-agent-based.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html#installing-ocp-agent-gather-log_installing-with-agent-based-installer[Gathering log data from a failed Agent-based installation]

--- a/modules/creating-config-files-cluster-install-oci.adoc
+++ b/modules/creating-config-files-cluster-install-oci.adoc
@@ -1,0 +1,138 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_oci/installing-oci-agent-based-installer.adoc [Using the Agent-based Installer to install a cluster on OCI]
+
+:_mod-docs-content-type: PROCEDURE
+[id="creating-config-files-cluster-install-oci_{context}"]
+= Creating configuration files for installing a cluster on OCI
+
+You need to create the `install-config.yaml` and the `agent-config.yaml` configuration files so that you can use the Agent-based Installer to generate a bootable ISO image. The Agent-based installation comprises a bootable ISO that contains the Assisted discovery agent and the Assisted Service. Both of these components are required to perform the cluster installation, but the latter component runs on only one of the hosts.
+
+In a subsequent procedure, you can upload your generated Agent ISO image to Oracle’s default Object Storage bucket, which is the initial step for integrating your {product-title} cluster on {oci-first}.
+
+You can also use the Agent-based Installer to generate or accept Zero Touch Provisioning (ZTP) custom resources.
+
+.Prerequisites
+* You reviewed details about the xref:../../architecture/architecture-installation.html#installation-overview_architecture-installation[{product-title} installation and update processes].
+* You read the documentation on xref:../../installing/installing-preparing.html#installing-preparing-selecting-cluster-type[Selecting a cluster installation method and preparing it for users].
+* You have read the xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#about-the-agent-based-installer[Preparing to install with the Agent-based Installer] documentation.
+* You downloaded the xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html#installing-ocp-agent-retrieve_installing-with-agent-based-installer[Agent-Based Installer] and the command-line interface (CLI) from Red Hat’s Hybrid Cloud Console.
+* For a disconnected environment, you created a container image registry, such as Red Hat Quay. See xref:../../installing/disconnected_install/installing-mirroring-creating-registry.html#mirror-registry-introduction_installing-mirroring-creating-registry[Mirror registry for Red Hat OpenShift introduction].
+* You have logged into the {product-title} with administrator privileges. 
+
+.Procedure
+
+. Configure the `install-config.yaml` configuration file to meet the needs of your organization. 
++
+.Example `install-config.yaml` configuration file that demonstrates setting an external platform
++
+[source,yaml]
+----
+# install-config.yaml
+apiVersion: v1
+baseDomain: <base_domain> <1>
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  network type: OVNKubernetes
+  machineNetwork:
+  - cidr: <ip_address_from_cidr> <2>
+  serviceNetwork: 
+  - 172.30.0.0/16
+compute:
+  - architecture: amd64 <3>
+  hyperthreading: Enabled
+  name: worker
+  replicas: 0
+controlPlane:
+  architecture: amd64 <3>
+  hyperthreading: Enabled
+  name: master
+  replicas: 3
+platform:
+   external:
+    platformName: oci <4>
+    cloudControllerManager: External
+sshKey: <public_ssh_key> <5>
+pullSecret: '<pull_secret>' <6>
+# ...
+----
+<1> The base domain of your cloud provider. 
+<2> The IP address from the VCN that the CIDR allocates to resources and components that operate on your network.
+<3> Depending on your infrastructure, you can select either `x86_64`, or `amd64`.
+<4> Set `OCI` as the external platform, so that {product-title} can integrate with {oci}. 
+<5> Specify your SSH public key.
+<6> The pull secret that you need for authenticate purposes when downloading container images for {product-title} components and services, such as Quay.io. See link:https://console.redhat.com/openshift/install/pull-secret[Install {product-title} 4] from the Red Hat Hybrid Cloud Console. 
+
+. Create a directory on your local system named `openshift`. 
++
+[IMPORTANT]
+====
+Do not move the `install-config.yaml` and `agent-config.yaml` configuration files to the `openshift` directory.
+====
+
+. From the link:https://github.com/oracle-quickstart/oci-openshift[`oracle-quickstart / oci-openshift`] GitHub web page, select the **<> Code** button and click **Download ZIP**. Save the archive file to your `openshift` directory,  so that all the {oci-ccm-full} and {oci-csi-full} manifests exist in the same directory. The downloaded archive file includes files for creating cluster resources and custom manifests. 
+
+. Go to the link:https://github.com/oracle-quickstart/oci-openshift/tree/main/custom_manifests[custom_manifests] web page on GitHub to access the custom manifest files.
++
+The {oci-ccm} manifest are required for deploying the {oci-ccm} during cluster installation so that {product-title} can connect to the external {oci} platform. The {oci-csi} custom manifests are required for deploying the {oci-csi} driver during cluster installation so that {product-title} can claim required objects from {oci}.
++
+[IMPORTANT]
+====
+You must modify the secret `oci-cloud-controller-manager` defined in the link:https://github.com/oracle-quickstart/oci-openshift/blob/main/custom_manifests/manifests/oci-ccm.yml[`oci-ccm.yml`] configuration file to match your organization's region, compartment {ocid}, VCN {ocid}, and the subnet {ocid} from the load balancer.
+====
+
+. Use the Agent-based Installer to generate a minimal ISO image, which excludes the `rootfs` image, by entering the following command in your {product-title} CLI. You can use this image later in the process to boot all your cluster’s nodes. 
++
+[source,terminal]
+----
+$ ./openshift-install agent create image --log-level debug
+----
++
+The previous command also completes the following actions:
++
+* Creates a subdirectory, `./<installation_directory>/auth directory:`, and places `kubeadmin-password` and `kubeconfig` files in the subdirectory.  
+* Creates a `rendezvousIP` file based on the IP address that you specified in the `agent-config.yaml` configuration file. 
+* Optional: Any modifications you made to `agent-config.yaml` and `install-config.yaml` configuration files get imported to the Zero Touch Provisioning (ZTP) custom resources. 
++
+[IMPORTANT]
+====
+The Agent-based Installer uses {op-system-first}. The `rootfs` image, which is mentioned in a subsequent listed item,  is required for booting, recovering, and repairing your operating system. 
+====
+
+. Configure the `agent-config.yaml` configuration file to meet your organization’s requirements. 
++
+.Example `agent-config.yaml` configuration file that sets values for an IPv4 formatted network.
+[source,yaml]
+----
+apiVersion: v1alpha1
+metadata:
+  name: <cluster_name> <1>
+  namespace: <cluster_namespace> <2>
+rendezvousIP:<ip_address_from_CIDR> <3>
+bootArtifactsBaseURL:<server_URL> <4>
+# …
+----
+<1> The cluster name that you specified in your DNS record. 
+<2> The name of your cluster on {product-title}. 
+<3> If you are using IPv4 as the network IP address format, ensure that you set the `rendezvousIP` parameter to an IPv4 address that the VCN’s Classless Inter-Domain Routing (CIDR) method allocates on your network. Also ensure that at least one instance from the pool of instances that you booted with the ISO matches the IP address value you set for `rendezvousIP`.  
+<4> The URL of the server where you want to upload the `rootfs` image.
+
+. Apply one of the following two updates to your `agent-config.yaml` configuration file:
++
+* For a disconnected network:  After you run the command to generate a minimal ISO Image, the Agent-based installer saves the `rootfs` image into the `./<installation_directory>/boot-artifacts` directory on your local system. Upload `rootfs` to the location stated in the `bootArtifactsBaseURL` parameter in the `agent-config.yaml` configuration file. 
++
+For example, if the URL states \http://192.168.122.20, you would upload the generated `rootfs` image to this location, so that the installer can access the image from \http://192.168.122.20/agent.x86_64-rootfs.img. After the installer boots the minimal ISO for the external platform, the Agent-based Installer downloads the `rootfs` image from the \http://192.168.122.20/agent.x86_64-rootfs.img location into the system memory. 
++
+[NOTE]
+====
+The Agent-based Installer also adds the value of the `bootArtifactsBaseURL` to the minimal ISO Image’s configuration, so that when the Operator boots a cluster’s node, the Agent-based Installer  downloads the `rootfs` image into system memory.
+====
++
+* For a connected network: You do not need to specify the `bootArtifactsBaseURL` parameter in the `agent-config.yaml` configuration file, because the Agent-based Installer, by default, reads the a `rootfs` URL location from \https://rhcos.mirror.openshift.com. After the Agent-based Installer  boots the minimal ISO for the external platform, the Agent-based Installer then downloads the `rootfs` file into your system’s memory from the default {op-system} URL.
++
+[IMPORTANT]
+====
+Consider that the full ISO image, which is in excess of `1` GB, includes the `rootfs` image and the image is considerably larger than the minimal ISO Image, which is typical less than `150` MB.
+====

--- a/modules/creating-oci-infra-resources-services.adoc
+++ b/modules/creating-oci-infra-resources-services.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_oci/installing-oci-agent-based-installer.adoc [Using the Agent-based Installer to install a cluster on OCI]
+
+:_mod-docs-content-type: PROCEDURE
+[id="creating-oci-infra-resources-services_{context}"]
+= Creating OCI infrastructure resources and services
+
+// Removed "or bare-metal shape" as BM route is dev preview. Feature support progression is dependent on OSDOCS-8631 progress.
+Before you install {product-title} on {oci-first}, you must create an {oci} environment on your virtual machine (VM) shape. By creating this environment, you can install {product-title} and deploy a cluster on infrastructure that supports a wide range of cloud options and strong security policies.
+
+.Prerequisites
+* You have prior knowledge of {oci} components. See link:https://docs.oracle.com/en-us/iaas/Content/GSG/Concepts/concepts.htm[Learn About Oracle Cloud Basics] in the Oracle documentation.  
+* Your organization signed up for an Oracle account and Identity Domain. This step is required so that you can access an administrator account, which is the initial cloud-identity and access management (IAM) user for your organization. See link:https://docs.oracle.com/en-us/iaas/Content/Identity/Concepts/overview.htm#ariaid-title4[The administrators group and policy] section in the Oracle documentation.
+* You have logged into your organization’s {oci} account with administrator privileges.
+
+.Procedure
+
+. Create a compartment and ensure you defined your {ocid-first} in the compartment. A compartment is a component where you can organize and isolate your cloud resources. After you create a compartment, Oracle automatically assigns an {ocid} to your organization’s account. An administrator can access all compartments tagged to your organization’s {oci} account.
+
+. Create a virtual cloud network (VCN). A compute instance, load balancer, and other resources need this network infrastructure to connect to each other over an internet connection. To establish an on-premise network you must manually create subnets, gateways, routing rules, and security policies. Ensure that you complete the following steps:
+.. In **Primary VNIC IP addresses > Primary network**, select a VCN, such as *oci-cluster-vcn*. 
+.. From the **Subnet** section, select your subnet, such as *ici-cluster-private-subnet*. 
+.. For public IPV4 subnets, ensure that you select the **Do not assign a public IPv4 address** checkbox.
+
+. Create a network security group (NSG) in your VCN. You can use the NSG to establish advanced security rules for your network. You must locate the NSG in your compartment, so that certain groups can access network resources. Ensure that you complete the following steps:
+.. Click **Show advanced options**. 
+.. Select the **Use network security groups** to control traffic checkbox.
+.. Set your NSG, such as *oci-cluster-controlplane-nsg*.
+
+. Create a dynamic group that hosts compute instances. After you create the dynamic group, you can then create a policy statement that defines rules for your cluster environment. This statement sets the precedent  for each compute instance to join your {product-title} cluster as a self-managed node. 
+
+. Create a policy statement. You must create a policy so that your administrator can grant access to your groups, users, or resources that operate in your network.
+
+. Create a load balancer, so that you can provide automated traffic distribution on your VCN.
+
+. Create three Domain Name System (DNS) records and then add the records to a DNS, so that Oracle’s edge-network can maintain your domain’s DNS queries.
++
+[IMPORTANT]
+====
+To ensure compatibility with {product-title}, set `A` as the record type for each DNS record and name records as follows:
+
+* `api.<cluster_name>.<base_domain>`, which targets the `apiVIP` parameter of the API load balancer.
+* `api-int.<cluster_name>.<base_domain>`, which targets the `apiVIP` parameter of the API load balancer.
+* `*.apps.<cluster_name>.<base_domain>`, which targets the `ingressVIP` parameter of the Ingress load balancer.
+
+The `api.+*+` and `api-int.+*+` DNS records relate to control plane machines, so you must ensure that all nodes in your installed {product-title} cluster can access these DNS records.
+====

--- a/modules/installing-oci-about-agent-based-installer.adoc
+++ b/modules/installing-oci-about-agent-based-installer.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_oci/installing-oci-agent-based-installer.adoc [Using the Agent-based Installer to install a cluster on OCI]
+
+:_mod-docs-content-type: CONCEPT
+[id="installing-oci-about-agent-based-installer_{context}"]
+= The Agent-based Installer and OCI overview
+
+You can install an {product-title} cluster on {oci-first} by using the Agent-based Installer. Both Red Hat and Oracle test, validate, and support running {oci} and {ocvs-first} workloads in an {product-title} cluster on {oci}. 
+
+:FeatureName: Using the Agent-based Installer to install an {product-title} cluster on OCI that is configured with a virtual machine (VM) compute instance
+include::snippets/technology-preview.adoc[]
+
+The Agent-based installer provides the ease of use of the Assisted Installation service, but with the capability to install a cluster in either a connected or disconnected environment.
+
+{oci} provides services that can meet your regulatory compliance, performance, and cost-effectiveness needs. {oci} supports 64-bit `x86` instances and 64-bit `ARM` instances. Additionally, {oci} provides an {ocvs} service where you can move VMware workloads to {oci} with minimal application re-architecture.
+
+[NOTE]
+====
+Consider selecting a nonvolatile memory express (NVMe) drive or a solid-state drive (SSD) for your boot disk, because these drives offer low latency and high throughput capabilities for your boot disk. 
+====
+
+By running your {product-title} cluster on {oci}, you can access the following capabilities:
+
+* Compute flexible shapes, where you can customize the number of Oracle(R) CPUs (OCPUs) and memory resources for your VM. With access to this capability, a cluster’s workload can perform operations in a resource-balanced environment. You can find all RHEL-certified {oci} shapes by going to the Oracle page on the Red Hat Ecosystem Catalog portal.
+
+* Block Volume storage, where you can configure scaling and auto-tuning settings for your storage volume, so that the Block Volume service automatically adjusts the performance level to optimize performance.
+
+* {ocvs}, where you can deploy a cluster in a public-cloud environment that operates on a VMware® vSphere software-defined data center (SDDC). You continue to retain full-administrative control over your VMware vSphere environment, but you can use {oci} services to improve your applications on flexible, scalable, and secure infrastructure.
+
+[IMPORTANT]
+====
+To ensure the best performance conditions for your cluster workloads that operate on {oci} and on the OCVS service, ensure volume performance units (VPUs) for your block volume is sized for your workloads. The following list provides some guidance in selecting the VPUs needed for specific performance needs:
+
+* Test or proof of concept environment: `100` GB, and `20` to `30` VPUs.
+* Basic environment: `500` GB, and `60` VPUs.
+* Heavy production environment: More than `500` GB,  and `100` or more VPUs.
+
+Consider reserving additional VPUs to provide sufficient capacity for updates and scaling activities. For more information about VPUs, see Volume Performance Units in the Oracle documentation.
+====

--- a/modules/running-cluster-oci-agent-based.adoc
+++ b/modules/running-cluster-oci-agent-based.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_oci/installing-oci-agent-based-installer.adoc [Using the Agent-based Installer to install a cluster on OCI]
+
+:_mod-docs-content-type: PROCEDURE
+[id="running-cluster-oci-agent-based_{context}"]
+= Running a cluster on OCI
+
+To run a cluster on {oci-first}, you must upload the generated Agent ISO image to the default Object Storage bucket on {oci}. Additionally, you must create a compute instance from the supplied base image, so that your {product-title} and {oci} can communicate with each other for the purposes of running the cluster on {oci}.
+
+.Prerequisites
+
+* You generated an Agent ISO image. See the "Creating configuration files for installing a cluster on OCI" section.
+
+.Procedure
+
+. Upload the Agent ISO image to Oracle’s default Object Storage bucket and then import the Agent ISO image as a custom image to this bucket. You must then configure the custom image to boot in Unified Extensible Firmware Interface (UEFI) mode. See link:https://docs.oracle.com/en-us/iaas/secure-desktops/create-custom-image.htm[Creating a custom image] and link:https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/configuringimagecapabilities.htm#ariaid-title5[Using the Console] in Oracle’s documentation.
++
+For example, from **Compute > Custom images**, import the Agent ISO image to the bucket, and enter values in the following fields:
++
+* Name: *oci-cluster*
+* Bucket: Select the bucket where you uploaded the discovery ISO image
+* Object name: Select the name of the discovery ISO
+* Image type: *QCOW2*
++
+After the image imports, go to the **Edit image capabilities** setting and ensure  that `UEFI_64` is selected for the **Firmware** field. 
+
+. Create a compute instance from the supplied base image for your preferred cluster topology, such as a single-node OpenShift (SNO) cluster, a highly-availability cluster that contains a minimum of 3 control plane instances and two compute instances, or a compact three-node cluster that contains a minimum of three control plane instances. See link:https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/launchinginstance.htm#top[Creating an instance] (Oracle documentation).
++
+[IMPORTANT]
+====
+Before you create the compute instance, check that you have enough memory and disk resources for your cluster. See xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#recommended-resources-for-topologies[Recommended resources for topologies].  Additionally, ensure that at least one compute instance has the same IP address as the address stated under `rendezvousIP` in the `agent-config.yaml` file.
+====
++
+The following example lists important settings for an instance named *oci-cluster-master*. 
++
+* Go to **Image and shape section >  Image >  My images** and then select your custom image.  
+* Go to  **Image and shape section > Shape menu** and then select at least 4 CPUs and 16 GB of memory.
+* From the **Boot volume** section, select the **Specify a custom boot volume size** checkbox. Enter a value that is at least `100` GB for the boot volume size. Allocate the number of VPUs for your organization needs, such as a value in the range of `20` to `30` VPUs. 

--- a/modules/verifying-cluster-install-oci-agent-based.adoc
+++ b/modules/verifying-cluster-install-oci-agent-based.adoc
@@ -1,0 +1,70 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_oci/installing-oci-agent-based-installer.adoc [Using the Agent-based Installer to install a cluster on OCI]
+
+:_mod-docs-content-type: PROCEDURE
+[id="verifying-cluster-install-oci-agent-based_{context}"]
+= Verifying that your Agent-based cluster installation runs on OCI
+
+Verify that your cluster was installed and is running effectively on {oci-first}. 
+
+.Prerequisites
+
+* You created all the required {oci} resources and services. See the "Creating OCI infrastructure resources and services" section.
+* You created `install-config.yaml` and `agent-config.yaml` configuration files. See the "Creating configuration files for installing a cluster on OCI" section.
+* You uploaded the Agent ISO image to Oracle’s default Object Storage bucket, and you created a compute instance on {oci}. See the "running-cluster-oci-agent-based" section
+
+.Procedure
+
+After you deploy the compute instance on a self-managed node in your {product-title} cluster, you can monitor the cluster’s status by choosing one of the following options:
+
+* From the {product-title} CLI, enter the following command:
++
+[source,terminal]
+----
+$ ./openshift-install agent wait-for install-complete --log-level debug
+----
++
+Check the status of the `rendezvous` host node that runs the bootstrap node.  After the host reboots, the host forms part of the cluster.
++
+* Use the `kubeconfig` API to check the status of various {product-title} components. For the  `KUBECONFIG` environment variable, set the relative path of the cluster’s `kubeconfig` configuration file:
++
+[source,terminal]
+----
+$  export KUBECONFIG=~/auth/kubeconfig
+----
++
+Check the status of each of the cluster’s self-managed nodes. CCM applies a label to each node to designate the node as running in a cluster on {oci}. 
++
+[source,terminal]
+----
+$ oc get nodes -A
+----
++
+.Output example
++
+[source,terminal]
+----
+NAME                                   STATUS ROLES                 AGE VERSION 
+main-0.private.agenttest.oraclevcn.com Ready  control-plane, master 7m  v1.27.4+6eeca63
+main-1.private.agenttest.oraclevcn.com Ready  control-plane, master 15m v1.27.4+d7fa83f
+main-2.private.agenttest.oraclevcn.com Ready  control-plane, master 15m v1.27.4+d7fa83f
+----
++
+Check the status of each of the cluster’s Operators, with the CCM Operator status being a good indicator that your cluster is running.
++
+[source,terminal]
+----
+$ oc get co
+----
++
+.Truncated output example
++
+[source,terminal]
+----
+NAME           VERSION     AVAILABLE  PROGRESSING    DEGRADED   SINCE   MESSAGE
+authentication 4.15.0-0    True       False          False      6m18s
+baremetal      4.15.0-0    True       False          False      2m42s
+network        4.15.0-0    True       True           False      5m58s  Progressing: …
+    …
+----


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-6888](https://issues.redhat.com/browse/OSDOCS-6888)

Link to docs preview:
[Installing a cluster OCI by using the Agent-based Installer](https://70025--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci/installing-oci-agent-based-installer)

SME review:
- [x]

QE review:
- [x]

Additional information:
* BM on Oraclewill remain as Dev Preview feature because of https://github.com/openshift/openshift-docs/pull/70381 . Only VM will make customer docs for now.
* [Deep dive OCI](https://docs.google.com/document/d/1bKewJXMXDTlwbTVzbW0UidCpszFitcq1b4aDXQsyu50/edit#heading=h.ow5dpnvdogeo)
* [OCI AI](https://docs.google.com/document/d/1Rkg-yX4hVlOXQ75im9-1VPRMGcLUHHweZPAB184puAs/edit#heading=h.1888zwhbwvy8)
* [Eng. video](https://drive.google.com/file/d/18-zf7NFVTHxQHXiL0vMpnZvAKNDdK_o0/view)
* [Kbase article](https://access.redhat.com/articles/7038262)
