### PR TITLE
Fixed formatting issue that caused problems with numbering

### DIFF
--- a/modules/gathering-application-diagnostic-data.adoc
+++ b/modules/gathering-application-diagnostic-data.adoc
@@ -76,9 +76,9 @@ $ oc exec -it my-app-1-akdlg /bin/bash
 Root privileges are required to run some diagnostic binaries. In these situations you can start a debug pod with root access, based on a problematic pod's `DeploymentConfig` object, by running `oc debug dc/<deployment_configuration> --as-root`. Then, you can run diagnostic binaries as root from within the debug pod.
 ====
 
-// cannot create resource "namespaces" in API group
 ifndef::openshift-rosa,openshift-dedicated[]
 . If diagnostic binaries are not available within a container, you can run a host's diagnostic binaries within a container's namespace by using `nsenter`. The following example runs `ip ad` within a container's namespace, using the host`s `ip` binary.
+// cannot create resource "namespaces" in API group
 .. Enter into a debug session on the target node. This step instantiates a debug pod called `<node_name>-debug`:
 +
 [source,terminal]


### PR DESCRIPTION
Noticed that a misplaced comment in a procedure is causing the numbering to restart. 

Preview:

