### PR TITLE
OSDOCS-8767: Adding information about configuring consistent IP

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1399,7 +1399,6 @@ Topics:
     File: uninstalling-sriov-operator
 - Name: OVN-Kubernetes network plugin
   Dir: ovn_kubernetes_network_provider
-  Distros: openshift-origin,openshift-enterprise
   Topics:
   - Name: About the OVN-Kubernetes network plugin
     File: about-ovn-kubernetes

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -993,6 +993,11 @@ Topics:
     File: deleting-network-policy
   - Name: Configuring multitenant isolation with network policy
     File: multitenant-network-policy
+- Name: OVN-Kubernetes network plugin
+  Dir: ovn_kubernetes_network_provider
+  Topics:
+  - Name: Configuring an egress IP address
+    File: configuring-egress-ips-ovn
 - Name: Configuring Routes
   Dir: routes
   Topics:

--- a/cloud_experts_tutorials/cloud-experts-consistent-egress-ip.adoc
+++ b/cloud_experts_tutorials/cloud-experts-consistent-egress-ip.adoc
@@ -78,11 +78,6 @@ The above example uses `jq` as a friendly filter. If you do not have `jq` instal
 
 == Create the egress IP rule(s)
 
-[NOTE]
-====
-Generally speaking, it would be ideal to label the nodes prior to assigning the egress IP addresses, however there is a bug that exists which needs to be fixed first. Once this is fixed, the process and documentation will be re-ordered to address this. See link:https://issues.redhat.com/browse/OCPBUGS-4969[OCPBUGS-4969].
-====
-
 === Identify the egress IPs
 
 Before creating the rules, we should identify which egress IPs that we will use. It should be noted that the egress IPs that you select should exist as a part of the subnets in which the worker nodes are provisioned into.
@@ -97,7 +92,7 @@ Create a project to demonstrate assigning egress IP addresses based on a namespa
 
 [source,terminal]
 ----
-$ oc new-project demo-egress-ns
+$ oc create -f demo-egress-pod.yaml
 ----
 
 Create the egress rule. This rule will ensure that egress traffic will be applied to all pods within the namespace that we just created using the `spec.namespaceSelector` field:

--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -21,17 +21,26 @@ To ensure that you can reliably allow access to the server from only that specif
 
 An egress IP address assigned to a namespace is different from an egress router, which is used to send traffic to specific destinations.
 
-In some cluster configurations, application pods and ingress router pods run on the same node. If you configure an egress IP address for an application project in this scenario, the IP address is not used when you send a request to a route from the application project.
+ifndef::openshift-rosa[]
+In some cluster configurations,
+endif::openshift-rosa[]
+ifdef::openshift-rosa[]
+In {hcp-title} clusters,
+endif::openshift-rosa[]
+application pods and ingress router pods run on the same node. If you configure an egress IP address for an application project in this scenario, the IP address is not used when you send a request to a route from the application project.
 
 ifdef::openshift-sdn[]
 An egress IP address is implemented as an additional IP address on the primary network interface of a node and must be in the same subnet as the primary IP address of the node. The additional IP address must not be assigned to any other node in the cluster.
 endif::openshift-sdn[]
 
+ifndef::openshift-rosa[]
 [IMPORTANT]
 ====
 Egress IP addresses must not be configured in any Linux network configuration files, such as `ifcfg-eth0`.
 ====
+endif::openshift-rosa[]
 
+ifndef::openshift-rosa[]
 [id="nw-egress-ips-platform-support_{context}"]
 == Platform support
 
@@ -54,12 +63,20 @@ Support for the egress IP address functionality on various platforms is summariz
 | Nutanix | Yes
 
 |===
+endif::openshift-rosa[]
 
 [IMPORTANT]
 ====
-The assignment of egress IP addresses to control plane nodes with the EgressIP feature is not supported on a cluster provisioned on Amazon Web Services (AWS). (link:https://bugzilla.redhat.com/show_bug.cgi?id=2039656[*BZ#2039656*])
+The assignment of egress IP addresses to control plane nodes with the EgressIP feature is
+ifdef::openshift-rosa[]
+not supported.
+endif::openshift-rosa[]
+ifndef::openshift-rosa[]
+not supported on a cluster provisioned on Amazon Web Services (AWS). (link:https://bugzilla.redhat.com/show_bug.cgi?id=2039656[*BZ#2039656*]).
+endif::openshift-rosa[]
 ====
 
+ifndef::openshift-rosa[]
 [id="nw-egress-ips-public-cloud-platform-considerations_{context}"]
 == Public cloud platform considerations
 
@@ -93,6 +110,7 @@ endif::openshift-sdn[]
 ====
 When an {rh-openstack} cluster administrator assigns a floating IP to the reservation port, {product-title} cannot delete the reservation port. The `CloudPrivateIPConfig` object cannot perform delete and move operations until an {rh-openstack} cluster administrator unassigns the floating IP from the reservation port.
 ====
+endif::openshift-rosa[]
 
 The following examples illustrate the annotation from nodes on several public cloud providers. The annotations are indented for readability.
 
@@ -108,6 +126,7 @@ cloud.network.openshift.io/egress-ipconfig: [
 ]
 ----
 
+ifndef::openshift-rosa[]
 .Example `cloud.network.openshift.io/egress-ipconfig` annotation on GCP
 [source,yaml]
 ----
@@ -119,6 +138,7 @@ cloud.network.openshift.io/egress-ipconfig: [
   }
 ]
 ----
+endif::openshift-rosa[]
 
 The following sections describe the IP address capacity for supported public cloud environments for use in your capacity calculation.
 
@@ -127,6 +147,7 @@ The following sections describe the IP address capacity for supported public clo
 
 On AWS, constraints on IP address assignments depend on the instance type configured. For more information, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI[IP addresses per network interface per instance type]
 
+ifndef::openshift-rosa[]
 [id="nw-egress-ips-capacity-gcp_{context}"]
 === Google Cloud Platform (GCP) IP address capacity limits
 
@@ -148,11 +169,12 @@ On Azure, the following capacity limits exist for IP address assignment:
 - Per virtual network, the maximum number of assigned IP addresses cannot exceed 65,536.
 
 For more information, see link:https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits?toc=/azure/virtual-network/toc.json#networking-limits[Networking limits].
+endif::openshift-rosa[]
 
 [id="nw-egress-ips-multi-nic-considerations_{context}"]
 == Considerations for using an egress IP on additional network interfaces
 
-In {product-title}, egress IPs provide administrators a way to control network traffic. Egress IPs can be used with the `br-ex`, or primary, network interface, which is a Linux bridge interface associated with Open vSwitch, or they can be used with additional network interfaces. 
+In {product-title}, egress IPs provide administrators a way to control network traffic. Egress IPs can be used with the `br-ex`, or primary, network interface, which is a Linux bridge interface associated with Open vSwitch, or they can be used with additional network interfaces.
 
 You can inspect your network interface type by running the following command:
 
@@ -165,15 +187,16 @@ The primary network interface is assigned a node IP address which also contains 
 
 If the egress IP is not within the subnet of the primary network interface subnet, you can use an egress IP on another Linux network interface that is not of the primary network interface type. By doing so, {product-title} administrators are provided with a greater level of control over networking aspects such as routing, addressing, segmentation, and security policies. This feature provides users with the option to route workload traffic over specific network interfaces for purposes such as traffic segmentation or meeting specialized requirements.
 
-If the egress IP is not within the subnet of the primary network interface, then the selection of another network interface for egress traffic might occur if they are present on a node. 
+If the egress IP is not within the subnet of the primary network interface, then the selection of another network interface for egress traffic might occur if they are present on a node.
 
-You can determine which other network interfaces might support egress IPs by inspecting the `k8s.ovn.org/host-cidrs` Kubernetes node annotation. This annotation contains the addresses and subnet mask found for the primary network interface. It also contains additional network interface addresses and subnet mask information. These addresses and subnet masks are assigned to network interfaces that use the link:https://networklessons.com/cisco/ccna-200-301/longest-prefix-match-routing[longest prefix match routing] mechanism to determine which network interface supports the egress IP. 
+You can determine which other network interfaces might support egress IPs by inspecting the `k8s.ovn.org/host-cidrs` Kubernetes node annotation. This annotation contains the addresses and subnet mask found for the primary network interface. It also contains additional network interface addresses and subnet mask information. These addresses and subnet masks are assigned to network interfaces that use the link:https://networklessons.com/cisco/ccna-200-301/longest-prefix-match-routing[longest prefix match routing] mechanism to determine which network interface supports the egress IP.
 
 [NOTE]
 ====
 OVN-Kubernetes provides a mechanism to control and direct outbound network traffic from specific namespaces and pods. This ensures that it exits the cluster through a particular network interface and with a specific egress IP address.
 ====
 
+ifndef::openshift-rosa[]
 [discrete]
 [id="nw-egress-ips-multi-nic-requirements_{context}"]
 === Requirements for assigning an egress IP to a network interface that is not the primary network interface
@@ -203,7 +226,7 @@ spec:
         ipForwarding: Global
 # ...
 ----
-
+endif::openshift-rosa[]
 ifdef::openshift-sdn[]
 [id="nw-egress-ips-limitations_{context}"]
 == Limitations

--- a/modules/nw-egress-ips-node.adoc
+++ b/modules/nw-egress-ips-node.adoc
@@ -10,13 +10,19 @@ You can apply the `k8s.ovn.org/egress-assignable=""` label to a node in your clu
 
 .Prerequisites
 
+ifndef::openshift-rosa[]
 * Install the OpenShift CLI (`oc`).
+endif::openshift-rosa[]
+ifdef::openshift-rosa[]
+* Install the ROSA CLI (`rosa`).
+endif::openshift-rosa[]
 * Log in to the cluster as a cluster administrator.
 
 .Procedure
 
 * To label a node so that it can host one or more egress IP addresses, enter the following command:
 +
+ifndef::openshift-rosa[]
 [source,terminal]
 ----
 $ oc label nodes <node_name> k8s.ovn.org/egress-assignable="" <1>
@@ -38,3 +44,15 @@ metadata:
   name: <node_name>
 ----
 ====
+endif::openshift-rosa[]
+ifdef::openshift-rosa[]
+[source,terminal]
+----
+$ rosa edit machinepool <machinepool_name> --cluster=<cluster_name> --labels "k8s.ovn.org/egress-assignable="
+----
++
+[IMPORTANT]
+====
+This command replaces any exciting node labels on your machinepool. You should include any of the desired labels to the `--labels` field to ensure that your existing node labels persist.
+====
+endif::openshift-rosa[]

--- a/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
@@ -2,6 +2,7 @@
 [id="configuring-egress-ips-ovn"]
 = Configuring an egress IP address
 include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: configuring-egress-ips-ovn
 
 toc::[]
@@ -12,18 +13,31 @@ include::modules/nw-egress-ips-about.adoc[leveloffset=+1]
 
 include::modules/nw-egress-ips-object.adoc[leveloffset=+1]
 
+ifndef::openshift-rosa[]
 include::modules/nw-egress-ips-config-object.adoc[leveloffset=+1]
+endif::openshift-rosa[]
 
 include::modules/nw-egress-ips-node.adoc[leveloffset=+1]
 
 [id="configuring-egress-ips-next-steps"]
 == Next steps
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../networking/ovn_kubernetes_network_provider/assigning-egress-ips-ovn.adoc#assigning-egress-ips-ovn[Assigning egress IPs]
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* link:https://docs.openshift.com/container-platform/4.14/networking/ovn_kubernetes_network_provider/assigning-egress-ips-ovn.html#assigning-egress-ips-ovn[Assigning egress IPs]
+endif::openshift-dedicated,openshift-rosa[]
 
 [role="_additional-resources"]
 [id="configuring-egress-ips-additional-resources"]
 == Additional resources
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../rest_api/objects/index.adoc#labelselector-meta-v1[LabelSelector meta/v1]
 * xref:../../rest_api/objects/index.adoc#labelselectorrequirement-meta-v1[LabelSelectorRequirement meta/v1]
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* link:https://docs.openshift.com/container-platform/4.14/rest_api/objects/index.html#labelselector-meta-v1[LabelSelector meta/v1]
+* link:https://docs.openshift.com/container-platform/4.14/rest_api/objects/index.html#labelselectorrequirement-meta-v1[LabelSelectorRequirement meta/v1]
+endif::openshift-dedicated,openshift-rosa[]


### PR DESCRIPTION
Version(s):
`enterprise-4.14+`

Issue:
**[OSDOCS-8767](https://issues.redhat.com/browse/OSDOCS-8767)**

Link to docs preview:
- [Assign Consistent Egress IP for External Traffic](https://file.rdu.redhat.com/eponvell/OSDOCS-8767_Configuring-EgressIP/cloud_experts_tutorials/cloud-experts-consistent-egress-ip.html) (Tutorial)
- [Configuring an egress IP address](https://file.rdu.redhat.com/eponvell/OSDOCS-8767_Configuring-EgressIP/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html) (Migration from OCP)
- [Original OCP version](https://70210--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn) (unchanged)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR migrates a topic about Egress IP from OCP and adds a new tutorial for consistent Egress IP.
