### PR TITLE
OSDOCS#9120: Adding Assisted Installer and Agent-based Installer entr…

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -493,6 +493,12 @@ Topics:
       File: installing-vsphere-network-customizations
     - Name: Installing a cluster in a restricted network
       File: installing-restricted-networks-vsphere
+  - Name: Assisted Installer
+    Distros: openshift-enterprise
+    File: installing-vsphere-assisted-installer
+  - Name: Agent-based Installer
+    Distros: openshift-enterprise
+    File: installing-vsphere-agent-based-installer
   - Name: Installing a three-node cluster
     File: installing-vsphere-three-node
   - Name: Configuring the vSphere connection settings after an installation

--- a/installing/installing_vsphere/installing-vsphere-agent-based-installer.adoc
+++ b/installing/installing_vsphere/installing-vsphere-agent-based-installer.adoc
@@ -1,0 +1,17 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="installing-vsphere-agent-based-installer"]
+= Installing a cluster on vSphere using the Agent-based Installer
+include::_attributes/common-attributes.adoc[]
+:context: installing-vsphere-agent-based-installer
+
+toc::[]
+
+The Agent-based installation method provides the flexibility to boot your on-premises servers in any way that you choose. It combines the ease of use of the Assisted Installation service with the ability to run offline, including in air-gapped environments.
+
+Agent-based installation is a subcommand of the {product-title} installer. It generates a bootable ISO image containing all of the information required to deploy an {product-title} cluster with an available release image.
+
+[role="_additional-resources"]
+[id="additional-resources_installing-vsphere-agent-based-installer"]
+== Additional resources
+
+* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#preparing-to-install-with-agent-based-installer[Preparing to install with the Agent-based Installer]

--- a/installing/installing_vsphere/installing-vsphere-assisted-installer.adoc
+++ b/installing/installing_vsphere/installing-vsphere-assisted-installer.adoc
@@ -1,0 +1,21 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="installing-vsphere-assisted-installer"]
+= Installing a cluster on vSphere using the Assisted Installer
+include::_attributes/common-attributes.adoc[]
+:context: installing-vsphere-assisted-installer
+
+toc::[]
+
+You can install {product-title} on on-premise hardware or on-premise VMs by using the {ai-full}. Installing {product-title} by using the {ai-full} supports `x86_64`, `AArch64`, `ppc64le`, and `s390x` CPU architectures.
+
+The {ai-full} is a user-friendly installation solution offered on the Red{nbsp}Hat Hybrid Cloud Console. The {ai-full} supports the various deployment platforms with a focus on the following infrastructures:
+
+* Bare metal
+* Nutanix
+* vSphere
+
+[role="_additional-resources"]
+[id="additional-resources_installing-vsphere-assisted-installer"]
+== Additional resources
+
+* link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2024/html/installing_openshift_container_platform_with_the_assisted_installer/index[Installing {product-title} with the {ai-full}]


### PR DESCRIPTION
Version(s):
4.15 +

Issue:
This issue addresses [osdocs-9120](https://issues.redhat.com/browse/OSDOCS-9120) and implements a refactored vSphere installation TOC, which is detailed in this Miro [board](https://miro.com/app/board/uXjVNbUhuKQ=/). This refactor has been approved by Stephanie Stout (CS) and Ju Lim (Senior Manager, Product Management).

Link to docs preview:

- [Installing a cluster on vSphere using the Assisted Installer](https://70279--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-assisted-installer)
- [Installing a cluster on vSphere using the Agent-based installer](https://70279--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-agent-based-installer)

QE review:
[N/A] QE has approved this change.

QE approval is not required for this change. While this PR adds two new assemblies to Installing on vSphere, the content of each assembly [1] [2] reuses existing approved docs. The new assemblies were added at the request of PM as part of the overall effort so that each type of installation method supported on vSphere was referenced from a single location.

Additional information:

[1] The abstract that is used for `installing/installing_vsphere/installing-vsphere-assisted-installer.adoc` is a combination of content that leveraged from the following existing content:

- `installing/installing_on_prem_assisted/installing-on-prem-assisted.adoc` 
- `modules/assisted-installer-using-the-assisted-installer.adoc`

[2] The abstract that is used for `installing/installing_vsphere/installing-vsphere-agent-based-installer.adoc` leverages existing documentation from `installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc`
