### PR TITLE
OSDOCS#4348: Adding release note for IBM Cloud restricted installs

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -72,6 +72,13 @@ You can now specify your own {ibm-name} Key Protect for {ibm-cloud-name} or {ibm
 
 For more information, see xref:../installing/installing_ibm_cloud_public/user-managed-encryption-ibm-cloud.adoc#user-managed-encryption-ibm-cloud[User-managed encryption for IBM Cloud].
 
+[id="ocp-4-15-installation-and-update-ibm-cloud-restricted-install"]
+==== Installing a cluster on IBM Cloud with limited internet access
+
+You can now install a cluster on {ibm-cloud-name} in an environment with limited internet access, such as a disconnected or restricted network cluster. With this type of installation, you create a registry that mirrors the contents of the {product-title} installation images. You can create this registry on a mirror host, which can access both the internet and your restricted network.
+
+// For more information see <insert links to restricted install assembly after docs merge>.
+
 [id="ocp-4-15-web-console"]
 === Web console
 
@@ -758,7 +765,7 @@ The Bare Metal Event Relay Operator is deprecated. The ability to monitor bare-m
 ==== Dedicated service monitors for core platform monitoring
 With this release, the dedicated service monitors feature for core platform monitoring is deprecated.
 The ability to enable dedicated service monitors by configuring the `dedicatedServiceMonitors` setting in the `cluster-monitoring-config` config map object in the `openshift-monitoring` namespace will be removed in a future {product-title} release.
-To replace this feature, Prometheus functionality has been improved in order to ensure that alerts and time aggregations are accurate. 
+To replace this feature, Prometheus functionality has been improved in order to ensure that alerts and time aggregations are accurate.
 This improved functionality is active by default and makes the dedicated service monitors feature obsolete.
 
 [id="ocp-4-15-removed-features"]


### PR DESCRIPTION
Version(s):
4.15

Issue:

This issue adds the release note for [osdocs-4348](https://issues.redhat.com/browse/OSDOCS-4348).

Link to docs preview:

[Installing a cluster on IBM Cloud with limited internet access](https://70636--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-installation-and-update-ibm-cloud-restricted-install)

QE review:
- [x] QE has approved this change.
