### PR TITLE
[enterprise-4.14]OSDOCS#8126: cert-manager 1.13 changes

### DIFF
--- a/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
@@ -12,6 +12,38 @@ These release notes track the development of {cert-manager-operator}.
 
 For more information, see xref:../../security/cert_manager_operator/index.adoc#cert-manager-operator-about[About the {cert-manager-operator}].
 
+[id="cert-manager-operator-release-notes-1.13"]
+== Release notes for {cert-manager-operator} 1.13.0
+
+Issued: 2024-01-16
+
+The following advisory is available for the {cert-manager-operator} 1.13.0:
+
+* link:https://access.redhat.com/errata/RHEA-2024:0260[RHEA-2024:0260]
+
+Version `1.13.0` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.13.3`. For more information, see the link:https://cert-manager.io/docs/release-notes/release-notes-1.13/#v1133[cert-manager project release notes for v1.13.0].
+
+[id="cert-manager-operator-new-features-1.13"]
+=== New features and enhancements
+
+* You can now manage certificates for API Server and Ingress Controller by using the {cert-manager-operator}. 
+For more information, see xref:../../security/cert_manager_operator/cert-manager-creating-certificate.adoc#cert-manager-creating-certificate[Configuring certificates with an issuer].
+
+* With this release, the scope of the {cert-manager-operator}, which was previously limited to the {product-title} on AMD64 architecture, has now been expanded to include support for managing certificates on {product-title} running on {ibm-z-name} (`s390x`), {ibm-power-name} (`ppc64le`) and ARM64 architectures.
+
+* With this release, you can use DNS over HTTPS (DoH) for performing the self-checks during the ACME DNS-01 challenge verification. The DNS self-check method can be controlled by using the command line flags, `--dns01-recursive-nameservers-only` and `--dns01-recursive-nameservers`.
+For more information, see xref:../../security/cert_manager_operator/cert-manager-customizing-api-fields.html#cert-manager-override-arguments_cert-manager-customizing-api-fields[Customizing cert-manager by overriding arguments from the cert-manager Operator API].
+
+[id="cert-manager-operator-1.13-CVEs"]
+=== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2023-39615[CVE-2023-39615]
+* link:https://access.redhat.com/security/cve/CVE-2023-3978[CVE-2023-3978]
+* link:https://access.redhat.com/security/cve/CVE-2023-37788[CVE-2023-37788]
+* link:https://access.redhat.com/security/cve/CVE-2023-29406[CVE-2023-29406]
+
+
+
 [id="cert-manager-operator-release-notes-1.12.1"]
 == Release notes for {cert-manager-operator} 1.12.1
 


### PR DESCRIPTION
CP of #69800 
Version(s):4.14

Link to docs preview: https://70098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-operator-release-notes