### PR TITLE
OSDOCS-9407: Update FIPs relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -44,8 +44,8 @@ This release adds improvements related to the following components and concepts.
 === Security and compliance
 
 [id="microshift-4-15-rhel-fips"]
-==== FIPS compliance
-* When {op-system-base-full} is installed and started with FIPS enabled, {microshift-short} containers are automatically enabled to run in FIPS-compliant mode. See xref:../microshift_install/microshift-fips.adoc#microshift-fips[Running {microshift-short} containers in FIPS mode] for details.
+==== FIPS mode
+* When {op-system-base-full} is installed and started with FIPS enabled, {microshift-short} containers are automatically enabled to run in FIPS mode. See xref:../microshift_install/microshift-fips.adoc#microshift-fips[Running {microshift-short} containers in FIPS mode].
 
 [id="microshift-4-15-updating"]
 === Updating


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-9407](https://issues.redhat.com/browse/OSDOCS-9407)

Link to docs preview:
[FIPS release note](https://70566--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes#microshift-4-15-rhel-fips)

QE review:
- N/A previously approved

Additional information:
[Content updates](https://github.com/openshift/openshift-docs/pull/70567)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
