### PR TITLE
Fix the channel value for tang-operator

### DIFF
--- a/modules/nbde-tang-server-operator-installing-cli.adoc
+++ b/modules/nbde-tang-server-operator-installing-cli.adoc
@@ -41,7 +41,7 @@ metadata:
   name: tang-operator
   namespace: openshift-operators
 spec:
-  channel: latest <1>
+  channel: stable <1>
   installPlanApproval: Automatic
   name: tang-operator <2>
   source: redhat-operators <3>


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-25998

OCPBUGS-25998: Issue in file security/nbde_tang_server_operator/nbde-tang-server-operator-installing.adoc

Version(s):
4.13, 4.14, 4.15 

Link to docs preview:
https://70432--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/nbde_tang_server_operator/nbde-tang-server-operator-installing#installing-nbde-tang-server-operator-using-cli_installing-nbde-tang-server-operator

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
