### PR TITLE
to add ap-south-2 region to ROSA hcp

### DIFF
--- a/modules/rosa-hcp-classic-comparison.adoc
+++ b/modules/rosa-hcp-classic-comparison.adoc
@@ -60,6 +60,7 @@
 * US East - Ohio (us-east-2)
 * US West - Oregon (us-west-2)
 * Asia Pacific - Tokyo (ap-northeast-1)
+* Asia Pacific - Hyderabad (ap-south-2)
 * Asia Pacific - Singapore (ap-southest-1)
 * Asia Pacific - Sydney (ap-southest-2)
 * Asia Pacific - Jakarta (ap-southeast-3)

--- a/modules/rosa-sdpolicy-am-regions-az.adoc
+++ b/modules/rosa-sdpolicy-am-regions-az.adoc
@@ -44,8 +44,8 @@ ifndef::rosa-with-hcp[]
 * ap-northeast-2 (Seoul)
 * ap-northeast-3 (Osaka)
 * ap-south-1 (Mumbai)
-* ap-south-2 (Hyderabad, AWS opt-in required)
 endif::rosa-with-hcp[]
+* ap-south-2 (Hyderabad, AWS opt-in required)
 * ap-southeast-1 (Singapore)
 * ap-southeast-2 (Sydney)
 * ap-southeast-3 (Jakarta, AWS opt-in required)


### PR DESCRIPTION
It adds `ap-south-2` region to ROSA hcp