### PR TITLE
OCP 4.15: IPI for PowerVS updates

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -177,11 +177,6 @@ ifdef::ibm-power-vs[]
 |Specifies the {ibm-cloud-name} colo region where the cluster will be created.
 |String. For example, `existing_zone`.
 
-|platform:
-  powervs:
-    serviceInstanceID:
-|The ServiceInstanceID is the ID of the Power IAAS instance created from the {ibm-cloud-name} Catalog.
-|String. For example, `existing_service_instance_ID`.
 endif::ibm-power-vs[]
 |====
 
@@ -515,6 +510,12 @@ accounts for the dramatically decreased machine performance.
 ====
 |`Enabled` or `Disabled`
 endif::vsphere[]
+ifdef::ibm-power-vs[]
+|compute:
+  smtLevel:
+|The SMTLevel specifies the level of SMT to set to the control plane and compute machines. Valid values are 1, 2, 3, 4, 5, 6, 7, 8, `off`, and `on`.
+|String
+endif::ibm-power-vs[]
 
 |compute:
   name:
@@ -726,9 +727,9 @@ ifdef::ibm-power-vs[]
 
 |platform:
   powervs:
-    cloudConnectionName:
-|The CloudConnectionName is the name of an existing PowerVS Cloud connection.
-|String. For example, `existing_cloudConnectionName`.
+    serviceInstanceGUID:
+|The ServiceInstanceGUID is the ID of the Power IAAS instance created from the {ibm-cloud-name} Catalog.
+|String. For example, `existing_service_instance_GUID`.
 
 |platform:
   powervs:
@@ -785,13 +786,6 @@ ifdef::aws,gcp,azure[]
 Setting this parameter to `Manual` enables alternatives to storing administrator-level secrets in the `kube-system` project, which require additional configuration steps. For more information, see "Alternatives to storing administrator-level secrets in the kube-system project".
 ====
 endif::aws,gcp,azure[]
-ifdef::ibm-power-vs[]
-+
-[NOTE]
-====
-Cloud connections are no longer supported in the `install-config.yaml` while deploying in the `dal10` region, as they have been replaced by the Power Edge Router (PER).
-====
-endif::ibm-power-vs[]
 --
 
 ifdef::aws[]

--- a/modules/installation-ibm-cloud-iam-policies-api-key.adoc
+++ b/modules/installation-ibm-cloud-iam-policies-api-key.adoc
@@ -114,7 +114,7 @@ ifdef::ibm-power-vs[]
 |<resource_group> (Resource Group Created for Your Team)
 
 |Viewer, Operator, Editor, Reader, Writer, Manager
-|All service in Default resource group
+|All Identity and IAM enabled services in Default resource group
 
 |Viewer, Reader
 |Internet Services service
@@ -126,13 +126,13 @@ ifdef::ibm-power-vs[]
 |Default resource group: The resource type should equal `Resource group`, with a value of `Default`. If your account administrator changed your account's default resource group to something other than Default, use that value instead.
 
 |Viewer, Operator, Editor, Reader, Manager
-|{ibm-power-server-name} service in <resource_group> resource group
+|Workspace for {ibm-power-server-name} service in <resource_group> resource group
 
 |Viewer, Operator, Editor, Reader, Writer, Manager, Administrator
 |Internet Services service in <resource_group> resource group: CIS functional scope string equals reliability
 
 |Viewer, Operator, Editor
-|Direct Link service
+|Transit Gateway service
 
 |Viewer, Operator, Editor, Administrator, Reader, Writer, Manager, Console Administrator
 |VPC Infrastructure Services service <resource_group> resource group

--- a/modules/installation-ibm-cloud-regions.adoc
+++ b/modules/installation-ibm-cloud-regions.adoc
@@ -40,29 +40,23 @@ ifdef::ibm-power-vs[]
 * `dal` (Dallas, USA)
 ** `dal10`
 ** `dal12`
-* `us-east` (Washington DC, USA)
-** `us-east`
 * `eu-de` (Frankfurt, Germany)
 ** `eu-de-1`
 ** `eu-de-2`
-* `lon` (London, UK)
-** `lon04`
-** `lon06`
-* `osa` (Osaka, Japan)
-** `osa21`
+* `mad` (Madrid, Spain)
+** `mad02`
+** `mad04`
 * `sao` (Sao Paulo, Brazil)
-** `sao01`
-* `syd` (Sydney, Australia)
-** `syd04`
-* `tok` (Tokyo, Japan)
-** `tok04`
-* `tor` (Toronto, Canada)
-** `tor01`
+** `sao04`
+* `wdc` (Washington DC, USA)
+** `wdc06`
+** `wdc07`
 
 You might optionally specify the {ibm-cloud-name} region in which the installer will create any VPC components. Supported regions in {ibm-cloud-name} are:
 
 * `us-south`
 * `eu-de`
+* `eu-es`
 * `eu-gb`
 * `jp-osa`
 * `au-syd`

--- a/modules/installation-ibm-power-vs-config-yaml.adoc
+++ b/modules/installation-ibm-power-vs-config-yaml.adoc
@@ -64,7 +64,7 @@ platform:
     region: powervs-region
     zone: powervs-zone
     powervsResourceGroup: "ibmcloud-resource-group" <5>
-    serviceInstanceID: "powervs-region-service-instance-id"
+    serviceInstanceGUID: "powervs-region-service-instance-guid"
 vpcRegion : vpc-region
 publish: External
 pullSecret: '{"auths": ...}' <6>
@@ -135,12 +135,11 @@ platform:
     powervsResourceGroup: "ibmcloud-resource-group"
     region: powervs-region
     vpcName: name-of-existing-vpc <6>
-    cloudConnectionName: powervs-region-example-cloud-con-priv
     vpcSubnets:
     - powervs-region-example-subnet-1
     vpcRegion : vpc-region
     zone: powervs-zone
-    serviceInstanceID: "powervs-region-service-instance-id"
+    serviceInstanceGUID: "powervs-region-service-instance-guid"
 publish: Internal <7>
 pullSecret: '{"auths": ...}' <8>
 sshKey: ssh-ed25519 AAAA... <9>
@@ -218,7 +217,7 @@ platform:
     vpcSubnets: <7>
     - powervs-region-example-subnet-1
     zone: powervs-zone
-    serviceInstanceID: "powervs-region-service-instance-id"
+    serviceInstanceGUID: "powervs-region-service-instance-guid"
 credentialsMode: Manual
 publish: External <8>
 pullSecret: '{"auths": ...}' <9>

--- a/modules/quotas-and-limits-ibm-power-vs.adoc
+++ b/modules/quotas-and-limits-ibm-power-vs.adoc
@@ -28,14 +28,9 @@ You can create additional `LoadBalancer` service objects to create additional AL
 VPC ALBs are supported. Classic ALBs are not supported for {ibm-power-server-name}.
 
 [discrete]
-== Cloud connections
+== Transit Gateways
 
-There is a limit of two cloud connections per {ibm-power-server-name} instance. It is recommended that you have only one cloud connection in your {ibm-power-server-name} instance to serve your cluster.
-
-[NOTE]
-====
-Cloud Connections are no longer supported in `dal10`. A transit gateway is used instead.
-====
+Each {product-title} cluster creates its own Transit Gateway to enable communication with a VPC. The default quota of transit gateways per account is 10. If you have 10 transit gateways created, you will need to increase your quota before attempting an installation.
 
 [discrete]
 == Dynamic Host Configuration Protocol Service


### PR DESCRIPTION
Version(s): 4.15

Issue: https://issues.redhat.com/browse/MULTIARCH-4115

Link to docs preview: 
- https://70885--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/installing-ibm-cloud-account-power-vs#installation-ibm-cloud-iam-policies-api-key_installing-ibm-cloud-account-power-vs
- https://70885--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/installing-ibm-power-vs-private-cluster#installation-ibm-power-vs-config-yaml_installing-ibm-power-vs-private-cluster
- https://70885--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/installing-ibm-cloud-account-power-vs#quotas-and-limits-ibm-power-vs_installing-ibm-cloud-account-power-vs

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
