### PR TITLE
OSDOCS#2314: OSUS Operator update info

### DIFF
--- a/updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update-osus.adoc
+++ b/updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update-osus.adoc
@@ -135,6 +135,13 @@ The release image signature config map allows the Cluster Version Operator (CVO)
 ====
 * The current release and update target release images are mirrored to a locally accessible registry.
 * A recent graph data container image has been mirrored to your local registry.
+* A recent version of the OpenShift Update Service Operator is installed.
++
+[NOTE]
+====
+If you have not recently installed or updated the OpenShift Update Service Operator, there might be a more recent version available.
+See xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks] for more information about how to update your OLM catalog in a disconnected environment.
+====
 
 After you configure your cluster to use the locally-installed OpenShift Update Service and local mirror registry, you can use any of the following update methods:
 


### PR DESCRIPTION
[OSDOCS-2314](https://issues.redhat.com/browse/OSDOCS-2314)

Versions: 4.11+ (Note to merge reviewer: CPs to 4.11-4.13 will likely fail)

This PR provides a link in the disconnected update docs to where users could learn to update OLM Operators in disconnected environments, in case they need to update the OSUS Operator.

QE review:
- [x] QE has approved this change.

Preview: [Next steps](https://70701--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update-osus#next-steps_updating-restricted-network-cluster-osus)