### PR TITLE
OSDOCS-8687:updates status management for OVN-K i/c

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -369,6 +369,19 @@ This release adds improvements related to the following components and concepts.
 
 Pods created using the macvlan CNI plugin, where the IP address management CNI plug-in has assigned IPs, now send IPv6 unsolicited neighbor advertisements by default onto the network. This enhancement notifies hosts of the new pod's MAC address for a particular IP to refresh IPv6 neighbor caches.
 
+[id="ocp-4-15-egressfirewall-updates-status-management"]
+==== Status management updates for EgressFirewall and AdminPolicyBasedExternalRoute CR
+
+The following updates have been made to the status management of `EgressFirewall` and `AdminPolicyBasedExternalRoute` custom resource policy:
+
+** The `status.status` field is set to `failure` if at least one message reports `failure`.
+
+** The `status.status` field is empty if no failures are reported and not all nodes have reported their status.
+
+** The `status.status` field is set to `success` if all nodes report `success`.
+
+** The `status.mesages` field lists messages. The messages are listed by the node name by default and are prefixed with the node name.
+
 [id="ocp-4-15-registry"]
 === Registry
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-8687
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://70058--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-egressfirewall-updates-status-management
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
PTAL @npinaeva and @qiowang721 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
