### PR TITLE
OSDOCS-9463: Fix Azure availabilitySet label in spec

### DIFF
--- a/modules/machineset-yaml-azure.adoc
+++ b/modules/machineset-yaml-azure.adoc
@@ -68,7 +68,7 @@ endif::infra[]
       metadata:
         creationTimestamp: null
         labels:
-          machine.openshift.io/cluster-api-machineset: <machineset_name> <4>
+          machine.openshift.io/cluster-api-machineset: <machineset_name>
 ifndef::infra[]
           node-role.kubernetes.io/<role>: "" <2>
 endif::infra[]
@@ -81,15 +81,15 @@ endif::infra[]
           credentialsSecret:
             name: azure-cloud-credentials
             namespace: openshift-machine-api
-          image: <5>
+          image: <4>
             offer: ""
             publisher: ""
-            resourceID: /resourceGroups/<infrastructure_id>-rg/providers/Microsoft.Compute/images/<infrastructure_id> <6>
+            resourceID: /resourceGroups/<infrastructure_id>-rg/providers/Microsoft.Compute/images/<infrastructure_id> <5>
             sku: ""
             version: ""
           internalLoadBalancer: ""
           kind: AzureMachineProviderSpec
-          location: <region> <7>
+          location: <region> <6>
           managedIdentity: <infrastructure_id>-identity <1>
           metadata:
             creationTimestamp: null
@@ -106,16 +106,16 @@ endif::infra[]
           sshPrivateKey: ""
           sshPublicKey: ""
           tags:
-            - name: <custom_tag_name> <9>
-              value: <custom_tag_value> <9>
+            - name: <custom_tag_name> <8>
+              value: <custom_tag_value> <8>
           subnet: <infrastructure_id>-<role>-subnet <1> <2>
           userDataSecret:
             name: worker-user-data <2>
           vmSize: Standard_D4s_v3
           vnet: <infrastructure_id>-vnet <1>
-          zone: "1" <8>
+          zone: "1" <7>
 ifdef::infra[]
-      taints: <10>
+      taints: <9>
       - key: node-role.kubernetes.io/infra
         effect: NoSchedule
 endif::infra[]
@@ -151,14 +151,13 @@ ifdef::infra[]
 <2> Specify the `<infra>` node label.
 <3> Specify the infrastructure ID, `<infra>` node label, and region.
 endif::infra[]
-<4> Optional: Specify the compute machine set name to enable the use of availability sets. This setting only applies to new compute machines.
-<5> Specify the image details for your compute machine set. If you want to use an Azure Marketplace image, see "Selecting an Azure Marketplace image".
-<6> Specify an image that is compatible with your instance type. The Hyper-V generation V2 images created by the installation program have a `-gen2` suffix, while V1 images have the same name without the suffix.
-<7> Specify the region to place machines on.
-<8> Specify the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
-<9> Optional: Specify custom tags in your machine set. Provide the tag name in `<custom_tag_name>` field and the corresponding tag value in `<custom_tag_value>` field.
+<4> Specify the image details for your compute machine set. If you want to use an Azure Marketplace image, see "Selecting an Azure Marketplace image".
+<5> Specify an image that is compatible with your instance type. The Hyper-V generation V2 images created by the installation program have a `-gen2` suffix, while V1 images have the same name without the suffix.
+<6> Specify the region to place machines on.
+<7> Specify the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
+<8> Optional: Specify custom tags in your machine set. Provide the tag name in `<custom_tag_name>` field and the corresponding tag value in `<custom_tag_value>` field.
 ifdef::infra[]
-<10> Specify a taint to prevent user workloads from being scheduled on infra nodes.
+<9> Specify a taint to prevent user workloads from being scheduled on infra nodes.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):
4.11+

Issue:
[OSDOCS-9463](https://issues.redhat.com//browse/OSDOCS-9463)

Link to docs preview:
[Sample YAML for a compute machine set custom resource on Azure](https://70883--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure.html#machineset-yaml-azure_creating-machineset-azure) (removes callout `<4>` and renumbers after)

QE review:
- [ ] QE has approved this change.

Additional information: