### PR TITLE
TELCODOCS-999 adding RN description

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -417,6 +417,10 @@ With this update, MetalLB exposes additional metrics relating to communication b
 
 For more information about all-multicast mode, see xref:../networking/hardware_networks/configuring-interface-sysctl-sriov-device.adoc#nw-about-all-multi-cast-mode_configuring-sysctl-interface-sriov-device[About all-multicast mode].
 
+[id="ocp-4-15-multi-network-policy-ipv6"]
+==== Multi-network policy support for IPv6 networks
+With this update, you can now create multi-network policies for IPv6 networks. For more information, see xref:../networking/multiple_networks/configuring-multi-network-policy.adoc#nw-multi-network-policy-ipv6-support_configuring-multi-network-policy[Supporting multi-network policies in IPv6 networks].
+
 [id="ocp-4-15-registry"]
 === Registry
 


### PR DESCRIPTION
[TELCODOCS-999]: Support MultiNetworkPolicies in IPv6 networks
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15, main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-999
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
Link to docs preview: https://70819--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-multi-network-policy-ipv6
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
