### PR TITLE
OSDOCS#9001: Adding vSphere credentials to Agent

### DIFF
--- a/installing/installing_with_agent_based_installer/installation-config-parameters-agent.adoc
+++ b/installing/installing_with_agent_based_installer/installation-config-parameters-agent.adoc
@@ -14,6 +14,7 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#bmc-addressing_ipi-install-installation-workflow[BMC addressing]
+* xref:../../installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.adoc#configuring-vsphere-regions-zones_installing-vsphere-installer-provisioned-customizations[Configuring regions and zones for a VMware vCenter]
 
 include::modules/agent-configuration-parameters.adoc[leveloffset=+1]
 

--- a/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
@@ -28,6 +28,10 @@ include::modules/installing-ocp-agent-download.adoc[leveloffset=+2]
 // Creating the preferred configuration inputs
 include::modules/installing-ocp-agent-inputs.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.adoc#configuring-vsphere-regions-zones_installing-vsphere-installer-provisioned-customizations[Configuring regions and zones for a VMware vCenter]
+
 [id="installing-ocp-agent-opt-manifests_{context}"]
 === Optional: Creating additional manifest files
 

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -2603,17 +2603,24 @@ Valid names include:
 --
 endif::ibm-cloud[]
 
-ifdef::vsphere[]
-
+ifdef::agent,vsphere[]
 [id="installation-configuration-parameters-additional-vsphere_{context}"]
 == Additional VMware vSphere configuration parameters
 
 Additional VMware vSphere configuration parameters are described in the following table:
 
 .Additional VMware vSphere cluster parameters
-[cols=".^2l,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
+[cols=".^2l,.^3a,.^3",options="header,word-wrap",subs="+quotes,+attributes"]
 |====
 |Parameter|Description|Values
+ifdef::agent[]
+
+|platform:
+  vsphere:
+| Describes your account on the cloud platform that hosts your cluster. You can use the parameter to customize the platform. If you provide additional configuration settings for compute and control plane machines in the machine pool, the parameter is not required. You can only specify one vCenter server for your {product-title} cluster.
+|A dictionary of vSphere configuration objects
+endif::agent[]
+ifdef::vsphere[]
 
 |platform:
   vsphere:
@@ -2634,6 +2641,29 @@ Additional VMware vSphere configuration parameters are described in the followin
     failureDomains:
 |Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
 |String
+endif::vsphere[]
+ifdef::agent[]
+
+|platform:
+  vsphere:
+    failureDomains:
+|Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
+|An array of failure domain configuration objects.
+
+|platform:
+  vsphere:
+    failureDomains:
+      name:
+|The name of the failure domain.
+|String
+
+|platform:
+  vsphere:
+    failureDomains:
+      server:
+|The fully qualified domain name (FQDN) of the vCenter server.
+|An FQDN such as example.com
+endif::agent[]
 
 |platform:
   vsphere:
@@ -2642,6 +2672,65 @@ Additional VMware vSphere configuration parameters are described in the followin
         networks:
 |Lists any network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured.
 |String
+ifdef::agent[]
+
+|platform:
+  vsphere:
+    failureDomains:
+      topology:
+        computeCluster:
+|The path to the vSphere compute cluster.
+|String
+
+|platform:
+  vsphere:
+    failureDomains:
+      topology:
+        datacenter:
+|Lists and defines the datacenters where {product-title} virtual machines (VMs) operate.
+The list of datacenters must match the list of datacenters specified in the `vcenters` field.
+|String
+
+|platform:
+  vsphere:
+    failureDomains:
+      topology:
+        datastore:
+|The path to the vSphere datastore that holds virtual machine files, templates, and ISO images.
+[IMPORTANT]
+====
+You can specify the path of any datastore that exists in a datastore cluster.
+By default, Storage vMotion is automatically enabled for a datastore cluster.
+Red{nbsp}Hat does not support Storage vMotion, so you must disable Storage vMotion to avoid data loss issues for your {product-title} cluster.
+
+If you must specify VMs across multiple datastores, use a `datastore` object to specify a failure domain in your cluster's `install-config.yaml` configuration file.
+For more information, see "VMware vSphere region and zone enablement".
+====
+|String
+
+|platform:
+  vsphere:
+    failureDomains:
+      topology:
+        resourcePool:
+// When this content is added to vSphere docs, the line below should likely say "where the installation program creates the virtual machines".
+|Optional: The absolute path of an existing resource pool where the user creates the virtual machines, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
+// Commenting out the line below because it doesn't apply to Agent, but it may be needed when this content is brought into the regular vSphere docs.
+// If you do not specify a value, resources are installed in the root of the cluster, for example `/example_datacenter/host/example_cluster/Resources`.
+|String
+
+|platform:
+  vsphere:
+    failureDomains:
+      topology:
+        folder:
+// When this content is added to vSphere docs, the line below should likely say "where the installation program creates the virtual machines", and should be Optional.
+|The absolute path of an existing folder where the user creates the virtual machines, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
+// Commenting out the two lines below because they don't apply to Agent, but they may be needed when this content is brought into the regular vSphere docs.
+// If you do not provide this value, the installation program creates a top-level folder in the datacenter virtual machine folder that is named with the infrastructure ID.
+// If you are providing the infrastructure for the cluster and you do not want to use the default `StorageClass` object, named `thin`, you can omit the `folder` parameter from the `install-config.yaml` file.
+|String
+endif::agent[]
 
 |platform:
   vsphere:
@@ -2663,6 +2752,7 @@ Additional VMware vSphere configuration parameters are described in the followin
       template:
 |Specify the absolute path to a pre-existing {op-system-first} image template or virtual machine. The installation program can use the image template or virtual machine to quickly install {op-system} on vSphere hosts. Consider using this parameter as an alternative to uploading an {op-system} image on vSphere hosts. The parameter is available for use only on installer-provisioned infrastructure.
 |String
+ifdef::vsphere[]
 
 |platform:
   vsphere:
@@ -2682,6 +2772,16 @@ Additional VMware vSphere configuration parameters are described in the followin
     vcenters:
 |Lists any fully-qualified hostname or IP address of a vCenter server.
 |String
+endif::vsphere[]
+ifdef::agent[]
+
+|platform:
+  vsphere:
+    vcenters:
+|Configures the connection details so that services can communicate with vCenter.
+Currently, only a single vCenter is supported.
+|An array of vCenter configuration objects.
+endif::agent[]
 
 |platform:
   vsphere:
@@ -2689,6 +2789,36 @@ Additional VMware vSphere configuration parameters are described in the followin
       datacenters:
 |Lists and defines the datacenters where {product-title} virtual machines (VMs) operate. The list of datacenters must match the list of datacenters specified in the `failureDomains` field.
 |String
+ifdef::agent[]
+
+|platform:
+  vsphere:
+    vcenters:
+      password:
+|The password associated with the vSphere user.
+|String
+
+|platform:
+  vsphere:
+    vcenters:
+      port:
+|The port number used to communicate with the vCenter server.
+|Integer
+
+|platform:
+  vsphere:
+    vcenters:
+      server:
+|The fully qualified host name (FQHN) or IP address of the vCenter server.
+|String
+
+|platform:
+  vsphere:
+    vcenters:
+      user:
+|The username associated with the vSphere user.
+|String
+endif::agent[]
 |====
 
 [id="deprecated-parameters-vsphere_{context}"]
@@ -2702,6 +2832,7 @@ The following table lists each deprecated vSphere configuration parameter:
 [cols=".^2l,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
 |====
 |Parameter|Description|Values
+ifdef::vsphere[]
 
 |platform:
   vsphere:
@@ -2710,6 +2841,7 @@ The following table lists each deprecated vSphere configuration parameter:
 
 *Note:* In {product-title} 4.12 and later, the `apiVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `apiVIPs` configuration setting.
 a|An IP address, for example `128.0.0.1`.
+endif::vsphere[]
 
 |platform:
   vsphere:
@@ -2735,6 +2867,8 @@ a|An IP address, for example `128.0.0.1`.
 |Optional. The absolute path of an existing folder where the installation program creates the virtual machines. If you do not provide this value, the installation program creates a folder that is named with the infrastructure ID in the data center virtual machine folder.
 |String, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
 
+ifdef::vsphere[]
+
 |platform:
   vsphere:
     ingressVIP:
@@ -2748,6 +2882,7 @@ a|An IP address, for example `128.0.0.1`.
     network:
 |The network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured.
 |String
+endif::vsphere[]
 
 |platform:
   vsphere:
@@ -2777,6 +2912,7 @@ in vSphere.
 |String
 |====
 
+ifdef::vsphere[]
 [id="installation-configuration-parameters-optional-vsphere_{context}"]
 == Optional VMware vSphere machine pool configuration parameters
 
@@ -2819,6 +2955,7 @@ Optional VMware vSphere machine pool configuration parameters are described in t
 |Integer
 |====
 endif::vsphere[]
+endif::agent,vsphere[]
 
 ifdef::ash[]
 [id="installation-configuration-parameters-additional-azure-stack-hub_{context}"]


### PR DESCRIPTION
[OSDOCS-9001](https://issues.redhat.com/browse/OSDOCS-9001)

Versions: 4.15+

This PR adds existing vSphere credential parameters for the install-config that are now available for the Agent-based Installer

QE review:
- [x] QE has approved this change.

Preview: 

- [vSphere parameters on the Agent page](https://70551--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installation-config-parameters-agent#installation-configuration-parameters-additional-vsphere_installation-config-parameters-agent)
- [Creating the preferred configuration inputs](https://70551--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer#installing-ocp-agent-inputs_installing-with-agent-based-installer) (Additional resources section at end of procedure)
- [vSphere parameters on the vSphere page](https://70551--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere#installation-configuration-parameters-additional-vsphere_installation-config-parameters-vsphere) (should be unchanged)

Existing docs:

- [Agent config parameters](https://docs.openshift.com/container-platform/4.14/installing/installing_with_agent_based_installer/installation-config-parameters-agent.html)
- [vSphere config parameters](https://docs.openshift.com/container-platform/4.14/installing/installing_vsphere/installation-config-parameters-vsphere.html#installation-configuration-parameters-additional-vsphere_installation-config-parameters-vsphere)
