### PR TITLE
OSSM-5786: Extend cleanup commands about ossm-cni resources

### DIFF
--- a/modules/ossm-remove-cleanup.adoc
+++ b/modules/ossm-remove-cleanup.adoc
@@ -47,7 +47,7 @@ $ oc -n openshift-operators delete ds -lmaistra-version
 +
 [source,terminal]
 ----
-$ oc delete clusterrole/istio-admin clusterrole/istio-cni clusterrolebinding/istio-cni
+$ oc delete clusterrole/istio-admin clusterrole/istio-cni clusterrolebinding/istio-cni clusterrole/ossm-cni clusterrolebinding/ossm-cni
 ----
 +
 [source,terminal]
@@ -87,10 +87,10 @@ $ oc delete cm -n openshift-operators maistra-operator-cabundle
 +
 [source,terminal]
 ----
-$ oc delete cm -n openshift-operators istio-cni-config istio-cni-config-v2-3
+$ oc delete cm -n openshift-operators -lmaistra-version
 ----
 +
 [source,terminal]
 ----
-$ oc delete sa -n openshift-operators istio-cni
+$ oc delete sa -n openshift-operators -lmaistra-version
 ----


### PR DESCRIPTION

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): OCP 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSSM-5786
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://70583--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/removing-ossm#ossm-remove-cleanup_removing-ossm
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
