### PR TITLE
OCPSTRAT-898 - Need to ensure ICSP and IDMS interoperate especially in multi-tenant scenario

### DIFF
--- a/modules/builds-image-source.adoc
+++ b/modules/builds-image-source.adoc
@@ -43,10 +43,7 @@ source:
 <5> The location of the file to be copied out of the referenced image.
 <6> An optional secret provided if credentials are needed to access the input image.
 +
-[NOTE]
-====
-If your cluster uses an `ImageDigestMirrorSet` or `ImageTagMirrorSet` object to configure repository mirroring, you can use only global pull secrets for mirrored registries. You cannot add a pull secret to a project.
-====
+include::snippets/idms-global-pull-secret.adoc[]
 
 .Images that require pull secrets
 

--- a/modules/images-configuration-registry-mirror-configuring.adoc
+++ b/modules/images-configuration-registry-mirror-configuring.adoc
@@ -1,0 +1,265 @@
+// Module included in the following assemblies:
+//
+// * openshift_images/image-configuration.adoc
+// * post_installation_configuration/preparing-for-users.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="images-configuration-registry-mirror-configuring_{context}"]
+= Configuring image registry repository mirroring
+
+You can create postinstallation mirror configuration custom resources (CR) to redirect image pull requests from a source image registry to a mirrored image registry.
+
+.Prerequisites
+ifndef::openshift-rosa,openshift-dedicated[]
+* Access to the cluster as a user with the `cluster-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* Access to the cluster as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+
+.Procedure
+
+. Configure mirrored repositories, by either:
++
+* Setting up a mirrored repository with Red Hat Quay, as described in link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/manage_red_hat_quay/repo-mirroring-in-red-hat-quay[Red Hat Quay Repository Mirroring]. Using Red Hat Quay allows you to copy images from one repository to another and also automatically sync those repositories repeatedly over time.
+
+* Using a tool such as `skopeo` to copy images manually from the source repository to the mirrored repository.
++
+For example, after installing the skopeo RPM package on a Red Hat Enterprise Linux (RHEL) 7 or RHEL 8 system, use the `skopeo` command as shown in this example:
++
+[source,terminal]
+----
+$ skopeo copy \
+docker://registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:5cf... \
+docker://example.io/example/ubi-minimal
+----
++
+In this example, you have a container image registry that is named `example.io` with an image repository named `example` to which you want to copy the `ubi9/ubi-minimal` image from `registry.access.redhat.com`. After you create the mirrored registry, you can configure your {product-title} cluster to redirect requests made of the source repository to the mirrored repository.
+
+. Log in to your {product-title} cluster.
+
+. Create a postinstallation mirror configuration CR, by using one of the following examples:
+
+* Create an `ImageDigestMirrorSet` or `ImageTagMirrorSet` CR, as needed, replacing the source and mirrors with your own registry and repository pairs and images:
++
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1 <1>
+kind: ImageDigestMirrorSet <2>
+metadata:
+  name: ubi9repo
+spec:
+  imageDigestMirrors: <3>
+  - mirrors:
+    - example.io/example/ubi-minimal <4>
+    - example.com/example/ubi-minimal <5>
+    source: registry.access.redhat.com/ubi9/ubi-minimal <6>
+    mirrorSourcePolicy: AllowContactingSource <7>
+  - mirrors:
+    - mirror.example.com/redhat
+    source: registry.redhat.io/openshift4 <8>
+    mirrorSourcePolicy: AllowContactingSource
+  - mirrors:
+    - mirror.example.com
+    source: registry.redhat.io <9>
+    mirrorSourcePolicy: AllowContactingSource
+  - mirrors:
+    - mirror.example.net/image
+    source: registry.example.com/example/myimage <10>
+    mirrorSourcePolicy: AllowContactingSource
+  - mirrors:
+    - mirror.example.net
+    source: registry.example.com/example <11>
+    mirrorSourcePolicy: AllowContactingSource
+  - mirrors:
+    - mirror.example.net/registry-example-com
+    source: registry.example.com <12>
+    mirrorSourcePolicy: AllowContactingSource
+----
+<1> Indicates the API to use with this CR. This must be `config.openshift.io/v1`.
+<2> Indicates the kind of object according to the pull type:
+** `ImageDigestMirrorSet`: Pulls a digest reference image.
+** `ImageTagMirrorSet`: Pulls a tag reference image.
+<3> Indicates the type of image pull method, either:
+** `imageDigestMirrors`: Use for an `ImageDigestMirrorSet` CR.
+** `imageTagMirrors`: Use for an `ImageTagMirrorSet` CR.
+<4> Indicates the name of the mirrored image registry and repository.
+<5> Optional: Indicates a secondary mirror repository for each target repository. If one mirror is down, the target repository can use another mirror.
+<6> Indicates the registry and repository source, which is the repository that is referred to in image pull specifications.
+<7> Optional: Indicates the fallback policy if the image pull fails:
+** `AllowContactingSource`: Allows continued attempts to pull the image from the source repository. This is the default.
+** `NeverContactSource`: Prevents continued attempts to pull the image from the source repository.
+<8> Optional: Indicates a namespace inside a registry, which allows you to use any image in that namespace. If you use a registry domain as a source, the object is applied to all repositories from the registry.
+<9> Optional: Indicates a registry, which allows you to use any image in that registry. If you specify a registry name, the object is applied to all repositories from a source registry to a mirror registry.
+<10> Pulls the image `registry.example.com/example/myimage@sha256:...` from the mirror `mirror.example.net/image@sha256:..`.
+<11> Pulls the image `registry.example.com/example/image@sha256:...` in the source registry namespace from the mirror `mirror.example.net/image@sha256:...`.
+<12> Pulls the image `registry.example.com/myimage@sha256` from the mirror registry `example.net/registry-example-com/myimage@sha256:...`. 
+
+* Create an `ImageContentSourcePolicy` custom resource, replacing the source and mirrors with your own registry and repository pairs and images:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ImageContentSourcePolicy
+metadata:
+  name: mirror-ocp
+spec:
+  repositoryDigestMirrors:
+  - mirrors:
+    - mirror.registry.com:443/ocp/release <1>
+    source: quay.io/openshift-release-dev/ocp-release <2>
+  - mirrors:
+    - mirror.registry.com:443/ocp/release
+    source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+----
+<1> Specifies the name of the mirror image registry and repository.
+<2> Specifies the online registry and repository containing the content that is mirrored.
+
+. Create the new object:
++
+[source,terminal]
+----
+$ oc create -f registryrepomirror.yaml
+----
++
+After the object is created, the Machine Config Operator (MCO) drains the nodes for `ImageTagMirrorSet` objects only. The MCO does not drain the nodes for `ImageDigestMirrorSet` and `ImageContentSourcePolicy` objects.
+
+. To check that the mirrored configuration settings are applied, do the following on one of the nodes.
+
+.. List your nodes:
++
+[source,terminal]
+----
+$ oc get node
+----
++
+.Example output
+[source,terminal]
+----
+NAME                           STATUS                     ROLES    AGE  VERSION
+ip-10-0-137-44.ec2.internal    Ready                      worker   7m   v1.28.5
+ip-10-0-138-148.ec2.internal   Ready                      master   11m  v1.28.5
+ip-10-0-139-122.ec2.internal   Ready                      master   11m  v1.28.5
+ip-10-0-147-35.ec2.internal    Ready                      worker   7m   v1.28.5
+ip-10-0-153-12.ec2.internal    Ready                      worker   7m   v1.28.5
+ip-10-0-154-10.ec2.internal    Ready                      master   11m  v1.28.5
+----
+
+.. Start the debugging process to access the node:
++
+[source,terminal]
+----
+$ oc debug node/ip-10-0-147-35.ec2.internal
+----
++
+.Example output
+[source,terminal]
+----
+Starting pod/ip-10-0-147-35ec2internal-debug ...
+To use host binaries, run `chroot /host`
+----
+
+.. Change your root directory to `/host`:
++
+[source,terminal]
+----
+sh-4.2# chroot /host
+----
+
+.. Check the `/etc/containers/registries.conf` file to make sure the changes were made:
++
+[source,terminal]
+----
+sh-4.2# cat /etc/containers/registries.conf
+----
++
+The following output represents a `registries.conf` file where postinstallation mirror configuration CRs were applied. The final two entries are marked `digest-only` and `tag-only` respectively.
++
+.Example output
+[source,terminal]
+----
+unqualified-search-registries = ["registry.access.redhat.com", "docker.io"]
+short-name-mode = ""
+
+[[registry]]
+  prefix = ""
+  location = "registry.access.redhat.com/ubi9/ubi-minimal" <1>
+
+  [[registry.mirror]]
+    location = "example.io/example/ubi-minimal" <2>
+    pull-from-mirror = "digest-only" <3>
+
+  [[registry.mirror]]
+    location = "example.com/example/ubi-minimal"
+    pull-from-mirror = "digest-only"
+
+[[registry]]
+  prefix = ""
+  location = "registry.example.com"
+
+  [[registry.mirror]]
+    location = "mirror.example.net/registry-example-com"
+    pull-from-mirror = "digest-only"
+
+[[registry]]
+  prefix = ""
+  location = "registry.example.com/example"
+
+  [[registry.mirror]]
+    location = "mirror.example.net"
+    pull-from-mirror = "digest-only"
+
+[[registry]]
+  prefix = ""
+  location = "registry.example.com/example/myimage"
+
+  [[registry.mirror]]
+    location = "mirror.example.net/image"
+    pull-from-mirror = "digest-only"
+
+[[registry]]
+  prefix = ""
+  location = "registry.redhat.io"
+
+  [[registry.mirror]]
+    location = "mirror.example.com"
+    pull-from-mirror = "digest-only"
+
+[[registry]]
+  prefix = ""
+  location = "registry.redhat.io/openshift4"
+
+  [[registry.mirror]]
+    location = "mirror.example.com/redhat"
+    pull-from-mirror = "digest-only"
+[[registry]]
+  prefix = ""
+  location = "registry.access.redhat.com/ubi9/ubi-minimal"
+  blocked = true <4>
+
+  [[registry.mirror]]
+    location = "example.io/example/ubi-minimal-tag"
+    pull-from-mirror = "tag-only" <5>
+----
+<1> Indicates the repository that is referred to in a pull spec.
+<2> Indicates the mirror for that repository.
+<3> Indicates that the image pull from the mirror is a digest reference image.
+<4> Indicates that the `NeverContactSource` parameter is set for this repository.
+<5> Indicates that the image pull from the mirror is a tag reference image.
+
+.. Pull an image to the node from the source and check if it is resolved by the mirror.
++
+[source,terminal]
+----
+sh-4.2# podman pull --log-level=debug registry.access.redhat.com/ubi9/ubi-minimal@sha256:5cf...
+----
+
+.Troubleshooting repository mirroring
+
+If the repository mirroring procedure does not work as described, use the following information about how repository mirroring works to help troubleshoot the problem.
+
+* The first working mirror is used to supply the pulled image.
+* The main registry is only used if no other mirror works.
+* From the system context, the `Insecure` flags are used as fallback.
+* The format of the `/etc/containers/registries.conf` file has changed recently. It is now version 2 and in TOML format.

--- a/modules/images-configuration-registry-mirror-convert.adoc
+++ b/modules/images-configuration-registry-mirror-convert.adoc
@@ -12,6 +12,8 @@ Using an `ImageContentSourcePolicy` (ICSP) object to configure repository mirror
 
 ICSP objects are being replaced by `ImageDigestMirrorSet` and `ImageTagMirrorSet` objects to configure repository mirroring. If you have existing YAML files that you used to create `ImageContentSourcePolicy` objects, you can use the `oc adm migrate icsp` command to convert those files to an `ImageDigestMirrorSet` YAML file. The command updates the API to the current version, changes the `kind` value to `ImageDigestMirrorSet`, and changes `spec.repositoryDigestMirrors` to `spec.imageDigestMirrors`. The rest of the file is not changed.
 
+Because the migration does not change the `registries.conf` file, the cluster does not need to reboot. 
+
 For more information about `ImageDigestMirrorSet` or `ImageTagMirrorSet` objects, see "Configuring image registry repository mirroring" in the previous section.
 
 .Prerequisites
@@ -68,4 +70,7 @@ where:
 `<path_to_the_directory>`:: Specifies the path to the directory, if you used the `--dest-dir` flag.
 `<file_name>`:: Specifies the name of the `ImageDigestMirrorSet` YAML.
 --
+
+. Remove the ICSP objects after the IDMS objects are rolled out.
+
 

--- a/modules/images-configuration-registry-mirror.adoc
+++ b/modules/images-configuration-registry-mirror.adoc
@@ -4,9 +4,9 @@
 // * post_installation_configuration/preparing-for-users.adoc
 // * updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="images-configuration-registry-mirror_{context}"]
-= Configuring image registry repository mirroring
+= Understanding image registry repository mirroring
 
 Setting up container registry repository mirroring enables you to perform the following tasks:
 
@@ -29,12 +29,14 @@ By pulling container images needed by {product-title} and then bringing those im
 
 * After {product-title} installation:
 +
-If you did not configure mirroring during {product-title} installation, you can do so postinstallation by using one of the following custom resource (CR) objects:
+If you did not configure mirroring during {product-title} installation, you can do so postinstallation by using any of the following custom resource (CR) objects:
 +
 --
-** `ImageDigestMirrorSet`. This CR allows you to pull images from a mirrored registry by using digest specifications.
+** `ImageDigestMirrorSet` (IDMS). This object allows you to pull images from a mirrored registry by using digest specifications. The IDMS CR enables you to set a fall back policy that allows or stops continued attempts to pull from the source registry if the image pull fails.
 +
-** `ImageTagMirrorSet`. This CR allows you to pull images from a mirrored registry by using image tags.
+** `ImageTagMirrorSet` (ITMS). This object allows you to pull images from a mirrored registry by using image tags. The ITMS CR enables you to set a fall back policy that allows or stops continued attempts to pull from the source registry if the image pull fails.
++
+** `ImageContentSourcePolicy` (ICSP). This object allows you to pull images from a mirrored registry by using digest specifications. An ICSP always falls back to the source registry if the mirrors do not work.
 --
 +
 [IMPORTANT]
@@ -42,263 +44,15 @@ If you did not configure mirroring during {product-title} installation, you can 
 Using an `ImageContentSourcePolicy` (ICSP) object to configure repository mirroring is a deprecated feature. Deprecated functionality is still included in {product-title} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments. If you have existing YAML files that you used to create `ImageContentSourcePolicy` objects, you can use the `oc adm migrate icsp` command to convert those files to an `ImageDigestMirrorSet` YAML file. For more information, see "Converting ImageContentSourcePolicy (ICSP) files for image registry repository mirroring" in the following section.
 ====
 
-Both of these custom resource objects identify the following information:
+Each of these custom resource objects identify the following information:
 --
 * The source of the container image repository you want to mirror.
 * A separate entry for each mirror repository you want to offer the content
 requested from the source repository.
 --
 
-[NOTE]
-====
-If your cluster uses an `ImageDigestMirrorSet` or `ImageTagMirrorSet` object to configure repository mirroring, you can use only global pull secrets for mirrored registries. You cannot add a pull secret to a project.
-====
+For new clusters, you can use IDMS, ITMS, and ICSP CRs objects as desired. However, using IDMS and ITMS is recommended.
 
-The following procedure creates a postinstallation mirror configuration, where you create an `ImageDigestMirrorSet` object.
+If you upgraded a cluster, any existing ICSP objects remain stable, and both IDMS and ICSP objects are supported. Workloads using ICSP objects continue to function as expected. However, if you want to take advantage of the fallback policies introduced in the IDMS CRs, you can migrate current workloads to IDMS objects by using the `oc adm migrate icsp` command as shown in the *Converting ImageContentSourcePolicy (ICSP) files for image registry repository mirroring* section that follows. Migrating to IDMS objects does not require a cluster reboot. 
 
-.Prerequisites
-ifndef::openshift-rosa,openshift-dedicated[]
-* Access to the cluster as a user with the `cluster-admin` role.
-endif::openshift-rosa,openshift-dedicated[]
-ifdef::openshift-rosa,openshift-dedicated[]
-* Access to the cluster as a user with the `dedicated-admin` role.
-endif::openshift-rosa,openshift-dedicated[]
-
-* Ensure that there are no `ImageContentSourcePolicy` objects on your cluster. For example, you can use the following command:
-+
-[source,terminal]
-----
-$ oc get ImageContentSourcePolicy
-----
-+
-.Example output
-[source,terminal]
-----
-No resources found
-----
-
-.Procedure
-
-. Configure mirrored repositories, by either:
-+
-* Setting up a mirrored repository with Red Hat Quay, as described in link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/manage_red_hat_quay/repo-mirroring-in-red-hat-quay[Red Hat Quay Repository Mirroring]. Using Red Hat Quay allows you to copy images from one repository to another and also automatically sync those repositories repeatedly over time.
-* Using a tool such as `skopeo` to copy images manually from the source directory to the mirrored repository.
-+
-For example, after installing the skopeo RPM package on a Red Hat Enterprise Linux (RHEL) 7 or RHEL 8 system, use the `skopeo` command as shown in this example:
-+
-[source,terminal]
-----
-$ skopeo copy \
-docker://registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:5cf... \
-docker://example.io/example/ubi-minimal
-----
-+
-In this example, you have a container image registry that is named `example.io` with an image repository named `example` to which you want to copy the `ubi9/ubi-minimal` image from `registry.access.redhat.com`. After you create the registry, you can configure your {product-title} cluster to redirect requests made of the source repository to the mirrored repository.
-
-. Log in to your {product-title} cluster.
-
-. Create an `ImageDigestMirrorSet` or `ImageTagMirrorSet` CR, as needed, replacing the source and mirrors with your own registry and repository pairs and images:
-+
-[source,yaml]
-----
-apiVersion: config.openshift.io/v1 <1>
-kind: ImageDigestMirrorSet <2>
-metadata:
-  name: ubi9repo
-spec:
-  imageDigestMirrors: <3>
-  - mirrors:
-    - example.io/example/ubi-minimal <4>
-    - example.com/example/ubi-minimal <5>
-    source: registry.access.redhat.com/ubi9/ubi-minimal <6>
-    mirrorSourcePolicy: AllowContactingSource <7>
-  - mirrors:
-    - mirror.example.com/redhat
-    source: registry.redhat.io/openshift4 <8>
-    mirrorSourcePolicy: AllowContactingSource
-  - mirrors:
-    - mirror.example.com
-    source: registry.redhat.io <9>
-    mirrorSourcePolicy: AllowContactingSource
-  - mirrors:
-    - mirror.example.net/image
-    source: registry.example.com/example/myimage <10>
-    mirrorSourcePolicy: AllowContactingSource
-  - mirrors:
-    - mirror.example.net
-    source: registry.example.com/example <11>
-    mirrorSourcePolicy: AllowContactingSource
-  - mirrors:
-    - mirror.example.net/registry-example-com
-    source: registry.example.com <12>
-    mirrorSourcePolicy: AllowContactingSource
-----
-<1> Indicates the API to use with this CR. This must be `config.openshift.io/v1`.
-<2> Indicates the kind of object according to the pull type:
-** `ImageDigestMirrorSet`: Pulls a digest reference image.
-** `ImageTagMirrorSet`: Pulls a tag reference image.
-<3> Indicates the type of image pull method, either:
-** `imageDigestMirrors`: Use for an `ImageDigestMirrorSet` CR.
-** `imageTagMirrors`: Use for an `ImageTagMirrorSet` CR.
-<4> Indicates the name of the mirrored image registry and repository.
-<5> Optional: Indicates a secondary mirror repository for each target repository. If one mirror is down, the target repository can use another mirror.
-<6> Indicates the registry and repository source, which is the repository that is referred to in image pull specifications.
-<7> Optional: Indicates the fallback policy if the image pull fails:
-** `AllowContactingSource`: Allows continued attempts to pull the image from the source repository. This is the default.
-** `NeverContactSource`: Prevents continued attempts to pull the image from the source repository.
-<8> Optional: Indicates a namespace inside a registry, which allows you to use any image in that namespace. If you use a registry domain as a source, the object is applied to all repositories from the registry.
-<9> Optional: Indicates a registry, which allows you to use any image in that registry. If you specify a registry name, the object is applied to all repositories from a source registry to a mirror registry.
-<10> Pulls the image `registry.example.com/example/myimage@sha256:...` from the mirror `mirror.example.net/image@sha256:..`.
-<11> Pulls the image `registry.example.com/example/image@sha256:...` in the source registry namespace from the mirror `mirror.example.net/image@sha256:...`.
-<12> Pulls the image `registry.example.com/myimage@sha256` from the mirror registry `example.net/registry-example-com/myimage@sha256:...`. The `ImageContentSourcePolicy` resource is applied to all repositories from a source registry to a mirror registry `mirror.example.net/registry-example-com`.
-
-. Create the new object:
-+
-[source,terminal]
-----
-$ oc create -f registryrepomirror.yaml
-----
-+
-After the object is created, the Machine Config Operator (MCO) cordons the nodes as the new settings are deployed to each node. The MCO restarts the nodes for an `ImageTagMirrorSet` object only. The MCO does not restart the nodes for `ImageDigestMirrorSet` objects. When the nodes are uncordoned, the cluster starts using the mirrored repository for requests to the source repository.
-
-. To check that the mirrored configuration settings are applied, do the following on one of the nodes.
-
-.. List your nodes:
-+
-[source,terminal]
-----
-$ oc get node
-----
-+
-.Example output
-[source,terminal]
-----
-NAME                           STATUS                     ROLES    AGE  VERSION
-ip-10-0-137-44.ec2.internal    Ready                      worker   7m   v1.28.5
-ip-10-0-138-148.ec2.internal   Ready                      master   11m  v1.28.5
-ip-10-0-139-122.ec2.internal   Ready                      master   11m  v1.28.5
-ip-10-0-147-35.ec2.internal    Ready                      worker   7m   v1.28.5
-ip-10-0-153-12.ec2.internal    Ready                      worker   7m   v1.28.5
-ip-10-0-154-10.ec2.internal    Ready                      master   11m  v1.28.5
-----
-
-.. Start the debugging process to access the node:
-+
-[source,terminal]
-----
-$ oc debug node/ip-10-0-147-35.ec2.internal
-----
-+
-.Example output
-[source,terminal]
-----
-Starting pod/ip-10-0-147-35ec2internal-debug ...
-To use host binaries, run `chroot /host`
-----
-
-.. Change your root directory to `/host`:
-+
-[source,terminal]
-----
-sh-4.2# chroot /host
-----
-
-.. Check the `/etc/containers/registries.conf` file to make sure
-the changes were made:
-+
-[source,terminal]
-----
-sh-4.2# cat /etc/containers/registries.conf
-----
-+
-The following output represents a `registries.conf` file where an `ImageDigestMirrorSet` object and an `ImageTagMirrorSet` object were applied. The final two entries are marked `digest-only` and `tag-only` respectively.
-+
-.Example output
-[source,terminal]
-----
-unqualified-search-registries = ["registry.access.redhat.com", "docker.io"]
-short-name-mode = ""
-
-[[registry]]
-  prefix = ""
-  location = "registry.access.redhat.com/ubi9/ubi-minimal" <1>
-
-  [[registry.mirror]]
-    location = "example.io/example/ubi-minimal" <2>
-    pull-from-mirror = "digest-only" <3>
-
-  [[registry.mirror]]
-    location = "example.com/example/ubi-minimal"
-    pull-from-mirror = "digest-only"
-
-[[registry]]
-  prefix = ""
-  location = "registry.example.com"
-
-  [[registry.mirror]]
-    location = "mirror.example.net/registry-example-com"
-    pull-from-mirror = "digest-only"
-
-[[registry]]
-  prefix = ""
-  location = "registry.example.com/example"
-
-  [[registry.mirror]]
-    location = "mirror.example.net"
-    pull-from-mirror = "digest-only"
-
-[[registry]]
-  prefix = ""
-  location = "registry.example.com/example/myimage"
-
-  [[registry.mirror]]
-    location = "mirror.example.net/image"
-    pull-from-mirror = "digest-only"
-
-[[registry]]
-  prefix = ""
-  location = "registry.redhat.io"
-
-  [[registry.mirror]]
-    location = "mirror.example.com"
-    pull-from-mirror = "digest-only"
-
-[[registry]]
-  prefix = ""
-  location = "registry.redhat.io/openshift4"
-
-  [[registry.mirror]]
-    location = "mirror.example.com/redhat"
-    pull-from-mirror = "digest-only"
-[[registry]]
-  prefix = ""
-  location = "registry.access.redhat.com/ubi9/ubi-minimal"
-  blocked = true <4>
-
-  [[registry.mirror]]
-    location = "example.io/example/ubi-minimal-tag"
-    pull-from-mirror = "tag-only" <5>
-----
-<1> Indicates the repository that is referred to in a pull spec.
-<2> Indicates the mirror for that repository.
-<3> Indicates that the image pull from the mirror is a digest reference image.
-<4> Indicates that the `NeverContactSource` parameter is set for this repository.
-<5> Indicates that the image pull from the mirror is a tag reference image.
-
-.. Pull an image to the node from the source and check if it is resolved by the mirror.
-+
-[source,terminal]
-----
-sh-4.2# podman pull --log-level=debug registry.access.redhat.com/ubi9/ubi-minimal@sha256:5cf...
-----
-
-.Troubleshooting repository mirroring
-
-If the repository mirroring procedure does not work as described, use the following information about how repository mirroring works to help troubleshoot the problem.
-
-* The first working mirror is used to supply the pulled image.
-* The main registry is only used if no other mirror works.
-* From the system context, the `Insecure` flags are used as fallback.
-* The format of the `/etc/containers/registries.conf` file has changed recently. It is now version 2 and in TOML format.
-* You cannot add the same repository to both an `ImageDigestMirrorSet` and an `ImageTagMirrorSet` object.
-
+include::snippets/idms-global-pull-secret.adoc[]

--- a/openshift_images/image-configuration.adoc
+++ b/openshift_images/image-configuration.adoc
@@ -27,7 +27,7 @@ include::modules/images-configuration-shortname.adoc[leveloffset=+2]
 
 include::modules/images-configuration-cas.adoc[leveloffset=+2]
 
-include::modules/images-configuration-registry-mirror.adoc[leveloffset=+2]
+include::modules/images-configuration-registry-mirror.adoc[leveloffset=+1]
 
 ifndef::openshift-rosa,openshift-dedicated[]
 [role="_additional-resources"]
@@ -35,6 +35,8 @@ ifndef::openshift-rosa,openshift-dedicated[]
 
 * For more information about global pull secrets, see xref:../openshift_images/managing_images/using-image-pull-secrets.adoc#images-update-global-pull-secret_using-image-pull-secrets[Updating the global cluster pull secret].
 endif::openshift-rosa,openshift-dedicated[]
+
+include::modules/images-configuration-registry-mirror-configuring.adoc[leveloffset=+2]
 
 include::modules/images-configuration-registry-mirror-convert.adoc[leveloffset=+2]
 

--- a/post_installation_configuration/preparing-for-users.adoc
+++ b/post_installation_configuration/preparing-for-users.adoc
@@ -130,7 +130,9 @@ For more information on the allowed, blocked, and insecure registry parameters, 
 
 include::modules/images-configuration-cas.adoc[leveloffset=+2]
 
-include::modules/images-configuration-registry-mirror.adoc[leveloffset=+2]
+include::modules/images-configuration-registry-mirror.adoc[leveloffset=+1]
+
+include::modules/images-configuration-registry-mirror-configuring.adoc[leveloffset=+2]
 
 include::modules/images-configuration-registry-mirror-convert.adoc[leveloffset=+2]
 

--- a/snippets/idms-global-pull-secret.adoc
+++ b/snippets/idms-global-pull-secret.adoc
@@ -1,0 +1,12 @@
+// Text snippet included in the following modules:
+//
+// * modules/builds-image-source
+// * modules/images-configuration-registry-mirror
+
+:_mod-docs-content-type: SNIPPET
+
+
+[NOTE]
+====
+If your cluster uses an `ImageDigestMirrorSet`, `ImageTagMirrorSet`, or `ImageContentSourcePolicy` object to configure repository mirroring, you can use only global pull secrets for mirrored registries. You cannot add a pull secret to a project.
+====

--- a/snippets/node-icsp-no-drain.adoc
+++ b/snippets/node-icsp-no-drain.adoc
@@ -1,7 +1,7 @@
 // Text snippet included in the following modules:
 //
-// * modules/about-crio.adoc
-// * modules/nodes-containers-using.adoc
+// * modules/understanding-machine-config-operator.adoc
+// * modules/troubleshooting-disabling-autoreboot-mco.adoc
 
 :_mod-docs-content-type: SNIPPET
 
@@ -13,8 +13,7 @@ The following modifications do not trigger a node reboot:
 ** Changes to the global pull secret or pull secret in the `openshift-config` namespace.
 ** Automatic rotation of the `/etc/kubernetes/kubelet-ca.crt` certificate authority (CA) by the Kubernetes API Server Operator.
 
-* When the MCO detects changes to the `/etc/containers/registries.conf` file, such as adding or editing an `ImageDigestMirrorSet` or `ImageTagMirrorSet` object, it drains the corresponding nodes, applies the changes, and uncordons the nodes.The node drain does not happen for the following changes:
+* When the MCO detects changes to the `/etc/containers/registries.conf` file, such as adding or editing an `ImageDigestMirrorSet`, `ImageTagMirrorSet`, or `ImageContentSourcePolicy` object, it drains the corresponding nodes, applies the changes, and uncordons the nodes. The node drain does not happen for the following changes:
 ** The addition of a registry with the `pull-from-mirror = "digest-only"` parameter set for each mirror.
 ** The addition of a mirror with the `pull-from-mirror = "digest-only"` parameter set in a registry.
 ** The addition of items to the `unqualified-search-registries` list.
-

--- a/updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update.adoc
+++ b/updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update.adoc
@@ -50,8 +50,11 @@ include::modules/update-restricted.adoc[leveloffset=+1]
 
 * xref:../../../updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc#mirroring-ocp-image-repository[Mirroring {product-title} images]
 
-// Configuring image registry repository mirroring
+// Understanding image registry repository mirroring
 include::modules/images-configuration-registry-mirror.adoc[leveloffset=+1]
+
+// Configuring image registry repository mirroring
+include::modules/images-configuration-registry-mirror-configuring.adoc[leveloffset=+2]
 
 // Converting ImageContentSourcePolicy (ICSP) files for image registry repository mirroring
 include::modules/images-configuration-registry-mirror-convert.adoc[leveloffset=+2]


### PR DESCRIPTION
Because the ICSP functionality cannot be removed from the API in 4.x, IDMS/ITMS objects can now exist with ICSP. This PR removes the requirement to delete ICMPs before using IDMS/ITMS objects, replaces references to ICSP in places where [they were removed](https://github.com/openshift/openshift-docs/pull/56250/files). 

[OSDOCS-8697 - update Openshift document about migration details](https://issues.redhat.com/browse/OSDOCS-8697)
[OCPSTRAT-898 - Need to ensure ICSP and IDMS interoperate especially in multi-tenant scenario](https://issues.redhat.com/browse/OCPSTRAT-898)


Previews:
CI/CD -> Builds using BuildConfig -> Creating build inputs -> Builds using BuildConfig -> [Image source](https://70881--ocpdocs-pr.netlify.app/openshift-enterprise/latest/cicd/builds/creating-build-inputs#builds-image-source_creating-build-inputs) -- Replaced text with _you can use only global pull secrets_ snippet.

Images -> Image configuration resources -> [Configuring image registry repository mirroring](https://70881--ocpdocs-pr.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration#images-configuration-registry-mirror_image-configuration) -- Other than the following, the text is unchanged:
* Removed conceptual material and moved to a new module
* Removed prereq about `ImageContentSourcePolicy` objects 
* Added ICSP references/example to step 3 
* Replaced text with _you can use only global pull secrets_ snippet.

[Converting ImageContentSourcePolicy (ICSP) files for image registry repository mirroring
](https://70881--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/preparing-for-users#images-configuration-registry-mirror-convert_post-install-preparing-for-users) -- Added two sentences:
* Because the migration results 
* Step 3

[Understanding image registry repository mirroring](https://70881--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/preparing-for-users#images-configuration-registry-mirror_post-install-preparing-for-users) -- New concept module based largely on existing text. 
* Some updated to text to put info on ICSP into the docs.
* Moved prereq and procedure to new module.
* Added final two paragraphs.
* Added the  _you can use only global pull secrets_ snippet.

Architecture -> Control plane architecture -> [About the Machine Config Operator](https://70881--ocpdocs-pr.netlify.app/openshift-enterprise/latest/architecture/control-plane#about-machine-config-operator_control-plane) - Updated the _The following modifications do not trigger a node reboot_ snippet. 

Renamed _Configuring image registry repository mirroring_ to _Understanding image registry repository mirroring_ and promoted to H2 level. Added new _Configuring image registry repository mirroring_ procedural module. For the following assemblies:
[Preparing for users](https://70881--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/preparing-for-users#images-configuration-registry-mirror_post-install-preparing-for-users)  [Current docs](https://docs.openshift.com/container-platform/4.14/post_installation_configuration/preparing-for-users.html#images-configuration-registry-mirror_post-install-preparing-for-users).
[Updating a cluster in a disconnected environment without the OpenShift Update Service
](https://70881--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update#images-configuration-registry-mirror_updating-restricted-network-cluster) [Current docs](https://docs.openshift.com/container-platform/4.14/updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update.html#images-configuration-registry-mirror_updating-restricted-network-cluster).
[Image configuration resources](https://70881--ocpdocs-pr.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration#images-configuration-registry-mirror_image-configuration)  [Current docs](https://docs.openshift.com/container-platform/4.14/openshift_images/image-configuration.html#images-configuration-registry-mirror_image-configuration).

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
