### PR TITLE
ROX-21602: Update Release Notes for 4.3.3 patch

### DIFF
--- a/release_notes/43-release-notes.adoc
+++ b/release_notes/43-release-notes.adoc
@@ -18,6 +18,7 @@ toc::[]
 |`4.3.0` | 15 November 2023
 |`4.3.1` | 11 December 2023
 |`4.3.2` | 8 January 2024
+|`4.3.3` | 16 January 2024
 
 |====
 
@@ -262,6 +263,13 @@ Vulnerability deferral management for host (`/node`) and platform (`/cluster`) v
 
 * Fixed an issue with manual delegated scanning that caused Central to crash.
 * Fixed PostgreSQL vulnerabilities in `scanner-db` containers.
+
+[id="resolved-in-version-433_{context}"]
+=== Resolved in version 4.3.3
+
+*Release date*: 16 January 2024
+
+* This release contains updates to the versions of golang and go-git used in {product-title-short}.
 
 [id="known-issues-430_{context}"]
 == Known issues


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-4.3`

[Issue](https://issues.redhat.com/browse/ROX-21602)

[Link to docs preview
](https://70236--docspreview.netlify.app/openshift-acs/latest/release_notes/43-release-notes#resolved-in-version-433_release-notes-43)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
