### PR TITLE
[OSDOCS#9209]: Docs work for UPI: ShiftStack dual stack support

### DIFF
--- a/installing/installing_openstack/installing-openstack-user.adoc
+++ b/installing/installing_openstack/installing-openstack-user.adoc
@@ -45,6 +45,11 @@ include::modules/installation-initializing.adoc[leveloffset=+1]
 
 include::modules/installation-osp-custom-subnet.adoc[leveloffset=+2]
 include::modules/installation-osp-config-yaml.adoc[leveloffset=+2]
+
+//Dual-stack networking
+include::modules/install-osp-dualstack.adoc[leveloffset=+2]
+include::modules/install-osp-deploy-dualstack.adoc[leveloffset=+3]
+
 include::modules/installation-osp-fixing-subnet.adoc[leveloffset=+2]
 include::modules/installation-osp-emptying-worker-pools.adoc[leveloffset=+2]
 include::modules/installation-osp-provider-networks.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-9209

Link to docs preview:
https://70894--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-user#install-osp-dualstack_installing-openstack-user

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
