### PR TITLE
Fix mustgather image location for secrets-store-csi-driver-operator

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -75,7 +75,7 @@ endif::openshift-dedicated[]
 |`registry.redhat.io/openshift-gitops-1/must-gather-rhel8:v<installed_version_GitOps>`
 |Data collection for {gitops-title}.
 
-|`registry.redhat.io/openshift4/ose-csi-driver-shared-resource-mustgather-rhel8:v<installed_version_secret_store>`
+|`registry.redhat.io/openshift4/ose-secrets-store-csi-mustgather-rhel8:v<installed_version_secret_store>`
 |Data collection for the {secrets-store-operator}.
 
 |===


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Fix mustgather image location for secrets-store-csi-driver-operator

The 4.14+ docs on [Gathering data about specific features](https://docs.openshift.com/container-platform/4.14/support/gathering-cluster-data.html#gathering-data-specific-features_gathering-cluster-data) references the wrong image.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
None

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://71105--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data#gathering-data-specific-features_gathering-cluster-data

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
/cc @lpettyjo @bergerhoffer