### PR TITLE
OSDOCS#8793: Agent DNS requirements

### DIFF
--- a/modules/installing-ocp-agent-gather-log.adoc
+++ b/modules/installing-ocp-agent-gather-log.adoc
@@ -8,6 +8,10 @@
 
 Use the following procedure to gather log data about a failed Agent-based installation to provide for a support case.
 
+.Prerequisites
+
+* You have configured a DNS record for the Kubernetes API server.
+
 .Procedure
 
 . Run the following command and collect the output:

--- a/modules/installing-ocp-agent-verify.adoc
+++ b/modules/installing-ocp-agent-verify.adoc
@@ -8,6 +8,10 @@
 
 Use the following procedure to track installation progress and to verify a successful installation.
 
+.Prerequisites
+
+* You have configured a DNS record for the Kubernetes API server.
+
 .Procedure
 
 . Optional: To know when the bootstrap host (rendezvous host) reboots, run the following command:


### PR DESCRIPTION
[OSDOCS-8793](https://issues.redhat.com/browse/OSDOCS-8793)

Versions: 4.13+

This PR clarifies that DNS is required if you wish to use `wait-for` during an Agent install to track progress or gather data for support.

QE review:
- [x] QE has approved this change.

Preview: 

- [Tracking and verifying installation progress](https://70530--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer#installing-ocp-agent-verify_installing-with-agent-based-installer)
- [Gathering log data from a failed Agent-based installation](https://70530--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer#installing-ocp-agent-gather-log_installing-with-agent-based-installer)