### PR TITLE
TELCODOCS-1671 Adding note clarifying when bug is fixed and in what z…

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3059,10 +3059,25 @@ The default `IngressController` CR is configured with 4 HAProxy threads. If you 
 * For {sno-caps} on {product-version} and Google Cloud Platform (GCP), there is a known issue with the Cloud Network Config Controller (CNCC) entering a `CrashLoopBackOff` state. This occurs at initialization time when the CNCC tries to reach the GCP internal load balancer address and the resulting hairpin traffic is not correctly prevented in OVN-Kubernetes shared gateway mode on GCP causing it to get dropped. Cluster Network Operator will show a `Progressing=true` status in such case. Currently, there is no workaround for this issue. (link:https://issues.redhat.com/browse/OCPBUGS-20554[*OCPBUGS-20554*])
 
 * On an {sno-caps} that has guaranteed CPUs and where Interrupt Request (IRQ) load balancing is disabled, large latency spikes can occur at container startup. (link:https://issues.redhat.com/browse/OCPBUGS-22901[*OCPBUGS-22901*])
++
+[NOTE]
+====
+This issue is fixed in 4.14.6.
+====
 
 * When deploying an application that has a large number of pods, some of which have CPU limits configured, the deployment can fail. The workaround is to re-deploy the application. (link:https://issues.redhat.com/browse/RHEL-7232[*RHEL-7232*])
++
+[NOTE]
+====
+This issue is fixed in 4.14.5.
+====
 
 * On an {sno-caps} that has disabled capabilities, the `openshift-controller-manager-operator` may continuously restart. As a workaround, enable the build capability or manually create the `builds.config.openshift.io` CRD.
++
+[NOTE]
+====
+This issue is fixed in 4.14.5. The fix is included in the link:https://access.redhat.com/errata/RHSA-2023:7599[RHSA-2023:7599] advisory under the cloned issue (link:https://issues.redhat.com/browse/OCPBUGS-23490[*OCPBUGS-23490*]).
+====
 +
 Perform the following steps to manually create the `builds.config.openshift.io` CRD:
 +


### PR DESCRIPTION
[TELCODOCS-1671]: Adding note clarifying when bug is fixed and in what z stream

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14 (only)
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-1671
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://70249--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-known-issues
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
