### PR TITLE
OSDOCS-8499: RHOSP release notes added

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -61,9 +61,9 @@ This release adds improvements related to the following components and concepts.
 [id="ocp-4-15-CAPO-tech-preview-no-upgrade"]
 ==== CAPO integration into the cluster CAPI Operator (Tech Preview)
 
-If you enable the `TechPreviewNoUpgrade` feature flag, the Coherent Accelerator Processor Interface (CAPI) Operator deploys the Cluster API Provider for OpenStack (CAPO) and manages its lifestyle. The CAPI Operator automatically creates an additional OpenStack cluster and an additional {product-title} cluster for the current {product-title} cluster.
+If you enable the `TechPreviewNoUpgrade` feature flag, the Cluster API (CAPI) Operator deploys the Cluster API Provider for OpenStack (CAPO) and manages its lifecycle. The CAPI Operator automatically creates an additional OpenStack cluster and an additional {product-title} cluster for the current {product-title} cluster.
 
-It is now possible to configure the CAPI machine and OpenStack machine resources in a similar fashion to how the Mail Application Programming Interface (MAPI) resources are configured. It is important to note that the CAPI resources are equivalent to MAPI resources and not identical.
+It is now possible to configure the CAPI machine and OpenStack machine resources in a similar fashion to how the Machine API (MAPI) resources are configured. It is important to note that the CAPI resources are equivalent to MAPI resources and not identical.
 
 [id="ocp-4-15-installation-and-update-ibm-cloud-user-managed-encryption"]
 ==== IBM Cloud and user-managed encryption
@@ -1317,9 +1317,27 @@ In the following tables, features are marked with the following statuses:
 |Dual-stack networking with installer-provisioned infrastructure
 |Not Available
 |Technology Preview
+|General Availability
+
+|Dual-stack networking with user-provisioned infrastructure
+|Not Available
+|Not Available
+|General Availability
+
+|CAPO integration into the cluster CAPI Operator ^[1]^
+|Not Available
+|Not Available
 |Technology Preview
 
+|Control Plane with `rootVolumes` and `etcd` on local disk
+|Not Available
+|Not Available
+|Technology Preview
 |====
+[.small]
+--
+1. For more information, see xref:../release_notes/ocp-4-15-release-notes.adoc#ocp-4-15-CAPO-tech-preview-no-upgrade[CAPO integration into the cluster CAPI Operator].
+--
 
 [discrete]
 === Architecture Technology Preview features


### PR DESCRIPTION
Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-8499

Link to docs preview (VPN required):
[4.15 release notes](https://file.rdu.redhat.com/antaylor/OSDOCS-8499/release_notes/ocp-4-15-release-notes.html) **I recommend `ctrl+f` for "table 29"**

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This update adds more information to the tech preview table, as some features are newly GA and some are newly TP. Deprecation of Kuryr has previously been documented elsewhere in the release notes, as well as CAPO description as a new TP feature, which I added to the TP table as well. Control Plane with rootVolumes and etcd on local disk was mentioned in the 4.14 release notes, however I added it to the TP table too for this release. 

Please let me know if I missed anything!
