### PR TITLE
RHDEVDOCS-5881 - Document Release Notes for 1.11.1 release

### DIFF
--- a/modules/gitops-release-notes-1-10-2.adoc
+++ b/modules/gitops-release-notes-1-10-2.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assembly:
+//
+// * release_notes/gitops-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="gitops-release-notes-1-10-2_{context}"]
+= Release notes for {gitops-title} 1.10.2
+
+{gitops-title} 1.10.2 is now available on {OCP} 4.12, 4.13, and 4.14.
+
+[id="fixed-issues-1-10-2_{context}"]
+== Fixed issues
+
+The following issue has been resolved in the current release:
+
+* Before this update, all versions of Argo CD `v2.8.3` and later were vulnerable to cross-server request forgery (CSRF) attacks. As a result, Argo CD would accept non-GET requests even if they did not specify their content type. This update fixes the issue by upgrading the Argo CD to `v.2.8.9` and patching this vulnerability in the Argo CD API. link:https://issues.redhat.com/browse/GITOPS-3922[GITOPS-3922]
++
+[IMPORTANT]
+====
+Breaking change: The Argo CD API will no longer accept non-GET requests that do not specify application or JSON as their content type. Although the accepted content types list is configurable, do not disable the content type check completely.
+====

--- a/modules/gitops-release-notes-1-11-1.adoc
+++ b/modules/gitops-release-notes-1-11-1.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assembly:
+//
+// * release_notes/gitops-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="gitops-release-notes-1-11-1_{context}"]
+= Release notes for {gitops-title} 1.11.1
+
+{gitops-title} 1.11.1 is now available on {OCP} 4.12, 4.13, and 4.14.
+
+[id="fixed-issues-1-11-1_{context}"]
+== Fixed issues
+
+The following issue has been resolved in the current release:
+
+* Before this update, all versions of Argo CD `v2.9.2` and later were vulnerable to cross-server request forgery (CSRF) attacks. As a result, Argo CD would accept non-GET requests even if they did not specify their content type. This update fixes the issue by upgrading the Argo CD to `v.2.9.5` and patching this vulnerability in the Argo CD API. link:https://issues.redhat.com/browse/GITOPS-3923[GITOPS-3923]
++
+[IMPORTANT]
+====
+Breaking change: The Argo CD API will no longer accept non-GET requests that do not specify application or JSON as their content type. Although the accepted content types list is configurable, do not disable the content type check completely.
+====

--- a/modules/gitops-release-notes-1-9-4.adoc
+++ b/modules/gitops-release-notes-1-9-4.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assembly:
+//
+// * release_notes/gitops-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="gitops-release-notes-1-9-4_{context}"]
+= Release notes for {gitops-title} 1.9.4
+
+{gitops-title} 1.9.4 is now available on {OCP} 4.12, 4.13, and 4.14.
+
+[id="fixed-issues-1-9-4_{context}"]
+== Fixed issues
+
+The following issue has been resolved in the current release:
+
+* Before this update, all versions of Argo CD `v2.7.2` and later were vulnerable to cross-server request forgery (CSRF) attacks. As a result, Argo CD would accept non-GET requests even if they did not specify their content type. This update fixes the issue by upgrading the Argo CD to `v.2.7.16` and patching this vulnerability in the Argo CD API. link:https://issues.redhat.com/browse/GITOPS-3921[GITOPS-3921]
++
+[IMPORTANT]
+====
+Breaking change: The Argo CD API will no longer accept non-GET requests that do not specify application or JSON as their content type. Although the accepted content types list is configurable, do not disable the content type check completely.
+====

--- a/release_notes/gitops-release-notes.adoc
+++ b/release_notes/gitops-release-notes.adoc
@@ -25,14 +25,23 @@ include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
 
+// Release notes for Red Hat OpenShift GitOps 1.11.1
+include::modules/gitops-release-notes-1-11-1.adoc[leveloffset=+1]
+
 // Release notes for Red Hat OpenShift GitOps 1.11.0
 include::modules/gitops-release-notes-1-11-0.adoc[leveloffset=+1]
+
+// Release notes for Red Hat OpenShift GitOps 1.10.2
+include::modules/gitops-release-notes-1-10-2.adoc[leveloffset=+1]
 
 // Release notes for Red Hat OpenShift GitOps 1.10.1
 include::modules/gitops-release-notes-1-10-1.adoc[leveloffset=+1]
 
 // Release notes for Red Hat OpenShift GitOps 1.10.0
 include::modules/gitops-release-notes-1-10-0.adoc[leveloffset=+1]
+
+// Release notes for Red Hat OpenShift GitOps 1.9.4
+include::modules/gitops-release-notes-1-9-4.adoc[leveloffset=+1]
 
 // Release notes for Red Hat OpenShift GitOps 1.9.3
 include::modules/gitops-release-notes-1-9-3.adoc[leveloffset=+1]


### PR DESCRIPTION
**This PR is for the `GitOps 1.11.1` release that is scheduled for `Feb 5`. Do not merge until this date and the following errata show the status as SHIPPED LIVE:** 

- https://errata.devel.redhat.com/docs/show/126895
- https://errata.devel.redhat.com/docs/show/126897
- https://errata.devel.redhat.com/docs/show/127108
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
Jira issue : [RHDEVDOCS-5881](https://issues.redhat.com/browse/RHDEVDOCS-5881),  [RHDEVDOCS-5880](https://issues.redhat.com/browse/RHDEVDOCS-5880),  [RHDEVDOCS-5879](https://issues.redhat.com/browse/RHDEVDOCS-5879)

Aligned team: DevTools 
Cherry-pick to versions: `gitops-docs-1.11`

Docs preview: [Release notes for Red Hat OpenShift GitOps 1.11.1](https://70955--docspreview.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes#gitops-release-notes-1-11-1_gitops-release-notes), [Release notes for Red Hat OpenShift GitOps 1.10.2](https://70955--docspreview.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes#gitops-release-notes-1-10-2_gitops-release-notes), [Release notes for Red Hat OpenShift GitOps 1.9.4](https://70955--docspreview.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes#gitops-release-notes-1-9-4_gitops-release-notes)

SME review: Completed by @reginapizza 

QE review: Completed by @varshab1210 

Peer review: Completed by @gaurav-nelson

Additional information - **Note to SME, QE, peer/merge reviewers**: To avoid manual CPs to 1.10.2 and 1.9.4 RN branches, I have created the following release-specifc PRs but with same release-specific content:

- #70965 
- #70972 70972

After you approve the current PR, please approve the preceding PRs as well. TY!
