### PR TITLE
OSDOCS-9467:adds TP for RHOSP rootVolume and etcd on local disk to RNs

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -86,6 +86,13 @@ By default, the installation program installs control plane and compute machines
 
 //For more information, see <insert link to Fault tolerant deployments using multiple Prism Elements when docs merge>.
 
+[id="ocp-4-15-deploying-osp-with-root-volume-etcd-on-local-disk"]
+==== Deploying {rh-openstack-first} with root volume and etcd on local disk (Technology Preview)
+
+You can now move etcd from a root volume (Cinder) to a dedicated ephemeral local disk as a day 2 deployment. With this Technology Preview feature, you can resolve and prevent performance issues of your {rh-openstack} installation.
+
+//For more information, see < insert link to Deploying OpenStack with rootVolume and etcd on local disk when docs merge>.
+
 [id="ocp-4-15-web-console"]
 === Web console
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-9467
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://70932--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-deploying-osp-with-root-volume-etcd-on-local-disk
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
https://issues.redhat.com/browse/OSDOCS-9015
https://github.com/openshift/openshift-docs/pull/70208/files
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
