### PR TITLE
OSDOCS#9352: Moved vSphere post-installation task to Postinstallation

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -495,8 +495,6 @@ Topics:
       File: installing-restricted-networks-vsphere
   - Name: Installing a three-node cluster
     File: installing-vsphere-three-node
-  - Name: Configuring the vSphere connection settings after an installation
-    File: installing-vsphere-post-installation-configuration
   - Name: Uninstalling a cluster
     File: uninstalling-cluster-vsphere-installer-provisioned
   - Name: Using the vSphere Problem Detector Operator
@@ -566,6 +564,8 @@ Topics:
     File: multi-architecture-compute-managing
 - Name: Enabling encryption on a vSphere cluster
   File: vsphere-post-installation-encryption
+- Name: Configuring the vSphere connection settings after an installation
+  File: installing-vsphere-post-installation-configuration
 - Name: Machine configuration tasks
   File: machine-configuration-tasks
 - Name: Cluster tasks

--- a/installing/installing_vsphere/preparing-to-install-on-vsphere.adoc
+++ b/installing/installing_vsphere/preparing-to-install-on-vsphere.adoc
@@ -57,10 +57,6 @@ User-provisioned infrastructure requires the user to provision all resources req
 
 * **xref:../../installing/installing_vsphere/upi/installing-restricted-networks-vsphere.adoc#installing-restricted-networks-vsphere[Installing a cluster on vSphere in a restricted network with user-provisioned infrastructure]**: {product-title} can be installed on VMware vSphere infrastructure that you provision in a restricted network.
 
-== Configuring the vSphere connection settings
-
-* **xref:../../installing/installing_vsphere/installing-vsphere-post-installation-configuration.adoc#installing-vsphere-post-installation-configuration[Updating the vSphere connection settings following an installation]**: For installations on vSphere using the Assisted Installer, you must manually update the vSphere connection settings to complete the installation. For installer-provisioned or user-provisioned infrastructure installations on vSphere, you can optionally validate or modify the vSphere connection settings at any time.
-
 == Uninstalling an installer-provisioned infrastructure installation of {product-title} on vSphere
 
 * **xref:../../installing/installing_vsphere/uninstalling-cluster-vsphere-installer-provisioned.adoc#uninstalling-cluster-vsphere-installer-provisioned[Uninstalling a cluster on vSphere that uses installer-provisioned infrastructure]**: You can remove a cluster that you deployed on VMware vSphere infrastructure that used installer-provisioned infrastructure.

--- a/post_installation_configuration/installing-vsphere-post-installation-configuration.adoc
+++ b/post_installation_configuration/installing-vsphere-post-installation-configuration.adoc
@@ -17,4 +17,4 @@ include::modules/configuring-vsphere-connection-settings.adoc[leveloffset=+1]
 
 include::modules/configuring-vsphere-verifying-configuration.adoc[leveloffset=+1]
 
-For instructions on creating storage objects, see xref:../../storage/dynamic-provisioning.adoc#dynamic-provisioning[Dynamic provisioning].
+For instructions on creating storage objects, see xref:../storage/dynamic-provisioning.adoc#dynamic-provisioning[Dynamic provisioning].


### PR DESCRIPTION
Version(s):
4.15+

Issue:
This PR addresses [osdocs-9352](https://issues.redhat.com/browse/OSDOCS-9352).

Link to docs preview:

- [Installing on vSphere](https://70344--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/preparing-to-install-on-vsphere) (note the absence of the post-installation topic)
- Postinstallation configuration > [Configuring the vSphere connection settings after an installation](https://70344--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/installing-vsphere-post-installation-configuration) (new home)

QE review:
- [N/A] QE has approved this change.
No content has changed. This PR simply moves an assembly in the TOC.