### PR TITLE
OSDOCS#8867: Adding RN for Nutanix failure domains

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -79,6 +79,13 @@ You can now install a cluster on {ibm-cloud-name} in an environment with limited
 
 // For more information see <insert links to restricted install assembly after docs merge>.
 
+[id="ocp-4-15-installation-and-update-nutanix-failure-domains"]
+==== Nutanix and fault tolerant deployments
+
+By default, the installation program installs control plane and compute machines into a single Nutanix Prism Element (cluster). To improve the fault tolerance of your {product-title} cluster, you can now specify that these machines be distributed across multiple Nutanix clusters by configuring failure domains.
+
+//For more information, see <insert link to Fault tolerant deployments using multiple Prism Elements when docs merge>.
+
 [id="ocp-4-15-web-console"]
 === Web console
 


### PR DESCRIPTION
Version(s):
4.15

Issue:

This PR adds the release note for [osdocs-8867](https://issues.redhat.com/browse/OSDOCS-8867).

Link to docs preview:

[Nutanix and fault tolerant deployments](https://70495--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-installation-and-update-nutanix-failure-domains)

QE review:
[yes] QE has approved this change.