### PR TITLE
OCPBUGS#26565: Expanded the FIPS cryptography mode note with RHEL 9 c…

### DIFF
--- a/installing/installing-fips.adoc
+++ b/installing/installing-fips.adoc
@@ -14,7 +14,9 @@ For more information about the NIST validation program, see link:https://csrc.ni
 
 [IMPORTANT]
 ====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode].
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base} 8 computer that is configured to operate in FIPS mode. Running {op-system-base} 9 with FIPS mode enabled to install an {product-title} cluster is not possible.
+
+For more information about configuring FIPS mode on {op-system-base}, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/assembly_installing-a-rhel-8-system-with-fips-mode-enabled_security-hardening[Installing the system in FIPS mode].
 ====
 
 For the {op-system-first} machines in your cluster, this change is applied when the machines are deployed based on the status of an option in the `install-config.yaml` file, which governs the cluster options that a user can change during cluster deployment. With {op-system-base-full} machines, you must enable FIPS mode when you install the operating system on the machines that you plan to use as worker machines.


### PR DESCRIPTION
Version(s):
4.15 to 4.11

Issue:
[OCPBUGS-26565](https://issues.redhat.com/browse/OCPBUGS-26565)

Link to docs preview:
[Support for FIPS cryptography](https://70555--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing-fips)

SME review:
- [x] SME has approved this change.

QE review:
- [x] QE has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
