### PR TITLE
TELCODOCS-1685 - Reuse the ArgoCD patch steps for ZTP install and upgrade procedures

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2878,6 +2878,8 @@ Topics:
     File: ztp-deploying-far-edge-clusters-at-scale
   - Name: Preparing the hub cluster for ZTP
     File: ztp-preparing-the-hub-cluster
+  - Name: Updating GitOps ZTP
+    File: ztp-updating-gitops
   - Name: Installing managed clusters with RHACM and SiteConfig resources
     File: ztp-deploying-far-edge-sites
   - Name: Configuring managed clusters with policies and PolicyGenTemplate resources
@@ -2897,8 +2899,6 @@ Topics:
     Distros: openshift-origin,openshift-enterprise
   - Name: Updating managed clusters in a disconnected environment with the Topology Aware Lifecycle Manager
     File: ztp-talm-updating-managed-policies
-  - Name: Updating GitOps ZTP
-    File: ztp-updating-gitops
   - Name: Expanding single-node OpenShift clusters with GitOps ZTP
     File: ztp-sno-additional-worker-node
   - Name: Pre-caching images for single-node OpenShift deployments

--- a/modules/ztp-installing-the-new-gitops-ztp-applications.adoc
+++ b/modules/ztp-installing-the-new-gitops-ztp-applications.adoc
@@ -10,18 +10,4 @@ Using the extracted `argocd/deployment` directory, and after ensuring that the a
 
 .Procedure
 
-. To patch the ArgoCD instance in the hub cluster by using the patch file that you previously extracted into the `update/argocd/deployment/` directory, enter the following command:
-+
-[source,terminal]
-----
-$ oc patch argocd openshift-gitops \
--n openshift-gitops --type=merge \
---patch-file update/argocd/deployment/argocd-openshift-gitops-patch.json
-----
-
-. To apply the contents of the `argocd/deployment` directory, enter the following command:
-+
-[source,terminal]
-----
-$ oc apply -k update/argocd/deployment
-----
+include::snippets/ztp-patch-argocd-hub-cluster.adoc[]

--- a/modules/ztp-preparing-the-hub-cluster-for-ztp.adoc
+++ b/modules/ztp-preparing-the-hub-cluster-for-ztp.adoc
@@ -39,27 +39,5 @@ You can configure the hub cluster with a set of ArgoCD applications that generat
 
 *** `path` specifies the path to the `SiteConfig` and `PolicyGenTemplate` CRs, respectively.
 
-. To install the {ztp} plugin you must patch the ArgoCD instance in the hub cluster by using the patch file previously extracted into the `out/argocd/deployment/` directory. Run the following command:
-+
-[source,terminal]
-----
-$ oc patch argocd openshift-gitops \
--n openshift-gitops --type=merge \
---patch-file out/argocd/deployment/argocd-openshift-gitops-patch.json
-----
-
-. In {rh-rhacm} 2.7 and later, the multicluster engine enables the `cluster-proxy-addon` feature by default.
-To disable this feature, apply the following patch to disable and remove the relevant hub cluster and managed cluster pods that are responsible for this add-on.
-Run the following command:
-+
-[source,terminal]
-----
-$ oc patch multiclusterengines.multicluster.openshift.io multiclusterengine --type=merge --patch-file out/argocd/deployment/disable-cluster-proxy-addon.json
-----
-
-. Apply the pipeline configuration to your hub cluster by using the following command:
-+
-[source,terminal]
-----
-$ oc apply -k out/argocd/deployment
-----
+[start=2]
+include::snippets/ztp-patch-argocd-hub-cluster.adoc[]

--- a/snippets/ztp-patch-argocd-hub-cluster.adoc
+++ b/snippets/ztp-patch-argocd-hub-cluster.adoc
@@ -1,0 +1,26 @@
+:_mod-docs-content-type: SNIPPET
+. To install the {ztp} plugin, patch the ArgoCD instance in the hub cluster by using the patch file that you previously extracted into the `out/argocd/deployment/` directory.
+Run the following command:
++
+[source,terminal]
+----
+$ oc patch argocd openshift-gitops \
+-n openshift-gitops --type=merge \
+--patch-file out/argocd/deployment/argocd-openshift-gitops-patch.json
+----
+
+. In {rh-rhacm} 2.7 and later, the multicluster engine enables the `cluster-proxy-addon` feature by default.
+Apply the following patch to disable the `cluster-proxy-addon` feature and remove the relevant hub cluster and managed pods that are responsible for this add-on.
+Run the following command:
++
+[source,terminal]
+----
+$ oc patch multiclusterengines.multicluster.openshift.io multiclusterengine --type=merge --patch-file out/argocd/deployment/disable-cluster-proxy-addon.json
+----
+
+. Apply the pipeline configuration to your hub cluster by running the following command:
++
+[source,terminal]
+----
+$ oc apply -k out/argocd/deployment
+----


### PR DESCRIPTION
Version(s): 4.14+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1685

Link to docs preview:
* https://70737--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster#ztp-configuring-hub-cluster-with-argocd_ztp-preparing-the-hub-cluster
* https://70737--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-updating-gitops#ztp-installing-the-new-gitops-ztp-applications_ztp-updating-gitops

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->