### PR TITLE
TELCODOCS-1678 Adding note to clarify that the Kubernetes NMState Ope…

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1305,9 +1305,7 @@ Topics:
   Topics:
   - Name: About the Kubernetes NMState Operator
     File: k8s-nmstate-about-the-k8s-nmstate-operator
-  - Name: Observing node network state
-    File: k8s-nmstate-observing-node-network-state
-  - Name: Updating node network configuration
+  - Name: Observing and updating node network state and configuration
     File: k8s-nmstate-updating-node-network-config
   - Name: Troubleshooting node network configuration
     File: k8s-nmstate-troubleshooting-node-network

--- a/modules/virt-about-nmstate.adoc
+++ b/modules/virt-about-nmstate.adoc
@@ -29,5 +29,5 @@ Node networking is monitored and updated by the following objects:
 
 [NOTE]
 ====
-If your {product-title} cluster uses OVN-Kubernetes as the network plugin, you cannot make configuration changes to the `br-ex` bridge or its underlying interfaces. As a workaround, use a secondary network interface connected to your host or switch to the OpenShift SDN network plugin.
+You cannot make configuration changes to the `br-ex` bridge or its underlying interfaces. As a workaround, use a secondary network interface connected to your host or switch.
 ====

--- a/modules/virt-node-network-config-console.adoc
+++ b/modules/virt-node-network-config-console.adoc
@@ -1,0 +1,5 @@
+:_mod-docs-content-type: CONCEPT
+[id="virt-node-network-config-console_{context}"]
+= Managing policy from the web console
+You can update the node network configuration, such as adding or removing interfaces from nodes, by applying `NodeNetworkConfigurationPolicy` manifests to the cluster.
+Manage the policy from the web console by accessing the list of created policies in the *NodeNetworkConfigurationPolicy* page under the *Networking* menu. This page enables you to create, update, monitor, and delete the policies.

--- a/modules/virt-viewing-network-state-of-node.adoc
+++ b/modules/virt-viewing-network-state-of-node.adoc
@@ -7,7 +7,7 @@
 [id="virt-viewing-network-state-of-node_{context}"]
 = Viewing the network state of a node
 
-A `NodeNetworkState` object exists on every node in the cluster. This object is periodically updated and captures the state of the network for that node.
+Node network state is the network configuration for all nodes in the cluster. A `NodeNetworkState` object exists on every node in the cluster. This object is periodically updated and captures the state of the network for that node.
 
 .Procedure
 

--- a/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
@@ -21,6 +21,19 @@ When using OVN-Kubernetes, changing the default gateway interface is not support
 
 Before you can use NMState with {product-title}, you must install the Kubernetes NMState Operator.
 
+[NOTE]
+====
+The Kubernetes NMState Operator updates the network configuration of a secondary NIC. It cannot update the network configuration of the primary NIC or the `br-ex` bridge.
+====
+
+{product-title} uses link:https://nmstate.github.io/[`nmstate`] to report on and configure the state of the node network. This makes it possible to modify the network policy configuration, such as by creating a Linux bridge on all nodes, by applying a single configuration manifest to the cluster.
+
+Node networking is monitored and updated by the following objects:
+
+`NodeNetworkState`:: Reports the state of the network on that node.
+`NodeNetworkConfigurationPolicy`:: Describes the requested network configuration on nodes. You update the node network configuration, including adding and removing interfaces, by applying a `NodeNetworkConfigurationPolicy` manifest to the cluster.
+`NodeNetworkConfigurationEnactment`:: Reports the network policies enacted upon each node.
+
 [id="installing-the-kubernetes-nmstate-operator-cli"]
 == Installing the Kubernetes NMState Operator
 

--- a/networking/k8s_nmstate/k8s-nmstate-observing-node-network-state.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-observing-node-network-state.adoc
@@ -9,6 +9,4 @@ toc::[]
 
 Node network state is the network configuration for all nodes in the cluster.
 
-include::modules/virt-about-nmstate.adoc[leveloffset=+1]
-
 include::modules/virt-viewing-network-state-of-node.adoc[leveloffset=+1]

--- a/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
@@ -1,14 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="k8s-nmstate-updating-node-network-config"]
-= Updating node network configuration
+= Observing and updating the node network state and configuration
 include::_attributes/common-attributes.adoc[]
 :VirtProductName: OpenShift Container Platform
 :context: k8s_nmstate-updating-node-network-config
 
 toc::[]
 
-You can update the node network configuration, such as adding or removing interfaces from nodes, by applying `NodeNetworkConfigurationPolicy` manifests to the cluster.
 
+<<<<<<< HEAD
 [WARNING]
 ====
 When using OVN-Kubernetes, changing the default gateway interface is not supported.
@@ -17,6 +17,24 @@ When using OVN-Kubernetes, changing the default gateway interface is not support
 include::modules/virt-about-nmstate.adoc[leveloffset=+1]
 
 include::modules/virt-creating-interface-on-nodes.adoc[leveloffset=+1]
+=======
+include::modules/virt-viewing-network-state-of-node.adoc[leveloffset=+1]
+
+include::modules/virt-viewing-network-state-of-node-console.adoc[leveloffset=+1]
+
+include::modules/virt-node-network-config-console.adoc[leveloffset=+1]
+include::modules/virt-monitor-node-network-config-console.adoc[leveloffset=+2]
+include::modules/virt-create-node-network-config-console.adoc[leveloffset=+2]
+
+=== Updating the policy
+include::modules/virt-update-node-network-config-form.adoc[leveloffset=+3]
+include::modules/virt-update-node-network-config-yaml.adoc[leveloffset=+3]
+include::modules/virt-delete-node-network-config.adoc[leveloffset=+2]
+
+[id="virt-manage-nncp-cli"]
+== Managing policy by using the CLI
+include::modules/virt-creating-interface-on-nodes.adoc[leveloffset=+2]
+>>>>>>> b67fb998bc (TELCODOCS-1678 Adding note to clarify that the Kubernetes NMState Operator)
 
 [discrete]
 [role="_additional-resources"]

--- a/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
@@ -8,16 +8,6 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 
-<<<<<<< HEAD
-[WARNING]
-====
-When using OVN-Kubernetes, changing the default gateway interface is not supported.
-====
-
-include::modules/virt-about-nmstate.adoc[leveloffset=+1]
-
-include::modules/virt-creating-interface-on-nodes.adoc[leveloffset=+1]
-=======
 include::modules/virt-viewing-network-state-of-node.adoc[leveloffset=+1]
 
 include::modules/virt-viewing-network-state-of-node-console.adoc[leveloffset=+1]
@@ -34,7 +24,6 @@ include::modules/virt-delete-node-network-config.adoc[leveloffset=+2]
 [id="virt-manage-nncp-cli"]
 == Managing policy by using the CLI
 include::modules/virt-creating-interface-on-nodes.adoc[leveloffset=+2]
->>>>>>> b67fb998bc (TELCODOCS-1678 Adding note to clarify that the Kubernetes NMState Operator)
 
 [discrete]
 [role="_additional-resources"]


### PR DESCRIPTION
[TELCODOCS-1678]: Adding note to clarify that the Kubernetes NMState

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-1678
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

- https://69749--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.html
- https://69749--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
