### PR TITLE
[Removed ]Updating the certificate authority (CA) will cause the nodes of your cluster to reboot

### DIFF
--- a/security/certificates/updating-ca-bundle.adoc
+++ b/security/certificates/updating-ca-bundle.adoc
@@ -6,10 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-[IMPORTANT]
-====
-Updating the certificate authority (CA) will cause the nodes of your cluster to reboot.
-====
 
 include::modules/ca-bundle-understanding.adoc[leveloffset=+1]
 


### PR DESCRIPTION
…es of your cluster to reboot.

[Removed]

Updating the certificate authority (CA) will cause the nodes of your cluster to reboot.

Because starting with OCP 4.14, updating ca-bundle do not require node reboot as the certificate update/addition handled by MCC now.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
[Removed ]Updating the certificate authority (CA) will cause the nodes of your cluster to reboot 
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://70617--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificates/updating-ca-bundle
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
Starting with OCP 4.14 adding the ca-bundle.crt using proxy/cluster yaml do not trigger node reboot. The machineconfigcontroller takes care of  ca update on the node level.
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
