### PR TITLE
OCPBUGS-28587: Documented annotation for explicit LoadBalancer IP is wrong

### DIFF
--- a/modules/nw-metallb-addresspool-cr.adoc
+++ b/modules/nw-metallb-addresspool-cr.adoc
@@ -45,7 +45,7 @@ Specify each range in CIDR notation or as starting and ending IP addresses separ
 |`spec.autoAssign`
 |`boolean`
 |Optional: Specifies whether MetalLB automatically assigns IP addresses from this pool.
-Specify `false` if you want explicitly request an IP address from this pool with the `metallb.universe.tf/address-pool` annotation.
+If you want to explicitly request an IP address, specify `false` and use the `metallb.universe.tf/loadBalancerIPs` annotation to configure a specific address.
 The default value is `true`.
 
 |`spec.avoidBuggyIPs`


### PR DESCRIPTION
Fixed mistaken annotation to choose a custom load balancer IP when an IPAddressPool has `spec.autoAssign` set to false.

Version(s):
4.14, 4.13, 4.12

Issue:
[OCPBUGS-28587](https://issues.redhat.com/browse/OCPBUGS-28587)

Link to docs preview:

https://70927--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-configure-address-pools

QE review:
- [ ] QE has approved this change.

Additional information:

Upstream reference: https://metallb.universe.tf/usage/