### PR TITLE
HCIDOCS-149: [docs] Remove SDN for OCP 4.15+

### DIFF
--- a/modules/assisted-installer-using-the-assisted-installer.adoc
+++ b/modules/assisted-installer-using-the-assisted-installer.adoc
@@ -21,7 +21,7 @@ The {ai-full} provides installation functionality as a service. This software-as
 ** Eliminates the need to install and run the {product-title} installer locally.
 ** Ensures the latest version of the installer up to the latest tested z-stream releases. Older versions remain available, if needed.
 ** Enables building automation by using the API without the need to run the {product-title} installer locally.
-* *Advanced networking:* The {ai-full} supports IPv4 networking with SDN and OVN, IPv6 and dual stack networking with OVN only, NMState-based static IP addressing, and an HTTP/S proxy. OVN is the default Container Network Interface (CNI) for OpenShift Container Platform 4.12 and later, but you can use SDN.
+* *Advanced networking:* The {ai-full} supports IPv4 networking with SDN and OVN, IPv6 and dual stack networking with OVN only, NMState-based static IP addressing, and an HTTP/S proxy. OVN is the default Container Network Interface (CNI) for OpenShift Container Platform 4.12 and later releases. SDN is supported up to {product-title} 4.14, but is not supported for {product-title} 4.15 and later releases.
 
 * *Preinstallation validation:* The {ai-full} validates the configuration before installation to ensure a high probability of success. The validation process includes the following checks:
 ** Ensuring network connectivity


### PR DESCRIPTION
Made a note of non-support of SDN for 4.15 and later releases.

Fixes: [HCIDOCS-149](https://issues.redhat.com//browse/HCIDOCS-149)

See https://issues.redhat.com/browse/HCIDOCS-149 for additional details.

Preview URL: http://jowilkin.com:8080/HCIDOCS-149/installing/installing_on_prem_assisted/installing-on-prem-assisted.html

For release(s): 4.15
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
