### PR TITLE
OCPBUGS#18942: Update etcd restore procedure for Keepalived

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -127,9 +127,50 @@ If the output of this command is not empty, wait a few minutes and check again.
 $ sudo mv /var/lib/etcd/ /tmp
 ----
 
+.. If the `/etc/kubernetes/manifests/keepalived.yaml` file exists, follow these steps:
+
+... Move the `/etc/kubernetes/manifests/keepalived.yaml` file out of the kubelet manifest directory:
++
+[source,terminal]
+----
+$ sudo mv /etc/kubernetes/manifests/keepalived.yaml /tmp
+----
+
+... Verify that any containers managed by the `keepalived` daemon are stopped:
++
+[source,terminal]
+----
+$ sudo crictl ps --name keepalived
+----
++
+The output of this command should be empty. If it is not empty, wait a few minutes and check again.
+
+... Check if the control plane has any Virtual IPs (VIPs) assigned to it:
++
+[source,terminal]
+----
+$ ip -o address | egrep '<api_vip>|<ingress_vip>'
+----
+
+... For each reported VIP, run the following command to remove it:
++
+[source,terminal]
+----
+$ sudo ip address del <reported_vip> dev <reported_vip_device>
+----
+
 .. Repeat this step on each of the other control plane hosts that is not the recovery host.
 
 . Access the recovery control plane host.
+
+. If the `keepalived` daemon is in use, verify that the recovery control plane node owns the VIP:
++
+[source,terminal]
+----
+$ ip -o address | grep <api_vip>
+----
++
+The address of the VIP is highlighted in the output if it exists. This command returns an empty string if the VIP is not set or configured incorrectly.
 
 . If the cluster-wide proxy is enabled, be sure that you have exported the `NO_PROXY`, `HTTP_PROXY`, and `HTTPS_PROXY` environment variables.
 +


### PR DESCRIPTION
Version(s):
4.11+

Issue:
[OCPBUGS-18942](https://issues.redhat.com/browse/OCPBUGS-18942)

Link to docs preview:
[Restoring to a previous cluster state](https://70698--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state#dr-scenario-2-restoring-cluster-state_dr-restoring-cluster-state)

QE review:
- [x] QE has approved this change.

Additional information:

N/A
