### PR TITLE
OSDOCS-9311: Documented the 4.13.29 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -3651,3 +3651,24 @@ $ oc adm release info 4.13.28 --pullspecs
 [id="ocp-4-13-28-updating"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+
+[id="ocp-4-13-29"]
+=== RHSA-2024:0193 - {product-title} 4.13.29 bug fix and security update
+
+Issued: 2024-01-17
+
+{product-title} release 4.13.29 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:0193[RHSA-2024:0193] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0195[RHSA-2024:0195] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.29 --pullspecs
+----
+
+[id="ocp-4-13-29-updating"]
+==== Updating
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OSDOCS-9311](https://issues.redhat.com/browse/OSDOCS-9311)

Link to docs preview:
[4.13.29 z-stream release notes](https://70341--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes#ocp-4-13-29)

QE review:
- QE review is not required. See the peer-review checklist.

Additional information:
<!--- Optional: Include additional context or expand the descriptionRHBA-2024:0057 here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
