### PR TITLE
[virt] DPDK checkup: fix image build instruction

### DIFF
--- a/modules/virt-building-vm-containerdisk-image.adoc
+++ b/modules/virt-building-vm-containerdisk-image.adoc
@@ -131,7 +131,7 @@ EOF
 +
 [source,terminal]
 ----
-$ virt-customize -a <UUID>.qcow2 --run=customize-vm --selinux-relabel
+$ virt-customize -a <UUID>-disk.qcow2 --run=customize-vm --selinux-relabel
 ----
 
 . To create a Dockerfile that contains all the commands to build the container disk image, enter the following command:
@@ -140,13 +140,13 @@ $ virt-customize -a <UUID>.qcow2 --run=customize-vm --selinux-relabel
 ----
 $ cat << EOF > Dockerfile
 FROM scratch
-COPY --chown=107:107 <uuid>-disk.qcow2 /disk/
+COPY --chown=107:107 <UUID>-disk.qcow2 /disk/
 EOF
 ----
 +
 where:
 
-<uuid>-disk.qcow2:: Specifies the name of the custom image in `qcow2` format.
+<UUID>-disk.qcow2:: Specifies the name of the custom image in `qcow2` format.
 
 . Build and tag the container by running the following command:
 +


### PR DESCRIPTION
When running the `composer-cli compose image`, the image that is generated is in the following template:
<UUID>-disk.qcow2
Currently the template is incomplete.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
v4.15+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://71077--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-running-cluster-checkups#virt-building-vm-containerdisk-image_virt-running-cluster-checkups

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
