### PR TITLE
CNV#13682: Added procedure for OVN-K localnet topology

### DIFF
--- a/modules/virt-attaching-vm-to-ovn-secondary-nw-cli.adoc
+++ b/modules/virt-attaching-vm-to-ovn-secondary-nw-cli.adoc
@@ -40,7 +40,7 @@ spec:
         pod: {}
       - name: secondary  <2>
         multus:
-          networkName: l2-network <3>
+          networkName: <nad_name> <3>
 # ...
 ----
 <1> The name of the OVN-Kubernetes secondary interface.

--- a/modules/virt-creating-layer2-nad-cli.adoc
+++ b/modules/virt-creating-layer2-nad-cli.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="virt-creating-layer2-nad-cli_{context}"]
-= Creating a NAD for flat layer 2 topology using the CLI
+= Creating a NAD for layer 2 topology using the CLI
 
 You can create a network attachment definition (NAD) which describes how to attach a pod to the layer 2 overlay network.
 

--- a/modules/virt-creating-localnet-nad-cli.adoc
+++ b/modules/virt-creating-localnet-nad-cli.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-creating-localnet-nad-cli_{context}"]
+= Creating a NAD for localnet topology using the CLI
+
+You can create a network attachment definition (NAD) which describes how to attach a pod to the underlying physical network.
+
+.Prerequisites
+* You have access to the cluster as a user with `cluster-admin` privileges.
+* You have installed the OpenShift CLI (`oc`).
+* You have installed the Kubernetes NMState Operator.
+* You have created a `NodeNetworkConfigurationPolicy` object to map the OVN-Kubernetes secondary network to an Open vSwitch (OVS) bridge.
+
+.Procedure
+
+. Create a `NetworkAttachmentDefinition` object:
++
+[source,yaml]
+----
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: localnet-network
+  namespace: default
+spec:
+  config: |2
+    {
+            "cniVersion": "0.3.1", <1>
+            "name": "localnet-network", <2>
+            "type": "ovn-k8s-cni-overlay", <3>
+            "topology": "localnet", <4>
+            "netAttachDefName": "default/localnet-network" <5>
+    }
+----
+<1> The CNI specification version. The required value is `0.3.1`.
+<2> The name of the network. This attribute must match the value of the `spec.desiredState.ovn.bridge-mappings.localnet` field of the `NodeNetworkConfigurationPolicy` object that defines the OVS bridge mapping.
+<3> The name of the CNI plug-in to be configured. The required value is `ovn-k8s-cni-overlay`.
+<4> The topological configuration for the network. The required value is `localnet`.
+<5> The value of the `namespace` and `name` fields in the `metadata` stanza of the `NetworkAttachmentDefinition` object.
+
+. Apply the manifest:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
+

--- a/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc
+++ b/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc
@@ -6,20 +6,27 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can connect a virtual machine (VM) to an Open Virtual Network (OVN)-Kubernetes secondary network. The OVN-Kubernetes Container Network Interface (CNI) plug-in uses the Geneve (Generic Network Virtualization Encapsulation) protocol to create an overlay network between nodes.
+You can connect a virtual machine (VM) to an Open Virtual Network (OVN)-Kubernetes secondary network. {VirtProductName} supports the layer 2 and localnet topologies for OVN-Kubernetes.
 
-{VirtProductName} currently supports the flat layer 2 topology. This topology connects workloads by a cluster-wide logical switch. You can use this overlay network to connect VMs on different nodes, without having to configure any additional physical networking infrastructure.
+* A layer 2 topology connects workloads by a cluster-wide logical switch. The OVN-Kubernetes Container Network Interface (CNI) plug-in uses the Geneve (Generic Network Virtualization Encapsulation) protocol to create an overlay network between nodes. You can use this overlay network to connect VMs on different nodes, without having to configure any additional physical networking infrastructure.
+
+* A localnet topology connects the secondary network to the physical underlay. This enables both east-west cluster traffic and access to services running outside the cluster, but it requires additional configuration of the underlying Open vSwitch (OVS) system on cluster nodes.
 
 To configure an OVN-Kubernetes secondary network and attach a VM to that network, perform the following steps:
 
-. Create a network attachment definition (NAD) by using the web console or the xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#virt-creating-layer2-nad-cli_virt-connecting-vm-to-ovn-secondary-network[CLI].
+. xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#creating-ovn-nad[Configure an OVN-Kubernetes secondary network] by creating a network attachment definition (NAD).
++
+[NOTE]
+====
+For localnet topology, you must xref:../../networking/multiple_networks/configuring-additional-network.adoc#configuring-additional-network_ovn-kubernetes-configuration-for-a-localnet-topology[configure an OVS bridge] by creating a `NodeNetworkConfigurationPolicy` object before creating the NAD.
+====
 
-. Add information about the secondary network interface to the VM specification by using the web console or the xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#virt-attaching-vm-to-ovn-secondary-nw-cli_virt-connecting-vm-to-ovn-secondary-network[CLI].
+. xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#attaching-vm-to-ovn-secondary-nw[Connect the VM to the OVN-Kubernetes secondary network] by adding the network details to the VM specification.
 
-[id="creating-ovn-layer2-nad"]
+[id="creating-ovn-nad"]
 == Creating an OVN-Kubernetes NAD
 
-You can create an OVN-Kubernetes flat layer 2 network attachment definition (NAD) by using the {product-title} web console or the CLI.
+You can create an OVN-Kubernetes layer 2 or localnet network attachment definition (NAD) by using the {product-title} web console or the CLI.
 
 [NOTE]
 ====
@@ -27,6 +34,8 @@ Configuring IP address management (IPAM) in a network attachment definition for 
 ====
 
 include::modules/virt-creating-layer2-nad-cli.adoc[leveloffset=+2]
+
+include::modules/virt-creating-localnet-nad-cli.adoc[leveloffset=+2]
 
 [id="attaching-vm-to-ovn-secondary-nw"]
 == Attaching a virtual machine to the OVN-Kubernetes secondary network
@@ -39,3 +48,4 @@ include::modules/virt-attaching-vm-to-ovn-secondary-nw-cli.adoc[leveloffset=+2]
 [id="additional-resources_virt-connecting-vm-to-ovn-secondary-network"]
 == Additional resources
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#configuration-ovnk-additional-networks_configuring-additional-network[Configuration for an OVN-Kubernetes additional network]
+* xref:../../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#k8s-nmstate-about-the-k8s-nmstate-operator[About the Kubernetes NMState Operator]

--- a/virt/vm_networking/virt-networking-overview.adoc
+++ b/virt/vm_networking/virt-networking-overview.adoc
@@ -50,9 +50,22 @@ You can connect a VM to an SR-IOV network by performing the following steps:
 
 xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#virt-connecting-vm-to-ovn-secondary-network[Connecting a virtual machine to an OVN-Kubernetes secondary network]::
 
-You can connect a VM to an Open Virtual Network (OVN)-Kubernetes secondary network. To configure an OVN-Kubernetes secondary network and attach a VM to that network, perform the following steps:
+You can connect a VM to an Open Virtual Network (OVN)-Kubernetes secondary network. {VirtProductName} supports the layer 2 and localnet topologies for OVN-Kubernetes.
++
+--
+* A layer 2 topology connects workloads by a cluster-wide logical switch. The OVN-Kubernetes Container Network Interface (CNI) plug-in uses the Geneve (Generic Network Virtualization Encapsulation) protocol to create an overlay network between nodes. You can use this overlay network to connect VMs on different nodes, without having to configure any additional physical networking infrastructure.
 
-. xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#creating-ovn-layer2-nad[Configure an OVN-Kubernetes secondary network] by creating a `NetworkAttachmentDefinition` CRD.
+* A localnet topology connects the secondary network to the physical underlay. This enables both east-west cluster traffic and access to services running outside the cluster, but it requires additional configuration of the underlying Open vSwitch (OVS) system on cluster nodes.
+--
++
+To configure an OVN-Kubernetes secondary network and attach a VM to that network, perform the following steps:
+
+. xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#creating-ovn-nad[Configure an OVN-Kubernetes secondary network] by creating a network attachment definition (NAD).
++
+[NOTE]
+====
+For localnet topology, you must xref:../../networking/multiple_networks/configuring-additional-network.adoc#configuring-additional-network_ovn-kubernetes-configuration-for-a-localnet-topology[configure an OVS bridge] by creating a `NodeNetworkConfigurationPolicy` object before creating the NAD.
+====
 
 . xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#attaching-vm-to-ovn-secondary-nw[Connect the VM to the OVN-Kubernetes secondary network] by adding the network details to the VM specification.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-13682](https://issues.redhat.com//browse/CNV-13682)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://70729--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network

[Networking overview](https://70729--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-networking-overview#secondary-network-config)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- Additional information: --->
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
