### PR TITLE
TELCODOCS-1671 adding missed bug fixes missed in z-stream

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3334,6 +3334,8 @@ For more information see, xref:../networking/ptp/configuring-ptp.adoc#configurin
 
 * Previously, when you deployed IPv6-only hosts from a dual-stack cluster, an issue prevented the Baseboard Management Controller (BMC) from receiving the correct callback URL. Instead, the BMC received an IPv4 URL. With this update, the issue no longer occurs because the IP version of the URL depends on the IP version of the BMC address.(link:https://issues.redhat.com/browse/OCPBUGS-23903[*OCPBUGS-23903*])
 
+* Previously, on an {sno-caps} that has guaranteed CPUs and where Interrupt Request (IRQ) load balancing is disabled, large latency spikes could occur at container startup. With this update, the issue no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-22901[*OCPBUGS-22901*]) (link:https://issues.redhat.com/browse/OCPBUGS-OCPBUGS-24281[*OCPBUGS-24281*])
+
 [id="ocp-4-14-6-known-issue"]
 ==== Known issues
 
@@ -3365,9 +3367,11 @@ $ oc adm release info 4.14.5 --pullspecs
 ==== Bug fixes
 
 * Previously, when the build capability is not enabled, ConfigObserver controller would fail when trying to sync with build informer. With this release, ConfigObserver starts successfully when build capability is not enabled.
-(link:https://issues.redhat.com/browse/OCPBUGS-23490[*OCPBUGS-23490*])
+(link:https://issues.redhat.com/browse/OCPBUGS-23490[*OCPBUGS-23490*]) (link:https://issues.redhat.com/browse/OCPBUGS-21778[*OCPBUGS-21778*])
 
 * Previously, the Cloud Credential Operator (CCO) did not support updating the VMware vSphere root secret (`vsphere-creds`) in the `kube-system` namespace. This prevented the component secrets from synchronizing correctly. With this release, the CCO supports updating the vSphere root secret and resets the secret data when synchronized. (link:https://issues.redhat.com/browse/OCPBUGS-23426[*OCPBUGS-23426*])
+
+* Previously, when deploying an application that has a large number of pods, some of which have CPU limits configured, the deployment can fail. With this update, the issue no longer occurs. (link:https://issues.redhat.com/browse/RHEL-7232[*RHEL-7232*])
 
 [id="ocp-4-14-5-updating"]
 ==== Updating


### PR DESCRIPTION
[TELCODOCS-1671]: Adding note clarifying when bug is fixed and in what z stream

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14 (only)
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:: https://issues.redhat.com/browse/TELCODOCS-1671
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 

- https://70817--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-6

- https://70817--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-5

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
See https://github.com/openshift/openshift-docs/pull/70249 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
