### PR TITLE
OSDOCS#9462: Removed Hyper Protect from IBM Cloud BYOK docs

### DIFF
--- a/installing/installing_ibm_cloud_public/user-managed-encryption-ibm-cloud.adoc
+++ b/installing/installing_ibm_cloud_public/user-managed-encryption-ibm-cloud.adoc
@@ -11,7 +11,7 @@ By default, provider-managed encryption is used to secure the following when you
 * The root (boot) volume of control plane and compute machines
 * Persistent volumes (data volumes) that are provisioned after the cluster is deployed
 
-You can override the default behavior by specifying an {ibm-name} Key Protect for {ibm-cloud-name} (Key Protect) or {ibm-name} Hyper Protect Crypto Services (Hyper Protect Crypto Services) root key as part of the installation process.
+You can override the default behavior by specifying an {ibm-name} Key Protect for {ibm-cloud-name} (Key Protect) root key as part of the installation process.
 
 When you bring our own root key, you modify the installation configuration file (`install-config.yaml`) to specify the Cloud Resource Name (CRN) of the root key by using the `encryptionKey` parameter.
 
@@ -27,7 +27,7 @@ For more information about the `encryptionKey` parameter, see xref:../../install
 
 [NOTE]
 ====
-Be sure you have integrated Key Protect or Hyper Protect Crypto Services with your IBM Cloud Block Storage service. For more information, see the Key Protect link:https://cloud.ibm.com/docs/key-protect?topic=key-protect-integrate-services#grant-access[documentation] or Hyper Protect Crypto Services link:https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-integrate-services[documentation].
+Make sure you have integrated Key Protect with your IBM Cloud Block Storage service. For more information, see the Key Protect link:https://cloud.ibm.com/docs/key-protect?topic=key-protect-integrate-services#grant-access[documentation].
 ====
 
 

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -2332,7 +2332,7 @@ Additional {ibm-cloud-name} configuration parameters are described in the follow
     ibmcloud:
       bootVolume:
         encryptionKey:
-|An {ibm-name} Key Protect for {ibm-cloud-name} (Key Protect) or {ibm-name} Hyper Protect Crypto Services (Hyper Protect Crypto Services) root key that should be used to encrypt the root (boot) volume of only control plane machines.
+|An {ibm-name} Key Protect for {ibm-cloud-name} (Key Protect) root key that should be used to encrypt the root (boot) volume of only control plane machines.
 d|The Cloud Resource Name (CRN) of the root key.
 
 The CRN must be enclosed in quotes ("").
@@ -2342,7 +2342,7 @@ The CRN must be enclosed in quotes ("").
     ibmcloud:
       bootVolume:
         encryptionKey:
-|A Key Protect or Hyper Protect Crypto Services root key that should be used to encrypt the root (boot) volume of only compute machines.
+|A Key Protect root key that should be used to encrypt the root (boot) volume of only compute machines.
 d|The CRN of the root key.
 
 The CRN must be enclosed in quotes ("").
@@ -2352,7 +2352,7 @@ The CRN must be enclosed in quotes ("").
     defaultMachinePlatform:
       bootvolume:
         encryptionKey:
-d|A Key Protect or Hyper Protect Crypto Services root key that should be used to encrypt the root (boot) volume of all of the cluster's machines.
+d|A Key Protect root key that should be used to encrypt the root (boot) volume of all of the cluster's machines.
 
 When specified as part of the default machine configuration, all managed storage classes are updated with this key. As such, data volumes that are provisioned after the installation are also encrypted using this key.
 d|The CRN of the root key.


### PR DESCRIPTION
Version(s):
4.15+

Issue:

- [User-managed encryption for IBM Cloud](https://70840--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/user-managed-encryption-ibm-cloud)
- [Additional IBM Cloud configuration parameters](https://70840--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installation-config-parameters-ibm-cloud-vpc#installation-configuration-parameters-additional-ibm-cloud_installation-config-parameters-ibm-cloud-vpc)

This PR addresses [osdocs-9462](https://issues.redhat.com/browse/OSDOCS-9462).

QE review:
- [x] QE has approved this change.