### PR TITLE
OBSDOCS-722 - Logging 5.6.15 Release Notes

### DIFF
--- a/logging/logging_release_notes/logging-5-6-release-notes.adoc
+++ b/logging/logging_release_notes/logging-5-6-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-6-15.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-6-14.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-6-13.adoc[leveloffset=+1]

--- a/modules/logging-release-notes-5-6-15.adoc
+++ b/modules/logging-release-notes-5-6-15.adoc
@@ -1,0 +1,21 @@
+//module included in logging-5-6-release-notes.adoc
+:content-type: REFERENCE
+[id="logging-release-notes-5-6-15"]
+= Logging 5.6.15
+This release includes link:https://access.redhat.com/errata/RHBA-2024:0270[OpenShift Logging Bug Fix Release 5.6.15].
+
+[id="logging-release-notes-5-6-15-bug-fixes"]
+== Bug fixes
+Before this update, the LokiStack ruler pods would not format the IPv6 pod IP in HTTP URLs used for cross pod communication, causing querying rules and alerts through the Prometheus-compatible API to fail. With this update, the LokiStack ruler pods encapsulate the IPv6 pod IP in square brackets, resolving the issue. (link:https://issues.redhat.com/browse/LOG-4892[LOG-4892])
+
+[id="logging-release-notes-5-6-15-CVEs"]
+== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2021-3468[CVE-2021-3468]
+* link:https://access.redhat.com/security/cve/CVE-2023-3446[CVE-2023-3446]
+* link:https://access.redhat.com/security/cve/CVE-2023-3817[CVE-2023-3817]
+* link:https://access.redhat.com/security/cve/CVE-2023-5678[CVE-2023-5678]
+* link:https://access.redhat.com/security/cve/CVE-2023-38469[CVE-2023-38469]
+* link:https://access.redhat.com/security/cve/CVE-2023-38470[CVE-2023-38470]
+* link:https://access.redhat.com/security/cve/CVE-2023-38471[CVE-2023-38471]
+* link:https://access.redhat.com/security/cve/CVE-2023-38472[CVE-2023-38472]
+* link:https://access.redhat.com/security/cve/CVE-2023-38473[CVE-2023-38473]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11. 4.12, 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OBSDOCS-722](https://issues.redhat.com//browse/OBSDOCS-722)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://70383--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/logging_release_notes/logging-5-6-release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: @anpingli  / @QiaolingTang / @kabirbhartiRH 
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:  CPs to be created after review. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
