### PR TITLE
OCPBUGS-27224 Change vmname to hostname and variable bracket format

### DIFF
--- a/modules/machine-user-infra-machines-ibm-z-kvm.adoc
+++ b/modules/machine-user-infra-machines-ibm-z-kvm.adoc
@@ -87,21 +87,21 @@ $ curl -LO $(oc -n openshift-machine-config-operator get configmap/coreos-bootim
 ----
 $ virt-install \
    --connect qemu:///system \
-   --name {vm_name} \
+   --name <vm_name> \
    --autostart \
    --os-variant rhel9.2 \ <1>
    --cpu host \
-   --vcpus {vcpus} \
-   --memory {memory_mb} \
-   --disk {vm_name}.qcow2,size={image_size | default(100,true)} \
-   --network network={virt_network_parm} \
-   --location {media_location},kernel={rhcos_kernel},initrd={rhcos_initrd} \ <2>
+   --vcpus <vcpus> \
+   --memory <memory_mb> \
+   --disk <vm_name>.qcow2,size=<image_size> \
+   --network network=<virt_network_parm> \
+   --location <media_location>,kernel=<rhcos_kernel>,initrd=<rhcos_initrd> \ <2>
    --extra-args "rd.neednet=1" \
    --extra-args "coreos.inst.install_dev=/dev/vda" \
-   --extra-args "coreos.inst.ignition_url={worker_ign}" \ <3>
-   --extra-args "coreos.live.rootfs_url={rhcos_rootfs}" \ <4>
-   --extra-args "ip={ip}::{default_gateway}:{subnet_mask_length}:{vm_name}::none:{MTU}" \
-   --extra-args "nameserver={dns}" \
+   --extra-args "coreos.inst.ignition_url=<worker_ign>" \ <3>
+   --extra-args "coreos.live.rootfs_url=<rhcos_rootfs>" \ <4>
+   --extra-args "ip=<ip>::<default_gateway>:<subnet_mask_length>:<hostname>::none:<MTU>" \ <5>
+   --extra-args "nameserver=<dns>" \
    --extra-args "console=ttysclp0" \
    --noautoconsole \
    --wait
@@ -121,6 +121,7 @@ The `os-variant` is case sensitive.
 <2> For `--location`, specify the location of the kernel/initrd on the HTTP or HTTPS server.
 <3> For `coreos.inst.ignition_url=`, specify the `worker.ign` Ignition file for the machine role. Only HTTP and HTTPS protocols are supported.
 <4> For `coreos.live.rootfs_url=`, specify the matching rootfs artifact for the `kernel` and `initramfs` you are booting. Only HTTP and HTTPS protocols are supported.
+<5> Optional: For `hostname`, specify the fully qualified hostname of the client machine.
 --
 +
 [NOTE]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-27224
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://70557--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z-kvm#machine-user-infra-machines-ibm-z-kvm_creating-multi-arch-compute-nodes-ibm-z-kvm
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: @werled 
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
