### PR TITLE
OCPBUGS#27181 Correct the RHCOS version in 4.14 RNs

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -19,7 +19,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 {product-title} {product-version} clusters are available at https://console.redhat.com/openshift. With the {cluster-manager-first} application for {product-title}, you can deploy {product-title} clusters to either on-premises or cloud environments.
 
 // Double check OP system versions
-{product-title} {product-version} is supported on {op-system-base-full} 8.6, 8.7, and 8.8 as well as on {op-system-first} 4.13.
+{product-title} {product-version} is supported on {op-system-base-full} 8.6, 8.7, and 8.8 as well as on {op-system-first} 4.14.
 
 You must use {op-system} machines for the control plane, and you can use either {op-system} or {op-system-base} for compute machines.
 //Removed the note per https://issues.redhat.com/browse/GRPA-3517


### PR DESCRIPTION
Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUGS-27181](https://issues.redhat.com/browse/OCPBUGS-27181)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Preview](https://70300--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-about-this-release)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Kathryn approved this change and said it doesn't need change management. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
