### PR TITLE
OADP-3353: Multiple BSL are supported

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
@@ -18,6 +18,10 @@ To back up Kubernetes resources and internal images, you must have object storag
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc#installing-oadp-mcg[Multicloud Object Gateway]
 * AWS S3 compatible object storage, such as Multicloud Object Gateway or MinIO
 
+You can configure multiple backup storage locations within the same namespace for each individual OADP deployment.
+
+include::snippets/snip-noobaa-and-mcg.adoc[]
+
 :FeatureName: The `CloudStorage` API, which automates the creation of a bucket for object storage,
 include::snippets/technology-preview.adoc[]
 

--- a/modules/about-installing-oadp-on-multiple-namespaces.adoc
+++ b/modules/about-installing-oadp-on-multiple-namespaces.adoc
@@ -12,7 +12,7 @@ You can install OpenShift API for Data Protection (OADP) into multiple namespace
 You install each instance of OADP as specified by the per-platform procedures contained in this document with the following additional requirements:
 
 * All deployments of OADP on the same cluster must be the same version, for example, 1.1.4. Installing different versions of OADP on the same cluster is *not* supported.
-* Each individual deployment of OADP must have a unique set of credentials and a unique `BackupStorageLocation` configuration.
+* Each individual deployment of OADP must have a unique set of credentials and at least one `BackupStorageLocation` configuration. You can also use multiple `BackupStorageLocation` configurations within the same namespace.
 * By default, each OADP deployment has cluster-level access across namespaces. {product-title} administrators need to review security and RBAC settings carefully and make any necessary changes to them to ensure that each OADP instance has the correct permissions.
 
 


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/OADP-3353
OADP 1.3.0
OCP 4.12+
Preview:
https://70623--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp (a note after the list of cloud providers)
https://70623--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp#about-installing-oadp-on-multiple-namespaces_about-installing-oadp
