### PR TITLE
[OSDOCS-9319] ROSA CLI 1.2.33 release what's new

### DIFF
--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -13,6 +13,11 @@ toc::[]
 [id="rosa-new-changes-and-updates_{context}"]
 == New changes and updates
 
+[id="rosa-q1-2024_{context}"]
+=== Q1 2024
+
+* **ROSA CLI update.** The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/tag/v1.2.33[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-about_rosa-getting-started-cli[About the ROSA CLI].
+
 [id="rosa-q4-2023_{context}"]
 === Q4 2023
 


### PR DESCRIPTION
[OSDOCS-9319] ROSA CLI 1.2.33 release what's new

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-9319

Link to docs preview:
https://70164--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes#rosa-q1-2024_rosa-whats-new

QE review:
- [x] No QE needed.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
