### PR TITLE
OSDOCS-8804: Adding the MicroShift service to a blueprint section is …

### DIFF
--- a/modules/microshift-adding-service-to-blueprint.adoc
+++ b/modules/microshift-adding-service-to-blueprint.adoc
@@ -9,16 +9,26 @@
 
 Adding the {microshift-short} RPM package to an Image Builder blueprint enables the build of a {op-system-ostree} image with {microshift-short} embedded.
 
+* Start with step 1 to create your own minimal blueprint file which results in a faster {microshift-short} installation.
+* Start with step 2 to use the generated blueprint for installation which includes all the RPM packages and container images. This is a longer installation process, but a faster start up because container references are accessed locally.
++
+[IMPORTANT]
+====
+* Replace _<microshift_blueprint.toml>_ in the following procedures with the name of the TOML file you are using.
+* Replace _<microshift_blueprint>_ in the following procedures with the name you want to use for your blueprint.
+====
+
 .Procedure
 
-. Use the following example to create your blueprint:
+. Use the following example to create your own blueprint file:
 +
-.Image Builder blueprint example
+.Custom Image Builder blueprint example
 +
 [source,text]
+[subs="+quotes"]
 ----
-cat > minimal-microshift.toml <<EOF
-name = "minimal-microshift"
+cat > _<microshift_blueprint.toml>_ <<EOF <1>
+name = "_<microshift_blueprint>_" <2>
 
 description = ""
 version = "0.0.1"
@@ -33,43 +43,90 @@ version = "*"
 enabled = ["microshift"]
 EOF
 ----
+<1> _<microshift_blueprint.toml>_ is the name of the TOML file.
+<2> _<microshift_blueprint>_ is the name of your blueprint.
 +
 [NOTE]
 ====
 The wildcard `*` in the commands uses the latest {microshift-short} RPMs. If you need a specific version, substitute the wildcard for the version you want. For example, insert `4.15.0` to download the {microshift-short} 4.15.0 RPMs.
 ====
 
+. Optional. Use the blueprint installed in the `/usr/share/microshift/blueprint` directory that is specific to your platform architecture. See the following example snippet for an explanation of the blueprint sections:
++
+.Generated Image Builder blueprint example snippet
++
+[source,text]
+----
+name = "microshift_blueprint"
+description = "MicroShift 4.15.1 on x86_64 platform"
+version = "0.0.1"
+modules = []
+groups = []
+
+[[packages]] <1>
+name = "microshift"
+version = "4.15.1"
+...
+...
+
+[customizations.services] <2>
+enabled = ["microshift"]
+
+[customizations.firewall]
+ports = ["22:tcp", "80:tcp", "443:tcp", "5353:udp", "6443:tcp", "30000-32767:tcp", "30000-32767:udp"]
+...
+...
+
+[[containers]] <3>
+source = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f41e79c17e8b41f1b0a5a32c3e2dd7cd15b8274554d3f1ba12b2598a347475f4"
+
+[[containers]]
+source = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:dbc65f1fba7d92b36cf7514cd130fe83a9bd211005ddb23a8dc479e0eea645fd"
+...
+…
+EOF
+----
+<1> References for all non-optional {microshift-short} RPM packages using the same version compatible with the `microshift-release-info` RPM.
+<2> References for automatically enabling {microshift-short} on system startup and applying default networking settings.
+<3> References for all non-optional {microshift-short} container images necessary for an offline deployment.
+
 . Add the blueprint to the Image Builder by running the following command:
 +
 [source,terminal]
+[subs="+quotes"]
 ----
-$ sudo composer-cli blueprints push minimal-microshift.toml
+$ sudo composer-cli blueprints push __<microshift_blueprint.toml>__ <1>
 ----
+<1> Replace _<microshift_blueprint.toml>_ with the name of your TOML file.
 
 .Verification
 
 . Verify the Image Builder configuration listing only {microshift-short} packages by running the following command:
 +
 [source,terminal]
+[subs="+quotes"]
 ----
-$ sudo composer-cli blueprints depsolve minimal-microshift | grep microshift
+$ sudo composer-cli blueprints depsolve __<microshift_blueprint>__ | grep microshift <1>
 ----
+<1> Replace _<microshift_blueprint>_ with the name of your blueprint.
 +
 .Example output
 +
 [source,terminal]
 ----
-blueprint: minimal-microshift v0.0.1
-    microshift-greenboot-4.13.1-202305250827.p0.g4105d3b.assembly.4.13.1.el9.noarch
-    microshift-networking-4.13.1-202305250827.p0.g4105d3b.assembly.4.13.1.el9.x86_64
-    microshift-release-info-4.13.1-202305250827.p0.g4105d3b.assembly.4.13.1.el9.noarch
-    microshift-4.13.1-202305250827.p0.g4105d3b.assembly.4.13.1.el9.x86_64
-    microshift-selinux-4.13.1-202305250827.p0.g4105d3b.assembly.4.13.1.el9.noarch
+blueprint: microshift_blueprint v0.0.1
+    microshift-greenboot-4.15.1-202305250827.p0.g4105d3b.assembly.4.15.1.el9.noarch
+    microshift-networking-4.15.1-202305250827.p0.g4105d3b.assembly.4.15.1.el9.x86_64
+    microshift-release-info-4.15.1-202305250827.p0.g4105d3b.assembly.4.15.1.el9.noarch
+    microshift-4.15.1-202305250827.p0.g4105d3b.assembly.4.15.1.el9.x86_64
+    microshift-selinux-4.15.1-202305250827.p0.g4105d3b.assembly.4.15.1.el9.noarch
 ----
 //need updated example output
 . Optional: Verify the Image Builder configuration listing all components to be installed by running the following command:
 +
 [source,terminal]
+[subs="+quotes"]
 ----
-$ sudo composer-cli blueprints depsolve minimal-microshift
+$ sudo composer-cli blueprints depsolve __<microshift_blueprint>__ <1>
 ----
+<1> Replace _<microshift_blueprint>_ with the name of your blueprint.


### PR DESCRIPTION
Version(s):
4.15+

Issue:
[OSDOCS-8804](https://issues.redhat.com/browse/OSDOCS-8804)

Link to docs preview:
[Embedding in a RHEL for image - regular install](https://70554--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree#adding-microshift-service-to-blueprint_microshift-embed-in-rpm-ostree)
[Embedding in a RHEL for Edge image - offline use](https://70554--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree-offline-use#adding-microshift-service-to-blueprint_microshift-embed-rpm-ostree-offline-use)

QE review:
- [x] QE approval is required.
