### PR TITLE
KMM: Add configuration & firmware docs for v2.0.1

### DIFF
--- a/hardware_enablement/kmm-kernel-module-management.adoc
+++ b/hardware_enablement/kmm-kernel-module-management.adoc
@@ -20,6 +20,9 @@ include::modules/kmm-uninstalling-kmm.adoc[leveloffset=+1]
 include::modules/kmm-uninstalling-kmmo-red-hat-catalog.adoc[leveloffset=+2]
 include::modules/kmm-uninstalling-kmmo-cli.adoc[leveloffset=+2]
 
+include::modules/kmm-configuration.adoc[leveloffset=+1]
+include::modules/kmm-configuration-reference.adoc[leveloffset=+2]
+
 include::modules/kmm-deploying-modules.adoc[leveloffset=+1]
 include::modules/kmm-creating-module-cr.adoc[leveloffset=+2]
 

--- a/modules/kmm-configuration-reference.adoc
+++ b/modules/kmm-configuration-reference.adoc
@@ -1,0 +1,78 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="kmm-configure-reference_{context}"]
+= Configuration Reference
+
+[cols="1,2"]
+|===
+| `healthProbeBindAddress`
+| Defines the address on which the operator should listen for kubelet health probes. +
+Recommended value: `:8081`.
+
+| `healthProbeBindAddress`
+| Defines the address on which the operator should listen for kubelet health probes. +
+Recommended value: `:8081`.
+
+| `leaderElection.enabled`
+| Determines whether https://kubernetes.io/docs/concepts/architecture/leases/[leader election] is used to ensure that only one replica of the KMM operator is running at any time. +
+Recommended value: `true`.
+
+| `leaderElection.resourceID`
+| Determines the name of the resource that leader election will use for holding the leader lock. +
+Recommended value: `kmm.sigs.x-k8s.io`.
+
+| `metrics.bindAddress`
+| Determines the bind address for the metrics server. +
+It will be defaulted to `:8080` if unspecified. +
+Set this to "0" to disable the metrics server. +
+Recommended value: `0.0.0.0:8443`.
+
+| `metrics.disableHTTP2`
+| If `true`, disables HTTP/2 for the metrics server, as a mitigation for
+https://access.redhat.com/security/cve/cve-2023-44487[CVE-2023-44487]. +
+Recommended value: `true`.
+
+| `metrics.enableAuthnAuthz`
+a| Determines if metrics should be authenticated (via `TokenReviews`) and authorized (via `SubjectAccessReviews`) with the kube-apiserver. +
+For the authentication and authorization the controller needs a ClusterRole with the following rules:
+
+* `apiGroups: authentication.k8s.io, resources: tokenreviews, verbs: create`
+* `apiGroups: authorization.k8s.io, resources: subjectaccessreviews, verbs: create`
+
+To scrape metrics e.g. via Prometheus the client needs a `ClusterRole` with the following rule:
+
+* `nonResourceURLs: "/metrics", verbs: get`
+
+Recommended value: `true`.
+
+| `metrics.secureServing`
+| Determines whether the metrics should be served over HTTPS instead of HTTP.
+Recommended value: `true`.
+
+| `webhook.disableHTTP2`
+| If `true`, disables HTTP/2 for the webhook server, as a mitigation for
+https://access.redhat.com/security/cve/cve-2023-44487[CVE-2023-44487]. +
+Recommended value: `true`.
+
+| `webhook.port`
+| Defines the port on which the operator should be listening for webhook requests. +
+Recommended value: `9443`.
+
+| `worker.runAsUser`
+| Determines the value of the `runAsUser` field of the worker container's
+https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[SecurityContext]. +
+Recommended value: `9443`.
+
+| `worker.seLinuxType`
+| Determines the value of the `seLinuxOptions.type` field of the worker container's
+https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[SecurityContext]. +
+Recommended value: `spc_t`.
+
+| `worker.setFirmwareClassPath`
+| If set, the value of this field will be written by the worker into the `/sys/module/firmware_class/parameters/path` file on the node. +
+This configures the <<kmm-configuring-the-lookup-path-on-nodes_{context},kernel's firmware search path>>. +
+Recommended value: `/var/lib/firmware` if you need to set that value through the worker app; otherwise, unset.
+|===

--- a/modules/kmm-configuration.adoc
+++ b/modules/kmm-configuration.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="kmm-configure_{context}"]
+= Configuring the Kernel Module Management Operator
+
+KMM should be configured out of the box with sensible defaults.
+The operator configuration is set in the `kmm-operator-manager-config` `ConfigMap` in the operator namespace.
+To modify any setting, use the procedure below.
+
+.Procedure
+
+. Edit the `ConfigMap` data:
++
+[source,terminal]
+----
+oc edit configmap -n openshift-kmm kmm-operator-manager-config
+----
++
+. Restart the controller:
++
+[source,terminal]
+----
+oc rollout restart -n openshift-kmm deployment/kmm-operator-controller
+----

--- a/modules/kmm-configuring-the-lookup-path-on-nodes.adoc
+++ b/modules/kmm-configuring-the-lookup-path-on-nodes.adoc
@@ -8,23 +8,5 @@
 
 On {product-title} nodes, the set of default lookup paths for firmwares does not include the `/var/lib/firmware` path.
 
-.Procedure
-
-. Use the Machine Config Operator to create a `MachineConfig` custom resource (CR) that contains the `/var/lib/firmware` path:
-+
-[source,yaml]
-----
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
-metadata:
-  labels:
-    machineconfiguration.openshift.io/role: worker <1>
-  name: 99-worker-kernel-args-firmware-path
-spec:
-  kernelArguments:
-    - 'firmware_class.path=/var/lib/firmware'
-----
-<1> You can configure the label based on your needs. In the case of {sno}, use either `control-pane` or `master` objects.
-
-
-. By applying the `MachineConfig` CR, the nodes are automatically rebooted.
+Since version 2.0.0, KMM workers can set that value on nodes by writing to sysfs, before attempting to load kmods.
+To enable that feature, set `worker.setFirmwareClassPath` to `/var/lib/firmware` in the <<kmm-configure_{context},operator configuration>>.


### PR DESCRIPTION
Version(s): openshift-4.16, openshift-4.15, openshift-4.14-z

Link to docs preview: https://70319--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management

QE review:
- [ ] QE has approved this change.