### PR TITLE
PV1 fix: Security and compliance - cert manager RN

### DIFF
--- a/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
@@ -12,7 +12,7 @@ These release notes track the development of {cert-manager-operator}.
 
 For more information, see xref:../../security/cert_manager_operator/index.adoc#cert-manager-operator-about[About the {cert-manager-operator}].
 
-[id="cert-manager-operator-release-notes-1.13"]
+[id="cert-manager-operator-release-notes-1-13"]
 == Release notes for {cert-manager-operator} 1.13.0
 
 Issued: 2024-01-16
@@ -23,10 +23,10 @@ The following advisory is available for the {cert-manager-operator} 1.13.0:
 
 Version `1.13.0` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.13.3`. For more information, see the link:https://cert-manager.io/docs/release-notes/release-notes-1.13/#v1133[cert-manager project release notes for v1.13.0].
 
-[id="cert-manager-operator-new-features-1.13"]
+[id="cert-manager-operator-new-features-1-13"]
 === New features and enhancements
 
-* You can now manage certificates for API Server and Ingress Controller by using the {cert-manager-operator}. 
+* You can now manage certificates for API Server and Ingress Controller by using the {cert-manager-operator}.
 For more information, see xref:../../security/cert_manager_operator/cert-manager-creating-certificate.adoc#cert-manager-creating-certificate[Configuring certificates with an issuer].
 
 * With this release, the scope of the {cert-manager-operator}, which was previously limited to the {product-title} on AMD64 architecture, has now been expanded to include support for managing certificates on {product-title} running on {ibm-z-name} (`s390x`), {ibm-power-name} (`ppc64le`) and ARM64 architectures.
@@ -34,7 +34,7 @@ For more information, see xref:../../security/cert_manager_operator/cert-manager
 * With this release, you can use DNS over HTTPS (DoH) for performing the self-checks during the ACME DNS-01 challenge verification. The DNS self-check method can be controlled by using the command line flags, `--dns01-recursive-nameservers-only` and `--dns01-recursive-nameservers`.
 For more information, see xref:../../security/cert_manager_operator/cert-manager-customizing-api-fields.html#cert-manager-override-arguments_cert-manager-customizing-api-fields[Customizing cert-manager by overriding arguments from the cert-manager Operator API].
 
-[id="cert-manager-operator-1.13-CVEs"]
+[id="cert-manager-operator-1-13-CVEs"]
 === CVEs
 
 * link:https://access.redhat.com/security/cve/CVE-2023-39615[CVE-2023-39615]


### PR DESCRIPTION
PV1 does not accept `.` in `id`s

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
