### PR TITLE
Removed snippet from ifdef

### DIFF
--- a/modules/nodes-clusters-cgroups-2.adoc
+++ b/modules/nodes-clusters-cgroups-2.adoc
@@ -26,7 +26,7 @@ endif::post[]
 endif::openshift-origin[]
 
 ifdef::post[]
-include::snippets/cgroupv2-vs-cgroupv1.adoc[]
+cgroup v2 is the current version of the Linux cgroup API. cgroup v2 offers several improvements over cgroup v1, including a unified hierarchy, safer sub-tree delegation, new features such as link:https://www.kernel.org/doc/html/latest/accounting/psi.html[Pressure Stall Information], and enhanced resource management and isolation. However, cgroup v2 has different CPU, memory, and I/O management characteristics than cgroup v1. Therefore, some workloads might experience slight differences in memory or CPU usage on clusters that run cgroup v2.
 
 You can change between cgroup v1 and cgroup v2, as needed. Enabling cgroup v1 in {product-title} disables all cgroup v2 controllers and hierarchies in your cluster. 
 endif::post[]

--- a/snippets/cgroupv2-vs-cgroupv1.adoc
+++ b/snippets/cgroupv2-vs-cgroupv1.adoc
@@ -1,10 +1,10 @@
 // Text snippet included in the following modules:
 //
 // * installing/install-config/enabling-cgroup-v1.adoc
-// * modules/nodes-clusters-cgroups-2.adoc
 // * nodes/clusters/nodes-cluster-cgroups-2.adoc 
 
 :_mod-docs-content-type: SNIPPET
 
+// * Text included in modules/nodes-cluster-cgroups-2.adoc as text, not a snippet because snippets cannt be in an ifdef. Also update there if you edit this text.
 cgroup v2 is the current version of the Linux cgroup API. cgroup v2 offers several improvements over cgroup v1, including a unified hierarchy, safer sub-tree delegation, new features such as link:https://www.kernel.org/doc/html/latest/accounting/psi.html[Pressure Stall Information], and enhanced resource management and isolation. However, cgroup v2 has different CPU, memory, and I/O management characteristics than cgroup v1. Therefore, some workloads might experience slight differences in memory or CPU usage on clusters that run cgroup v2.
 


### PR DESCRIPTION
Per Slack conversation, remove snippet from ifdef, as not supported.

Preview:
Post install -> Cluster tasks -> [Configuring Linux cgroup](https://70534--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks#nodes-clusters-cgroups-2_post-install-cluster-tasks) -- Second paragraph is no longer a snippet.
Nodes: -> Clusters -> [Configuring the Linux cgroup version on your nodes](https://70534--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-cgroups-2) -- Second paragraph is previously added snippet with the same text.
