### PR TITLE
[enterprise-4.11] OCPBUGS#12446: Update docs to move etcd to a different disk

### DIFF
--- a/modules/move-etcd-different-disk.adoc
+++ b/modules/move-etcd-different-disk.adoc
@@ -8,22 +8,36 @@
 
 You can move etcd from a shared disk to a separate disk to prevent or resolve performance issues.
 
-.Prerequisites
-
-*  The `MachineConfigPool` must match `metadata.labels[machineconfiguration.openshift.io/role]`. This applies to a controller, worker, or a custom pool.
-*  The node's auxiliary storage device, such as `/dev/sdb`, must match the sdb. Change this reference in all places in the file.
+The Machine Config Operator (MCO) is responsible for mounting a secondary disk for {product-title} {product-version} container storage.
 
 [NOTE]
 ====
 This procedure does not move parts of the root file system, such as `/var/`, to another disk or partition on an installed node.
 ====
 
-The Machine Config Operator (MCO) is responsible for mounting a secondary disk for an {product-title} {product-version} container storage.
+.Prerequisites
 
-Use the following steps to move etcd to a different device:
+* You have installed the {oc-first}.
+* You have access to the cluster with `cluster-admin` privileges.
+* The `MachineConfigPool` must match `metadata.labels[machineconfiguration.openshift.io/role]`. This applies to a controller, worker, or a custom pool.
 
 .Procedure
-.  Create a `machineconfig` YAML file named `etcd-mc.yml` and add the following information:
+
+. Attach the new disk to the cluster and verify that the disk is detected in the node by using the `lsblk` command in a debug shell:
++
+[source,terminal]
+----
+$ oc debug node/<node_name>
+----
++
+[source,terminal]
+----
+# lsblk
+----
++
+Note the device name of the new disk reported by the `lsblk` command.
+
+. Create a `MachineConfig` YAML file named `etcd-mc.yml` with contents such as the following, replacing instances of `<new_disk_name>` with the noted device name:
 +
 [source,yaml]
 ----
@@ -41,31 +55,31 @@ spec:
       units:
       - contents: |
           [Unit]
-          Description=Make File System on /dev/sdb
+          Description=Make File System on /dev/<new_disk_name>
           DefaultDependencies=no
-          BindsTo=dev-sdb.device
-          After=dev-sdb.device var.mount
-          Before=systemd-fsck@dev-sdb.service
+          BindsTo=dev-<new_disk_name>.device
+          After=dev-<new_disk_name>.device var.mount
+          Before=systemd-fsck@dev-<new_disk_name>.service
 
           [Service]
           Type=oneshot
           RemainAfterExit=yes
-          ExecStart=/usr/lib/systemd/systemd-makefs xfs /dev/sdb
+          ExecStart=/usr/lib/systemd/systemd-makefs xfs /dev/<new_disk_name>
           TimeoutSec=0
 
           [Install]
           WantedBy=var-lib-containers.mount
         enabled: true
-        name: systemd-mkfs@dev-sdb.service
+        name: systemd-mkfs@dev-<new_disk_name>.service
       - contents: |
           [Unit]
-          Description=Mount /dev/sdb to /var/lib/etcd
+          Description=Mount /dev/<new_disk_name> to /var/lib/etcd
           Before=local-fs.target
-          Requires=systemd-mkfs@dev-sdb.service
-          After=systemd-mkfs@dev-sdb.service var.mount
+          Requires=systemd-mkfs@dev-<new_disk_name>.service
+          After=systemd-mkfs@dev-<new_disk_name>.service var.mount
 
           [Mount]
-          What=/dev/sdb
+          What=/dev/<new_disk_name>
           Where=/var/lib/etcd
           Type=xfs
           Options=defaults,prjquota
@@ -111,42 +125,29 @@ spec:
           WantedBy=multi-user.target graphical.target
         enabled: true
         name: restorecon-var-lib-etcd.service
-
 ----
 
-. Create the machine configuration by entering the following commands:
+. Log in to the cluster as a user with `cluster-admin` privileges and create the machine configuration:
 +
 [source,terminal]
 ----
-$ oc login -u ${ADMIN} -p ${ADMINPASSWORD} ${API}
-... output omitted ...
+$ oc login -u <username> -p <password>
 ----
 +
 [source,terminal]
 ----
 $ oc create -f etcd-mc.yml
-machineconfig.machineconfiguration.openshift.io/98-var-lib-etcd created
-----
-+
-[source,terminal]
-----
-$ oc login -u ${ADMIN} -p ${ADMINPASSWORD} ${API}
- [... output omitted ...]
-----
-+
-[source, terminal]
-----
-$ oc create -f etcd-mc.yml machineconfig.machineconfiguration.openshift.io/98-var-lib-etcd created
 ----
 +
 The nodes are updated and rebooted. After the reboot completes, the following events occur:
 +
-*  An XFS file system is created on the specified disk.
-*  The disk mounts to `/var/lib/etc`.
-*  The content from `/sysroot/ostree/deploy/rhcos/var/lib/etcd` syncs to `/var/lib/etcd`.
-*  A restore of `SELinux` labels is forced for `/var/lib/etcd`.
-*  The old content is not removed.
-.  After the nodes are on a separate disk, update the machine configuration file, `etcd-mc.yml` with the following information:
+* An XFS file system is created on the specified disk.
+* The disk mounts to `/var/lib/etcd`.
+* The content from `/sysroot/ostree/deploy/rhcos/var/lib/etcd` syncs to `/var/lib/etcd`.
+* A restore of `SELinux` labels is forced for `/var/lib/etcd`.
+* The old content is not removed.
+
+. After the nodes are on a separate disk, update the `etcd-mc.yml` file with contents such as the following, replacing instances of `<new_disk_name>` with the noted device name:
 +
 [source,yaml]
 ----
@@ -164,13 +165,13 @@ spec:
       units:
       - contents: |
           [Unit]
-          Description=Mount /dev/sdb to /var/lib/etcd
+          Description=Mount /dev/<new_disk_name> to /var/lib/etcd
           Before=local-fs.target
-          Requires=systemd-mkfs@dev-sdb.service
-          After=systemd-mkfs@dev-sdb.service var.mount
+          Requires=systemd-mkfs@dev-<new_disk_name>.service
+          After=systemd-mkfs@dev-<new_disk_name>.service var.mount
 
           [Mount]
-          What=/dev/sdb
+          What=/dev/<new_disk_name>
           Where=/var/lib/etcd
           Type=xfs
           Options=defaults,prjquota
@@ -180,11 +181,31 @@ spec:
         enabled: true
         name: var-lib-etcd.mount
 ----
-. Apply the modified version that removes the logic for creating and syncing the device by entering the following command:
+
+. Apply the modified version that removes the logic for creating and syncing the device to prevent the nodes from rebooting:
 +
 [source,terminal]
 ----
 $ oc replace -f etcd-mc.yml
 ----
+
+.Verification steps
+
+* Run the `grep <new_disk_name> /proc/mounts` command in a debug shell for the node to ensure that the disk mounted:
 +
-The previous step prevents the nodes from rebooting.
+[source,terminal]
+----
+$ oc debug node/<node_name>
+----
++
+[source,terminal]
+----
+# grep <new_disk_name> /proc/mounts
+----
++
+.Example output
++
+[source,terminal]
+----
+/dev/nvme1n1 /var/lib/etcd xfs rw,seclabel,relatime,attr2,inode64,logbufs=8,logbsize=32k,prjquota 0 0
+----


### PR DESCRIPTION
Cherry Picked from 66127d05c64682e6f3c0d163f5fb6b128fbde48e xref: https://github.com/openshift/openshift-docs/pull/70452

Version(s):
4.11