### PR TITLE
OCPBUGS#13638-rework: Important section under discovery for local sto…

### DIFF
--- a/modules/persistent-storage-local-discovery.adoc
+++ b/modules/persistent-storage-local-discovery.adoc
@@ -8,13 +8,12 @@
 
 The Local Storage Operator automates local storage discovery and provisioning. With this feature, you can simplify installation when dynamic provisioning is not available during deployment, such as with bare metal, VMware, or AWS store instances with attached devices.
 
+:FeatureName: Automatic discovery and provisioning
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
 [IMPORTANT]
 ====
-Automatic discovery and provisioning is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
-
-However, automatic discovery and provisioning is fully supported when used to deploy {rh-storage-first} on-premise or with platform-agnostic deployment.
-
-For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+Automatic discovery and provisioning is fully supported when used to deploy {rh-storage-first} on-premise or with platform-agnostic deployment.
 ====
 
 Use the following procedure to automatically discover local devices, and to automatically provision local volumes for selected devices.


### PR DESCRIPTION
Version(s):
4.11,4.12,4.13,4.14, 4.15

Issue:
[OCPBUGS-13638](https://issues.redhat.com/browse/OCPBUGS-13638)

Link to docs preview:
https://70091--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-local#local-storage-discovery_persistent-storage-local

QE review:
- [ ] QE approval is required.
