### PR TITLE
OSSM-5818 Update Automatic Routes content (2.5 Release)

### DIFF
--- a/service_mesh/v2x/ossm-traffic-manage.adoc
+++ b/service_mesh/v2x/ossm-traffic-manage.adoc
@@ -23,6 +23,11 @@ include::modules/ossm-routing-gateways.adoc[leveloffset=+2]
 
 OpenShift routes for gateways are automatically managed in {SMProductShortName}. Every time an Istio Gateway is created, updated or deleted inside the service mesh, an OpenShift route is created, updated or deleted.
 
+[NOTE]
+====
+Starting with {SMProductShortName} 2.5, automatic routes are disabled by default for new instances of the `ServiceMeshControlPlane` resource.
+====
+
 [id="ossm-auto-route-subdomains_{context}"]
 === Routes with subdomains
 


### PR DESCRIPTION
[OSSM-5818](https://issues.redhat.com//browse/OSSM-5818) Update Automatic Routes content

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSSM-5818

Link to docs preview:
https://70688--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-traffic-manage#ossm-auto-route_traffic-management

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

To be released with OSSM 2.5.

Adds a Note stipulating/clarifying that starting with OSSM 2.5, automatic routes are disabled by default for new control planes.

Dev/QE review: Done.
Doc Peer Review: Done.
Merge Review: 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
