### PR TITLE
OSDOCS-9262: adds 4.14.10 release note MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -412,3 +412,12 @@ Issued: 2024-01-17
 {product-title} release 4.14.9, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0206[RHBA-2024:0206] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0204[RHSA-2024:0204] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-14-10-dp"]
+=== RHSA-2024:0292 - {microshift-short} 4.14.10 bug fix update and security advisory
+
+Issued: 2024-01-24
+
+{product-title} release 4.14.10, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:0292[RHSA-2024:0292] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0290[RHSA-2024:0290] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-9262](https://issues.redhat.com/browse/OSDOCS-9262)

Link to docs preview:
[MicroShift 4.14.10 Release Note](https://70697--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes#microshift-4-14-10-dp)

QE review:
- N/A Routine async advisory, no bug release notes

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
