### PR TITLE
OSDOCS-9004 RODOO 1.1.0 RNs

### DIFF
--- a/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
+++ b/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="run-once-duration-override-release-notes"]
-= {run-once-operator} release notes
+= Run Once Duration Override Operator release notes
 include::_attributes/common-attributes.adoc[]
 :context: run-once-duration-override-release-notes
 
@@ -12,5 +12,18 @@ To apply the run-once duration override from the {run-once-operator} to run-once
 
 These release notes track the development of the {run-once-operator} for {product-title}.
 
-:operator-name: The {run-once-operator}
-include::snippets/operator-not-available.adoc[]
+For an overview of the {run-once-operator}, see xref:../../../nodes/pods/run_once_duration_override/index.adoc#run-once-about_run-once-duration-override-about[About the {run-once-operator}].
+
+[id="run-once-duration-override-operator-release-notes-1-1-0"]
+== Run Once Duration Override Operator 1.1.0
+
+Issued: 2024-02-28
+
+The following advisory is available for the {run-once-operator} 1.1.0:
+
+* link:https://access.redhat.com/errata/RHSA-2024:0269[RHSA-2024:0269]
+
+[id="run-once-duration-override-operator-1-1-0-bug-fixes"]
+=== Bug fixes
+
+* This release of the {run-once-operator} addresses several Common Vulnerabilities and Exposures (CVEs).


### PR DESCRIPTION
Version(s): 4.15+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-9004](https://issues.redhat.com/browse/OSDOCS-9004)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Preview](https://70526--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes#run-once-duration-override-operator-release-notes-1-1-0)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Release date is Feb. 28th. Errata link will not work until then. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
