### PR TITLE
OCPBUGS-23115: Clarify instructions for builds with subscriptions

### DIFF
--- a/cicd/builds/running-entitled-builds.adoc
+++ b/cicd/builds/running-entitled-builds.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Use the following sections to run entitled builds on {product-title}.
+Use the following sections to install Red Hat subscription content within {product-title} builds.
 
 include::modules/builds-create-imagestreamtag.adoc[leveloffset=+1]
 

--- a/modules/builds-create-imagestreamtag.adoc
+++ b/modules/builds-create-imagestreamtag.adoc
@@ -6,11 +6,11 @@
 [id="builds-create-imagestreamtag_{context}"]
 = Creating an image stream tag for the Red Hat Universal Base Image
 
-To use Red Hat subscriptions within a build, you create an image stream tag to reference the Universal Base Image (UBI).
+To install Red Hat Enterprise Linux packages within a build, you create an image stream tag to reference the Universal Base Image (UBI).
 
 To make the UBI available *in every project* in the cluster, you add the image stream tag to the `openshift` namespace. Otherwise, to make it available *in a specific project*, you add the image stream tag to that project.
 
-The benefit of using image stream tags this way is that doing so grants access to the UBI based on the `registry.redhat.io` credentials in the install pull secret without exposing the pull secret to other users. This is more convenient than requiring each developer to install pull secrets with `registry.redhat.io` credentials in each project.
+Image stream tags grant access to the UBI based on the `registry.redhat.io` credentials in the install pull secret without exposing the pull secret to other users. This is more convenient than requiring each developer to install pull secrets with `registry.redhat.io` credentials in each project.
 
 .Procedure
 
@@ -18,7 +18,7 @@ The benefit of using image stream tags this way is that doing so grants access t
 +
 [source,terminal]
 ----
-$ oc tag --source=docker registry.redhat.io/ubi9/ubi:latest ubi:latest -n openshift
+$ oc tag --source=docker registry.redhat.io/ubi9/ubi:latest ubi9:latest -n openshift
 ----
 +
 [TIP]
@@ -29,7 +29,7 @@ You can alternatively apply the following YAML to create an `ImageStreamTag` in 
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  name: ubi
+  name: ubi9
   namespace: openshift
 spec:
   tags:
@@ -46,7 +46,7 @@ spec:
 +
 [source,terminal]
 ----
-$ oc tag --source=docker registry.redhat.io/ubi9/ubi:latest ubi:latest
+$ oc tag --source=docker registry.redhat.io/ubi9/ubi:latest ubi9:latest
 ----
 +
 [TIP]
@@ -57,7 +57,7 @@ You can alternatively apply the following YAML to create an `ImageStreamTag` in 
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  name: ubi
+  name: ubi9
 spec:
   tags:
   - from:

--- a/modules/builds-running-entitled-builds-with-sharedsecret-objects.adoc
+++ b/modules/builds-running-entitled-builds-with-sharedsecret-objects.adoc
@@ -1,197 +1,118 @@
 :_mod-docs-content-type: PROCEDURE
 [id="builds-running-entitled-builds-with-sharedsecret-objects_{context}"]
-= Running entitled builds using SharedSecret objects
+= Running builds using SharedSecret objects
 
-You can configure and perform a build in one namespace that securely uses RHEL entitlements from a `Secret` object in another namespace.
+Starting in {product-title} 4.10 and later, you can use a `SharedSecret` object to securely access the cluster's entitlement keys in builds.
+`SharedSecret` objects allow `Secret` content to be shared across namespaces and kept synchronized.
 
-You can still access RHEL entitlements from OpenShift Builds by creating a `Secret` object with your subscription credentials in the same namespace as your `Build` object. However, now, in {product-title} 4.10 and later, you can access your credentials and certificates from a `Secret` object in one of the {product-title} system namespaces. You run entitled builds with a CSI volume mount of a `SharedSecret` custom resource (CR) instance that references the `Secret` object.
+This procedure relies on the Shared Resource CSI Driver feature.
 
-This procedure relies on the newly introduced Shared Resources CSI Driver feature, which you can use to declare CSI Volume mounts in {product-title} Builds. It also relies on the {product-title} Insights Operator.
-
-:FeatureName: Managing machines with the Cluster API
+:FeatureName: Shared Resource CSI Driver
 include::snippets/technology-preview.adoc[]
 
-The Shared Resources CSI Driver feature also belongs to the `TechPreviewNoUpgrade` feature set, which is a subset of the current Technology Preview features. You can enable the `TechPreviewNoUpgrade` feature set on test clusters, where you can fully test them while leaving the features disabled on production clusters. Enabling this feature set cannot be undone and prevents minor version updates. This feature set is not recommended on production clusters. See "Enabling Technology Preview features using feature gates" in the following "Additional resources" section.
+See xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates] for more information on how to enable this feature.
 
 .Prerequisites
 
-* You have enabled the  `TechPreviewNoUpgrade` feature set by using the feature gates.
-* You have a `SharedSecret` custom resource (CR) instance that references the `Secret` object where the Insights Operator stores the subscription credentials.
-* You must have permission to perform the following actions:
-** Create build configs and start builds.
-** Discover which `SharedSecret` CR instances are available by entering the `oc get sharedsecrets` command and getting a non-empty list back.
-** Determine if the `builder` service account available to you in your namespace is allowed to use the given `SharedSecret` CR instance. In other words, you can run `oc adm policy who-can use <identifier of specific SharedSecret>` to see if the `builder` service account in your namespace is listed.
+* You have enabled the  `TechPreviewNoUpgrade` feature set enabled.
+* Your cluster must be subscribed and have the Insights Operator import its xref:../../support/remote_health_monitoring/insights-operator-simple-access.adoc#insights-operator-simple-access[Simple Content Access certificates].
 
-[NOTE]
-====
-If neither of the last two prerequisites in this list are met, establish, or ask someone to establish, the necessary role-based access control (RBAC) so that you can discover `SharedSecret` CR instances and enable service accounts to use `SharedSecret` CR instances.
-====
 
 .Procedure
 
-. Grant the `builder` service account RBAC permissions to use the `SharedSecret` CR instance by using `oc apply` with YAML content:
+. Create a `SharedSecret` object instance referencing the cluster's entitlement secret.
 +
-[NOTE]
-====
-Currently, `kubectl` and `oc` have hard-coded special case logic restricting the `use` verb to roles centered around pod security. Therefore, you cannot use `oc create role ...` to create the role needed for consuming `SharedSecret` CR instances.
-====
+[source,terminal]
+----
+$ oc apply -f - <<EOF
+kind: SharedSecret
+apiVersion: sharedresource.openshift.io/v1alpha1
+metadata:
+  name: etc-pki-entitlement
+spec:
+  secretRef:
+    name: etc-pki-entitlement
+    namespace: openshift-config-managed
+EOF
+----
 +
-.Example `oc apply -f` command with YAML `Role` object definition
+[IMPORTANT]
+====
+Your user account must have cluster administrator permissions to create `SharedSecret` objects.
+====
+
+. Create a role that will be used to grant the `builder` service account permission to access the `SharedSecret`.
++
 [source,terminal]
 ----
 $ oc apply -f - <<EOF
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: shared-resource-my-share
-  namespace: my-namespace
+  name: builder-etc-pki-entitlement
 rules:
   - apiGroups:
       - sharedresource.openshift.io
     resources:
       - sharedsecrets
     resourceNames:
-      - my-share
+      - etc-pki-entitlement
     verbs:
       - use
 EOF
 ----
 
-. Create the `RoleBinding` associated with the role by using the `oc` command:
+. Create a `RoleBinding` that grants the `builder` service account permission to access the `SharedSecret` object.
 +
-.Example `oc create rolebinding` command
 [source,terminal]
 ----
-$ oc create rolebinding shared-resource-my-share --role=shared-resource-my-share --serviceaccount=my-namespace:builder
+$ oc create rolebinding builder-etc-pki-entitlement --role=builder-etc-pki-entitlement --serviceaccount=builder
 ----
 
-. Create a `BuildConfig` object that accesses the RHEL entitlements.
+. Add the entitlement secret to your `BuildConfig` using a `csi` volume mount.
 +
-.Example YAML `BuildConfig` object definition
 [source,yaml]
 ----
 apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
-  name: my-csi-bc
-  namespace: my-csi-app-namespace
+  name: uid-wrapper-rhel9
 spec:
   runPolicy: Serial
   source:
     dockerfile: |
       FROM registry.redhat.io/ubi9/ubi:latest
-      RUN ls -la /etc/pki/entitlement
-      RUN rm /etc/rhsm-host
-      RUN yum repolist --disablerepo=*
-      RUN subscription-manager repos --enable rhocp-4.9-for-rhel-8-x86_64-rpms
-      RUN yum -y update
-      RUN yum install -y openshift-clients.x86_64
+      RUN rm -rf /etc/rhsm-host <1>
+      RUN yum --enablerepo=codeready-builder-for-rhel-9-x86_64-rpms install \ <2>
+          nss_wrapper \
+          uid_wrapper -y && \
+          yum clean all -y
+      RUN ln -s /run/secrets/rhsm /etc/rhsm-host <3>
   strategy:
     type: Docker
     dockerStrategy:
       volumes:
         - mounts:
             - destinationPath: "/etc/pki/entitlement"
-          name: my-csi-shared-secret
+          name: etc-pki-entitlement
           source:
             csi:
               driver: csi.sharedresource.openshift.io
-              readOnly: true
+              readOnly: true <4>
               volumeAttributes:
-                sharedSecret: my-share-bc
+                sharedSecret: etc-pki-entitlement <5>
             type: CSI
 ----
++
+<1> You *must* include this instruction in your Dockerfile before executing any `yum` or `dnf` commands.
+<2> Use the link:https://access.redhat.com/downloads/content/package-browser[Red Hat Package Browser] to find the correct repositories for your installed packages.
+<3> You *must* restore the `/etc/rhsm-host` symbolic link to keep your image compatible with other Red Hat container images.
+<4> You *must* set `readOnly` to `true` in order to mount the shared resource in your build.
+<5> Reference the name of the `SharedSecret` object to include its contents in the build. 
 
 . Start a build from the `BuildConfig` object and follow the logs with the `oc` command.
 +
-.Example oc start-build command
 [source,terminal]
 ----
-$ oc start-build my-csi-bc -F
+$ oc start-build uid-wrapper-rhel9 -F
 ----
-+
-.Example output from the oc start-build command
-[%collapsible]
-====
-[NOTE]
-=====
-Some sections of the following output have been replaced with `...`
-=====
-[source,terminal]
-----
-build.build.openshift.io/my-csi-bc-1 started
-Caching blobs under "/var/cache/blobs".
-
-Pulling image registry.redhat.io/ubi9/ubi:latest ...
-Trying to pull registry.redhat.io/ubi9/ubi:latest...
-Getting image source signatures
-Copying blob sha256:5dcbdc60ea6b60326f98e2b49d6ebcb7771df4b70c6297ddf2d7dede6692df6e
-Copying blob sha256:8671113e1c57d3106acaef2383f9bbfe1c45a26eacb03ec82786a494e15956c3
-Copying config sha256:b81e86a2cb9a001916dc4697d7ed4777a60f757f0b8dcc2c4d8df42f2f7edb3a
-Writing manifest to image destination
-Storing signatures
-Adding transient rw bind mount for /run/secrets/rhsm
-STEP 1/9: FROM registry.redhat.io/ubi9/ubi:latest
-STEP 2/9: RUN ls -la /etc/pki/entitlement
-total 360
-drwxrwxrwt. 2 root root 	80 Feb  3 20:28 .
-drwxr-xr-x. 10 root root	154 Jan 27 15:53 ..
--rw-r--r--. 1 root root   3243 Feb  3 20:28 entitlement-key.pem
--rw-r--r--. 1 root root 362540 Feb  3 20:28 entitlement.pem
-time="2022-02-03T20:28:32Z" level=warning msg="Adding metacopy option, configured globally"
---> 1ef7c6d8c1a
-STEP 3/9: RUN rm /etc/rhsm-host
-time="2022-02-03T20:28:33Z" level=warning msg="Adding metacopy option, configured globally"
---> b1c61f88b39
-STEP 4/9: RUN yum repolist --disablerepo=*
-Updating Subscription Management repositories.
-
-
-...
-
---> b067f1d63eb
-STEP 5/9: RUN subscription-manager repos --enable rhocp-4.9-for-rhel-8-x86_64-rpms
-Repository 'rhocp-4.9-for-rhel-8-x86_64-rpms' is enabled for this system.
-time="2022-02-03T20:28:40Z" level=warning msg="Adding metacopy option, configured globally"
---> 03927607ebd
-STEP 6/9: RUN yum -y update
-Updating Subscription Management repositories.
-
-...
-
-Upgraded:
-  systemd-239-51.el8_5.3.x86_64      	systemd-libs-239-51.el8_5.3.x86_64
-  systemd-pam-239-51.el8_5.3.x86_64
-Installed:
-  diffutils-3.6-6.el8.x86_64           	libxkbcommon-0.9.1-1.el8.x86_64
-  xkeyboard-config-2.28-1.el8.noarch
-
-Complete!
-time="2022-02-03T20:29:05Z" level=warning msg="Adding metacopy option, configured globally"
---> db57e92ff63
-STEP 7/9: RUN yum install -y openshift-clients.x86_64
-Updating Subscription Management repositories.
-
-...
-
-Installed:
-  bash-completion-1:2.7-5.el8.noarch
-  libpkgconf-1.4.2-1.el8.x86_64
-  openshift-clients-4.9.0-202201211735.p0.g3f16530.assembly.stream.el8.x86_64
-  pkgconf-1.4.2-1.el8.x86_64
-  pkgconf-m4-1.4.2-1.el8.noarch
-  pkgconf-pkg-config-1.4.2-1.el8.x86_64
-
-Complete!
-time="2022-02-03T20:29:19Z" level=warning msg="Adding metacopy option, configured globally"
---> 609507b059e
-STEP 8/9: ENV "OPENSHIFT_BUILD_NAME"="my-csi-bc-1" "OPENSHIFT_BUILD_NAMESPACE"="my-csi-app-namespace"
---> cab2da3efc4
-STEP 9/9: LABEL "io.openshift.build.name"="my-csi-bc-1" "io.openshift.build.namespace"="my-csi-app-namespace"
-COMMIT temp.builder.openshift.io/my-csi-app-namespace/my-csi-bc-1:edfe12ca
---> 821b582320b
-Successfully tagged temp.builder.openshift.io/my-csi-app-namespace/my-csi-bc-1:edfe12ca
-821b582320b41f1d7bab4001395133f86fa9cc99cc0b2b64c5a53f2b6750db91
-Build complete, no image push requested
-----
-====

--- a/modules/builds-running-entitled-builds-with-sharedsecret-objects.adoc
+++ b/modules/builds-running-entitled-builds-with-sharedsecret-objects.adoc
@@ -5,7 +5,7 @@
 Starting in {product-title} 4.10 and later, you can use a `SharedSecret` object to securely access the cluster's entitlement keys in builds.
 `SharedSecret` objects allow `Secret` content to be shared across namespaces and kept synchronized.
 
-This procedure relies on the Shared Resource CSI Driver feature.
+Running builds with `SharedSecret` objects uses the Shared Resource CSI Driver feature.
 
 :FeatureName: Shared Resource CSI Driver
 include::snippets/technology-preview.adoc[]

--- a/modules/builds-source-input-satellite-config.adoc
+++ b/modules/builds-source-input-satellite-config.adoc
@@ -43,7 +43,7 @@ strategy:
   dockerStrategy:
     from:
       kind: ImageStreamTag
-      name: ubi:latest
+      name: ubi9:latest
     volumes:
     - name: yum-repos-d
       mounts:

--- a/modules/builds-source-secrets-entitlements.adoc
+++ b/modules/builds-source-secrets-entitlements.adoc
@@ -10,20 +10,31 @@ Builds that use Red Hat subscriptions to install content must include the entitl
 
 .Prerequisites
 
-You must have access to Red Hat entitlements through your subscription. The entitlement secret is automatically created by the Insights Operator.
-
-
-[TIP]
-====
-When you perform an Entitlement Build using {op-system-base-full} 7, you must have the following instructions in your Dockerfile before you run any `yum` commands:
-
-[source,terminal]
-----
-RUN rm /etc/rhsm-host
-----
-====
+You must have access to Red Hat Enterpise Linux package repositories through your subscription.
+The entitlement secret to access these repositories is automatically created by the Insights Operator when your cluster is subscribed.
 
 .Procedure
+
+. Copy the entitlement secret from the "openshift-config-managed" namespace to the build's namespace:
++
+[source,bash]
+----
+$ cat << EOF > secret-template.txt
+kind: Secret
+apiVersion: v1
+metadata:
+  name: etc-pki-entitlement
+type: Opaque
+data: {{ range \$key, \$value := .data }}
+  {{ \$key }}: {{ \$value }} {{ end }}
+EOF
+$ oc get secret etc-pki-entitlement -n openshift-config-managed -o=go-template-file --template=secret-template.txt | oc apply -f -
+----
++
+[IMPORTANT]
+====
+Your user account must have permission to access secrets in the `openshift-config-managed` project. This is generally reserved for cluster administrators.
+====
 
 . Add the etc-pki-entitlement secret as a build volume in the build configuration’s Docker strategy:
 +

--- a/modules/builds-strategy-docker-entitled-satellite.adoc
+++ b/modules/builds-strategy-docker-entitled-satellite.adoc
@@ -18,6 +18,13 @@ Use the following as an example Dockerfile to install content with Satellite:
 [source,terminal]
 ----
 FROM registry.redhat.io/ubi9/ubi:latest
-RUN dnf search kernel-devel --showduplicates && \
-        dnf install -y kernel-devel
+RUN rm -rf /etc/rhsm-host <1>
+RUN yum --enablerepo=codeready-builder-for-rhel-9-x86_64-rpms install \ <2>
+    nss_wrapper \
+    uid_wrapper -y && \
+    yum clean all -y
+RUN ln -s /run/secrets/rhsm /etc/rhsm-host <3>
 ----
+<1> You *must* include this instruction in your Dockerfile before executing any `yum` or `dnf` commands.
+<2> Contact your Satellite system administrator to find the correct repositories for the build's installed packages.
+<3> You *must* restore the `/etc/rhsm-host` symbolic link to keep your image compatible with other Red Hat container images.

--- a/modules/builds-strategy-docker-entitled-subman.adoc
+++ b/modules/builds-strategy-docker-entitled-subman.adoc
@@ -6,7 +6,7 @@
 [id="builds-strategy-docker-entitled-subman_{context}"]
 = Docker builds using Subscription Manager
 
-Docker strategy builds can use the Subscription Manager to install subscription content.
+Docker strategy builds can use `yum` or `dnf` to install additional Red Hat Enterprise Linux packages.
 
 .Prerequisites
 
@@ -19,6 +19,13 @@ Use the following as an example Dockerfile to install content with the Subscript
 [source,terminal]
 ----
 FROM registry.redhat.io/ubi9/ubi:latest
-RUN dnf search kernel-devel --showduplicates && \
-        dnf install -y kernel-devel
+RUN rm -rf /etc/rhsm-host <1>
+RUN yum --enablerepo=codeready-builder-for-rhel-9-x86_64-rpms install \ <2>
+    nss_wrapper \
+    uid_wrapper -y && \
+    yum clean all -y
+RUN ln -s /run/secrets/rhsm /etc/rhsm-host <3>
 ----
+<1> You *must* include this instruction in your Dockerfile before executing any `yum` or `dnf` commands.
+<2> Use the link:https://access.redhat.com/downloads/content/package-browser[Red Hat Package Browser] to find the correct repositories for your installed packages.
+<3> You *must* restore the `/etc/rhsm-host` symbolic link to keep your image compatible with other Red Hat container images.


### PR DESCRIPTION
Builds that install RHEL packages need to include the `RUN rm -rf /etc/rhsm-host` instruction in the Dockerfile. This effectively tricks the subscription manager into thinking it is running outside of a container. Builds may also need to enable additional RHEL repositories if the package is not included in the base UBI or RHEL app stream repos.

This was tested with the latest UBI 7, 8, and 9 images as of 2024-01-26.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12 and higher

Issue:
[OCPBUGS-23115](https://issues.redhat.com/browse/OCPBUGS-23115)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
