### PR TITLE
GH70054: Removed EUS mentions from OKD update docs

### DIFF
--- a/modules/gathering-log-data.adoc
+++ b/modules/gathering-log-data.adoc
@@ -6,4 +6,4 @@
 [id="gathering-log-data_{context}"]
 = Gathering log data for a support case
 
-To gather data from your cluster, including log data, use the `oc adm must-gather` command. See _Gathering data about your cluster for Red Hat Support_.
+To gather data from your cluster, including log data, use the `oc adm must-gather` command. See _Gathering data about your cluster_.

--- a/modules/migrating-to-multi-arch-cli.adoc
+++ b/modules/migrating-to-multi-arch-cli.adoc
@@ -36,6 +36,7 @@ $ oc adm upgrade
 +
 For more information about cluster version condition types, see _Understanding cluster version condition types_.
 
+ifndef::openshift-origin[]
 . If the condition `RetrievedUpdates` is `False`, change the channel to `stable-<4.y>` or `fast-<4.y>` with the following command:
 +
 [source,terminal]
@@ -46,6 +47,7 @@ $ oc adm upgrade channel <channel>
 After setting the channel, verify if `RetrievedUpdates` is `True`.
 +
 For more information about channels, see _Understanding update channels and releases_.
+endif::openshift-origin[]
 
 . Migrate to the multi-architecture payload with following command:
 +

--- a/modules/update-upgrading-cli.adoc
+++ b/modules/update-upgrading-cli.adoc
@@ -30,35 +30,52 @@ you want to apply:
 $ oc adm upgrade
 ----
 +
+ifndef::openshift-origin[]
 .Example output
 [source,terminal]
 ----
-$ oc adm upgrade
 Cluster version is 4.13.10
-
 Upstream is unset, so the cluster will use an appropriate default.
 Channel: stable-4.13 (available channels: candidate-4.13, candidate-4.14, fast-4.13, stable-4.13)
-
 Recommended updates:
-
   VERSION     IMAGE
   4.13.14     quay.io/openshift-release-dev/ocp-release@sha256:406fcc160c097f61080412afcfa7fd65284ac8741ac7ad5b480e304aba73674b
   4.13.13     quay.io/openshift-release-dev/ocp-release@sha256:d62495768e335c79a215ba56771ff5ae97e3cbb2bf49ed8fb3f6cefabcdc0f17
   4.13.12     quay.io/openshift-release-dev/ocp-release@sha256:73946971c03b43a0dc6f7b0946b26a177c2f3c9d37105441315b4e3359373a55
   4.13.11     quay.io/openshift-release-dev/ocp-release@sha256:e1c2377fdae1d063aaddc753b99acf25972b6997ab9a0b7e80cfef627b9ef3dd
 ----
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+.Example output
+[source,terminal]
+----
+Cluster version is 4.13.0-0.okd-2023-10-28-065448
+
+Upstream: https://amd64.origin.releases.ci.openshift.org/graph
+Channel: stable-4
+
+Recommended updates:
+
+  VERSION                        IMAGE
+  4.14.0-0.okd-2024-01-06-084517 registry.ci.openshift.org/origin/release@sha256:c4a6b6850701202f629c0e451de784b02f0de079650a1b9ccbf610448ebc9227
+  4.14.0-0.okd-2023-11-14-101924 registry.ci.openshift.org/origin/release@sha256:72d40c51e7c4d1b9c31e9b0d276d045f1b2b93def5ecee49186df856d40bcb5c
+  4.14.0-0.okd-2023-11-12-042703 registry.ci.openshift.org/origin/release@sha256:2242d1df4e4cbcc0cd27191ab9ad5f55ac4f0c60c3cda2a186181a2435e3bd00
+  4.14.0-0.okd-2023-10-28-073550 registry.ci.openshift.org/origin/release@sha256:7a6200e347a1b857e47f2ab0735eb1303af7d796a847d79ef9706f217cd12f5c
+----
+endif::openshift-origin[]
 +
 [NOTE]
 ====
 * If there are no available updates, updates that are supported but not recommended might still be available.
 See _Updating along a conditional update path_ for more information.
-
+ifndef::openshift-origin[]
 * For details and information on how to perform an `EUS-to-EUS` channel update, please refer to the _Preparing to perform an EUS-to-EUS upgrade_ page, listed in the Additional resources section.
+endif::openshift-origin[]
 ====
-
+ifndef::openshift-origin[]
 . Based on your organization requirements, set the appropriate update channel. For example, you can set your channel to `stable-4.13` or `fast-4.13`. For more information about channels, refer to _Understanding update channels and releases_ listed in the Additional resources section.
+// In OKD, no need to set the channel.
 //this example will need to be updated per eus release to reflect options available
-
 +
 [source,terminal]
 ----
@@ -86,6 +103,7 @@ Update recommendations can change over time, as they are based on what update op
 
 If you cannot see an update path to your target minor version, keep updating your cluster to the latest patch release for your current version until the next minor version is available in the path.
 ====
+endif::openshift-origin[]
 
 . Apply an update:
 ** To update to the latest version:

--- a/updating/troubleshooting_updates/gathering-data-cluster-update.adoc
+++ b/updating/troubleshooting_updates/gathering-data-cluster-update.adoc
@@ -6,7 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+ifndef::openshift-origin[]
 When reaching out to Red Hat support for issues with an update, it is important to provide data for the support team to use for troubleshooting your failed cluster update.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+If your cluster update fails, you can examine cluster data to troubleshoot the failure.
+endif::openshift-origin[]
 
 include::modules/gathering-log-data.adoc[leveloffset=+1]
 
@@ -14,4 +19,4 @@ include::modules/gathering-log-data.adoc[leveloffset=+1]
 [id="additional-resources_gathering-cluster-data"]
 .Additional resources
 
-* xref:../../support/gathering-cluster-data.adoc#support_gathering_data_gathering-cluster-data[Gathering data about your cluster for Red Hat Support]
+* xref:../../support/gathering-cluster-data.adoc#support_gathering_data_gathering-cluster-data[Gathering data about your cluster]

--- a/updating/updating_a_cluster/updating-cluster-cli.adoc
+++ b/updating/updating_a_cluster/updating-cluster-cli.adoc
@@ -59,9 +59,13 @@ include::modules/update-upgrading-cli.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
+ifndef::openshift-origin[]
 * xref:../../updating/updating_a_cluster/eus-eus-update.adoc#eus-eus-update[Performing an EUS-to-EUS update]
+endif::openshift-origin[]
 * xref:../../updating/updating_a_cluster/updating-cluster-cli.adoc#update-conditional-upgrade-pathupdating-cluster-cli[Updating along a conditional update path]
+ifndef::openshift-origin[]
 * xref:../../updating/understanding_updates/understanding-update-channels-release.adoc#understanding-update-channels-releases[Understanding update channels and releases]
+endif::openshift-origin[]
 
 // Updating along a conditional update path
 include::modules/update-conditional-updates.adoc[leveloffset=+1]


### PR DESCRIPTION
Remove references to eus-to-eus updates in OKD documentation and a few other changes.

Issues:[
GH70054: Removed EUS mentions from OKD update docs](https://github.com/openshift/openshift-docs/issues/70054)

Previews:
* Troubleshooting -> **Gathering data about your cluster update** -- Removed references to RH Support and changed link text to match the assembly.
** [OKD](https://file.rdu.redhat.com/mburke/okd-remove-eus-update/updating/troubleshooting_updates/gathering-data-cluster-update.html)
** [OCP](https://70149--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/troubleshooting_updates/gathering-data-cluster-update)
* Performing a cluster update -> **Migrating to a cluster with multi-architecture compute machines** -- Hid the step to set the update channel (step 2 in OCP), not required in OKD.
** [OKD](https://file.rdu.redhat.com/mburke/okd-remove-eus-update/updating/updating_a_cluster/migrating-to-multi-payload.html#migrating-to-multi-arch-cli_updating-clusters-overview)
** [OCP](https://70149--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/migrating-to-multi-payload#migrating-to-multi-arch-cli_updating-clusters-overview)
* Performing a cluster update -> **Updating a cluster by using the CLI** -- Added OKD command output, hid cross-ref to EUS update topic, hid the step to set the update channel, not required in OKD.
** [OKD](https://file.rdu.redhat.com/mburke/okd-remove-eus-update/updating/updating_a_cluster/updating-cluster-cli.html#update-upgrading-cli_updating-cluster-cli)
** [OCP](https://70149--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-cluster-cli#update-upgrading-cli_updating-cluster-cli)
* **Performing an EUS-to-EUS update** -- Hid assembly in OKD, not applicable.
** [OKD](https://file.rdu.redhat.com/mburke/okd-remove-eus-update/updating/updating_a_cluster/updating-cluster-web-console.html) (assembly not present in TOC after _Updating a cluster using the web console_)
** [OCP](https://70149--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/eus-eus-update)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->