### PR TITLE
OBSDOCS-748: release notes for Cluster Observability Operator 0.1.1

### DIFF
--- a/monitoring/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
+++ b/monitoring/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
@@ -16,8 +16,11 @@ The {coo-short} complements the built-in monitoring capabilities of {product-tit
 
 These release notes track the development of the {coo-full} in {product-title}.
 
+[id="cluster-observability-operator-release-notes-0-1-1"]
+== {coo-full} 0.1.1
+This release updates the {coo-full} to support installing the Operator in restricted networks or disconnected environments.
+
 [id="cluster-observability-operator-release-notes-0-1"]
 == {coo-full} 0.1
 
 This release makes a Technology Preview version of the {coo-full} available on OperatorHub.
-


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

**This PR is for the Cluster Observability Operator 0.1.1 release that is scheduled for January 25, 2024. Do not merge until this date.**

Version(s): 4.11+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-748
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://70674--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/cluster_observability_operator/cluster-observability-operator-release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR updates the COO release notes with information describing the changes in the 0.1.1 release.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
