### PR TITLE
OSDOCS-9223 removing openshiftsdn from install doc

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -197,8 +197,6 @@ endif::agent,bare,ibm-power,ibm-z,vsphere[]
 ifdef::agent,bare,ibm-power,ibm-z,vsphere[]
 * If you use the {openshift-networking} OVN-Kubernetes network plugin, both IPv4 and IPv6 address families are supported.
 
-* If you use the {openshift-networking} OpenShift SDN network plugin, only the IPv4 address family is supported.
-
 ifdef::ibm-cloud[]
 [NOTE]
 ====
@@ -259,11 +257,11 @@ You cannot modify parameters specified by the `networking` object after installa
 |The {openshift-networking} network plugin to install.
 |
 ifdef::openshift-origin[]
-Either `OpenShiftSDN` or `OVNKubernetes`. The default value is `OVNKubernetes`.
+`OVNKubernetes`.
 endif::openshift-origin[]
 ifndef::openshift-origin[]
 ifndef::ibm-power-vs[]
-Either `OpenShiftSDN` or `OVNKubernetes`. `OpenShiftSDN` is a CNI plugin for all-Linux networks. `OVNKubernetes` is a CNI plugin for Linux networks and hybrid networks that contain both Linux and Windows servers. The default value is `OVNKubernetes`.
+`OVNKubernetes`. `OVNKubernetes` is a CNI plugin for Linux networks and hybrid networks that contain both Linux and Windows servers. The default value is `OVNKubernetes`.
 endif::ibm-power-vs[]
 ifdef::ibm-power-vs[]
 The default value is `OVNKubernetes`.
@@ -309,7 +307,7 @@ An IPv4 network.
 endif::agent,bare[]
 
 ifdef::agent,bare[]
-If you use the OpenShift SDN network plugin, specify an IPv4 network. If you use the OVN-Kubernetes network plugin, you can specify IPv4 and IPv6 networks.
+If you use the OVN-Kubernetes network plugin, you can specify IPv4 and IPv6 networks.
 endif::agent,bare[]
 |
 An IP address block in Classless Inter-Domain Routing (CIDR) notation.
@@ -339,7 +337,7 @@ endif::agent,bare[]
 |
 The IP address block for services. The default value is `172.30.0.0/16`.
 
-The OpenShift SDN and OVN-Kubernetes network plugins support only a single IP address block for the service network.
+The OVN-Kubernetes network plugins supports only a single IP address block for the service network.
 
 ifdef::agent,bare[]
 If you use the OVN-Kubernetes network plugin, you can specify an IP address block for both of the IPv4 and IPv6 address families.

--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -148,7 +148,7 @@ endif::ibm-z-kvm[]
 |N/A
 |Network reachability tests
 
-.4+|TCP
+.3+|TCP
 |`1936`
 |Metrics
 
@@ -158,9 +158,6 @@ the Cluster Version Operator on port `9099`.
 
 |`10250`-`10259`
 |The default ports that Kubernetes reserves
-
-|`10256`
-|openshift-sdn
 
 .5+|UDP
 |`4789`

--- a/modules/nw-modifying-operator-install-config.adoc
+++ b/modules/nw-modifying-operator-install-config.adoc
@@ -55,22 +55,9 @@ metadata:
 spec:
 ----
 
-. Specify the advanced network configuration for your cluster in the `cluster-network-03-config.yml` file, such as in the following examples:
+. Specify the advanced network configuration for your cluster in the `cluster-network-03-config.yml` file, such as in the following example:
 +
 --
-.Specify a different VXLAN port for the OpenShift SDN network provider
-[source,yaml]
-----
-apiVersion: operator.openshift.io/v1
-kind: Network
-metadata:
-  name: cluster
-spec:
-  defaultNetwork:
-    openshiftSDNConfig:
-      vxlanPort: 4800
-----
-
 .Enable IPsec for the OVN-Kubernetes network provider
 [source,yaml]
 ----

--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -44,7 +44,8 @@ The CNO configuration inherits the following fields during cluster installation 
 
 `clusterNetwork`:: IP address pools from which pod IP addresses are allocated.
 `serviceNetwork`:: IP address pool for services.
-`defaultNetwork.type`:: Cluster network plugin, such as OpenShift SDN or OVN-Kubernetes.
+//Installation no longer supports SDN, so excluding it from install docs here
+`defaultNetwork.type`:: Cluster network plugin. `OVNKubernetes` is the only supported plugin during installation.
 
 // For the post installation assembly, no further content is provided.
 ifdef::post-install-network-configuration,operator[]
@@ -128,15 +129,11 @@ The values for the `defaultNetwork` object are defined in the following table:
 
 |`type`
 |`string`
-|Either `OpenShiftSDN` or `OVNKubernetes`. The {openshift-networking} network plugin is selected during installation. You can change this value by migrating from OpenShift SDN to OVN-Kubernetes. 
+|`OVNKubernetes`. The {openshift-networking} network plugin is selected during installation. This value cannot be changed after cluster installation.
 [NOTE]
 ====
-{product-title} uses the OVN-Kubernetes network plugin by default.
+{product-title} uses the OVN-Kubernetes network plugin by default. OpenShift SDN is no longer available as an installation choice for new clusters.
 ====
-
-|`openshiftSDNConfig`
-|`object`
-|This object is only valid for the OpenShift SDN network plugin.
 
 |`ovnKubernetesConfig`
 |`object`
@@ -144,6 +141,7 @@ The values for the `defaultNetwork` object are defined in the following table:
 
 |====
 
+ifdef::operator,post-installation-network-configuration[]
 [discrete]
 [id="nw-operator-configuration-parameters-for-openshift-sdn_{context}"]
 ==== Configuration for the OpenShift SDN network plugin
@@ -209,6 +207,7 @@ defaultNetwork:
     mtu: 1450
     vxlanPort: 4789
 ----
+endif::[]
 
 [discrete]
 [id="nw-operator-configuration-parameters-for-ovn-sdn_{context}"]
@@ -401,14 +400,13 @@ kind: Network
 metadata:
   name: cluster
 spec:
-  clusterNetwork: 
+  clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
-  serviceNetwork: 
+  serviceNetwork:
   - 172.30.0.0/16
-  networkType: OVNKubernetes 
+  networkType: OVNKubernetes
       clusterNetworkMTU: 8900
-    
 ----
 endif::operator[]
 endif::post-install-network-configuration[]


### PR DESCRIPTION
Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-9223

Link to docs preview:
[vSphere installation requirements](https://70848--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/upi-vsphere-installation-reqs#installation-network-connectivity-user-infra_upi-vsphere-installation-reqs)
[vSphere UPI network customization installation](https://70848--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/installing-vsphere-network-customizations#nw-operator-cr_installing-vsphere-network-customizations)
[Cluster network operator doc](https://70848--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/cluster-network-operator#nw-operator-cr_cluster-network-operator)
[Postinstallation network configuration](https://70848--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/network-configuration#nw-operator-cr_post-install-network-configuration)

QE review:
- [ ] QE has approved this change.
