### PR TITLE
OCPBUGS#5913: The string host is removed from any file paths in the i…

### DIFF
--- a/modules/images-configuration-allowed.adoc
+++ b/modules/images-configuration-allowed.adoc
@@ -59,7 +59,7 @@ status:
 Either the `allowedRegistries` parameter or the `blockedRegistries` parameter can be set, but not both.
 ====
 +
-The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` resource for any changes to the registries. When the MCO detects a change, it drains the nodes, applies the change, and uncordons the nodes. After the nodes return to the `Ready` state, the allowed registries list is used to update the image signature policy in the `/host/etc/containers/policy.json` file on each node.
+The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` resource for any changes to the registries. When the MCO detects a change, it drains the nodes, applies the change, and uncordons the nodes. After the nodes return to the `Ready` state, the allowed registries list is used to update the image signature policy in the `/etc/containers/policy.json` file on each node.
 
 ifndef::openshift-rosa,openshift-dedicated[]
 .Verification
@@ -83,14 +83,14 @@ NAME               STATUS   ROLES                  AGE   VERSION
 +
 [source,terminal]
 ----
-$ oc debug node/<node_name> 
+$ oc debug node/<node_name>
 ----
 
-. When prompted, enter `chroot/host` into the terminal:
+. When prompted, enter `chroot /host` into the terminal:
 +
 [source,terminal]
 ----
-sh-4.4# chroot/host
+sh-4.4# chroot /host
 ----
 
 . Enter the following command to check that the registries have been added to the policy file:

--- a/modules/images-configuration-blocked.adoc
+++ b/modules/images-configuration-blocked.adoc
@@ -80,14 +80,14 @@ NAME                STATUS   ROLES                  AGE   VERSION
 +
 [source,terminal]
 ----
-$ oc debug node/<node_name> 
+$ oc debug node/<node_name>
 ----
 
-. When prompted, enter `chroot/host` into the terminal:
+. When prompted, enter `chroot /host` into the terminal:
 +
 [source,terminal]
 ----
-sh-4.4# chroot/host
+sh-4.4# chroot /host
 ----
 
 . Enter the following command to check that the registries have been added to the policy file:

--- a/modules/images-configuration-insecure.adoc
+++ b/modules/images-configuration-insecure.adoc
@@ -73,7 +73,7 @@ ifndef::openshift-rosa,openshift-dedicated[]
 +
 [source,terminal]
 ----
-$ cat /host/etc/containers/registries.conf
+$ cat /etc/containers/registries.conf
 ----
 +
 The following example indicates that images from the `insecure.com` registry is insecure and is allowed for image pulls and pushes.

--- a/modules/images-configuration-shortname.adoc
+++ b/modules/images-configuration-shortname.adoc
@@ -31,7 +31,7 @@ Potentially add the last line to the Ignoring image registry repository mirrorin
 ////
 ====
 
-The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` resource for any changes to the registries. When the MCO detects a change, it drains the nodes, applies the change, and uncordons the nodes. After the nodes return to the `Ready` state, if the `containerRuntimeSearchRegistries` parameter is added, the MCO creates a file in the `/etc/containers/registries.conf.d` directory on each node with the listed registries. The file overrides the default list of unqualified search registries in the `/host/etc/containers/registries.conf` file. There is no way to fall back to the default list of unqualified search registries.
+The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` resource for any changes to the registries. When the MCO detects a change, it drains the nodes, applies the change, and uncordons the nodes. After the nodes return to the `Ready` state, if the `containerRuntimeSearchRegistries` parameter is added, the MCO creates a file in the `/etc/containers/registries.conf.d` directory on each node with the listed registries. The file overrides the default list of unqualified search registries in the `/etc/containers/registries.conf` file. There is no way to fall back to the default list of unqualified search registries.
 
 The `containerRuntimeSearchRegistries` parameter works only with the Podman and CRI-O container engines. The registries in the list can be used only in pod specs, not in builds and image streams.
 
@@ -112,21 +112,21 @@ NAME                STATUS   ROLES                  AGE   VERSION
 +
 [source,terminal]
 ----
-$ oc debug node/<node_name> 
+$ oc debug node/<node_name>
 ----
 
-. When prompted, enter `chroot/host` into the terminal:
+. When prompted, enter `chroot /host` into the terminal:
 +
 [source,terminal]
 ----
-sh-4.4# chroot/host
+sh-4.4# chroot /host
 ----
 
 . Enter the following command to check that the registries have been added to the policy file:
 +
 [source,terminal]
 ----
-sh-5.1# cat /etc/containers/registries.conf.d/01-image-searchRegistries.conf 
+sh-5.1# cat /etc/containers/registries.conf.d/01-image-searchRegistries.conf
 ----
 +
 .Example output


### PR DESCRIPTION
Version(s):
4.11, 4.12, 4.13, 4.14, 4.15

Issue:
[OCPBUGS-5913](https://issues.redhat.com/browse/OCPBUGS-5913)

Link to docs preview:
https://70161--ocpdocs-pr.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration

QE review:
- [x] QE approval required.
