### PR TITLE
OBSDOCS-721: add Vector to monitoring components list

### DIFF
--- a/modules/monitoring-default-monitoring-targets.adoc
+++ b/modules/monitoring-default-monitoring-targets.adoc
@@ -27,6 +27,7 @@ endif::openshift-dedicated,openshift-rosa[]
 * OpenShift API server
 * OpenShift Controller Manager
 * Operator Lifecycle Manager (OLM)
+* Vector (if Logging is installed)
 
 ifndef::openshift-dedicated,openshift-rosa[]
 [NOTE]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-721
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://70134--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/monitoring-overview#default-monitoring-targets_monitoring-overview
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Adds the Vector collector component for logging to the list of default  targets monitored by the in-cluster monitoring stack.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
