### PR TITLE
TELCODOCS-1724: Adding OLM cluster capability

### DIFF
--- a/installing/cluster-capabilities.adoc
+++ b/installing/cluster-capabilities.adoc
@@ -91,6 +91,13 @@ include::modules/operator-marketplace.adoc[leveloffset=+2]
 .Additional resources
 * xref:../operators/understanding/olm-rh-catalogs.adoc#olm-rh-catalogs[Red Hat-provided Operator catalogs]
 
+// OperatorLifecycleManager capability
+include::modules/olm-overview.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../operators/understanding/olm/olm-understanding-olm.adoc#olm-understanding-olm[Operator Lifecycle Manager concepts and resources]
+
 // Node Tuning capability
 include::modules/node-tuning-operator.adoc[leveloffset=+2]
 

--- a/modules/olm-overview.adoc
+++ b/modules/olm-overview.adoc
@@ -1,18 +1,37 @@
 // Module included in the following assemblies:
 //
+// * installing/cluster-capabilities.adoc
 // * operators/understanding/olm/olm-understanding-olm.adoc
 // * operators/operator-reference.adoc
 
+ifeval::["{context}" == "cluster-operators-ref"]
+:operators:
+endif::[]
+ifeval::["{context}" == "cluster-capabilities"]
+:cluster-caps:
+endif::[]
+
+
+:_mod-docs-content-type: CONCEPT
 [id="olm-overview_{context}"]
-ifeval::["{context}" != "cluster-operators-ref"]
+ifndef::operators[]
+ifndef::cluster-caps[]
 = What is Operator Lifecycle Manager?
 endif::[]
-ifeval::["{context}" == "cluster-operators-ref"]
+endif::[]
+ifdef::operators[]
 = Purpose
+endif::[]
+ifdef::cluster-caps[]
+= Operator Lifecycle Manager capability
+
+[discrete]
+== Purpose
 endif::[]
 
 _Operator Lifecycle Manager_ (OLM) helps users install, update, and manage the lifecycle of Kubernetes native applications (Operators) and their associated services running across their {product-title} clusters. It is part of the link:https://operatorframework.io/[Operator Framework], an open source toolkit designed to manage Operators in an effective, automated, and scalable way.
 
+ifndef::cluster-caps[]
 .Operator Lifecycle Manager workflow
 image::olm-workflow.png[]
 
@@ -33,3 +52,27 @@ endif::openshift-dedicated,openshift-rosa[]
 to install Operators, as well as grant specific projects access to use the catalog of Operators available on the cluster.
 
 For developers, a self-service experience allows provisioning and configuring instances of databases, monitoring, and big data services without having to be subject matter experts, because the Operator has that knowledge baked into it.
+endif::[]
+
+ifdef::cluster-caps[]
+If an Operator requires any of the following APIs, then you must enable the `OperatorLifecycleManager` capability:
+
+* `ClusterServiceVersion` 
+* `CatalogSource`
+* `Subscription`
+* `InstallPlan`
+* `OperatorGroup`
+
+[IMPORTANT]
+====
+The `marketplace` capability depends on the `OperatorLifecycleManager` capability. You cannot disable the `OperatorLifecycleManager` capability and enable the `marketplace` capability.
+====
+endif::[]
+
+ifeval::["{context}" == "cluster-operators-ref"]
+:!operators:
+endif::[]
+
+ifeval::["{context}" == "cluster-caps"]
+:!cluster-caps:
+endif::[]

--- a/snippets/capabilities-table.adoc
+++ b/snippets/capabilities-table.adoc
@@ -22,6 +22,9 @@ The following table describes the `baselineCapabilitySet` values.
 |`v4.14`
 |Specify this option when you want to enable the default capabilities for {product-title} 4.14. By specifying `v4.14`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.14 are `baremetal`, `MachineAPI`, `marketplace`, `openshift-samples`, `Console`, `Insights`, `Storage`, `CSISnapshot`, `NodeTuning`, `ImageRegistry`, `Build`, and `DeploymentConfig`.
 
+|`v4.15`
+|Specify this option when you want to enable the default capabilities for {product-title} 4.15. By specifying `v4.15`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.15 are `baremetal`, `MachineAPI`, `marketplace`, `OperatorLifecycleManager`, `openshift-samples`, `Console`, `Insights`, `Storage`, `CSISnapshot`, `NodeTuning`, `ImageRegistry`, `Build`, and `DeploymentConfig`.
+
 |`None`
 |Specify when the other sets are too large, and you do not need any capabilities or want to fine-tune via `additionalEnabledCapabilities`.
 


### PR DESCRIPTION
[TELCODOCS-1724](https://issues.redhat.com//browse/TELCODOCS-1724): Adds the OLM cluster capability for optional configuration at install time

Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1724

Link to docs preview:
- OLM capability
https://71069--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/cluster-capabilities#olm-overview_cluster-capabilities
- Updated table for 4.15
https://71069--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/cluster-capabilities#selecting-cluster-capabilities_cluster-capabilities

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
