### PR TITLE
[enterprise-4.12] OCPBUGS#26565: Expanded the FIPS cryptography mode note with RHEL 9 c…

### DIFF
--- a/installing/installing-fips.adoc
+++ b/installing/installing-fips.adoc
@@ -10,7 +10,9 @@ You can install an {product-title} cluster that uses FIPS validated or Modules I
 
 [IMPORTANT]
 ====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode].
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base} 8 computer that is configured to operate in FIPS mode. Running {op-system-base} 9 with FIPS mode enabled to install an {product-title} cluster is not possible.
+
+For more information about configuring FIPS mode on {op-system-base}, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/assembly_installing-a-rhel-8-system-with-fips-mode-enabled_security-hardening[Installing the system in FIPS mode].
 ====
 
 For the {op-system-first} machines in your cluster, this change is applied when the machines are deployed based on the status of an option in the `install-config.yaml` file, which governs the cluster options that a user can change during cluster deployment. With {op-system-base-full} machines, you must enable FIPS mode when you install the operating system on the machines that you plan to use as worker machines. These configuration methods ensure that your cluster meets the requirements of a FIPS compliance audit: only FIPS validated or Modules In Process cryptography packages are enabled before the initial system boot.


### PR DESCRIPTION
Commit cherry pickd from #70555 with commit d03f48df9f79856f88c998ce312881109c611242

Version: 4.12

Preview link: [Support for FIPS cryptography](https://70815--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing-fips)