### PR TITLE
OCPBUGS#26021: Updated the PreserveBootstrapIgnition in AWS parameter…

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -959,7 +959,7 @@ For clusters that use AWS Local Zones, you must add AWS Local Zone subnets to th
 
 |platform:
   aws:
-    PreserveBootstrapIgnition:
+    preserveBootstrapIgnition:
 |Prevents the S3 bucket from being deleted after completion of bootstrapping.
 |`true` or `false`. The default value is `false`, which results in the S3 bucket being deleted.
 


### PR DESCRIPTION
Version(s):
4.15 and 4.14

Issue:
[OCPBUGS-26021](https://issues.redhat.com/browse/OCPBUGS-26021)

Link to docs preview:
[Optional configuration parameters](https://70186--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installation-config-parameters-aws#installation-configuration-parameters-optional-aws_installation-config-parameters-aws)

SME review:
- [x] SME has approved this change.

QE review:
- [x] QE has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
