### PR TITLE
OSDOCS-9402: Documented the 4.14.10 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3175,6 +3175,27 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+[id="ocp-4-14-10"]
+=== RHSA-2024:0290 - {product-title} 4.14.10 bug fix and security update
+
+Issued: 2024-01-23
+
+{product-title} release 4.14.10, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:0290[RHSA-2024:0290] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0293[RHSA-2024:0293] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.10 --pullspecs
+----
+
+[id="ocp-4-14-10-bug-fixes"]
+==== Bug fixes
+
+* Previously, when the Cloud Credential Operator (CCO) was in default mode, CCO used an incorrect client for root credential queries. The CCO failed to find the intended secret and wrongly reported a `credsremoved` mode in the `cco_credentials_mode` metric. With this release, the CCO now uses the correct client so to ensure accurate reporting of the `cco_credentials_mode` metric. (link:https://issues.redhat.com/browse/OCPBUGS-26512[*OCPBUGS-26512*])
+
 [id="ocp-4-14-9"]
 === RHSA-2024:0204 - {product-title} 4.14.9 bug fix and security update
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
* [OSDOCS-9402](https://issues.redhat.com/browse/OSDOCS-9402)

Link to docs preview:
* [4.14.10 z-stream release notes](https://70670--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-10)

QE review:
- [x] QE is not required. See the peer-review checklist.

