### PR TITLE
Updates bare metal configuration docs

### DIFF
--- a/modules/installation-registry-storage-block-recreate-rollout-bare-metal.adoc
+++ b/modules/installation-registry-storage-block-recreate-rollout-bare-metal.adoc
@@ -8,7 +8,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="installation-registry-storage-block-recreate-rollout-bare-metal_{context}"]
-= Configuring block registry storage
+= Configuring block registry storage for bare metal
 
 To allow the image registry to use block storage types during upgrades as a cluster administrator, you can use the `Recreate` rollout strategy.
 
@@ -21,13 +21,55 @@ If you choose to use a block storage volume with the image registry, you must us
 
 .Procedure
 
-. To set the image registry storage as a block storage type, patch the registry so that it uses the `Recreate` rollout strategy and runs with only one (`1`) replica:
+. Enter the following command to set the image registry storage as a block storage type, patch the registry so that it uses the `Recreate` rollout strategy, and runs with only one (`1`) replica:
 +
 [source,terminal]
 ----
 $ oc patch config.imageregistry.operator.openshift.io/cluster --type=merge -p '{"spec":{"rolloutStrategy":"Recreate","replicas":1}}'
 ----
-+
+
 . Provision the PV for the block storage device, and create a PVC for that volume. The requested block volume uses the ReadWriteOnce (RWO) access mode.
+.. Create a `pvc.yaml` file with the following contents to define a VMware vSphere `PersistentVolumeClaim` object:
 +
-. Edit the registry configuration so that it references the correct PVC.
+[source,yaml]
+----
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: image-registry-storage <1>
+  namespace: openshift-image-registry <2>
+spec:
+  accessModes:
+  - ReadWriteOnce <3>
+  resources:
+    requests:
+      storage: 100Gi <4>
+----
+<1> A unique name that represents the `PersistentVolumeClaim` object.
+<2> The namespace for the `PersistentVolumeClaim` object, which is `openshift-image-registry`.
+<3> The access mode of the persistent volume claim. With `ReadWriteOnce`, the volume can be mounted with read and write permissions by a single node.
+<4> The size of the persistent volume claim.
+
+.. Enter the following command to create the `PersistentVolumeClaim` object from the file:
++
+[source,terminal]
+----
+$ oc create -f pvc.yaml -n openshift-image-registry
+----
+
++
+. Enter the following command to edit the registry configuration so that it references the correct PVC:
++
+[source,terminal]
+----
+$ oc edit config.imageregistry.operator.openshift.io -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+storage:
+  pvc:
+    claim: <1>
+----
+<1> By creating a custom PVC, you can leave the `claim` field blank for the default automatic creation of an `image-registry-storage` PVC.

--- a/modules/installation-registry-storage-block-recreate-rollout-nutanix.adoc
+++ b/modules/installation-registry-storage-block-recreate-rollout-nutanix.adoc
@@ -21,7 +21,7 @@ If you choose to use a block storage volume with the image registry, you must us
 
 .Procedure
 
-. To set the image registry storage as a block storage type, patch the registry so that it uses the `Recreate` rollout strategy and runs with only one (`1`) replica:
+. Enter the following command to set the image registry storage as a block storage type, patch the registry so that it uses the `Recreate` rollout strategy, and runs with only one (`1`) replica:
 +
 [source,terminal]
 ----
@@ -51,14 +51,14 @@ spec:
 <3> The access mode of the persistent volume claim. With `ReadWriteOnce`, the volume can be mounted with read and write permissions by a single node.
 <4> The size of the persistent volume claim.
 
-.. Create the `PersistentVolumeClaim` object from the file:
+.. Enter the following command to create the `PersistentVolumeClaim` object from the file:
 +
 [source,terminal]
 ----
 $ oc create -f pvc.yaml -n openshift-image-registry
 ----
 
-. Edit the registry configuration so that it references the correct PVC:
+. Enter the following command to edit the registry configuration so that it references the correct PVC:
 +
 [source,terminal]
 ----

--- a/modules/installation-registry-storage-block-recreate-rollout.adoc
+++ b/modules/installation-registry-storage-block-recreate-rollout.adoc
@@ -24,7 +24,7 @@ have more than one replica.
 
 .Procedure
 
-. To set the image registry storage as a block storage type, patch the registry so that it uses the `Recreate` rollout strategy and runs with only `1` replica:
+. Enter the following command to set the image registry storage as a block storage type, patch the registry so that it uses the `Recreate` rollout strategy, and runs with only `1` replica:
 +
 [source,terminal]
 ----
@@ -53,7 +53,7 @@ spec:
 <3> The access mode of the persistent volume claim. With `ReadWriteOnce`, the volume can be mounted with read and write permissions by a single node.
 <4> The size of the persistent volume claim.
 
-.. Create the `PersistentVolumeClaim` object from the file:
+.. Enter the following command to create the `PersistentVolumeClaim` object from the file:
 +
 [source,terminal]
 ----
@@ -61,7 +61,7 @@ $ oc create -f pvc.yaml -n openshift-image-registry
 ----
 
 +
-. Edit the registry configuration so that it references the correct PVC:
+. Enter the following command to edit the registry configuration so that it references the correct PVC:
 +
 [source,terminal]
 ----

--- a/modules/persistent-storage-vsphere-dynamic-provisioning-cli.adoc
+++ b/modules/persistent-storage-vsphere-dynamic-provisioning-cli.adoc
@@ -33,7 +33,7 @@ spec:
 <2> The access mode of the persistent volume claim. With `ReadWriteOnce`, the volume can be mounted with read and write permissions by a single node.
 <3> The size of the persistent volume claim.
 
-. Create the `PersistentVolumeClaim` object from the file:
+. Enter the following command to create the `PersistentVolumeClaim` object from the file:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
PR copies content from Swift documentation to bare metal

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-9446

Link to docs preview:
https://70110--ocpdocs-pr.netlify.app/openshift-enterprise/latest/registry/configuring_registry_storage/configuring-registry-storage-baremetal#installation-registry-storage-block-recreate-rollout-bare-metal_configuring-registry-storage-baremetal

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
