### PR TITLE
Network Observability 1.5 release notes

### DIFF
--- a/network_observability/network-observability-operator-release-notes.adoc
+++ b/network_observability/network-observability-operator-release-notes.adoc
@@ -13,6 +13,91 @@ These release notes track the development of the Network Observability Operator 
 
 For an overview of the Network Observability Operator, see xref:../network_observability/network-observability-overview.adoc#dependency-network-observability[About Network Observability Operator].
 
+[id="network-observability-operator-release-notes-1-5"]
+== Network Observability Operator 1.5.0
+The following advisory is available for the Network Observability Operator 1.5.0:
+
+* link:https://access.redhat.com/errata/RHSA-2024:0853[Network Observability Operator 1.5.0]
+
+[id="network-observability-operator-1.5.0-features-enhancements"]
+=== New features and enhancements
+
+[id="network-observability-dns-enhancements-1.5"]
+==== DNS tracking enhancements
+In 1.5, the TCP protocol is now supported in addition to UDP. New dashboards are also added to the *Overview* view of the Network Traffic page. For more information, see xref:../network_observability/observing-network-traffic.adoc#network-observability-dns-overview_nw-observe-network-traffic[Configuring DNS tracking] and xref:../network_observability/observing-network-traffic.adoc#network-observability-dns-tracking_nw-observe-network-traffic[Working with DNS tracking].
+
+[id="network-observability-RTT-1.5"]
+==== Round-trip time (RTT)
+You can use TCP handshake Round-Trip Time (RTT) captured from the `fentry/tcp_rcv_established` Extended Berkeley Packet Filter (eBPF) hookpoint to read smoothed round-trip time (SRTT) and analyze network flows. In the *Overview*, *Network Traffic*, and *Topology* pages in web console, you can monitor network traffic and troubleshoot with RTT metrics, filtering, and edge labeling. For more information, see xref:../network_observability/observing-network-traffic.adoc#network-observability-RTT-overview_nw-observe-network-traffic[RTT Overview] and xref:../network_observability/observing-network-traffic.adoc#network-observability-RTT_nw-observe-network-traffic[Working with RTT].
+
+[id="network-observability-metrics-dashboard-enhancements"]
+==== Metrics, dashboards, and alerts enhancements
+The Network Observability metrics dashboards in *Observe* → *Dashboards* → *NetObserv* have new metrics types you can use to create Prometheus alerts. You can now define available metrics in the `includeList` specification. In previous releases, these metrics were defined in the `ignoreTags` specification. For a complete list of these metrics, see xref:../network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network Observability Metrics].
+
+[id="network-observability-improved-lokistack-integration"]
+==== Improvements for Network Observability without Loki
+You can create Prometheus alerts for the *Netobserv* dashboard using DNS, Packet drop, and RTT metrics, even if you don't use Loki. In the previous version of Network Observability, 1.4, these metrics were only available for querying and analysis in the *Network Traffic*, *Overview*, and *Topology* views, which are not available without Loki. For more information, see xref:../network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network Observability Metrics].
+
+[id="network-observability-zones"]
+==== Availability zones
+You can configure the `FlowCollector` resource to collect information about the cluster availability zones. This configuration enriches the network flow data with the link:https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesiozone[`topology.kubernetes.io/zone`] label value applied to the nodes. For more information, see xref:../network_observability/observing-network-traffic.adoc#network-observability-zonesnw-observe-network-traffic[Working with availability zones].
+
+[id="network-observability-enhanced-configuration-and-ui-1.5"]
+==== Notable enhancements 
+The 1.5 release of the Network Observability Operator adds improvements and new capabilities to the {product-title} web console plugin and the Operator configuration.
+
+[discrete]
+[id="performance-enhancements-1.5"]
+===== Performance enhancements
+* The `spec.agent.ebpf.kafkaBatchSize` default is changed from `10MB` to `1MB` to enhance eBPF performance when using Kafka. 
++
+[IMPORTANT]
+====
+When upgrading from an existing installation, this new value is not set automatically in the configuration. If you monitor a performance regression with the eBPF Agent memory consumption after upgrading, you might consider reducing the `kafkaBatchSize` to the new value.
+====
+
+[discrete]
+[id="web-console-enhancements-1.5"]
+===== Web console enhancements:
+
+* There are new panels added to the *Overview* view for DNS and RTT: Min, Max, P90, P99.
+* There are new panel display options added:
+** Focus on one panel while keeping others viewable but with smaller focus. 
+** Switch graph type. 
+** Show *Top* and *Overall*.
+* A collection latency warning is shown in the *Custom time range* pop-up window.
+* There is enhanced visibility for the contents of the *Manage panels* and *Manage columns* pop-up windows.
+* The Differentiated Services Code Point (DSCP) field for egress QoS is available for filtering QoS DSCP in the web console *Network Traffic* page.
+
+[discrete]
+[id="configuration-enhancements-1.5"]
+===== Configuration enhancements:
+
+* The `LokiStack` mode in the `spec.loki.mode` specification simplifies installation by automatically setting URLs, TLS, cluster roles and a cluster role binding, as well as the `authToken` value. The `Manual` mode allows more control over configuration of these settings.
+* The API version changes from `flows.netobserv.io/v1beta1` to `flows.netobserv.io/v1beta2`.
+
+[id="network-observability-operator-1.5.0-bug-fixes"]
+=== Bug fixes
+
+* Previously, it was not possible to register the console plugin manually in the web console interface if the automatic registration of the console plugin was disabled. If the `spec.console.register` value was set to `false` in the `FlowCollector` resource, the Operator would override and erase the plugin registration.
+With this fix, setting the `spec.console.register` value to `false` does not impact the console plugin registration or registration removal. As a result, the plugin can be safely registered manually. (link:https://issues.redhat.com/browse/NETOBSERV-1134[*NETOBSERV-1134*])
+* Previously, using the default metrics settings, the *NetObserv/Health* dashboard was showing an empty graph named *Flows Overhead*. This metric was only available by removing "namespaces-flows" and "namespaces" from the `ignoreTags` list. With this fix, this metric is visible when you use the default metrics setting. (link:https://issues.redhat.com/browse/NETOBSERV-1351[*NETOBSERV-1351*])
+* Previously, the node on which the eBPF Agent was running would not resolve with a specific cluster configuration. This resulted in cascading consequences that culminated in a failure to provide some of the traffic metrics. With this fix, the eBPF agent's node IP is safely provided by the Operator, inferred from the pod status. Now, the missing metrics are restored. (link:https://issues.redhat.com/browse/NETOBSERV-1430[*NETOBSERV-1430*])
+* Previously, the Loki error 'Input size too long' error for the Loki Operator did not include additional information to troubleshoot the problem.
+With this fix, help is directly displayed in the web console next to the error with a direct link for more guidance. (link:https://issues.redhat.com/browse/NETOBSERV-1464[*NETOBSERV-1464*])
+* Previously, the console plugin read timeout was forced to 30s.
+With the `FlowCollector` `v1beta2` API update, you can configure the `spec.loki.readTimeout` specification to update this value according to the Loki Operator `queryTimeout` limit. (link:https://issues.redhat.com/browse/NETOBSERV-1443[*NETOBSERV-1443*])
+* Previously, the Operator bundle did not display some of the supported features by CSV annotations as expected, such as `features.operators.openshift.io/...`
+With this fix, these annotations are set in the CSV as expected. (link:https://issues.redhat.com/browse/NETOBSERV-1305[*NETOBSERV-1305*])
+* Previously, the `FlowCollector` status sometimes oscillated between `DeploymentInProgress` and `Ready` states during reconciliation.
+With this fix, the status only becomes `Ready` when all the underlying components are fully ready.(link:https://issues.redhat.com/browse/NETOBSERV-1293[NETOBSERV-1293])
+
+[id="network-observability-operator-1.5.0-known-issue"]
+=== Known issues
+* When trying to access the web console, cache issues on OCP 4.14.10 prevent access to the *Observe* view. The web console shows the error message: `Failed to get a valid plugin manifest from /api/plugins/monitoring-plugin/`. The recommended workaround is to update the cluster to the latest minor version. If this does not work, you need to apply the workarounds described in this link:https://access.redhat.com/solutions/7052408[Red Hat Knowledgebase article].(link:https://issues.redhat.com/browse/NETOBSERV-1493[*NETOBSERV-1493*])
+
+//1.4.2 release notes were not pulled in when no-1.5 branch was created. They will need to be manually added when I rebase no-1.5 against main branch on GA day. 
+
 [id="network-observability-operator-release-notes-1-4-1"]
 == Network Observability Operator 1.4.1
 The following advisory is available for the Network Observability Operator 1.4.1:
@@ -64,7 +149,7 @@ The 1.4 release of the Network Observability Operator adds improvements and new 
 ** The *NetObserv / Health* dashboard shows flows overhead as well as top flow rates per nodes, namespaces, and workloads.
 ** Infrastructure and Application metrics are shown in a split-view for namespaces and workloads.
 
-For more information, see xref:../network_observability/metrics-alerts-dashboards.adoc#network-observability-viewing-dashboards_metrics-dashboards-alerts[Viewing Network Observability metrics dashboards] and xref:../network_observability/observing-network-traffic.adoc#network-observability-quickfilternw-observe-network-traffic[Quick filters].
+For more information, see xref:../network_observability/network-observability-overview.adoc#network-observability-dashboards[Network Observability metrics] and xref:../network_observability/observing-network-traffic.adoc#network-observability-quickfilternw-observe-network-traffic[Quick filters].
 
 [discrete]
 [id="configuration-enhancements-1.4_{context}"]
@@ -85,7 +170,6 @@ In 1.4, the Network Observability Operator makes use of eBPF tracepoint hooks to
 
 For more information, see xref:../network_observability/observing-network-traffic.adoc#network-observability-dns-overview_nw-observe-network-traffic[Configuring DNS tracking] and xref:../network_observability/observing-network-traffic.adoc#network-observability-dns-tracking_nw-observe-network-traffic[Working with DNS tracking].
 
-//Packet drops needs separate RN PR that doesn't cherrypick to 4.10+ since its only supported in 4.13+. This PR will go to 4.10+
 [id="SR-IOV-configuration-1.4"]
 ==== SR-IOV support
 You can now collect traffic from a cluster with Single Root I/O Virtualization (SR-IOV) device. For more information, see xref:../network_observability/configuring-operator.adoc#network-observability-SR-IOV-config_network_observability[Configuring the monitoring of SR-IOV interface traffic].
@@ -145,7 +229,7 @@ You must switch your channel from `v1.0.x` to `stable` to receive future Operato
 
 [id="flow-based-dashboard-1.3"]
 ==== Flow-based metrics dashboard
-* This release adds a new dashboard, which provides an overview of the network flows in your {product-title} cluster. For more information, see xref:../network_observability/metrics-alerts-dashboards.adoc#network-observability-viewing-dashboards_metrics-dashboards-alerts[Viewing Network Observability metrics dashboards].
+* This release adds a new dashboard, which provides an overview of the network flows in your {product-title} cluster. For more information, see xref:../network_observability/network-observability-overview.adoc#network-observability-dashboards[Network Observability metrics].
 
 [id="must-gather-1.3"]
 ==== Troubleshooting with the must-gather tool


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->
Merge to only the no-1.5 branch - no cherrypicks are required.
This PR is part of an experiment for simplifying merges for asynchronous content, and I will open one PR against main to incorporate all of the Network Observability 1.5 content just before its GA.
Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
## New features and enhancements
- Zones: https://issues.redhat.com/browse/OSDOCS-9419
- Round-trip time: https://issues.redhat.com/browse/OSDOCS-7593
- Improved LokiStack integration: https://issues.redhat.com/browse/OSDOCS-8253
- DNS enhancements: https://issues.redhat.com/browse/OSDOCS-8429
- Dashboard enhancements for Lokiless use: https://issues.redhat.com/browse/OSDOCS-8427
- Update to Network Traffic overview (under Web console enhancements in the RN): https://issues.redhat.com/browse/OSDOCS-8465
- `kafkaBatchSize` update under Notable enhancements-> Performance enhancements: https://issues.redhat.com/browse/NETOBSERV-1470

## Bug fixes
- https://issues.redhat.com/browse/NETOBSERV-1134
- https://issues.redhat.com/browse/NETOBSERV-1351
- https://issues.redhat.com/browse/NETOBSERV-1430
- https://issues.redhat.com/browse/NETOBSERV-1464
- https://issues.redhat.com/browse/NETOBSERV-1443
- https://issues.redhat.com/browse/NETOBSERV-1305
- https://issues.redhat.com/browse/NETOBSERV-1293
## Known Issues
- NetObserv plugin not showing: https://issues.redhat.com/browse/NETOBSERV-1493

Link to docs preview:
https://70738--docspreview.netlify.app/openshift-enterprise/latest/network_observability/network-observability-operator-release-notes#network-observability-operator-release-notes-1-5

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
*NOTE*: 1.4.2 release notes were not available at the time the `no-1.5` branch for documentation was created; therefore they are not included in this preview. When `no-1.5` docs branch is merged with `main`, I will rebase the release notes and the 1.4.2 note will be added in. 
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
