### PR TITLE
CNV#32030 - Default storage class - planning cluster

### DIFF
--- a/virt/install/preparing-cluster-for-virt.adoc
+++ b/virt/install/preparing-cluster-for-virt.adoc
@@ -96,14 +96,14 @@ See xref:../../architecture/architecture-rhcos.adoc#rhcos-about_architecture-rhc
 
 * Supported by {product-title}. See xref:../../scalability_and_performance/optimization/optimizing-storage.adoc#_optimizing-storage[Optimizing storage].
 
-* {rh-storage-first}: You must create a dedicated storage class for Windows virtual machine disks. See link:https://access.redhat.com/articles/6978371[Optimizing ODF PersistentVolumes for Windows VMs] for details.
-
+* You must create a default {VirtProductName} or {product-title} storage class. The purpose of this is to address the unique storage needs of VM workloads and offer optimized performance, reliability, and user experience. If both {VirtProductName} and {product-title} default storage classes exist, the {VirtProductName} class takes precedence when creating VM disks.
++
 [NOTE]
 ====
-You must specify a default storage class for the cluster. See xref:../../storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc#persistent-storage-csi-sc-manage[Managing the default storage class]. If the default storage class provisioner supports the `ReadWriteMany` (RWX) xref:../../storage/understanding-persistent-storage.adoc#pv-access-modes_understanding-persistent-storage[access mode], use the RWX mode for the associated persistent volumes for optimal performance.
-
-If the storage provisioner supports snapshots, there must be a xref:../../storage/container_storage_interface/persistent-storage-csi-snapshots.adoc#volume-snapshot-crds[`VolumeSnapshotClass`] object associated with the default storage class.
+To mark a storage class as the default for virtualization workloads, set the annotation `storageclass.kubevirt.io/is-default-virt-class` to `"true"`.
 ====
+
+* If the storage provisioner supports snapshots, you must associate a `VolumeSnapshotClass` object with the default storage class.
 
 include::modules/virt-about-storage-volumes-for-vm-disks.adoc[leveloffset=+3]
 


### PR DESCRIPTION
Version(s):
4.15

Issue:
https://issues.redhat.com/browse/CNV-32030

Link to docs preview:
https://70639--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/install/preparing-cluster-for-virt#storage-requirements_preparing-cluster-for-virt

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
