### PR TITLE
OSDOCS#8989: Installing OLM on MicroShift

### DIFF
--- a/microshift_install/microshift-embed-in-rpm-ostree.adoc
+++ b/microshift_install/microshift-embed-in-rpm-ostree.adoc
@@ -32,6 +32,12 @@ include::modules/microshift-adding-repos-to-image-builder.adoc[leveloffset=+1]
 
 include::modules/microshift-adding-service-to-blueprint.adoc[leveloffset=+1]
 
+include::modules/microshift-adding-olm-to-blueprint.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../microshift_updating/microshift-update-rpms-ostree.adoc[Applying updates on an OSTree system]
+
 include::modules/microshift-ca-adding-bundle.adoc[leveloffset=+1]
 
 include::modules/microshift-ca-adding-bundle-ostree.adoc[leveloffset=+2]

--- a/microshift_install/microshift-install-rpm.adoc
+++ b/microshift_install/microshift-install-rpm.adoc
@@ -37,6 +37,10 @@ include::modules/microshift-install-rpm-preparing.adoc[leveloffset=+1]
 
 include::modules/microshift-install-rpms.adoc[leveloffset=+1]
 
+include::modules/microshift-install-rpms-olm.adoc[leveloffset=+1]
+
+//TODO: Additional resources section that includes OLM resources when docs are complete
+
 //additional resources for install rpms module
 [role="_additional-resources"]
 .Additional resources

--- a/modules/microshift-adding-olm-to-blueprint.adoc
+++ b/modules/microshift-adding-olm-to-blueprint.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * microshift/microshift-update-rpms-ostree.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-adding-olm-to-blueprint_{context}"]
+== Adding the Operator Lifecycle Manager (OLM) service to a blueprint 
+
+When you install {microshift-short}, the Operator Lifecycle Manager (OLM) package is not installed by default. You can add the `microshift-olm` package in the ostree blueprint to enable OLM in {microshift-short}.
+
+. Edit your ostree blueprint by running the following example command:
++
+[source,terminal]
+[subs="+quotes"]
+----
+$ vi _<microshift_blueprint.toml>_ <1>
+----
+<1> Specify the name of the blueprint file you used when adding the MicroShift service.
+
+. Add the following example text to your ostree blueprint:
++
+[source,text]
+----
+[[packages]]
+name = "microshift-olm"
+version = "*"
+----
+. To apply the manifest from the package to an active cluster, you must build a new OSTree system then deploy it on the machine. To update your OSTree system, use the instruction's in "Applying updates on an OSTree system"

--- a/modules/microshift-install-rpms-olm.adoc
+++ b/modules/microshift-install-rpms-olm.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// microshift/microshift-install-rpm.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-installing-with-olm-from-rpm-package_{context}"]
+== Installing the Operator Lifecycle Manager (OLM) from an RPM package
+
+When you install {microshift-short}, the Operator Lifecycle Manager (OLM) package is not installed by default. You can install the OLM on your {microshift-short} instance using a RPM package. 
+
+.Procedure 
+
+. Install the OLM package by running the following command: 
++
+[source,terminal]
+----
+$ sudo dnf install microshift-olm
+----
+
+. To apply the manifest from the package to an active cluster, run the following command: 
++
+[source,terminal]
+----
+$ sudo systemctl restart microshift
+----


### PR DESCRIPTION
**Version(s):** 4.15+
**Issue:** [OSDOCS-8989](https://issues.redhat.com//browse/OSDOCS-8989)

**Link to docs preview:**

- [Installing the Operator Lifecycle Manager (OLM) for MicroShift from an RPM package](https://70359--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-install-rpm#installing-microshift-with-olm-from-rpm-package_microshift-install-rpm)
- [Adding the Operator Lifecycle Manager (OLM) service to a blueprint](https://70359--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree#adding-olm-to-blueprint_microshift-embed-in-rpm-ostree)


**QE review:**
- [x] QE has approved this change.

