### PR TITLE
OCP 4.15: Setting SMT levels for Power in OpenShift Installer

### DIFF
--- a/modules/installation-ibm-power-vs-config-yaml.adoc
+++ b/modules/installation-ibm-power-vs-config-yaml.adoc
@@ -38,13 +38,17 @@ compute: <1> <2>
 - architecture: ppc64le
   hyperthreading: Enabled <3>
   name: worker
-  platform: {}
+  platform:
+    powervs:
+      smtLevel: 8 <4>
   replicas: 3
 controlPlane: <1> <2>
   architecture: ppc64le
   hyperthreading: Enabled <3>
   name: master
-  platform: {}
+  platform:
+    powervs:
+      smtLevel: 8 <4>
   replicas: 3
 metadata:
   creationTimestamp: null
@@ -55,7 +59,7 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 192.168.0.0/24
-  networkType: OVNKubernetes <4>
+  networkType: OVNKubernetes <5>
   serviceNetwork:
   - 172.30.0.0/16
 platform:
@@ -63,12 +67,12 @@ platform:
     userID: ibm-user-id
     region: powervs-region
     zone: powervs-zone
-    powervsResourceGroup: "ibmcloud-resource-group" <5>
+    powervsResourceGroup: "ibmcloud-resource-group" <6>
     serviceInstanceGUID: "powervs-region-service-instance-guid"
 vpcRegion : vpc-region
 publish: External
-pullSecret: '{"auths": ...}' <6>
-sshKey: ssh-ed25519 AAAA... <7>
+pullSecret: '{"auths": ...}' <7>
+sshKey: ssh-ed25519 AAAA... <8>
 ----
 <1> If you do not provide these parameters and values, the installation program provides the default value.
 <2> The `controlPlane` section is a single mapping, but the compute section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Although both sections currently define a single machine pool, it is possible that {product-title} will support defining multiple compute pools during installation. Only one control plane pool is used.
@@ -87,11 +91,17 @@ If you disable simultaneous multithreading, ensure that your capacity planning a
 //====
 //<6> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 //endif::openshift-origin[]
-<4> The cluster network plugin to install. The supported values are `OVNKubernetes` and `OpenShiftSDN`. The default value is `OVNKubernetes`.
-<5> The name of an existing resource group.
-<6> Required. The installation program prompts you for this value.
+<4> The smtLevel specifies the level of SMT to set to the control plane and compute machines. The supported values are 1, 2, 4, 8, `'off'` and `'on'`. The default value is 8. The smtLevel `'off'` sets SMT to off and smtlevel `'on'` sets SMT to the default value 8 on the cluster nodes.
++
+[NOTE]
+====
+When simultaneous multithreading (SMT), or hyperthreading is not enabled, one vCPU is equivalent to one physical core. When enabled, total vCPUs is computed as: (Thread(s) per core * Core(s) per socket) * Socket(s). The smtLevel controls the threads per core. Lower SMT levels may require additional assigned cores when deploying the cluster nodes. You can do this by setting the `'processors'` parameter in the `install-config.yaml` file to an appropriate value to meet the requirements for deploying {product-title} successfully.
+====
+<5> The cluster network plugin to install. The supported value is `OVNKubernetes`.
+<6> The name of an existing resource group.
+<7> Required. The installation program prompts you for this value.
 ifdef::openshift-origin[]
-<7> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+<8> Optional. You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 +
 [NOTE]
@@ -109,24 +119,28 @@ compute: <1> <2>
 - architecture: ppc64le
   hyperthreading: Enabled <3>
   name: worker
-  platform: {}
+  platform:
+    powervs:
+      smtLevel: 8 <4>
   replicas: 3
 controlPlane: <1> <2>
   architecture: ppc64le
   hyperthreading: Enabled <3>
   name: master
-  platform: {}
+  platform:
+    powervs:
+      smtLevel: 8 <4>
   replicas: 3
 metadata:
   creationTimestamp: null
   name: example-private-cluster-name
 networking:
   clusterNetwork:
-  - cidr: 10.128.0.0/14 <4>
+  - cidr: 10.128.0.0/14 <5>
     hostPrefix: 23
   machineNetwork:
   - cidr: 192.168.0.0/24
-  networkType: OVNKubernetes <5>
+  networkType: OVNKubernetes <6>
   serviceNetwork:
   - 172.30.0.0/16
 platform:
@@ -134,25 +148,31 @@ platform:
     userID: ibm-user-id
     powervsResourceGroup: "ibmcloud-resource-group"
     region: powervs-region
-    vpcName: name-of-existing-vpc <6>
+    vpcName: name-of-existing-vpc <7>
     vpcSubnets:
     - powervs-region-example-subnet-1
     vpcRegion : vpc-region
     zone: powervs-zone
     serviceInstanceGUID: "powervs-region-service-instance-guid"
-publish: Internal <7>
-pullSecret: '{"auths": ...}' <8>
-sshKey: ssh-ed25519 AAAA... <9>
+publish: Internal <8>
+pullSecret: '{"auths": ...}' <9>
+sshKey: ssh-ed25519 AAAA... <10>
 ----
 <1> If you do not provide these parameters and values, the installation program provides the default value.
 <2> The `controlPlane` section is a single mapping, but the compute section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Both sections currently define a single machine pool. Only one control plane pool is used.
 <3> Whether to enable or disable simultaneous multithreading, or `hyperthreading`. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores. You can disable it by setting the parameter value to `Disabled`. If you disable simultaneous multithreading in some cluster machines, you must disable it in all cluster machines.
-<4> The machine CIDR must contain the subnets for the compute machines and control plane machines.
-<5> The cluster network plugin to install. The supported values are `OVNKubernetes` and `OpenShiftSDN`. The default value is `OVNKubernetes`.
-<6> Specify the name of an existing VPC.
-<7> How to publish the user-facing endpoints of your cluster. Set publish to `Internal` to deploy a private cluster.
-<8> Required. The installation program prompts you for this value.
-<9> Provide the `sshKey` value that you use to access the machines in your cluster.
+<4> The smtLevel specifies the level of SMT to set to the control plane and compute machines. The supported values are 1, 2, 4, 8, `'off'` and `'on'`. The default value is 8. The smtLevel `'off'` sets SMT to off and smtlevel `'on'` sets SMT to the default value 8 on the cluster nodes.
++
+[NOTE]
+====
+When simultaneous multithreading (SMT), or hyperthreading is not enabled, one vCPU is equivalent to one physical core. When enabled, total vCPUs is computed as (Thread(s) per core * Core(s) per socket) * Socket(s). The smtLevel controls the threads per core. Lower SMT levels may require additional assigned cores when deploying the cluster nodes. You can do this by setting the `'processors'` parameter in the `install-config.yaml` file to an appropriate value to meet the requirements for deploying {product-title} successfully.
+====
+<5> The machine CIDR must contain the subnets for the compute machines and control plane machines.
+<6> The cluster network plugin to install. The supported value is `OVNKubernetes`.
+<7> Specify the name of an existing VPC.
+<8> Specify how to publish the user-facing endpoints of your cluster. Set publish to `Internal` to deploy a private cluster.
+<9> Required. The installation program prompts you for this value.
+<10> Provide the `sshKey` value that you use to access the machines in your cluster.
 +
 [IMPORTANT]
 ====
@@ -187,24 +207,28 @@ compute: <1> <2>
 - architecture: ppc64le
   hyperthreading: Enabled <3>
   name: worker
-  platform: {}
+  platform:
+    powervs:
+      smtLevel: 8 <4>
   replicas: 3
 controlPlane: <1> <2>
   architecture: ppc64le
   hyperthreading: Enabled <3>
   name: master
-  platform: {}
+  platform:
+    powervs:
+      smtLevel: 8 <4>
   replicas: 3
 metadata:
   creationTimestamp: null
   name: example-cluster-existing-vpc
 networking:
   clusterNetwork:
-  - cidr: 10.128.0.0/14 <4>
+  - cidr: 10.128.0.0/14 <5>
     hostPrefix: 23
   machineNetwork:
   - cidr: 192.168.0.0/24
-  networkType: OVNKubernetes <5>
+  networkType: OVNKubernetes <6>
   serviceNetwork:
   - 172.30.0.0/16
 platform:
@@ -213,27 +237,33 @@ platform:
     powervsResourceGroup: "ibmcloud-resource-group"
     region: powervs-region
     vpcRegion : vpc-region
-    vpcName: name-of-existing-vpc <6>
-    vpcSubnets: <7>
+    vpcName: name-of-existing-vpc <7>
+    vpcSubnets: <8>
     - powervs-region-example-subnet-1
     zone: powervs-zone
     serviceInstanceGUID: "powervs-region-service-instance-guid"
 credentialsMode: Manual
-publish: External <8>
-pullSecret: '{"auths": ...}' <9>
+publish: External <9>
+pullSecret: '{"auths": ...}' <10>
 fips: false
-sshKey: ssh-ed25519 AAAA... <10>
+sshKey: ssh-ed25519 AAAA... <11>
 ----
 <1> If you do not provide these parameters and values, the installation program provides the default value.
 <2> The `controlPlane` section is a single mapping, but the compute section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Both sections currently define a single machine pool. Only one control plane pool is used.
 <3> Whether to enable or disable simultaneous multithreading, or `hyperthreading`. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores. You can disable it by setting the parameter value to `Disabled`. If you disable simultaneous multithreading in some cluster machines, you must disable it in all cluster machines.
-<4> The machine CIDR must contain the subnets for the compute machines and control plane machines.
-<5> The cluster network plugin to install. The supported values are `OVNKubernetes` and `OpenShiftSDN`. The default value is `OVNKubernetes`.
-<6> Specify the name of an existing VPC.
-<7> Specify the name of the existing VPC subnet. The subnets must belong to the VPC that you specified. Specify a subnet for each availability zone in the region.
-<8> How to publish the user-facing endpoints of your cluster.
-<9> Required. The installation program prompts you for this value.
-<10> Provide the `sshKey` value that you use to access the machines in your cluster.
+<4> The smtLevel specifies the level of SMT to set to the control plane and compute machines. The supported values are 1, 2, 4, 8, `'off'` and `'on'`. The default value is 8. The smtLevel `'off'` sets SMT to off and smtlevel `'on'` sets SMT to the default value 8 on the cluster nodes.
++
+[NOTE]
+====
+When simultaneous multithreading (SMT), or hyperthreading is not enabled, one vCPU is equivalent to one physical core. When enabled, total vCPUs is computed as (Thread(s) per core * Core(s) per socket) * Socket(s). The smtLevel controls the threads per core. Lower SMT levels may require additional assigned cores when deploying the cluster nodes. You can do this by setting the `'processors'` parameter in the `install-config.yaml` file to an appropriate value to meet the requirements for deploying {product-title} successfully.
+====
+<5> The machine CIDR must contain the subnets for the compute machines and control plane machines.
+<6> The cluster network plugin for installation. The supported value is `OVNKubernetes`.
+<7> Specify the name of an existing VPC.
+<8> Specify the name of the existing VPC subnet. The subnets must belong to the VPC that you specified. Specify a subnet for each availability zone in the region.
+<9> Specify how to publish the user-facing endpoints of your cluster.
+<10> Required. The installation program prompts you for this value.
+<11> Provide the `sshKey` value that you use to access the machines in your cluster.
 +
 [IMPORTANT]
 ====
@@ -268,44 +298,48 @@ controlPlane: <2> <3>
   hyperthreading: Enabled <4>
   name: master
   platform:
+    powervs:
+      smtLevel: 8 <5>
   replicas: 3
 compute: <2> <3>
 - hyperthreading: Enabled <4>
   name: worker
   platform:
+    powervs:
+      smtLevel: 8 <5>
     ibmcloud: {}
   replicas: 3
 metadata:
   name: example-restricted-cluster-name <1>
 networking:
   clusterNetwork:
-  - cidr: 10.128.0.0/14 <5>
+  - cidr: 10.128.0.0/14 <6>
     hostPrefix: 23
   machineNetwork:
-  - cidr: 10.0.0.0/16 <6>
-  networkType: OVNKubernetes <7>
+  - cidr: 10.0.0.0/16 <7>
+  networkType: OVNKubernetes <8>
   serviceNetwork:
   - 192.168.0.0/24
 platform:
   powervs:
     userid: ibm-user-id
-    powervsResourceGroup: "ibmcloud-resource-group" <8>
+    powervsResourceGroup: "ibmcloud-resource-group" <9>
     region: "powervs-region"
     vpcRegion: "vpc-region"
-    vpcName: name-of-existing-vpc <9>
-    vpcSubnets: <10>
+    vpcName: name-of-existing-vpc <10>
+    vpcSubnets: <11>
        - name-of-existing-vpc-subnet
     zone: "powervs-zone"
     serviceInstanceID: "service-instance-id"
 publish: Internal
 credentialsMode: Manual
-pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <11>
-sshKey: ssh-ed25519 AAAA... <12>
-additionalTrustBundle: | <13>
+pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <12>
+sshKey: ssh-ed25519 AAAA... <13>
+additionalTrustBundle: | <14>
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
     -----END CERTIFICATE-----
-imageContentSources: <14>
+imageContentSources: <15>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -322,16 +356,22 @@ imageContentSources: <14>
 ====
 If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance. Use larger machine types, such as `n1-standard-8`, for your machines if you disable simultaneous multithreading.
 ====
-<5> The machine CIDR must contain the subnets for the compute machines and control plane machines.
-<6> The CIDR must contain the subnets defined in `platform.ibmcloud.controlPlaneSubnets` and `platform.ibmcloud.computeSubnets`.
-<7> The cluster network plugin to install. The supported values are `OVNKubernetes` and `OpenShiftSDN`. The default value is `OVNKubernetes`.
-<8> The name of an existing resource group. The existing VPC and subnets should be in this resource group. The cluster is deployed to this resource group.
-<9> Specify the name of an existing VPC.
-<10> Specify the name of the existing VPC subnet. The subnets must belong to the VPC that you specified. Specify a subnet for each availability zone in the region.
-<11> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example, registry.example.com or registry.example.com:5000. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
-<12> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
-<13> Provide the contents of the certificate file that you used for your mirror registry.
-<14> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+<5> The smtLevel specifies the level of SMT to set to the control plane and compute machines. The supported values are 1, 2, 4, 8, `'off'` and `'on'`. The default value is 8. The smtLevel `'off'` sets SMT to off and smtlevel `'on'` sets SMT to the default value 8 on the cluster nodes.
++
+[NOTE]
+====
+When simultaneous multithreading (SMT), or hyperthreading is not enabled, one vCPU is equivalent to one physical core. When enabled, total vCPUs is computed as (Thread(s) per core * Core(s) per socket) * Socket(s). The smtLevel controls the threads per core. Lower SMT levels may require additional assigned cores when deploying the cluster nodes. You can do this by setting the `'processors'` parameter in the `install-config.yaml` file to an appropriate value to meet the requirements for deploying {product-title} successfully.
+====
+<6> The machine CIDR must contain the subnets for the compute machines and control plane machines.
+<7> The CIDR must contain the subnets defined in `platform.ibmcloud.controlPlaneSubnets` and `platform.ibmcloud.computeSubnets`.
+<8> The cluster network plugin to install. The supported value is `OVNKubernetes`.
+<9> The name of an existing resource group. The existing VPC and subnets should be in this resource group. The cluster is deployed to this resource group.
+<10> Specify the name of an existing VPC.
+<11> Specify the name of the existing VPC subnet. The subnets must belong to the VPC that you specified. Specify a subnet for each availability zone in the region.
+<12> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example, registry.example.com or registry.example.com:5000. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
+<13> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+<14> Provide the contents of the certificate file that you used for your mirror registry.
+<15> Provide the `imageContentSources` section from the output of the command to mirror the repository.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Version(s): 4.15

Issue: https://issues.redhat.com/browse/MULTIARCH-3966

Link to docs preview:
https://71019--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/installing-ibm-power-vs-customizations#installation-ibm-power-vs-config-yaml_installing-ibm-power-vs-customizations

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Draft: https://docs.google.com/document/d/1PqaWntfyu3wbdEC3NYZhzaSubZnPylavlj0jmzhFMDc/edit
