### PR TITLE
OSDOCS-9418: OSD GCP new permission need for service account osd-managed-admin - roles/iam.roleAdmin

### DIFF
--- a/modules/ccs-gcp-iam.adoc
+++ b/modules/ccs-gcp-iam.adoc
@@ -52,6 +52,10 @@ When applied to an individual *bucket*, control applies only to the specified bu
 |`roles/iam.serviceAccountUser`
 |Run operations as the service account.
 
+|Role Administrator
+|`roles/iam.roleAdmin`
+|Provides access to all custom roles in the project.
+
 |===
 
 [id="ccs-gcp-iam-group-roles_{context}"]


### PR DESCRIPTION
OSD GCP new permission need for service account osd-managed-admin - roles/iam.roleAdmin


Version(s): 4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-9418

Link to docs preview:
https://70654--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/gcp-ccs#ccs-gcp-iam-service-account-roles_gcp-ccs

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
