### PR TITLE
Update the file metadata for all the GitOps assemblies and modules to…

### DIFF
--- a/accesscontrol_usermanagement/configuring-argo-cd-rbac.adoc
+++ b/accesscontrol_usermanagement/configuring-argo-cd-rbac.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="configuring-argo-cd-rbac"]
 = Configuring Argo CD RBAC
@@ -8,5 +8,8 @@ toc::[]
 
 By default, if you are logged into Argo CD using Red Hat SSO (RH SSO), you are a read-only user. You can change and manage the user level access.
 
+// Configuring user level access
 include::modules/gitops-configuring-user-level-access.adoc[leveloffset=+1]
+
+// Modifying RHSSO resource requests/limits
 include::modules/gitops-modifying-rhsso-requests-limits.adoc[leveloffset=+1]

--- a/accesscontrol_usermanagement/configuring-sso-for-argo-cd-using-keycloak.adoc
+++ b/accesscontrol_usermanagement/configuring-sso-for-argo-cd-using-keycloak.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="configuring-sso-for-argo-cd-using-keycloak"]
 = Configuring SSO for Argo CD using Keycloak
@@ -14,10 +14,13 @@ After the {gitops-title} Operator is installed, Argo CD automatically creates a 
 * {gitops-title} Operator is installed on the cluster.
 * Argo CD is installed on the cluster.
 
+// Configuring a new client in Keycloak
 include::modules/gitops-creating-a-new-client-using-keycloak.adoc[leveloffset=+1]
 
+// Logging in to Keycloak
 include::modules/gitops-logging-into-keycloak.adoc[leveloffset=+1]
 
+// Uninstalling Keycloak
 include::modules/gitops-uninstall-keycloak.adoc[leveloffset=+1]
 
 ////

--- a/accesscontrol_usermanagement/configuring-sso-on-argo-cd-using-dex.adoc
+++ b/accesscontrol_usermanagement/configuring-sso-on-argo-cd-using-dex.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="configuring-sso-for-argo-cd-using-dex"]
 = Configuring SSO for Argo CD using Dex
@@ -13,14 +13,17 @@ After the {gitops-title} Operator is installed, Argo CD automatically creates a 
 The `spec.dex` parameter in the ArgoCD CR is no longer supported from {gitops-title} v1.10.0 onwards. Consider using the `.spec.sso` parameter instead.
 ====
 
+// Configuration to enable the Dex OpenShift OAuth Connector
 include::modules/gitops-creating-a-new-client-in-dex.adoc[leveloffset=+1]
 
+// Mapping users to specific roles
 include::modules/gitops-dex-role-mappings.adoc[leveloffset=+2]
 
 //include::modules/gitops-configuring-argo-cd-using-dex-github-conector.adoc[leveloffset=+1]
 
 //include::modules/gitops-disable-dex.adoc[leveloffset=+1]
 
+// Disabling Dex by replacing .spec.sso
 include::modules/gitops-disable-dex-using-spec-sso.adoc[leveloffset=+1]
 
 ////

--- a/argo_rollouts/using-argo-rollouts-for-progressive-deployment-delivery.adoc
+++ b/argo_rollouts/using-argo-rollouts-for-progressive-deployment-delivery.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="using-argo-rollouts-for-progressive-deployment-delivery"]
 = Using Argo Rollouts for progressive deployment delivery
@@ -24,12 +24,16 @@ You can use Argo Rollouts to manage multiple replica sets that represent differe
 * You have access to the {OCP} web console.
 * {gitops-title} 1.9.0 or a newer version is installed in your cluster.
 
+// Benefits of Argo Rollouts
 include::modules/gitops-benefits-of-argo-rollouts.adoc[leveloffset=+1]
 
+// About RolloutManager custom resources and specification
 include::modules/gitops-about-argo-rollout-manager-custom-resources-and-spec.adoc[leveloffset=+1]
 
+// Creating a RolloutManager custom resource
 include::modules/gitops-creating-rolloutmanager-custom-resource.adoc[leveloffset=+1]
 
+// Deleting a RolloutManager custom resource
 include::modules/gitops-deleting-rolloutmanager-custom-resource.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/argocd_applications/deploying-a-spring-boot-application-with-argo-cd.adoc
+++ b/argocd_applications/deploying-a-spring-boot-application-with-argo-cd.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="deploying-a-spring-boot-application-with-argo-cd"]
 = Deploying a Spring Boot application with Argo CD
@@ -14,8 +14,11 @@ With Argo CD, you can deploy your applications to the OpenShift cluster either b
 * Red Hat OpenShift GitOps is installed in your cluster.
 * Logged into Argo CD instance.
 
+// Creating an application by using the Argo CD dashboard
 include::modules/gitops-creating-an-application-by-using-the-argo-cd-dashboard.adoc[leveloffset=+1]
 
+// Creating an application by using the `oc` tool
 include::modules/gitops-creating-an-application-by-using-the-oc-tool.adoc[leveloffset=+1]
 
+// Verifying Argo CD self-healing behavior
 include::modules/gitops-verifying-argo-cd-self-healing-behavior.adoc[leveloffset=+1]

--- a/argocd_instance/argo-cd-cr-component-properties.adoc
+++ b/argocd_instance/argo-cd-cr-component-properties.adoc
@@ -8,7 +8,14 @@ toc::[]
 
 The `ArgoCD` custom resource is a Kubernetes Custom Resource (CRD) that describes the desired state for a given Argo CD cluster that allows you to configure the components which make up an Argo CD cluster.
 
+// Argo CD CLI tool
 include::modules/gitops-argo-cd-command-line.adoc[leveloffset=+1]
+
+// Argo CD custom resource properties
 include::modules/gitops-argo-cd-properties.adoc[leveloffset=+1]
+
+// Repo server properties
 include::modules/gitops-repo-server-properties.adoc[leveloffset=+1]
+
+// Enabling notifications with Argo CD instance
 include::modules/gitops-argo-cd-notification.adoc[leveloffset=+1]

--- a/argocd_instance/setting-up-argocd-instance.adoc
+++ b/argocd_instance/setting-up-argocd-instance.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="setting-up-argocd-instance"]
 = Setting up an Argo CD instance
@@ -8,10 +8,14 @@ toc::[]
 
 By default, the {gitops-title} installs an instance of Argo CD in the `openshift-gitops` namespace with additional permissions for managing certain cluster-scoped resources. To manage cluster configurations or deploy applications, you can install and deploy a new Argo CD instance. By default, any new instance has permissions to manage resources only in the namespace where it is deployed.
 
+// Installing an Argo CD instance
 include::modules/gitops-argo-cd-installation.adoc[leveloffset=+1]
 
+// Enabling replicas for Argo CD server and repo server
 include::modules/gitops-enable-replicas-for-argo-cd-server.adoc[leveloffset=+1]
 
+// Deploying resources to a different namespace
 include::modules/gitops-deploy-resources-different-namespaces.adoc[leveloffset=+1]
 
+// Customizing the Argo CD console link
 include::modules/gitops-customize-argo-cd-consolelink.adoc[leveloffset=+1]

--- a/declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc
+++ b/declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations"]
 = Configuring an OpenShift cluster by deploying an application with cluster configurations
@@ -15,10 +15,13 @@ With {gitops-title}, you can configure Argo CD to recursively sync the content o
 * You have installed the {gitops-title} Operator in your cluster.
 * You have logged into Argo CD instance.
 
+// Using an Argo CD instance to manage cluster-scoped resources
 include::modules/gitops-using-argo-cd-instance-to-manage-cluster-scoped-resources.adoc[leveloffset=+1]
 
+// Default permissions of an Argocd instance
 include::modules/gitops-default-permissions-of-an-argocd-instance.adoc[leveloffset=+1]
 
+// Running the Argo CD instance at the cluster-level
 include::modules/go-run-argo-cd-instance-on-infrastructure-nodes.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -26,14 +29,20 @@ include::modules/go-run-argo-cd-instance-on-infrastructure-nodes.adoc[leveloffse
 * To learn more about taints and tolerations, see link:https://docs.openshift.com/container-platform/latest/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations[Controlling pod placement using node taints].
 * For more information on infrastructure machine sets, see link:https://docs.openshift.com/container-platform/latest/machine_management/creating-infrastructure-machinesets.html#creating-infrastructure-machinesets[Creating infrastructure machine sets].
 
+// Creating an application by using the Argo CD dashboard
 include::modules/gitops-creating-an-application-by-using-the-argo-cd-dashboard.adoc[leveloffset=+1]
 
+// Creating an application by using the `oc` tool
 include::modules/gitops-creating-an-application-by-using-the-oc-tool.adoc[leveloffset=+1]
 
+// Synchronizing your application with your Git repository
 include::modules/gitops-synchronizing-your-application-application-with-your-git-repository.adoc[leveloffset=+1]
 
+// In-built permissions for cluster configuration
 include::modules/gitops-inbuilt-permissions-for-cluster-config.adoc[leveloffset=+1]
 
+// Adding permissions for cluster configuration
 include::modules/gitops-additional-permissions-for-cluster-config.adoc[leveloffset=+1]
 
+// Installing OLM Operators using Red Hat OpenShift GitOps
 include::modules/gitops-installing-olm-operators-using-gitops.adoc[leveloffset=+1]

--- a/gitops_workloads_infranodes/run-gitops-control-plane-workload-on-infra-nodes.adoc
+++ b/gitops_workloads_infranodes/run-gitops-control-plane-workload-on-infra-nodes.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="run-gitops-control-plane-workload-on-infra-nodes"]
 = Running {gitops-shortname} control plane workloads on infrastructure nodes
@@ -15,6 +15,7 @@ You can use the {OCP} to run certain workloads on infrastructure nodes installed
 Any other Argo CD instances installed to user namespaces are not eligible to run on infrastructure nodes.
 ====
 
+// Moving GitOps workloads to infrastructure nodes
 include::modules/go-add-infra-nodes.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/installing_gitops/installing-openshift-gitops.adoc
+++ b/installing_gitops/installing-openshift-gitops.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="installing-openshift-gitops"]
 = Installing {gitops-title}
@@ -30,8 +30,11 @@ The `latest` channel enables installation of the most recent stable version of t
 To install a specific version of the {gitops-title} Operator, cluster administrators can use the corresponding `gitops-<version>` channel. For example, to install the {gitops-title} Operator version 1.8.x, you can use the `gitops-1.8` channel.
 ====
 
+// Installing Red Hat OpenShift GitOps Operator in web console
 include::modules/installing-gitops-operator-in-web-console.adoc[leveloffset=+1]
 
+// Installing Red Hat OpenShift GitOps Operator using CLI
 include::modules/installing-gitops-operator-using-cli.adoc[leveloffset=+1]
 
+// Logging in to the Argo CD instance by using the Argo CD admin account
 include::modules/logging-in-to-the-argo-cd-instance-by-using-the-argo-cd-admin-account.adoc[leveloffset=+1]

--- a/installing_gitops/preparing-gitops-install.adoc
+++ b/installing_gitops/preparing-gitops-install.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="preparing-gitops-install"]
 = Preparing to install {gitops-title}
@@ -8,4 +8,5 @@ toc::[]
 
 Read the following information about sizing requirements and prerequisites before you install {gitops-title} on {OCP}. Sizing requirements also provides the sizing details for the default ArgoCD instance that is instantiated by the {gitops-title} Operator.
 
+// Sizing requirements for GitOps
 include::modules/sizing-requirements-for-gitops.adoc[leveloffset=+1]

--- a/managing_resource/configuring-resource-quota.adoc
+++ b/managing_resource/configuring-resource-quota.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="configuring-resource-quota"]
 = Configuring resource quota or requests
@@ -8,6 +8,11 @@ toc::[]
 
 With the Argo CD custom resource (CR), you can create, update, and delete resource requests and limits for Argo CD workloads. 
 
+// Configuring workloads with resource requests and limits
 include::modules/gitops-configuring-workloads.adoc[leveloffset=+1]
+
+// Patching Argo CD instance to update the resource requirements
 include::modules/gitops-patching-argocd-instance.adoc[leveloffset=+1]
+
+// Removing resource requests
 include::modules/gitops-removing-resource-requirements.adoc[leveloffset=+1]

--- a/modules/about-must-gather.adoc
+++ b/modules/about-must-gather.adoc
@@ -8,7 +8,7 @@
 // * serverless/serverless-support.adoc
 // * understanding_openshift_gitops/gathering-gitops-diagnostic-information-for-support.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="about-must-gather_{context}"]
 = About the must-gather tool
 

--- a/modules/collecting-gitops-debugging-data.adoc
+++ b/modules/collecting-gitops-debugging-data.adoc
@@ -2,7 +2,7 @@
 //
 // * understanding_openshift_gitops/gathering-gitops-diagnostic-information-for-support.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="collecting-debugging-data-for-gitops_{context}"]
 = Collecting debugging data for {gitops-title}
 

--- a/modules/gitops-about-argo-rollout-manager-custom-resources-and-spec.adoc
+++ b/modules/gitops-about-argo-rollout-manager-custom-resources-and-spec.adoc
@@ -2,7 +2,7 @@
 //
 // * argo_rollouts/using-argo-rollouts-for-progressive-deployment-delivery.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="gitops-about-argo-rollout-manager-custom-resources-and-spec_{context}"]
 = About RolloutManager custom resources and specification
 

--- a/modules/gitops-accessing-gitops-monitoring-dashboards.adoc
+++ b/modules/gitops-accessing-gitops-monitoring-dashboards.adoc
@@ -2,7 +2,7 @@
 //
 // * observability/monitoring/monitoring-with-gitops-dashboards.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-accessing-gitops-monitoring-dashboards_{context}"]
 = Accessing {gitops-shortname} monitoring dashboards
 

--- a/modules/gitops-accessing-the-gitops-operator-metrics.adoc
+++ b/modules/gitops-accessing-the-gitops-operator-metrics.adoc
@@ -2,7 +2,7 @@
 //
 // * observability/monitoring/monitoring-the-gitops-operator-performance.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-accessing-the-gitops-operator-metrics_{context}"]
 = Accessing the {gitops-shortname} Operator metrics
 

--- a/modules/gitops-additional-permissions-for-cluster-config.adoc
+++ b/modules/gitops-additional-permissions-for-cluster-config.adoc
@@ -2,7 +2,7 @@
 //
 // * declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-additional-permissions-for-cluster-config_{context}"]
 = Adding permissions for cluster configuration
 
@@ -11,7 +11,7 @@ You can grant permissions for an Argo CD instance to manage cluster configuratio
 .Procedure
 
 . Log in to the {OCP} web console as an admin.
-. In the web console, select **User Management** -> **Roles** -> **Create Role**. Use the following `ClusterRole` YAML template to add rules to specify the additional permissions.
+. In the web console, select *User Management* -> *Roles* -> *Create Role*. Use the following `ClusterRole` YAML template to add rules to specify the additional permissions.
 +
 [source,yaml]
 ----
@@ -24,17 +24,17 @@ rules:
   resources: ["secrets"]
   verbs: ["*"]
 ----
-. Click **Create** to add the cluster role.  
-. Now create the cluster role binding. In the web console, select **User Management** -> **Role Bindings** -> **Create Binding**.
-. Select **All Projects** from the **Project** drop-down.
-. Click **Create binding**.
-. Select **Binding type** as **Cluster-wide role binding (ClusterRoleBinding)**.
-. Enter a unique value for the **RoleBinding name**.
+. Click *Create* to add the cluster role.  
+. Now create the cluster role binding. In the web console, select *User Management* -> *Role Bindings* -> *Create Binding*.
+. Select *All Projects* from the *Project* drop-down.
+. Click *Create binding*.
+. Select *Binding type* as *Cluster-wide role binding (ClusterRoleBinding)*.
+. Enter a unique value for the *RoleBinding name*.
 . Select the newly created cluster role or an existing cluster role from the drop down list.
-. Select the **Subject** as **ServiceAccount** and the provide the **Subject namespace** and **name**.
-.. **Subject namespace**: `openshift-gitops`
-.. **Subject name**: `openshift-gitops-argocd-application-controller`
-. Click **Create**. The YAML file for the `ClusterRoleBinding` object is as follows:
+. Select the *Subject* as *ServiceAccount* and the provide the *Subject namespace* and *name*.
+.. *Subject namespace*: `openshift-gitops`
+.. *Subject name*: `openshift-gitops-argocd-application-controller`
+. Click *Create*. The YAML file for the `ClusterRoleBinding` object is as follows:
 +
 [source,yaml]
 ----

--- a/modules/gitops-additional-steps-for-disconnected-clusters.adoc
+++ b/modules/gitops-additional-steps-for-disconnected-clusters.adoc
@@ -1,4 +1,4 @@
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-additional-steps-disconnected-clusters_{context}"]
 = Integrating Keycloak with the OpenShift OAuth server in a disconnected cluster
 

--- a/modules/gitops-argo-cd-command-line.adoc
+++ b/modules/gitops-argo-cd-command-line.adoc
@@ -2,7 +2,7 @@
 //
 // * argocd_instance/argo-cd-cr-component-properties.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="command-line-tool_{context}"]
 = Argo CD CLI tool
 

--- a/modules/gitops-argo-cd-installation.adoc
+++ b/modules/gitops-argo-cd-installation.adoc
@@ -2,7 +2,7 @@
 //
 // * argocd_instance/setting-up-argocd-instance.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-argo-cd-installation_{context}"]
 = Installing an Argo CD instance 
 
@@ -19,8 +19,8 @@ To manage cluster configurations or deploy applications, you can install and dep
 
 . Click *Create* to configure the parameters:
 
-.. Enter the **Name** of the instance. By default, the *Name* is set to *argocd*. 
+.. Enter the *Name* of the instance. By default, the *Name* is set to *argocd*. 
 
 .. Create an external OS Route to access Argo CD server. Click *Server* -> *Route* and check *Enabled*.  
 
-. To open the Argo CD web UI, click the route by navigating to **Networking -> Routes -> <instance name>-server** in the project where the Argo CD instance is installed.
+. To open the Argo CD web UI, click the route by navigating to *Networking* -> *Routes* -> *<instance name>-server* in the project where the Argo CD instance is installed.

--- a/modules/gitops-argo-cd-properties.adoc
+++ b/modules/gitops-argo-cd-properties.adoc
@@ -2,14 +2,14 @@
 //
 // * argocd_instance/argo-cd-cr-component-properties.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="argo-cd-properties_{context}"]
 = Argo CD custom resource properties
 
 The Argo CD Custom Resource consists of the following properties:
 
 |===
-|**Name** |**Description** |**Default** | **Properties**
+|*Name* |*Description* |*Default* | *Properties*
 |`ApplicationInstanceLabelKey` |The `metadata.label` key name where Argo CD injects the app name as a tracking label.|`app.kubernetes.io/instance` |
 |`ApplicationSet` 
 |`ApplicationSet` controller configuration options.

--- a/modules/gitops-benefits-of-argo-rollouts.adoc
+++ b/modules/gitops-benefits-of-argo-rollouts.adoc
@@ -2,7 +2,7 @@
 //
 // * argo_rollouts/using-argo-rollouts-for-progressive-deployment-delivery.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="gitops-benefits-of-argo-rollouts_{context}"]
 = Benefits of Argo Rollouts
 

--- a/modules/gitops-configuring-tls-for-redis-with-autotls-disabled.adoc
+++ b/modules/gitops-configuring-tls-for-redis-with-autotls-disabled.adoc
@@ -2,7 +2,7 @@
 //
 // * securing_openshift_gitops/configuring-secure-communication-with-redis.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-configuring-tls-for-redis-with-autotls-disabled_{context}"]
 = Configuring TLS for Redis with autotls disabled
 

--- a/modules/gitops-configuring-tls-for-redis-with-autotls-enabled.adoc
+++ b/modules/gitops-configuring-tls-for-redis-with-autotls-enabled.adoc
@@ -2,7 +2,7 @@
 //
 // * securing_openshift_gitops/configuring-secure-communication-with-redis.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-configuring-tls-for-redis-with-autotls-enabled_{context}"]
 = Configuring TLS for Redis with autotls enabled
 

--- a/modules/gitops-configuring-user-level-access.adoc
+++ b/modules/gitops-configuring-user-level-access.adoc
@@ -2,7 +2,7 @@
 //
 // * accesscontrol_usermanagement/configuring-argo-cd-rbac.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="configuring-user-level-access_{context}"]
 = Configuring user level access
 

--- a/modules/gitops-configuring-workloads.adoc
+++ b/modules/gitops-configuring-workloads.adoc
@@ -2,7 +2,7 @@
 //
 // * managing_resource/configuring-resource-quota.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="configuring-workloads_{context}"]
 = Configuring workloads with resource requests and limits
 

--- a/modules/gitops-creating-a-new-client-in-dex.adoc
+++ b/modules/gitops-creating-a-new-client-in-dex.adoc
@@ -2,7 +2,7 @@
 //
 // * accesscontrol_usermanagement/configuring-sso-on-argo-cd-using-dex.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="gitops-creating-a-new-client-in-dex_{context}"]
 = Configuration to enable the Dex OpenShift OAuth Connector
 

--- a/modules/gitops-creating-a-new-client-using-keycloak.adoc
+++ b/modules/gitops-creating-a-new-client-using-keycloak.adoc
@@ -2,7 +2,7 @@
 //
 // * accesscontrol_usermanagement/configuring-sso-for-argo-cd-using-keycloak.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-creating-a-new-client-in-keycloak_{context}"]
 = Configuring a new client in Keycloak
 

--- a/modules/gitops-creating-an-application-by-using-the-argo-cd-dashboard.adoc
+++ b/modules/gitops-creating-an-application-by-using-the-argo-cd-dashboard.adoc
@@ -10,7 +10,7 @@ ifeval::["{context}" == "deploying-a-spring-boot-application-with-argo-cd"]
 :app:
 endif::[]
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="creating-an-application-by-using-the-argo-cd-dashboard_{context}"]
 = Creating an application by using the Argo CD dashboard
 

--- a/modules/gitops-creating-an-application-by-using-the-oc-tool.adoc
+++ b/modules/gitops-creating-an-application-by-using-the-oc-tool.adoc
@@ -10,7 +10,7 @@ ifeval::["{context}" == "deploying-a-spring-boot-application-with-argo-cd"]
 :app:
 endif::[]
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="creating-an-application-by-using-the-oc-tool_{context}"]
 = Creating an application by using the `oc` tool
 

--- a/modules/gitops-creating-rolloutmanager-custom-resource.adoc
+++ b/modules/gitops-creating-rolloutmanager-custom-resource.adoc
@@ -2,7 +2,7 @@
 //
 // * argo_rollouts/using-argo-rollouts-for-progressive-deployment-delivery.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-creating-rolloutmanager-custom-resource_{context}"]
 = Creating a RolloutManager custom resource
 

--- a/modules/gitops-customize-argo-cd-consolelink.adoc
+++ b/modules/gitops-customize-argo-cd-consolelink.adoc
@@ -2,7 +2,7 @@
 //
 // * argocd_instance/setting-up-argocd-instance.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-customize-argo-cd-consolelink_{context}"]
 = Customizing the Argo CD console link
 

--- a/modules/gitops-default-permissions-of-an-argocd-instance.adoc
+++ b/modules/gitops-default-permissions-of-an-argocd-instance.adoc
@@ -2,13 +2,13 @@
 //
 // * declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="default-permissions-of-an-argocd-instance.adoc{context}"]
-= Default permissions of an Argocd instance
+= Default permissions of an Argo CD instance
 
 By default Argo CD instance has the following permissions:
 
-* Argo CD instance has the `admin` privileges to manage resources only in the namespace where it is deployed. For instance, an Argo CD instance deployed in the **foo** namespace has the `admin` privileges to manage resources only for that namespace.
+* Argo CD instance has the `admin` privileges to manage resources only in the namespace where it is deployed. For instance, an Argo CD instance deployed in the *foo* namespace has the `admin` privileges to manage resources only for that namespace.
 
 * Argo CD has the following cluster-scoped permissions because Argo CD requires cluster-wide `read` privileges on resources to function appropriately:
 +

--- a/modules/gitops-deleting-rolloutmanager-custom-resource.adoc
+++ b/modules/gitops-deleting-rolloutmanager-custom-resource.adoc
@@ -2,7 +2,7 @@
 //
 // * argo_rollouts/using-argo-rollouts-for-progressive-deployment-delivery.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-deleting-rolloutmanager-custom-resource_{context}"]
 = Deleting a RolloutManager custom resource
 

--- a/modules/gitops-deploy-resources-different-namespaces.adoc
+++ b/modules/gitops-deploy-resources-different-namespaces.adoc
@@ -2,7 +2,7 @@
 //
 // * argocd_instance/setting-up-argocd-instance.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-deploy-resources-different-namespaces_{context}"]
 = Deploying resources to a different namespace
 

--- a/modules/gitops-dex-role-mappings.adoc
+++ b/modules/gitops-dex-role-mappings.adoc
@@ -2,7 +2,7 @@
 //
 // * accesscontrol_usermanagement/configuring-sso-on-argo-cd-using-dex.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-dex-role-mappings_{context}"]
 = Mapping users to specific roles
 

--- a/modules/gitops-disable-dex-using-spec-sso.adoc
+++ b/modules/gitops-disable-dex-using-spec-sso.adoc
@@ -2,7 +2,7 @@
 //
 // * accesscontrol_usermanagement/configuring-sso-on-argo-cd-using-dex.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-disable-dex-using-spec-sso_{context}"]
 = Disabling Dex by replacing .spec.sso
 

--- a/modules/gitops-disabling-monitoring-for-argo-cd-custom-resource-workloads.adoc
+++ b/modules/gitops-disabling-monitoring-for-argo-cd-custom-resource-workloads.adoc
@@ -2,7 +2,7 @@
 //
 // * observability/monitoring/monitoring-argo-cd-custom-resource-workloads.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-disabling-monitoring-for-argo-cd-custom-resource-workloads_{context}"]
 = Disabling Monitoring for Argo CD custom resource workloads
 

--- a/modules/gitops-enable-replicas-for-argo-cd-server.adoc
+++ b/modules/gitops-enable-replicas-for-argo-cd-server.adoc
@@ -2,7 +2,7 @@
 //
 // * argocd_instance/setting-up-argocd-instance.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-enable-replicas-for-argo-cd-server_{context}"]
 = Enabling replicas for Argo CD server and repo server
 

--- a/modules/gitops-enabling-monitoring-for-argo-cd-custom-resource-workloads.adoc
+++ b/modules/gitops-enabling-monitoring-for-argo-cd-custom-resource-workloads.adoc
@@ -2,7 +2,7 @@
 //
 // * observability/monitoring/monitoring-argo-cd-custom-resource-workloads.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-enabling-monitoring-for-argo-cd-custom-resource-workloads_{context}"]
 = Enabling Monitoring for Argo CD custom resource workloads
 

--- a/modules/gitops-in-built-permissions.adoc
+++ b/modules/gitops-in-built-permissions.adoc
@@ -2,7 +2,7 @@
 //
 // * openshift-docs/cicd/gitops/configuring-a-cluster-to-use-gitops.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="in-built-permissions_{context}"]
 = In-built permissions for Argo CD
 

--- a/modules/gitops-inbuilt-permissions-for-cluster-config.adoc
+++ b/modules/gitops-inbuilt-permissions-for-cluster-config.adoc
@@ -2,7 +2,7 @@
 //
 // * declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="gitops-inbuilt-permissions-for-cluster-config_{context}"]
 = In-built permissions for cluster configuration
 
@@ -15,7 +15,7 @@ Argo CD does not have cluster-admin permissions.
 
 Permissions for the Argo CD instance:
 |===
-|**Resources** |**Descriptions**
+|*Resources* |*Descriptions*
 |Resource Groups | Configure the user or administrator
 |`operators.coreos.com` | Optional Operators managed by OLM
 |`user.openshift.io` , `rbac.authorization.k8s.io`    | Groups, Users and their permissions

--- a/modules/gitops-installing-olm-operators-using-gitops.adoc
+++ b/modules/gitops-installing-olm-operators-using-gitops.adoc
@@ -2,7 +2,7 @@
 //
 // * declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-installing-olm-operators-using-gitops_{context}"]
 = Installing OLM Operators using {gitops-title}
 

--- a/modules/gitops-logging-into-keycloak.adoc
+++ b/modules/gitops-logging-into-keycloak.adoc
@@ -2,7 +2,7 @@
 //
 // * accesscontrol_usermanagement/configuring-sso-for-argo-cd-using-keycloak.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-logging-into-keycloak_{context}"]
 = Logging in to Keycloak
 

--- a/modules/gitops-modifying-rhsso-requests-limits.adoc
+++ b/modules/gitops-modifying-rhsso-requests-limits.adoc
@@ -2,7 +2,7 @@
 //
 // * accesscontrol_usermanagement/configuring-argo-cd-rbac.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="modifying-rhsso-resource-requests-limits_{context}"]
 = Modifying RHSSO resource requests/limits
 

--- a/modules/gitops-monitoring-argo-cd-health-using-prometheus-metrics.adoc
+++ b/modules/gitops-monitoring-argo-cd-health-using-prometheus-metrics.adoc
@@ -2,7 +2,7 @@
 //
 // * observability/monitoring/monitoring-argo-cd-instances.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-monitoring-argo-cd-health-using-promethous-metrics_{context}"]
 = Monitoring Argo CD health using Prometheus metrics
 

--- a/modules/gitops-patching-argocd-instance.adoc
+++ b/modules/gitops-patching-argocd-instance.adoc
@@ -2,7 +2,7 @@
 //
 // * managing_resource/configuring-resource-quota.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="patch-argocd-instance_{context}"]
 = Patching Argo CD instance to update the resource requirements
 

--- a/modules/gitops-release-notes-1-10-0.adoc
+++ b/modules/gitops-release-notes-1-10-0.adoc
@@ -2,7 +2,7 @@
 //
 // * release_notes/gitops-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="gitops-release-notes-1-10-0_{context}"]
 = Release notes for {gitops-title} 1.10.0
 

--- a/modules/gitops-release-notes-1-10-1.adoc
+++ b/modules/gitops-release-notes-1-10-1.adoc
@@ -2,7 +2,7 @@
 //
 // * release_notes/gitops-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="gitops-release-notes-1-10-1_{context}"]
 = Release notes for {gitops-title} 1.10.1
 

--- a/modules/gitops-release-notes-1-9-0.adoc
+++ b/modules/gitops-release-notes-1-9-0.adoc
@@ -2,7 +2,7 @@
 //
 // * release_notes/gitops-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="gitops-release-notes-1-9-0_{context}"]
 = Release notes for {gitops-title} 1.9.0
 

--- a/modules/gitops-release-notes-1-9-1.adoc
+++ b/modules/gitops-release-notes-1-9-1.adoc
@@ -2,7 +2,7 @@
 //
 // * release_notes/gitops-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="gitops-release-notes-1-9-1_{context}"]
 = Release notes for {gitops-title} 1.9.1
 

--- a/modules/gitops-release-notes-1-9-2.adoc
+++ b/modules/gitops-release-notes-1-9-2.adoc
@@ -2,7 +2,7 @@
 //
 // * release_notes/gitops-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="gitops-release-notes-1-9-2_{context}"]
 = Release notes for {gitops-title} 1.9.2
 

--- a/modules/gitops-release-notes-1-9-3.adoc
+++ b/modules/gitops-release-notes-1-9-3.adoc
@@ -2,7 +2,7 @@
 //
 // * release_notes/gitops-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="gitops-release-notes-1-9-3_{context}"]
 = Release notes for {gitops-title} 1.9.3
 

--- a/modules/gitops-removing-resource-requirements.adoc
+++ b/modules/gitops-removing-resource-requirements.adoc
@@ -2,7 +2,7 @@
 //
 // * managing_resource/configuring-resource-quota.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="remove-resource-requirements_{context}"]
 = Removing resource requests
 

--- a/modules/gitops-repo-server-properties.adoc
+++ b/modules/gitops-repo-server-properties.adoc
@@ -2,14 +2,14 @@
 //
 // * argocd_instance/argo-cd-cr-component-properties.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="argo-repo-server-properties_{context}"]
 = Repo server properties
 
 The following properties are available for configuring the Repo server component:
 
 |===
-|**Name** |**Default** | **Description** 
+|*Name* |*Default* | *Description* 
 |`Resources` |`__<empty>__` |The container compute resources.
 |`MountSAToken` |`false` |Whether the `ServiceAccount` token should be mounted to the repo-server pod.
 |`ServiceAccount` |`""` |The name of the `ServiceAccount` to use with the repo-server pod.

--- a/modules/gitops-storing-and-retrieving-argo-cd-logs.adoc
+++ b/modules/gitops-storing-and-retrieving-argo-cd-logs.adoc
@@ -2,7 +2,7 @@
 //
 // * observability/logging/viewing-argo-cd-logs.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-storing-and-retrieving-argo-cd-logs_{context}"]
 = Storing and retrieving Argo CD logs
 

--- a/modules/gitops-synchronizing-your-application-application-with-your-git-repository.adoc
+++ b/modules/gitops-synchronizing-your-application-application-with-your-git-repository.adoc
@@ -2,7 +2,7 @@
 //
 // * declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="synchronizing-your-application-application-with-your-git-repository_{context}"]
 = Synchronizing your application with your Git repository
 

--- a/modules/gitops-uninstall-keycloak.adoc
+++ b/modules/gitops-uninstall-keycloak.adoc
@@ -2,7 +2,7 @@
 //
 // * accesscontrol_usermanagement/configuring-sso-for-argo-cd-using-keycloak.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-uninstalling-keycloak_{context}"]
 = Uninstalling Keycloak
 

--- a/modules/gitops-using-argo-cd-instance-to-manage-cluster-scoped-resources.adoc
+++ b/modules/gitops-using-argo-cd-instance-to-manage-cluster-scoped-resources.adoc
@@ -2,7 +2,7 @@
 //
 // * declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="using-argo-cd-instance-to-manage-cluster-scoped-resources{context}"]
 = Using an Argo CD instance to manage cluster-scoped resources
 
@@ -10,9 +10,9 @@ To manage cluster-scoped resources, update the existing `Subscription` object fo
 
 [discrete]
 .Procedure
-. In the **Administrator** perspective of the web console, navigate to **Operators** → **Installed Operators** → **{gitops-title}** → **Subscription**. 
-. Click the **Actions** drop-down menu then click **Edit Subscription**.
-. On the **openshift-gitops-operator** Subscription details page, under the **YAML** tab, edit the `Subscription` YAML file by adding the namespace of the Argo CD instance to the `ARGOCD_CLUSTER_CONFIG_NAMESPACES` environment variable in the `spec` section:
+. In the *Administrator* perspective of the web console, navigate to *Operators* → *Installed Operators* → *{gitops-title}* → *Subscription*. 
+. Click the *Actions* drop-down menu then click *Edit Subscription*.
+. On the *openshift-gitops-operator* Subscription details page, under the *YAML* tab, edit the `Subscription` YAML file by adding the namespace of the Argo CD instance to the `ARGOCD_CLUSTER_CONFIG_NAMESPACES` environment variable in the `spec` section:
 +
 [source,yaml]
 ----
@@ -32,10 +32,10 @@ spec:
 +
 . To verify that the Argo instance is configured with a cluster role to manage cluster-scoped resources, perform the following steps:
 +
-.. Navigate to **User Management** → **Roles** and from the **Filter**  drop-down menu select **Cluster-wide Roles**.
-.. Search for the `argocd-application-controller` by using the **Search by name** field.
+.. Navigate to *User Management* → *Roles* and from the *Filter*  drop-down menu select *Cluster-wide Roles*.
+.. Search for the `argocd-application-controller` by using the *Search by name* field.
 +
-The **Roles** page displays the created cluster role.
+The *Roles* page displays the created cluster role.
 +
 [TIP]
 ====

--- a/modules/gitops-verifying-argo-cd-self-healing-behavior.adoc
+++ b/modules/gitops-verifying-argo-cd-self-healing-behavior.adoc
@@ -2,7 +2,7 @@
 //
 // * argocd_applications/deploying-a-spring-boot-application-with-argo-cd.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="verifying-argo-cd-self-healing-behavior_{context}"]
 = Verifying Argo CD self-healing behavior
 

--- a/modules/go-add-infra-nodes.adoc
+++ b/modules/go-add-infra-nodes.adoc
@@ -2,7 +2,7 @@
 //
 // * gitops_workloads_infranodes/run-gitops-control-plane-workload-on-infra-nodes.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="add-infra-nodes_{context}"]
 = Moving {gitops-shortname} workloads to infrastructure nodes
 

--- a/modules/go-deleting-argocd-instance.adoc
+++ b/modules/go-deleting-argocd-instance.adoc
@@ -2,7 +2,7 @@
 //
 // * removing_gitops/uninstalling-openshift-gitops.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id='go-deleting-argocd-instance_{context}']
 = Deleting the Argo CD instances
 

--- a/modules/go-health-monitoring.adoc
+++ b/modules/go-health-monitoring.adoc
@@ -2,7 +2,7 @@
 //
 // * observability/monitoring/health-information-for-resources-deployment.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="health-information-resources_{context}"]
 = Checking health information
 

--- a/modules/go-run-argo-cd-instance-on-infrastructure-nodes.adoc
+++ b/modules/go-run-argo-cd-instance-on-infrastructure-nodes.adoc
@@ -2,7 +2,7 @@
 //
 // * declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="run-argo-cd-instance-on-cluster_{context}"]
 = Running the Argo CD instance at the cluster-level
 

--- a/modules/go-settings-for-environment-labels-and-annotations.adoc
+++ b/modules/go-settings-for-environment-labels-and-annotations.adoc
@@ -2,7 +2,7 @@
 //
 // * observability/monitoring/health-information-for-resources-deployment.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="go-settings-for-environment-labels-and-annotations_{context}"]
 = Settings for environment labels and annotations
 

--- a/modules/go-uninstalling-gitops-operator.adoc
+++ b/modules/go-uninstalling-gitops-operator.adoc
@@ -2,7 +2,7 @@
 //
 // * removing_gitops/uninstalling-openshift-gitops.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id='go-uninstalling-gitops-operator_{context}']
 = Uninstalling the {gitops-shortname} Operator
 

--- a/modules/installing-gitops-operator-in-web-console.adoc
+++ b/modules/installing-gitops-operator-in-web-console.adoc
@@ -2,7 +2,7 @@
 //
 // * installing_gitops/installing-openshift-gitops.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="installing-gitops-operator-in-web-console_{context}"]
 = Installing {gitops-title} Operator in web console
 

--- a/modules/installing-gitops-operator-using-cli.adoc
+++ b/modules/installing-gitops-operator-using-cli.adoc
@@ -2,7 +2,7 @@
 //
 // * installing_gitops/installing-openshift-gitops.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="installing-gitops-operator-using-cli_{context}"]
 = Installing {gitops-title} Operator using CLI
 

--- a/modules/logging-in-to-the-argo-cd-instance-by-using-the-argo-cd-admin-account.adoc
+++ b/modules/logging-in-to-the-argo-cd-instance-by-using-the-argo-cd-admin-account.adoc
@@ -2,7 +2,7 @@
 //
 // * installing_gitops/installing-openshift-gitops.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="logging-in-to-the-argo-cd-instance-by-using-the-argo-cd-admin-account_{context}"]
 = Logging in to the Argo CD instance by using the Argo CD admin account
 

--- a/modules/making-open-source-more-inclusive.adoc
+++ b/modules/making-open-source-more-inclusive.adoc
@@ -2,7 +2,7 @@
 //
 // * release_notes/gitops-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="making-open-source-more-inclusive_{context}"]
 = Making open source more inclusive
 

--- a/modules/performance-challenges-in-machine-configurations-and-argo-cd.adoc
+++ b/modules/performance-challenges-in-machine-configurations-and-argo-cd.adoc
@@ -2,7 +2,7 @@
 //
 // * troubleshooting_gitops_issues/auto-reboot-during-argo-cd-sync-with-machine-configurations.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="performance-challenges-in-machine-configurations-and-argo-cd_{context}"]
 = Solution: Enhance performance in machine configurations and Argo CD
 

--- a/modules/sizing-requirements-for-gitops.adoc
+++ b/modules/sizing-requirements-for-gitops.adoc
@@ -2,7 +2,7 @@
 //
 // * installing_gitops/preparing-gitops-install.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="sizing-requirements-for-gitops_{context}"]
 = Sizing requirements for {gitops-shortname}
 

--- a/observability/logging/viewing-argo-cd-logs.adoc
+++ b/observability/logging/viewing-argo-cd-logs.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="viewing-argo-cd-logs"]
 = Viewing Argo CD logs
@@ -8,6 +8,7 @@ toc::[]
 
 You can view the Argo CD logs with the {logging-title}. The {logging} visualizes the logs on a Kibana dashboard. The OpenShift Logging Operator enables logging with Argo CD by default.
 
+// Storing and retrieving Argo CD logs
 include::modules/gitops-storing-and-retrieving-argo-cd-logs.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/observability/monitoring/health-information-for-resources-deployment.adoc
+++ b/observability/monitoring/health-information-for-resources-deployment.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="health-information-for-resources-deployment"]
 = Monitoring health information for application resources and deployments
@@ -12,6 +12,8 @@ The *Application environments* page in the *Developer* perspective of the {OCP} 
 
 The environments pages in the *Developer* perspective of the {OCP} web console are decoupled from the {gitops-title} Application Manager command-line interface (CLI), `kam`. You do not have to use `kam` to generate Application Environment manifests for the environments to show up in the *Developer* perspective of the {OCP} web console. You can use your own manifests, but the environments must still be represented by namespaces. In addition, specific labels and annotations are still needed.
 
+// Settings for environment labels and annotations
 include::modules/go-settings-for-environment-labels-and-annotations.adoc[leveloffset=+1]
 
+// Checking health information
 include::modules/go-health-monitoring.adoc[leveloffset=+1]

--- a/observability/monitoring/monitoring-argo-cd-custom-resource-workloads.adoc
+++ b/observability/monitoring/monitoring-argo-cd-custom-resource-workloads.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="monitoring-argo-cd-custom-resource-workloads"]
 = Monitoring Argo CD custom resource workloads

--- a/observability/monitoring/monitoring-argo-cd-instances.adoc
+++ b/observability/monitoring/monitoring-argo-cd-instances.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="monitoring-argo-cd-instances"]
 = Monitoring Argo CD instances
@@ -15,4 +15,5 @@ By default, the {gitops-title} Operator automatically detects an installed Argo 
 * You have installed the {gitops-title} Operator in your cluster.
 * You have installed an Argo CD application in your defined namespace, for example, `openshift-gitops`.
 
+// Monitoring Argo CD health using Prometheus metrics
 include::modules/gitops-monitoring-argo-cd-health-using-prometheus-metrics.adoc[leveloffset=+1]

--- a/observability/monitoring/monitoring-the-gitops-operator-performance.adoc
+++ b/observability/monitoring/monitoring-the-gitops-operator-performance.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="monitoring-the-gitops-operator-performance"]
 = Monitoring the {gitops-shortname} Operator performance
@@ -30,6 +30,7 @@ The {gitops-title} Operator emits metrics about its performance. With the OpenSh
 Gauge is a value that can go up or down. Counter is a value that can only go up.
 ====
 
+// Accessing the GitOps Operator metrics
 include::modules/gitops-accessing-the-gitops-operator-metrics.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/observability/monitoring/monitoring-with-gitops-dashboards.adoc
+++ b/observability/monitoring/monitoring-with-gitops-dashboards.adoc
@@ -1,8 +1,8 @@
-:_content-type: ASSEMBLY
-[id="monitoring-with-gitops-dashboards"]
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
-:context: monitoring-with-gitops-dashboards
+[id="monitoring-with-gitops-dashboards"]
 = Monitoring with {gitops-shortname} dashboards
+:context: monitoring-with-gitops-dashboards
 
 toc::[]
 
@@ -14,6 +14,7 @@ There are three {gitops-shortname} dashboards available:
 * *{gitops-shortname} Components*: View detailed information, such as CPU or memory, for application-controller, repo-server, server, and other {gitops-shortname} components.
 * *{gitops-shortname} gRPC Services*: View metrics related to gRPC service activity between the various components in {gitops-title}.
 
+// Accessing GitOps monitoring dashboards
 include::modules/gitops-accessing-gitops-monitoring-dashboards.adoc[leveloffset=+1]
 
 //[role="_additional-resources"]

--- a/release_notes/gitops-release-notes.adoc
+++ b/release_notes/gitops-release-notes.adoc
@@ -17,23 +17,33 @@ toc::[]
 
 For an overview of {gitops-title}, see xref:../understanding_openshift_gitops/about-redhat-openshift-gitops.adoc#about-redhat-openshift-gitops[About Red Hat OpenShift GitOps].
 
+// Compatibility and support matrix
 include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 
+// Making open source more inclusive
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+
+// Release notes for Red Hat OpenShift GitOps 1.11.0
 include::modules/gitops-release-notes-1-11-0.adoc[leveloffset=+1]
 
+// Release notes for Red Hat OpenShift GitOps 1.10.1
 include::modules/gitops-release-notes-1-10-1.adoc[leveloffset=+1]
 
+// Release notes for Red Hat OpenShift GitOps 1.10.0
 include::modules/gitops-release-notes-1-10-0.adoc[leveloffset=+1]
 
+// Release notes for Red Hat OpenShift GitOps 1.9.3
 include::modules/gitops-release-notes-1-9-3.adoc[leveloffset=+1]
 
+// Release notes for Red Hat OpenShift GitOps 1.9.2
 include::modules/gitops-release-notes-1-9-2.adoc[leveloffset=+1]
 
+// Release notes for Red Hat OpenShift GitOps 1.9.1
 include::modules/gitops-release-notes-1-9-1.adoc[leveloffset=+1]
 
+// Release notes for Red Hat OpenShift GitOps 1.9.0
 include::modules/gitops-release-notes-1-9-0.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/removing_gitops/uninstalling-openshift-gitops.adoc
+++ b/removing_gitops/uninstalling-openshift-gitops.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="uninstalling-openshift-gitops"]
 = Uninstalling {gitops-title}
@@ -13,8 +13,10 @@ Uninstalling the {gitops-title} Operator is a two-step process:
 
 Uninstalling only the Operator will not remove the Argo CD instances created.
 
+// Deleting the Argo CD instances
 include::modules/go-deleting-argocd-instance.adoc[leveloffset=+1]
 
+// Uninstalling the GitOps Operator
 include::modules/go-uninstalling-gitops-operator.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/securing_openshift_gitops/configuring-secure-communication-with-redis.adoc
+++ b/securing_openshift_gitops/configuring-secure-communication-with-redis.adoc
@@ -1,7 +1,7 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="configuring-secure-communication-with-redis"]
 = Configuring secure communication with Redis
-include::_attributes/common-attributes.adoc[]
 :context: configuring-secure-communication-with-redis
 
 toc::[]
@@ -21,7 +21,9 @@ Both configurations are possible with or without the High Availability (HA) enab
 * You have access to the {OCP} web console.
 * {gitops-title} Operator is installed on your cluster.
 
+// Configuring TLS for Redis with autotls enabled
 include::modules/gitops-configuring-tls-for-redis-with-autotls-enabled.adoc[leveloffset=+1]
 
+// Configuring TLS for Redis with autotls disabled
 include::modules/gitops-configuring-tls-for-redis-with-autotls-disabled.adoc[leveloffset=+1]
 

--- a/securing_openshift_gitops/managing-secrets-securely-using-sscsid-with-gitops.adoc
+++ b/securing_openshift_gitops/managing-secrets-securely-using-sscsid-with-gitops.adoc
@@ -8,6 +8,7 @@ toc::[]
 
 This guide walks you through the process of integrating the Secrets Store Container Storage Interface (SSCSI) driver with the {gitops-shortname} Operator in {OCP} 4.14 and later.
 
+// Overview of managing secrets using Secrets Store CSI driver with GitOps
 include::modules/gitops-managing-secrets-using-sscsid-with-gitops-overview.adoc[leveloffset=+1]
 
 [id="prerequisites_managing-secrets-securely-using-sscsid-with-gitops"]
@@ -23,14 +24,17 @@ include::modules/gitops-managing-secrets-using-sscsid-with-gitops-overview.adoc[
 * You have a {gitops-shortname} repository ready to use the secrets.
 * You are logged in to the Argo CD instance by using the Argo CD admin account.
 
+// Storing AWS Secrets Manager resources in GitOps repository
 include::modules/gitops-storing-aws-secret-manager-resources-in-gitops-repository.adoc[leveloffset=+1]
 
+// Configuring SSCSI driver to mount secrets from AWS Secrets Manager
 include::modules/gitops-configuring-sscsi-driver-to-mount-secrets-from-aws-secrets-manager.adoc[leveloffset=+1]
 
+// Configuring GitOps managed resources to use mounted secrets
 include::modules/gitops-configuring-gitops-managed-resources-to-use-mounted-secrets.adoc[leveloffset=+1]
 
-[id="additional-resources_managing-secrets-securely-using-sscsid-with-gitops"]
 [role="_additional-resources"]
+[id="additional-resources_managing-secrets-securely-using-sscsid-with-gitops"]
 == Additional resources
 
 * link:https://github.com/redhat-developer/gitops-operator/blob/bfdf81944ea60b1d62d7de7c223c3bea3e7363a6/docs/Integrate%20GitOps%20with%20Secrets%20Management.md#obtain-the-ccoctl-tool[Obtaining the `ccoctl` tool]

--- a/troubleshooting_gitops_issues/auto-reboot-during-argo-cd-sync-with-machine-configurations.adoc
+++ b/troubleshooting_gitops_issues/auto-reboot-during-argo-cd-sync-with-machine-configurations.adoc
@@ -1,7 +1,7 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="auto-reboot-during-argo-cd-sync-with-machine-configurations"]
 = Issue: Auto-reboot during Argo CD sync with machine configurations
-include::_attributes/common-attributes.adoc[]
 :context: auto-reboot-during-argo-cd-sync-with-machine-configurations
 
 toc::[]
@@ -12,6 +12,7 @@ When an MCO resource is created or updated in a cluster, the MCO picks up the up
 
 However, interactions between the MCO and the GitOps workflow can introduce major performance issues and other undesired behaviors. This section shows how to make the MCO and the Argo CD GitOps orchestration tool work well together.
 
+// Solution: Enhance performance in machine configurations and Argo CD
 include::modules/performance-challenges-in-machine-configurations-and-argo-cd.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/understanding_openshift_gitops/about-redhat-openshift-gitops.adoc
+++ b/understanding_openshift_gitops/about-redhat-openshift-gitops.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="about-redhat-openshift-gitops"]
 = About {gitops-title}

--- a/understanding_openshift_gitops/gathering-gitops-diagnostic-information-for-support.adoc
+++ b/understanding_openshift_gitops/gathering-gitops-diagnostic-information-for-support.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="gathering-gitops-diagnostic-information-for-support"]
 = Gathering diagnostic information for support
@@ -13,7 +13,10 @@ When you open a support case, you must provide debugging information about your 
 For prompt support, provide diagnostic information for both {OCP} and {gitops-title}.
 ====
 
+// About the must-gather tool
 include::modules/about-must-gather.adoc[leveloffset=+1]
+
+// Collecting debugging data for Red Hat OpenShift GitOps
 include::modules/collecting-gitops-debugging-data.adoc[leveloffset=+1]
 
 [id="additional-resources_collecting-debugging-data-for-support"]

--- a/understanding_openshift_gitops/what-is-gitops.adoc
+++ b/understanding_openshift_gitops/what-is-gitops.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="what-is-gitops"]
 = What is {gitops-shortname}?


### PR DESCRIPTION
**Aligned team**: Dev Tools

**Please cherry-pick to**: `gitops-docs-1.11`. `gitops-docs-1.10`, and `gitops-docs-1.9`

**JIRA issues**: [RHDEVDOCS-5797](https://issues.redhat.com/browse/RHDEVDOCS-5797)

**Preview pages**: 
- [Adding permissions for cluster configuration](https://70044--docspreview.netlify.app/openshift-gitops/latest/declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations#gitops-additional-permissions-for-cluster-config_configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations)
- [Installing an Argo CD instance](https://70044--docspreview.netlify.app/openshift-gitops/latest/argocd_instance/setting-up-argocd-instance#gitops-argo-cd-installation_setting-up-argocd-instance)
- [Argo CD custom resource properties](https://70044--docspreview.netlify.app/openshift-gitops/latest/argocd_instance/argo-cd-cr-component-properties#argo-cd-properties_argo-cd-cr-component-properties)
- [Repo server properties](https://70044--docspreview.netlify.app/openshift-gitops/latest/argocd_instance/argo-cd-cr-component-properties#argo-repo-server-properties_argo-cd-cr-component-properties)
- [Default permissions of an Argocd instance](https://70044--docspreview.netlify.app/openshift-gitops/latest/declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations#default-permissions-of-an-argocd-instance.adocconfiguring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations)
- [In-built permissions for cluster configuration](https://70044--docspreview.netlify.app/openshift-gitops/latest/declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations#gitops-inbuilt-permissions-for-cluster-config_configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations)
- [Using an Argo CD instance to manage cluster-scoped resources](https://70044--docspreview.netlify.app/openshift-gitops/latest/declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations#using-argo-cd-instance-to-manage-cluster-scoped-resourcesconfiguring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations)


**SME Review**: Not applicable

**QE review**: Not applicable

**Peer review**:  

**Additional information**:  This PR updates the file metadata for all the GitOps assemblies and modules to reflect the latest `:_mod-docs-content-type` as per the OCP docs guidelines. In addition, this PR replaces double asterisks with single asterisks for web console / GUI items (menus, buttons, page titles, etc.) as per the OCP docs guidelines.