### PR TITLE
[OSDOCS-5880] Example `aws sts get-caller-identity` output is outdated

### DIFF
--- a/modules/rosa-configuring-aws-account.adoc
+++ b/modules/rosa-configuring-aws-account.adoc
@@ -58,20 +58,13 @@ The ROSA service evaluates regions in the following priority order:
 +
 [source,terminal]
 ----
-$ aws sts get-caller-identity
+$ aws sts get-caller-identity --output text
 ----
 +
 .Example output
 [source,terminal]
 ----
----------------------------------------------------------------------------------
-|                                GetCallerIdentity                              |
-+-------------------------------------------------------------------------------+
-|+-----------------------------------+-----------------------+-----------------+|
-||      Account        |                Arn              |       UserID        ||
-|+-----------------------------------+-----------------------+-----------------+|
-||  <account_name>     |  arn:aws:iam<string>:user:name  |      <userID>       ||
-|+-----------------------------------+-----------------------+-----------------+|
+<aws_account_id>    arn:aws:iam::<aws_account_id>:user/<username>  <aws_user_id>
 ----
 +
 After completing these steps, install ROSA.

--- a/modules/rosa-getting-started-install-configure-cli-tools.adoc
+++ b/modules/rosa-getting-started-install-configure-cli-tools.adoc
@@ -50,7 +50,7 @@ You can alternatively use the `AWS_DEFAULT_REGION` environment variable to set t
 +
 [source,terminal]
 ----
-$ aws sts get-caller-identity
+$ aws sts get-caller-identity  --output text
 ----
 +
 .Example output


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-5880
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://70679--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-config-aws-account
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
REVIEWERS: I found another example of this command in the current docs here: 
https://docs.openshift.com/rosa/rosa_getting_started/rosa-quickstart-guide-ui.html 
![image](https://github.com/openshift/openshift-docs/assets/122639474/a655894a-73c9-425f-98a4-e8e18a069db0)
and used that example to correct the reported bug. 





![image](https://github.com/openshift/openshift-docs/assets/122639474/3fba7fc9-3cf7-41d1-b5a8-1ab6dcf8050c)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
