### PR TITLE
OCPBUGS#27381: Add quotes to Operator infra annotations

### DIFF
--- a/modules/osdk-csv-annotations-infra.adoc
+++ b/modules/osdk-csv-annotations-infra.adoc
@@ -2,10 +2,11 @@
 //
 // * operators/operator_sdk/osdk-generating-csvs.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-csv-annotations-infra_{context}"]
 = Infrastructure features annotations
 
-Annotations in the `features.operators.openshift.io` group detail the infrastructure features that an Operator might support, specified by setting a `true` or `false` value. Users can view and filter by these features when discovering Operators through OperatorHub in the web console or on the link:https://catalog.redhat.com/software/search?deployed_as=Operator[Red Hat Ecosystem Catalog]. These annotations are supported in {product-title} 4.10 and later.
+Annotations in the `features.operators.openshift.io` group detail the infrastructure features that an Operator might support, specified by setting a `"true"` or `"false"` value. Users can view and filter by these features when discovering Operators through OperatorHub in the web console or on the link:https://catalog.redhat.com/software/search?deployed_as=Operator[Red Hat Ecosystem Catalog]. These annotations are supported in {product-title} 4.10 and later.
 
 [IMPORTANT]
 ====
@@ -15,49 +16,53 @@ The `features.operators.openshift.io` infrastructure feature annotations depreca
 .Infrastructure features annotations
 [cols="4a,5a,3a,options="header"]
 |===
-|Annotation |Description |Valid values
+|Annotation |Description |Valid values^[1]^
 
 |`features.operators.openshift.io/disconnected`
 |Specify whether an Operator leverages the `spec.relatedImages` CSV field and can run without an internet connection by referring to any related image by its digest.
-|`true` or `false`
+|`"true"` or `"false"`
 
 |`features.operators.openshift.io/fips-compliant`
 |Specify whether an Operator accepts the FIPS-140 configuration of the underlying platform and works on nodes that are booted into FIPS mode. In this mode, the Operator and any workloads it manages (operands) are solely calling the {op-system-base-full} cryptographic library submitted for FIPS-140 validation.
-|`true` or `false`
+|`"true"` or `"false"`
 
 |`features.operators.openshift.io/proxy-aware`
 |Specify whether an Operator supports running on a cluster behind a proxy by accepting the standard `HTTP_PROXY` and `HTTPS_PROXY` proxy environment variables. If applicable, the Operator passes this information to the workload it manages (operands).
-|`true` or `false`
+|`"true"` or `"false"`
 
 |`features.operators.openshift.io/tls-profiles`
 |Specify whether an Operator implements well-known tunables to modify the TLS cipher suite used by the Operator and, if applicable, any of the workloads it manages (operands).
-|`true` or `false`
+|`"true"` or `"false"`
 
 |`features.operators.openshift.io/token-auth-aws`
 |Specify whether an Operator supports configuration for tokenzied authentication with AWS APIs via AWS Secure Token Service (STS) by using the Cloud Credential Operator (CCO).
-|`true` or `false`
+|`"true"` or `"false"`
 
 |`features.operators.openshift.io/token-auth-azure`
 |Specify whether an Operator supports configuration for tokenzied authentication with Azure APIs via Azure Managed Identity by using the Cloud Credential Operator (CCO).
-|`true` or `false`
+|`"true"` or `"false"`
 
 |`features.operators.openshift.io/token-auth-gcp`
 |Specify whether an Operator supports configuration for tokenzied authentication with Google Cloud APIs via GCP Workload Identity Foundation (WIF) by using the Cloud Credential Operator (CCO).
-|`true` or `false`
+|`"true"` or `"false"`
 
 |`features.operators.openshift.io/cnf`
 |Specify whether an Operator provides a Cloud-Native Network Function (CNF) Kubernetes plugin.
-|`true` or `false`
+|`"true"` or `"false"`
 
 |`features.operators.openshift.io/cni`
 |Specify whether an Operator provides a Container Network Interface (CNI) Kubernetes plugin.
-|`true` or `false`
+|`"true"` or `"false"`
 
 |`features.operators.openshift.io/csi`
 |Specify whether an Operator provides a Container Storage Interface (CSI) Kubernetes plugin.
-|`true` or `false`
+|`"true"` or `"false"`
 
 |===
+[.small]
+--
+1. Valid values are shown intentionally with double quotes, because Kubernetes annotations must be strings.
+--
 
 .Example CSV with infrastructure feature annotations
 [source,yaml]


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-27381

4.14+

Adding quotes to values in "Valid values" column and a [fake footnote](https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#alternative-footnote-styling-in-tables) explaining the need for the quotes.

Preview: [Operator metadata annotations -> Infrastructure features annotations](https://70546--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-generating-csvs.html#osdk-csv-annotations-infra_osdk-generating-csvs)

Follow-up to https://github.com/openshift/openshift-docs/pull/69171