### PR TITLE
OADP - 3343 Update Using the must-gather tool

### DIFF
--- a/modules/migration-combining-must-gather.adoc
+++ b/modules/migration-combining-must-gather.adoc
@@ -9,7 +9,7 @@ Currently, it is not possible to combine must-gather scripts, for example specif
 
 [source,terminal]
 ----
-$ oc adm must-gather --image=brew.registry.redhat.io/rh-osbs/oadp-oadp-mustgather-rhel8:1.1.1-8  -- skip_tls=true /usr/bin/gather_with_timeout <timeout_value_in_seconds>
+oc adm must-gather --image=registry.redhat.io/oadp/oadp-mustgather-rhel9:v1.3 -- skip_tls=true /usr/bin/gather_with_timeout <timeout_value_in_seconds>
 ----
 
 In this example, set the `skip_tls` variable before running the `gather_with_timeout` script. The result is a combination of `gather_with_timeout` and `gather_without_tls`.
@@ -18,3 +18,10 @@ The only other variables that you can specify this way are the following:
 
 * `logs_since`, with a default value of `72h`
 * `request_timeout`, with a default value of `0s`
+
+If `DataProtectionApplication` custom resource (CR) is configured with `s3Url` and `insecureSkipTLS: true`, the CR does not collect the necessary logs because of a missing CA certificate. To collect those logs, run the `must-gather` command with the following option:
+
+[source,terminal]
+----
+$ oc adm must-gather --image=registry.redhat.io/oadp/oadp-mustgather-rhel9:v1.3 -- /usr/bin/gather_without_tls true
+----

--- a/modules/migration-using-must-gather.adoc
+++ b/modules/migration-using-must-gather.adoc
@@ -28,6 +28,8 @@ endif::[]
 
 * You must be logged in to the {product-title} cluster as a user with the `cluster-admin` role.
 * You must have the OpenShift CLI (`oc`) installed.
+* You must use {op-system-base-full} 8.x with OADP 1.2.
+* You must use {op-system-base-full} {op-system-version} with OADP 1.3.
 
 .Procedure
 
@@ -40,10 +42,18 @@ endif::[]
 ifdef::oadp-troubleshooting[]
 * Full `must-gather` data collection, including Prometheus metrics:
 endif::[]
+.. For OADP 1.2, use the following command:
 +
-[source,terminal,subs="attributes+"]
+[source,terminal]
 ----
-$ oc adm must-gather --image={must-gather}
+oc adm must-gather --image=registry.redhat.io/oadp/oadp-mustgather-rhel8:v1.2
+----
++
+.. For OADP 1.3, use the following command:
++
+[source,terminal]
+----
+oc adm must-gather --image=registry.redhat.io/oadp/oadp-mustgather-rhel9:v1.3
 ----
 +
 The data is saved as `must-gather/must-gather.tar.gz`. You can upload this file to a support case on the link:https://access.redhat.com/[Red Hat Customer Portal].
@@ -73,12 +83,17 @@ endif::[]
 ifdef::oadp-troubleshooting[]
 * Prometheus metrics data dump:
 endif::[]
+.. For OADP 1.2, use the following command:
 +
-[source,terminal,subs="attributes+"]
+[source,terminal]
 ----
-$ oc adm must-gather --image={must-gather} \
-  -- /usr/bin/gather_metrics_dump
+oc adm must-gather --image=registry.redhat.io/oadp/oadp-mustgather-rhel8:v1.2 -- /usr/bin/gather_metrics_dump
 ----
+.. For OADP 1.3, use the following command:
 +
+[source,terminal]
+----
+oc adm must-gather --image=registry.redhat.io/oadp/oadp-mustgather-rhel9:v1.3 -- /usr/bin/gather_metrics_dump
+----
 This operation can take a long time. The data is saved as `must-gather/metrics/prom_data.tar.gz`.
 


### PR DESCRIPTION
OADP 1.3.1

OCP 4.13+

Resolves - https://issues.redhat.com/browse/OADP-3343

Deploy preview - https://70665--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting#migration-using-must-gather_oadp-troubleshooting
