### PR TITLE
OSDOCS#9207 Mixed public/private API and Ingress during azure installation

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -677,8 +677,11 @@ endif::openshift-origin[]
 |publish:
 |How to publish or expose the user-facing endpoints of your cluster, such as the Kubernetes API, OpenShift routes.
 |
-ifdef::aws,azure,gcp,ibm-cloud[]
+ifdef::aws,gcp,ibm-cloud[]
 `Internal` or `External`. To deploy a private cluster, which cannot be accessed from the internet, set `publish` to `Internal`. The default value is `External`.
+endif::[]
+ifdef::azure[]
+`Internal`, `External`, or `Mixed`. To deploy a private cluster, which cannot be accessed from the internet, set `publish` to `Internal`. The default value is `External`. To deploy a cluster where the API and the ingress server have different publishing strategies, set `publish` to `Mixed` and use the `operatorPublishingStrategy` parameter.
 endif::[]
 ifndef::aws,azure,gcp,ibm-cloud[]
 `Internal` or `External`. The default value is `External`.
@@ -1869,6 +1872,16 @@ at least two zones.
       vmNetworkingType:
 |Enables accelerated networking. Accelerated networking enables single root I/O virtualization (SR-IOV) to a VM, improving its networking performance.
 |`Accelerated` or `Basic`. If instance type of control plane and compute machines support `Accelerated` networking, by default, the installer enables `Accelerated` networking, otherwise the default networking type is `Basic`.
+
+|operatorPublishingStrategy:
+  apiserver:
+|Determines whether the load balancers that service the API are public or private. Set this parameter to `Internal` to prevent the API server from being accessible outside of your VNet. Set this parameter to `External` to make the API server accessible outside of your VNet. If you set this parameter, you must set the `publish` parameter to `Mixed`.
+|`External` or `Internal`. The default value is `External`.
+
+|operatorPublishingStrategy:
+  ingress:
+|Determines whether the DNS resources that the cluster creates for ingress traffic are publicly visible. Set this parameter to `Internal` to prevent the ingress VIP from being publicly accessible. Set this parameter to `External` to make the ingress VIP publicly accessible. If you set this parameter, you must set the `publish` parameter to `Mixed`.
+|`External` or `Internal`. The default value is `External`.
 
 |====
 


### PR DESCRIPTION
Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-9207

Link to docs preview:
[Installation configuration parameters for Azure (last 2 params)](https://70268--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/installation-config-parameters-azure#installation-configuration-parameters-additional-azure_installation-config-parameters-azure)


QE review:
- [x] QE has approved this change.