### PR TITLE
OSDOCS-8400: Migrate "OpenShift Concepts" from rosaworkshop.io

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -124,6 +124,8 @@ Topics:
   Dir: cloud-experts-getting-started
   Distros: openshift-rosa
   Topics:
+  - Name: OpenShift concepts
+    File: cloud-experts-getting-started-openshift-concepts
   - Name: Deploying a cluster
     Dir: cloud-experts-getting-started-deploying
     Topics:

--- a/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-openshift-concepts.adoc
+++ b/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-openshift-concepts.adoc
@@ -9,3 +9,82 @@ toc::[]
 //rosaworkshop.io content metadata
 //Brought into ROSA product docs 2024-01-19
 
+== Source-to-Image (S2I)
+Source-to-Image (S2I) is a toolkit and workflow for building reproducible container images from source code. S2I produces ready-to-run images by inserting source code into a container image and letting the container prepare the source code. By creating self-assembling builder images, you can version and control your build environments exactly like you use container images to version your runtime environments.
+
+* link:https://github.com/openshift/source-to-image[S2I Builds]
+* xref:../../../openshift_images/create-images.adoc#images-create-guidelines_create-images[Creating Images]
+
+== How it works
+
+For a dynamic language such as Ruby, the build time and run time environments are typically the same. Assuming that Ruby, Bundler, Rake, Apache, GCC, and all other packages needed to set up and run a Ruby application are already installed, a builder image performs the following steps:
+
+. The builder image starts a container with the application source injected into a known directory.
+
+. The container process transforms that source code into the appropriate runnable setup. For example, it installs dependencies with Bundler and moves the source code into a directory where Apache has been preconfigured to look for the Ruby configuration file.
+
+. It then commits the new container and sets the image entrypoint to be a script that will start Apache to host the Ruby application.
+
+For compiled languages like C, C++, Go, or Java, the necessary dependencies for compilation might outweigh the size of the runtime artifacts. To keep runtime images small, S2I enables a multiple-step build process, where a binary artifact such as an executable file is created in the first builder image, extracted, and injected into a second runtime image that simply places the executable in the correct location.
+
+For example, to create a reproducible build pipeline for Tomcat and Maven:
+
+. Create a builder image containing OpenJDK and Tomcat that expects to have a WAR file injected.
+
+. Create a second image that layers on top of the first image Maven and any other standard dependencies, and expects to have a Maven project injected.
+
+. Invoke S2I using the Java application source and the Maven image to create the desired application WAR.
+
+. Invoke S2I a second time using the WAR file from the previous step and the initial Tomcat image to create the runtime image.
+
+By placing build logic inside of images and combining the images into multiple steps, the runtime environment is close to the build environment without requiring the deployment of build tools to production.
+
+== Goals and benefits
+
+=== Reproducibility
+Allow build environments to be tightly versioned by encapsulating them within a container image and defining a simple interface of injected source code for callers. Reproducible builds are a key requirement for enabling security updates and continuous integration in containerized infrastructure, and builder images help ensure repeatability as well as the ability to swap run times.
+
+=== Flexibility
+Any existing build system that can run on Linux can run inside of a container, and each individual builder can also be part of a larger pipeline. The scripts that process the application source code can be injected into the builder image, allowing authors to adapt existing images to enable source handling.
+
+=== Speed
+Instead of building multiple layers in a single Dockerfile, S2I encourages authors to represent an application in a single image layer. This saves time during creation and deployment and allows for better control over the output of the final image.
+
+=== Security
+Dockerfiles are run without many of the normal operational controls of containers. They usually run as root and have access to the container network. S2I can control what permissions and privileges are available to the builder image since the build is launched in a single container. In concert with platforms like OpenShift, S2I allows administrators to control what privileges developers have at build time.
+
+== Routes
+An OpenShift Route exposes a service at a host name so that external clients can reach it by name. When a Route object is created on OpenShift, it gets picked up by the built-in HAProxy load balancer in order to expose the requested service and make it externally available with the given configuration. Similar to the Kubernetes Ingress object, Red Hat created the concept of Route in order to fill a need and then contributed the design principles behind it to the community, which heavily influenced the Ingress design.  A Route does have some additional features as can be seen in the chart below.
+
+![routes vs ingress](images/2-routes_vs_ingress.png)
+
+[NOTE]
+====
+DNS resolution for a host name is handled separately from routing. Your administrator may have configured a cloud domain that will always correctly resolve to the router or modify your unrelated host name DNS records independently to resolve to the router.
+====
+
+An individual route can override some defaults by providing specific configurations in its annotations. See xref:../../../networking/routes/route-configuration.adoc#nw-route-specific-annotations_route-configuration[route specific annotations] for more details.
+
+== ImageStreams
+An ImageStream stores a mapping of tags to images, metadata overrides that are applied when images are tagged in a stream, and an optional reference to a Docker image repository on a registry.
+
+=== ImageStream benefits
+Using an ImageStream makes it easy to change a tag for a container image. Otherwise to change a tag you need to download the whole image, change it locally, then push it all back. Also promoting applications by having to do that to change the tag and then update the deployment object entails many steps. With ImageStreams you upload a container image once and then you manage its virtual tags internally in OpenShift. In one project you may use the dev tag and only change a reference to it internally, while in production you may use a prod tag and also manage it internally. You do not have to deal with the registry.
+
+You can also use ImageStreams in conjunction with DeploymentConfigs to set a trigger that will start a deployment as soon as a new image appears or a tag changes its reference.
+
+See below for more details:
+
+* link:https://blog.openshift.com/image-streams-faq/[Image Streams Blog post]
+* xref:../openshift_images/images-understand.adoc[OpenShift Docs - Understanding containers, images, and image streams]
+* [ImageStream and Builds](https://cloudowski.com/articles/why-managing-container-images-on-openshift-is-better-than-on-kubernetes/)
+
+
+== Builds
+A build is the process of transforming input parameters into a resulting object. Most often, the process is used to transform input parameters or source code into a runnable image. A BuildConfig object is the definition of the entire build process.
+
+OpenShift Container Platform leverages Kubernetes by creating Docker-formatted containers from build images and pushing them to a container image registry.
+
+Build objects share common characteristics: inputs for a build, the need to complete a build process, logging the build process, publishing resources from successful builds, and publishing the final status of the build. Builds take advantage of resource restrictions, specifying limitations on resources such as CPU usage, memory usage, and build or pod execution time.
+
+See [Understanding image builds](https://docs.openshift.com/container-platform/latest/cicd/builds/understanding-image-builds.html) for more details.

--- a/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-openshift-concepts.adoc
+++ b/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-openshift-concepts.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="cloud-experts-getting-started-openshift-concepts"]
+= Tutorial: OpenShift concepts
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: cloud-experts-getting-started-openshift-concepts
+
+toc::[]
+
+//rosaworkshop.io content metadata
+//Brought into ROSA product docs 2024-01-19
+


### PR DESCRIPTION
[OSDOCS-8400](https://issues.redhat.com//browse/OSDOCS-8400): Migrate "OpenShift Concepts" from rosaworkshop.io

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-8400

Link to docs preview:
https://70607--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-openshift-concepts

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
