### PR TITLE
OSDOCS-9443: Update note to reflect that US GovCloud is supported

### DIFF
--- a/modules/rosa-sdpolicy-am-regions-az.adoc
+++ b/modules/rosa-sdpolicy-am-regions-az.adoc
@@ -22,7 +22,14 @@ endif::rosa-with-hcp[]
 
 [NOTE]
 ====
-China and GovCloud (US) regions are not supported, regardless of their support on OpenShift 4.
+China regions are not supported, regardless of their support on OpenShift 4.
+====
+
+[NOTE]
+====
+For GovCloud (US) regions, you must submit an link:https://console.redhat.com/openshift/create/rosa/govcloud[Access request for Red Hat OpenShift Service on AWS (ROSA) FedRAMP]. 
+
+GovCloud (US) regions are only supported on ROSA Classic clusters. 
 ====
 
 .AWS Regions
@@ -62,6 +69,8 @@ endif::rosa-with-hcp[]
 * us-east-1 (N. Virginia)
 * us-east-2 (Ohio)
 ifndef::rosa-with-hcp[]
+* us-gov-east-1 - (AWS GovCloud - US-East)
+* us-gov-west-1 - (AWS GovCloud - US-West)	
 * us-west-1 (N. California)
 endif::rosa-with-hcp[]
 * us-west-2 (Oregon)


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-9443

Link to docs preview:
https://70835--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition#rosa-sdpolicy-regions-az_rosa-service-definition

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
