### PR TITLE
MIG 1512 - MTC 1.8 only supports OCP4->4 migrations

### DIFF
--- a/modules/migration-compatibility-guidelines.adoc
+++ b/modules/migration-compatibility-guidelines.adoc
@@ -20,29 +20,35 @@ modern operator:: The {mtc-short} Operator designed for modern platforms.
 control cluster:: The cluster that runs the {mtc-short} controller and GUI.
 remote cluster:: A source or destination cluster for a migration that runs Velero. The Control Cluster communicates with Remote clusters via the Velero API to drive migrations.
 
+You must use the compatible {mtc-short} version for migrating your {product-title} clusters. For the migration to succeed both your source cluster and the destination cluster must use the same version of MTC.
 
-[cols="1,2,2", options="header"]
-.{mtc-short} compatibility: Migrating from a legacy platform
+MTC 1.7 supports migrations from {product-title} 3.11 to 4.8.
+
+MTC 1.8 only supports migrations from {product-title} 4.9 and later.
+
+.{mtc-short} compatibility: Migrating from a legacy or a modern platform
 |===
-||{product-title} 4.5 or earlier |{product-title} 4.6 or later
-|Stable {mtc-short} version a|{mtc-short} {mtc-version}._z_
+|Details |{product-title} 3.11 |{product-title} 4.0 to 4.5 |{product-title} 4.6 to 4.8 |{product-title} 4.9 or later
 
-Legacy {mtc-version} operator: Install manually with the `operator.yml` file.
-[IMPORTANT]
-====
+|Stable {mtc-short} version
+|{mtc-short} v.1.7._z_
+|{mtc-short} v.1.7._z_
+|{mtc-short} v.1.7._z_
+|{mtc-short} v.1.8._z_
+
+|Installation
+|
+|Legacy {mtc-short} v.1.7._z_ operator: Install manually with the `operator.yml` file.
+
+[*IMPORTANT*]
 This cluster cannot be the control cluster.
-====
-
-|{mtc-short} {mtc-version}._z_
-
-Install with OLM, release channel `release-v1.7`
+|Install with OLM, release channel `release-v1.7`
+|Install with OLM, release channel `release-v1.8`
 |===
 
-[NOTE]
-====
 Edge cases exist in which network restrictions prevent modern clusters from connecting to other clusters involved in the migration. For example, when migrating from an {product-title} 3.11 cluster on premises to a modern {product-title} cluster in the cloud, where the modern cluster cannot connect to the {product-title} 3.11 cluster.
 
-With {mtc-short} {mtc-version}, if one of the remote clusters is unable to communicate with the control cluster because of network restrictions, use the `crane tunnel-api` command.
+With {mtc-short} v.1.7._z_, if one of the remote clusters is unable to communicate with the control cluster because of network restrictions, use the `crane tunnel-api` command.
 
 With the stable {mtc-short} release, although you should always designate the most modern cluster as the control cluster, in this specific case it is possible to designate the legacy cluster as the control cluster and push workloads to the remote cluster.
-====
+

--- a/modules/migration-installing-legacy-operator.adoc
+++ b/modules/migration-installing-legacy-operator.adoc
@@ -43,18 +43,16 @@ $ podman login registry.redhat.io
 
 . Download the `operator.yml` file by entering the following command:
 +
-[source,terminal,subs="attributes+"]
+[source,terminal]
 ----
-$ podman cp $(podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version}):/operator.yml ./
+podman cp $(podman create registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v1.7):/operator.yml ./
 ----
 
 . Download the `controller.yml` file by entering the following command:
 +
-[source,terminal,subs="attributes+"]
+[source,terminal]
 ----
-$ podman cp $(podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version}):/controller.yml ./
+podman cp $(podman create registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v1.7):/controller.yml ./
 ----
 
 ifdef::installing-restricted-3-4,installing-mtc-restricted[]


### PR DESCRIPTION
MTC 1.8.3

OCP 4.11+

Resolves - https://issues.redhat.com/browse/MIG-1512

Deploy preview - https://70463--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/installing-3-4#migration-compatibility-guidelines_installing-3-4

(Compatibility guidelines)

https://70463--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/installing-3-4#migration-installing-legacy-operator_installing-3-4

(Installing MTC) 
