### PR TITLE
OCPBUG 24744: Modified the steps in replacing the default ingress certificate.

### DIFF
--- a/modules/customize-certificates-replace-default-router.adoc
+++ b/modules/customize-certificates-replace-default-router.adoc
@@ -32,10 +32,13 @@ root CA certificate.
 [source,terminal]
 ----
 $ oc create configmap custom-ca \
-     --from-file=ca-bundle.crt=</path/to/example-ca.crt> \//<1>
+     --from-file=ca-bundle.crt=</path/to/example-ca.crt> \ <1>
      -n openshift-config
 ----
 <1> `</path/to/example-ca.crt>` is the path to the root CA certificate file on your local file system.
+
+. Observe that a new machine-config file is generated, triggering rollout to all nodes.
+
 
 . Update the cluster-wide proxy configuration with the newly created config map:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUG 24744](https://issues.redhat.com/browse/OCPBUGS-24744)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
