### PR TITLE
[OSDOCS-9251]:  Remove references to 'machineconfigpools' from NTO on ROSA with HCP docs

### DIFF
--- a/modules/custom-tuning-specification.adoc
+++ b/modules/custom-tuning-specification.adoc
@@ -134,12 +134,11 @@ ifdef::rosa-hcp-tuning[]
   "recommend": [
     {
       "profile": <tuned_profile_name>, <1>
-      "priority": <priority>, <2>
-      "machineConfigLabels": { <Key_Pair_for_MachineConfig> <3>
+      "priority":{ <priority>, <2>
       },
-      "match": [ <4>
+      "match": [ <3>
         {
-          "label": <label_information> <5>
+          "label": <label_information> <4>
         },
       ]
     },
@@ -148,9 +147,8 @@ ifdef::rosa-hcp-tuning[]
 ----
 <1> A TuneD profile to apply on a match. For example `tuned_profile_1`.
 <2> Profile ordering priority. Lower numbers mean higher priority (`0` is the highest priority).
-<3> Optional: A dictionary of key-value pairs `MachineConfig` labels. The keys must be unique.
-<4> If omitted, profile match is assumed unless a profile with a higher priority matches first or `machineConfigLabels` is set.
-<5> The label for the profile matched items.
+<3> If omitted, profile match is assumed unless a profile with a higher priority matches first.
+<4> The label for the profile matched items.
 endif::[]
 
 `<match>` is an optional list recursively defined as follows:
@@ -181,6 +179,7 @@ ifdef::rosa-hcp-tuning[]
 endif::[]
 
 If `<match>` is not omitted, all nested `<match>` sections must also evaluate to `true`. Otherwise, `false` is assumed and the profile with the respective `<match>` section will not be applied or recommended. Therefore, the nesting (child `<match>` sections) works as logical AND operator. Conversely, if any item of the `<match>` list matches, the entire `<match>` list evaluates to `true`. Therefore, the list acts as logical OR operator.
+ifndef::rosa-hcp-tuning[]
 
 If `machineConfigLabels` is defined, machine config pool based matching is turned on for the given `recommend:` list item. `<mcLabels>` specifies the labels for a machine config. The machine config is created automatically to apply host settings, such as kernel boot parameters, for the profile `<tuned_profile_name>`. This involves finding all machine config pools with machine config selector matching `<mcLabels>` and setting the profile `<tuned_profile_name>` on all nodes that are assigned the found machine config pools. To target nodes that have both master and worker roles, you must use the master role.
 
@@ -190,7 +189,7 @@ The list items `match` and `machineConfigLabels` are connected by the logical OR
 ====
 When using machine config pool based matching, it is advised to group nodes with the same hardware configuration into the same machine config pool. Not following this practice might result in TuneD operands calculating conflicting kernel parameters for two or more nodes sharing the same machine config pool.
 ====
-
+endif::rosa-hcp-tuning[]
 .Example: Node or pod label based matching
 
 ifndef::rosa-hcp-tuning[]
@@ -263,8 +262,8 @@ Finally, the profile `openshift-node` has the lowest priority of `30`. It lacks 
 
 image::node-tuning-operator-workflow-revised.png[Decision workflow]
 
-.Example: Machine config pool based matching
 ifndef::rosa-hcp-tuning[]
+.Example: Machine config pool based matching
 [source,yaml]
 ----
 apiVersion: tuned.openshift.io/v1
@@ -290,6 +289,7 @@ spec:
 ----
 endif::rosa-hcp-tuning[]
 ifdef::rosa-hcp-tuning[]
+.Example: Machine pool based matching
 [source,JSON]
 ----
 {
@@ -308,9 +308,6 @@ ifdef::rosa-hcp-tuning[]
     ],
     "recommend": [
       {
-        "machineConfigLabels": {
-          "machineconfiguration.openshift.io/role": "worker-custom"
-        },
         "priority": 20,
         "profile": "openshift-node-custom"
       }
@@ -320,8 +317,9 @@ ifdef::rosa-hcp-tuning[]
 ----
 endif::[]
 
+ifndef::rosa-hcp-tuning[]
 To minimize node reboots, label the target nodes with a label the machine config pool's node selector will match, then create the Tuned CR above and finally create the custom machine config pool itself.
-
+endif::rosa-hcp-tuning[]
 // $ oc label node <node> node-role.kubernetes.io/worker-custom=
 // $ oc create -f <tuned-cr-above>
 // $ oc create -f- <<EOF
@@ -342,7 +340,13 @@ To minimize node reboots, label the target nodes with a label the machine config
 
 *Cloud provider-specific TuneD profiles*
 
-With this functionality, all Cloud provider-specific nodes can conveniently be assigned a TuneD profile specifically tailored to a given Cloud provider on a {product-title} cluster. This can be accomplished without adding additional node labels or grouping nodes into machine config pools.
+With this functionality, all Cloud provider-specific nodes can conveniently be assigned a TuneD profile specifically tailored to a given Cloud provider on a {product-title} cluster. This can be accomplished without adding additional node labels or grouping nodes into
+ifndef::rosa-hcp-tuning[]
+machine config pools.
+endif::rosa-hcp-tuning[]
+ifdef::rosa-hcp-tuning[]
+machine pools.
+endif::rosa-hcp-tuning[]
 
 This functionality takes advantage of `spec.providerID` node object values in the form of `<cloud-provider>://<cloud-provider-specific-id>` and writes the file `/var/lib/tuned/provider` with the value `<cloud-provider>` in NTO operand containers.  The content of this file is then used by TuneD to load `provider-<cloud-provider>` profile if such profile exists.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-9251
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://70125--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-tuning-config

Reviewers: You can use this link to confirm that nothing was changed in the OCP docs, as this doc update should not affect those docs: 
https://70125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/using-node-tuning-operator#custom-tuning-specification_node-tuning-operator
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
