### PR TITLE
Updating the machine set docs to use newer GCP marketplace images

### DIFF
--- a/modules/cpmso-yaml-provider-spec-gcp.adoc
+++ b/modules/cpmso-yaml-provider-spec-gcp.adoc
@@ -76,9 +76,9 @@ providerSpec:
 To use a GCP Marketplace image, specify the offer to use:
 +
 --
-* {product-title}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-ocp-48-x86-64-202210040145`
-* {opp}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-opp-48-x86-64-202206140145`
-* {oke}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-oke-48-x86-64-202206140145`
+* {product-title}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-ocp-413-x86-64-202305021736`
+* {opp}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-opp-413-x86-64-202305021736`
+* {oke}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-oke-413-x86-64-202305021736`
 --
 <3> Specifies the cloud provider platform type. Do not change this value.
 <4> Specifies the name of the GCP project that you use for your cluster.

--- a/modules/machineset-yaml-gcp.adoc
+++ b/modules/machineset-yaml-gcp.adoc
@@ -133,9 +133,9 @@ endif::infra[]
 To use a GCP Marketplace image, specify the offer to use:
 +
 --
-* {product-title}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-ocp-48-x86-64-202210040145`
-* {opp}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-opp-48-x86-64-202206140145`
-* {oke}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-oke-48-x86-64-202206140145`
+* {product-title}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-ocp-413-x86-64-202305021736`
+* {opp}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-opp-413-x86-64-202305021736`
+* {oke}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-oke-413-x86-64-202305021736`
 --
 <4> Optional: Specify custom metadata in the form of a `key:value` pair. For example use cases, see the GCP documentation for link:https://cloud.google.com/compute/docs/metadata/setting-custom-metadata[setting custom metadata].
 <5> For `<project_name>`, specify the name of the GCP project that you use for your cluster.


### PR DESCRIPTION
Version(s):
4.13+

Issue:
N/A

Link to docs preview:
* [Sample YAML for a compute machine set custom resource on GCP](https://70365--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp#machineset-yaml-gcp_creating-machineset-gcp)
* [Sample GCP provider specification](https://70365--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration#cpmso-yaml-provider-spec-gcp_cpmso-configuration)

QE review:
- [x] QE has approved this change.

Additional information: