### PR TITLE
ROX-21783: Update release notes for 4.3.4 patch

### DIFF
--- a/release_notes/43-release-notes.adoc
+++ b/release_notes/43-release-notes.adoc
@@ -19,6 +19,7 @@ toc::[]
 |`4.3.1` | 11 December 2023
 |`4.3.2` | 8 January 2024
 |`4.3.3` | 16 January 2024
+|`4.3.4` | 22 January 2024
 
 |====
 
@@ -270,6 +271,27 @@ Vulnerability deferral management for host (`/node`) and platform (`/cluster`) v
 *Release date*: 16 January 2024
 
 * This release contains updates to the versions of golang and go-git used in {product-title-short}.
+
+[id="resolved-in-version-434_{context}"]
+=== Resolved in version 4.3.4
+
+*Release date*: 22 January 2024
+
+This release contains the following bug fixes and enhancements.
+
+The following fixes and enhancements for integration with Jira and Jira Cloud are implemented:
+
+* The priority is now correctly set on Jira issues created by {product-title-short}.
+* The {product-title-short} integration with Jira Cloud can successfully be created.
+* The default priority mappings in the integration creation page in the {product-title-short} portal have been updated to match the default Jira priorities.
+* Checks were added for integration creation to minimize the risk that issue creation will fail after the integration is saved.
+* A checkbox was added to give you the option to disable setting the priority.
+
+A TLS certificate rotation fix is included. In the past, the Operator attempted to rotate TLS certificates for Central components only after they expired. Additionally, a bug prevented update of the expired certificate in the `central-tls` secret. With this fix, the Operator will rotate all Central components' service TLS certificates 6 months before they expire. The following conditions apply:
+
+* The rotation of certificates in the secrets does not trigger the components to automatically reload them. However, reloads typically occur when the pod is replaced as part of an {product-title-short} upgrade or as a result of node reboots. If neither of those events happens at least every 6 months, you must restart the pods before the old (in-memory) service certificates expire. For example, you can delete the pods with an `app` label that contains one of the values of `central`, `central-db`, `scanner`, or `scanner-db`.
+* CA certificates are not updated. They are valid for 5 years.
+* The service certificates in the init bundles used by secured cluster components are not updated. You must rotate the init bundles at regular intervals.
 
 [id="known-issues-430_{context}"]
 == Known issues


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-4.3`

[Issue](https://issues.redhat.com/browse/ROX-21783)

[Link to docs preview
](https://70576--docspreview.netlify.app/openshift-acs/latest/release_notes/43-release-notes#resolved-in-version-434_release-notes-43)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
