### PR TITLE
OSDOCS#8474: Bump version in  link to ARM template for network and lo…

### DIFF
--- a/modules/installation-arm-dns.adoc
+++ b/modules/installation-arm-dns.adoc
@@ -21,10 +21,10 @@ cluster:
 [source,json]
 ----
 ifndef::ash[]
-include::https://raw.githubusercontent.com/openshift/installer/release-4.14/upi/azure/03_infra.json[]
+include::https://raw.githubusercontent.com/openshift/installer/release-4.15/upi/azure/03_infra.json[]
 endif::ash[]
 ifdef::ash[]
-include::https://raw.githubusercontent.com/openshift/installer/release-4.14/upi/azurestack/03_infra.json[]
+include::https://raw.githubusercontent.com/openshift/installer/release-4.15/upi/azurestack/03_infra.json[]
 endif::ash[]
 ----
 ====


### PR DESCRIPTION
Version(s):
4.15

Issue:
This PR addresses [osdocs-8474](https://issues.redhat.com/browse/OSDOCS-8474)

Link to docs preview:

QE review:
- [ ] QE has approved this change.

Additional information:
While this work typically updates all of the links to the UPI JSON templates for AWS Azure, Azure Stack Hub, and GCP, these updates were already captured by https://github.com/openshift/openshift-docs/pull/70177. The latter PR simply missed one of the files.
