### PR TITLE
RHDEVDOCS-5865: To correct the component ID in the bug reporting URL …

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -375,7 +375,7 @@
             </span>
           </a>
           <% unless (unsupported_versions_builds.include? version) %>
-            <a href="https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12317820&issuetype=1&components=12332358&priority=4&summary=<%= "[build-docs-#{version}]+Issue+in+file+#{repo_path}"%>">
+            <a href="https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12317820&issuetype=1&components=12393741&priority=4&summary=<%= "[build-docs-#{version}]+Issue+in+file+#{repo_path}"%>">
               <span class="material-icons-outlined" title="Open an issue">bug_report
               </span>
             </a>


### PR DESCRIPTION
**Purpose**: To resolve this issue: https://issues.redhat.com/browse/RHDEVDOCS-5865

**Aligned team**: DevTools

**Version** : main only

**Context**:  The bug reporting URL for the[ Builds doc](https://docs.openshift.com/builds/1.0/about/overview-openshift-builds.html) was not correct and showed pipelines as the selected component. The bug reporting URL is now updated to point to the Builds component, that is, (Builds) Shipwright: https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12317820&issuetype=1&components=12393741&priority=4

![Screenshot 2024-01-10 at 12 21 45](https://github.com/openshift/openshift-docs/assets/94683525/5832ccf5-5a73-4ab0-a893-42e5f78fc886)


**SME review**:  NA

**QE review**:  NA

**Peer review**:  @xenolinux 