### PR TITLE
[enterprise-4.11] OCPBUGS#23390: Removed the root statement from RH OCP 1.3.0 registry …

### DIFF
--- a/modules/mirror-registry-localhost-update.adoc
+++ b/modules/mirror-registry-localhost-update.adoc
@@ -30,3 +30,10 @@ $ sudo ./mirror-registry upgrade -v
 ====
 Users who upgrade the _mirror registry for Red Hat OpenShift_ with the `./mirror-registry upgrade -v` flag must include the same credentials used when creating their mirror registry. For example, if you installed the _mirror registry for Red Hat OpenShift_ with `--quayHostname <host_example_com>` and `--quayRoot <example_directory_name>`, you must include that string to properly upgrade the mirror registry.
 ====
+
+* If you are upgrading the _mirror registry for Red Hat OpenShift_ from 1.2.z -> 1.3.0 and you used a specified directory in your 1.2.z deployment, you must pass in the new `--pgStorage` and `--quayStorage` flags. For example:
++
+[source,terminal]
+----
+$ sudo ./mirror-registry upgrade --quayHostname <host_example_com> --quayRoot <example_directory_name> --pgStorage <example_directory_name>/pg-data --quayStorage <example_directory_name>/quay-storage -v
+----

--- a/modules/mirror-registry-release-notes.adoc
+++ b/modules/mirror-registry-release-notes.adoc
@@ -140,9 +140,9 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 +
 IPv6 is currently unsupported on _mirror registry for Red Hat OpenShift_ remote host installations.
 
-* A new feature flag, `--quayStorage`, has been added. With this flag, users with root privileges can manually set the location of their Quay persistent storage.
+* A new feature flag, `--quayStorage`, has been added. By specifying this flag, you can manually set the location for the Quay persistent storage.
 
-* A new feature flag, `--pgStorage`, has been added. With this flag, users with root privileges can manually set the location of their Postgres persistent storage.
+* A new feature flag, `--pgStorage`, has been added. By specifying this flag, you can manually set the location for the Postgres persistent storage.
 
 * Previously, users were required to have root privileges (`sudo`) to install _mirror registry for Red Hat OpenShift_. With this update, `sudo` is no longer required to install _mirror registry for Red Hat OpenShift_.
 +


### PR DESCRIPTION
Cherry picked from #69083 with commit ID 2f690dd8e95b619a853f7534e7a13a7395845bd6

Version(s):
4.11

Link to docs preview:
* [Updating mirror registry for Red Hat OpenShift from a local host](https://69083--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-creating-registry#mirror-registry-localhost-update_installing-mirroring-creating-registry)
* [New features](https://69083--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-creating-registry#new-features)
