### PR TITLE
OSDOCS#9003: Agent BMC configuration parameters

### DIFF
--- a/installing/installing_with_agent_based_installer/installation-config-parameters-agent.adoc
+++ b/installing/installing_with_agent_based_installer/installation-config-parameters-agent.adoc
@@ -11,6 +11,10 @@ When you create the `install-config.yaml` and `agent-config.yaml` files, you mus
 
 include::modules/installation-configuration-parameters.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#bmc-addressing_ipi-install-installation-workflow[BMC addressing]
+
 include::modules/agent-configuration-parameters.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1882,6 +1882,139 @@ with an Azure cluster.
 ====
 endif::azure[]
 
+ifdef::agent[]
+[id="installation-configuration-parameters-additional-bare_{context}"]
+== Additional bare metal configuration parameters for the Agent-based Installer
+
+Additional bare metal installation configuration parameters for the Agent-based Installer are described in the following table:
+
+[NOTE]
+====
+These fields are not used during the initial provisioning of the cluster, but they are available to use once the cluster has been installed.
+Configuring these fields at install time eliminates the need to set them as a Day 2 operation.
+====
+
+.Additional bare metal parameters
+[cols=".^2l,.^3a,.^3a",options="header"]
+|====
+|Parameter|Description|Values
+
+|platform:
+  baremetal:
+    clusterProvisioningIP:
+|The IP address within the cluster where the provisioning services run.
+Defaults to the third IP address of the provisioning subnet.
+For example, `172.22.0.3` or `2620:52:0:1307::3`.
+|IPv4 or IPv6 address.
+
+|platform:
+  baremetal:
+    provisioningNetwork:
+|The `provisioningNetwork` configuration setting determines whether the cluster uses the provisioning network.
+If it does, the configuration setting also determines if the cluster manages the network.
+
+`Managed`: Default. Set this parameter to `Managed` to fully manage the provisioning network, including DHCP, TFTP, and so on.
+
+`Disabled`: Set this parameter to `Disabled` to disable the requirement for a provisioning network.
+When set to `Disabled`, you can use only virtual media based provisioning on Day 2.
+If `Disabled` and using power management, BMCs must be accessible from the bare-metal network.
+If Disabled, you must provide two IP addresses on the bare-metal network that are used for the provisioning services.
+
+|`Managed` or `Disabled`.
+
+|platform:
+  baremetal:
+    provisioningMACAddress:
+|The MAC address within the cluster where provisioning services run.
+|MAC address.
+
+|platform:
+  baremetal:
+    provisioningNetworkCIDR:
+|The CIDR for the network to use for provisioning.
+This option is required when not using the default address range on the provisioning network.
+|Valid CIDR, for example `10.0.0.0/16`.
+
+|platform:
+  baremetal:
+    provisioningNetworkInterface:
+|The name of the network interface on nodes connected to the provisioning network.
+Use the `bootMACAddress` configuration setting to enable Ironic to identify the IP address of the NIC instead of using the `provisioningNetworkInterface` configuration setting to identify the name of the NIC.
+|String.
+
+|platform:
+  baremetal:
+    provisioningDHCPRange:
+|Defines the IP range for nodes on the provisioning network, for example `172.22.0.10,172.22.0.254`.
+|IP address range.
+
+|platform:
+  baremetal:
+    hosts:
+|Configuration for bare metal hosts.
+|Array of host configuration objects.
+
+|platform:
+  baremetal:
+    hosts:
+      name:
+|The name of the host.
+|String.
+
+|platform:
+  baremetal:
+    hosts:
+      bootMACAddress:
+|The MAC address of the NIC used for provisioning the host.
+|MAC address.
+
+|platform:
+  baremetal:
+    hosts:
+      bmc:
+|Configuration for the host to connect to the baseboard management controller (BMC).
+|Dictionary of BMC configuration objects.
+
+|platform:
+  baremetal:
+    hosts:
+      bmc:
+        username:
+|The username for the BMC.
+|String.
+
+|platform:
+  baremetal:
+    hosts:
+      bmc:
+        password:
+|Password for the BMC.
+|String.
+
+|platform:
+  baremetal:
+    hosts:
+      bmc:
+        address:
+|The URL for communicating with the host's BMC controller.
+The address configuration setting specifies the protocol.
+For example, `redfish+http://10.10.10.1:8000/redfish/v1/Systems/1234` enables Redfish.
+For more information, see "BMC addressing" in the "Deploying installer-provisioned clusters on bare metal" section.
+|URL.
+
+|platform:
+  baremetal:
+    hosts:
+      bmc:
+        disableCertificateVerification:
+|`redfish` and `redfish-virtualmedia` need this parameter to manage BMC addresses.
+The value should be `True` when using a self-signed certificate for BMC addresses.
+|Boolean.
+
+|====
+endif::agent[]
+
+
 ifdef::gcp[]
 [id="installation-configuration-parameters-additional-gcp_{context}"]
 == Additional Google Cloud Platform (GCP) configuration parameters


### PR DESCRIPTION
[OSDOCS-9003](https://issues.redhat.com/browse/OSDOCS-9003)

Versions: 4.15+

This PR adds BMC and provisioning config parameters to the Agent docs.

QE review:
- [x] QE has approved this change.

Preview: [Additional bare metal configuration parameters for the Agent-based Installer](https://70677--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installation-config-parameters-agent#installation-configuration-parameters-additional-bare_installation-config-parameters-agent)