### PR TITLE
OSDOCS#9261: Release note z-stream for MicroShift 4.14.9

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -403,3 +403,12 @@ Issued: 2024-01-09
 {product-title} release 4.14.8, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0052[RHBA-2024:0052] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0050[RHSA-2024:0050] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-14-9-dp"]
+=== RHBA-2024:0206 - {microshift-short} 4.14.9 bug fix update advisory
+
+Issued: 2024-01-17
+
+{product-title} release 4.14.9, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0206[RHBA-2024:0206] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0204[RHSA-2024:0204] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
**Version(s):** 4.14
**Issue:** [OSDOCS-9261](https://issues.redhat.com//browse/OSDOCS-9261)

**Link to docs preview:**

[Red Hat build of MicroShift 4.14 release notes -> RHBA-2024:0206 - MicroShift 4.14.9 bug fix update advisory](https://70257--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes#microshift-4-14-9-dp)

QE review:
- QE not required