### PR TITLE
[OSDOCS-9275] changing to gp3 for accuracy

### DIFF
--- a/modules/rosa-aws-provisioned.adoc
+++ b/modules/rosa-aws-provisioned.adoc
@@ -31,7 +31,7 @@ Volume requirements for each EC2 instance:
 
 - Control Plane Volume
 * Size: 350GB
-* Type: io1
+* Type: gp3
 * Input/Output Operations Per Second: 1000
 
 - Infrastructure Volume


### PR DESCRIPTION
[OSDOCS-9275] changing to gp3 for accuracy

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-9275

Link to docs preview:
https://70352--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs#rosa-ebs-storage_prerequisites

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
