### PR TITLE
OCPBUGS-17935: Updated example output with correct cpuset config

### DIFF
--- a/modules/ztp-sno-du-enabling-workload-partitioning.adoc
+++ b/modules/ztp-sno-du-enabling-workload-partitioning.adoc
@@ -47,7 +47,7 @@ Check that the applications and cluster system CPU pinning is correct. Run the f
 $ oc debug node/example-sno-1
 ----
 
-. Check that the user applications CPU pinning is correct:
+. Check that the OpenShift infrastructure applications CPU pinning is correct:
 +
 [source,terminal]
 ----
@@ -57,13 +57,13 @@ sh-4.4# pgrep ovn | while read i; do taskset -cp $i; done
 .Example output
 [source,terminal]
 ----
-pid 8481's current affinity list: 0-3
-pid 8726's current affinity list: 0-3
-pid 9088's current affinity list: 0-3
-pid 9945's current affinity list: 0-3
-pid 10387's current affinity list: 0-3
-pid 12123's current affinity list: 0-3
-pid 13313's current affinity list: 0-3
+pid 8481's current affinity list: 0-1,52-53
+pid 8726's current affinity list: 0-1,52-53
+pid 9088's current affinity list: 0-1,52-53
+pid 9945's current affinity list: 0-1,52-53
+pid 10387's current affinity list: 0-1,52-53
+pid 12123's current affinity list: 0-1,52-53
+pid 13313's current affinity list: 0-1,52-53
 ----
 
 . Check that the system applications CPU pinning is correct:
@@ -76,8 +76,8 @@ sh-4.4# pgrep systemd | while read i; do taskset -cp $i; done
 .Example output
 [source,terminal]
 ----
-pid 1's current affinity list: 0-3
-pid 938's current affinity list: 0-3
-pid 962's current affinity list: 0-3
-pid 1197's current affinity list: 0-3
+pid 1's current affinity list: 0-1,52-53
+pid 938's current affinity list: 0-1,52-53
+pid 962's current affinity list: 0-1,52-53
+pid 1197's current affinity list: 0-1,52-53
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11, 4.12, 4.13, 4.14, 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-17935
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://70179--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu#ztp-sno-du-enabling-workload-partitioning_sno-configure-for-vdu
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
