### PR TITLE
[enterprise-4.12] OBSDOCS-719: Add checkmark for PHP support

### DIFF
--- a/logging/cluster-logging-upgrading.adoc
+++ b/logging/cluster-logging-upgrading.adoc
@@ -13,7 +13,11 @@ There are two types of {logging} updates: minor release updates (5.y.z) and majo
 
 If you installed the {logging} Operators using the *Automatic* update approval option, your Operators receive minor version updates automatically. You do not need to complete any manual update steps.
 
-If you installed the {logging} Operators using the *Manual* update approval option, you must manually approve minor version updates. For more information, see xref:../operators/admin/olm-upgrading-operators.adoc#olm-approving-pending-upgrade_olm-upgrading-operators[Manually approving a pending Operator update].
+If you installed the {logging} Operators using the *Manual* update approval option, you must manually approve minor version updates.
+
+ifdef::openshift-enterprise[]
+For more information, see xref:../operators/admin/olm-upgrading-operators.adoc#olm-approving-pending-upgrade_olm-upgrading-operators[Manually approving a pending Operator update].
+endif::[]
 
 [id="cluster-logging-upgrading-major"]
 == Major release updates

--- a/logging/log_storage/cluster-logging-loki.adoc
+++ b/logging/log_storage/cluster-logging-loki.adoc
@@ -22,7 +22,10 @@ include::modules/logging-loki-reliability-hardening.adoc[leveloffset=+1]
 .Additional resources
 * link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#podantiaffinity-v1-core[`PodAntiAffinity` v1 core Kubernetes documentation]
 * link:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity[Assigning Pods to Nodes Kubernetes documentation]
+
+ifdef::openshift-enterprise[]
 * xref:../../nodes/scheduling/nodes-scheduler-pod-affinity.adoc#nodes-scheduler-pod-affinity[Placing pods relative to other pods using affinity and anti-affinity rules]
+endif::[]
 
 include::modules/logging-loki-zone-aware-rep.adoc[leveloffset=+1]
 

--- a/logging/logging_alerts/troubleshooting-logging-alerts.adoc
+++ b/logging/logging_alerts/troubleshooting-logging-alerts.adoc
@@ -12,7 +12,9 @@ include::modules/es-cluster-health-is-red.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
+ifdef::openshift-enterprise[]
 * xref:../../monitoring/reviewing-monitoring-dashboards.adoc#reviewing-monitoring-dashboards[Reviewing monitoring dashboards]
+endif::[]
 * link:https://www.elastic.co/guide/en/elasticsearch/reference/7.13/fix-common-cluster-issues.html#fix-red-yellow-cluster-status[Fix a red or yellow cluster status]
 
 [id="elasticsearch-cluster-health-is-yellow"]

--- a/modules/logging-multiline-except.adoc
+++ b/modules/logging-multiline-except.adoc
@@ -55,7 +55,7 @@ When log messages appear as a consecutive sequence forming an exception stack tr
 |Ruby | ✓ | ✓
 |Python | ✓ | ✓
 |Golang | ✓ | ✓
-|PHP | ✓ |
+|PHP | ✓ | ✓
 |Dart | ✓ | ✓
 |===
 


### PR DESCRIPTION
Manual CP of https://github.com/openshift/openshift-docs/pull/70001 xref: https://github.com/openshift/openshift-docs/pull/70001/commits/b44baff32e75e2f8cef53a0abb45cfa526fe4180 to fix OSD build issues with links in 4.12.

Previews:
- https://70082--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/cluster-logging-upgrading#cluster-logging-upgrading-minor
- https://70082--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_collection_forwarding/log-forwarding#details
- https://70082--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_storage/cluster-logging-loki#logging-loki-reliability-hardening_cluster-logging-loki
- https://70082--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/logging_alerts/troubleshooting-logging-alerts#es-cluster-health-is-red_troubleshooting-logging-alerts