### PR TITLE
OSDOCS-9070

### DIFF
--- a/modules/rosa-upgrading-preparing-4-8-to-4-9.adoc
+++ b/modules/rosa-upgrading-preparing-4-8-to-4-9.adoc
@@ -14,5 +14,5 @@ You must meet the following requirements before upgrading a {product-title} (ROS
 * You have installed 1.1.10 or later of the ROSA CLI (`rosa`) on your installation host.
 * You have installed version 4.9 or later of the OpenShift CLI (`oc`) on your workstation(s) as needed.
 * You have the permissions required to update the AWS account-wide roles and policies.
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You must be the owner or the creator of the cluster.
 * You updated the AWS Identity and Access Management (IAM) account-wide roles and policies, including the Operator policies to version 4.9.


### PR DESCRIPTION
[OSDOCS-9070](https://issues.redhat.com/browse/OSDOCS-9070): Clarify who can perform ROSA cluster upgrades

Aligned team: Service Delivery
OCP version for cherry-picking: enterprise-4.14+
JIRA issues: [OSDOCS-9070](https://issues.redhat.com/browse/OSDOCS-9070)
Preview pages: [ROSA build preview](https://70725--ocpdocs-pr.netlify.app/openshift-rosa/latest/upgrading/rosa-upgrading-cluster-prepare)
SME review **completed**: @madhusudanupadhyay
QE review **completed**:  @mgahagan73
Peer review **completed**: @bmcelvee and @Srivaralakshmi 

Note: We have SME approval in [Jira comment](https://issues.redhat.com/browse/OSDOCS-9070?focusedId=23880074&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-23880074).