### PR TITLE
GH-64738: fix backticks in 4.11 OCP release notes

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -1710,13 +1710,13 @@ With this update, the container requests `1m` of CPU and `10Mi` of memory. These
 
 * Previously, contrack entries for `LoadBalancer` IPs were not removed when the service endpoints were removed causing connections to fail. With this update, contrack entries do not cause connections to fail. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2061002[*BZ#2061002*])
 
-* Previously, a missing `jq package` caused the scale up of a cluster with RHEL nodes to fail on node deployment. With this update,` jq package` is installed on deployment and the scale up of a cluster with RHEL nodes succeeds. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2052393[*BZ#2052393*])
+* Previously, a missing `jq package` caused the scale up of a cluster with RHEL nodes to fail on node deployment. With this update, `jq package` is installed on deployment and the scale up of a cluster with RHEL nodes succeeds. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2052393[*BZ#2052393*])
 
 * Previously, OVN-Kubernetes spent excessive time when a service configuration change was made. This caused a noticeable latency in service configuration changes. With this update, OVN-Kubernetes is optimized to reduce the latency of service configuration changes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2070674[*BZ#2070674*])
 
 * Previously, the IP reconciliation CronJob for Whereabouts IPAM CNI would fail due to API connectivity issues, which caused CronJob to intermittently fail. With this update, CronJob launched on Whereabouts IPAM CNI use the api-internal server address and an extended api timeout to prevent these connectivity issues. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2048575[*BZ#2048575*])
 
-* With this update, {product-title} clusters with Kubernetes-NMstate installed now include in the` must-gathers` Kubernetes-NMstate resources. This improves issue handling by including resources from Kubernetes-NMstate in `must-gathers`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2062355[*BZ#2062355*])
+* With this update, {product-title} clusters with Kubernetes-NMstate installed now include in the `must-gathers` Kubernetes-NMstate resources. This improves issue handling by including resources from Kubernetes-NMstate in `must-gathers`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2062355[*BZ#2062355*])
 
 * There is currently a known issue with host routes being ignored when load-balancer services are configured with cluster traffic policy. Consequently, egress traffic of load balancer services is steered to the default gateway and not towards the best matching route that is present on the host routing table. As a workaround, set the load balancer type Services to `Local` traffic policy. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2060159[*BZ#2060159*])
 
@@ -2436,7 +2436,7 @@ Identify the disk that holds the live image, in this example `nvme0n1p3`, and ru
 
 * Previously, if you were using the OVN-Kubernetes cluster network provider, if a service with `type=LoadBalancer` was configured with `internalTrafficPolicy=cluster` set, then all traffic was routed to the default gateway, even if the host routing table included better routes to use. Now the best route is used rather than always using the default gateway. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2060159[*BZ#2060159*])
 
-* When an OVN cluster has more than 75 worker nodes, simultaneously creating 2000 or more services and route objects can cause pods created at the same time to hang in the `ContainerCreating` status. If this problem occurs, entering the `oc describe pod <podname>` command will show events with the following warning: `FailedCreatePodSandBox...failed to configure pod interface: timed out waiting for OVS port binding (ovn-installed)'. There is currently no workaround for this issue.  (link:https://bugzilla.redhat.com/show_bug.cgi?id=2084062[*BZ#2084062*])
+* When an OVN cluster has more than 75 worker nodes, simultaneously creating 2000 or more services and route objects can cause pods created at the same time to hang in the `ContainerCreating` status. If this problem occurs, entering the `oc describe pod <podname>` command will show events with the following warning: `FailedCreatePodSandBox...failed to configure pod interface: timed out waiting for OVS port binding (ovn-installed)`. There is currently no workaround for this issue.  (link:https://bugzilla.redhat.com/show_bug.cgi?id=2084062[*BZ#2084062*])
 
 * There is currently a known issue with OVN-Kubernetes that whenever the `NetworkManager` service restarts the node will lose network connectivity and must be recovered. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2074009[*BZ#2074009*])
 
@@ -2891,7 +2891,7 @@ Currently, there is no workaround for this issue. (link:https://issues.redhat.co
 
 * When secure boot is enabled `stalld`, service fails to start because it is not able to open the `/sys/kernel/debug/sched_features` file. (link:https://issues.redhat.com/browse/OCPBUGS-1466[*OCPBUGSM-1466*])
 
-* When secure boot is enabled, the `kdump` service might fail to start with `kexec: failed to load kdump kernel` error. To workaround this issue, add `efi=runtime`to the kernel arguments. (link:https://issues.redhat.com/browse/OCPBUGS-97[*OCPBUGSM-97*])
+* When secure boot is enabled, the `kdump` service might fail to start with `kexec: failed to load kdump kernel` error. To workaround this issue, add `efi=runtime` to the kernel arguments. (link:https://issues.redhat.com/browse/OCPBUGS-97[*OCPBUGSM-97*])
 
 * If an SNO cluster is upgraded from OCP 4.10 to OCP 4.11, the SNO cluster might  get rebooted three times during the upgrade process. (link:https://issues.redhat.com/browse/OCPBUGSM-46704[*OCPBUGSM-46704*])
 


### PR DESCRIPTION
Version(s):
4.11

Issue:
[GitHub issue 64738](https://github.com/openshift/openshift-docs/issues/64738)

Link to docs preview:
[Release notes--bug fixes](https://70971--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes#ocp-4-11-bug-fixes)

QE review:
- N/A docs punctuation only, no content changes

Additional information:
Issue originally marked for Hacktoberfest 2023, but not completed by contributor. Completing GH issue to close. 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
