### PR TITLE
OSDOCS#9312: Catalogd doesn't support global pull secrets admonition

### DIFF
--- a/snippets/olmv1-secure-registry-pull-secret.adoc
+++ b/snippets/olmv1-secure-registry-pull-secret.adoc
@@ -1,8 +1,17 @@
 // Text snippet included in the following modules:
 //
-// * modules/olmv1-operator-api.adoc
+// * modules/olmv1-adding-a-catalog.adoc
+// * modules/olmv1-creating-a-pull-secret-for-catalogd.adoc
+// * modules/olmv1-red-hat-catalogs.adoc
 
 :_mod-docs-content-type: SNIPPET
 
 If you want to use a catalog that is hosted on a secure registry, such as Red Hat-provided Operator catalogs from `registry.redhat.io`, you must have a pull secret scoped to the `openshift-catalogd` namespace.
 ifndef::olmv1-pullsecret-proc[For more information, see "Creating a pull secret for catalogs hosted on a secure registry".]
+
+ifdef::olmv1-pullsecret-proc[]
+[NOTE]
+====
+Currently, catalogd cannot read global pull secrets from {product-title} clusters. Catalogd can read references to secrets only in the namespace where it is deployed.
+====
+endif::[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-9312](https://issues.redhat.com//browse/OSDOCS-9312)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
* [Creating a pull secret for catalogs hosted on a secure registry](https://70147--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/olm_v1/olmv1-installing-an-operator-from-a-catalog#olmv1-creating-a-pull-secret-for-catalogs-secure-registry_olmv1-installing-operator) (the NOTE is present here)
* [Red Hat-provided Operator catalogs in OLM 1.0](https://70147--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/olm_v1/olmv1-installing-an-operator-from-a-catalog#olmv1-red-hat-catalogs_olmv1-installing-operator) (the NOTE is intentionally not present here)
* [Installing an Operator from a catalog](https://70147--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/olm_v1/olmv1-installing-an-operator-from-a-catalog#olmv1-adding-a-catalog-to-a-cluster_olmv1-installing-operator) (NOTE is intentionally not present here)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Adds a NOTE admonition to the tech preview OLM 1.0 docs in the procedure for adding a pull secret to the catalogd namespace. This admonition is part of a snippet that will likely be removed in the next release or before GA. As a result, the admonition uses conditionals to only render the admonition in the appropriate place. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
