### PR TITLE
OSDOCS-8924: update RHDE page for MicroShift 4.15

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -13,8 +13,8 @@
 :op-system-version: 9.2
 :op-system-version-major: 9
 :microshift-first: Red Hat build of MicroShift
-:microshift: Red Hat build of MicroShift
+:microshift: MicroShift
 //removing short form of MicroShift pending approval of use
-:microshift-version: 4.14
+:microshift-version: 4.15
 :ansible: Red Hat Ansible Automation Platform
 :ansible-version: 2.4

--- a/modules/about-rhde.adoc
+++ b/modules/about-rhde.adoc
@@ -23,7 +23,9 @@ The latest release notes for each product that is part of {product-title} are av
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/{microshift-version}/html/release_notes/index[{microshift-first}]
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/{op-system-version-major}/html/9.2_release_notes/index[{op-system-ostree-first}] release notes contain details about {op-system-ostree}
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/{op-system-version-major}/html/9.2_release_notes/index[{op-system-ostree-first}] 9.2 release notes contain details about {op-system-ostree}
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/{op-system-version-major}/html/9.3_release_notes/index[{op-system-ostree-first}] 9.3 release notes contain details about {op-system-ostree}
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{ansible-version}/html/red_hat_ansible_automation_platform_release_notes/index[{ansible} Release Notes]
 
@@ -39,7 +41,12 @@ The latest release notes for each product that is part of {product-title} are av
 ^|*{microshift} release status*
 ^|*{microshift} supported updates*
 
-^|9.2
+^|9.2, 9.3
+^|4.15
+^|Generally Available
+^|4.15.0&#8594;4.15.z and 4.14&#8594;future minor version
+
+^|9.2, 9.3
 ^|4.14
 ^|Generally Available
 ^|4.14.0&#8594;4.14.z and 4.14&#8594;4.15
@@ -67,7 +74,7 @@ The latest release notes for each product that is part of {product-title} are av
 
 For more information about the {product-title} products, see the following documentation:
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/4.14[Red Hat build of MicroShift]
+* link:https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/{microshift-version}[Red Hat build of MicroShift]
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/{op-system-version-major}/html/composing_installing_and_managing_rhel_for_edge_images/index[Composing, installing, and managing RHEL for Edge images]
 


### PR DESCRIPTION
Version(s):
N/A (no CPs, version "4" is for Pantheon only; versionless branch in the repo)
Can be merged, but Pantheon sync is EMBARGOED for after OCP 4.15 GA when the rest of the docs are published.

Issue:
[OSDOCS-8924](https://issues.redhat.com/browse/OSDOCS-8924)

Link to docs preview:
[Red Hat Device Edge release notes and compatibility](https://70143--docspreview.netlify.app/openshift-rhde/latest/overview/rhde-overview#device-edge-relnotes_device-edge-overview)

QE review:
- N/A

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
