### PR TITLE
OSDOCS-9410 z-stream RNs for 4.11.57

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -3905,7 +3905,7 @@ To update a {product-title} 4.11 cluster to this latest release, see xref:../upd
 [id="ocp-4-11-56"]
 === RHSA-2024:0059 {product-title} 4.11.56 bug fix update and security update
 
-Issued: 2023-01-10
+Issued: 2024-01-10
 
 {product-title} release 4.11.56, which includes security updates, is now available. Bug fixes included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2024:0059[RHSA-2024:0059] advisory. RPM packages included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:0061[RHBA-2024:0061] advisory.
 
@@ -3917,6 +3917,25 @@ $ oc adm release info 4.11.56 --pullspecs
 ----
 
 [id="ocp-4-11-56-upgrading"]
+==== Updating
+
+To update a {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-11-57"]
+=== RHSA-2024:0306 {product-title} 4.11.57 bug fix update and security update
+
+Issued: 2024-01-25
+
+{product-title} release 4.11.57, which includes security updates, is now available. Bug fixes included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2024:0306[RHSA-2024:0306] advisory. RPM packages included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0308[RHSA-2024:0308] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.57 --pullspecs
+----
+
+[id="ocp-4-11-57-upgrading"]
 ==== Updating
 
 To update a {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s): 4.11
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-9410](https://issues.redhat.com/browse/OSDOCS-9410)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Preview](https://70586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes#ocp-4-11-57)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Not needed
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Expected merge date is Jan 24th (actual release date is now Jan 25th), errata links will not work until then. I also changed the year of the previous release from 2023 to 2024 since it was an error. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
