### PR TITLE
OADP-1689  Clarify what is/is not supported with the CloudStorage API

### DIFF
--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
@@ -14,8 +14,15 @@ You back up applications by creating a `Backup` custom resource (CR). See xref:.
 
 For more information about CSI volume snapshots, see xref:../../../storage/container_storage_interface/persistent-storage-csi-snapshots.adoc#persistent-storage-csi-snapshots[CSI volume snapshots].
 
-:FeatureName: The `CloudStorage` API for S3 storage
+:FeatureName: The `CloudStorage` API, which automates the creation of a bucket for object storage,
 include::snippets/technology-preview.adoc[]
+
+[NOTE]
+====
+The `CloudStorage` API is a Technology Preview feature when you use a `CloudStorage` object and want OADP to use the `CloudStorage` API to automatically create an S3 bucket for use as a `BackupStorageLocation`.
+
+The `CloudStorage` API supports manually creating a `BackupStorageLocation` object by specifying an existing S3 bucket. The `CloudStorage` API that creates an S3 bucket automatically is currently only enabled for AWS S3 storage.
+====
 
 * If your cloud provider does not support snapshots or if your applications are on NFS data volumes, you can create backups by using Kopia or Restic. See xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#oadp-backing-up-applications-restic-doc[Backing up applications with File System Backup: Kopia or Restic].
 

--- a/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
@@ -18,10 +18,15 @@ To back up Kubernetes resources and internal images, you must have object storag
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc#installing-oadp-mcg[Multicloud Object Gateway]
 * AWS S3 compatible object storage, such as Multicloud Object Gateway or MinIO
 
-include::snippets/snip-noobaa-and-mcg.adoc[]
-
 :FeatureName: The `CloudStorage` API, which automates the creation of a bucket for object storage,
 include::snippets/technology-preview.adoc[]
+
+[NOTE]
+====
+The `CloudStorage` API is a Technology Preview feature when you use a `CloudStorage` object and want OADP to use the `CloudStorage` API to automatically create an S3 bucket for use as a `BackupStorageLocation`.
+
+The `CloudStorage` API supports manually creating a `BackupStorageLocation` object by specifying an existing S3 bucket. The `CloudStorage` API that creates an S3 bucket automatically is currently only enabled for AWS S3 storage.
+====
 
 You can back up persistent volumes (PVs) by using snapshots or a File System Backup (FSB).
 


### PR DESCRIPTION
OADP 1.3.1
OCP 4.13+

Resolves - https://issues.redhat.com/browse/OADP-1689

Deploy preview - 

https://70409--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp

(About installing OADP)

https://70409--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications

(Backing up applications)
