### PR TITLE
Adding more object names to the Image Prune Conditions

### DIFF
--- a/modules/pruning-images-manual.adoc
+++ b/modules/pruning-images-manual.adoc
@@ -188,6 +188,9 @@ You can apply conditions to your manually pruned images.
 *** Replica sets
 *** Build configurations
 *** Builds
+*** Jobs
+*** Cronjobs
+*** Stateful sets
 *** `--keep-tag-revisions` most recent items in `stream.status.tags[].items`
 ** That are exceeding the smallest limit defined in the same project and are not currently referenced by any:
 *** Running pods
@@ -198,6 +201,9 @@ You can apply conditions to your manually pruned images.
 *** Replica sets
 *** Build configurations
 *** Builds
+*** Jobs
+*** Cronjobs
+*** Stateful sets
 * There is no support for pruning from external registries.
 * When an image is pruned, all references to the image are removed from all
 image streams that have a reference to the image in `status.tags`.


### PR DESCRIPTION
Adding more object names to the Image Prune Conditions as per https://issues.redhat.com/browse/OCPBUGS-15311

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14, 4.13, 4.12, 4.11

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-15311

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://70386--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/pruning-objects.html#pruning-images-conditions_pruning-objects

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
