### PR TITLE
OSDOCS-8966 updating 4.15 RNs to K8s 1.28 info

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -14,7 +14,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 == About this release
 
 // TODO: Update with the relevant information closer to release.
-{product-title} (link:https://access.redhat.com/errata/RHSA-2024:XXXX[RHSA-2024:XXXX]) is now available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md[Kubernetes 1.27] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
+{product-title} (link:https://access.redhat.com/errata/RHSA-2024:XXXX[RHSA-2024:XXXX]) is now available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md[Kubernetes 1.28] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
 
 {product-title} {product-version} clusters are available at https://console.redhat.com/openshift. With the {cluster-manager-first} application for {product-title}, you can deploy {product-title} clusters to either on-premises or cloud environments.
 
@@ -693,16 +693,16 @@ In the following tables, features are marked with the following statuses:
 
 {product-title} {product-version} has removed support for the `OPENSHIFT_DEFAULT_REGISTRY` variable. This variable was primarily used to enable backwards compatibility of the internal image registry for earlier setups. The `REGISTRY_OPENSHIFT_SERVER_ADDR` variable can be used in its place.
 
-.APIs removed from Kubernetes 1.27
-[cols="2,2,2",options="header",]
-|===
-|Resource |Removed API |Migrate to
+//.APIs removed from Kubernetes 1.27
+//[cols="2,2,2",options="header",]
+//|===
+//|Resource |Removed API |Migrate to
 
-|`CSIStorageCapacity`
-|`storage.k8s.io/v1beta1`
-|`storage.k8s.io/v1`
+//|`CSIStorageCapacity`
+//|`storage.k8s.io/v1beta1`
+//|`storage.k8s.io/v1`
 
-|===
+//|===
 
 [id="ocp-4-15-future-deprecation"]
 === Notice of future deprecation


### PR DESCRIPTION
Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-8966](https://issues.redhat.com/browse/OSDOCS-8966)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Also deleting a section that is no longer needed. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
