### PR TITLE
GH65982 - Add note: cgroupsv2 has different characteristics than cgroupsv1

### DIFF
--- a/installing/install_config/enabling-cgroup-v1.adoc
+++ b/installing/install_config/enabling-cgroup-v1.adoc
@@ -9,7 +9,7 @@ toc::[]
 
 As of {product-title} 4.14, {product-title} uses link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[Linux control group version 2] (cgroup v2) in your cluster. If you are using cgroup v1 on {product-title} 4.13 or earlier, migrating to {product-title} 4.14 will not automatically update your cgroup configuration to version 2. A fresh installation of {product-title} 4.14 will use cgroup v2 by default. However, you can enable link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1/index.html[Linux control group version 1] (cgroup v1) upon installation. Enabling cgroup v1 in {product-title} disables all cgroup v2 controllers and hierarchies in your cluster.
 
-cgroup v2 is the current version of the Linux cgroup API. cgroup v2 offers several improvements over cgroup v1, including a unified hierarchy, safer sub-tree delegation, new features such as link:https://www.kernel.org/doc/html/latest/accounting/psi.html[Pressure Stall Information], and enhanced resource management and isolation.
+include::snippets/cgroupv2-vs-cgroupv1.adoc[]
 
 ifndef::openshift-origin[]
 You can switch between cgroup v1 and cgroup v2, as needed, by editing the `node.config` object. For more information, see "Configuring the Linux cgroup on your nodes" in the "Additional resources" of this section.

--- a/modules/nodes-clusters-cgroups-2.adoc
+++ b/modules/nodes-clusters-cgroups-2.adoc
@@ -26,7 +26,7 @@ endif::post[]
 endif::openshift-origin[]
 
 ifdef::post[]
-cgroup v2 is the current version of the Linux cgroup API. cgroup v2 offers several improvements over cgroup v1, including a unified hierarchy, safer sub-tree delegation, new features such as link:https://www.kernel.org/doc/html/latest/accounting/psi.html[Pressure Stall Information], and enhanced resource management and isolation.
+include::snippets/cgroupv2-vs-cgroupv1.adoc[]
 
 You can change between cgroup v1 and cgroup v2, as needed. Enabling cgroup v1 in {product-title} disables all cgroup v2 controllers and hierarchies in your cluster. 
 endif::post[]

--- a/nodes/clusters/nodes-cluster-cgroups-2.adoc
+++ b/nodes/clusters/nodes-cluster-cgroups-2.adoc
@@ -13,7 +13,7 @@ ifdef::openshift-origin[]
 {product-title} uses link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[Linux control group version 2] (cgroup v2) in your cluster.
 endif::openshift-origin[]
 
-cgroup v2 is the current version of the Linux cgroup API. cgroup v2 offers several improvements over cgroup v1, including a unified hierarchy, safer sub-tree delegation, new features such as link:https://www.kernel.org/doc/html/latest/accounting/psi.html[Pressure Stall Information], and enhanced resource management and isolation.
+include::snippets/cgroupv2-vs-cgroupv1.adoc[]
 
 You can change between cgroup v1 and cgroup v2, as needed. Enabling cgroup v1 in {product-title} disables all cgroup v2 controllers and hierarchies in your cluster. 
 

--- a/snippets/cgroupv2-vs-cgroupv1.adoc
+++ b/snippets/cgroupv2-vs-cgroupv1.adoc
@@ -1,0 +1,10 @@
+// Text snippet included in the following modules:
+//
+// * installing/install-config/enabling-cgroup-v1
+// * modules/configure-web-terminal-image-admin.adoc
+// * modules/configure-web-terminal-timeout-admin.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+cgroup v2 is the current version of the Linux cgroup API. cgroup v2 offers several improvements over cgroup v1, including a unified hierarchy, safer sub-tree delegation, new features such as link:https://www.kernel.org/doc/html/latest/accounting/psi.html[Pressure Stall Information], and enhanced resource management and isolation. However, cgroup v2 has different CPU, memory, and I/O management characteristics than cgroup v1. As such, some workloads might experience slight differences in memory or CPU usage on clusters that run cgroup v2.
+

--- a/snippets/cgroupv2-vs-cgroupv1.adoc
+++ b/snippets/cgroupv2-vs-cgroupv1.adoc
@@ -1,10 +1,10 @@
 // Text snippet included in the following modules:
 //
-// * installing/install-config/enabling-cgroup-v1
-// * modules/configure-web-terminal-image-admin.adoc
-// * modules/configure-web-terminal-timeout-admin.adoc
+// * installing/install-config/enabling-cgroup-v1.adoc
+// * modules/nodes-clusters-cgroups-2.adoc
+// * nodes/clusters/nodes-cluster-cgroups-2.adoc 
 
 :_mod-docs-content-type: SNIPPET
 
-cgroup v2 is the current version of the Linux cgroup API. cgroup v2 offers several improvements over cgroup v1, including a unified hierarchy, safer sub-tree delegation, new features such as link:https://www.kernel.org/doc/html/latest/accounting/psi.html[Pressure Stall Information], and enhanced resource management and isolation. However, cgroup v2 has different CPU, memory, and I/O management characteristics than cgroup v1. As such, some workloads might experience slight differences in memory or CPU usage on clusters that run cgroup v2.
+cgroup v2 is the current version of the Linux cgroup API. cgroup v2 offers several improvements over cgroup v1, including a unified hierarchy, safer sub-tree delegation, new features such as link:https://www.kernel.org/doc/html/latest/accounting/psi.html[Pressure Stall Information], and enhanced resource management and isolation. However, cgroup v2 has different CPU, memory, and I/O management characteristics than cgroup v1. Therefore, some workloads might experience slight differences in memory or CPU usage on clusters that run cgroup v2.
 


### PR DESCRIPTION
Add a sentence here stating something to the affect, cgroupsv2 has different characteristics than cgroupsv1 with CPU, Memory, and IO management. You might see workloads behave slightly differently running on cgroupsv2 with memory or cpu usage than on cgoupsv1.

This PR creates [a new snippet](https://github.com/openshift/openshift-docs/pull/70180/files#diff-a6d56673312c4e16740963af1b6010243dd9650d101738f28f1a34f3e86a7363) from existing and new text.  The first two sentences are existing and the last two are new. 

Issue
https://github.com/openshift/openshift-docs/issues/65982

Previews:
[Enabling Linux control group version 1 (cgroup v1)](https://70180--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/enabling-cgroup-v1)  -- Second paragraph is a new snippet.
[Configuring Linux cgroup](https://70180--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks#nodes-clusters-cgroups-2_post-install-cluster-tasks) -- Second paragraph is a new snippet.
[Configuring the Linux cgroup version on your nodes](https://70180--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-cgroups-2) -- Second paragraph is a new snippet.

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

