### PR TITLE
OSDOCS#8719: Refactor of pre-installation tasks for an IPI installation

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -477,6 +477,8 @@ Topics:
     Topics:
     - Name: vSphere installation requirements
       File: ipi-vsphere-installation-reqs
+    - Name: Preparing to install a cluster
+      File: ipi-vsphere-preparing-to-install
     - Name: Installing a cluster
       File: installing-vsphere-installer-provisioned
     - Name: Installing a cluster with customizations

--- a/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc
+++ b/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc
@@ -13,6 +13,7 @@ include::snippets/vcenter-support.adoc[]
 [id="prerequisites_installing-restricted-networks-installer-provisioned-vsphere"]
 == Prerequisites
 
+* You have completed the tasks in xref:../../../installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc#ipi-vsphere-preparing-to-install[Preparing to install a cluster using installer-provisioned infrastructure].
 * You reviewed your VMware platform licenses. Red{nbsp}Hat does not place any restrictions on your VMware licenses, but some VMware infrastructure components require licensing.
 * You reviewed details about the xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
@@ -35,10 +36,6 @@ If you are configuring a proxy, be sure to also review this site list.
 include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
-
-include::modules/ssh-agent-using.adoc[leveloffset=+1]
-
-include::modules/installation-adding-vcenter-root-certificates.adoc[leveloffset=+1]
 
 include::modules/installation-creating-image-restricted.adoc[leveloffset=+1]
 
@@ -68,8 +65,6 @@ include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 include::modules/configuring-vsphere-regions-zones.adoc[leveloffset=+2]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
-
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 

--- a/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.adoc
+++ b/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.adoc
@@ -14,6 +14,7 @@ include::snippets/vcenter-support.adoc[]
 
 == Prerequisites
 
+* You have completed the tasks in xref:../../../installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc#ipi-vsphere-preparing-to-install[Preparing to install a cluster using installer-provisioned infrastructure].
 * You reviewed your VMware platform licenses. Red{nbsp}Hat does not place any restrictions on your VMware licenses, but some VMware infrastructure components require licensing.
 * You reviewed details about the xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
@@ -28,12 +29,6 @@ Be sure to also review this site list if you are configuring a proxy.
 ====
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
-
-include::modules/ssh-agent-using.adoc[leveloffset=+1]
-
-include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
-
-include::modules/installation-adding-vcenter-root-certificates.adoc[leveloffset=+1]
 
 include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
 
@@ -61,8 +56,6 @@ include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 include::modules/configuring-vsphere-regions-zones.adoc[leveloffset=+2]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
-
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 

--- a/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations.adoc
+++ b/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations.adoc
@@ -15,6 +15,7 @@ include::snippets/vcenter-support.adoc[]
 
 == Prerequisites
 
+* You have completed the tasks in xref:../../../installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc#ipi-vsphere-preparing-to-install[Preparing to install a cluster using installer-provisioned infrastructure].
 * You reviewed your VMware platform licenses. Red{nbsp}Hat does not place any restrictions on your VMware licenses, but some VMware infrastructure components require licensing.
 * You reviewed details about the xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
@@ -30,12 +31,6 @@ Be sure to also review this site list if you are configuring a proxy.
 ====
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
-
-include::modules/ssh-agent-using.adoc[leveloffset=+1]
-
-include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
-
-include::modules/installation-adding-vcenter-root-certificates.adoc[leveloffset=+1]
 
 include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
 
@@ -71,8 +66,6 @@ include::modules/nw-operator-cr.adoc[leveloffset=+1]
 // end network customization
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
-
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 

--- a/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned.adoc
+++ b/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned.adoc
@@ -13,6 +13,7 @@ include::snippets/vcenter-support.adoc[]
 
 == Prerequisites
 
+* You have completed the tasks in xref:../../../installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc#ipi-vsphere-preparing-to-install[Preparing to install a cluster using installer-provisioned infrastructure].
 * You reviewed your VMware platform licenses. Red{nbsp}Hat does not place any restrictions on your VMware licenses, but some VMware infrastructure components require licensing.
 * You reviewed details about the xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
@@ -29,15 +30,7 @@ Be sure to also review this site list if you are configuring a proxy.
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
-include::modules/ssh-agent-using.adoc[leveloffset=+1]
-
-include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
-
-include::modules/installation-adding-vcenter-root-certificates.adoc[leveloffset=+1]
-
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
-
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 

--- a/installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc
+++ b/installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc
@@ -1,0 +1,32 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="ipi-vsphere-preparing-to-install"]
+= Preparing to install a cluster using installer-provisioned infrastructure
+include::_attributes/common-attributes.adoc[]
+:context: ipi-vsphere-preparing-to-install
+
+toc::[]
+
+You prepare to install an {product-title} cluster on vSphere by completing the following steps:
+
+* Downloading the installation program.
++
+[NOTE]
+====
+If you are installing in a disconnected environment, you extract the installation program from the mirrored content. For more information, see xref:../../../installing/disconnected_install/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Mirroring images for a disconnected installation].
+====
+* Installing the {oc-first}.
++
+[NOTE]
+====
+If you are installing in a disconnected environment, install `oc` to the mirror host.
+====
+* Generating an SSH key pair. You can use this key pair to authenticate into the {product-title} cluster's nodes after it is deployed.
+* Adding your vCenter’s trusted root CA certificates to your system trust.
+
+include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
+
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
+include::modules/ssh-agent-using.adoc[leveloffset=+1]
+
+include::modules/installation-adding-vcenter-root-certificates.adoc[leveloffset=+1]

--- a/modules/cli-installing-cli.adoc
+++ b/modules/cli-installing-cli.adoc
@@ -35,10 +35,6 @@
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-private.adoc
 // * installing/install_config/installing-restricted-networks-preparations.adoc
 // * installing/installing_vsphere/installing-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
-// * installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
 // * installing/installing_ibm_z/installing-ibm-z.adoc
 // * openshift_images/samples-operator-alt-registry.adoc
 // * updating/updating-restricted-network-cluster/mirroring-image-repository.adoc
@@ -51,6 +47,7 @@
 // * installing/installing_ibm_powervs/installing-ibm-powervs-vpc.adoc
 // * installing/installing-restricted-networks-azure-installer-provisioned.adoc
 // * installing/installing_azure/installing-restricted-networks-azure-user-provisioned.adoc
+// * installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc
 // AMQ docs link to this; do not change anchor
 
 ifeval::["{context}" == "mirroring-ocp-image-repository"]

--- a/modules/installation-adding-vcenter-root-certificates.adoc
+++ b/modules/installation-adding-vcenter-root-certificates.adoc
@@ -1,9 +1,5 @@
 // Module included in the following assemblies:
-//
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
-// * installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
+// * installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="installation-adding-vcenter-root-certificates_{context}"]

--- a/modules/installation-obtaining-installer.adoc
+++ b/modules/installation-obtaining-installer.adoc
@@ -35,13 +35,11 @@
 // * installing/installing_ibm_powervs/installing-ibm-powervs-vpc.adoc
 // * installing/installing_vsphere/installing-vsphere.adoc
 // * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
 // * installing/installing_ibm_z/installing-ibm-z.adoc
 // * installing/installing_ibm_z/installing-ibm-z-kvm.adoc
 // * installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
 // * installing/installing_azure/installing-restricted-networks-azure-user-provisioned.adoc
+// * installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc
 
 
 ifeval::["{context}" == "installing-ibm-z"]
@@ -62,13 +60,7 @@ endif::[]
 ifeval::["{context}" == "installing-ibm-cloud-private"]
 :private:
 endif::[]
-ifeval::["{context}" == "installing-vsphere-installer-provisioned"]
-:vsphere:
-endif::[]
-ifeval::["{context}" == "installing-vsphere-installer-provisioned-customizations"]
-:vsphere:
-endif::[]
-ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
+ifeval::["{context}" == "ipi-vsphere-preparing-to-install"]
 :vsphere:
 endif::[]
 
@@ -170,12 +162,6 @@ endif::[]
 ifeval::["{context}" == "installing-ibm-cloud-private"]
 :!private:
 endif::[]
-ifeval::["{context}" == "installing-vsphere-installer-provisioned"]
-:!vsphere:
-endif::[]
-ifeval::["{context}" == "installing-vsphere-installer-provisioned-customizations"]
-:!vsphere:
-endif::[]
-ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
+ifeval::["{context}" == "ipi-vsphere-preparing-to-install"]
 :!vsphere:
 endif::[]

--- a/modules/ssh-agent-using.adoc
+++ b/modules/ssh-agent-using.adoc
@@ -43,10 +43,6 @@
 // * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
 // * installing/installing_vsphere/installing-vsphere.adoc
 // * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
-// * installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
 // * installing/installing_ibm_z/installing-ibm-z.adoc
 // * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
 // * installing/installing_ibm_z/installing-ibm-z-kvm.adoc
@@ -56,6 +52,7 @@
 // * installing/installing-restricted-networks-nutanix-installer-provisioned.adoc
 // * installing/installing_azure/installing-restricted-networks-azure-installer-provisioned.adoc
 // * installing/installing_azure/installing-restricted-networks-azure-user-provisioned.adoc
+// * installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc
 
 
 ifeval::["{context}" == "installing-restricted-networks-vsphere"]


### PR DESCRIPTION
Version(s):
4.15+

Issue:
This PR addresses [osdocs-8719](https://issues.redhat.com//browse/osdocs-8719) and implements refactored vSphere pre-installation tasks for an IPI installation, which is detailed in this Miro [board](https://miro.com/app/board/uXjVNbUhuKQ=/). This refactor has been approved by Stephanie Stout (CS) and Ju Lim (Senior Manager, Product Management).

Link to docs preview:

[Preparing to install a cluster](https://71093--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install)

QE review:
[x] QE has approved this change.

