### PR TITLE
OSDOCS#8973: Add test/invoke for functions in ODC to serverless docs

### DIFF
--- a/functions/serverless-functions-on-cluster-builds.adoc
+++ b/functions/serverless-functions-on-cluster-builds.adoc
@@ -11,3 +11,4 @@ Instead of building a function locally, you can build a function directly on the
 include::modules/serverless-functions-creating-on-cluster-builds.adoc[leveloffset=+1]
 include::modules/serverless-functions-specifying-function-revision.adoc[leveloffset=+1]
 include::modules/serverless-functions-setting-custom-volume-size.adoc[leveloffset=+1]
+include::modules/odc-invoke-serverless-function.adoc[leveloffset=+1]

--- a/modules/odc-invoke-serverless-function.adoc
+++ b/modules/odc-invoke-serverless-function.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * serverless/functions/serverless-functions-on-cluster-builds.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="odc-invoke-serverless-function_{context}"]
+= Testing a function in the web console
+
+You can test a deployed serverless function by invoking it in the *Developer* perspective of the {product-title} web console.
+
+.Prerequisites
+
+* The {ServerlessOperatorName} and Knative Serving are installed on your {product-title} cluster.
+* You have logged in to the web console and are in the *Developer* perspective.
+* You have created and deployed a function.
+
+.Procedure
+
+. In the *Developer* perspective, navigate to *Topology*.
+
+. Click on a function, then click *Test Serverless Function* from the *Actions* drop-down list in the *Details* panel. This opens the *Test Serverless Function* dialog box.
+
+. In the *Test Serverless Function* dialog box, modify the settings for your test as required:
+
+.. Choose the *Format* for your test. This can be either *CloudEvent* or *HTTP*.
+.. The *Content-Type* defaults to the `Content-Type` HTTP header value.
+.. You can use the *Advanced Settings* to modify the *Type* or *Source* for CloudEvent tests, or to add optional headers.
+.. You can modify the input data for the test.
+
+. Click *Test* to run your test.
+. After the test is complete, the *Test Serverless Function* dialog box displays a status code and a message that informs you whether your test was succesful.
+. Click *Back* to perform another test, or *Close* to close the testing dialog box.


### PR DESCRIPTION
DO NOT ACTUALLY MERGE! waiting for 1.32 release tomorrow.

This is a copy over from https://github.com/openshift/openshift-docs/pull/59750.

This PR is for the Serverless 1.32 release that is currently planned to release Q1. Do not merge until this date.

Version(s):
Serverless 1.32 tbd on other serverless branches

Issue:
https://issues.redhat.com/browse/OSDOCS-8973
Note that the original RHDEVDOCS ticket is linked to this one.

Link to docs preview:
https://70510--docspreview.netlify.app/openshift-serverless/latest/functions/serverless-functions-on-cluster-builds#odc-invoke-serverless-function_serverless-functions-on-cluster-builds

QE review:
- [ x] QE has approved this change.
**see acks in https://github.com/openshift/openshift-docs/pull/59750**

Additional information:

**SME acks are in #59750**
