### PR TITLE
[Virt] DPDK Checkup: Update image building scripts

### DIFF
--- a/modules/virt-building-vm-containerdisk-image.adoc
+++ b/modules/virt-building-vm-containerdisk-image.adoc
@@ -55,6 +55,10 @@ description = "Image to use with the DPDK checkup"
 version = "0.0.1"
 distro = "rhel-87"
 
+[[customizations.user]]
+name = "root"
+password = "redhat"
+
 [[packages]]
 name = "dpdk"
 
@@ -68,7 +72,7 @@ name = "driverctl"
 name = "tuned-profiles-cpu-partitioning"
 
 [customizations.kernel]
-append = "default_hugepagesz=1GB hugepagesz=1G hugepages=8 isolcpus=2-7"
+append = "default_hugepagesz=1GB hugepagesz=1G hugepages=1"
 
 [customizations.services]
 disabled = ["NetworkManager-wait-online", "sshd"]
@@ -108,20 +112,18 @@ EOF
 [source,terminal]
 ----
 $ cat <<EOF >customize-vm
-echo  isolated_cores=2-7 > /etc/tuned/cpu-partitioning-variables.conf
-tuned-adm profile cpu-partitioning
-echo "options vfio enable_unsafe_noiommu_mode=1" > /etc/modprobe.d/vfio-noiommu.conf
-EOF
-----
-+
-[source,terminal]
-----
-$ cat <<EOF >first-boot
-driverctl set-override 0000:06:00.0 vfio-pci
-driverctl set-override 0000:07:00.0 vfio-pci
+#!/bin/bash
 
-mkdir /mnt/huge
-mount /mnt/huge --source nodev -t hugetlbfs -o pagesize=1GB
+# Setup hugepages mount
+mkdir -p /mnt/huge
+echo "hugetlbfs /mnt/huge hugetlbfs defaults,pagesize=1GB 0 0" >> /etc/fstab
+
+# Create vfio-noiommu.conf
+echo "options vfio enable_unsafe_noiommu_mode=1" > /etc/modprobe.d/vfio-noiommu.conf
+
+# Enable guest-exec,guest-exec-status on the qemu-guest-agent configuration
+sed -i '/^BLACKLIST_RPC=/ { s/guest-exec-status//; s/guest-exec//g }' /etc/sysconfig/qemu-ga
+sed -i '/^BLACKLIST_RPC=/ { s/,\+/,/g; s/^,\|,$//g }' /etc/sysconfig/qemu-ga
 EOF
 ----
 
@@ -129,7 +131,7 @@ EOF
 +
 [source,terminal]
 ----
-$ virt-customize -a <UUID>.qcow2 --run=customize-vm --firstboot=first-boot --selinux-relabel
+$ virt-customize -a <UUID>.qcow2 --run=customize-vm --selinux-relabel
 ----
 
 . To create a Dockerfile that contains all the commands to build the container disk image, enter the following command:
@@ -138,7 +140,7 @@ $ virt-customize -a <UUID>.qcow2 --run=customize-vm --firstboot=first-boot --sel
 ----
 $ cat << EOF > Dockerfile
 FROM scratch
-COPY <uuid>-disk.qcow2 /disk/
+COPY --chown=107:107 <uuid>-disk.qcow2 /disk/
 EOF
 ----
 +
@@ -160,4 +162,4 @@ $ podman build . -t dpdk-rhel:latest
 $ podman push dpdk-rhel:latest
 ----
 
-. Provide a link to the container disk image in the `spec.param.vmContainerDiskImage` attribute in the DPDK checkup config map.
+. Provide a link to the container disk image in the `spec.param.vmUnderTestContainerDiskImage` attribute in the DPDK checkup config map.


### PR DESCRIPTION
This PR is updating the scripts used to creation the rhel DPDK container disk image.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
v4.15+

Issue:
https://issues.redhat.com/browse/CNV-35859

Link to docs preview:
https://70090--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-running-cluster-checkups#virt-building-vm-containerdisk-image_virt-running-cluster-checkups

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
