### PR TITLE
OSDOCS-8991: OLM on MicroShift intro

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -446,6 +446,8 @@ Topics:
   File: microshift-authentication
 - Name: Using Operators
   File: microshift-operators
+- Name: Using Operator Lifecycle Manager
+  File: microshift-operators-olm
 ---
 Name: Backup and restore
 Dir: microshift_backup_and_restore

--- a/microshift_install/microshift-embed-in-rpm-ostree.adoc
+++ b/microshift_install/microshift-embed-in-rpm-ostree.adoc
@@ -29,13 +29,13 @@ include::modules/microshift-adding-repos-to-image-builder.adoc[leveloffset=+1]
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/setting-up-image-builder_composing-installing-managing-rhel-for-edge-images#edge-image-builder-system-requirements_setting-up-image-builder[Image Builder system requirements]
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/setting-up-image-builder_composing-installing-managing-rhel-for-edge-images#edge-installing-image-builder_setting-up-image-builder[Installing Image Builder]
 
-
 include::modules/microshift-adding-service-to-blueprint.adoc[leveloffset=+1]
 
 include::modules/microshift-adding-olm-to-blueprint.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
+* xref:../microshift_running_apps/microshift-operators-olm.adoc#microshift-operators-olm[Using Operator Lifecycle Manager with {microshift-short}]
 * xref:../microshift_updating/microshift-update-rpms-ostree.adoc[Applying updates on an OSTree system]
 
 include::modules/microshift-ca-adding-bundle.adoc[leveloffset=+1]

--- a/microshift_install/microshift-install-rpm.adoc
+++ b/microshift_install/microshift-install-rpm.adoc
@@ -39,13 +39,12 @@ include::modules/microshift-install-rpms.adoc[leveloffset=+1]
 
 include::modules/microshift-install-rpms-olm.adoc[leveloffset=+1]
 
-//TODO: Additional resources section that includes OLM resources when docs are complete
-
-//additional resources for install rpms module
+//additional resources for install rpms modules
 [role="_additional-resources"]
 .Additional resources
-* xref:../microshift_install/microshift-install-rpm.adoc#microshift-install-system-requirements_microshift-install-rpm[System requirements for installing MicroShift].
-* xref:../microshift_install/microshift-install-rpm.adoc#microshift-install-rpm-preparing_microshift-install-rpm[Preparing to install MicroShift from an RPM package].
+* xref:../microshift_install/microshift-install-rpm.adoc#microshift-install-system-requirements_microshift-install-rpm[System requirements for installing MicroShift]
+* xref:../microshift_install/microshift-install-rpm.adoc#microshift-install-rpm-preparing_microshift-install-rpm[Preparing to install MicroShift from an RPM package]
+* xref:../microshift_running_apps/microshift-operators-olm.adoc#microshift-operators-olm[Using Operator Lifecycle Manager with {microshift-short}]
 
 include::modules/microshift-service-starting.adoc[leveloffset=+1]
 

--- a/microshift_running_apps/microshift-operators-olm.adoc
+++ b/microshift_running_apps/microshift-operators-olm.adoc
@@ -1,0 +1,70 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="microshift-operators-olm"]
+= Using Operator Lifecycle Manager with {microshift-short}
+include::_attributes/attributes-microshift.adoc[]
+:context: microshift-operators-olm
+
+toc::[]
+
+The Operator Lifecycle Manager (OLM) package manager is used in {microshift-short} for installing and running optional link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/architecture/control-plane#olm-operators_control-plane[add-on Operators].
+
+* Cluster Operators as applied in {ocp} are not used in {microshift-short}.
+* You must create your own catalogs for the add-on Operators you want to use with your applications. Catalogs are not provided by default.
+** Each catalog must have an accessible `CatalogSource` added to a cluster, so that the OLM catalog Operator can use the catalog for content.
+* You must use the CLI to conduct OLM activities with {microshift-short}. The console and OperatorHub GUIs are not available.
+** Use the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/cli_tools/opm-cli#cli-opm-install[Operator Package Manager `opm` CLI] with network-connected clusters, or for building catalogs for custom Operators that use an internal registry.
+** To mirror your catalogs and Operators for disconnected or offline clusters, install link:https://docs.openshift.com/container-platform/{ocp-version}/installing/disconnected_install/installing-mirroring-disconnected.html#installation-oc-mirror-installing-plugin_installing-mirroring-disconnected[the oc-mirror OpenShift CLI plugin].
+
+[IMPORTANT]
+====
+Before using an Operator, verify with the provider that the Operator is supported on {product-title}.
+====
+
+[id="microshift-installing-olm-options_{context}"]
+== Determining your OLM installation type
+You can install the OLM package manager for use with {microshift-short} 4.15 or newer versions. There are different ways to install OLM for {microshift-short} clusters, depending on your use case.
+
+* You can install the `microshift-olm` RPM at the same time you install the {microshift-short} RPM on {op-system-base-full}.
+* You can install the `microshift-olm` on an existing {microshift-short} {product-version}. Restart the {microshift-short} service after installing OLM for the changes to apply.
+See xref:../microshift_install/microshift-install-rpm.adoc#microshift-install-rpms-olm_microshift-install-rpm[Installing the Operator Lifecycle Manager (OLM) from an RPM package].
+* You can embed OLM in a {op-system-ostree-first} image. See xref:../microshift_install/microshift-embed-in-rpm-ostree.adoc#microshift-adding-olm-to-blueprint_microshift-embed-in-rpm-ostree[Adding the Operator Lifecycle Manager (OLM) service to a blueprint].
+
+include::modules/microshift-olm-namespaces.adoc[leveloffset=+1]
+
+include::modules/microshift-olm-build-op-catalogs.adoc[leveloffset=+1]
+
+//additional resources for builing catalogs module
+[role="_additional-resources"]
+.Additional resources
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/cli_tools/opm-cli[`opm` CLI reference]
+* link:https://docs.openshift.com/container-platform/{ocp-version}/operators/understanding/olm-rh-catalogs.html#olm-about-catalogs_olm-rh-catalogs[About Operator catalogs]
+* For instructions about creating file-based catalogs by using the `opm` CLI, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/operators/administrator-tasks#olm-managing-custom-catalogs[Managing custom catalogs]
+
+include::modules/microshift-olm-deploy-ops-con.adoc[leveloffset=+1]
+
+//additional resources for deploying operators concept module
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.openshift.com/container-platform/4.14/operators/understanding/olm/olm-understanding-operatorgroups.html#olm-operatorgroups-membership_olm-understanding-operatorgroups[Operator group membership]
+
+include::modules/microshift-olm-deploy-ops-global-ns.adoc[leveloffset=+2]
+
+include::modules/microshift-olm-deploy-ops-spec-ns.adoc[leveloffset=+2]
+
+//additional resources for working with operators after deployment
+[role="_additional-resources"]
+.Additional resources
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/operators/administrator-tasks#olm-upgrading-operators[Updating installed Operators]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/operators/administrator-tasks#olm-deleting-operator-from-a-cluster-using-cli_olm-deleting-operators-from-a-cluster[Deleting Operators from a cluster using the CLI]
+
+include::modules/microshift-olm-deploy-op-disconnected.adoc[leveloffset=+2]
+
+//additional resources for deploying operators in disconnected and offline environments
+[role="_additional-resources"]
+.Additional resources
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/operators/administrator-tasks#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks] for more information.
+* link:https://docs.openshift.com/container-platform/{ocp-version}/installing/disconnected_install/installing-mirroring-disconnected.html#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin]
+* xref:../microshift_install/microshift-deploy-with-mirror-registry.adoc#microshift-configuring-hosts-for-mirror_microshift-deployment-mirror[Configuring hosts for mirror registry access]
+* xref:../microshift_networking/microshift-disconnected-network-config.adoc#microshift-disconnected-network-config[Configuring network settings for fully disconnected hosts]
+* xref:../microshift_install/microshift-deploy-with-mirror-registry.adoc#microshift-get-mirror-reg-container-image-list_microshift-deploy-with-mirror-registry[Getting the mirror registry container image list]
+* xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-in-rpm-ostree-offline-use[Embedding in a {op-system-ostree} image for offline use]

--- a/microshift_running_apps/microshift-operators.adoc
+++ b/microshift_running_apps/microshift-operators.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="operators-with-microshift"]
-= How Operators work with {microshift-short}
+= Using Operators with {microshift-short}
 include::_attributes/attributes-microshift.adoc[]
 :context: operators-microshift
 
@@ -10,9 +10,17 @@ You can use Operators with {microshift-short} to create applications that monito
 
 Operators offer a more localized configuration experience and integrate with Kubernetes APIs and CLI tools such as `kubectl` and `oc`. Operators are designed specifically for your applications. Operators enable you to configure components instead of modifying a global configuration file.
 
-{microshift-short} applications are generally expected to be deployed in static environments. However, Operators are available if helpful in your use case. To determine an Operator's compatibility with {microshift-short}, check the Operator's documentation.
+{microshift-short} applications are generally expected to be deployed in static environments. However, Operators are available if helpful in your use case. To determine the compatibility of an Operator with {microshift-short}, check the Operator documentation.
 
-[id="how-to-install-operators_{context}"]
-== How to install Operators in {microshift-short}
+[id="microshift-operators-installation-paths_{context}"]
+== How to use Operators with {microshift-short} clusters
 
-To minimize the footprint of {microshift-short}, Operators are installed directly with manifests instead of using the Operator Lifecycle Manager (OLM). You can use the `kustomize` configuration management tool with {microshift-short} to deploy an application. Use the same steps to install Operators with manifests. Read xref:../microshift_running_apps/microshift-applications.adoc#microshift-manifests-overview_applications-microshift[Using Kustomize manifests to deploy applications] for more information about manifests.
+There are two ways to use Operators for your {microshift-short} clusters:
+
+[id="microshift-operators-paths-manifests_{context}"]
+=== Manifests for Operators
+* Operators can be installed and managed directly by using manifests. You can use the `kustomize` configuration management tool with {microshift-short} to deploy an application. Use the same steps to install Operators with manifests. See xref:../microshift_running_apps/microshift-applications.adoc#microshift-manifests-overview_applications-microshift[Using Kustomize manifests to deploy applications] and xref:../microshift_running_apps/microshift-applications.adoc#microshift-applying-manifests-example_applications-microshift[Using manifests example] for details.
+
+[id="microshift-operators-paths-olm_{context}"]
+=== Operator Lifecycle Manager for Operators
+* You can also install add-on Operators to a {microshift-short} cluster using Operator Lifecycle Manager (OLM). OLM can be used to manage both custom Operators and Operators that are widely available. Building catalogs is required to use OLM with {microshift-short}. For details, see xref:../microshift_running_apps/microshift-operators-olm.adoc#microshift-operators-olm[Using Operator Lifecycle Manager with {microshift-short}].

--- a/modules/microshift-get-mirror-reg-container-image-list.adoc
+++ b/modules/microshift-get-mirror-reg-container-image-list.adoc
@@ -4,9 +4,14 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="microshift-get-mirror-reg-container-image-list_{context}"]
-= Getting the {microshift-short} mirror registry container image list
+= Getting the mirror registry container image list
 
 To use a mirror registry, you must know which container image references are used by a specific version of {microshift-short}. These references are provided in the `release-<arch>.json` files that are part of the `microshift-release-info` RPM package.
+
+[NOTE]
+====
+To mirror the Operator Lifecycle Manager (OLM) in disconnected environments, add the references provided in the `release-olm-$ARCH.json` that is included in the `microshift-olm` RPM and follow the same procedure. Use `oc-mirror` for mirroring Operator catalogs and Operators.
+====
 
 .Prerequisites
 

--- a/modules/microshift-olm-build-op-catalogs.adoc
+++ b/modules/microshift-olm-build-op-catalogs.adoc
@@ -1,0 +1,22 @@
+//Module included in the following assemblies:
+//
+//* microshift_running_apps/microshift-operators-olm.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-options-building-operator-catalogs_{context}"]
+= About building Operator catalogs
+
+To use Operator Lifecycle Manager (OLM) with {microshift-short}, you must build custom Operator catalogs that you can then manage with OLM. The standard catalogs that are included with {OCP} are not included with {microshift-short}.
+
+[id="microshift-file-based-olm-catalogs_{context}"]
+== File-based Operator catalogs
+You can create catalogs for your custom Operators or filter catalogs of widely available Operators. You can combine both methods to create the catalogs needed for your specific use case. To run {microshift-short} with your own Operators and OLM, make a catalog by using the file-based catalog structure.
+
+* For details, see link:https://docs.openshift.com/container-platform/4.14/operators/admin/olm-managing-custom-catalogs.html#olm-creating-fb-catalog-image_olm-managing-custom-catalogs[Managing custom catalogs] and link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/operators/understanding-operators#olm-fb-catalogs-example_olm-packaging-format[Example catalog].
+
+* See also link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/cli_tools/opm-cli[`opm` CLI reference].
+
+[IMPORTANT]
+====
+* When link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/operators/administrator-tasks#olm-creating-catalog-from-index_olm-restricted-networks[adding a catalog source to a cluster], set the `securityContextConfig` value to `restricted` in the `catalogSource.yaml` file. Ensure that your catalog can run with `restricted` permissions.
+====

--- a/modules/microshift-olm-deploy-op-disconnected.adoc
+++ b/modules/microshift-olm-deploy-op-disconnected.adoc
@@ -1,0 +1,19 @@
+//Module included in the following assemblies:
+//
+//* microshift_running_apps/microshift-operators-olm.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-adding-OLM-Operators-to-offline-cluster_{context}"]
+= About adding OLM-based Operators to an offline cluster
+
+For {microshift-short} clusters that are installed on disconnected or offline clusters, Operator Lifecycle Manager (OLM) by default cannot access sources hosted on remote registries because those remote sources require full internet connectivity.
+
+The following steps are required to use OLM-based Operators in offline situations:
+
+* Include OLM in your container image list for your mirror registry.
+* Configure the system to use the mirror by updating your CRI-O configuration directly. `ImageContentSourcePolicy` is not supported in {microshift-short}.
+* Add a `CatalogSource` object to the cluster so that the OLM catalog Operator can use the local catalog on the mirror registry.
+* Ensure that {microshift-short} is installed to run in an offline capacity.
+* Ensure that the network settings are configured to run in a disconnected mode.
+
+After enabling OLM in an offline cluster, you can continue to use your unrestricted workstation to keep your local catalog sources updated as newer versions of Operators are released.

--- a/modules/microshift-olm-deploy-ops-con.adoc
+++ b/modules/microshift-olm-deploy-ops-con.adoc
@@ -1,0 +1,23 @@
+//Module included in the following assemblies:
+//
+//* microshift_running_apps/microshift-operators-olm.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-deploy-operators_{context}"]
+= How to deploy Operators
+
+After you create and deploy your custom catalog, you must create a Subscription custom resource (CR) that can access the catalog and install the Operators you choose. Where Operators run depends on the namespace in which you create the Subscription CR.
+
+[IMPORTANT]
+====
+Operators in OLM have a watch scope. For example, some Operators only support watching their own namespace, while others support watching every namespace in the cluster. All Operators installed in a given namespace must have the same watch scope.
+====
+
+[id="microshift-operators-connection-details_{context}"]
+== Connectivity and Operator deployment
+Operators can be deployed anywhere a catalog is running.
+
+* For clusters that are connected to the internet, mirroring images is not required. Images can be pulled over the network.
+* For restricted networks in which {microshift-short} has access to an internal network only, images must be mirrored to an internal registry.
+* For use cases in which {microshift-short} clusters are completely offline, all images must be embedded into an `osbuild` blueprint.
+//TODO point to correct ref docs

--- a/modules/microshift-olm-deploy-ops-global-ns.adoc
+++ b/modules/microshift-olm-deploy-ops-global-ns.adoc
@@ -1,0 +1,210 @@
+//Module included in the following assemblies:
+//
+//* microshift_running_apps/microshift-operators-olm.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-OLM-deploy-Operators_{context}"]
+= Adding OLM-based Operators to a networked cluster using the global namespace
+
+To deploy different operators to different namespaces, use this procedure. For {microshift-short} clusters that have network connectivity, Operator Lifecycle Manager (OLM) can access sources hosted on remote registries. The following procedure lists the basic steps of using configuration files to install an Operator that uses the global namespace.
+
+[NOTE]
+====
+To use an Operator installed in a different namespace, or in more than one namespace, make sure that the catalog source and the Subscription CR that references the Operator are running in the `openshift-marketplace` namespace.
+====
+
+.Prerequisites
+* The {oc-first} is installed.
+* Operator Lifecycle Manager (OLM) is installed.
+* You have created a custom catalog in the global namespace.
+
+.Procedure
+
+. Confirm that OLM is running by using the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-operator-lifecycle-manager get pod -l app=olm-operator
+----
++
+.Example output
+[source,terminal]
+----
+NAME                            READY   STATUS    RESTARTS   AGE
+olm-operator-85b5c6786-n6kbc    1/1     Running   0          2m24s
+----
+
+. Confirm that the OLM catalog Operator is running by using the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-operator-lifecycle-manager get pod -l app=catalog-operator
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                READY   STATUS    RESTARTS   AGE
+catalog-operator-5fc7f857b6-tj8cf   1/1     Running   0          2m33s
+----
+
+[NOTE]
+====
+The following steps assume you are using the global namespace, `openshift-marketplace`. The catalog must run in the same namespace as the Operator. The Operator must support the *AllNamespaces* mode.
+====
+
+. Create the `CatalogSource` object by using the following example YAML:
++
+.Example catalog source YAML
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: operatorhubio-catalog
+  namespace: openshift-marketplace <1>
+spec:
+  sourceType: grpc
+  image: quay.io/operatorhubio/catalog:latest
+  displayName: Community Operators <2>
+  publisher: OperatorHub.io
+  grpcPodConfig:
+    securityContextConfig: restricted <3>
+  updateStrategy:
+    registryPoll:
+      interval: 60m
+----
+<1> The global namespace. Setting the `metadata.namespace` to `openshift-marketplace` enables the catalog to run in all namespaces. Subscriptions in any namespace can reference catalogs created in the `openshift-marketplace` namespace.
+<2> Community Operators are not installed by default with OLM for {miroshift-short}. Listed here for example only.
+<3> The value of `securityContextConfig` must be set to `restricted` for {microshift-short}.
+
+. Apply the `CatalogSource` configuration by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f _<my-catalog-source.yaml>_ <1>
+----
+<1> Replace _<my-catalog-source.yaml>_ with your catalog source configuration file name. In this example, `catalogsource.yaml` is used.
++
+.Example output
+[source,terminal]
+----
+catalogsource.operators.coreos.com/operatorhubio-catalog created
+----
+
+. To verify that the catalog source is applied, check for the `READY` state by using the following command:
++
+[source,terminal]
+----
+$ oc describe catalogsources.operators.coreos.com -n openshift-marketplace operatorhubio-catalog
+----
++
+.Example output
+[source,terminal]
+----
+Name:         operatorhubio-catalog
+Namespace:    openshift-marketplace
+Labels:       <none>
+Annotations:  <none>
+API Version:  operators.coreos.com/v1alpha1
+Kind:         CatalogSource
+Metadata:
+  Creation Timestamp:  2024-01-31T09:55:31Z
+  Generation:          1
+  Resource Version:    1212
+  UID:                 4edc1a96-83cd-4de9-ac8c-c269ca895f3e
+Spec:
+  Display Name:  Community Operators
+  Grpc Pod Config:
+    Security Context Config:  restricted
+  Image:                      quay.io/operatorhubio/catalog:latest
+  Publisher:                  OperatorHub.io
+  Source Type:                grpc
+  Update Strategy:
+    Registry Poll:
+      Interval:  60m
+Status:
+  Connection State:
+    Address:              operatorhubio-catalog.openshift-marketplace.svc:50051
+    Last Connect:         2024-01-31T09:55:57Z
+    Last Observed State:  READY <1>
+  Registry Service:
+    Created At:         2024-01-31T09:55:31Z
+    Port:               50051
+    Protocol:           grpc
+    Service Name:       operatorhubio-catalog
+    Service Namespace:  openshift-marketplace
+Events:                 <none>
+----
+<1> The status is reported as `READY`.
+
+. Confirm that the catalog source is running by using the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-marketplace -l olm.catalogSource=operatorhubio-catalog
+----
++
+.Example output
+[source,terminal]
+----
+NAME                          READY   STATUS    RESTARTS   AGE
+operatorhubio-catalog-x24nh   1/1     Running   0          59s
+----
+
+. Create a Subscription CR configuration file by using the following example YAML:
++
+.Example Subscription custom resource YAML
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: my-cert-manager
+  namespace: openshift-operators
+spec:
+  channel: stable
+  name: cert-manager
+  source: operatorhubio-catalog
+  sourceNamespace: openshift-marketplace <1>
+----
+<1> The global namespace. Setting the `sourceNamespace` value to `openshift-marketplace` enables Operators to run in multiple namespaces if the catalog also runs in the `openshift-marketplace` namespace.
+
+. Apply the Subscription CR configuration by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f _<my-subscription-cr.yaml>_ <1>
+----
+<1> Replace _<my-subscription-cr.yaml>_ with your Subscription CR filename. In this example, `sub.yaml` is used.
++
+.Example output
+[source,terminal]
+----
+subscription.operators.coreos.com/my-cert-manager created
+----
+
+. You can create a configuration file for the specific Operand you want to use and apply it now.
+
+.Verification
+. Verify that your Operator is running by using the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-operators <1>
+----
+<1> The namespace from the Subscription CR is used.
++
+[NOTE]
+====
+Allow a minute or two for the Operator start.
+====
++
+.Example output
+[source,terminal]
+----
+NAME                                       READY   STATUS    RESTARTS   AGE
+cert-manager-7df8994ddb-4vrkr              1/1     Running   0          19s
+cert-manager-cainjector-5746db8fd7-69442   1/1     Running   0          18s
+cert-manager-webhook-f858bf58b-748nt       1/1     Running   0          18s
+----

--- a/modules/microshift-olm-deploy-ops-spec-ns.adoc
+++ b/modules/microshift-olm-deploy-ops-spec-ns.adoc
@@ -1,0 +1,251 @@
+//Module included in the following assemblies:
+//
+//* microshift_running_apps/microshift-operators-olm.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-OLM-deploy-Operators-specific-namespace_{context}"]
+= Adding OLM-based Operators to a networked cluster in a specific namespace
+
+Use this procedure if you want to specify a namespace for an Operator, for example, `olm-microshift`. In this example, the catalog is scoped and available in the global `openshift-marketplace` namespace. The Operator uses content from the global namespace, but runs only in the `olm-microshift` namespace. For {microshift-short} clusters that have network connectivity, Operator Lifecycle Manager (OLM) can access sources hosted on remote registries.
+
+[IMPORTANT]
+====
+All of the Operators installed in a specific namespace must have the same watch scope. In this case, the watch scope is *OwnNamespace*.
+====
+
+.Prerequisites
+* The {oc-first} is installed.
+* Operator Lifecycle Manager (OLM) is installed.
+* You have created a custom catalog that is running in the global namespace.
+
+.Procedure
+
+. Confirm that OLM is running by using the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-operator-lifecycle-manager get pod -l app=olm-operator
+----
++
+.Example output
+[source,terminal]
+----
+NAME                           READY   STATUS    RESTARTS   AGE
+olm-operator-85b5c6786-n6kbc   1/1     Running   0          16m
+----
+
+. Confirm that the OLM catalog Operator is running by using the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-operator-lifecycle-manager get pod -l app=catalog-operator
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                READY   STATUS    RESTARTS   AGE
+catalog-operator-5fc7f857b6-tj8cf   1/1     Running   0          16m
+----
+
+. Create a namespace by using the following example YAML:
++
+.Example namespace YAML
+[source,YAML]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: olm-microshift
+----
++
+. Apply the namespace configuration using the following command:
++
+----
+$ oc apply -f _<ns.yaml>_ <1>
+----
+<1> Replace _<ns.yaml>_ with the name of your namespace configuration file. In this example, `olm-microshift` is used.
++
+.Example output
+[source,terminal]
+----
+namespace/olm-microshift created
+----
+
+. Create the Operator group YAML by using the following example YAML:
++
+.Example Operator group YAML
+[source,yaml]
+----
+kind: OperatorGroup
+apiVersion: operators.coreos.com/v1
+metadata:
+  name: og
+  namespace: olm-microshift
+spec: <1>
+  targetNamespaces:
+  - olm-microshift
+----
+<1> For Operators using the global namespace, omit the `spec.targetNamespaces` field and values.
+
+. Apply the Operator group configuration by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f _<og.yaml>_ <1>
+----
+<1> Replace _<og.yaml>_ with the name of your operator group configuration file.
++
+.Example output
+[source,terminal]
+----
+operatorgroup.operators.coreos.com/og created
+----
+
+. Create the `CatalogSource` object by using the following example YAML:
++
+.Example catalog source YAML
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: operatorhubio-catalog
+  namespace: openshift-marketplace <1>
+spec:
+  sourceType: grpc
+  image: quay.io/operatorhubio/catalog:latest
+  displayName: Community Operators <2>
+  publisher: OperatorHub.io
+  grpcPodConfig:
+    securityContextConfig: restricted <3>
+  updateStrategy:
+    registryPoll:
+      interval: 60m
+----
+<1> The global namespace. Setting the `metadata.namespace` to `openshift-marketplace` enables the catalog to run in all namespaces. Subscriptions CRs in any namespace can reference catalogs created in the `openshift-marketplace` namespace.
+<2> Community Operators are not installed by default with OLM for {microshift-short}. Listed here for example only.
+<3> The value of `securityContextConfig` must be set to `restricted` for {microshift-short}.
+
+. Apply the `CatalogSource` configuration by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f _<my-catalog-source.yaml>_ <1>
+----
+<1> Replace _<my-catalog-source.yaml>_ with your catalog source configuration file name.
+
+. To verify that the catalog source is applied, check for the `READY` state by using the following command:
++
+[source,terminal]
+----
+$ oc describe catalogsources.operators.coreos.com -n openshift-marketplace operatorhubio-catalog
+----
++
+.Example output
+[source,terminal]
+----
+Name:         operatorhubio-catalog
+Namespace:    openshift-marketplace
+Labels:       <none>
+Annotations:  <none>
+API Version:  operators.coreos.com/v1alpha1
+Kind:         CatalogSource
+Metadata:
+  Creation Timestamp:  2024-01-31T10:09:46Z
+  Generation:          1
+  Resource Version:    2811
+  UID:                 60ce4a36-86d3-4921-b9fc-84d67c28df48
+Spec:
+  Display Name:  Community Operators
+  Grpc Pod Config:
+    Security Context Config:  restricted
+  Image:                      quay.io/operatorhubio/catalog:latest
+  Publisher:                  OperatorHub.io
+  Source Type:                grpc
+  Update Strategy:
+    Registry Poll:
+      Interval:  60m
+Status:
+  Connection State:
+    Address:              operatorhubio-catalog.openshift-marketplace.svc:50051
+    Last Connect:         2024-01-31T10:10:04Z
+    Last Observed State:  READY <1>
+  Registry Service:
+    Created At:         2024-01-31T10:09:46Z
+    Port:               50051
+    Protocol:           grpc
+    Service Name:       operatorhubio-catalog
+    Service Namespace:  openshift-marketplace
+Events:                 <none>
+----
+<1> The status is reported as `READY`.
+
+. Confirm that the catalog source is running by using the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-marketplace -l olm.catalogSource=operatorhubio-catalog
+----
++
+.Example output
+[source,terminal]
+----
+NAME                          READY   STATUS    RESTARTS   AGE
+operatorhubio-catalog-j7sc8   1/1     Running   0          43s
+----
+
+. Create a Subscription CR configuration file by using the following example YAML:
++
+.Example Subscription custom resource YAML
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: my-gitlab-operator-kubernetes
+  namespace: olm-microshift <1>
+spec:
+  channel: stable
+  name: gitlab-operator-kubernetes
+  source: operatorhubio-catalog
+  sourceNamespace: openshift-marketplace <2>
+----
+<1> The specific namespace. Operators reference the global namespace for content, but run in the `olm-microshift` namespace.
+<2> The global namespace. Subscriptions CRs in any namespace can reference catalogs created in the `openshift-marketplace` namespace.
+
+. Apply the Subscription CR configuration by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f _<my-subscription-cr.yaml>_
+----
++
+.Example output
+[source,terminal]
+----
+subscription.operators.coreos.com/my-gitlab-operator-kubernetes
+----
+
+. You can create a configuration file for the specific Operand you want to use and apply it now.
+
+.Verification
+. Verify that your Operator is running by using the following command:
++
+[source,terminal]
+----
+$ oc get pods -n olm-microshift <1>
+----
+<1> The namespace from the Subscription CR is used.
++
+[NOTE]
+====
+Allow a minute or two for the Operator start.
+====
++
+.Example output
+[source,terminal]
+----
+NAME                                         READY   STATUS    RESTARTS   AGE
+gitlab-controller-manager-69bb6df7d6-g7ntx   2/2     Running   0          3m24s
+----

--- a/modules/microshift-olm-namespaces.adoc
+++ b/modules/microshift-olm-namespaces.adoc
@@ -1,0 +1,34 @@
+//Module included in the following assemblies:
+//
+//* microshift_running_apps/microshift-operators-olm.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-olm-namespaces_{context}"]
+= Namespace use in {microshift-short}
+
+The `microshift-olm` RPM creates the three default namespaces: one for running OLM, and two for catalog and Operator installation. You can create additional namespaces as needed for your use case.
+
+[id="microshift-olm-default-namespaces_{context}"]
+== Default namespaces
+
+The following table lists the default namespaces and a brief description of how each namespace works.
+
+.Default namespaces created by OLM for {microshift-short}
+[cols="2",%autowidth]
+|===
+|*Default Namespace*
+|*Details*
+
+|`openshift-operator-lifecycle-manager`
+|The OLM package manager runs in this namespace.
+
+|`openshift-marketplace`
+|The global namespace. Empty by default. To make the catalog source to be available globally to users in all namespaces, set the `openshift-marketplace` namespace in the catalog-source YAML.
+
+|`openshift-operators`
+|The default namespace where Operators run in {microshift-short}. Operators that reference catalogs in the `openshift-operators` namespace must have the *AllNamespaces* watch scope.
+|===
+
+[id="microshift-olm-custom-namespace_{context}"]
+== Custom namespaces
+If you want to use a catalog and Operator together in a single namespace, then you must create a custom namespace. After you create the namespace, you must create the catalog in that namespace. All Operators running in the custom namespace must have the same single-namespace watch scope.


### PR DESCRIPTION
Version(s):
4.15+

Issue:
[OSDOCS-8991](https://issues.redhat.com/browse/OSDOCS-8991)

Link to docs preview:
[How Operators work with MicroShift](https://70128--ocpdocs-pr.netlify.app/microshift/latest/microshift_running_apps/microshift-operators#operators-installation-paths_operators-microshift)
[Using OLM with MicroShift](https://70128--ocpdocs-pr.netlify.app/microshift/latest/microshift_running_apps/microshift-operators-olm)
[xref in Install with RPMs](https://70128--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-install-rpm#microshift-installing-with-olm-from-rpm-package_microshift-install-rpm)
[xref in Add to Blueprint](https://70128--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree#microshift-adding-olm-to-blueprint_microshift-embed-in-rpm-ostree)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[Install updates for OLM](https://github.com/openshift/openshift-docs/pull/70359)
SME and PM LGTM 2 Feb 2024

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
