### PR TITLE
OSDOCS#8867: Adding xref to failure domain release note

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -84,7 +84,7 @@ You can now install a cluster on {ibm-cloud-name} in an environment with limited
 
 By default, the installation program installs control plane and compute machines into a single Nutanix Prism Element (cluster). To improve the fault tolerance of your {product-title} cluster, you can now specify that these machines be distributed across multiple Nutanix clusters by configuring failure domains.
 
-//For more information, see <insert link to Fault tolerant deployments using multiple Prism Elements when docs merge>.
+For more information, see xref:../installing/installing_nutanix/nutanix-failure-domains.adoc#nutanix-failure-domains[Fault tolerant deployments using multiple Prism Elements].
 
 [id="ocp-4-15-web-console"]
 === Web console


### PR DESCRIPTION
Version(s):
4.15

Issue:
This PR addresses [osdocs-8867](https://issues.redhat.com/browse/OSDOCS-8867) and updates the failure domains release note with a cross reference to the docs.

Link to docs preview:

[Nutanix and fault tolerant deployments](https://71073--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-installation-and-update-nutanix-failure-domains)

QE review:
[N/A] QE has approved this change.
This PR is only adding an xref. The release note was approved by QE in https://github.com/openshift/openshift-docs/pull/70495.