### PR TITLE
RHDEVDOCS-5863: add the OCP 4.15 version in the rewrite rule

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -244,7 +244,7 @@ AddType text/vtt                            vtt
     RewriteRule ^builds/(1\.0)/?$ /builds/$1/about/overview-openshift-builds.html  [L,R=302]
 
     # Builds using Shipwright landing page
-    RewriteRule ^container-platform/(4\.14)/cicd/builds_using_shipwright/overview-openshift-builds.html /builds/latest/about/overview-openshift-builds.html  [L,R=302]
+    RewriteRule ^container-platform/(4\.14|4\.15)/cicd/builds_using_shipwright/overview-openshift-builds.html /builds/latest/about/overview-openshift-builds.html  [L,R=302]
 
     # redirect gitops latest to 1.11
     RewriteRule ^gitops/?$ /gitops/latest [R=302]


### PR DESCRIPTION
Purpose: https://issues.redhat.com/browse/RHDEVDOCS-5863, redirect users to the Builds standalone page with OCP 4.15 release

version(s): main only

**Context**:

* With the OCP 4.15 release, we need to redirect users to to the [standalone page](https://docs.openshift.com/builds/1.0/about/overview-openshift-builds.html) when they click _CI/CD ->_ _Builds using Shipwright -> Overview of Builds_. 