### PR TITLE
OSDOCS-9341: adds OLM release note to MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -6,14 +6,14 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-{product-title-first} provides developers and IT organizations with small-form-factor and edge computing, delivered as an application that customers can deploy on top of their managed {op-system-base-full} devices at the edge. Built on {OCP} and Kubernetes, {microshift-short} provides an efficient way to operate single-node clusters in low-resource edge environments.
+{product-title-first} provides developers and IT organizations with small-form-factor and edge computing delivered as an application that customers can deploy on top of their managed {op-system-base-full} devices at the edge. Built on {OCP} and Kubernetes, {microshift-short} provides an efficient way to operate single-node clusters in low-resource edge environments.
 
 {microshift-short} is designed to make control plane restarts economical and be lifecycle-managed as a single unit by the operating system. Updates, roll-backs, and configuration changes consist of simply staging another version in parallel and then - without relying on a network - flipping to and from that version and restarting.
 
 [id="microshift-4-15-about-this-release"]
 == About this release
 // TODO: Update with the relevant information closer to release.
-Version 4.15 of {microshift-short} includes new features and enhancements. {microshift-short} was introduced as Generally Available with {microshift-short} 4.14. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md[Kubernetes 1.27] with the CRI-O container runtime. New features, changes, and known issues that pertain to {product-title} {microshift-short} are included in this topic.
+Version 4.15 of {product-title} includes new features and enhancements. {microshift-short} was introduced as Generally Available with {microshift-short} 4.14. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md[Kubernetes 1.28] with the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
 
 You can deploy {microshift-short} clusters to either on-premise, cloud, or disconnected environments.
 
@@ -45,8 +45,7 @@ This release adds improvements related to the following components and concepts.
 
 [id="microshift-4-15-rhel-fips"]
 ==== FIPS compliance
-* When {op-system-base-full} is installed and started with FIPS enabled, {microshift-short} containers are automatically enabled to run in FIPS-compliant mode.
-//TODO add link to section once merged
+* When {op-system-base-full} is installed and started with FIPS enabled, {microshift-short} containers are automatically enabled to run in FIPS-compliant mode. See xref:../microshift_install/microshift-fips.adoc#microshift-fips[Running {microshift-short} containers in FIPS mode] for details.
 
 [id="microshift-4-15-updating"]
 === Updating
@@ -69,6 +68,7 @@ The following list provides update details:
 [id="microshift-4-15-blueprint-included"]
 ==== Sample blueprints now included
 The `microshift-release-info` RPM now contains sample blueprints that can be used for image building. The blueprints include both {microshift-short} RPM packages and container image references.
+//TODO link to install section once merged
 
 [id="microshift-4-15-support"]
 === Support
@@ -105,13 +105,18 @@ Previously, you could not query for the etcd version included with {microshift-s
 //[id="microshift-backup-and-restore"]
 //=== Backup and restore
 
-//[id="microshift-4-15-running-apps"]
-//=== Running Applications
+[id="microshift-4-15-running-apps"]
+=== Running Applications
 
-[id="microshift-4-15-notable-technical-changes"]
-== Notable technical changes
+[id="microshift-4-15-olm"]
+==== Operator Lifecyle Manager
+With this release, you can use Operator Lifecyle Manager (OLM) to create, apply, and administer add-on Operators. OLM can be used with both connected and disconnected {microshift-short} clusters.
+//TODO add xrefs once content is merged
 
-{microshift-short} {product-version} introduces the following notable technical changes.
+//[id="microshift-4-15-notable-technical-changes"]
+//== Notable technical changes
+
+//{microshift-short} {product-version} introduces the following notable technical changes.
 // Note: use [discrete] for these sub-headings.
 
 [discrete]
@@ -188,36 +193,6 @@ In the following tables, features are marked with the following statuses:
 //[id="microshift-4-15-known-issues"]
 //== Known issues
 
-//* OVN-Kubernetes sets up an iptable chain in the network address translation (NAT) table to handle incoming traffic to the NodePort service. When the NodePort service is not reachable or the connection is refused, check the iptable rules on the host to make sure the relevant rules are properly inserted.
-//+
-//. View the iptable rules for the NodePort service by running the following command:
-//+
-//[source, terminal]
-//----
-//$ sudo iptables-save | grep NODEPORT
-//----
-//+
-//.Example output
-//[source, terminal]
-//----
-//-A OUTPUT -j OVN-KUBE-NODEPORT
-//-A OVN-KUBE-NODEPORT -p tcp -m addrtype --dst-type LOCAL -m tcp --dport 30326 -j DNAT --to-destination 10.43.95.170:80
-//----
-//OVN-Kubernetes configures the `OVN-KUBE-NODEPORT` iptable chain in the NAT table to match the packet with the destination port and Destination Network Address Translates (DNATs) the packet to the `clusterIP` service. The packet is then routed to the OVN network through the gateway bridge `br-ex` using routing rules on the host.
-//+
-//. View the hosts routing table by running the following command:
-//+
-//[source, terminal]
-//----
-//$ ip route
-//----
-//+
-//.Example output
-//[source, terminal]
-//----
-//10.43.0.0/16 via 192.168.122.1 dev br-ex mtu 1400
-//----
-//This routing rule matches the Kubernetes service IP address range and forwards the packet to the gateway bridge `br-ex`. You must enable `ip_forward` on the host. After the packet is forwarded to the OVS bridge `br-ex`, it is handled by OpenFlow rules in OVS. OpenFlow then steers the packet to the OVN network and eventually to the pod.
 
 [id="microshift-4-15-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-9341](https://issues.redhat.com/browse/OSDOCS-9341)

Link to docs preview:
[OLM release note](https://70318--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes#microshift-4-15-olm)
[FIPs link](https://70318--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes#microshift-4-15-rhel-fips)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
