### PR TITLE
OBSDOCS-125: Update callouts to clarify log collection behavior

### DIFF
--- a/modules/cluster-logging-collector-log-forward-project.adoc
+++ b/modules/cluster-logging-collector-log-forward-project.adoc
@@ -6,7 +6,7 @@
 [id="cluster-logging-collector-log-forward-project_{context}"]
 = Forwarding application logs from specific projects
 
-You can use the Cluster Log Forwarder to send a copy of the application logs from specific projects to an external log aggregator. You can do this in addition to, or instead of, using the default Elasticsearch log store. You must also configure the external log aggregator to receive log data from {product-title}.
+You can forward a copy of the application logs from specific projects to an external log aggregator, in addition to, or instead of, using the internal log store. You must also configure the external log aggregator to receive log data from {product-title}.
 
 To configure forwarding application logs from a project, you must create a `ClusterLogForwarder` custom resource (CR) with at least one input from a project, optional outputs for other log aggregators, and pipelines that use those inputs and outputs.
 
@@ -16,8 +16,9 @@ To configure forwarding application logs from a project, you must create a `Clus
 
 .Procedure
 
-. Create or edit a YAML file that defines the `ClusterLogForwarder` CR object:
+. Create or edit a YAML file that defines the `ClusterLogForwarder` CR:
 +
+.Example `ClusterLogForwarder` CR
 [source,yaml]
 ----
 apiVersion: logging.openshift.io/v1
@@ -39,18 +40,18 @@ spec:
    - name: my-app-logs
      application:
         namespaces:
-        - my-project
+        - my-project <8>
   pipelines:
-   - name: forward-to-fluentd-insecure <8>
-     inputRefs: <9>
+   - name: forward-to-fluentd-insecure <9>
+     inputRefs: <10>
      - my-app-logs
-     outputRefs: <10>
+     outputRefs: <11>
      - fluentd-server-insecure
      labels:
-       project: "my-project" <11>
-   - name: forward-to-fluentd-secure <12>
+       project: "my-project" <12>
+   - name: forward-to-fluentd-secure <13>
      inputRefs:
-     - application
+     - application <14>
      - audit
      - infrastructure
      outputRefs:
@@ -61,25 +62,28 @@ spec:
 ----
 <1> The name of the `ClusterLogForwarder` CR must be `instance`.
 <2> The namespace for the `ClusterLogForwarder` CR must be `openshift-logging`.
-<3> Specify a name for the output.
-<4> Specify the output type: `elasticsearch`, `fluentdForward`, `syslog`, or `kafka`.
-<5> Specify the URL and port of the external log aggregator as a valid absolute URL. If the cluster-wide proxy using the CIDR annotation is enabled, the output must be a server name or FQDN, not an IP address.
+<3> The name of the output.
+<4> The output type: `elasticsearch`, `fluentdForward`, `syslog`, or `kafka`.
+<5> The URL and port of the external log aggregator as a valid absolute URL. If the cluster-wide proxy using the CIDR annotation is enabled, the output must be a server name or FQDN, not an IP address.
 <6> If using a `tls` prefix, you must specify the name of the secret required by the endpoint for TLS communication. The secret must exist in the `openshift-logging` project and have *tls.crt*, *tls.key*, and *ca-bundle.crt* keys that each point to the certificates they represent.
-<7> Configuration for an input to filter application logs from the specified projects.
-<8> Configuration for a pipeline to use the input to send project application logs to an external Fluentd instance.
-<9> The `my-app-logs` input.
-<10> The name of the output to use.
-<11> Optional: String. One or more labels to add to the logs.
-<12> Configuration for a pipeline to send logs to other log aggregators.
-** Optional: Specify a name for the pipeline.
-** Specify which log types to forward by using the pipeline: `application,` `infrastructure`, or `audit`.
-** Specify the name of the output to use when forwarding logs with this pipeline.
-** Optional: Specify the `default` output to forward logs to the internal Elasticsearch instance.
-** Optional: String. One or more labels to add to the logs.
+<7> The configuration for an input to filter application logs from the specified projects.
+<8> If no namespace is specified, logs are collected from all namespaces.
+<9> The pipeline configuration directs logs from a named input to a named output. In this example, a pipeline named `forward-to-fluentd-insecure` forwards logs from an input named `my-app-logs` to an output named `fluentd-server-insecure`.
+<10> A list of inputs.
+<11> The name of the output to use.
+<12> Optional: String. One or more labels to add to the logs.
+<13> Configuration for a pipeline to send logs to other log aggregators.
++
+* Optional: Specify a name for the pipeline.
+* Specify which log types to forward by using the pipeline: `application,` `infrastructure`, or `audit`.
+* Specify the name of the output to use when forwarding logs with this pipeline.
+* Optional: Specify the `default` output to forward logs to the default log store.
+* Optional: String. One or more labels to add to the logs.
+<14> Note that application logs from all namespaces are collected when using this configuration.
 
-. Create the CR object:
+. Apply the `ClusterLogForwarder` CR by running the following command:
 +
 [source,terminal]
 ----
-$ oc create -f <file-name>.yaml
+$ oc apply -f <filename>.yaml
 ----


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OBSDOCS-125

Link to docs preview:
https://70592--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_collection_forwarding/configuring-log-forwarding#cluster-logging-collector-log-forward-project_configuring-log-forwarding

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
