### PR TITLE
OCPBUGS#15179: Fix missing units when moving etcd to a different disk

### DIFF
--- a/modules/move-etcd-different-disk.adoc
+++ b/modules/move-etcd-different-disk.adoc
@@ -167,8 +167,7 @@ spec:
           [Unit]
           Description=Mount /dev/<new_disk_name> to /var/lib/etcd
           Before=local-fs.target
-          Requires=systemd-mkfs@dev-<new_disk_name>.service
-          After=systemd-mkfs@dev-<new_disk_name>.service var.mount
+          After=var.mount
 
           [Mount]
           What=/dev/<new_disk_name>


### PR DESCRIPTION
Version(s):
4.13+

Issue:
[OCPBUGS-15179](https://issues.redhat.com/browse/OCPBUGS-15179)

Link to docs preview:
[Moving etcd to a different disk](https://70775--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices#move-etcd-different-disk_recommended-etcd-practices)

QE review:
- [x] QE has approved this change.

Additional information:

N/A