### PR TITLE
Fix envVars for SecuredCluster proxy variables

### DIFF
--- a/modules/specifying-the-environment-variables-in-the-securedcluster-cr.adoc
+++ b/modules/specifying-the-environment-variables-in-the-securedcluster-cr.adoc
@@ -22,9 +22,12 @@ For example:
 # proxy collector
 customize:
   envVars:
-    HTTP_PROXY: http://egress-proxy.stackrox.svc:xxxx <1>
-    HTTPS_PROXY: http://egress-proxy.stackrox.svc:xxxx <2>
-    NO_PROXY: .stackrox.svc <3>
+    - name: HTTP_PROXY
+      value: http://egress-proxy.stackrox.svc:xxxx <1>
+    - name: HTTPS_PROXY
+      value: http://egress-proxy.stackrox.svc:xxxx <2>
+    - name: NO_PROXY
+      value: .stackrox.svc <3>
 ----
 <1> The variable `HTTP_PROXY` is set to the value `\http://egress-proxy.stackrox.svc:xxxx`. This is the proxy server used for HTTP connections.
 <2> The variable `HTTPS_PROXY` is set to the value `\http://egress-proxy.stackrox.svc:xxxx`. This is the proxy server used for HTTPS connections.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

In the modified docs module the proxy env variables `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` are set in form of a name, value map. The CR requires them to be set as a list of items with name and value fields like proposed in this PR.

Actual type definition in the project: https://github.com/stackrox/stackrox/blob/8c4a06a5a64da357c5bb7e65c52a47a9283e6e3c/operator/apis/platform/v1alpha1/common_types.go#L30

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): Looks like it has been in the docs >= 4.0
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 

Cherrypick:
- `rhacs-docs-4.1`
- `rhacs-docs-4.2`
- `rhacs-docs-4.3`
- `rhacs-docs-4.4`

