### PR TITLE
OCPBUGS-18605: Replacing host name with generic host name

### DIFF
--- a/modules/cnf-topology-aware-lifecycle-manager-backup-feature.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-backup-feature.adoc
@@ -31,7 +31,7 @@ The following is an example `SiteConfig` custom resource (CR) for a recovery par
 [source,yaml]
 ----
 nodes:
-    - hostName: "snonode.sno-worker-0.e2e.bos.redhat.com"
+    - hostName: "node-1.example.com"
     role: "master"
     rootDeviceHints:
         hctl: "0:2:0:0"


### PR DESCRIPTION
OCPBUGS-18605: Typo: replacing RH specific host name with generic host name.

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-18605

Link to docs preview:
https://70678--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/cnf-talm-for-cluster-upgrades.html#talo-backup-start_and_update_cnf-topology-aware-lifecycle-manager

Additional information:
QE not required because it's just replacing a RH specific example host name with a generic host name per docs guidelines.

NOTE: Checks are succeeding in Prow, they are just not reporting on PRs due to a temporary issue. The checks for this PR have succeeded despite what it says below:
- https://prow.ci.openshift.org/log?job=pull-ci-openshift-openshift-docs-main-deploy-preview&id=1749816652842668032 
- https://prow.ci.openshift.org/log?job=pull-ci-openshift-openshift-docs-main-validate-asciidoc&id=1749816652876222464