### PR TITLE
replace git diff HEAD@{1} with git diff HEAD~1 HEAD in scripts/get-updated-distros.sh

### DIFF
--- a/scripts/get-updated-distros.sh
+++ b/scripts/get-updated-distros.sh
@@ -3,7 +3,7 @@
 # The list includes any topic maps that are themselves modified, and indirectly modifed topic maps where incldued AsciiDoc files have been updated.
 
 # Get the *.adoc and distro maps files in the pull request
-FILES=$(git diff --name-only HEAD@{1} --diff-filter=AMRD "*.yml" "*.adoc" ':(exclude)_unused_topics/*')
+FILES=$(git diff --name-only HEAD~1 HEAD --diff-filter=AMRD "*.yml" "*.adoc" ':(exclude)_unused_topics/*')
 
 REPO_PATH=$(git rev-parse --show-toplevel)
 


### PR DESCRIPTION
git diff HEAD@{1} does not return the modified files in the current commit when you are not rebased to latest. This doesn't matter much in the CI build, since we git fetch on top of latest in Prow, but it does make it confusing when you run the script locally. 

HEAD~1 HEAD makes the script work locally regardless of the state of HEAD compared to the local copy.

All the other scripts use HEAD~1 HEAD.