### PR TITLE
OSDOCS-9460: Documented the 4.13.31 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -3697,3 +3697,31 @@ $ oc adm release info 4.13.30 --pullspecs
 [id="ocp-4-13-30-updating"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+
+[id="ocp-4-13-31"]
+=== RHSA-2024:0484 - {product-title} 4.13.31 bug fix and security update
+
+Issued: 2024-02-01
+
+{product-title} release 4.13.31, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:0484[RHSA-2024:0484] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:0488[RHBA-2024:0488] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.31 --pullspecs
+----
+
+[id="ocp-4-13-31-bug-fixes"]
+==== Bug fixes
+
+* Previously, pods assigned an IP from the pool created by the Whereabouts CNI plugin were getting stuck in `ContainerCreating` state after a node force reboot. With this release, the Whereabouts CNI plugin issue associated with the IP allocation after a node force reboot is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-27367[*OCPBUGS-27367*])
+
+* Previously by default, the `container_t` SELinux context could not access the `dri_device_t` object, which provides access to DRI devices. Now, a new container policy `container-selinux` ensures that pods can use a device plugin to access the `dri_device_t` object. (link:https://issues.redhat.com/browse/OCPBUGS-27416[*OCPBUGS-27416*])
+
+[id="ocp-4-13-31-updating"]
+==== Updating
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OSDOCS-9460](https://issues.redhat.com/browse/OSDOCS-9460)

Link to docs preview:
* [4.13.31 z-stream release notes](https://70967--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes#ocp-4-13-31)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
