### PR TITLE
Added guideline for IBM-related attributes

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -195,6 +195,11 @@ ifdef::openshift-origin[]
 endif::[]
 ----
 
+[NOTE]
+====
+When backporting content that contains IBM-related attributes to `enterprise-4.13` and earlier branches, you might need to create manual cherry picks because IBM-related attributes names are not consistent with later release branches.
+====
+
 == Assembly/module file names
 
 Try to shorten the file name as much as possible _without_ abbreviating important terms that may cause confusion. For example, the `managing-authorization-policies.adoc` file name would be appropriate for an assembly titled "Managing Authorization Policies".


### PR DESCRIPTION
As per the conversation [here](https://redhat-internal.slack.com/archives/C85JYPHL3/p1705491039469869), adding a note to create manual CP to 4.13 for any content that might be using IBM-related attributes.

cc: @kalexand-rh @bergerhoffer @SNiemann15 