### PR TITLE
HCIDOCS-202: Document updated RAID support

### DIFF
--- a/modules/bmo-about-the-baremetalhost-resource.adoc
+++ b/modules/bmo-about-the-baremetalhost-resource.adoc
@@ -94,7 +94,12 @@ a|  (Optional) Contains the information about the RAID configuration for bare me
 
 [NOTE]
 ====
-{product-title} {product-version} supports hardware RAID for BMCs using the iRMC protocol only. {product-title} {product-version} does not support software RAID.
+{product-title} {product-version} supports hardware RAID for BMCs, including:
+
+* Fujitsu iRMC with support for RAID levels 0, 1, 5, 6, and 10 
+* Dell iDRAC using the Redfish API with firmware version 6.10.30.20 or later and RAID levels 0, 1, and 5
+
+{product-title} {product-version} does not support software RAID.
 ====
 
 See the following configuration settings:

--- a/modules/ipi-install-configuring-the-raid.adoc
+++ b/modules/ipi-install-configuring-the-raid.adoc
@@ -6,13 +6,20 @@
 [id="configuring-the-raid_{context}"]
 = Optional: Configuring the RAID
 
-The following procedure configures a redundant array of independent disks (RAID) during the installation process.
+The following procedure configures a redundant array of independent disks (RAID) using baseboard management controllers (BMCs) during the installation process.
 
 [NOTE]
 ====
-. {product-title} supports hardware RAID for baseboard management controllers (BMCs) using the iRMC protocol only. {product-title} {product-version} does not support software RAID.
-. If you want to configure a hardware RAID for the node, verify that the node has a RAID controller.
+If you want to configure a hardware RAID for the node, verify that the node has a supported RAID controller. {product-title} {product-version} does not support software RAID.
 ====
+
+.Hardware RAID support by vendor
+[options="header"]
+|====
+|Vendor | BMC and protocol |Firmware version|RAID levels
+|Fujitsu | iRMC |N/A|0, 1, 5, 6, and 10
+|Dell | iDRAC with Redfish  | Version 6.10.30.20 or later | 0, 1, and 5
+|====
 
 .Procedure
 


### PR DESCRIPTION
Updated the note to include Redfish API and Dell iDRAC.

Fixes: [HCIDOCS-202](https://issues.redhat.com//browse/HCIDOCS-202)

See https://issues.redhat.com/browse/HCIDOCS-202 for additional details.

Preview URL: http://184.23.213.161:8080/HCIDOCS-202/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-the-raid_ipi-install-installation-workflow and http://184.23.213.161:8080/HCIDOCS-202/post_installation_configuration/bare-metal-configuration.html#the-baremetalhost-spec

For release(s): 4.15
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
