### PR TITLE
[enterprise-4.13] OCPBUGS#25991: removed info on creating lvmcluster CR in lvm installation with cli proc

### DIFF
--- a/modules/lvms-installing-logical-volume-manager-operator-using-cli.adoc
+++ b/modules/lvms-installing-logical-volume-manager-operator-using-cli.adoc
@@ -88,46 +88,6 @@ spec:
 $ oc create -f lvms-sub.yaml
 ----
 
-. Create the `LVMCluster` resource:
-
-.. Save the following YAML in the `lvmcluster.yaml` file:
-+
-[source,yaml]
-----
-apiVersion: lvm.topolvm.io/v1alpha1
-kind: LVMCluster
-metadata:
- name: my-lvmcluster
- namespace: openshift-storage
-spec:
- storage:
-   deviceClasses:
-   - name: vg1
-     deviceSelector:
-       paths:
-       - /dev/disk/by-path/pci-0000:87:00.0-nvme-1
-       - /dev/disk/by-path/pci-0000:88:00.0-nvme-1
-     thinPoolConfig:
-       name: thin-pool-1
-       sizePercent: 90
-       overprovisionRatio: 10
-     nodeSelector:
-       nodeSelectorTerms:
-       - matchExpressions:
-         - key: app
-           operator: In
-           values:
-           - test1
-----
-
-.. Create the `LVMCluster` CR:
-+
-[source,yaml]
-----
-$ oc create -f lvmcluster.yaml
-----
-
-
 . To verify that the Operator is installed, enter the following command:
 +
 [source,terminal]


### PR DESCRIPTION
Cherry Picked from 7fb3b89a4ec47b495c9159213869e9abfe936754 
xref:https://github.com/openshift/openshift-docs/pull/69742