### PR TITLE
OSSM-5725: Add content to exclude the creation of CNI pods (2.5 Release)

### DIFF
--- a/modules/ossm-vs-istio.adoc
+++ b/modules/ossm-vs-istio.adoc
@@ -118,6 +118,12 @@ You can deploy virtual machines to OpenShift using OpenShift Virtualization. The
 
 {SMProductName} includes CNI plugin, which provides you with an alternate way to configure application pod networking. The CNI plugin replaces the `init-container` network configuration eliminating the need to grant service accounts and projects access to security context constraints (SCCs) with elevated privileges.
 
+[NOTE]
+====
+By default, Istio Container Network Interface (CNI) pods are created on all {product-title} nodes. To exclude the creation of CNI pods in a specific node, apply the  `maistra.io/exclude-cni=true` label to the node.
+Adding this label removes any previously deployed Istio CNI pods from the node.
+====
+
 [id="ossm-global-mtls_{context}"]
 == Global mTLS settings
 {SMProductName} creates a `PeerAuthentication` resource that enables or disables Mutual TLS authentication (mTLS) within the mesh.


### PR DESCRIPTION
**PR for Service Mesh 2.5 layered product release.**

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): OCP 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSSM-5725
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://70539--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-vs-community#ossm-cni_ossm-vs-istio
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
