### PR TITLE
OSDOCS#9482: release note EUS version fix

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -27,10 +27,10 @@ You must use {op-system} machines for the control plane, and you can use either 
 //TODO: Add this for 4.14
 Starting with {product-title} 4.12, an additional six months is added to the Extended Update Support (EUS) phase on even numbered releases from 18 months to two years. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
 
-Starting with {product-title} {product-version}, Extended Update Support (EUS) is extended to 64-bit ARM, {ibm-power-name} (ppc64le), and {ibm-z-name} (s390x) platforms. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
+Starting with {product-title} 4.14, Extended Update Support (EUS) is extended to 64-bit ARM, {ibm-power-name} (ppc64le), and {ibm-z-name} (s390x) platforms. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
 
-//TODO: Add the line below for EUS releases.
-{product-title} {product-version} is an Extended Update Support (EUS) release. More information on Red Hat OpenShift EUS is available in link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[OpenShift Life Cycle] and link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
+//TODO: Add the line below for EUS releases and comment it out for non-EUS releases.
+// {product-title} {product-version} is an Extended Update Support (EUS) release. More information on Red Hat OpenShift EUS is available in link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[OpenShift Life Cycle] and link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
 
 //TODO: The line below should be used when it is next appropriate. Revisit in August 2023 time frame.
 Maintenance support ends for version 4.12 on 25 January 2025 and goes to extended life phase. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
@@ -480,7 +480,7 @@ Previously, when SELinux was enabled, the persistent volume's (PV's) files were 
 
 In {product-title} 4.15, for Container Storage Interface (CSI) driver that support this feature, the driver will mount the volume directly with the correct SELinux labels, eliminating the need to recursively relabel the volume, and pod startup can be significantly faster.
 
-This feature is supported with Technology Preview status. 
+This feature is supported with Technology Preview status.
 
 If the following conditions are true, the feature is enabled by default:
 


### PR DESCRIPTION
[OSDOCS-9482](https://issues.redhat.com/browse/OSDOCS-9482)

Version: 4.15

This PR fixes an issue where, in the 4.14 release notes, new support statements specific to 4.14 are described using a dynamic product-version variable instead of `4.14`. This resulted in the 4.15 RNs incorrectly describing things as relating to 4.15 instead of its original version.

QE review:
- [x] QE has approved this change.

Old docs:

- [OpenShift Container Platform 4.14 release notes](https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-about-this-release:~:text=Starting%20with%20OpenShift%20Container%20Platform%204.14)
- [OpenShift Container Platform 4.15 release notes](https://docs.openshift.com/container-platform/4.15/release_notes/ocp-4-15-release-notes.html#ocp-4-14-about-this-release:~:text=Starting%20with%20OpenShift%20Container%20Platform%204.15)

Preview: [OpenShift Container Platform 4.15 release notes](https://71010--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#:~:text=Cycle%20Policy.-,Starting%20with%20OpenShift%20Container%20Platform%204.14,-%2C%20Extended%20Update%20Support)