### PR TITLE
OBSDOCS-749: add deprecation notice of dedicatedservicemonitors feature to 4.15 RNs

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -534,6 +534,11 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.13 |4.14 |4.15
 
+|`dedicatedServiceMonitors` setting that enables dedicated service monitors for core platform monitoring
+|General Availability
+|General Availability
+|Deprecated
+
 |====
 
 [discrete]
@@ -738,6 +743,13 @@ In the following tables, features are marked with the following statuses:
 ==== Bare Metal Event Relay Operator
 
 The Bare Metal Event Relay Operator is deprecated. The ability to monitor bare-metal hosts by using the Bare Metal Event Relay Operator will be removed in a future {product-title} release.
+
+[id="ocp-4-15-dedicated-service-monitors-for-core-platform-monitoring"]
+==== Dedicated service monitors for core platform monitoring
+With this release, the dedicated service monitors feature for core platform monitoring is deprecated.
+The ability to enable dedicated service monitors by configuring the `dedicatedServiceMonitors` setting in the `cluster-monitoring-config` config map object in the `openshift-monitoring` namespace will be removed in a future {product-title} release.
+To replace this feature, Prometheus functionality has been improved in order to ensure that alerts and time aggregations are accurate. 
+This improved functionality is active by default and makes the dedicated service monitors feature obsolete.
 
 [id="ocp-4-15-removed-features"]
 === Removed features


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15 only
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-749
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://70431--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-dedicated-service-monitors-for-core-platform-monitoring
- https://70431--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-deprecated-removed-features
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR adds deprecation information to the OCP 4.15 release notes for the `dedicatedServiceMonitors` feature in-cluster monitoring .
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
