### PR TITLE
OCPBUGS#24002: MetalLB mentioned as external load balancer

### DIFF
--- a/modules/nw-osp-configuring-external-load-balancer.adoc
+++ b/modules/nw-osp-configuring-external-load-balancer.adoc
@@ -30,6 +30,11 @@ on {rh-openstack-first}
 endif::[]
 to use an external load balancer in place of the default load balancer.
 
+[NOTE]
+====
+MetalLB, that runs on a cluster, functions as an external load balancer.
+====
+
 [IMPORTANT]
 ====
 Configuring an external load balancer depends on your vendor's load balancer.


### PR DESCRIPTION
Version(s): 4.13+

Issue: https://issues.redhat.com/browse/OCPBUGS-24002

Link to docs preview: https://71014--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration#nw-osp-configuring-external-load-balancer_ipi-install-post-installation-configuration

QE review:
- [x] QE has approved this change. @asood-rh 
- [x] SME has approved this change. @cybertron 