### PR TITLE
[OSDOCS#9208]: Docs work for IPI: ShiftStack dual stack support

### DIFF
--- a/modules/install-osp-deploy-dualstack.adoc
+++ b/modules/install-osp-deploy-dualstack.adoc
@@ -7,7 +7,7 @@
 
 .Procedure
 
-. Create a network with IPv4 and IPv6 subnets. The available address modes for `ipv6-ra-mode` and `ipv6-address-mode` fields are: `stateful`, `stateless` and `slaac`.
+. Create a network with IPv4 and IPv6 subnets. The available address modes for the `ipv6-ra-mode` and `ipv6-address-mode` fields are: `dhcpv6-stateful`, `dhcpv6-stateless`, and `slaac`.
 +
 [NOTE]
 ====
@@ -24,15 +24,14 @@ DHCP must be enabled on the subnets.
 . Add the IPv6 subnet to the router to enable router advertisements. If you are using a provider network, you can enable router advertisements by adding the network as an external gateway, which also enables external connectivity.
 
 
-. To configure IPv4 and IPv6 address endpoints for cluster nodes, edit the `install-config.yaml` file. The following is an example of an `install-config.yaml` file.
-
+. To configure IPv4 and IPv6 address endpoints for cluster nodes, edit the `install-config.yaml` file. The following is an example of an `install-config.yaml` file:
++
 .Example `install-config.yaml`
 
 [source, yaml]
 ----
 apiVersion: v1
 baseDomain: mydomain.test
-featureSet: TechPreviewNoUpgrade <1>
 compute:
 - name: worker
   platform:
@@ -48,38 +47,95 @@ controlPlane:
 metadata:
   name: mycluster
 networking:
-  machineNetwork: <2>
+  machineNetwork: <1>
   - cidr: "192.168.25.0/24"
   - cidr: "fd2e:6f44:5dd8:c956::/64"
-  clusterNetwork: <2>
+  clusterNetwork: <1>
   - cidr: 10.128.0.0/14
     hostPrefix: 23
   - cidr: fd01::/48
     hostPrefix: 64
-  serviceNetwork: <2>
+  serviceNetwork: <1>
   - 172.30.0.0/16
   - fd02::/112
 platform:
   openstack:
-    ingressVIPs: ['192.168.25.79', 'fd2e:6f44:5dd8:c956:f816:3eff:fef1:1bad'] <3>
-    apiVIPs: ['192.168.25.199', 'fd2e:6f44:5dd8:c956:f816:3eff:fe78:cf36'] <4>
-    controlPlanePort: <5>
-      fixedIPs: <6>
-      - subnet: <7>
+    ingressVIPs: ['192.168.25.79', 'fd2e:6f44:5dd8:c956:f816:3eff:fef1:1bad'] <2>
+    apiVIPs: ['192.168.25.199', 'fd2e:6f44:5dd8:c956:f816:3eff:fe78:cf36'] <3>
+    controlPlanePort: <4>
+      fixedIPs: <5>
+      - subnet: <6>
           name: subnet-v4
           id: subnet-v4-id
-      - subnet: <7>
+      - subnet: <6>
           name: subnet-v6
           id: subnet-v6-id
       network: <7>
         name: dualstack
         id: network-id
 ----
+<1> You must specify an IP address range for both the IPv4 and IPv6 address families.
+<2> Specify the virtual IP (VIP) address endpoints for the Ingress VIP services to provide an interface to the cluster.
+<3> Specify the virtual IP (VIP) address endpoints for the API VIP services to provide an interface to the cluster.
+<4> Specify the dual-stack network details that are used by all of the nodes across the cluster.
+<5> The CIDR of any subnet specified in this field must match the CIDRs listed on `networks.machineNetwork`.
+<6> You can specify a value for either `name` or `id`, or both.
+<7> Specifying the `network` under the `ControlPlanePort` field is optional.
++
+Alternatively, if you want an IPv6 primary dual-stack cluster, edit the `install-config.yaml` file following the example below:
++
+.Example `install-config.yaml`
 
-<1> Dual-stack clusters are supported only with the `TechPreviewNoUpgrade` value.
-<2> You must specify an IP address range in the `cidr` field for both IPv4 and IPv6 address families.
-<3> Specify the virtual IP (VIP) address endpoints for the Ingress VIP services to provide an interface to the cluster.
-<4> Specify the virtual IP (VIP) address endpoints for the API VIP services to provide an interface to the cluster.
-<5> Specify the dual-stack network details that are used by all the nodes across the cluster.
-<6> The CIDR of any subnet specified in this field must match the CIDRs listed on `networks.machineNetwork`.
-<7> You can specify a value for either `name` or `id`, or both.
+[source, yaml]
+----
+apiVersion: v1
+baseDomain: mydomain.test
+compute:
+- name: worker
+  platform:
+    openstack:
+      type: m1.xlarge
+  replicas: 3
+controlPlane:
+  name: master
+  platform:
+    openstack:
+      type: m1.xlarge
+  replicas: 3
+metadata:
+  name: mycluster
+networking:
+  machineNetwork: <1>
+  - cidr: "fd2e:6f44:5dd8:c956::/64"
+  - cidr: "192.168.25.0/24"
+  clusterNetwork: <1>
+  - cidr: fd01::/48
+    hostPrefix: 64
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  serviceNetwork: <1>
+  - fd02::/112
+  - 172.30.0.0/16
+platform:
+  openstack:
+    ingressVIPs: ['fd2e:6f44:5dd8:c956:f816:3eff:fef1:1bad', '192.168.25.79'] <2>
+    apiVIPs: ['fd2e:6f44:5dd8:c956:f816:3eff:fe78:cf36', '192.168.25.199'] <3>
+    controlPlanePort: <4>
+      fixedIPs: <5>
+      - subnet: <6>
+          name: subnet-v6
+          id: subnet-v6-id
+      - subnet: <6>
+          name: subnet-v4
+          id: subnet-v4-id
+      network: <7>
+        name: dualstack
+        id: network-id
+----
+<1> You must specify an IP address range for both the IPv4 and IPv6 address families.
+<2> Specify the virtual IP (VIP) address endpoints for the Ingress VIP services to provide an interface to the cluster.
+<3> Specify the virtual IP (VIP) address endpoints for the API VIP services to provide an interface to the cluster.
+<4> Specify the dual-stack network details that are used by all the nodes across the cluster.
+<5> The CIDR of any subnet specified in this field must match the CIDRs listed on `networks.machineNetwork`.
+<6> You can specify a value for either `name` or `id`, or both.
+<7> Specifying the `network` under the `ControlPlanePort` field is optional.

--- a/modules/install-osp-dualstack.adoc
+++ b/modules/install-osp-dualstack.adoc
@@ -6,16 +6,11 @@
 = Optional: Configuring a cluster with dual-stack networking
 
 :FeatureName: Dual-stack configuration for OpenStack
-include::snippets/technology-preview.adoc[]
 
 You can create a dual-stack cluster on {rh-openstack}. However, the dual-stack configuration is enabled only if you are using an {rh-openstack} network with IPv4 and IPv6 subnets.
 
 [NOTE]
 ====
-{rh-openstack} does not support the following configurations:
-
-* Conversion of an IPv4 single-stack cluster to a dual-stack cluster network.
-
-* IPv6 as the primary address family for dual-stack cluster network.
+{rh-openstack} does not support the conversion of an IPv4 single-stack cluster to a dual-stack cluster network.
 ====
 


### PR DESCRIPTION
Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-9208

Link to docs preview:
https://71011--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-custom#install-osp-dualstack_installing-openstack-installer-custom

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
