### PR TITLE
[OSDOCS-3989] OCP content port to ROSA and OSD: Nodes Follow Up

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -888,29 +888,31 @@ Topics:
 #   File: nodes-scheduler-node-projects
 # - Name: Keeping your cluster balanced using the descheduler
 #   File: nodes-scheduler-descheduler
-  - Name: Descheduler
-    Dir: descheduler
-    Topics:
-    - Name: Descheduler overview
-      File: index
-    - Name: Descheduler release notes
-      File: nodes-descheduler-release-notes
-    - Name: Evicting pods using the descheduler
-      File: nodes-descheduler-configuring
-    - Name: Uninstalling the descheduler
-      File: nodes-descheduler-uninstalling
-  - Name: Secondary scheduler
-    Dir: secondary_scheduler
-    Distros: openshift-enterprise
-    Topics:
-    - Name: Secondary scheduler overview
-      File: index
-    - Name: Secondary Scheduler Operator release notes
-      File: nodes-secondary-scheduler-release-notes
-    - Name: Scheduling pods using a secondary scheduler
-      File: nodes-secondary-scheduler-configuring
-    - Name: Uninstalling the Secondary Scheduler Operator
-      File: nodes-secondary-scheduler-uninstalling
+# Cannot create namespace to install Desceduler Operator; revisit after Operator book converted
+#  - Name: Descheduler
+#    Dir: descheduler
+#    Topics:
+#    - Name: Descheduler overview
+#      File: index
+#    - Name: Descheduler release notes
+#      File: nodes-descheduler-release-notes
+#    - Name: Evicting pods using the descheduler
+#      File: nodes-descheduler-configuring
+#    - Name: Uninstalling the descheduler
+#      File: nodes-descheduler-uninstalling
+# Cannot create namespace to install Secondary Scheduler Operator; revisit after Operator book converted
+# - Name: Secondary scheduler
+#   Dir: secondary_scheduler
+#   Distros: openshift-dedicated
+#   Topics:
+#   - Name: Secondary scheduler overview
+#     File: index
+#   - Name: Secondary Scheduler Operator release notes
+#     File: nodes-secondary-scheduler-release-notes
+#   - Name: Scheduling pods using a secondary scheduler
+#     File: nodes-secondary-scheduler-configuring
+#   - Name: Uninstalling the Secondary Scheduler Operator
+#     File: nodes-secondary-scheduler-uninstalling
 - Name: Using Jobs and DaemonSets
   Dir: jobs
   Topics:


### PR DESCRIPTION
Missed commenting-out the Descheduler and Secondary Scheduler assemblies in initial pass of the [Nodes ROSA/OSD content port for OSD](https://github.com/openshift/openshift-docs/pull/62147/files#diff-54b6c45a07b510755a4b365a48b7130a0369666209fd2e835b543de5e909e2f6R706-R719). This PR fixes the oversight.

Previews: 
[Descheduler and Secondary Scheduler not present](https://70825--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/scheduling/nodes-scheduler-about). [Current docs](https://docs.openshift.com/dedicated/nodes/scheduling/nodes-descheduler.html).

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

