### PR TITLE
GH70054: Removed EUS mentions from OKD update docs- Follow up

### DIFF
--- a/modules/api-compatibility-common-terminology.adoc
+++ b/modules/api-compatibility-common-terminology.adoc
@@ -38,10 +38,12 @@ For example, in the release 4.13.2:
 * 13 is the minor release version
 * 2 is the z-stream release version
 
+ifndef::openshift-origin[]
 [id="api-compatibility-common-terminology-eus_{context}"]
 == Extended user support (EUS)
 
 A minor release in an {product-title} major release that has an extended support window for critical bug fixes. Users are able to migrate between EUS releases by incrementally adopting minor versions between EUS releases. It is important to note that the deprecation policy is defined across minor releases and not EUS releases. As a result, an EUS user might have to respond to a deprecation when migrating to a future EUS while sequentially upgrading through each minor release.
+endif::openshift-origin[]
 
 [id="api-compatibility-common-terminology-dev-preview_{context}"]
 == Developer Preview

--- a/modules/persistent-storage-csi-migration-vsphere.adoc
+++ b/modules/persistent-storage-csi-migration-vsphere.adoc
@@ -46,4 +46,6 @@ oc -n openshift-config patch cm admin-acks --patch '{"data":{"ack-4.13-kube-127-
 If you do *not* update to vSphere 7.0 Update 3L or 8.0 Update 2 and use an administrator acknowledgment to update to {product-title} 4.14, known issues can occur due to CSI migration being enabled by default in {product-title} 4.14. link:https://access.redhat.com/node/7011683[Before proceeding with the administrator acknowledgement, carefully read this knowledge base article].
 ====
 
+ifndef::openshift-origin[]
 Updating from {product-title} 4.12 to 4.14 is an Extended Update Support (EUS)-to-EUS update. To understand the ramifications for this type of update and how to perform it, see the _EUS-to-EUS update_ link in the _Additional resources_ section below.
+endif::openshift-origin[]

--- a/modules/update-upgrading-cli.adoc
+++ b/modules/update-upgrading-cli.adoc
@@ -121,7 +121,6 @@ $ oc adm upgrade --to=<version> <1>
 ----
 <1> `<version>` is the update version that you obtained from the output of the
 `oc adm upgrade` command.
-
 +
 [IMPORTANT]
 ====
@@ -134,6 +133,18 @@ When using `oc adm upgrade --help`, there is a listed option for `--force`. This
 ----
 $ oc adm upgrade
 ----
+ifdef::openshift-origin[]
++
+[source,terminal]
+.Example output
+----
+info: An upgrade is in progress. Working towards 4.14.0-0.okd-2024-01-06-084517: 117 of 864 done (13% complete), waiting on etcd, kube-apiserver
+
+Upstream: https://amd64.origin.releases.ci.openshift.org/graph
+Channel: stable-4
+No updates available. You may still upgrade to a specific release image with --to-image or wait for new updates to be available.
+----
+endif::openshift-origin[]
 
 . After the update completes, you can confirm that the cluster version has
 updated to the new version:
@@ -142,6 +153,7 @@ updated to the new version:
 ----
 $ oc adm upgrade
 ----
+ifndef::openshift-origin[]
 +
 .Example output
 [source,terminal]
@@ -153,6 +165,19 @@ Channel: stable-<version> (available channels: candidate-<version>, eus-<version
 
 No updates available. You may force an update to a specific release image, but doing so might not be supported and might result in downtime or data loss.
 ----
+endif::openshift-origin[]
+ifdef::openshift-origin[]
++
+[source,terminal]
+.Example output
+----
+Cluster version is 4.14.0-0.okd-2024-01-06-084517
+
+Upstream: https://amd64.origin.releases.ci.openshift.org/graph
+Channel: stable-4
+No updates available. You may still upgrade to a specific release image with --to-image or wait for new updates to be available.
+----
+endif::openshift-origin[]
 +
 . If you are updating your cluster to the next minor version, such as version X.y to X.(y+1), it is recommended to confirm that your nodes are updated before deploying workloads that rely on a new feature:
 +

--- a/storage/container_storage_interface/persistent-storage-csi-migration.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-migration.adoc
@@ -15,6 +15,8 @@ To change the default storage class, see xref:../../storage/container_storage_in
 
 include::modules/persistent-storage-csi-migration-vsphere.adoc[leveloffset=+1]
 
+ifndef::openshift-origin[]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../updating/updating_a_cluster/eus-eus-update.adoc#eus-eus-update[Performing an EUS-to-EUS update]
+endif::openshift-origin[]

--- a/virt/updating/upgrading-virt.adoc
+++ b/virt/updating/upgrading-virt.adoc
@@ -14,11 +14,13 @@ include::modules/virt-about-upgrading-virt.adoc[leveloffset=+1]
 
 include::modules/virt-about-workload-updates.adoc[leveloffset=+2]
 
+ifndef::openshift-origin[]
 include::modules/virt-about-eus-updates.adoc[leveloffset=+2]
 
 Learn more about xref:../../updating/updating_a_cluster/eus-eus-update.adoc#eus-eus-update[performing an EUS-to-EUS update].
 
 include::modules/virt-preventing-workload-updates-during-eus-update.adoc[leveloffset=+1]
+endif::openshift-origin[]
 
 include::modules/virt-configuring-workload-update-methods.adoc[leveloffset=+1]
 
@@ -42,7 +44,9 @@ Configure workload updates to ensure that VMIs update automatically.
 [id="additional-resources_upgrading-virt"]
 [role="_additional-resources"]
 == Additional resources
+ifndef::openshift-origin[]
 * xref:../../updating/updating_a_cluster/eus-eus-update.adoc#eus-eus-update[Performing an EUS-to-EUS update]
+endif::openshift-origin[]
 * xref:../../operators/understanding/olm-what-operators-are.adoc#olm-what-operators-are[What are Operators?]
 * xref:../../operators/understanding/olm/olm-understanding-olm.adoc#olm-understanding-olm[Operator Lifecycle Manager concepts and resources]
 * xref:../../operators/understanding/olm/olm-understanding-olm.adoc#olm-csv_olm-understanding-olm[Cluster service versions (CSVs)]


### PR DESCRIPTION
Follow up to https://github.com/openshift/openshift-docs/pull/70149

See: [comment in issue](https://github.com/openshift/openshift-docs/issues/70054#issuecomment-1892213073): 

```
I noticed a remaining eus-* mention is on Updating a cluster by using the CLI, at step 4, "After the update completes, you can confirm that the cluster version has updated to the new version:" in the example output.
Other than that, I found the About EUS-to-EUS updates title on the Updating OKD virtualization page.
```

Previews:
[Updating a cluster by using the CLI](https://file.rdu.redhat.com/~mburke/okd-remove-eus-update-2/updating/updating_a_cluster/updating-cluster-cli.html#update-upgrading-cli_updating-cluster-cli) -- Added OKD-specific command output to step 4 and 5. 
[Updating OKD Virtualization](https://file.rdu.redhat.com/~mburke/okd-remove-eus-update-2/virt/updating/upgrading-virt.html) -- Hid About EUS-to-EUS updates and Preventing workload updates during an EUS-to-EUS update in OKD. [Current docs](https://docs.okd.io/4.14/virt/updating/upgrading-virt.html).
API reference -> [Extended user support (EUS)](https://file.rdu.redhat.com/~mburke/okd-remove-eus-update-2/rest_api/understanding-compatibility-guidelines.html#api-compatibility-common-terminology-releases_compatibility-guidelines) -- Hid this module. [Current docs](https://docs.okd.io/latest/rest_api/understanding-compatibility-guidelines.html#api-compatibility-common-terminology-eus_compatibility-guidelines)
Storage -> CSI -> [Updating from OKD 4.12 to 4.14](https://file.rdu.redhat.com/~mburke/okd-remove-eus-update-2/storage/container_storage_interface/persistent-storage-csi-migration.html#updating-openshift_from_4.12_persistent-storage-csi-migration) -- Hid final paragraph and Additional references. [Current docs](https://docs.okd.io/4.14/storage/container_storage_interface/persistent-storage-csi-migration.html#updating-openshift_from_4.12_persistent-storage-csi-migration)

OCP docs,  no changes:
[Updating a cluster by using the CLI](https://70260--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-cluster-cli.html#update-upgrading-cli_updating-cluster-cli)
Updating OpenShift Virtualization -> [About EUS-to-EUS updates](https://70260--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/updating/upgrading-virt.html#virt-about-eus-updates_upgrading-virt) and [Preventing workload updates during an EUS-to-EUS update](https://70260--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/updating/upgrading-virt.html#virt-preventing-workload-updates-during-eus-update_upgrading-virt)
API reference -> [Extended user support (EUS)](https://70260--ocpdocs-pr.netlify.app/openshift-enterprise/latest/rest_api/understanding-compatibility-guidelines.html#api-compatibility-common-terminology-eus_compatibility-guidelines) 
Storage -> CSI -> [Updating from OKD 4.12 to 4.14](https://70260--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-migration.html#updating-openshift_from_4.12_persistent-storage-csi-migration)