### PR TITLE
[enterprise-4.13]OCPBUGS#23165: Moved user-defined tags section after installation configuration

### DIFF
--- a/installing/installing_azure/installing-azure-customizations.adoc
+++ b/installing/installing_azure/installing-azure-customizations.adoc
@@ -29,10 +29,6 @@ include::modules/installation-azure-marketplace-subscribe.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
-include::modules/installation-user-defined-tags-azure.adoc[leveloffset=+1]
-
-include::modules/querying-user-defined-tags-azure.adoc[leveloffset=+1]
-
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
@@ -56,6 +52,10 @@ include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 .Additional resources
 
 * For more details about Accelerated Networking, see xref:../../machine_management/creating_machinesets/creating-machineset-azure.adoc#machineset-azure-accelerated-networking_creating-machineset-azure[Accelerated Networking for Microsoft Azure VMs].
+
+include::modules/installation-user-defined-tags-azure.adoc[leveloffset=+1]
+
+include::modules/querying-user-defined-tags-azure.adoc[leveloffset=+1]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 


### PR DESCRIPTION
CP of #70396

Version(s): 4.13

Link to docs preview: 