### PR TITLE
OCPBUGS#11325-4.13: Supported access table is modified for Fibre Chan…

### DIFF
--- a/modules/storage-persistent-storage-pv.adoc
+++ b/modules/storage-persistent-storage-pv.adoc
@@ -150,7 +150,7 @@ ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 //|Ceph RBD  | ✅ | ✅ |  -
 //|CephFS  | ✅ | ✅ |  ✅
 |Cinder  | ✅ | - |  -
-|Fibre Channel  | ✅ | ✅ |  -
+|Fibre Channel  | ✅ | ✅ |  ✅ ^[3]^
 endif::[]
 ifndef::openshift-rosa[]
 |GCP Persistent Disk  | ✅ | - |  -
@@ -161,12 +161,12 @@ ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 |HostPath  | ✅ | - |  -
 |{ibmpowerProductName} Virtual Server Disk | ✅ | ✅ |  ✅
 |IBM VPC Disk | ✅ | - |  -
-|iSCSI  | ✅ | ✅ |  -
+|iSCSI  | ✅ | ✅ |  ✅ ^[3]^
 |Local volume | ✅ | - |  -
 |NFS  | ✅ | ✅ | ✅
 |OpenStack Manila  | - | - | ✅
 |{rh-storage-first}  | ✅ | - | ✅
-|VMware vSphere | ✅ | - | ✅ ^[3]^
+|VMware vSphere | ✅ | - |  ✅ ^[4]^
 endif::[]
 
 |===
@@ -174,8 +174,9 @@ endif::[]
 --
 1. ReadWriteOnce (RWO) volumes cannot be mounted on multiple nodes. If a node fails, the system does not allow the attached RWO volume to be mounted on a new node because it is already assigned to the failed node. If you encounter a multi-attach error message as a result, force delete the pod on a shutdown or crashed node to avoid data loss in critical workloads, such as when dynamic persistent volumes are attached.
 2. Use a recreate deployment strategy for pods that rely on Amazon EBS.
+3. Only raw block volumes support the ReadWriteMany (RWX) access mode for Fibre Channel and iSCSI. For more information, see "Block volume support".
 ifndef::openshift-dedicated,openshift-rosa[]
-3. If the underlying vSphere environment supports the vSAN file service, then the vSphere Container Storage Interface (CSI) Driver Operator installed by
+4. If the underlying vSphere environment supports the vSAN file service, then the vSphere Container Storage Interface (CSI) Driver Operator installed by
 {product-title} supports provisioning of ReadWriteMany (RWX) volumes. If you do not have vSAN file service configured, and you request RWX, the volume fails to get created and an error is logged. For more information, see "Using Container Storage Interface" -> "VMware vSphere CSI Driver Operator".
 endif::openshift-dedicated,openshift-rosa[]
 // GCE Persistent Disks, or Openstack Cinder PVs.


### PR DESCRIPTION
Version(s):
4.13, 4.12, 4.11

Issue:
[OCPBUGS-11325](https://issues.redhat.com/browse/OCPBUGS-11325)

Link to docs preview:
https://70560--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/understanding-persistent-storage#pv-access-modes_understanding-persistent-storage

QE review:
- [x] QE approval required.
