### PR TITLE
Add release note for IPsec n-s support

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -584,6 +584,20 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 [id="ocp-4-15-networking"]
 === Networking
 
+[id="ocp-4-14-networking-ovn-kubernetes-ipsec-support-for-external-traffic"]
+==== OVN-Kubernetes network plugin support for IPsec encryption of external traffic general availability (GA)
+
+{product-title} now supports encryption of external traffic, also known as _north-south traffic_. IPsec already supports encryption of network traffic between pods, known as _east-west traffic_. You can use both features together to provide full in-transit encryption for {product-title} clusters.
+
+This feature is supported on the following platforms:
+
+- Bare metal
+- {gcp-first}
+- {rh-openstack-first}
+- {vmw-full}
+
+For more information, see xref:../networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc#nw-ovn-ipsec-external_configuring-ipsec-ovn[Enabling IPsec encryption for external IPsec endpoints].
+
 [id="ocp-4-15-ipv6-default-macvlan"]
 ==== IPv6 unsolicited neighbor advertisements now default on macvlan CNI plugin
 
@@ -2545,6 +2559,12 @@ This is because the current implementation of the `ubxtool` CLI takes 2 seconds 
 If NMEA sentences are lost on their way to the e810 NIC, the T-GM cannot synchronize the devices in the network synchronization chain and the PTP Operator reports an error.
 A proposed fix is to report a `FREERUN` event when the NMEA string is lost.
 (link:https://issues.redhat.com/browse/OCPBUGS-19838[*OCPBUGS-19838*])
+
+* If you have IPsec enabled on the cluster and IPsec encryption is configured between the cluster and an external node, stopping the IPsec connection on the external node causes a loss of connectivity to the external node. This connectivity loss occurs because on the {product-title} side of the connection, the IPsec tunnel shutdown is not recognized. (link:https://issues.redhat.com/browse/RHEL-24802[*RHEL-24802*])
+
+* If you have IPsec enabled on the cluster, and your cluster is a hosted control planes for {product-title} cluster, the MTU adjustment to account for the IPsec tunnel for pod-to-pod traffic does not happen automatically. (link:https://issues.redhat.com/browse/OCPBUGS-28757[*OCPBUGS-28757*])
+
+* If you have IPsec enabled on the cluster, you cannot modify existing IPsec tunnels to external hosts that you have created. Modifying an existing NMState Operator `NodeNetworkConfigurationPolicy` object to adjust an existing IPsec configuration to encrypt traffic to external hosts is not recognized by {product-title}. (link:https://issues.redhat.com/browse/RHEL-22720[*RHEL-22720*])
 
 [id="ocp-telco-ran-4-15-known-issues"]
 


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-6863

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://70288--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-14-networking-ovn-kubernetes-ipsec-support-for-external-traffic
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
