### PR TITLE
OCPBUGS-26200: Removed the lbType from AWS Sample YAML

### DIFF
--- a/modules/installation-aws-config-yaml.adoc
+++ b/modules/installation-aws-config-yaml.adoc
@@ -76,9 +76,6 @@ controlPlane: <3> <4>
 ifndef::aws-outposts[]
   platform:
     aws:
-ifndef::openshift-origin[]
-      lbType: NLB
-endif::openshift-origin[]
       zones:
 ifdef::china[]
       - cn-north-1a


### PR DESCRIPTION
Version(s):
4.15 - 4.12

Issue:
[OCPBUGS-26200](https://issues.redhat.com/browse/OCPBUGS-26200)

Link to docs preview:
* [Sample customized install-config.yaml file for AWS - government region](https://70556--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-government-region#installation-aws-config-yaml_installing-aws-government-region)
* [Sample customized install-config.yaml file for AWS-Secret or Top Secret region](https://70556--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-secret-region#installation-aws-config-yaml_installing-aws-secret-region)


SME review:
- [x] SME has approved this change.

QE review:
- [x] QE has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
