### PR TITLE
RHDEVDOCS-5766: Update travis.yml for the new version Builds 1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,17 +23,17 @@ jobs:
         - if ! [[ -z $(git diff --name-only HEAD~1 HEAD --diff-filter=d '*.adoc' ':(exclude)_unused_topics/*') ]]; then chmod +x ./scripts/check-asciidoctor-build.sh && ./scripts/check-asciidoctor-build.sh; fi
 
     - stage: build
-      if: branch IN (build-docs, build-docs-1.0)
+      if: branch IN (build-docs, build-docs-1.0, build-docs-1.1)
       name: "Build openshift-builds distro"
       script:
-        - python3 build.py --distro openshift-builds --product "builds for Red Hat OpenShift" --version 1.0 --no-upstream-fetch && python3 makeBuild.py
+        - python3 build.py --distro openshift-builds --product "builds for Red Hat OpenShift" --version 1.1 --no-upstream-fetch && python3 makeBuild.py
 
     - stage: netlify
       name: "Build and deploy with Netlify"
       env:
         - CAN_FAIL=true
       language: minimal
-      if: type IN (pull_request) AND branch IN (build-docs, build-docs-1.0) AND sender != "openshift-cherrypick-robot"
+      if: type IN (pull_request) AND branch IN (build-docs, build-docs-1.0, build-docs-1.1) AND sender != "openshift-cherrypick-robot"
       script:
         - chmod +x autopreview.sh
         - ./autopreview.sh


### PR DESCRIPTION
Purpose: To resolve this issue: https://issues.redhat.com/browse/RHDEVDOCS-5766 (Update travis.yml for the new version 1.1)

Version for cherrypick: build-docs-1.1