### PR TITLE
CNV-27696: Created dummy release notes files

### DIFF
--- a/virt/release_notes/virt-4-11-release-notes.adoc
+++ b/virt/release_notes/virt-4-11-release-notes.adoc
@@ -1,0 +1,11 @@
+:_content-type: ASSEMBLY
+[id="virt-4-11-release-notes"]
+= {VirtProductName} release notes
+include::_attributes/common-attributes.adoc[]
+:context: virt-4-11-release-notes
+toc::[]
+
+Do not add or edit release notes here. Edit release notes directly in the branch
+that they are relevant for.
+
+This file is here to allow builds to work.

--- a/virt/release_notes/virt-4-12-release-notes.adoc
+++ b/virt/release_notes/virt-4-12-release-notes.adoc
@@ -1,0 +1,11 @@
+:_content-type: ASSEMBLY
+[id="virt-4-12-release-notes"]
+= {VirtProductName} release notes
+include::_attributes/common-attributes.adoc[]
+:context: virt-4-12-release-notes
+toc::[]
+
+Do not add or edit release notes here. Edit release notes directly in the branch
+that they are relevant for.
+
+This file is here to allow builds to work.

--- a/virt/release_notes/virt-4-13-release-notes.adoc
+++ b/virt/release_notes/virt-4-13-release-notes.adoc
@@ -1,0 +1,11 @@
+:_content-type: ASSEMBLY
+[id="virt-4-13-release-notes"]
+= {VirtProductName} release notes
+include::_attributes/common-attributes.adoc[]
+:context: virt-4-13-release-notes
+toc::[]
+
+Do not add or edit release notes here. Edit release notes directly in the branch
+that they are relevant for.
+
+This file is here to allow builds to work.

--- a/virt/release_notes/virt-4-14-release-notes.adoc
+++ b/virt/release_notes/virt-4-14-release-notes.adoc
@@ -1,0 +1,11 @@
+:_content-type: ASSEMBLY
+[id="virt-4-14-release-notes"]
+= {VirtProductName} release notes
+include::_attributes/common-attributes.adoc[]
+:context: virt-4-14-release-notes
+toc::[]
+
+Do not add or edit release notes here. Edit release notes directly in the branch
+that they are relevant for.
+
+This file is here to allow builds to work.

--- a/virt/release_notes/virt-4-15-release-notes.adoc
+++ b/virt/release_notes/virt-4-15-release-notes.adoc
@@ -1,0 +1,11 @@
+:_content-type: ASSEMBLY
+[id="virt-4-15-release-notes"]
+= {VirtProductName} release notes
+include::_attributes/common-attributes.adoc[]
+:context: virt-4-15-release-notes
+toc::[]
+
+Do not add or edit release notes here. Edit release notes directly in the branch
+that they are relevant for.
+
+This file is here to allow builds to work.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): No CP
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-27696](https://issues.redhat.com//browse/CNV-27696)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: N/A
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: N/A
<!--- [ ] QE has approved this change. --->
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Added a dummy release notes file for 4.15 to the main branch for the build to work properly. Restored the dummy files for versions 4.11- 4.14 that were deleted in https://github.com/openshift/openshift-docs/pull/62086.  This is because if we happen to xref to the version-specific release notes file from a feature branch based off `main`, it will cause a build error if that file isn’t present in `main`.

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
