### PR TITLE
OSDOCS#9497: editing canary rollout update page

### DIFF
--- a/modules/update-using-custom-machine-config-pools-about.adoc
+++ b/modules/update-using-custom-machine-config-pools-about.adoc
@@ -6,28 +6,29 @@
 [id="update-using-custom-machine-config-pools-about_{context}"]
 = About performing a canary rollout update
 
-This topic describes the general workflow of this canary rollout update process. The steps to perform each task in the workflow are described in the following sections.
+The following steps outline the high-level workflow of the canary rollout update process:
 
-. Create MCPs based on the worker pool. The number of nodes in each MCP depends on a few factors, such as your maintenance window duration for each MCP, and the amount of reserve capacity, meaning extra worker nodes, available in your cluster.
+. Create custom machine config pools (MCP) based on the worker pool.
 +
 [NOTE]
 ====
-You can change the `maxUnavailable` setting in an MCP to specify the percentage or the number of machines that can be updating at any given time. The default is 1.
+You can change the `maxUnavailable` setting in an MCP to specify the percentage or the number of machines that can be updating at any given time. The default is `1`.
 ====
 
 . Add a node selector to the custom MCPs. For each node that you do not want to update simultaneously with the rest of the cluster, add a matching label to the nodes. This label associates the node to the MCP.
 +
-[NOTE]
+[IMPORTANT]
 ====
-Do not remove the default worker label from the nodes. The nodes *must* have a role label to function properly in the cluster.
+Do not remove the default worker label from the nodes. The nodes must have a role label to function properly in the cluster.
 ====
 
 . Pause the MCPs you do not want to update as part of the update process.
 
 . Perform the cluster update. The update process updates the MCPs that are not paused, including the control plane nodes.
 
-. Test the applications on the updated nodes to ensure they are working as expected.
+. Test your applications on the updated nodes to ensure they are working as expected.
 
-. Unpause the remaining MCPs one-by-one and test the applications on those nodes until all worker nodes are updated. Unpausing an MCP starts the update process for the nodes associated with that MCP. You can check the progress of the update from the web console by clicking *Administration* -> *Cluster settings*. Or, use the `oc get machineconfigpools` CLI command.
+. Unpause one of the remaining MCPs, wait for the nodes in that pool to finish updating, and test the applications on those nodes.
+Repeat this process until all worker nodes are updated.
 
-. Optionally, remove the custom label from updated nodes and delete the custom MCPs.
+. Optional: Remove the custom label from updated nodes and delete the custom MCPs.

--- a/modules/update-using-custom-machine-config-pools-mcp-remove.adoc
+++ b/modules/update-using-custom-machine-config-pools-mcp-remove.adoc
@@ -5,14 +5,14 @@
 [id="update-using-custom-machine-config-pools-mcp-remove_{context}"]
 = Moving a node to the original machine config pool
 
-In this canary rollout update process, after you have unpaused a custom machine config pool (MCP) and verified that the applications on the nodes associated with that MCP are working as expected, you should move the node back to its original MCP by removing the custom label you added to the node.
+After you update and verify applications on nodes in a custom machine config pool (MCP), move the nodes back to their original MCP by removing the custom label that you added to the nodes.
 
 [IMPORTANT]
 ====
 A node must have a role to be properly functioning in the cluster.
 ====
 
-To move a node to its original MCP:
+.Procedure
 
 ////
 . Ensure that the nodes have a `worker` label or a label from an MCP that is updated.
@@ -32,11 +32,11 @@ error: 'node-role.kubernetes.io/worker' already has a value (), and --overwrite 
 If the node does not have a `worker` label or a label from an updated MCP, add the label.
 ////
 
-. Remove the custom label from the node.
+. For each node in a custom MCP, remove the custom label from the node by running the following command:
 +
 [source,terminal]
 ----
-$ oc label node <node_name> node-role.kubernetes.io/<custom-label>-
+$ oc label node <node_name> node-role.kubernetes.io/<custom_label>-
 ----
 +
 For example:
@@ -53,15 +53,16 @@ $ oc label node ci-ln-0qv1yp2-f76d1-kl2tq-worker-a-j2ssz node-role.kubernetes.io
 node/ci-ln-0qv1yp2-f76d1-kl2tq-worker-a-j2ssz labeled
 ----
 +
-The MCO moves the nodes back to the original MCP and reconciles the node to the MCP configuration.
+The Machine Config Operator moves the nodes back to the original MCP and reconciles the node to the MCP configuration.
 
-. View the list of MCPs in the cluster and their current state:
+. To ensure that node has been removed from the custom MCP, view the list of MCPs in the cluster and their current state by running the following command:
 +
 [source,terminal]
 ----
-$oc get mcp
+$ oc get mcp
 ----
 +
+.Example output
 [source,terminal]
 ----
 NAME                CONFIG                                                   UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
@@ -70,9 +71,9 @@ workerpool-canary   rendered-mcp-noupdate-5ad4791166c468f3a35cd16e734c9028   Tru
 worker              rendered-worker-5ad4791166c468f3a35cd16e734c9028         True      False      False      3              3                   3                     0                      61m
 ----
 +
-The node is removed from the custom MCP and moved back to the original MCP. It can take several minutes to update the machine counts. In this example, one node was moved from the removed `workerpool-canary` MCP to the `worker`MCP.
+When the node is removed from the custom MCP and moved back to the original MCP, it can take several minutes to update the machine counts. In this example, one node was moved from the removed `workerpool-canary` MCP to the `worker` MCP.
 
-. Optional: Delete the custom MCP:
+. Optional: Delete the custom MCP by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/update-using-custom-machine-config-pools-mcp.adoc
+++ b/modules/update-using-custom-machine-config-pools-mcp.adoc
@@ -5,11 +5,11 @@
 [id="update-using-custom-machine-config-pools-mcp_{context}"]
 = Creating machine config pools to perform a canary rollout update
 
-The first task in performing this canary rollout update is to create one or more machine config pools (MCP).
+To perform a canary rollout update, you must first create one or more custom machine config pools (MCP).
 
-. Create an MCP from a worker node.
+.Procedure
 
-.. List the worker nodes in your cluster.
+. List the worker nodes in your cluster by running the following command:
 +
 [source,terminal]
 ----
@@ -25,11 +25,11 @@ ci-ln-pwnll6b-f76d1-s8t9n-worker-b-dglj2
 ci-ln-pwnll6b-f76d1-s8t9n-worker-c-lldbm
 ----
 
-.. For the nodes you want to delay, add a custom label to the node:
+. For each node that you want to delay, add a custom label to the node by running the following command:
 +
 [source,terminal]
 ----
-$ oc label node <node name> node-role.kubernetes.io/<custom-label>=
+$ oc label node <node_name> node-role.kubernetes.io/<custom_label>=
 ----
 +
 For example:
@@ -46,7 +46,9 @@ $ oc label node ci-ln-0qv1yp2-f76d1-kl2tq-worker-a-j2ssz node-role.kubernetes.io
 node/ci-ln-gtrwm8t-f76d1-spbl7-worker-a-xk76k labeled
 ----
 
-.. Create the new MCP:
+. Create the new MCP:
+
+.. Create an MCP YAML file:
 +
 [source,yaml]
 ----
@@ -56,11 +58,11 @@ metadata:
   name: workerpool-canary <1>
 spec:
   machineConfigSelector:
-    matchExpressions: <2>
+    matchExpressions:
       - {
          key: machineconfiguration.openshift.io/role,
          operator: In,
-         values: [worker,workerpool-canary]
+         values: [worker,workerpool-canary] <2>
         }
   nodeSelector:
     matchLabels:
@@ -69,6 +71,8 @@ spec:
 <1> Specify a name for the MCP.
 <2> Specify the `worker` and custom MCP name.
 <3> Specify the custom label you added to the nodes that you want in this pool.
+
+.. Create the `MachineConfigPool` object by running the following command:
 +
 [source,terminal]
 ----
@@ -81,8 +85,8 @@ $ oc create -f <file_name>
 ----
 machineconfigpool.machineconfiguration.openshift.io/workerpool-canary created
 ----
-+
-.. View the list of MCPs in the cluster and their current state:
+
+. View the list of MCPs in the cluster and their current state by running the following command:
 +
 [source,terminal]
 ----
@@ -99,5 +103,3 @@ worker            rendered-worker-87ba3dec1ad78cb6aecebf7fbb476a36              
 ----
 +
 The new machine config pool, `workerpool-canary`, is created and the number of nodes to which you added the custom label are shown in the machine counts. The worker MCP machine counts are reduced by the same number. It can take several minutes to update the machine counts. In this example, one node was moved from the `worker` MCP to the `workerpool-canary` MCP.
-
-

--- a/modules/update-using-custom-machine-config-pools-pause.adoc
+++ b/modules/update-using-custom-machine-config-pools-pause.adoc
@@ -5,11 +5,11 @@
 [id="update-using-custom-machine-config-pools-pause_{context}"]
 = Pausing the machine config pools
 
-In this canary rollout update process, after you label the nodes that you do not want to update with the rest of your {product-title} cluster and create the machine config pools (MCPs), you pause those MCPs. Pausing an MCP prevents the Machine Config Operator (MCO) from updating the nodes associated with that MCP.
+After you create your custom machine config pools (MCPs), you then pause those MCPs. Pausing an MCP prevents the Machine Config Operator (MCO) from updating the nodes associated with that MCP.
 
-To pause an MCP:
+.Procedure
 
-. Patch the MCP that you want paused:
+. Patch the MCP that you want paused by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/update-using-custom-machine-config-pools-unpause.adoc
+++ b/modules/update-using-custom-machine-config-pools-unpause.adoc
@@ -5,9 +5,9 @@
 [id="update-using-custom-machine-config-pools-unpause_{context}"]
 = Unpausing the machine config pools
 
-In this canary rollout update process, after the {product-title} update is complete, unpause your custom MCPs one-by-one. Unpausing an MCP allows the Machine Config Operator (MCO) to update the nodes associated with that MCP.
+After the {product-title} update is complete, unpause your custom machine config pools (MCP) one at a time. Unpausing an MCP allows the Machine Config Operator (MCO) to update the nodes associated with that MCP.
 
-To unpause an MCP:
+.Procedure
 
 . Patch the MCP that you want to unpause:
 +
@@ -29,15 +29,23 @@ $  oc patch mcp/workerpool-canary --patch '{"spec":{"paused":false}}' --type=mer
 ----
 machineconfigpool.machineconfiguration.openshift.io/workerpool-canary patched
 ----
+
+. Optional: Check the progress of the update by using one of the following options:
+
+.. Check the progress from the web console by clicking *Administration* -> *Cluster settings*.
+
+.. Check the progress by running the following command:
 +
-You can check the progress of the update by using the `oc get machineconfigpools` command.
+[source,terminal]
+----
+$ oc get machineconfigpools
+----
 
 . Test your applications on the updated nodes to ensure that they are working as expected.
 
-. Unpause any other paused MCPs one-by-one and verify that your applications work.
+. Repeat this process for any other paused MCPs, one at a time.
 
-[id="update-using-custom-machine-config-pools-fail_{context}"]
-== In case of application failure
-
+[NOTE]
+====
 In case of a failure, such as your applications not working on the updated nodes, you can cordon and drain the nodes in the pool, which moves the application pods to other nodes to help maintain the quality-of-service for the applications. This first MCP should be no larger than the excess capacity.
-
+====

--- a/updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc
+++ b/updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc
@@ -12,21 +12,55 @@ WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to 
 To do: Remove this comment once 4.13 docs are EOL.
 ////
 
-There might be some scenarios where you want a more controlled rollout of an update to the worker nodes in order to ensure that mission-critical applications stay available during the whole update, even if the update process causes your applications to fail. Depending on your organizational needs, you might want to update a small subset of worker nodes, evaluate cluster and workload health over a period of time, then update the remaining nodes. This is commonly referred to as a _canary_ update. Or, you might also want to fit worker node updates, which often require a host reboot, into smaller defined maintenance windows when it is not possible to take a large maintenance window to update the entire cluster at one time.
+A _canary update_ is an update strategy where worker node updates are performed in discrete, sequential stages instead of updating all worker nodes at the same time.
+This strategy can be useful in the following scenarios:
 
-In these scenarios, you can create multiple custom machine config pools (MCPs) to prevent certain worker nodes from updating when you update the cluster. After the rest of the cluster is updated, you can update those worker nodes in batches at appropriate times.
+* You want a more controlled rollout of worker node updates to ensure that mission-critical applications stay available during the whole update, even if the update process causes your applications to fail.
+* You want to update a small subset of worker nodes, evaluate cluster and workload health over a period of time, and then update the remaining nodes.
+* You want to fit worker node updates, which often require a host reboot, into smaller defined maintenance windows when it is not possible to take a large maintenance window to update the entire cluster at one time.
 
-For example, if you have a cluster with 100 nodes with 10% excess capacity, maintenance windows that must not exceed 4 hours, and you know that it takes no longer than 8 minutes to drain and reboot a worker node, you can leverage MCPs to meet your goals. For example, you could define four MCPs, named *workerpool-canary*, *workerpool-A*, *workerpool-B*, and *workerpool-C*, with 10, 30, 30, and 30 nodes respectively.
+In these scenarios, you can create multiple custom machine config pools (MCPs) to prevent certain worker nodes from updating when you update the cluster.
+After the rest of the cluster is updated, you can update those worker nodes in batches at appropriate times.
 
-During your first maintenance window, you would pause the MCP for *workerpool-A*, *workerpool-B*, and *workerpool-C*, then initiate the cluster update. This updates components that run on top of {product-title} and the 10 nodes which are members of the *workerpool-canary* MCP, because that pool was not paused. The other three MCPs are not updated, because they were paused.  If for some reason, you determine that your cluster or workload health was negatively affected by the *workerpool-canary* update, you would then cordon and drain all nodes in that pool while still maintaining sufficient capacity until you have diagnosed the problem. When everything is working as expected, you would then evaluate the cluster and workload health before deciding to unpause, and thus update, *workerpool-A*, *workerpool-B*, and *workerpool-C* in succession during each additional maintenance window.
+[id="example_{context}"]
+== Example Canary update strategy
 
-While managing worker node updates using custom MCPs provides flexibility, it can be a time-consuming process that requires you execute multiple commands. This complexity can result in errors that can affect the entire cluster. It is recommended that you carefully consider your organizational needs and carefully plan the implemention of the process before you start.
+The following example describes a canary update strategy where you have a cluster with 100 nodes with 10% excess capacity, you have maintenance windows that must not exceed 4 hours, and you know that it takes no longer than 8 minutes to drain and reboot a worker node.
 
 [NOTE]
 ====
-It is not recommended to update the MCPs to different {product-title} versions. For example, do not update one MCP from 4.y.10 to 4.y.11 and another to 4.y.12.
-This scenario has not been tested and might result in an undefined cluster state.
+The previous values are an example only.
+The time it takes to drain a node might vary depending on factors such as workloads.
 ====
+
+[discrete]
+[id="defining-custom-mcps_{context}"]
+=== Defining custom machine config pools
+
+In order to organize the worker node updates into separate stages, you can begin by defining the following MCPs:
+
+* *workerpool-canary* with 10 nodes
+* *workerpool-A* with 30 nodes
+* *workerpool-B* with 30 nodes
+* *workerpool-C* with 30 nodes
+
+
+[discrete]
+[id="updating-canary-worker-pool_{context}"]
+=== Updating the canary worker pool
+
+During your first maintenance window, you pause the MCPs for *workerpool-A*, *workerpool-B*, and *workerpool-C*, and then initiate the cluster update.
+This updates components that run on top of {product-title} and the 10 nodes that are part of the unpaused *workerpool-canary* MCP.
+The other three MCPs are not updated because they were paused.
+
+[discrete]
+[id="determining-remaining-worker-pools_{context}"]
+=== Determining whether to proceed with the remaining worker pool updates
+
+If for some reason you determine that your cluster or workload health was negatively affected by the *workerpool-canary* update, you then cordon and drain all nodes in that pool while still maintaining sufficient capacity until you have diagnosed and resolved the problem.
+When everything is working as expected, you evaluate the cluster and workload health before deciding to unpause, and thus update, *workerpool-A*, *workerpool-B*, and *workerpool-C* in succession during each additional maintenance window.
+
+Managing worker node updates using custom MCPs provides flexibility, however it can be a time-consuming process that requires you execute multiple commands. This complexity can result in errors that might affect the entire cluster. It is recommended that you carefully consider your organizational needs and carefully plan the implementation of the process before you start.
 
 //The following wording comes from https://github.com/openshift/openshift-docs/pull/34704, not yet finalized
 
@@ -39,25 +73,56 @@ If the MCP is paused when the `kube-apiserver-to-kubelet-signer` CA certificate 
 Pausing an MCP should be done with careful consideration about the `kube-apiserver-to-kubelet-signer` CA certificate expiration and for short periods of time only.
 ====
 
+[NOTE]
+====
+It is not recommended to update the MCPs to different {product-title} versions. For example, do not update one MCP from 4.y.10 to 4.y.11 and another to 4.y.12.
+This scenario has not been tested and might result in an undefined cluster state.
+====
+
 [id="update-using-custom-machine-config-pools-about-mcp_{context}"]
 == About the canary rollout update process and MCPs
 
-In {product-title}, nodes are not considered individually. Nodes are grouped into machine config pools (MCP). There are two MCPs in a default {product-title} cluster: one for the control plane nodes and one for the worker nodes. An {product-title} update affects all MCPs concurrently.
+In {product-title}, nodes are not considered individually. Instead, they are grouped into machine config pools (MCPs).
+By default, nodes in an {product-title} cluster are grouped into two MCPs: one for the control plane nodes and one for the worker nodes.
+An {product-title} update affects all MCPs concurrently.
 
-During the update, the Machine Config Operator (MCO) drains and cordons all nodes within a MCP up to the specified `maxUnavailable` number of nodes (if specified), by default `1`. Draining and cordoning a node deschedules all pods on the node and marks the node as unschedulable. After the node is drained, the Machine Config Daemon applies a new machine configuration, which can include updating the operating system (OS). Updating the OS requires the host to reboot.
+During the update, the Machine Config Operator (MCO) drains and cordons all nodes within an MCP up to the specified `maxUnavailable` number of nodes, if a max number is specified.
+By default, `maxUnavailable` is set to `1`.
+Draining and cordoning a node deschedules all pods on the node and marks the node as unschedulable.
 
-To prevent specific nodes from being updated, and thus, not drained, cordoned, and updated, you can create custom MCPs. Then, pause those MCPs to ensure that the nodes associated with those MCPs are not updated. The MCO does not update any paused MCPs. You can create one or more custom MCPs, which can give you more control over the sequence in which you update those nodes. After you update the nodes in the first MCP, you can verify the application compatibility, and then update the rest of the nodes gradually to the new version.
+After the node is drained, the Machine Config Daemon applies a new machine configuration, which can include updating the operating system (OS). Updating the OS requires the host to reboot.
+
+[discrete]
+[id="using-custom-mcps_{context}"]
+=== Using custom machine config pools
+
+To prevent specific nodes from being updated, you can create custom MCPs.
+Because the MCO does not update nodes within paused MCPs, you can pause the MCPs containing nodes that you do not want to update before initiating a cluster update.
+
+Using one or more custom MCPs can give you more control over the sequence in which you update your worker nodes.
+For example, after you update the nodes in the first MCP, you can verify the application compatibility and then update the rest of the nodes gradually to the new version.
 
 [NOTE]
 ====
 To ensure the stability of the control plane, creating a custom MCP from the control plane nodes is not supported. The Machine Config Operator (MCO) ignores any custom MCP created for the control plane nodes.
 ====
 
-You should give careful consideration to the number of MCPs you create and the number of nodes in each MCP, based on your workload deployment topology. For example, If you need to fit updates into specific maintenance windows, you need to know how many nodes that {product-title} can update within a window. This number is dependent on your unique cluster and workload characteristics.
+[discrete]
+[id="custom-mcp-considerations_{context}"]
+=== Considerations when using custom machine config pools
 
-Also, you need to consider how much extra capacity you have available in your cluster. For example, in the case where your applications fail to work as expected on the updated nodes, you can cordon and drain those nodes in the pool, which moves the application pods to other nodes. You need to consider how much extra capacity you have available in order to determine the number of custom MCPs you need and how many nodes are in each MCP. For example, if you use two custom MCPs and 50% of your nodes are in each pool, you need to determine if running 50% of your nodes would provide sufficient quality-of-service (QoS) for your applications.
+Give careful consideration to the number of MCPs that you create and the number of nodes in each MCP, based on your workload deployment topology.
+For example, if you must fit updates into specific maintenance windows, you must know how many nodes {product-title} can update within a given window.
+This number is dependent on your unique cluster and workload characteristics.
 
+You must also consider how much extra capacity is available in your cluster to determine the number of custom MCPs and the amount of nodes within each MCP.
+In a case where your applications fail to work as expected on newly updated nodes, you can cordon and drain those nodes in the pool, which moves the application pods to other nodes.
+However, you must determine whether the available nodes in the remaining MCPs can provide sufficient quality-of-service (QoS) for your applications.
+
+[NOTE]
+====
 You can use this update process with all documented {product-title} update processes. However, the process does not work with {op-system-base-full} machines, which are updated using Ansible playbooks.
+====
 
 // About performing a canary rollout update
 include::modules/update-using-custom-machine-config-pools-about.adoc[leveloffset=+1]
@@ -71,12 +136,12 @@ include::modules/update-using-custom-machine-config-pools-pause.adoc[leveloffset
 [id="update-using-custom-machine-config-pools-update_{context}"]
 == Performing the cluster update
 
-When the MCPs enter ready state, you can perform the cluster update. See one of the following update methods, as appropriate for your cluster:
+After the machine config pools (MCP) enter a ready state, you can perform the cluster update. See one of the following update methods, as appropriate for your cluster:
 
 * xref:../../updating/updating_a_cluster/updating-cluster-web-console.adoc#update-upgrading-web_updating-cluster-web-console[Updating a cluster using the web console]
 * xref:../../updating/updating_a_cluster/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster using the CLI]
 
-After the update is complete, you can start to unpause the MCPs one-by-one.
+After the cluster update is complete, you can begin to unpause the MCPs one at a time.
 
 // Unpausing the machine config pools
 include::modules/update-using-custom-machine-config-pools-unpause.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSDOCS-9497](https://issues.redhat.com/browse/OSDOCS-9497)

Versions: 4.12+ (note to merge reviewer, CPs for 4.12 and 4.13 are likely to fail)

This PR makes formatting and sentence/paragraph level edits to the page for performing a canary rollout update, in order to make it more readable. This PR shouldn't change the technical meaning of any content.

QE review:
- [x] QE has approved this change.

Preview: [Performing a canary rollout update](https://71004--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/update-using-custom-machine-config-pools)
