### PR TITLE
OSDOCS#8861: Set target update version

### DIFF
--- a/modules/olmv1-finding-operators-to-install.adoc
+++ b/modules/olmv1-finding-operators-to-install.adoc
@@ -13,6 +13,7 @@ After you add a catalog to your cluster, you can query the catalog to find Opera
 
 * You have added a catalog to your cluster.
 * You have installed the `jq` CLI tool.
+* You have installed the `opm` CLI tool.
 
 .Procedure
 
@@ -98,7 +99,7 @@ $ jq -s '.[] | select( .schema == "olm.package") | \
 [source,terminal]
 ----
 $ jq -s '.[] | select( .schema == "olm.package") | \
-  select( .name == "serverless-operator")' rhoc.json
+  select( .name == "openshift-pipelines-operator-rh")' rhoc.json
 ----
 ====
 +
@@ -111,10 +112,62 @@ $ jq -s '.[] | select( .schema == "olm.package") | \
   "defaultChannel": "stable",
   "icon": {
     "base64data": "PHN2ZyB4bWxu..."
-    "mediatype": "image/svg+xml"
+    "mediatype": "image/png"
   },
-  "name": "serverless-operator",
+  "name": "openshift-pipelines-operator-rh",
   "schema": "olm.package"
 }
+----
+====
+
+. Currently, OLM 1.0 supports extensions that do not use webhooks and are configured to use the `AllNamespaces` install mode. Extensions that use webhooks or that target a single or specified set of namespaces cannot be installed. To search catalog for bundles that support `AllNamespaces` mode, run the following command:
++
+[source,terminal]
+----
+$ opm render --migrate <catalog_reference> | \
+  jq 'select(.schema == "olm.bundle" and (.properties[] | \
+  select(.type == "olm.csv.metadata" \
+  and (.value.installModes[] | \
+  select(.type == "AllNamespaces" and .supported == true) \
+  != null)) != null)).name'
+----
++
+.Example command
+[%collapsible]
+====
+[source,terminal]
+----
+$ opm render --migrate \
+  registry.redhat.io/redhat/redhat-operator-index:v4.15 | \
+  jq 'select(.schema == "olm.bundle" and (.properties[] | \
+  select(.type == "olm.csv.metadata" \
+  and (.value.installModes[] | \
+  select(.type == "AllNamespaces" and .supported == true) \
+  != null)) != null)).name'
+----
+====
++
+.Example output
+[%collapsible]
+====
+[source,text]
+----
+"3scale-operator.v0.10.0-mas"
+"3scale-operator.v0.10.5"
+"3scale-operator.v0.11.0-mas"
+"3scale-operator.v0.11.1-mas"
+"3scale-operator.v0.11.2-mas"
+"3scale-operator.v0.11.3-mas"
+"3scale-operator.v0.11.5-mas"
+"3scale-operator.v0.11.6-mas"
+"3scale-operator.v0.11.7-mas"
+"3scale-operator.v0.11.8-mas"
+"amq-broker-operator.v7.10.0-opr-1"
+"amq-broker-operator.v7.10.0-opr-2"
+"amq-broker-operator.v7.10.0-opr-3"
+"amq-broker-operator.v7.10.0-opr-4"
+"amq-broker-operator.v7.10.1-opr-1"
+"amq-broker-operator.v7.10.1-opr-2"
+...
 ----
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issues:
- Commit 1: Update to [OSDOCS-8884](https://issues.redhat.com//browse/OSDOCS-8884): Updating the "Finding an Operator to install docs" to clarify that OLM 1.0 only supports the `AllNamespaces` install mode and does not support webhooks.
<!--- - Commit 2: [OSDOCS-8861](https://issues.redhat.com//browse/OSDOCS-8861): Setting a target update version --->
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
