### PR TITLE
TELCODOCS-1508: Doc improvements from SME feedback

### DIFF
--- a/modules/cnf-assigning-a-secondary-network-to-a-vrf.adoc
+++ b/modules/cnf-assigning-a-secondary-network-to-a-vrf.adoc
@@ -2,22 +2,9 @@
 //
 // networking/multiple_networks/assigning-a-secondary-network-to-a-vrf.adoc
 
-
 :_mod-docs-content-type: PROCEDURE
-[id="cnf-assigning-a-secondary-network-to-a-vrf_{context}"]
-= Assigning a secondary network to a VRF
-
-As a cluster administrator, you can configure an additional network for your VRF domain by using the CNI VRF plugin. The virtual network created by this plugin is associated with a physical interface that you specify.
-
-[NOTE]
-====
-Applications that use VRFs need to bind to a specific device. The common usage is to use the `SO_BINDTODEVICE` option for a socket. `SO_BINDTODEVICE` binds the socket to a device that is specified in the passed interface name, for example, `eth1`. To use `SO_BINDTODEVICE`, the application must have `CAP_NET_RAW` capabilities.
-
-Using a VRF through the `ip vrf exec` command is not supported in {product-title} pods. To use VRF, bind applications directly to the VRF interface.
-====
-
 [id="cnf-creating-an-additional-network-attachment-with-the-cni-vrf-plug-in_{context}"]
-== Creating an additional network attachment with the CNI VRF plugin
+= Creating an additional network attachment with the CNI VRF plugin
 
 The Cluster Network Operator (CNO) manages additional network definitions. When you specify an additional network to create, the CNO creates the `NetworkAttachmentDefinition` custom resource (CR) automatically.
 
@@ -43,33 +30,33 @@ apiVersion: operator.openshift.io/v1
 kind: Network
 metadata:
   name: cluster
-  spec:
+spec:
   additionalNetworks:
-  - name: test-network-1
-    namespace: additional-network-1
-    type: Raw
-    rawCNIConfig: '{
-      "cniVersion": "0.3.1",
-      "name": "macvlan-vrf",
-      "plugins": [  <1>
-      {
-        "type": "macvlan",  <2>
-        "master": "eth1",
-        "ipam": {
-            "type": "static",
-            "addresses": [
-            {
-                "address": "191.168.1.23/24"
-            }
-            ]
-        }
-      },
-      {
-        "type": "vrf",
-        "vrfname": "example-vrf-name",  <3>
-        "table": 1001   <4>
-      }]
-    }'
+    - name: test-network-1
+      namespace: additional-network-1
+      type: Raw
+      rawCNIConfig: '{
+        "cniVersion": "0.3.1",
+        "name": "macvlan-vrf",
+        "plugins": [  <1>
+        {
+          "type": "macvlan", 
+          "master": "eth1",
+          "ipam": {
+              "type": "static",
+              "addresses": [
+              {
+                  "address": "191.168.1.23/24"
+              }
+              ]
+          }
+        },
+        {
+          "type": "vrf", <2>
+          "vrfname": "vrf-1",  <3>
+          "table": 1001   <4>
+        }]
+      }'
 ----
 <1> `plugins` must be a list. The first item in the list must be the secondary network underpinning the VRF network. The second item in the list is the VRF plugin configuration.
 <2> `type` must be set to `vrf`.
@@ -107,13 +94,47 @@ additional-network-1       14m
 There might be a delay before the CNO creates the CR.
 ====
 
-.Verifying that the additional VRF network attachment is successful
+.Verification
 
-To verify that the VRF CNI is correctly configured and the additional network attachment is attached, do the following:
+. Create a pod and assign it to the additional network with the VRF instance:
 
-. Create a network that uses the VRF CNI.
-. Assign the network to a pod.
-. Verify that the pod network attachment is connected to the VRF additional network. Remote shell into the pod and run the following command:
+.. Create a YAML file that defines the `Pod` resource:
++
+.Example `pod-additional-net.yaml` file
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+ name: pod-additional-net
+ annotations:
+   k8s.v1.cni.cncf.io/networks: '[
+       {
+               "name": "test-network-1" <1>
+       }
+ ]'
+spec:
+ containers:
+ - name: example-pod-1
+   command: ["/bin/bash", "-c", "sleep 9000000"]
+   image: centos:8
+----
+<1> Specify the name of the additional network with the VRF instance.
+
+.. Create the `Pod` resource by running the following command:
++
+[source,terminal]
+----
+$ oc create -f pod-additional-net.yaml
+----
++
+.Example output
+[source,terminal]
+----
+pod/test-pod created
+----
+
+. Verify that the pod network attachment is connected to the VRF additional network. Start a remote session with the pod and run the following command:
 +
 [source,terminal]
 ----
@@ -121,14 +142,13 @@ $ ip vrf show
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 Name              Table
 -----------------------
-red                 10
+vrf-1             1001
 ----
-. Confirm the VRF interface is master of the secondary interface:
+. Confirm that the VRF interface is the controller for the additional interface:
 +
 [source,terminal]
 ----
@@ -136,7 +156,6 @@ $ ip link
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 5: net1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master red state UP mode

--- a/networking/multiple_networks/assigning-a-secondary-network-to-a-vrf.adoc
+++ b/networking/multiple_networks/assigning-a-secondary-network-to-a-vrf.adoc
@@ -6,4 +6,23 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+As a cluster administrator, you can configure an additional network for a virtual routing and forwarding (VRF) domain by using the CNI VRF plugin. The virtual network that this plugin creates is associated with the physical interface that you specify.
+
+Using a secondary network with a VRF instance has the following advantages:
+
+Workload isolation:: Isolate workload traffic by configuring a VRF instance for the additional network. 
+Improved security:: Enable improved security through isolated network paths in the VRF domain.
+Multi-tenancy support:: Support multi-tenancy through network segmentation with a unique routing table in the VRF domain for each tenant.
+
+[NOTE]
+====
+Applications that use VRFs must bind to a specific device. The common usage is to use the `SO_BINDTODEVICE` option for a socket. The `SO_BINDTODEVICE` option binds the socket to the device that is specified in the passed interface name, for example, `eth1`. To use the `SO_BINDTODEVICE` option, the application must have `CAP_NET_RAW` capabilities.
+
+Using a VRF through the `ip vrf exec` command is not supported in {product-title} pods. To use VRF, bind applications directly to the VRF interface.
+====
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../networking/multiple_networks/about-virtual-routing-and-forwarding.adoc#cnf-about-virtual-routing-and-forwarding_about-virtual-routing-and-forwarding[About virtual routing and forwarding]
+
 include::modules/cnf-assigning-a-secondary-network-to-a-vrf.adoc[leveloffset=+1]


### PR DESCRIPTION
[TELCODOCS-1508](https://issues.redhat.com//browse/TELCODOCS-1508): SME requested doc improvements and some questions regarding functionality. 

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1508

Link to docs preview:
https://70756--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/assigning-a-secondary-network-to-a-vrf

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
More detailed SME feedback here: https://docs.google.com/document/d/1FSxqVwFT7uYT7obhjuZpMryuu5eVd5FekUHZZ67V2MM/edit?usp=sharing