### PR TITLE
OSDOCS-8481: Updated the TechPreviewNoUpgrade list

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -32,11 +32,21 @@ The following Technology Preview features are enabled by this feature set:
 ** Admin Network Policy and Baseline Admin Network Policy. Enables `AdminNetworkPolicy` and `BaselineAdminNetworkPolicy` resources, which are part of the Network Policy V2 API, in clusters running the OVN-Kubernetes CNI plugin. Cluster administrators can apply cluster-scoped policies and safeguards for an entire cluster before namespaces are created. Network administrators can secure clusters by enforcing network traffic controls that cannot be overridden by users. Network administrators can enforce optional baseline network traffic controls that can be overridden by users in the cluster, if necessary. Currently, these APIs support only expressing policies for intra-cluster traffic. (`AdminNetworkPolicy`)
 ** `MatchConditions` is a list of conditions that must be met for a request to be sent to this webhook. Match conditions filter requests that have already been matched by the rules, namespaceSelector, and objectSelector. An empty list of `matchConditions` matches all requests. (`admissionWebhookMatchConditions`)
 ** Gateway API. To enable the {product-title} Gateway API, set the value of the `enabled` field to `true` in the `techPreview.gatewayAPI` specification of the `ServiceMeshControlPlane` resource.(`gateGatewayAPI`)
-** `sigstoreImageVerification`
 ** `gcpLabelsTags`
 ** `vSphereStaticIPs`
 ** `routeExternalCertificate`
 ** `automatedEtcdBackup`
+** `gcpClusterHostedDNS`
+** `vSphereControlPlaneMachineset`
+** `dnsNameResolver`
+** `machineConfigNodes`
+** `metricsServer`
+** `installAlternateInfrastructureAWS`
+** `sdnLiveMigration`
+** `mixedCPUsAllocation`
+** `managedBootImages`
+** `onClusterBuild`
+** `signatureStores`
 --
 
 ////


### PR DESCRIPTION
Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-8481

Link to docs preview (VPN required):
[Understanding feature gates](https://file.rdu.redhat.com/antaylor/OSDOCS-8481/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-about_nodes-cluster-enabling)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This list is based on [release-4.15/config/v1/types_feature.go#L165](https://github.com/openshift/api/blob/release-4.15/config/v1/types_feature.go#L165). 
