### PR TITLE
[OSDOCS#9458]: 4.15 RN: Fix wrong acronyms

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -61,9 +61,9 @@ This release adds improvements related to the following components and concepts.
 [id="ocp-4-15-CAPO-tech-preview-no-upgrade"]
 ==== CAPO integration into the cluster CAPI Operator (Tech Preview)
 
-If you enable the `TechPreviewNoUpgrade` feature flag, the Cluster API (CAPI) Operator deploys the Cluster API Provider for OpenStack (CAPO) and manages its lifecycle. The CAPI Operator automatically creates an additional OpenStack cluster and an additional {product-title} cluster for the current {product-title} cluster.
+If you enable the `TechPreviewNoUpgrade` feature flag, the Cluster API (CAPI) Operator deploys the Cluster API Provider for OpenStack (CAPO) and manages its lifecycle. The CAPI Operator automatically creates `Cluster` and `OpenStackCluster` resources for the current {product-title} cluster.
 
-It is now possible to configure the CAPI machine and OpenStack machine resources in a similar fashion to how the Machine API (MAPI) resources are configured. It is important to note that the CAPI resources are equivalent to MAPI resources and not identical.
+It is now possible to configure the CAPI `Machine` and CAPO `OpenStackMachine` resources in similar fashion to how Machine API (MAPI) resources are configured. It is important to note that the CAPI resources are equivalent to MAPI resources but not identical.
 
 [id="ocp-4-15-installation-and-update-ibm-cloud-user-managed-encryption"]
 ==== IBM Cloud and user-managed encryption


### PR DESCRIPTION
CAPO stands for Cluster API and MAPO for Machine API. This commit fixes incorect explanations of these two acronyms.

This fixes mistakes introduced in #70637.

Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-9302

Link to docs preview:
https://70813--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes

QE review:
- [x] QE has approved this change.

Additional information:
