### PR TITLE
OCPBUGS-26418 Document avoidBuggyIPs

### DIFF
--- a/modules/nw-metallb-addresspool-cr.adoc
+++ b/modules/nw-metallb-addresspool-cr.adoc
@@ -48,6 +48,10 @@ Specify each range in CIDR notation or as starting and ending IP addresses separ
 Specify `false` if you want explicitly request an IP address from this pool with the `metallb.universe.tf/address-pool` annotation.
 The default value is `true`.
 
+|`spec.avoidBuggyIPs`
+|`boolean`
+|Optional: This ensures when enabled that IP addresses ending .0 and .255 are not allocated from the pool. The default value is `false`. Some older consumer network equipment mistakenly block IP addresses ending in .0 and .255.
+
 |===
 
 You can assign IP addresses from an `IPAddressPool` to services and namespaces by configuring the `spec.serviceAllocation` specification.


### PR DESCRIPTION
[OCPBUGS-26418]: Document in MetalLB avoidBuggyIPs

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-26418
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://70245--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-configure-address-pools
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
