### PR TITLE
OBSDOCS-677: update CMO config map ref for OCP 4.15

### DIFF
--- a/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+++ b/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
@@ -144,6 +144,8 @@ The `ClusterMonitoringConfiguration` resource defines settings that customize th
 
 |kubeStateMetrics|*link:#kubestatemetricsconfig[KubeStateMetricsConfig]|`KubeStateMetricsConfig` defines settings for the `kube-state-metrics` agent.
 
+|metricsServer|*link:#metricsserverconfig[MetricsServerConfig]|`MetricsServer` defines settings for the Metrics Server component.
+
 |prometheusK8s|*link:#prometheusk8sconfig[PrometheusK8sConfig]|`PrometheusK8sConfig` defines settings for the Prometheus component.
 
 |prometheusOperator|*link:#prometheusoperatorconfig[PrometheusOperatorConfig]|`PrometheusOperatorConfig` defines settings for the Prometheus Operator component.
@@ -165,6 +167,12 @@ The `ClusterMonitoringConfiguration` resource defines settings that customize th
 == DedicatedServiceMonitors
 
 === Description
+
+[IMPORTANT]
+====
+This setting is deprecated and is planned to be removed in a future {product-title} version. 
+In the current version, this setting still exists but has no effect.
+====
 
 You can use the `DedicatedServiceMonitors` resource to configure dedicated Service Monitors for the Prometheus Adapter
 
@@ -218,6 +226,30 @@ Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 |resources|*v1.ResourceRequirements|Defines resource requests and limits for the `KubeStateMetrics` container.
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
+
+|topologySpreadConstraints|[]v1.TopologySpreadConstraint|Defines a pod's topology spread constraints.
+
+|===
+
+== MetricsServerConfig
+
+=== Description
+
+:FeatureName: Metrics Server
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+The `MetricsServerConfig` resource defines settings for the Metrics Server component. Note that this setting only applies when the `TechPreviewNoUpgrade` feature gate is enabled.
+
+Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
+
+[options="header"]
+|===
+| Property | Type | Description 
+|nodeSelector|map[string]string|Defines the nodes on which the pods are scheduled.
+
+|tolerations|[]v1.Toleration|Defines tolerations for the pods.
+
+|resources|*v1.ResourceRequirements|Defines resource requests and limits for the Metrics Server container.
 
 |topologySpreadConstraints|[]v1.TopologySpreadConstraint|Defines a pod's topology spread constraints.
 
@@ -620,6 +652,9 @@ link:#prometheusrestrictedconfig[PrometheusRestrictedConfig]
 |queueConfig|*monv1.QueueConfig|Allows tuning configuration for remote write queue parameters.
 
 |remoteTimeout|string|Defines the timeout value for requests to the remote write endpoint.
+
+|sendExemplars|*bool|Enables sending exemplars via remote write. When enabled, this setting configures Prometheus to store a maximum of 100,000 exemplars in memory. 
+This setting only applies to user-defined monitoring and is not applicable to core platform monitoring.
 
 |sigv4|*monv1.Sigv4|Defines AWS Signature Version 4 authentication settings.
 


### PR DESCRIPTION
**Note for peer reviewer**: The content in the Cluster Monitoring Operator (CMO) config map API reference is generated from the CMO source code comments. This PR just needs a sanity check here to check for typos, formatting issues, and broken links. Feel free to suggest language or style changes to the content, but for the scope of this PR, I can only make fixes to typos or broken formatting. If other changes are suggested, they will need to be made in the CMO source code, so I will write them up as new Jiras to update the CMO source code comments so that when the reference content is generated for the next release, the updated content will appear in the newly generated content.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: 
- https://issues.redhat.com/browse/OBSDOCS-677
- https://issues.redhat.com/browse/OBSDOCS-676
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Links to docs previews:
- https://70762--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/config-map-reference-for-the-cluster-monitoring-operator#clustermonitoringconfiguration - Adds metricsserver component to the table.
- https://70762--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/config-map-reference-for-the-cluster-monitoring-operator#metricsserverconfig - new table for metrics server
- https://70762--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/config-map-reference-for-the-cluster-monitoring-operator#remotewritespec - adds sendExemplar setting to the table
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR updates the Cluster Monitoring Operator config map API reference to reflect changes made for the OCP 4.15 release.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
