### PR TITLE
OSDOCS#8863 & 8864: Version range comparison strings

### DIFF
--- a/modules/olmv1-version-range-comparisons.adoc
+++ b/modules/olmv1-version-range-comparisons.adoc
@@ -1,0 +1,134 @@
+// Module included in the following assemblies:
+//
+// * operators/olm_v1/olmv1-installing-an-operator-from-a-catalog.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="olmv1-version-range-comparisons_{context}"]
+= Version comparison strings
+
+You can define a version range by adding a comparison string to the `spec.version` field in an Operator or extension's custom resource (CR). A comparison string is a list of space- or comma-separated values and one or more comparison operators. You can add another comparison string by including an `OR`, or double vertical bar (`||`), comparison operator between the strings.
+
+.Basic comparisons
+[options="header"]
+|===
+
+|Comparison operator |Definition
+
+|`=`
+|Equal to
+
+|`!=`
+|Not equal to
+
+|`>`
+|Greater than
+
+| `<`
+|Less than
+
+|`>=`
+|Greater than or equal to
+
+|`\<=`
+|Less than or equal to
+
+|===
+
+You can specify a version range in an Operator or extension's CR by using a range comparison similar to the following example:
+
+.Example version range comparison
+[source,yaml]
+----
+apiVersion: operators.operatorframework.io/v1alpha1
+kind: Operator
+metadata:
+  name: pipelines-operator
+spec:
+  packageName: openshift-pipelines-operator-rh
+  version: >=1.11, <1.13
+----
+
+You can use wildcard characters in all types of comparison strings. {olmv1} accepts `x`, `X`, and asterisks (`*`) as wildcard characters. When you use a wildcard character with the equal sign (`=`) comparison operator, you define a comparison at the patch or minor version level.
+
+.Example wildcard characters in comparison strings
+[options="header"]
+|===
+
+|Wildcard comparison |Matching string
+
+|`1.11.x`
+|`>=1.11.0, <1.12.0`
+
+|`>=1.12.X`
+|`>=1.12.0`
+
+|`\<=2.x`
+|`<3`
+
+|`*`
+|`>=0.0.0`
+
+|===
+
+You can make patch release comparisons by using the tilde (`~`) comparison operator. Patch release comparisons specify a minor version up to the next major version.
+
+.Example patch release comparisons
+[options="header"]
+|===
+
+|Patch release comparison |Matching string
+
+|`~1.11.0`
+|`>=1.11.0, <1.12.0`
+
+|`~1`
+|`>=1, <2`
+
+|`~1.12`
+|`>=1.12, <1.13`
+
+|`~1.12.x`
+|`>=1.12.0, <1.13.0`
+
+|`~1.x`
+|`>=1, <2`
+
+|===
+
+You can use the caret (`^`) comparison operator to make a comparison for a major release. If you use a major release comparison before the first stable release is published, the minor versions define the API's level of stability. In the semantic versioning (SemVer) specification, the first stable release is published as the `1.0.0` version.
+
+.Example major release comparisons
+[options="header"]
+|===
+
+|Major release comparison |Matching string
+
+|`^0`
+|`>=0.0.0, <1.0.0`
+
+|`^0.0`
+|`>=0.0.0, <0.1.0`
+
+|`^0.0.3`
+|`>=0.0.3, <0.0.4`
+
+|`^0.2`
+|`>=0.2.0, <0.3.0`
+
+|`^0.2.3`
+|`>=0.2.3, <0.3.0`
+
+|`^1.2.x`
+|`>= 1.2.0, < 2.0.0`
+
+|`^1.2.3`
+|`>= 1.2.3, < 2.0.0`
+
+|`^2.x`
+|`>= 2.0.0, < 3`
+
+|`^2.3`
+|`>= 2.3, < 3`
+
+|===

--- a/modules/olmv1-version-range-support.adoc
+++ b/modules/olmv1-version-range-support.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * operators/olm_v1/olmv1-installing-an-operator-from-a-catalog.adoc
+
+:_mod-docs-content-type: CONCEPT
+
+[id="olmv1-version-range-support_{context}"]
+= Support for version ranges
+
+In {olmv1-first}, you can specify a version range by using a comparison string in an Operator or extension's custom resource (CR). If you specify a version range in the CR, {olmv1} installs or updates to the latest version of the Operator that can be resolved within the version range.
+
+.Resolved version workflow
+* The resolved version is the latest version of the Operator that satisfies the dependencies and constraints of the Operator and the environment.
+* An Operator update within the specified range is automatically installed if it is resolved successfully.
+* An update is not installed if it is outside of the specified range or if it cannot be resolved successfully.
+
+For more information about dependency and constraint resolution in {olmv1}, see "Dependency resolution in {olmv1}".

--- a/operators/olm_v1/olmv1-installing-an-operator-from-a-catalog.adoc
+++ b/operators/olm_v1/olmv1-installing-an-operator-from-a-catalog.adoc
@@ -57,5 +57,20 @@ include::modules/olmv1-finding-operators-to-install.adoc[leveloffset=+1]
 include::modules/olmv1-catalog-queries.adoc[leveloffset=+2]
 
 include::modules/olmv1-about-target-versions.adoc[leveloffset=+1]
+include::modules/olmv1-version-range-support.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../operators/olm_v1/arch/olmv1-dependency.adoc#olmv1-dependency[Dependency resolution in OLM 1.0]
+
+include::modules/olmv1-version-range-comparisons.adoc[leveloffset=+2]
+
+include::modules/olmv1-installing-an-operator.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../operators/olm_v1/olmv1-installing-an-operator-from-a-catalog.adoc#olmv1-about-operator-updates_olmv1-installing-operator[About target versions in OLM 1.0]
+* xref:../../operators/olm_v1/olmv1-installing-an-operator-from-a-catalog.adoc#olmv1-version-range-support_olmv1-installing-operator[Support for version ranges]
+
 include::modules/olmv1-updating-an-operator.adoc[leveloffset=+1]
 include::modules/olmv1-deleting-an-operator.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-8863](https://issues.redhat.com//browse/OSDOCS-8863) and [OSDOCS-8864](https://issues.redhat.com//browse/OSDOCS-8864)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
* [Support for version ranges](https://71044--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/olm_v1/olmv1-installing-an-operator-from-a-catalog#olmv1-version-range-support_olmv1-installing-operator)
* [Version range comparisons](https://71044--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/olm_v1/olmv1-installing-an-operator-from-a-catalog#olmv1-version-range-comparisons_olmv1-installing-operator)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
