### PR TITLE
Test current versus previous version of makeBuild.py with current build error on main

### DIFF
--- a/modules/nodes-clusters-cgroups-2.adoc
+++ b/modules/nodes-clusters-cgroups-2.adoc
@@ -14,6 +14,8 @@ endif::[]
 [id="nodes-clusters-cgroups-2_{context}"]
 = Configuring Linux cgroup
 
+Test
+
 ifndef::openshift-origin[]
 ifdef::post[]
 As of {product-title} 4.14, {product-title} uses link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[Linux control group version 2] (cgroup v2) in your cluster. If you are using cgroup v1 on {product-title} 4.13 or earlier, migrating to {product-title} 4.14 will not automatically update your cgroup configuration to version 2. A fresh installation of {product-title} 4.14 will use cgroup v2 by default. However, you can enable link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1/index.html[Linux control group version 1] (cgroup v1) upon installation. 


### PR DESCRIPTION
[The previous version of makeBuild.py errors and fails](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_openshift-docs/70405/pull-ci-openshift-openshift-docs-main-validate-asciidoc/1747612816824602624)
[The current version of makeBuild.py passes errors and succeeds](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_openshift-docs/70405/pull-ci-openshift-openshift-docs-main-validate-asciidoc/1747615433755725824)