### PR TITLE
OSDOCS-8904: Private Cluster on ROSA with HCP docs

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -210,6 +210,8 @@ Topics:
   File: rosa-hcp-sts-creating-a-cluster-quickly
 - Name: Creating ROSA with HCP clusters using a custom AWS KMS encryption key
   File: rosa-hcp-creating-cluster-with-aws-kms-key
+- Name: Creating a private cluster on ROSA with HCP
+  File: rosa-hcp-aws-privatelink-creating-cluster
 - Name: Using the Node Tuning Operator on ROSA with HCP
   File: rosa-tuning-config
 ---

--- a/modules/osd-aws-privatelink-about.adoc
+++ b/modules/osd-aws-privatelink-about.adoc
@@ -1,11 +1,23 @@
 // Module included in the following assemblies:
 //
 // * rosa_install_access_delete_clusters/rosa-aws-privatelink-creating-cluster.adoc
+// * rosa_hcp/rosa-hcp-aws-privatelink-creating-cluster.adoc
+ifeval::["{context}" == "rosa-hcp-aws-privatelink-creating-cluster"]
+:rosa-hcp:
+endif::[]
+ifeval::["{context}" == "rosa-aws-privatelink-creating-cluster"]
+:rosa-standalone:
+endif::[]
 :_mod-docs-content-type: CONCEPT
-[id="osd-aws-privatelink-about.adoc_{context}"]
+[id="osd-aws-privatelink-about_{context}"]
 = Understanding AWS PrivateLink
 
+ifdef::rosa-hcp[]
+All {hcp-title} clusters are created with an AWS PrivateLink connection to expose the private Kubernetes API server to the customer's virtual private cloud (VPC).
+endif::rosa-hcp[]
+ifndef::rosa-hcp[]
 A {product-title} cluster can be created without any requirements on public subnets, internet gateways, or network address translation (NAT) gateways. In this configuration, Red Hat uses AWS PrivateLink to manage and monitor a cluster to avoid all public ingress network traffic. Without a public subnet, it is not possible to configure an application router as public. Configuring private application routers is the only option.
+endif::rosa-hcp[]
 
 For more information, see link:https://aws.amazon.com/privatelink/[AWS PrivateLink] on the AWS website.
 
@@ -13,3 +25,10 @@ For more information, see link:https://aws.amazon.com/privatelink/[AWS PrivateLi
 ====
 You can only make a PrivateLink cluster at installation time. You cannot change a cluster to PrivateLink after installation.
 ====
+
+ifeval::["{context}" == "rosa-hcp-aws-privatelink-creating-cluster"]
+:!rosa-hcp:
+endif::[]
+ifeval::["{context}" == "rosa-aws-privatelink-creating-cluster"]
+:!rosa-standalone:
+endif::[]

--- a/modules/osd-aws-privatelink-required-resources.adoc
+++ b/modules/osd-aws-privatelink-required-resources.adoc
@@ -1,10 +1,21 @@
 // Module included in the following assemblies:
 //
 // * rosa_install_access_delete_clusters/rosa-aws-privatelink-creating-cluster.adoc
-[id="osd-aws-privatelink-required-resources.adoc_{context}"]
+// * rosa_hcp/rosa-hcp-aws-privatelink-creating-cluster.adoc
+ifeval::["{context}" == "rosa-hcp-aws-privatelink-creating-cluster"]
+:rosa-hcp:
+endif::[]
+ifeval::["{context}" == "rosa-aws-privatelink-creating-cluster"]
+:rosa-standalone:
+endif::[]
+[id="osd-aws-privatelink-required-resources_{context}"]
 = Requirements for using AWS PrivateLink clusters
-
-For AWS PrivateLink clusters, internet gateways, NAT gateways and public subnets are not required, but the private subnets must have internet connectivity provided to install required components. At least one single private subnet is required for Single-AZ clusters and at least 3 private subnets are required for Multi-AZ clusters. The following table shows the AWS resources that are required for a successful installation:
+ifdef::rosa-hcp[]
+For {hcp-title} private clusters, internet gateways, NAT gateways, and public subnets are not required, but the private subnets must have internet connectivity to install the required components. At least one private subnet is required. The following table shows the AWS resources that are required for a successful installation:
+endif::rosa-hcp[]
+ifndef::rosa-hcp[]
+For AWS PrivateLink clusters, internet gateways, NAT gateways, and public subnets are not required, but the private subnets must have internet connectivity provided to install required components. At least one single private subnet is required for Single-AZ clusters and at least 3 private subnets are required for Multi-AZ clusters. The following table shows the AWS resources that are required for a successful installation:
+endif::rosa-hcp[]
 
 .Required AWS resources
 [cols="1a,2a,3a",options="header"]
@@ -14,11 +25,11 @@ For AWS PrivateLink clusters, internet gateways, NAT gateways and public subnets
 |* AWS::EC2::VPC
 * AWS::EC2::VPCEndpoint
 | You must provide a VPC for the cluster to use.
+
 | Network access control
 |* AWS::EC2::NetworkAcl
 * AWS::EC2::NetworkAclEntry
 |
-
 You must allow access to the following ports:
 [cols="35%,65%",options="header"]
 !===
@@ -34,10 +45,23 @@ You must allow access to the following ports:
 ! 0-65535
 ! Outbound ephemeral traffic
 !===
+
 | Private subnets
 |* AWS::EC2::Subnet
 * AWS::EC2::RouteTable
 * AWS::EC2::SubnetRouteTableAssociation
-| Your VPC must have private subnets in 1 availability zone for Single-AZ deployments or 3 availability zones for Multi-AZ deployments.
+|
+ifdef::rosa-hcp[]
+Your VPC must have private subnets in at least 1 availability zone.
+endif::rosa-hcp[]
+ifndef::rosa-hcp[]
+Your VPC must have private subnets in 1 availability zone for Single-AZ deployments or 3 availability zones for Multi-AZ deployments.
+endif::rosa-hcp[]
 You must provide appropriate routes and route tables.
 |===
+ifeval::["{context}" == "rosa-hcp-aws-privatelink-creating-cluster"]
+:!rosa-hcp:
+endif::[]
+ifeval::["{context}" == "rosa-aws-privatelink-creating-cluster"]
+:!rosa-standalone:
+endif::[]

--- a/modules/rosa-aws-privatelink-create-cluster.adoc
+++ b/modules/rosa-aws-privatelink-create-cluster.adoc
@@ -22,7 +22,7 @@ AWS PrivateLink is supported on existing VPCs only.
 
 Creating a cluster can take up to 40 minutes.
 
-. With AWS PrivateLink, you can create a cluster with a single availability zone (Single-AZ) or multiple availability zones (Multi-AZ). In either case, your machine's classless inter-domain routing (CIDR) must match your virtual private cloud's CIDR. See https://docs.openshift.com/container-platform/4.13/installing/installing_aws/installing-aws-vpc.html#installation-custom-aws-vpc-requirements_installing-aws-vpc[Requirements for using your own VPC] and link:https://docs.openshift.com/container-platform/4.13/installing/installing_aws/installing-aws-vpc.html#installation-custom-aws-vpc-validation_installing-aws-vpc[VPC Validation] for more information.
+. With AWS PrivateLink, you can create a cluster with a single availability zone (Single-AZ) or multiple availability zones (Multi-AZ). In either case, your machine's classless inter-domain routing (CIDR) must match your virtual private cloud's CIDR. See https://docs.openshift.com/container-platform/4.14/installing/installing_aws/installing-aws-vpc.html#installation-custom-aws-vpc-requirements_installing-aws-vpc[Requirements for using your own VPC] and link:https://docs.openshift.com/container-platform/4.14/installing/installing_aws/installing-aws-vpc.html#installation-custom-aws-vpc-validation_installing-aws-vpc[VPC Validation] for more information.
 +
 [IMPORTANT]
 ====

--- a/modules/rosa-hcp-aws-privatelink-create-cluster.adoc
+++ b/modules/rosa-hcp-aws-privatelink-create-cluster.adoc
@@ -1,0 +1,92 @@
+// Module included in the following assemblies:
+//
+// * rosa_hcp/rosa-hcp-aws-privatelink-creating-cluster.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-hcp-aws-privatelink-create-cluster_{context}"]
+= Creating an AWS PrivateLink cluster
+
+You can create a private cluster with multiple availability zones (Multi-AZ) on {hcp-title} using the ROSA command line interface (CLI), `rosa`.
+
+[NOTE]
+====
+AWS PrivateLink is supported on preexisting VPCs only.
+====
+
+.Prerequisites
+
+* You have available AWS service quotas.
+* You have enabled the ROSA service in the AWS Console.
+* You have installed and configured the latest version of the ROSA CLI on your installation host.
+
+.Procedure
+
+Creating a cluster with {hcp} can take around 10 minutes.
+
+. Create a VPC with at least one private subnet. Ensure that your machine's classless inter-domain routing (CIDR) matches your virtual private cloud's CIDR. For more information, see https://docs.openshift.com/container-platform/4.14/installing/installing_aws/installing-aws-vpc.html#installation-custom-aws-vpc-requirements_installing-aws-vpc[Requirements for using your own VPC] and link:https://docs.openshift.com/container-platform/4.14/installing/installing_aws/installing-aws-vpc.html#installation-custom-aws-vpc-validation_installing-aws-vpc[VPC Validation].
++
+[IMPORTANT]
+====
+If you use a firewall, you must configure it so that ROSA can access the sites that required to function.
+
+For more information, see the "AWS PrivateLink firewall prerequisites" section.
+====
+
+. Create the account-wide IAM roles by running the following command:
++
+[source,terminal]
+----
+$ rosa create account-roles --hosted-cp
+----
+
+. Create the OIDC configuration by running the following command:
++
+[source,terminal]
+----
+$ rosa create oidc-config --mode=auto --yes
+----
++
+Save the OIDC configuration ID because you need it to create the Operator roles.
++
+.Example output
+[source,terminal]
+----
+I: Setting up managed OIDC configuration
+I: To create Operator Roles for this OIDC Configuration, run the following command and remember to replace <user-defined> with a prefix of your choice:
+	rosa create operator-roles --prefix <user-defined> --oidc-config-id 28s4avcdt2l318r1jbk3ifmimkurk384
+If you are going to create a Hosted Control Plane cluster please include '--hosted-cp'
+I: Creating OIDC provider using 'arn:aws:iam::46545644412:user/user'
+I: Created OIDC provider with ARN 'arn:aws:iam::46545644412:oidc-provider/oidc.op1.openshiftapps.com/28s4avcdt2l318r1jbk3ifmimkurk384'
+----
+
+. Create the Operator roles by running the following command:
++
+[source,terminal]
+----
+$ rosa create operator-roles --hosted-cp --prefix <operator_roles_prefix> --oidc-config-id <oidc_config_id> --installer-role-arn arn:aws:iam::$<account_roles_prefix>:role/$<account_roles_prefix>-HCP-ROSA-Installer-Role
+----
+
+. Create a private {hcp-title} cluster by running the following command:
++
+[source,terminal]
+----
+$ rosa create cluster --private-link --cluster-name=<cluster-name> --sts --mode=auto --hosted-cp --operator-roles-prefix <operator_role_prefix> --oidc-config-id <oidc_config_id> [--machine-cidr=<VPC CIDR>/16] --subnet-ids=<private-subnet-id1>[,<private-subnet-id2>,<private-subnet-id3>]
+----
+
+. Enter the following command to check the status of your cluster. During cluster creation, the `State` field from the output will transition from `pending` to `installing`, and finally, to `ready`.
++
+[source,terminal]
+----
+$ rosa describe cluster --cluster=<cluster_name>
+----
++
+[NOTE]
+====
+If installation fails or the `State` field does not change to `ready` after 10 minutes, see the "Troubleshooting Red Hat OpenShift Service on AWS installations" documentation in the Additional resources section.
+====
+
+. Enter the following command to follow the OpenShift installer logs to track the progress of your cluster:
++
+[source,terminal]
+----
+$ rosa logs install --cluster=<cluster_name> --watch
+----

--- a/modules/rosa-hcp-aws-privatelink-security-groups.adoc
+++ b/modules/rosa-hcp-aws-privatelink-security-groups.adoc
@@ -1,0 +1,66 @@
+// Module included in the following assemblies:
+//
+// * rosa_hcp/rosa-hcp-aws-privatelink-creating-cluster.adoc
+[id="rosa-hcp-aws-privatelink-security-groups_{context}"]
+:_mod-docs-content-type: PROCEDURE
+= Configuring AWS security groups to access the API
+
+With {hcp-title} private clusters, the AWS PrivateLink endpoint exposed in the customer's VPC has a default security group. This security group has access to the PrivateLink endpoint that is limited to only those resources that exist within the VPC or resources that are present with an IP address associated with the VPC CIDR range. In order to grant access to any entities outside of the VPC, through VPC peering and transit gateway, you must create and attach another security group to the PrivateLink endpoint to grant the necessary access.
+
+.Prerequisites
+
+* Your corporate network or other VPC has connectivity.
+* You have permission to create and attach security groups within the VPC.
+
+.Procedure
+
+. Set your cluster name as an environmental variable by running the following command:
++
+[source,terminal]
+----
+$ export CLUSTER_NAME=<cluster_name>
+----
++
+You can verify that the variable has been set by running the following command:
++
+[source,terminal]
+----
+$ echo $CLUSTER_NAME
+----
++
+.Example output
++
+[source,terminal]
+----
+hcp-private
+----
+
+. Find the VPC endpoint (VPCE) ID and VPC ID by running the following command:
++
+[source,terminal]
+----
+$ read -r VPCE_ID VPC_ID <<< $(aws ec2 describe-vpc-endpoints --filters "Name=tag:api.openshift.com/id,Values=$(rosa describe cluster -c ${CLUSTER_NAME} -o yaml | grep '^id: ' | cut -d' ' -f2)" --query 'VpcEndpoints[].[VpcEndpointId,VpcId]' --output text)
+----
+
+. Create your security group by running the following command:
++
+[source,terminal]
+----
+$ export SG_ID=$(aws ec2 create-security-group --description "Granting API access to ${CLUSTER_NAME} from outside of VPC" --group-name "${CLUSTER_NAME}-api-sg" --vpc-id $VPC_ID --output text)
+----
+
+. Add an ingress rule to the security group by running the following command:
++
+[source,terminal]
+----
+$ aws ec2 authorize-security-group-ingress --group-id $SG_ID --ip-permissions FromPort=443,ToPort=443,IpProtocol=tcp,IpRanges=[{CidrIp=0.0.0.0/0}]
+----
+
+. Add the the new security group to the VPCE by running the following command:
++
+[source,terminal]
+----
+$ aws ec2 modify-vpc-endpoint --vpc-endpoint-id $VPCE_ID --add-security-group-ids $SG_ID
+----
+
+You now can access the API with your {hcp-title} private cluster.

--- a/rosa_hcp/rosa-hcp-aws-privatelink-creating-cluster.adoc
+++ b/rosa_hcp/rosa-hcp-aws-privatelink-creating-cluster.adoc
@@ -1,0 +1,28 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="rosa-hcp-aws-privatelink-creating-cluster"]
+= Creating a private cluster on {hcp-title}
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: rosa-hcp-aws-privatelink-creating-cluster
+
+toc::[]
+
+This document describes how to create a {hcp-title-first} private cluster.
+
+include::modules/osd-aws-privatelink-about.adoc[leveloffset=+1]
+include::modules/osd-aws-privatelink-required-resources.adoc[leveloffset=+1]
+include::modules/rosa-hcp-aws-privatelink-create-cluster.adoc[leveloffset=+1]
+include::modules/rosa-hcp-aws-privatelink-security-groups.adoc[leveloffset=+1]
+
+[id="next-steps_rosa-hcp-aws-privatelink-creating-cluster"]
+== Next steps
+xref:../rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.adoc#rosa-sts-config-identity-providers[Configuring identity providers]
+
+[role="_additional-resources"]
+[id="additional-resources_rosa-hcp-aws-privatelink-creating-cluster"]
+== Additional resources
+
+* xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs[AWS PrivateLink firewall prerequisites]
+* xref:../rosa_getting_started/rosa-sts-getting-started-workflow.adoc#rosa-sts-overview-of-the-deployment-workflow[Overview of the ROSA with STS deployment workflow]
+* xref:../rosa_install_access_delete_clusters/rosa-sts-deleting-cluster.adoc#rosa-sts-deleting-cluster[Deleting a ROSA cluster]
+* xref:../rosa_architecture/rosa_architecture_sub/rosa-architecture-models.adoc#rosa-architecture-models[Architecture models]
+* xref:../support/troubleshooting/rosa-troubleshooting-installations.adoc#rosa-troubleshooting-installing[Troubleshooting Red Hat OpenShift Service on AWS installations]


### PR DESCRIPTION
Version(s):
`enterprise-4.14+`

Issue:
[OSDOCS-8904](https://issues.redhat.com/browse/OSDOCS-8904)

Link to docs preview:
- **[Creating a private cluster on ROSA with HCP](https://file.rdu.redhat.com/eponvell/OSDOCS-8904_Privatelink-ROSA-with-HCP/rosa_hcp/rosa-hcp-aws-privatelink-creating-cluster.html)**
- **[Creating an AWS PrivateLink cluster on ROSA](https://file.rdu.redhat.com/eponvell/OSDOCS-8904_Privatelink-ROSA-with-HCP/rosa_install_access_delete_clusters/rosa-aws-privatelink-creating-cluster.html)** (unchanged)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR creates a topic about creating a private cluster with ROSA with HCP.