### PR TITLE
OCPBUGS#11325-4.14: Supported access table is modified for Fibre Chan…

### DIFF
--- a/modules/storage-persistent-storage-pv.adoc
+++ b/modules/storage-persistent-storage-pv.adoc
@@ -152,7 +152,7 @@ ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 //|Ceph RBD  | ✅ | ✅ |✅ |  -
 //|CephFS  | ✅ | ✅ | ✅ |  ✅
 |Cinder  | ✅ | ✅ |- |  -
-|Fibre Channel  | ✅ | ✅ |✅ |  -
+|Fibre Channel  | ✅ | ✅ |✅ |  ✅ ^[4]^
 endif::[]
 ifndef::openshift-rosa[]
 |GCP Persistent Disk  | ✅ |✅ | - |  -
@@ -163,12 +163,12 @@ ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 |HostPath  | ✅ |✅ | - |  -
 |{ibm-power-server-title}  Disk | ✅ |✅  | ✅ |  ✅
 |{ibm-name} VPC Disk | ✅ |✅ | - |  -
-|iSCSI  | ✅ | ✅ |✅ |  -
+|iSCSI  | ✅ | ✅ |✅ |  ✅ ^[4]^
 |Local volume | ✅ |✅ | - |  -
 |NFS  | ✅ | ✅ |✅ | ✅
 |OpenStack Manila  | - |✅ | - | ✅
 |{rh-storage-first}  | ✅ |✅ | - | ✅
-|VMware vSphere | ✅ |✅ | - | ✅ ^[4]^
+|VMware vSphere | ✅ |✅ | - |  ✅ ^[5]^
 endif::[]
 |===
 [.small]
@@ -179,8 +179,10 @@ endif::[]
 
 3. Use a recreate deployment strategy for pods that rely on AWS EBS.
 
+4. Only raw block volumes support the ReadWriteMany (RWX) access mode for Fibre Channel and iSCSI. For more information, see "Block volume support".
+
 ifndef::openshift-dedicated,openshift-rosa[]
-4. If the underlying vSphere environment supports the vSAN file service, then the vSphere Container Storage Interface (CSI) Driver Operator installed by
+5. If the underlying vSphere environment supports the vSAN file service, then the vSphere Container Storage Interface (CSI) Driver Operator installed by
 {product-title} supports provisioning of ReadWriteMany (RWX) volumes. If you do not have vSAN file service configured, and you request RWX, the volume fails to get created and an error is logged. For more information, see "Using Container Storage Interface" -> "VMware vSphere CSI Driver Operator".
 endif::openshift-dedicated,openshift-rosa[]
 // GCE Persistent Disks, or Openstack Cinder PVs.


### PR DESCRIPTION
Version(s):
4.14, 4.15

Issue:
[OCPBUGS-11325](https://issues.redhat.com/browse/OCPBUGS-11325)

Link to docs preview:
https://70559--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/understanding-persistent-storage#pv-access-modes_understanding-persistent-storage

QE review:
- [x] QE approval required.
