### PR TITLE
Clarification to mention when the eventrouter image needs to be downloaded separately

### DIFF
--- a/modules/cluster-logging-eventrouter-deploy.adoc
+++ b/modules/cluster-logging-eventrouter-deploy.adoc
@@ -10,7 +10,7 @@ Use the following steps to deploy the Event Router into your cluster. You should
 
 [NOTE]
 ====
-The Event Router image is not a part of the {clo} and must be downloaded separately.
+The Event Router image is not a part of the {clo} and must be downloaded separately for restricted environment.
 ====
 
 The following `Template` object creates the service account, cluster role, and cluster role binding required for the Event Router. The template also configures and deploys the Event Router pod. You can either use this template without making changes or edit the template to change the deployment object CPU and memory requests.


### PR DESCRIPTION
Clarification to mention when the eventrouter image needs to be downloaded separately

Version(s):

All the version starting from 4.11

Issue:

https://issues.redhat.com/browse/OBSDOCS-608

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
