### PR TITLE
OCPBUGS#27838: Doc improvements in "Uninstalling LVM Storage" procs

### DIFF
--- a/modules/lvms-uninstalling-logical-volume-manager-operator-using-openshift-web-console.adoc
+++ b/modules/lvms-uninstalling-logical-volume-manager-operator-using-openshift-web-console.adoc
@@ -10,17 +10,17 @@ You can uninstall {lvms} using the {product-title} web console.
 
 .Prerequisites
 
-* You deleted all the applications on the clusters that are using the storage provisioned by {lvms}.
-* You deleted the persistent volume claims (PVCs) and persistent volumes (PVs) provisioned using {lvms}.
-* You deleted all volume snapshots provisioned by {lvms}.
-* You verified that no logical volume resources exist by using the `oc get logicalvolume` command.
-* You have access to the cluster using an account with `cluster-admin` permissions.
+* You have access to {product-title} as a user with `cluster-admin` permissions.
+* You have deleted the persistent volume claims (PVCs), volume snapshots, and volume clones provisioned by {lvms}. You have also deleted the applications that are using these resources.
+* You have deleted the `LVMCluster` custom resource (CR).
+
 
 .Procedure
 
-. From the *Operators* → *Installed Operators* page, scroll to *LVM Storage* or type `LVM Storage` into the *Filter by name* to find and click on it.
-. Click on the *LVMCluster* tab.
-. On the right-hand side of the *LVMCluster* page, select *Delete LVMCluster* from the *Actions* drop-down menu.
-. Click on the *Details* tab.
-. On the right-hand side of the *Operator Details* page, select *Uninstall Operator* from the *Actions* drop-down menu.
-. Select *Remove*. {lvms} stops running and is completely removed.
+. Log in to the {product-title} web console.
+. Click *Operators* → *Installed Operators*.
+. Click *LVM Storage* in the `openshift-storage` namespace.
+. Click the *Details* tab. 
+. From the *Actions* menu, select *Uninstall Operator*.
+. Optional: When prompted, select the *Delete all operand instances for this operator* checkbox to delete the operand instances for {lvms}. 
+. Click *Uninstall*.

--- a/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
+++ b/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
@@ -22,8 +22,6 @@ include::modules/lvms-installing-logical-volume-manager-operator-using-cli.adoc[
 
 include::modules/lvms-installing-logical-volume-manager-operator-using-openshift-web-console.adoc[leveloffset=+2]
 
-include::modules/lvms-uninstalling-logical-volume-manager-operator-using-openshift-web-console.adoc[leveloffset=+2]
-
 include::modules/lvms-installing-logical-volume-manager-operator-disconnected-environment.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -52,7 +50,7 @@ include::modules/lvms-installing-logical-volume-manager-operator-using-rhacm.ado
 * xref:../../../storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc#about-lvmcluster_logical-volume-manager-storage[About the `LVMCluster` custom resource]
 
 
-include::modules/lvms-uninstalling-logical-volume-manager-operator-using-rhacm.adoc[leveloffset=+2]
+// Creating an LVMCluster custom resource
 
 include::modules/lvms-about-lvmcluster-cr.adoc[leveloffset=+1]
 
@@ -147,6 +145,11 @@ include::modules/lvms-updating-lvms.adoc[leveloffset=+1]
 
 //Monitoring
 include::modules/lvms-monitoring-logical-volume-manager-operator.adoc[leveloffset=+1]
+
+// Uninstalling LVM Storage
+
+include::modules/lvms-uninstalling-logical-volume-manager-operator-using-openshift-web-console.adoc[leveloffset=+1]
+include::modules/lvms-uninstalling-logical-volume-manager-operator-using-rhacm.adoc[leveloffset=+1]
 
 //Must-gather
 include::modules/lvms-download-log-files-and-diagnostics.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.15+

Issue:
[OCPBUGS-27838](https://issues.redhat.com/browse/OCPBUGS-27838)

Link to docs preview:
https://70717--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms#lvms-unstalling-lvms_logical-volume-manager-storage

QE review:
- [x] QE has approved this change.