### PR TITLE
Preparing to install with Agent: formatting updates

### DIFF
--- a/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="preparing-to-install-with-agent-based-installer"]
-= Preparing to install with the Agent-based installer
+= Preparing to install with the Agent-based Installer
 include::_attributes/common-attributes.adoc[]
 :context: preparing-to-install-with-agent-based-installer
 
@@ -16,6 +16,7 @@ It generates a bootable ISO image containing all of the information required to 
 The configuration is in the same format as for the installer-provisioned infrastructure and user-provisioned infrastructure installation methods.
 The Agent-based Installer can also optionally generate or accept Zero Touch Provisioning (ZTP) custom resources. ZTP allows you to provision new edge sites with declarative configurations of bare-metal equipment.
 
+//Understanding Agent-based Installer
 include::modules/understanding-agent-install.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -27,8 +28,10 @@ include::modules/understanding-agent-install.adoc[leveloffset=+1]
 
 * xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno} clusters]
 
+//About FIPS compliance
 include::modules/agent-installer-fips-compliance.adoc[leveloffset=+1]
 
+//Configuring FIPS through the Agent-based Installer
 include::modules/agent-installer-configuring-fips-compliance.adoc[leveloffset=+1]
 
 [discrete]
@@ -39,6 +42,7 @@ include::modules/agent-installer-configuring-fips-compliance.adoc[leveloffset=+1
 
 * xref:../../installing/installing-fips.adoc#installing-fips[Support for FIPS cryptography]
 
+//About networking
 include::modules/agent-install-networking.adoc[leveloffset=+1]
 
 [id="installation-requirements-platform-none_{context}"]
@@ -46,12 +50,16 @@ include::modules/agent-install-networking.adoc[leveloffset=+1]
 
 This section describes the requirements for an Agent-based {product-title} installation that is configured to use the platform `none` option.
 
+//Platform "none" DNS requirements
 include::modules/agent-install-dns-none.adoc[leveloffset=+2]
 
+//Platform "none" Load balancing requirements
 include::modules/agent-install-load-balancing-none.adoc[leveloffset=+2]
 
+//Example: Bonds and VLAN interface node network configuration
 include::modules/agent-install-sample-config-bonds-vlans.adoc[leveloffset=+1]
 
+//Example: Bonds and SR-IOV dual-nic node network configuration
 include::modules/agent-install-sample-config-bond-sriov.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -59,10 +67,13 @@ include::modules/agent-install-sample-config-bond-sriov.adoc[leveloffset=+1]
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_networking/configuring-network-bonding_configuring-and-managing-networking[Configuring network bonding]
 
+//Sample install-config.yaml file for bare metal
 include::modules/installation-bare-metal-agent-installer-config-yaml.adoc[leveloffset=+1]
 
+//Validation checks before agent ISO creation
 include::modules/validations-before-agent-iso-creation.adoc[leveloffset=+1]
 
+//About root device hints
 include::modules/agent-install-ipi-install-root-device-hints.adoc[leveloffset=+1]
 
 [id="agent-based-installation-next-steps"]


### PR DESCRIPTION
Versions: 4.12+

This PR makes some minor formatting and spelling-level edits to the "Preparing to install with the Agent-based installer" page. 

No QE required

Preview: [Preparing to install with the Agent-based Installer](https://70453--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer)

