### PR TITLE
OSDOCS-9408: update FIPS in install MicroShift

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -51,7 +51,7 @@ Distros: microshift
 Topics:
 - Name: Installing from an RPM package
   File: microshift-install-rpm
-- Name: Installing for FIPS compliance
+- Name: Using FIPS mode
   File: microshift-fips
 - Name: Mirroring container images for disconnected installations
   File: microshift-deploy-with-mirror-registry

--- a/microshift_install/microshift-fips.adoc
+++ b/microshift_install/microshift-fips.adoc
@@ -1,14 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="microshift-fips"]
-= Running {microshift-short} containers in FIPS mode
+= Using FIPS mode with {microshift-short}
 include::_attributes/attributes-microshift.adoc[]
 :context: microshift-fips
 
 toc::[]
 
-You can use FIPS-compliant mode with RPM-based installations of {microshift-short} on {op-system-base-full} {op-system-version-major}.
+You can use FIPS mode with RPM-based installations of {microshift-short} on {op-system-base-full} {op-system-version-major}.
 
-* To enable FIPS mode in {microshift-short} containers, the worker machine kernel must be enabled to run in FIPS-compliant mode before the machine starts.
+* To enable FIPS mode in {microshift-short} containers, the worker machine kernel must be enabled to run in FIPS mode before the machine starts.
 * Using FIPS with {op-system-ostree-first} images is not supported.
 
 include::modules/microshift-fips-rpm-system.adoc[leveloffset=+1]

--- a/microshift_install/microshift-install-rpm.adoc
+++ b/microshift_install/microshift-install-rpm.adoc
@@ -22,7 +22,7 @@ include::modules/microshift-install-rpm-before.adoc[leveloffset=+1]
 //additional resources for install rpm before module
 [role="_additional-resources"]
 .Additional resources
-* xref:../microshift_install/microshift-fips.adoc#microshift-fips[Running {microshift-short} containers in FIPS mode]
+* xref:../microshift_install/microshift-fips.adoc#microshift-fips[Using FIPS mode with {microshift-short}]
 
 include::modules/microshift-install-rpm-preparing.adoc[leveloffset=+1]
 

--- a/modules/microshift-fips-rpm-system.adoc
+++ b/modules/microshift-fips-rpm-system.adoc
@@ -4,11 +4,11 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="microshift-fips-rpm-system_{context}"]
-= Enabling FIPS compliance with RPM-based installations
+= FIPS mode with {op-system-base} RPM-based installations
 
-Using FIPS with {product-title-first} requires enabling the cryptographic module self-checks in your {op-system-base-full} installation. After the host operating system has been configured to start with the FIPS modules, {microshift-short} containers are automatically enabled to run in FIPS mode.
+Using FIPS with {microshift-short} requires enabling the cryptographic module self-checks in your {op-system-base-full} installation. After the host operating system has been configured to start with the FIPS modules, {microshift-short} containers are automatically enabled to run in FIPS mode.
 
-* When {op-system-base} is started in FIPS mode, {microshift} core components use the {op-system} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 validation on only the x86_64 architectures.
+* When {op-system-base} is started in FIPS mode, {microshift-short} core components use the {op-system} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 validation on only the x86_64 architectures.
 
 * You must enable FIPS mode when you install {op-system-base} {op-system-version-major} on the machines that you plan to use as worker machines.
 +

--- a/modules/microshift-install-rpm-before.adoc
+++ b/modules/microshift-install-rpm-before.adoc
@@ -6,7 +6,7 @@
 [id="microshift-install-rpm-before_{context}"]
 = Before installing {microshift-short} from an RPM package
 
-Preparation of the host machine is recommended prior to installing {microshift-short} for memory configuration and FIPS compliance.
+Preparation of the host machine is recommended prior to installing {microshift-short} for memory configuration and FIPS mode.
 
 [id="microshift-configuring-volume-groups_{context}"]
 == Configuring volume groups
@@ -15,7 +15,12 @@ Preparation of the host machine is recommended prior to installing {microshift-s
 
 To configure a volume group (VG) that allows LVMS to create the LVs for your workload's PVs, lower the *Desired Size* of your root volume during the installation of {op-system}. Lowering the size of your root volume allows unallocated space on the disk for additional LVs created by LVMS at runtime.
 
-[id="microshift-running-containers-fips-mode_{context}"]
-== Running {microshift-short} in FIPS-compliant mode
+[id="microshift-prepare-for-fips-mode_{context}"]
+== Prepare for FIPS mode
 
-If your use case requires running {microshift-short} containers in FIPS mode, you must install {op-system-base} with FIPS enabled. After the worker machine is configured to run in FIPS mode, your {microshift-short} containers are automatically configured to also run in FIPS mode. See "Running {microshift-short} containers in FIPS mode" in the "Additional resources" of this section.
+If your use case requires running {microshift-short} containers in FIPS mode, you must install {op-system-base} with FIPS enabled. After the worker machine is configured to run in FIPS mode, your {microshift-short} containers are automatically configured to also run in FIPS mode.
+
+[IMPORTANT]
+====
+Because FIPS must be enabled before the operating system that your cluster uses starts for the first time, you cannot enable FIPS after you deploy a cluster.
+====


### PR DESCRIPTION
Version(s):
4.15+

Issue:
[OSDOCS-9408](https://issues.redhat.com/browse/OSDOCS-9408)

Link to docs preview:
[Installing for FIPS mode](https://70567--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-fips)
[Before installing](https://70567--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-install-rpm#microshift-install-rpm-before_microshift-install-rpm)

QE review:
- N/A previously approved

Additional information:
[Release note update](https://github.com/openshift/openshift-docs/pull/70566)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
