### PR TITLE
OCPBUGS#22472: Amend misleading reference to basic DDoS protection

### DIFF
--- a/modules/nw-route-specific-annotations.adoc
+++ b/modules/nw-route-specific-annotations.adoc
@@ -27,13 +27,13 @@ and "-". The default is the hashed internal key name for the route. |
 |`haproxy.router.openshift.io/pod-concurrent-connections`| Sets the maximum number of connections that are allowed to a backing pod from a router. +
 Note: If there are multiple pods, each can have this many connections.  If you have multiple routers, there is no coordination among them, each may connect this many times. If not set, or set to 0, there is no limit. |
 |`haproxy.router.openshift.io/rate-limit-connections`| Setting `'true'` or `'TRUE'` enables rate limiting functionality which is implemented through stick-tables on the specific backend per route. +
-Note: Using this annotation provides basic protection against distributed denial-of-service (DDoS) attacks. |
+Note: Using this annotation provides basic protection against denial-of-service attacks. |
 |`haproxy.router.openshift.io/rate-limit-connections.concurrent-tcp`| Limits the number of concurrent TCP connections made through the same source IP address. It accepts a numeric value. +
-Note: Using this annotation provides basic protection against distributed denial-of-service (DDoS) attacks. |
+Note: Using this annotation provides basic protection against denial-of-service attacks. |
 |`haproxy.router.openshift.io/rate-limit-connections.rate-http`| Limits the rate at which a client with the same source IP address can make HTTP requests. It accepts a numeric value.  +
-Note: Using this annotation provides basic protection against distributed denial-of-service (DDoS) attacks. |
+Note: Using this annotation provides basic protection against denial-of-service attacks. |
 |`haproxy.router.openshift.io/rate-limit-connections.rate-tcp`| Limits the rate at which a client with the same source IP address can make TCP connections. It accepts a numeric value.  +
-Note: Using this annotation provides basic protection against distributed denial-of-service (DDoS) attacks. |
+Note: Using this annotation provides basic protection against denial-of-service attacks. |
 |`haproxy.router.openshift.io/timeout` | Sets a server-side timeout for the route. (TimeUnits) | `ROUTER_DEFAULT_SERVER_TIMEOUT`
 |`haproxy.router.openshift.io/timeout-tunnel` | This timeout applies to a tunnel connection, for example, WebSocket over cleartext, edge, reencrypt, or passthrough routes. With cleartext, edge, or reencrypt route types, this annotation is applied as a timeout tunnel with the existing timeout value. For the passthrough route types, the annotation takes precedence over any existing timeout value set. | `ROUTER_DEFAULT_TUNNEL_TIMEOUT`
 |`ingresses.config/cluster ingress.operator.openshift.io/hard-stop-after` | You can set either an IngressController or the ingress config . This annotation redeploys the router and configures the HA proxy to emit the haproxy `hard-stop-after` global option, which defines the maximum time allowed to perform a clean soft-stop. | `ROUTER_HARD_STOP_AFTER`


### PR DESCRIPTION
Version(s):
4.11+

Issue:
[OCPBUGS-22472](https://issues.redhat.com/browse/OCPBUGS-22472)

Link to docs preview:
[Route-specific annotations](https://70540--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration#nw-route-specific-annotations_route-configuration)

QE review:
- [x] QE has approved this change.

Additional information:

N/A