### PR TITLE
OSSM-5726 Distributed Tracing Docs Section Updates and Tempo content (2.5 Release)

### DIFF
--- a/modules/ossm-config-external-jaeger.adoc
+++ b/modules/ossm-config-external-jaeger.adoc
@@ -5,7 +5,7 @@ This module is included in the following assemblies:
 
 :_mod-docs-content-type: PROCEDURE
 [id="ossm-config-external-jaeger_{context}"]
-= Connecting an existing distributed tracing instance
+= Connecting an existing distributed tracing Jaeger instance
 
 If you already have an existing {JaegerName} instance in {product-title}, you can configure your `ServiceMeshControlPlane` resource to use that instance for {DTShortName}.
 

--- a/modules/ossm-configuring-distr-tracing-tempo.adoc
+++ b/modules/ossm-configuring-distr-tracing-tempo.adoc
@@ -1,0 +1,98 @@
+////
+This module is included in the following assemblies:
+* service_mesh/v2x/ossm-observability.adoc
+////
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-configuring-distr-tracing-tempo_{context}"]
+= Configuring the distributed tracing platform (Tempo)
+
+You can expose tracing data to the {TempoName} stack by appending a named element and the `zipkin` provider to the `spec.meshConfig.extensionProviders` specification in the `ServiceMehControlPlane`, as shown in the following example. Then, a telemetry custom resource configures Istio proxies to collect trace spans and send them to the Tempo distributor service endpoint.
+
+You can create a TempoStack instance in the `tracing-system` namespace _after_ creating the `ServiceMeshControlPlane` and the `ServiceMeshMemberRoll` resources.
+
+.Prerequisites
+
+* You have installed the {TempoOperator} and {SMProductName} Operator in the `openshift-operators` namespace.
+* You have created namespaces such as `istio-system` and `tracing-system`.
+
+.Procedure
+
+. Configure the `ServiceMeshControlPlane` resource to define an extension provider:
++
+[source,yaml]
+----
+kind: ServiceMeshControlPlane
+apiVersion: maistra.io/v2
+metadata:
+  name: basic
+  namespace: istio-system
+spec:
+# ...
+  meshConfig:
+    extensionProviders:
+      - name: tempo
+        zipkin:
+          service: tempo-sample-distributor.tracing-system.svc.cluster.local
+          port: 9411
+  tracing:
+    sampling: 10000
+    type: None <1>
+  version: v2.5
+---
+kind: ServiceMeshMemberRoll
+apiVersion: maistra.io/v1
+metadata:
+  name: default
+  namespace: istio-system
+spec:
+  members:
+    - tracing-system
+----
+<1> The `spec.tracing.type` setting defines a deprecated Distributed Tracing Jaeger instance. Set `spec.tracing.type` to `None` when connecting to a TempoStack using an `extensionProvider` setting.
++
+[NOTE]
+====
+Create a TempoStack instance _after_ creating the `ServiceMeshControlPlane` and the `ServiceMeshMemberRoll` resources.
+====
+
+. Configure the Kiali resource specification to enable a Kiali workload traces dashboard. You can use the dashboard to view tracing query results.
++
+[source,yaml]
+----
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+# ...
+spec:
+  external_services:
+    tracing:
+      query_timeout: 30
+      enabled: true
+      in_cluster_url: 'http://tempo-sample-query-frontend.tracing-system.svc.cluster.local:16686'
+      url: '[Tempo query frontend Route url]'
+----
++
+[NOTE]
+====
+Kiali 1.73 uses the Jaeger Query API, which causes a longer response time depending on Tempo resource limits. If you see a `Could not fetch spans` error message in the Kiali UI, then check your Tempo configuration or reduce the limit per query in Kiali.
+====
+
+. Create a TempoStack instance using the Red Hat {TempoOperator} in the `tracing-system` namespace. For more information, see "Installing the distributed tracing platform (Tempo)" in the "Additional resources" section.
+
+. Apply a Telemetry custom resource for {SMProductShortName} to start the Tempo provider setting.
++
+[source,yaml]
+----
+apiVersion: telemetry.istio.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: mesh-default
+  namespace: istio-system
+spec:
+  tracing:
+  - providers:
+    - name: tempo
+    randomSamplingPercentage: 100
+----
+
+You can also create an Istio gateway and virtual service resources to expose an {product-title} route for accessing the Tempo Jaeger Query console.

--- a/service_mesh/v2x/ossm-observability.adoc
+++ b/service_mesh/v2x/ossm-observability.adoc
@@ -20,6 +20,14 @@ include::modules/ossm-kiali-viewing-metrics.adoc[leveloffset=+2]
 
 include::modules/ossm-distr-tracing.adoc[leveloffset=+1]
 
+include::modules/ossm-configuring-distr-tracing-tempo.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+ifndef::openshift-rosa,openshift-dedicated[]
+xref:../../distr_tracing/distr_tracing_tempo/distr-tracing-tempo-installing.adoc[Installing the distributed tracing platform (Tempo)].
+endif::[]
+
 include::modules/ossm-config-external-jaeger.adoc[leveloffset=+2]
 
 include::modules/ossm-config-sampling.adoc[leveloffset=+2]
@@ -42,4 +50,6 @@ include::modules/ossm-integrating-with-user-workload-monitoring.adoc[leveloffset
 
 ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../../monitoring/enabling-monitoring-for-user-defined-projects.adoc[Enabling monitoring for user-defined projects]
+* xref:../../distr_tracing/distr_tracing_tempo/distr-tracing-tempo-installing.adoc[Installing the distributed tracing platform (Tempo)]
+* xref:../../otel/otel-installing.adoc[Installing the Red Hat build of OpenTelemetry]
 endif::[]


### PR DESCRIPTION
[OSSM-5726](https://issues.redhat.com//browse/OSSM-5726) Distributed Tracing Docs Section Updates and Tempo content

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSSM-5726

Link to docs preview:
https://70517--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-observability#ossm-configuring-distr-tracing-tempo_observability

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

03/12/2024 Peer Review: Please review the NOTE added to Step 2. The NOTE reads:
	
Kiali 1.73 uses the Jaeger Query API which causes a longer response time depending on Tempo resource limits. If you see a Could not fetch spans error message in the Kiali UI, then check your Tempo configuration or reduce the limit per query in Kiali.

It has been approved by dev/QE already.

----------
To be released with OSSM 2.5.

This PR adds a new section, "Configuring the distributed tracing platform (Tempo)," under "Distributed tracing." 

There is a new "Additional resources" section with the new distributed tracing platform (Tempo) modules. There are also additions to the existing "Additional resources" section. A link to https://docs.openshift.com/container-platform/4.14/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-installing.html appears in both sections on purpose in case users skip over it in the "Configuring the distributed tracing platform (Tempo) section. 

Dev Review: Done
QE Review: Done
Doc Peer Review: Done
Doc Peer Review of NOTE added 03/12/2024: Done
Doc Merge Review: 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
