### PR TITLE
OSDOCS-9397: An extraneous character broke autonumbering

### DIFF
--- a/modules/ipi-install-establishing-communication-between-subnets.adoc
+++ b/modules/ipi-install-establishing-communication-between-subnets.adoc
@@ -33,15 +33,15 @@ In this procedure, the cluster spans two subnets:
 $ sudo su -
 ----
 
-.. Get the name of the network interface:
+.. Get the name of the network interface by running the following command:
 +
 [source,terminal]
 ----
 # nmcli dev status
 ----
 
-.. Add a route to the second subnet (`192.168.0.0`) via the gateway:
-s+
+.. Add a route to the second subnet (`192.168.0.0`) via the gateway by running the following command:
++
 [source,terminal]
 ----
 # nmcli connection modify <interface_name> +ipv4.routes "192.168.0.0/24 via <gateway>"
@@ -56,7 +56,7 @@ Replace `<interface_name>` with the interface name. Replace `<gateway>` with the
 # nmcli connection modify eth0 +ipv4.routes "192.168.0.0/24 via 192.168.0.1"
 ----
 
-.. Apply the changes:
+.. Apply the changes by running the following command:
 +
 [source,terminal]
 ----
@@ -81,21 +81,21 @@ Adjust the commands to match your actual interface names and gateway.
 
 . Configure the second subnet to communicate with the first subnet:
 
-.. Log in as `root` to a remote worker node:
+.. Log in as `root` to a remote worker node by running the following command:
 +
 [source,terminal]
 ----
 $ sudo su -
 ----
 
-.. Get the name of the network interface:
+.. Get the name of the network interface by running the following command:
 +
 [source,terminal]
 ----
 # nmcli dev status
 ----
 
-.. Add a route to the first subnet (`10.0.0.0`) via the gateway:
+.. Add a route to the first subnet (`10.0.0.0`) via the gateway by running the following command:
 +
 [source,terminal]
 ----
@@ -111,7 +111,7 @@ Replace `<interface_name>` with the interface name. Replace `<gateway>` with the
 # nmcli connection modify eth0 +ipv4.routes "10.0.0.0/24 via 10.0.0.1"
 ----
 
-.. Apply the changes:
+.. Apply the changes by running the following command:
 +
 [source,terminal]
 ----
@@ -120,7 +120,7 @@ Replace `<interface_name>` with the interface name. Replace `<gateway>` with the
 +
 Replace `<interface_name>` with the interface name.
 
-.. Verify the routing table to ensure the route has been added successfully:
+.. Verify the routing table to ensure the route has been added successfully by running the following command:
 +
 [source,terminal]
 ----
@@ -136,7 +136,7 @@ Adjust the commands to match your actual interface names and gateway.
 
 . Once you have configured the networks, test the connectivity to ensure the remote worker nodes can reach the control plane nodes and the control plane nodes can reach the remote worker nodes.
 
-.. From the control plane nodes in the first subnet, ping a remote worker node in the second subnet:
+.. From the control plane nodes in the first subnet, ping a remote worker node in the second subnet by running the following command:
 +
 [source,terminal]
 ----
@@ -145,7 +145,7 @@ $ ping <remote_worker_node_ip_address>
 +
 If the ping is successful, it means the control plane nodes in the first subnet can reach the remote worker nodes in the second subnet. If you don't receive a response, review the network configurations and repeat the procedure for the node.
 
-.. From the remote worker nodes in the second subnet, ping a control plane node in the first subnet:
+.. From the remote worker nodes in the second subnet, ping a control plane node in the first subnet by running the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Fixed an extraneous character that was breaking auto numbering and formatting, and performed some minor edits.

Fixes: [OSDOCS-9397](https://issues.redhat.com//browse/OSDOCS-9397)

See https://issues.redhat.com/browse/OSDOCS-9397 for additional details.

Preview URL: http://184.23.213.161:8080/HCIDOCS-149/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#ipi-install-establishing-communication-between-subnets_ipi-install-installation-workflow

For release(s): 4.15, 4.14
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
