### PR TITLE
OCPBUGS#24202: Added two vSphere FD parameters

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -58,6 +58,8 @@ ifeval::["{context}" == "installation-config-parameters-agent"]
 :agent:
 endif::[]
 
+// You can issue a command such as `openshift-install explain installconfig.platform.vsphere.failureDomains` to see information about a parameter. You must store the `openshift-install` binary in your bin directory.
+
 :_mod-docs-content-type: CONCEPT
 [id="installation-configuration-parameters_{context}"]
 ifndef::agent[]
@@ -68,7 +70,6 @@ The following tables specify the required, optional, and {platform}-specific ins
 ====
 After installation, you cannot modify these parameters in the `install-config.yaml` file.
 ====
-
 endif::agent[]
 
 ifdef::agent[]
@@ -2700,6 +2701,14 @@ endif::agent[]
   vsphere:
     failureDomains:
       topology:
+        datastore:
+|Specifies the path to a vSphere datastore that stores virtual machines files for a failure domain. You must apply the `datastore` role to the vSphere vCenter datastore location.
+|String
+
+|platform:
+  vsphere:
+    failureDomains:
+      topology:
         networks:
 |Lists any network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured.
 |String
@@ -2762,6 +2771,13 @@ For more information, see "VMware vSphere region and zone enablement".
 // If you are providing the infrastructure for the cluster and you do not want to use the default `StorageClass` object, named `thin`, you can omit the `folder` parameter from the `install-config.yaml` file.
 |String
 endif::agent[]
+
+|platform:
+  vsphere:
+    failureDomains:
+      server:
+|Specifies the fully-qualified hostname or IP address of the VMware vCenter server, so that a client can access failure domain resources. You must apply the `server` role to the vSphere vCenter server location.
+|String
 
 |platform:
   vsphere:


### PR DESCRIPTION
Version(s):
4.16 to 4.12

Issue:
[OCPBUGS-24202](https://issues.redhat.com/browse/OCPBUGS-24202)

Link to docs preview:
[Additional VMware vSphere configuration parameters](https://70233--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere#installation-configuration-parameters-additional-vsphere_installation-config-parameters-vsphere)

- [x] SME has approved this change.
- [x] QE has approved this change.

Additional information

Feedback from Joe; address post-4.15.

I don't see a bug with the installer here. It did what it was supposed to
provided the customer a list of privileges that were missing from their vcenter that we document
(https://redhat-internal.slack.com/archives/D04NQ32QFE0/p1707828043324199)
what was concerning to me is that they can't associate server with the vcenter role
and the vcenter datastore role with datastore
(https://redhat-internal.slack.com/archives/D04NQ32QFE0/p1707828129089459)
unless you write in the parameter description, make sure you apply role X and this vcenter location Y
