### PR TITLE
OCPBUGS#23165: Moved user-defined tags section after installation configuration

### DIFF
--- a/installing/installing_azure/installing-azure-customizations.adoc
+++ b/installing/installing_azure/installing-azure-customizations.adoc
@@ -28,10 +28,6 @@ include::modules/installation-azure-marketplace-subscribe.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
-include::modules/installation-user-defined-tags-azure.adoc[leveloffset=+1]
-
-include::modules/querying-user-defined-tags-azure.adoc[leveloffset=+1]
-
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -60,6 +56,10 @@ include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 .Additional resources
 
 * For more details about Accelerated Networking, see xref:../../machine_management/creating_machinesets/creating-machineset-azure.adoc#machineset-azure-accelerated-networking_creating-machineset-azure[Accelerated Networking for Microsoft Azure VMs].
+
+include::modules/installation-user-defined-tags-azure.adoc[leveloffset=+1]
+
+include::modules/querying-user-defined-tags-azure.adoc[leveloffset=+1]
 
 //Installing the OpenShift CLI by downloading the binary: Moved up to precede manual cred (short and long) steps, which require the use of `oc`
 include::modules/cli-installing-cli.adoc[leveloffset=+1]

--- a/installing/installing_gcp/installing-gcp-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-customizations.adoc
@@ -25,14 +25,6 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
-include::modules/installing-gcp-user-defined-labels-and-tags.adoc[leveloffset=+1]
-
-//Configuring user-defined labels and tags for GCP
-include::modules/installing-gcp-cluster-creation.adoc[leveloffset=+2]
-
-//Querying user-defined labels and tags for GCP
-include::modules/installing-gcp-querying-labels-tags-gcp.adoc[leveloffset=+2]
-
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -64,6 +56,14 @@ include::modules/installation-gcp-config-yaml.adoc[leveloffset=+2]
 * xref:../../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-enabling-customer-managed-encryption_creating-machineset-gcp[Enabling customer-managed encryption keys for a compute machine set]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+
+include::modules/installing-gcp-user-defined-labels-and-tags.adoc[leveloffset=+1]
+
+//Configuring user-defined labels and tags for GCP
+include::modules/installing-gcp-cluster-creation.adoc[leveloffset=+2]
+
+//Querying user-defined labels and tags for GCP
+include::modules/installing-gcp-querying-labels-tags-gcp.adoc[leveloffset=+2]
 
 //Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
 include::modules/cli-installing-cli.adoc[leveloffset=+1]

--- a/modules/installation-user-defined-tags-azure.adoc
+++ b/modules/installation-user-defined-tags-azure.adoc
@@ -3,7 +3,7 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="installing-azure-user-defined-tags_{context}"]
-= Configuring the user-defined tags for Azure
+= Configuring user-defined tags for Azure
 
 In {product-title}, you can use the tags for grouping resources and for managing resource access and cost. You can define the tags on the Azure resources in the `install-config.yaml` file only during {product-title} cluster creation. You cannot modify the user-defined tags after cluster creation.
 


### PR DESCRIPTION
Version(s): 4.11+

Issue: [OCPBUGS-23165](https://issues.redhat.com/browse/OCPBUGS-23165)

Link to docs preview: 
GCP: https://70396--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations
Azure: https://70396--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-customizations

QE review:
- [x] QE has approved this change. @jianli-wei 