### PR TITLE
RHIBMCS-145: Add SCC/PSA Coexistence Concept

### DIFF
--- a/authentication/understanding-and-managing-pod-security-admission.adoc
+++ b/authentication/understanding-and-managing-pod-security-admission.adoc
@@ -11,6 +11,9 @@ Pod security admission is an implementation of the link:https://kubernetes.io/do
 // About pod security admission
 include::modules/security-context-constraints-psa-about.adoc[leveloffset=+1]
 
+// Understanding pod security admission coexistence
+include::modules/security-context-constraints-psa-coexistence.adoc[leveloffset=+2]
+
 // About pod security admission synchronization
 include::modules/security-context-constraints-psa-synchronization.adoc[leveloffset=+1]
 

--- a/modules/security-context-constraints-psa-coexistence.adoc
+++ b/modules/security-context-constraints-psa-coexistence.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * authentication/understanding-and-managing-pod-security-admission.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="security-context-constraints-psa-coexistence_{context}"]
+= Pod security admission and security context constraints
+
+Pod security admission standards and security context constraints are reconciled and enforced by two independent controllers. The two controllers work independently using the following processes to enforce security policies:
+
+. The security context constraint controller may mutate some security context fields per the pod's assigned SCC. For example, if the seccomp profile is empty or not set and if the pod's assigned SCC enforces `seccompProfiles` field to be `runtime/default`, the controller sets the default type to `RuntimeDefault`.
+
+. The security context constraint controller validates the pod's security context against the matching SCC.
+
+. The pod security admission controller validates the pod's security context against the pod security standard assigned to the namespace.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
This PR adds a new concept section to the Pod security admission page to give customers details on how SCC's and the new PSA work together.  It's not at all obvious why the syncher is needed, so this attempts to tie the two together.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/RHIBMCS-145

Link to docs preview: https://70124--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/understanding-and-managing-pod-security-admission#security-context-constraints-psa-coexistence_understanding-and-managing-pod-security-admission
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
