### PR TITLE
to add ca-central-1 to rosa hcp

### DIFF
--- a/modules/rosa-hcp-classic-comparison.adoc
+++ b/modules/rosa-hcp-classic-comparison.adoc
@@ -63,6 +63,7 @@
 * Asia Pacific - Sydney (ap-southest-2)
 * Asia Pacific - Jakarta (ap-southeast-3)
 * Asia Pacific - Melbourne (ap-southeast-4)
+* Canada - Central (ca-central-1)
 | For AWS Region availability, see link:https://docs.aws.amazon.com/general/latest/gr/rosa.html[Red Hat OpenShift Service on AWS endpoints and quotas] in the AWS documentation.
 
 | *Compliance*

--- a/modules/rosa-sdpolicy-am-regions-az.adoc
+++ b/modules/rosa-sdpolicy-am-regions-az.adoc
@@ -41,9 +41,7 @@ endif::rosa-with-hcp[]
 * ap-southeast-2 (Sydney)
 * ap-southeast-3 (Jakarta, AWS opt-in required)
 * ap-southeast-4 (Melbourne, AWS opt-in required)
-ifndef::rosa-with-hcp[]
 * ca-central-1 (Central Canada)
-endif::rosa-with-hcp[]
 * eu-central-1 (Frankfurt)
 ifndef::rosa-with-hcp[]
 * eu-central-2 (Zurich, AWS opt-in required)


### PR DESCRIPTION
This PR adds ca-central-1 AWS region to ROSA HCP
