### PR TITLE
Updated the name of the role in the example RoleBinding YAML file to match the defined role.

### DIFF
--- a/modules/gitops-additional-permissions-for-cluster-config.adoc
+++ b/modules/gitops-additional-permissions-for-cluster-config.adoc
@@ -8,9 +8,12 @@
 
 You can grant permissions for an Argo CD instance to manage cluster configuration. Create a cluster role with additional permissions and then create a new cluster role binding to associate the cluster role with a service account. 
 
+.Prerequisites
+* You have access to an {OCP} cluster with `cluster-admin` privileges and are logged into the web console.
+* You have installed the {gitops-title} Operator on your cluster.
+
 .Procedure
 
-. Log in to the {OCP} web console as an admin.
 . In the web console, select *User Management* -> *Roles* -> *Create Role*. Use the following `ClusterRole` YAML template to add rules to specify the additional permissions.
 +
 [source,yaml]
@@ -24,8 +27,9 @@ rules:
   resources: ["secrets"]
   verbs: ["*"]
 ----
-. Click *Create* to add the cluster role.  
-. Now create the cluster role binding. In the web console, select *User Management* -> *Role Bindings* -> *Create Binding*.
+
+. Click *Create* to add the cluster role.
+. To create the cluster role binding, select *User Management* -> *Role Bindings* -> *Create Binding*.
 . Select *All Projects* from the *Project* drop-down.
 . Click *Create binding*.
 . Select *Binding type* as *Cluster-wide role binding (ClusterRoleBinding)*.
@@ -49,6 +53,6 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: admin
+  name: secrets-cluster-role
 ----
 


### PR DESCRIPTION
- Jira issue: [OCPBUGS-13363](https://issues.redhat.com/browse/OCPBUGS-13363)
- CherryPick versions: gitops-docs-1.9, gitops-docs-1.10 and gitops-docs-1.11 branches
- Doc preview: [Adding permissions for cluster configuration](https://70057--docspreview.netlify.app/openshift-gitops/latest/declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations#gitops-additional-permissions-for-cluster-config_configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations)
- OCP team: DevTools
- SME reviews by: @reginapizza 
- QE reviews by: 
- Peer reviews by: 