### PR TITLE
#CNV-29629 - CLI hotplug docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3938,7 +3938,7 @@ Topics:
       File: virt-specifying-nodes-for-vms
     - Name: Configuring certificate rotation
       File: virt-configuring-certificate-rotation
-    - Name: Configuring the default CPU model
+    - Name: Configuring the CPU model
       File: virt-configuring-default-cpu-model
     - Name: UEFI mode for virtual machines
       File: virt-uefi-mode-for-vms

--- a/modules/virt-enabling-cpu-hotplug.adoc
+++ b/modules/virt-enabling-cpu-hotplug.adoc
@@ -1,0 +1,88 @@
+// Module included in the following assemblies:
+//
+// * virt/advanced_vm_management/virt-configuring-default-cpu-model.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-enabling-cpu-hotplug_{context}"]
+= Enabling CPU hot plug
+
+Use the CPU hot plug feature to enable the addition or removal of virtual CPUs while the virtual machine (VM) is in operation by configuring the VM workload.
+
+[IMPORTANT]
+====
+The `VMLiveUpdateFeatures` feature gate must be added to the `HyperConverged` CR by an administrator before users can enable CPU hot plug.
+====
+
+== Enabling CPU hot plug on a cluster
+
+.Procedure
+
+. Add the `VMLiveUpdateFeatures` JSON annotation to the `HyperConverged` CR by running the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc annotate --overwrite -n openshift-cnv hyperconverged kubevirt-hyperconverged kubevirt.kubevirt.io/jsonpatch='[{
+     "op": "add",
+     "path": "/spec/configuration/developerConfiguration/featureGates/-",
+     "value": "VMLiveUpdateFeatures"
+ }]'
+
+----
++
+Users can now enable CPU hot plug at the VM level.
+
+. Optional: Set the `maxCPUSockets` value in the HyperConverged CR. By default, the `maxCpuSockets` value is four times the sockets value.
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: kubevirt.io/v1
+kind: KubeVirt
+spec:
+  configuration:
+    liveUpdateConfiguration:
+      maxCpuSockets: 8
+----
++
+[NOTE]
+====
+The VM-level `maxSockets` configuration takes precedence over the cluster-wide configuration.
+====
+
+== Enabling CPU hot plug on a virtual machine
+
+.Prerequisites
+
+* The `VMLiveUpdateFeatures` JSON annotation must be added to the `HyperConverged` CR by an administrator.
+
+.Procedure
+
+. Add the `cpu` field to the VM spec:
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+spec:
+  liveUpdateFeatures:
+    cpu: {}
+----
++
+CPU hot plug is now enabled.
+
+. Optional: Set the the `maxCpuSockets` value in the VM spec. By default, the `maxCpuSockets` value is four times the sockets value.
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+spec:
+  liveUpdateFeatures:
+    cpu:
+      maxSockets: 8
+----
++
+
+[NOTE]
+====
+The VM-level `maxSockets` configuration takes precedence over the cluster-wide configuration.
+====

--- a/virt/virtual_machines/advanced_vm_management/virt-configuring-default-cpu-model.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-configuring-default-cpu-model.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="virt-configuring-default-cpu-model"]
-= Configuring the default CPU model
+= Configuring the CPU model
 include::_attributes/common-attributes.adoc[]
 :context: virt-configuring-default-cpu-model
 
@@ -18,3 +18,4 @@ The virtual machine (VM) CPU model depends on the availability of CPU models wit
 toc::[]
 
 include::modules/virt-configuring-default-cpu-model.adoc[leveloffset=+1]
+include::modules/virt-enabling-cpu-hotplug.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-29629](https://issues.redhat.com//browse/CNV-29629)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://70514--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-configuring-default-cpu-model#virt-enabling-cpu-hotplug_virt-configuring-default-cpu-model
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
