### PR TITLE
Update module name in troubleshoot-jira-integration.adoc

### DIFF
--- a/modules/troubleshoot-jira-integration.adoc
+++ b/modules/troubleshoot-jira-integration.adoc
@@ -16,7 +16,7 @@ If you do not know the custom priority values in your JIRA project, use the `rox
 +
 [source,terminal]
 ----
-$ roxctl -e "$ROX_CENTRAL_ADDRESS" central debug log --level Debug --modules notifiers/jira
+$ roxctl -e "$ROX_CENTRAL_ADDRESS" central debug log --level Debug --modules pkg/notifiers/jira
 ----
 . Follow the instructions to configure {product-title} for Jira integration. When you test the integration, even if the integration test fails, the generated log includes your JIRA project schema and the custom priorities.
 . To save the debugging information as a compressed `.zip` file, run the following command:


### PR DESCRIPTION
RHACS: 4.2- as this was changed in 4.3 

Before 4.3 jira notifiers were in `pkg/jira/notifiers`

See:
- https://github.com/stackrox/stackrox/pull/8199
- https://github.com/stackrox/stackrox/issues/9447