### PR TITLE
OSSM-5605: image name example for service mesh must-gather is confusing

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -31,7 +31,7 @@ ifndef::openshift-origin[]
 |`registry.redhat.io/openshift-serverless-1/svls-must-gather-rhel8`
 |Data collection for OpenShift Serverless.
 
-|`registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel8:v<installed_version_service_mesh>`
+|`registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel8:<installed_version_service_mesh>`
 |Data collection for Red Hat OpenShift Service Mesh.
 
 ifndef::openshift-dedicated[]


### PR DESCRIPTION
[OSSM-5605](https://issues.redhat.com//browse/OSSM-5605): image name example for service mesh must-gather is confusing

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSSM-5605

Link to docs preview:
https://70280--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data#gathering-data-specific-features_gathering-cluster-data

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Removed "v" from Service Mesh mention in the table to be consistent with Service Mesh references https://docs.openshift.com/container-platform/4.14/service_mesh/v2x/ossm-troubleshooting-istio.html#ossm-about-collecting-ossm-data_troubleshooting-ossm
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
