### PR TITLE
OSDOCS-9283: add admonition about overriding default worker pool configs

### DIFF
--- a/modules/creating-infra-machines.adoc
+++ b/modules/creating-infra-machines.adoc
@@ -9,6 +9,11 @@
 
 If you need infrastructure machines to have dedicated configurations, you must create an infra pool.
 
+[IMPORTANT]
+====
+Creating a custom machine configuration pool overrides default worker pool configurations if they refer to the same file or unit.
+====
+
 .Procedure
 
 . Add a label to the node you want to assign as the infra node with a specific label:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-9283
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://70274--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks#creating-infra-machines_post-install-cluster-tasks
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
