### PR TITLE
OCPBUGS#27841: Removed "Adding a storage class" proc

### DIFF
--- a/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
+++ b/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
@@ -69,9 +69,6 @@ include::modules/lvms-unsupported-devices.adoc[leveloffset=+2]
 
 * xref:../../../storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc#lvms-reference-file_logical-volume-manager-storage[{lvms} reference YAML file]
 
-//Adding a storage class
-include::modules/lvms-adding-a-storage-class.adoc[leveloffset=+1]
-
 //Provisioning
 include::modules/lvms-provisioning-storage-using-logical-volume-manager-operator.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OCPBUGS-27841](https://issues.redhat.com/browse/OCPBUGS-27841)

Link to docs preview:
https://70753--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms


QE review:
- [x] QE has approved this change.