### PR TITLE
[OSDOCS-9416]: Clarify Cluster Uninstallation warning when using AWS VPC Peering connections

### DIFF
--- a/modules/aws-vpc.adoc
+++ b/modules/aws-vpc.adoc
@@ -11,7 +11,7 @@ A Virtual Private Cloud (VPC) peering connection is a networking connection betw
 
 [WARNING]
 ====
-Private clusters cannot be fully deleted by {cluster-manager-first} if the VPC the cluster is installed in is peered.
+Before you attempt to uninstall a cluster, you must remove any VPC peering connections from the cluster's VPC. Failure to do so might result in a cluster not completing the uninstall process.
 
 AWS supports inter-region VPC peering between all commercial regions link:https://aws.amazon.com/vpc/faqs/#Peering_Connections[excluding China].
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.15+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-9416
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://70838--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_cluster_admin/osd_private_connections/aws-private-connections#aws-vpc_aws-private-connections
![image](https://github.com/openshift/openshift-docs/assets/122639474/a6e72cc5-ca24-4beb-a3cb-3962457edfba)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
Please see ticket https://issues.redhat.com/browse/OSDOCS-9416 description. The requested change was a result of customer issue https://issues.redhat.com/browse/OHSS-30966. To avoid this in the future, it was suggested we need to make the warning clearer to users that are attempting to uninstall a cluster. 
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
