### PR TITLE
OCPBUGS-19883: Move reboot warning in "Replacing an unhealthy etcd member"

### DIFF
--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -114,11 +114,6 @@ sh-4.2# etcdctl member list -w table
 ----
 +
 You can now exit the node shell.
-+
-[IMPORTANT]
-====
-After you remove the member, the cluster might be unreachable for a short time while the remaining etcd instances reboot.
-====
 
 . Turn off the quorum guard by entering the following command:
 +
@@ -128,6 +123,16 @@ $ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides":
 ----
 +
 This command ensures that you can successfully re-create secrets and roll out the static pods.
++
+[IMPORTANT]
+====
+After you turn off the quorum guard, the cluster might be unreachable for a short time while the remaining etcd instances reboot to reflect the configuration change.
+====
++
+[NOTE]
+====
+etcd cannot tolerate any additional member failure when running with two members. Restarting either remaining member breaks the quorum and causes downtime in your cluster. The quorum guard protects etcd from restarts due to configuration changes that could cause downtime, so it must be disabled to complete this procedure.
+====
 
 . Delete the affected node by running the following command:
 +


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-19883

Link to docs preview:
https://70035--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member#restore-replace-stopped-etcd-member_replacing-unhealthy-etcd-member

QE review:
- [x] QE has approved this change.

Additional information:
N/A
