### PR TITLE
OSDOCS-9214

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -40,7 +40,7 @@ This section provides the necessary details that enable you to control egress tr
 |443
 |Provides core container images.
 
-|`*.quay.io`
+|`.quay.io`
 |443
 |Provides core container images.
 
@@ -137,7 +137,7 @@ endif::fedramp[]
 
 --
 +
-When you add a site such as `quay.io` to your allowlist, do not add a wildcard entry such as `*.quay.io` to your denylist. In most cases, image registries use a content delivery network (CDN) to serve images. If a firewall blocks access, then image downloads are denied when the initial download request is redirected to a host name such as `cdn01.quay.io`.
+When you add a site such as `quay.io` to your allowlist, do not add a wildcard entry such as `.quay.io` to your denylist. In most cases, image registries use a content delivery network (CDN) to serve images. If a firewall blocks access, then image downloads are denied when the initial download request is redirected to a host name such as `cdn01.quay.io`.
 +
 CDN host names, such as `cdn01.quay.io`, are covered when you add a wildcard entry, such as `.quay.io`, in your allowlist.
 
@@ -281,7 +281,7 @@ Alternatively, if you choose to not use a wildcard for Amazon Web Services (AWS)
 |443
 |Alerting service used by {product-title} to send periodic pings that indicate whether the cluster is available and running.
 
-|`*.osdsecuritylogs.splunkcloud.com`
+|`.osdsecuritylogs.splunkcloud.com`
 OR
 `inputs1.osdsecuritylogs.splunkcloud.com`
 `inputs2.osdsecuritylogs.splunkcloud.com`


### PR DESCRIPTION
[OSDOCS-9214](https://issues.redhat.com/browse/OSDOCS-9214): Use consistent formats for wildcard domain list in AWS firewall prerequisites

Aligned team: Service Delivery
OCP version for cherry-picking: enterprise-4.14+
JIRA issues: [OSDOCS-9214](https://issues.redhat.com/browse/OSDOCS-9214)
Preview pages: [ROSA build preview](https://70465--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_prerequisites)
SME review **completed**: @bysnupy 
QE review **completed**:  @yasun1 
Peer review **completed**: @stevsmit 