### PR TITLE
OSDOCS#9096: stable channel wording clarification

### DIFF
--- a/modules/understanding-update-channels.adoc
+++ b/modules/understanding-update-channels.adoc
@@ -14,11 +14,12 @@ The `fast-{product-version}` channel is updated with new versions of {product-ti
 
 [id="stable-version-channel_{context}"]
 == stable-{product-version} channel
-While the `fast-{product-version}` channel contains releases as soon as their errata are published, releases are added to the `stable-{product-version}` channel after a delay. During this delay, data is collected from multiple sources and analyzed for indications of product regressions. Once a significant number of data points have been collected, and absent negative signals, these releases are added to the stable channel.
+While the `fast-{product-version}` channel contains releases as soon as their errata are published, releases are added to the `stable-{product-version}` channel after a delay. During this delay, data is collected from multiple sources and analyzed for indications of product regressions. Once a significant number of data points have been collected, these releases are added to the stable channel.
 
 [NOTE]
+====
 Since the time required to obtain a significant number of data points varies based on many factors, Service LeveL Objective (SLO) is not offered for the delay duration between fast and stable channels. For more information, please see "Choosing the correct channel for your cluster"
-
+====
 
 Newly installed clusters default to using stable channels.
 

--- a/modules/update-availability-faq.adoc
+++ b/modules/update-availability-faq.adoc
@@ -32,6 +32,8 @@ The primary purpose of the `eus` channel is to serve as a convenience for cluste
 
 * The only difference between releases on the `fast` and `stable` channels is that a release only appears on the `stable` channel after it has been on the `fast` channel for some time, which provides more time for new update risks to be discovered.
 
+* A release that is available on the `fast` channel always becomes available on the `stable` channel after this delay.
+
 [id="supported-updates_{context}"]
 *What does it mean if an update is supported but not recommended?*
 
@@ -59,7 +61,7 @@ There may be a delay while the defect is corrected, tested, and promoted to your
 +
 [IMPORTANT]
 ====
-These are only estimates based on past data about z-stream releases. Red Hat reserves the right to change the release frequency as needed. Any number of issues could cause irregularities and delays in this release cadence.
+These are only estimates based on past data about z-stream releases. Red{nbsp}Hat reserves the right to change the release frequency as needed. Any number of issues could cause irregularities and delays in this release cadence.
 ====
 
 * Once a z-stream release is published, it also appears in the `fast` channel for that minor version. After a delay, the z-stream release may then appear in that minor version's `stable` channel.


### PR DESCRIPTION
[OSDOCS-9096](https://issues.redhat.com/browse/OSDOCS-9096)

Versions: 4.11+

This PR clarifies update channel phrasing to state that releases on the fast channel will always make it to the stable channel.

QE review:
- [x] QE has approved this change.

Preview:

- [Common questions about update availability](https://70687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/understanding_updates/intro-to-updates#update-availability_understanding-openshift-updates)
- [stable-4.x channel](https://70687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/understanding_updates/understanding-update-channels-release#stable-version-channel_understanding-update-channels-releases)