### PR TITLE
OSDOCS-8955

### DIFF
--- a/modules/rosa-create-an-identity-based-policy.adoc
+++ b/modules/rosa-create-an-identity-based-policy.adoc
@@ -18,7 +18,19 @@ You can create an identity-based Identity and Access Management (IAM) policy tha
 . In the IAM console, select *Policies* from the left navigation menu.
 . Click *Create policy*.
 . Select the *JSON* tab to define the policy using JSON format.
-. Copy and paste the following JSON policy document into the editor:
+. To get the IP addresses that you need to enter into the JSON policy document, run the following command:
++
+[source,terminal]
+----
+$ ocm get /api/clusters_mgmt/v1/trusted_ip_addresses
+----
++
+[NOTE]
+====
+These IP addresses are not permanent and are subject to change. You must continuously review the API output and make the necessary updates in the JSON policy document.
+====
++
+. Copy and paste the following `policy_document.json` file into the editor:
 +
 [source,json]
 ----
@@ -31,114 +43,7 @@ You can create an identity-based Identity and Access Management (IAM) policy tha
             "Resource": "*",
             "Condition": {
                 "NotIpAddress": {
-                    "aws:SourceIp": [
-                        "3.223.162.20/32",
-                        "3.233.177.185/32",
-                        "54.209.120.28/32",
-                        "23.21.192.204/32",
-                        "23.23.16.23/32",
-                        "3.217.67.187/32",
-                        "34.206.248.211/32",
-                        "34.237.192.147/32",
-                        "52.1.97.230/32",
-                        "18.214.192.218/32",
-                        "3.218.132.183/32",
-                        "52.202.67.83/32",
-                        "18.220.162.161/32",
-                        "18.224.36.208/32",
-                        "3.143.200.173/32",
-                        "54.197.245.192/32",
-                        "3.23.162.248/32",
-                        "44.217.70.145/32",
-                        "52.202.89.184/32",
-                        "54.174.41.137/32",
-                        "3.231.181.77/32",
-                        "44.193.253.218/32",
-                        "52.201.38.139/32",
-                        "34.205.217.112/32",
-                        "23.22.217.39/32",
-                        "44.193.121.36/32",
-                        "54.211.144.4/32",
-                        "34.194.251.19/32",
-                        "44.196.79.250/32",
-                        "52.45.208.183/32",
-                        "100.20.120.76/32",
-                        "100.20.197.29/32",
-                        "52.26.177.23/32",
-                        "34.197.214.203/32",
-                        "35.170.167.51/32",
-                        "52.23.44.43/32",
-                        "44.228.245.162/32",
-                        "44.238.205.35/32",
-                        "54.203.216.175/32",
-                        "34.237.49.153/32",
-                        "44.196.177.146/32",
-                        "52.23.117.40/32",
-                        "44.225.234.235/32",
-                        "44.241.225.78/32",
-                        "44.241.55.3/32",
-                        "34.237.180.56/32",
-                        "44.205.240.205/32",
-                        "52.54.93.238/32",
-                        "35.155.66.53/32",
-                        "44.231.249.237/32",
-                        "44.233.161.100/32",
-                        "3.229.185.234/32",
-                        "54.147.98.63/32",
-                        "54.163.100.197/32",
-                        "23.20.194.86/32",
-                        "23.22.242.238/32",
-                        "54.147.218.140/32",
-                        "52.21.229.141/32",
-                        "54.227.5.10/32",
-                        "54.146.138.135/32",
-                        "23.21.239.1/32",
-                        "52.20.145.130/32",
-                        "54.157.89.24/32",
-                        "107.22.162.110/32",
-                        "3.223.147.2/32",
-                        "54.88.225.66/32",
-                        "54.177.143.128/32",
-                        "54.219.250.189/32",
-                        "18.135.14.84/32",
-                        "18.135.218.119/32",
-                        "3.11.51.55/32",
-                        "3.233.86.181/32",
-                        "34.226.229.129/32",
-                        "44.194.44.138/32",
-                        "34.216.5.118/32",
-                        "52.11.52.9/32",
-                        "52.40.203.77/32",
-                        "18.217.173.123/32",
-                        "3.13.34.119/32",
-                        "3.19.160.232/32",
-                        "18.188.187.143/32",
-                        "18.216.245.132/32",
-                        "52.14.85.89/32",
-                        "52.21.184.148/32",
-                        "44.194.57.131/32",
-                        "18.188.65.148/32",
-                        "3.130.101.176/32",
-                        "3.130.198.233/32",
-                        "54.210.128.71/32",
-                        "54.227.100.14/32",
-                        "54.92.188.93/32",
-                        "107.22.5.187/32",
-                        "3.217.212.27/32",
-                        "52.22.56.3/32",
-                        "52.5.10.152/32",
-                        "54.237.41.201/32",
-                        "34.202.145.72/32",
-                        "52.205.239.95/32",
-                        "54.236.208.68/32",
-                        "3.234.64.191/32",
-                        "34.195.159.252/32",
-                        "34.228.34.122/32",
-                        "54.205.89.242/32",
-                        "209.132.0.0/16",
-                        "66.187.0.0/16",
-                        "2620:0052:0004:0000:0000:0000:0000:0000/48"
-                    ]
+                    "aws:SourceIp": []
                 },
                 "Bool": {
                     "aws:ViaAWSService": "false"
@@ -149,11 +54,7 @@ You can create an identity-based Identity and Access Management (IAM) policy tha
 }
 ----
 +
-[NOTE]
-====
-This list is subject to change. Additionally, you must specify the IP addresses in CIDR notation.
-====
-+
+. Copy and paste all of the IP addresses, which you got in Step 6, into the `"aws:SourceIp": []` array in your `policy_document.json` file.
 . Click *Review and create*.
 . Provide a name and description for the policy, and review the details for accuracy.
 . Click *Create policy* to save the policy.


### PR DESCRIPTION
[OSDOCS-8955](https://issues.redhat.com/browse/OSDOCS-8955): Update the docs "Adding additional constraints for IP-based AWS role assumption"

Aligned team: Service Delivery
OCP version for cherry-picking: enterprise-4.14+
JIRA issues: [OSDOCS-8955](https://issues.redhat.com/browse/OSDOCS-8955)
Preview pages: [ROSA build preview](https://70714--ocpdocs-pr.netlify.app/openshift-rosa/latest/security/rosa-adding-additional-constraints-for-ip-based-aws-role-assumption#rosa-create-an-identity-based-policy_rosa-adding-additional-constraints-for-ip-based-aws-role-assumption)
SME review **completed**: @wanghaoran1988 
QE review **completed**:  @yuwang-RH
Peer review **completed**:  @nalhadef 