### PR TITLE
OBSDOCS-708: Clean up collector pod taint and toleration docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2574,7 +2574,7 @@ Topics:
   Topics:
   - Name: Configuring CPU and memory limits for Logging components
     File: cluster-logging-memory
-  - Name: Using tolerations to control Logging pod placement
+  - Name: Using tolerations to control logging pod placement
     File: cluster-logging-tolerations
   - Name: Moving logging subsystem resources with node selectors
     File: cluster-logging-moving-nodes

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -1057,7 +1057,7 @@ Topics:
   Topics:
   - Name: Configuring CPU and memory limits for Logging components
     File: cluster-logging-memory
-  - Name: Using tolerations to control Logging pod placement
+  - Name: Using tolerations to control logging pod placement
     File: cluster-logging-tolerations
   - Name: Moving logging subsystem resources with node selectors
     File: cluster-logging-moving-nodes

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1287,7 +1287,7 @@ Topics:
   Topics:
   - Name: Configuring CPU and memory limits for Logging components
     File: cluster-logging-memory
-  - Name: Using tolerations to control Logging pod placement
+  - Name: Using tolerations to control logging pod placement
     File: cluster-logging-tolerations
   - Name: Moving logging subsystem resources with node selectors
     File: cluster-logging-moving-nodes

--- a/logging/config/cluster-logging-tolerations.adoc
+++ b/logging/config/cluster-logging-tolerations.adoc
@@ -1,31 +1,23 @@
 :_mod-docs-content-type: ASSEMBLY
 :context: cluster-logging-tolerations
-[id="cluster-logging-tolerations"]
-= Using tolerations to control OpenShift Logging pod placement
 include::_attributes/common-attributes.adoc[]
+[id="cluster-logging-tolerations"]
+= Using tolerations to control logging pod placement
 
 toc::[]
 
-You can use taints and tolerations to ensure that {logging} pods run
-on specific nodes and that no other workload can run on those nodes.
+You can use taints and tolerations to ensure that {logging} pods run on specific nodes and that no other workload can run on those nodes.
 
-Taints and tolerations are simple `key:value` pair. A taint on a node
-instructs the node to repel all pods that do not tolerate the taint.
+Taints and tolerations are simple `key:value` pair. A taint on a node instructs the node to repel all pods that do not tolerate the taint.
 
-The `key` is any string, up to 253 characters and the `value` is any string up to 63 characters.
-The string must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
+The `key` is any string, up to 253 characters and the `value` is any string up to 63 characters. The string must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
 
-.Sample {logging} CR with tolerations
+.Sample `ClusterLogging` custom resource with tolerations
 [source,yaml]
 ----
-apiVersion: "logging.openshift.io/v1"
-kind: "ClusterLogging"
-metadata:
-  name: "instance"
-  namespace: openshift-logging
-
-...
-
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogging
+# ...
 spec:
   managementState: "Managed"
   logStore:
@@ -60,45 +52,21 @@ spec:
           cpu: 100m
           memory: 1Gi
       replicas: 1
-  collection:
-    logs:
-      type: "fluentd"
-      fluentd:
-        tolerations: <3>
-        - key: "logging"
-          operator: "Exists"
-          effect: "NoExecute"
-          tolerationSeconds: 6000
-        resources:
-          limits:
-            memory: 2Gi
-          requests:
-            cpu: 100m
-            memory: 1Gi
 ----
-
 <1> This toleration is added to the Elasticsearch pods.
 <2> This toleration is added to the Kibana pod.
-<3> This toleration is added to the logging collector pods.
-
-// The following include statements pull in the module files that comprise
-// the assembly. Include any combination of concept, procedure, or reference
-// modules required to cover the user story. You can also include other
-// assemblies.
 
 include::modules/cluster-logging-elasticsearch-tolerations.adoc[leveloffset=+1]
-
 include::modules/cluster-logging-kibana-tolerations.adoc[leveloffset=+1]
 
-include::modules/cluster-logging-collector-tolerations.adoc[leveloffset=+1]
-
 [role="_additional-resources"]
-[id="cluster-logging-tolerations-addtl-resources"]
+[id="additional-resources_cluster-logging-tolerations"]
 == Additional resources
 
 ifdef::openshift-enterprise,openshift-origin[]
-* xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations[Controlling pod placement using node taints].
+* xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations[Controlling pod placement using node taints]
 endif::[]
 ifdef::openshift-rosa,openshift-dedicated[]
-* link:https://docs.openshift.com/container-platform/latest/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations[Controlling pod placement using node taints].
+* link:https://docs.openshift.com/container-platform/latest/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations[Controlling pod placement using node taints]
 endif::[]
+* xref:../../logging/log_collection_forwarding/cluster-logging-collector.adoc#cluster-logging-collector-tolerations_cluster-logging-collector[Using tolerations to control the log collector pod placement]

--- a/logging/log_collection_forwarding/cluster-logging-collector.adoc
+++ b/logging/log_collection_forwarding/cluster-logging-collector.adoc
@@ -16,6 +16,8 @@ include::modules/log-collector-resources-scheduling.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-collector-pod-location.adoc[leveloffset=+1]
 
+include::modules/cluster-logging-collector-tolerations.adoc[leveloffset=+1]
+
 include::modules/cluster-logging-collector-limits.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-collector-tuning.adoc[leveloffset=+1]

--- a/modules/cluster-logging-collector-tolerations.adoc
+++ b/modules/cluster-logging-collector-tolerations.adoc
@@ -1,31 +1,35 @@
 // Module included in the following assemblies:
 //
-// * logging/cluster-logging-collector.adoc
+// * logging/log_collection_forwarding/cluster-logging-collector.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="cluster-logging-collector-tolerations_{context}"]
-= Using tolerations to control the log collector pod placement
+= Using taints and tolerations to control log collector pod placement
 
-You can ensure which nodes the logging collector pods run on and prevent
-other workloads from using those nodes by using tolerations on the pods.
+You can specify which nodes the logging collector pods run on, and prevent other workloads from using those nodes, by configuring taints and tolerations.
 
-You apply tolerations to logging collector pods through the `ClusterLogging` custom resource (CR)
-and apply taints to a node through the node specification. You can use taints and tolerations
-to ensure the pod does not get evicted for things like memory and CPU issues.
+You apply tolerations to logging collector pods by modifying the `ClusterLogging` custom resource (CR), and apply taints to a node through the node specification. You can use taints and tolerations to ensure that the pod is not evicted due to memory or CPU issues.
 
-By default, the logging collector pods have the following toleration:
+By default, logging collector pods have the following toleration:
 
 [source,yaml]
 ----
-tolerations:
-- key: "node-role.kubernetes.io/master"
-  operator: "Exists"
-  effect: "NoExecute"
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogging
+# ...
+spec:
+  collection:
+# ...
+    tolerations:
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
+      effect: "NoExecute"
+# ...
 ----
 
 .Prerequisites
 
-* The Red Hat OpenShift Logging and Elasticsearch Operators must be installed.
+* You have installed the {clo}.
 
 .Procedure
 
@@ -33,7 +37,7 @@ tolerations:
 +
 [source,terminal]
 ----
-$ oc adm taint nodes <node-name> <key>=<value>:<effect>
+$ oc adm taint nodes <node_name> <key>=<value>:<effect>
 ----
 +
 For example:
@@ -43,27 +47,27 @@ For example:
 $ oc adm taint nodes node1 collector=node:NoExecute
 ----
 +
-This example places a taint on `node1` that has key `collector`, value `node`, and taint effect `NoExecute`.
-You must use the `NoExecute` taint effect. `NoExecute` schedules only pods that match the taint and removes existing pods
-that do not match.
+This example places a taint on `node1` that has key `collector`, value `node`, and taint effect `NoExecute`. You must use the `NoExecute` taint effect. `NoExecute` schedules only pods that match the taint and removes existing pods that do not match.
 
-. Edit the `collection` stanza of the `ClusterLogging` custom resource (CR) to configure a toleration for the logging collector pods:
+. Edit the `collection` stanza of the `ClusterLogging` custom resource (CR) to configure a toleration for the logging collector pods. The following example toleration configuration matches the taint created by the `oc adm taint` command. A pod with this toleration schedules onto `node1`.
 +
+.Example toleration configuration
 [source,yaml]
 ----
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogging
+# ...
+spec:
   collection:
-    logs:
-      type: "fluentd"
-      fluentd:
-        tolerations:
-        - key: "collector"  <1>
-          operator: "Exists"  <2>
-          effect: "NoExecute"  <3>
-          tolerationSeconds: 6000  <4>
+    type: vector
+    tolerations:
+    - key: "node.kubernetes.io/disk-pressure" # <1>
+      operator: "Exists" # <2>
+      effect: "NoSchedule" # <3>
+      tolerationSeconds: 6000 # <4>
+# ...
 ----
 <1> Specify the key that you added to the node.
 <2> Specify the `Exists` operator to require the `key`/`value`/`effect` parameters to match.
-<3> Specify the `NoExecute` effect.
-<4> Optionally, specify the `tolerationSeconds` parameter to set how long a pod can remain bound to a node before being evicted.
-
-This toleration matches the taint created by the `oc adm taint` command. A pod with this toleration would be able to schedule onto `node1`.
+<3> Specify the `NoSchedule` effect.
+<4> Optional. Specify the `tolerationSeconds` parameter to set how long a pod can remain bound to a node before being evicted.


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OBSDOCS-708

Link to docs preview:
- https://70588--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/config/cluster-logging-tolerations
- https://70588--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_collection_forwarding/cluster-logging-collector#cluster-logging-collector-tolerations_cluster-logging-collector

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
**NOTE:** This PR is only to update the collector docs. There is follow up work required for the ES and Kibana versions, which should be moved to the correct sections in the docs, and updated for Loki and OCP web console. This is out of scope for https://issues.redhat.com/browse/OBSDOCS-708
