### PR TITLE
Adds link to garbage collection feature for Quay

### DIFF
--- a/installing/disconnected_install/installing-mirroring-creating-registry.adoc
+++ b/installing/disconnected_install/installing-mirroring-creating-registry.adoc
@@ -37,10 +37,12 @@ include::modules/mirror-registry-flags.adoc[leveloffset=+1]
 include::modules/mirror-registry-release-notes.adoc[leveloffset=+1]
 include::modules/mirror-registry-troubleshooting.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
+[id="additional-resources_installing-mirroring-creating-registry"]
+== Additional resources
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/manage_red_hat_quay/using-ssl-to-protect-quay[Using SSL to protect connections to Red Hat Quay]
+* link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/manage_red_hat_quay/garbage-collection#doc-wrapper[{quay} garbage collection]
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/manage_red_hat_quay/using-ssl-to-protect-quay[Using SSL to protect connections to {quay}]
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/manage_red_hat_quay/using-ssl-to-protect-quay#configuring_the_system_to_trust_the_certificate_authority[Configuring the system to trust the certificate authority]
 

--- a/modules/mirror-registry-introduction.adoc
+++ b/modules/mirror-registry-introduction.adoc
@@ -21,6 +21,11 @@ The following limitations apply to the _mirror registry for Red Hat OpenShift_:
 * The _mirror registry for Red Hat OpenShift_ is not a highly-available registry and only local file system storage is supported. It is not intended to replace {quay} or the internal image registry for {product-title}.
 
 * The _mirror registry for Red Hat OpenShift_ is only supported for hosting images that are required to install a disconnected {product-title} cluster, such as Release images or Red Hat Operator images. It uses local storage on your {op-system-base-full} machine, and storage supported by {op-system-base} is supported by the _mirror registry for Red Hat OpenShift_.
++
+[NOTE]
+====
+Because the _mirror registry for Red Hat OpenShift_ uses local storage, you should remain aware of the storage usage consumed when mirroring images and use {quay}'s garbage collection feature to mitigate potential issues. For more information about this feature, see "{quay} garbage collection".
+====
 
 * Support for Red Hat product images that are pushed to the _mirror registry for Red Hat OpenShift_ for bootstrapping purposes are covered by valid subscriptions for each respective product. A list of exceptions to further enable the bootstrap experience can be found on the link:https://www.redhat.com/en/resources/self-managed-openshift-sizing-subscription-guide[Self-managed Red Hat OpenShift sizing and subscription guide].
 


### PR DESCRIPTION
1/2 of a PR for an OMR ticket. The other half will be done in Quay docs. 

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/PROJQUAY-3933

Link to docs preview:
https://71103--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-creating-registry#mirror-registry-limitations_installing-mirroring-creating-registry

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
