### PR TITLE
OSDOCS-9322: Rewriting the steps to modify a compute machine set

### DIFF
--- a/machine_management/modifying-machineset.adoc
+++ b/machine_management/modifying-machineset.adoc
@@ -18,8 +18,5 @@ include::modules/machineset-modifying.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 * xref:../machine_management/deleting-machine.adoc#machine-lifecycle-hook-deletion_deleting-machine[Lifecycle hooks for the machine deletion phase]
-
-[role="_additional-resources"]
-.Additional resources
 * xref:../machine_management/manually-scaling-machineset.adoc#machineset-manually-scaling_manually-scaling-machineset[Scaling a compute machine set manually]
 * xref:../nodes/scheduling/nodes-scheduler-about.adoc#nodes-scheduler-about[Controlling pod placement using the scheduler]

--- a/modules/machineset-modifying.adoc
+++ b/modules/machineset-modifying.adoc
@@ -5,21 +5,25 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="machineset-modifying_{context}"]
-= Modifying a compute machine set
+= Modifying a compute machine set by using the CLI
 
-To make changes to a compute machine set, edit the `MachineSet` YAML. Then, remove all machines associated with the compute machine set by deleting each machine or scaling down the compute machine set to `0` replicas. Then, scale the replicas back to the desired number. Changes you make to a compute machine set do not affect existing machines.
+When you modify a compute machine set, your changes only apply to compute machines that are created after you save the updated `MachineSet` custom resource (CR).
+The changes do not affect existing machines.
+You can replace the existing machines with new ones that reflect the updated configuration by scaling the compute machine set.
 
 If you need to scale a compute machine set without making other changes, you do not need to delete the machines.
 
 [NOTE]
 ====
-By default, the {product-title} router pods are deployed on workers. Because the router is required to access some cluster resources, including the web console, do not scale the compute machine set to `0` unless you first relocate the router pods.
+By default, the {product-title} router pods are deployed on compute machines.
+Because the router is required to access some cluster resources, including the web console, do not scale the compute machine set to `0` unless you first relocate the router pods.
 ====
 
 .Prerequisites
 
-* Install an {product-title} cluster and the `oc` command line.
-* Log in to `oc` as a user with `cluster-admin` permission.
+* Your {product-title} cluster uses the Machine API.
+
+* You are logged in to the cluster as an administrator by using the {oc-first}.
 
 .Procedure
 
@@ -27,69 +31,119 @@ By default, the {product-title} router pods are deployed on workers. Because the
 +
 [source,terminal]
 ----
-$ oc edit machineset <machineset> -n openshift-machine-api
+$ oc edit machineset <machine_set_name> -n openshift-machine-api
 ----
 
-. Scale down the compute machine set to `0` by running one of the following commands:
+. Note the value of the `spec.replicas` field, as you need it when scaling the machine set to apply the changes.
 +
-[source,terminal]
-----
-$ oc scale --replicas=0 machineset <machineset> -n openshift-machine-api
-----
-+
-Or:
-+
-[source,terminal]
-----
-$ oc edit machineset <machineset> -n openshift-machine-api
-----
-+
-[TIP]
-====
-You can alternatively apply the following YAML to scale the compute machine set:
-
 [source,yaml]
 ----
 apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
-  name: <machineset>
+  name: <machine_set_name>
   namespace: openshift-machine-api
 spec:
-  replicas: 0
+  replicas: 2 # <1>
+# ...
 ----
-====
-+
-Wait for the machines to be removed.
+<1> The examples in this procedure show a compute machine set that has a `replicas` value of `2`.
 
-. Scale up the compute machine set as needed by running one of the following commands:
+. Update the compute machine set CR with the configuration options that you want and save your changes.
+
+. List the machines that are managed by the updated compute machine set by running the following command:
 +
 [source,terminal]
 ----
-$ oc scale --replicas=2 machineset <machineset> -n openshift-machine-api
+$ oc get -n openshift-machine-api machines -l machine.openshift.io/cluster-api-machineset=<machine_set_name>
 ----
 +
-Or:
+.Example output
+[source,text]
+----
+NAME                        PHASE     TYPE         REGION      ZONE         AGE
+<machine_name_original_1>   Running   m6i.xlarge   us-west-1   us-west-1a   4h
+<machine_name_original_2>   Running   m6i.xlarge   us-west-1   us-west-1a   4h
+----
+
+. For each machine that is managed by the updated compute machine set, set the `delete` annotation by running the following command:
 +
 [source,terminal]
 ----
-$ oc edit machineset <machineset> -n openshift-machine-api
+$ oc annotate machine/<machine_name_original_1> \
+  -n openshift-machine-api \
+  machine.openshift.io/delete-machine="true"
 ----
-+
-[TIP]
-====
-You can alternatively apply the following YAML to scale the compute machine set:
 
-[source,yaml]
-----
-apiVersion: machine.openshift.io/v1beta1
-kind: MachineSet
-metadata:
-  name: <machineset>
-  namespace: openshift-machine-api
-spec:
-  replicas: 2
-----
-====
+. Scale the compute machine set to twice the number of replicas by running the following command:
 +
-Wait for the machines to start. The new machines contain changes you made to the compute machine set.
+[source,terminal]
+----
+$ oc scale --replicas=4 \// <1>
+  machineset <machine_set_name> \
+  -n openshift-machine-api
+----
+<1> The original example value of `2` is doubled to `4`.
+
+. List the machines that are managed by the updated compute machine set by running the following command:
++
+[source,terminal]
+----
+$ oc get -n openshift-machine-api machines -l machine.openshift.io/cluster-api-machineset=<machine_set_name>
+----
++
+.Example output
+[source,text]
+----
+NAME                        PHASE          TYPE         REGION      ZONE         AGE
+<machine_name_original_1>   Running        m6i.xlarge   us-west-1   us-west-1a   4h
+<machine_name_original_2>   Running        m6i.xlarge   us-west-1   us-west-1a   4h
+<machine_name_updated_1>    Provisioned    m6i.xlarge   us-west-1   us-west-1a   55s
+<machine_name_updated_2>    Provisioning   m6i.xlarge   us-west-1   us-west-1a   55s
+----
++
+When the new machines are in the `Running` phase, you can scale the compute machine set to the original number of replicas.
+
+. Scale the compute machine set to the original number of replicas by running the following command:
++
+[source,terminal]
+----
+$ oc scale --replicas=2 \// <1>
+  machineset <machine_set_name> \
+  -n openshift-machine-api
+----
+<1> The original example value of `2`.
+
+.Verification
+
+* To verify that the compute machines without the updated configuration are deleted, list the machines that are managed by the updated compute machine set by running the following command:
++
+[source,terminal]
+----
+$ oc get -n openshift-machine-api machines -l machine.openshift.io/cluster-api-machineset=<machine_set_name>
+----
++
+.Example output while deletion is in progress
+[source,text]
+----
+NAME                        PHASE           TYPE         REGION      ZONE         AGE
+<machine_name_original_1>   Deleting        m6i.xlarge   us-west-1   us-west-1a   4h
+<machine_name_original_2>   Deleting        m6i.xlarge   us-west-1   us-west-1a   4h
+<machine_name_updated_1>    Running         m6i.xlarge   us-west-1   us-west-1a   5m41s
+<machine_name_updated_2>    Running         m6i.xlarge   us-west-1   us-west-1a   5m41s
+----
++
+.Example output when deletion is complete
+[source,text]
+----
+NAME                        PHASE           TYPE         REGION      ZONE         AGE
+<machine_name_updated_1>    Running         m6i.xlarge   us-west-1   us-west-1a   6m30s
+<machine_name_updated_2>    Running         m6i.xlarge   us-west-1   us-west-1a   6m30s
+----
+
+* To verify that a machine created by the updated machine set has the correct configuration, examine the relevant fields in the CR for one of the new machines by running the following command:
++
+[source,terminal]
+----
+$ oc describe machine <machine_name_updated_1> -n openshift-machine-api
+----


### PR DESCRIPTION
Version(s):
4.11+

Issue:
[OSDOCS-9322](https://issues.redhat.com//browse/OSDOCS-9322)

Link to docs preview:
[Modifying a compute machine set](https://70199--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/modifying-machineset.html#machineset-modifying_modifying-machineset)

QE review:
- [x] QE has approved this change.

Additional information: