### PR TITLE
OSDOCS-8386: Migrate "Home" from rosaworkshop.io

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -124,6 +124,8 @@ Topics:
   Dir: cloud-experts-getting-started
   Distros: openshift-rosa
   Topics:
+  - Name: What is ROSA
+    File: cloud-experts-getting-started-what-is-rosa
   - Name: Deploying a cluster
     Dir: cloud-experts-getting-started-deploying
     Topics:

--- a/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-what-is-rosa.adoc
+++ b/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-what-is-rosa.adoc
@@ -1,0 +1,47 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="cloud-experts-getting-started-what-is-rosa"]
+= Tutorial: What is ROSA
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: cloud-experts-getting-started-what-is-rosa
+
+toc::[]
+
+//rosaworkshop.io content metadata
+//Brought into ROSA product docs 2024-01-18
+
+Red Hat OpenShift Service on AWS (ROSA) is a fully-managed turnkey application platform that allows you to focus on what matters most, delivering value to your customers by building and deploying applications. Red Hat and AWS SRE experts manage the underlying platform so you do not have to worry about infrastructure management. ROSA provides seamless integration with a wide range of AWS compute, database, analytics, machine learning, networking, mobile, and other services to further accelerate the building and delivering of differentiating experiences to your customers.
+
+ROSA makes use of AWS Security Token Service (STS) to obtain credentials to manage infrastructure in your AWS account. AWS STS is a global web service that creates temporary credentials for IAM users or federated users. ROSA uses this to assign short-term, limited-privilege, security credentials. These credentials are associated with IAM roles that are specific to each component that makes AWS API calls. This method aligns with the principals of least privilege and secure practices in cloud service resource management. The ROSA command line interface (CLI) tool manages the STS credentials that are assigned for unique tasks and takes action on AWS resources as part of OpenShift functionality.
+//For a detailed explanation, see "ROSA with STS Explained" (add xref when page is migrated).
+
+A list of the account-wide and per-cluster roles is provided in the xref:../../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies-creation-methods_rosa-sts-about-iam-resources[ROSA documentation].
+
+//== Creating your first ROSA cluster
+
+//Watch this demo for a short preview of the cluster deployment process:
+//link:https://youtu.be/KbzUbXWs6Ck
+
+//If you want an easy guide for creating your first ROSA cluster:
+
+//. Review the xref:../../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prereqs[prerequisites]. 
+//. Visit the quickstart guide.
+
+.Additional Resources
+
+* ROSA product pages:
+** link:https://www.openshift.com/products/amazon-openshift[Red Hat product page]
+** link:https://aws.amazon.com/rosa/[AWS product page]
+** link:https://access.redhat.com/products/red-hat-openshift-service-aws[Red Hat customer portal]
+* ROSA specific resources
+** link:https://docs.aws.amazon.com/ROSA/latest/userguide/getting-started.html[AWS ROSA getting started guide]
+** xref:../../welcome/index.adoc#welcome-index[ROSA documentation]
+** xref:../../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-service-definition[ROSA service definition]
+** xref:../../rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.adoc#rosa-policy-responsibility-matrix[ROSA responsibility assignment matrix]
+** xref:../../rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.adoc#rosa-policy-process-security[Understanding Process and Security]
+** xref:../../rosa_architecture/rosa_policy_service_definition/rosa-policy-understand-availability.adoc#rosa-policy-understand-availability[About Availability]
+** xref:../../rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc#rosa-life-cycle[Updates Lifecycle]
+** xref:../../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[Limits and Scalability]
+** link:https://red.ht/rosa-roadmap[ROSA roadmap]
+* link:https://learn.openshift.com[Learn about OpenShift]
+* link:https://console.redhat.com/OpenShift[OpenShift Cluster Manager]
+* link:https://support.redhat.com[Red Hat Support]


### PR DESCRIPTION
[OSDOCS-8386](https://issues.redhat.com//browse/OSDOCS-8386): Migrate "Home" from rosaworkshop.io

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-8386

Link to docs preview:
https://70552--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-what-is-rosa

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
