### PR TITLE
OSDOCS-9247: Admin console release notes

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -124,10 +124,31 @@ You can now move etcd from a root volume (Cinder) to a dedicated ephemeral local
 [id="ocp-4-15-web-console"]
 === Web console
 
+[id="ocp-4-15-administrator-perspective"]
+==== Administrator perspective
+
+This release introduces the following updates to the *Administrator* perspective of the web console:
+
+* Enable and disable the tailing to Pod log viewer to minimize load time.
+* View recomended values for `VerticalPodAutoscaler` on the *Deployment* page.
+
+[id="node-uptime-information"]
+===== Node uptime information
+With this update, you can enable the ability to view additional node uptime information to track node restarts or failures. Navigate to the *Compute* -> *Nodes* page, click *Manage columns*, and then select *Uptime*.
+
+[id="web-console-dynamic-plugin-enhancements"]
+===== Dynamic plugin enhancements
+
+With this update, you can add a new details item to the default resource summary on the *Details* page using `console.resource/details-item`. The {product-title} release also adds example implementation for annotation, label and the delete modal to the CronTab dynamic plugin.
+
+For more information, see xref:../web_console/dynamic-plugin/dynamic-plugins-reference.adoc#dynamic-plugin-reference[Dynamic plugin reference]
+
+For more information about `console.resource/details-item`, see xref:../web_console/dynamic-plugin/dynamic-plugins-reference.adoc#dynamic-plugin-sdk-extensions_dynamic-plugins-reference[{product-title} console API].
+
 [id="ocp-4-15-developer-perspective"]
 ==== Developer Perspective
 
-With this release, there are several updates to the *Developer* perspective of the web console.
+This release introduces the following updates to the *Developer* perspective of the web console:
 
 * Pipeline history and logs based on the data from Tekton Results are available in the dashboard without requiring PipelineRun CRs on the cluster.
 


### PR DESCRIPTION
Release notes for Admin console. ODC RNs will go in separate PR.

Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-8278
https://issues.redhat.com/browse/OSDOCS-9247

Link to docs preview:
https://70760--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-14-administrator-perspective

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

