### PR TITLE
OSDOCS-9364 updated ROSA PV Storage options

### DIFF
--- a/modules/persistent-storage-csi-drivers-supported.adoc
+++ b/modules/persistent-storage-csi-drivers-supported.adoc
@@ -69,8 +69,12 @@ ifndef::openshift-dedicated,openshift-rosa[]
 * Does not support offline snapshots or resize. Volume must be attached to a running pod.
 --
 endif::openshift-dedicated,openshift-rosa[]
-
+ifndef::openshift-rosa[]
 [IMPORTANT]
 ====
 If your CSI driver is not listed in the preceding table, you must follow the installation instructions provided by your CSI storage vendor to use their supported CSI features.
 ====
+endif::openshift-rosa[]
+ifdef::openshift-rosa[]
+In addition to the drivers listed in the preceding table, ROSA functions with CSI drivers from third-party storage vendors such as AWS FSX or Pure Storage Portworx. Red Hat does not oversee third-party provisioners or the connected CSI drivers and the vendors fully control source code, deployment, operation, and Kubernetes compatibility. These volume provisioners are considered customer-managed and the respective vendors are responsible for providing support. See the link:https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.html#rosa-policy-responsibilities_rosa-policy-responsibility-matrix[Shared responsibilities for {product-title}] matrix for more information. 
+endif::openshift-rosa[]

--- a/modules/storage-persistent-storage-block-volume.adoc
+++ b/modules/storage-persistent-storage-block-volume.adoc
@@ -27,10 +27,10 @@ The following table displays which volume plugins support block volumes.
 [cols="1,1,1,1", width="100%",options="header"]
 |===
 |Volume Plugin  |Manually provisioned  |Dynamically provisioned |Fully supported
-|AliCloud Disk | ✅ | ✅ | ✅
 |Amazon Elastic Block Store (Amazon EBS) | ✅ | ✅ | ✅
 |Amazon Elastic File Storage (Amazon EFS) | | |
 ifndef::openshift-dedicated,openshift-rosa[]
+|AliCloud Disk | ✅ | ✅ | ✅
 |Azure Disk | ✅ | ✅ | ✅
 |Azure File | | |
 |Cinder | ✅ | ✅ | ✅

--- a/modules/storage-persistent-storage-pv.adoc
+++ b/modules/storage-persistent-storage-pv.adoc
@@ -34,7 +34,12 @@ ifndef::microshift[]
 [id="types-of-persistent-volumes_{context}"]
 == Types of PVs
 
+ifndef::openshift-rosa[]
 {product-title} supports the following persistent volume plugins:
+endif::openshift-rosa[]
+ifdef::openshift-rosa[]
+{product-title} (ROSA) supports the following persistent volume storage options:
+endif::openshift-rosa[]
 
 // - GlusterFS
 // - Ceph RBD
@@ -75,6 +80,10 @@ ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 // - Local
 endif::openshift-enterprise,openshift-webscale,openshift-origin[]
 endif::microshift[]
+
+ifdef::openshift-rosa[]
+ROSA functions with Kubernetes Container Storage Interface (CSI) compatible volume provisioners from other storage vendors. See link:https://docs.openshift.com/rosa/storage/container_storage_interface/persistent-storage-csi.html[Configuring CSI volumes] for more information about CSI drivers in ROSA. 
+endif::openshift-rosa[]
 
 [id="pv-capacity_{context}"]
 == Capacity


### PR DESCRIPTION
Updated the ROSA PV storage options to more accurately reflect other providers. 

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.13+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-9364
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
Conditional-
ROSA:
https://70909--ocpdocs-pr.netlify.app/openshift-rosa/latest/storage/understanding-persistent-storage#types-of-persistent-volumes_understanding-persistent-storage

https://70909--ocpdocs-pr.netlify.app/openshift-rosa/latest/storage/container_storage_interface/persistent-storage-csi#csi-drivers-supported_persistent-storage-csi

ENTERPRISE:
 https://70909--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/understanding-persistent-storage#types-of-persistent-volumes_understanding-persistent-storage

https://70909--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi#csi-drivers-supported_persistent-storage-csi

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
