### PR TITLE
OCPBUGS#18020: Fixing install via console procedure

### DIFF
--- a/modules/cnf-installing-numa-resources-operator-console.adoc
+++ b/modules/cnf-installing-numa-resources-operator-console.adoc
@@ -10,17 +10,25 @@ As a cluster administrator, you can install the NUMA Resources Operator using th
 
 .Procedure
 
-. Install the NUMA Resources Operator using the {product-title} web console:
+. Create a namespace for the NUMA Resources Operator:
+
+.. In the {product-title} web console, click *Administration* -> *Namespaces*.
+
+.. Click *Create Namespace*, enter `openshift-numaresources` in the *Name* field, and then click *Create*.
+
+. Install the NUMA Resources Operator:
 
 .. In the {product-title} web console, click *Operators* -> *OperatorHub*.
 
 .. Choose *NUMA Resources Operator* from the list of available Operators, and then click *Install*.
 
+.. In the *Installed Namespaces* field, select the `openshift-numaresources` namespace, and then click *Install*.
+
 . Optional: Verify that the NUMA Resources Operator installed successfully:
 
 .. Switch to the *Operators* -> *Installed Operators* page.
 
-.. Ensure that *NUMA Resources Operator* is listed in the *default* project with a *Status* of *InstallSucceeded*.
+.. Ensure that *NUMA Resources Operator* is listed in the `openshift-numaresources` namespace with a *Status* of *InstallSucceeded*.
 +
 [NOTE]
 ====


### PR DESCRIPTION
OCPBUGS-18020: Install procedure from web console leaves out a step to create/specify a namespace for the NUMA Resources Operator.

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-18020

Link to docs preview:
https://70263--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-numa-aware-scheduling#cnf-installing-numa-resources-operator-console_numa-aware

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
