### PR TITLE
Adds MTU note for SDN to OVNK migration

### DIFF
--- a/modules/nw-ovn-kubernetes-migration.adoc
+++ b/modules/nw-ovn-kubernetes-migration.adoc
@@ -84,7 +84,15 @@ where:
 . Optional: You can customize the following settings for OVN-Kubernetes to meet your network infrastructure requirements:
 +
 --
-* Maximum transmission unit (MTU)
+* Maximum transmission unit (MTU). Consider the following before customizing the MTU for this optional step:
+** If you use the default MTU, and you want to keep the default MTU during migration, this step can be ignored. 
+** If you used a custom MTU, and you want to keep the custom MTU during migration, you must declare the custom MTU value in this step.
+** This step does not work if you want to change the MTU value during migration. Instead, you must first follow the instructions for "Changing the cluster MTU". You can then keep the custom MTU value by performing this procedure and declaring the custom MTU value in this step. 
++
+[NOTE]
+====
+OpenShift-SDN and OVN-Kubernetes have different overlay overhead. MTU values should be selected by following the guidelines found on the "MTU value selection" page.
+====
 * Geneve (Generic Network Virtualization Encapsulation) overlay network port
 * OVN-Kubernetes IPv4 internal subnet
 * OVN-Kubernetes IPv6 internal subnet

--- a/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
@@ -22,6 +22,8 @@ include::modules/nw-ovn-kubernetes-migration.adoc[leveloffset=+1]
 * xref:../../networking/cluster-network-operator.adoc#nw-operator-configuration-parameters-for-ovn-sdn_cluster-network-operator[Configuration parameters for the OVN-Kubernetes network plugin]
 * xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[Backing up etcd]
 * xref:../../networking/network_policy/about-network-policy.adoc#about-network-policy[About network policy]
+* xref:../../networking/changing-cluster-network-mtu.adoc#nw-cluster-mtu-change_changing-cluster-network-mtu[Changing the cluster MTU]
+* xref:../../networking/changing-cluster-network-mtu.adoc#mtu-value-selection_changing-cluster-network-mtu[MTU value selection]
 * OVN-Kubernetes capabilities
 - xref:../../networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc#configuring-egress-ips-ovn[Configuring an egress IP address]
 - xref:../../networking/ovn_kubernetes_network_provider/configuring-egress-firewall-ovn.adoc#configuring-egress-firewall-ovn[Configuring an egress firewall for a project]


### PR DESCRIPTION
Additional info for modifying MTU prior to migration. 

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-27427

Link to docs preview:
https://70655--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn#nw-ovn-kubernetes-migration_migrate-from-openshift-sdn

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
