### PR TITLE
OSDOCS#9462: Removed Hyper Protect from IBM Cloud BYOK RN

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -68,7 +68,7 @@ It is now possible to configure the CAPI machine and OpenStack machine resources
 [id="ocp-4-15-installation-and-update-ibm-cloud-user-managed-encryption"]
 ==== IBM Cloud and user-managed encryption
 
-You can now specify your own {ibm-name} Key Protect for {ibm-cloud-name} or {ibm-name} Hyper Protect Crypto Services root key as part of the installation process. This root key is used to encrypt the root (boot) volume of control plane and compute machines, as well as the persistent volumes (data volumes) that are provisioned after the cluster is deployed.
+You can now specify your own {ibm-name} Key Protect for {ibm-cloud-name} root key as part of the installation process. This root key is used to encrypt the root (boot) volume of control plane and compute machines, as well as the persistent volumes (data volumes) that are provisioned after the cluster is deployed.
 
 For more information, see xref:../installing/installing_ibm_cloud_public/user-managed-encryption-ibm-cloud.adoc#user-managed-encryption-ibm-cloud[User-managed encryption for IBM Cloud].
 


### PR DESCRIPTION
Version(s):
4.15

Issue:

This PR updates the Release Notes as part of [osdocs-9462](https://issues.redhat.com/browse/OSDOCS-9462). 

Link to docs preview:



QE review:
- [yes] QE has approved this change.
