### PR TITLE
OCPBUGS-26016: Changed the s3:HeadBucket entry to s3:ListBucket

### DIFF
--- a/modules/installation-aws-permissions.adoc
+++ b/modules/installation-aws-permissions.adoc
@@ -19,11 +19,11 @@ cluster, the IAM user requires the following permissions:
 .Required EC2 permissions for installation
 [%collapsible]
 ====
+* `ec2:AttachNetworkInterface`
 * `ec2:AuthorizeSecurityGroupEgress`
 * `ec2:AuthorizeSecurityGroupIngress`
 * `ec2:CopyImage`
 * `ec2:CreateNetworkInterface`
-* `ec2:AttachNetworkInterface`
 * `ec2:CreateSecurityGroup`
 * `ec2:CreateTags`
 * `ec2:CreateVolume`
@@ -48,8 +48,8 @@ cluster, the IAM user requires the following permissions:
 * `ec2:DescribePrefixLists`
 * `ec2:DescribeRegions`
 * `ec2:DescribeRouteTables`
-* `ec2:DescribeSecurityGroups`
 * `ec2:DescribeSecurityGroupRules`
+* `ec2:DescribeSecurityGroups`
 * `ec2:DescribeSubnets`
 * `ec2:DescribeTags`
 * `ec2:DescribeVolumes`
@@ -88,7 +88,7 @@ cluster, the IAM user requires the following permissions:
 
 [NOTE]
 =====
-If you use an existing VPC, your account does not require these permissions for creating network resources.
+If you use an existing Virtual Private Cloud (VPC), your account does not require these permissions for creating network resources.
 =====
 ====
 
@@ -99,37 +99,31 @@ If you use an existing VPC, your account does not require these permissions for 
 * `elasticloadbalancing:ApplySecurityGroupsToLoadBalancer`
 * `elasticloadbalancing:AttachLoadBalancerToSubnets`
 * `elasticloadbalancing:ConfigureHealthCheck`
-* `elasticloadbalancing:CreateLoadBalancer`
-* `elasticloadbalancing:CreateLoadBalancerListeners`
-* `elasticloadbalancing:DeleteLoadBalancer`
-* `elasticloadbalancing:DeregisterInstancesFromLoadBalancer`
-* `elasticloadbalancing:DescribeInstanceHealth`
-* `elasticloadbalancing:DescribeLoadBalancerAttributes`
-* `elasticloadbalancing:DescribeLoadBalancers`
-* `elasticloadbalancing:DescribeTags`
-* `elasticloadbalancing:ModifyLoadBalancerAttributes`
-* `elasticloadbalancing:RegisterInstancesWithLoadBalancer`
-* `elasticloadbalancing:SetLoadBalancerPoliciesOfListener`
-====
-
-.Required Elastic Load Balancing permissions (ELBv2) for installation
-[%collapsible]
-====
-* `elasticloadbalancing:AddTags`
 * `elasticloadbalancing:CreateListener`
 * `elasticloadbalancing:CreateLoadBalancer`
+* `elasticloadbalancing:CreateLoadBalancerListeners`
 * `elasticloadbalancing:CreateTargetGroup`
 * `elasticloadbalancing:DeleteLoadBalancer`
+* `elasticloadbalancing:DeregisterInstancesFromLoadBalancer`
 * `elasticloadbalancing:DeregisterTargets`
+* `elasticloadbalancing:DescribeInstanceHealth`
 * `elasticloadbalancing:DescribeListeners`
 * `elasticloadbalancing:DescribeLoadBalancerAttributes`
 * `elasticloadbalancing:DescribeLoadBalancers`
+* `elasticloadbalancing:DescribeTags`
 * `elasticloadbalancing:DescribeTargetGroupAttributes`
 * `elasticloadbalancing:DescribeTargetHealth`
 * `elasticloadbalancing:ModifyLoadBalancerAttributes`
 * `elasticloadbalancing:ModifyTargetGroup`
 * `elasticloadbalancing:ModifyTargetGroupAttributes`
+* `elasticloadbalancing:RegisterInstancesWithLoadBalancer`
 * `elasticloadbalancing:RegisterTargets`
+* `elasticloadbalancing:SetLoadBalancerPoliciesOfListener`
+
+[IMPORTANT]
+=====
+{product-title} uses both the ELB and ELBv2 API services to provision load balancers. The permission list shows permissions required by both services. A known issue exists in the {aws-short} web console where both services use the same `elasticloadbalancing` action prefix but do not recognize the same actions. You can ignore the warnings about the service not recognizing certain `elasticloadbalancing` actions.
+=====
 ====
 
 .Required IAM permissions for installation
@@ -152,6 +146,7 @@ If you use an existing VPC, your account does not require these permissions for 
 * `iam:PutRolePolicy`
 * `iam:RemoveRoleFromInstanceProfile`
 * `iam:SimulatePrincipalPolicy`
+* `iam:TagInstanceProfile`
 * `iam:TagRole`
 
 [NOTE]
@@ -176,7 +171,7 @@ If you have not created a load balancer in your AWS account, the IAM user also r
 * `route53:UpdateHostedZoneComment`
 ====
 
-.Required S3 permissions for installation
+.Required Amazon Simple Storage Service (S3) permissions for installation
 [%collapsible]
 ====
 * `s3:CreateBucket`
@@ -186,8 +181,8 @@ If you have not created a load balancer in your AWS account, the IAM user also r
 * `s3:GetBucketCors`
 * `s3:GetBucketLocation`
 * `s3:GetBucketLogging`
-* `s3:GetBucketPolicy`
 * `s3:GetBucketObjectLockConfiguration`
+* `s3:GetBucketPolicy`
 * `s3:GetBucketRequestPayment`
 * `s3:GetBucketTagging`
 * `s3:GetBucketVersioning`
@@ -218,13 +213,14 @@ If you have not created a load balancer in your AWS account, the IAM user also r
 [%collapsible]
 ====
 * `autoscaling:DescribeAutoScalingGroups`
-* `ec2:DeletePlacementGroup`
 * `ec2:DeleteNetworkInterface`
+* `ec2:DeletePlacementGroup`
 * `ec2:DeleteVolume`
 * `elasticloadbalancing:DeleteTargetGroup`
 * `elasticloadbalancing:DescribeTargetGroups`
 * `iam:DeleteAccessKey`
 * `iam:DeleteUser`
+* `iam:DeleteUserPolicy`
 * `iam:ListAttachedRolePolicies`
 * `iam:ListInstanceProfiles`
 * `iam:ListRolePolicies`
@@ -256,6 +252,19 @@ If you use an existing VPC, your account does not require these permissions to d
 =====
 ====
 
+.Optional permissions for installing a cluster with a custom Key Management Service (KMS) key
+[%collapsible]
+====
+* `kms:CreateGrant`
+* `kms:Decrypt`
+* `kms:DescribeKey`
+* `kms:Encrypt`
+* `kms:GenerateDataKey`
+* `kms:GenerateDataKeyWithoutPlainText`
+* `kms:ListGrants`
+* `kms:RevokeGrant`
+====
+
 .Required permissions to delete a cluster with shared instance roles
 [%collapsible]
 ====
@@ -265,19 +274,16 @@ If you use an existing VPC, your account does not require these permissions to d
 .Additional IAM and S3 permissions that are required to create manifests
 [%collapsible]
 ====
-* `iam:DeleteAccessKey`
-* `iam:DeleteUser`
-* `iam:DeleteUserPolicy`
 * `iam:GetUserPolicy`
 * `iam:ListAccessKeys`
 * `iam:PutUserPolicy`
 * `iam:TagUser`
-* `s3:PutBucketPublicAccessBlock`
+* `s3:AbortMultipartUpload`
 * `s3:GetBucketPublicAccessBlock`
-* `s3:PutLifecycleConfiguration`
 * `s3:ListBucket`
 * `s3:ListBucketMultipartUploads`
-* `s3:AbortMultipartUpload`
+* `s3:PutBucketPublicAccessBlock`
+* `s3:PutLifecycleConfiguration`
 
 [NOTE]
 =====


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OCPBUGS-26016](https://issues.redhat.com/browse/OCPBUGS-26016)

Link to docs preview:
[Required AWS permissions for the IAM user](https://70926--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account#installation-aws-permissions_installing-aws-account)

- [x] SME has approved this change.
- [x] QE has approved this change.


Additional resources:
* [permissions.go for AWS](https://github.com/openshift/installer/blob/master/pkg/asset/installconfig/aws/permissions.go)
* [Original permission published doc](https://docs.openshift.com/container-platform/4.15/installing/installing_aws/installing-aws-user-infra.html#installation-aws-permissions_installing-aws-user-infra)
