### PR TITLE
TELCODOCS-1480 - Adding new and missing PTP events

### DIFF
--- a/modules/nw-ptp-operator-metrics-reference.adoc
+++ b/modules/nw-ptp-operator-metrics-reference.adoc
@@ -22,7 +22,7 @@ Some of the following metrics are applicable for PTP grandmaster clocks (T-GM) o
 
 |`openshift_ptp_clock_class`
 |Returns the PTP clock class for the interface.
-Possible values for PTP clock class are 6 (`LOCKED`), 7 (`PRC UNLOCKED IN-SPEC`), 52 (`PRC UNLOCKED OUT-OF-SPEC`), 187 (`PRC UNLOCKED OUT-OF-SPEC`), 248 (`DEFAULT`), or 255 (`SLAVE ONLY CLOCK`).
+Possible values for PTP clock class are 6 (`LOCKED`), 7 (`PRC UNLOCKED IN-SPEC`), 52 (`PRC UNLOCKED OUT-OF-SPEC`), 187 (`PRC UNLOCKED OUT-OF-SPEC`), 135 (`T-BC HOLDOVER IN-SPEC`), 165 (`T-BC HOLDOVER OUT-OF-SPEC`), 248 (`DEFAULT`), or 255 (`SLAVE ONLY CLOCK`).
 Applicable to T-GM clocks only.
 |`{node="compute-1.example.com",process="ptp4l"} 6`
 

--- a/modules/nw-ptp-operator-metrics-reference.adoc
+++ b/modules/nw-ptp-operator-metrics-reference.adoc
@@ -22,54 +22,81 @@ Some of the following metrics are applicable for PTP grandmaster clocks (T-GM) o
 
 |`openshift_ptp_clock_class`
 |Returns the PTP clock class for the interface.
-Possible values for PTP clock class are `6` (`LOCKED`), `7` (`HOLDOVER` within specification), `140` (`HOLDOVER` outside specification), and `248` (`FREERUN`).
+Possible values for PTP clock class are 6 (`LOCKED`), 7 (`PRC UNLOCKED IN-SPEC`), 52 (`PRC UNLOCKED OUT-OF-SPEC`), 187 (`PRC UNLOCKED OUT-OF-SPEC`), 248 (`DEFAULT`), or 255 (`SLAVE ONLY CLOCK`).
 Applicable to T-GM clocks only.
-|`openshift_ptp_clock_class {node="compute-1.example.com", process="ptp4l"} 6`
+|`{node="compute-1.example.com",process="ptp4l"} 6`
 
 |`openshift_ptp_clock_state`
 |Returns the current PTP clock state for the interface.
 Possible values for PTP clock state are `FREERUN`, `LOCKED`, or `HOLDOVER`.
-|`openshift_ptp_clock_state {iface="CLOCK_REALTIME", node="compute-1.example.com", process="phc2sys"} 1`
+|`{iface="CLOCK_REALTIME", node="compute-1.example.com", process="phc2sys"} 1`
 
 |`openshift_ptp_delay_ns`
 |Returns the delay in nanoseconds between the primary clock sending the timing packet and the secondary clock receiving the timing packet.
-|`openshift_ptp_delay_ns {from="master", iface="ens2fx", node="compute-1.example.com", process="ts2phc"} 0`
+|`{from="master", iface="ens2fx", node="compute-1.example.com", process="ts2phc"} 0`
 
 |`openshift_ptp_frequency_adjustment_ns`
 |Returns the frequency adjustment in nanoseconds between 2 PTP clocks.
 For example, between the upstream clock and the NIC, between the system clock and the NIC, or between the PTP hardware clock (`phc`) and the NIC.
 Applicable to T-GM clocks only.
-|`openshift_ptp_frequency_adjustment_ns {from="phc", iface="CLOCK_REALTIME", node="compute-1.example.com", process="phc2sys"} -6768`
+|`{from="phc", iface="CLOCK_REALTIME", node="compute-1.example.com", process="phc2sys"} -6768`
+
+|`openshift_ptp_frequency_status`
+|Returns the current status of the digital phase-locked loop (DPLL) frequency for the NIC.
+Possible values are -1 (`UNKNOWN`), 0 (`INVALID`), 1 (`FREERUN`), 2 (`LOCKED`), 3 (`LOCKED_HO_ACQ`), or 4 (`HOLDOVER`).
+|`{from="dpll",iface="ens2fx",node="compute-1.example.com",process="dpll"} 3`
+
+|`openshift_ptp_phase_status`
+|Returns the status of the DPLL phase for the NIC.
+Possible values are -1 (`UNKNOWN`), 0 (`INVALID`), 1 (`FREERUN`), 2 (`LOCKED`), 3 (`LOCKED_HO_ACQ`), or 4 (`HOLDOVER`).
+|`{from="dpll",iface="ens2fx",node="compute-1.example.com",process="dpll"} 3`
 
 |`openshift_ptp_interface_role`
-|Describes the configured PTP clock role for the interface.
+|Returns the configured PTP clock role for the interface.
 Possible values are 0 (`PASSIVE`), 1 (`SLAVE`), 2 (`MASTER`), 3 (`FAULTY`), 4 (`UNKNOWN`), or 5 (`LISTENING`).
-
-|`openshift_ptp_interface_role {iface="ens2f0", node="compute-1.example.com", process="ptp4l"} 2`
+|`{iface="ens2f0", node="compute-1.example.com", process="ptp4l"} 2`
 
 |`openshift_ptp_max_offset_ns`
 |Returns the maximum offset in nanoseconds between 2 clocks or interfaces.
 For example, between the upstream GNSS clock and the NIC (`ts2phc`), or between the PTP hardware clock (`phc`) and the system clock (`phc2sys`).
 Applicable to T-GM clocks only.
-|`openshift_ptp_max_offset_ns {from="master", iface="ens2fx", node="compute-1.example.com", process="ts2phc"} 1.038099569e+09`
+|`{from="master", iface="ens2fx", node="compute-1.example.com", process="ts2phc"} 1.038099569e+09`
 
 |`openshift_ptp_offset_ns`
 |Returns the offset in nanoseconds between the DPLL clock or the GNSS clock source and the NIC hardware clock.
 Applicable to T-GM clocks only.
-|`openshift_ptp_offset_ns {from="phc", iface="CLOCK_REALTIME", node="compute-1.example.com", process="phc2sys"} -9`
+|`{from="phc", iface="CLOCK_REALTIME", node="compute-1.example.com", process="phc2sys"} -9`
 
 |`openshift_ptp_process_restart_count`
 |Returns a count of the number of times the `ptp4l` process was restarted.
-|`openshift_ptp_process_restart_count {config="ptp4l.0.config", node="compute-1.example.com",process="phc2sys"} 1`
+|`{config="ptp4l.0.config", node="compute-1.example.com",process="phc2sys"} 1`
 
 |`openshift_ptp_process_status`
 |Returns a status code that shows whether the PTP process is running or not.
-|`openshift_ptp_process_status {config="ptp4l.0.config", node="compute-1.example.com",process="phc2sys"} 1`
+|`{config="ptp4l.0.config", node="compute-1.example.com",process="phc2sys"} 1`
 
 |`openshift_ptp_threshold`
 a|Returns values for `HoldOverTimeout`, `MaxOffsetThreshold`, and `MinOffsetThreshold`.
 
 * `holdOverTimeout` is the time value in seconds before the PTP clock event state changes to `FREERUN` when the PTP master clock is disconnected.
 * `maxOffsetThreshold` and `minOffsetThreshold` are offset values in nanoseconds that compare against the values for `CLOCK_REALTIME` (`phc2sys`) or master offset (`ptp4l`) values that you configure in the `PtpConfig` CR for the NIC.
-|`openshift_ptp_threshold {node="compute-1.example.com", profile="grandmaster", threshold="HoldOverTimeout"} 5`
+|`{node="compute-1.example.com", profile="grandmaster", threshold="HoldOverTimeout"} 5`
+
+|`openshift_ptp_pps_status`
+|Returns the current status of the NIC 1PPS connection.
+You use the 1PPS connection to synchronize timing between connected NICs.
+Possible values are 0 (`UNAVAILABLE`) and 1 (`AVAILABLE`).
+|`{from="dpll",iface="ens2fx",node="compute-1.example.com",process="dpll"} 1`
+
+|`openshift_ptp_nmea_status`
+|Returns the current status of the NMEA connection.
+NMEA is the protocol that is used for 1PPS NIC connections.
+Possible values are 0 (`UNAVAILABLE`) and 1 (`AVAILABLE`).
+|`{iface="ens2fx",node="compute-1.example.com",process="ts2phc"} 1`
+
+|`openshift_ptp_gnss_status`
+|Returns the current status of the global navigation satellite system (GNSS) connection.
+GNSS provides satellite-based positioning, navigation, and timing services globally.
+Possible values are 0 (`NOFIX`), 1 (`DEAD RECKONING ONLY`), 2 (`2D-FIX`), 3 (`3D-FIX`), 4 (`GPS+DEAD RECKONING FIX`), 5, (`TIME ONLY FIX`).
+|`{from="gnss",iface="ens2fx",node="compute-1.example.com",process="gnss"} 3`
 |====


### PR DESCRIPTION
Adding new and missing PTP events for https://issues.redhat.com//browse/TELCODOCS-1480 - PTP T-GM dual NIC config for D-RAN use cases.

Version(s):
enterprise-4.14+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1480

Link to docs preview:
https://70235--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ptp/using-ptp-events#nw-ptp-operator-metrics-reference_using-ptp-hardware-fast-events-framework

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

