### PR TITLE
OSDOCS-9249: Create an installation guide for enabling autoscaling on a cluster with Terraform

### DIFF
--- a/modules/rosa-cluster-cluster-role-name-change.adoc
+++ b/modules/rosa-cluster-cluster-role-name-change.adoc
@@ -10,58 +10,33 @@ endif::[]
 = Changing your cluster and role prefix name
 :source-highlighter: coderay
 
-By default, the Terraform files used in this guide create a cluster that uses the naming convention of `rosa-` with six-random letters or numbers. This Terraform plan uses your cluster name to create your account role and Operator role prefixes.
+By default, the Terraform files used in this guide create a cluster that uses the naming convention of `rosa-` followed by six-random letters or numbers. Terraform uses your cluster name to create your account role and Operator role prefixes.
 
-.Sample code
-[source,terminal]
-----
-# If cluster_name is not null, use that, otherwise generate a random cluster name
-  cluster_name = coalesce(var.cluster_name, "rosa-${random_string.random_name.result}")
-----
-
-This code snippet from the `main.tf` file shows that if you set a name for the `cluster_name` variable, that value will be used instead of a randomly-generated string.
+You can customize your cluster and role prefix name by editing your `main.tf` file. If you set a name for the `cluster_name` variable in the `main.tf` file, this value is used instead of a randomly-generated string.
 
 .Procedure
 
-You can set the cluster name three different ways:
+* Choose one of the following methods to set the cluster name:
 
-. You export the name of your cluster in the command line by running the following command:
+** Export the name of your cluster in the command line by running the following command:
 +
 [source,terminal]
 ----
 $ export TF_VAR_cluster_name=<your_cluster_name>
 ----
+
+** Set a `cluster_name` value in your `terraform.tfvars` file:
 +
-After exporting this variable, you can build your Terraform cluster by running the following command:
+.`terraform.tfvars` file excerpt
 +
 [source,terminal]
 ----
-$ terraform init && terraform apply
+cluster_name = "<your_cluster_name>"
 ----
 
-. You set a `cluster_name` value in the `terraform.tfvars` file:
-+
-[source,console]
-----
-###############################
-# General Cluster Information #
-###############################
-
-# You can choose any OpenShift version that is currently supported. Make sure to use X.Y.Z when setting your version.
-rosa_openshift_version = "4.14.8"
-cluster_name = "test-tf"
-----
-+
-After setting this variable in the `terraform.tfvars` file, you can build your Terraform cluster by running the following command:
+** Enter the cluster name when prompted in the terminal:
 +
 [source,terminal]
-----
-$ terraform init && terraform apply
-----
-
-. You enter the cluster name when prompted in the terminal:
-+
-[source,terraform]
 ----
 FORTHCOMING
 ----
@@ -69,3 +44,7 @@ FORTHCOMING
 ifeval::["{context}" == "rosa-sts-creating-a-cluster-quickly-terraform"]
 :tf-defaults:
 endif::[]
+
+ifndef::tf-defaults[]
+You are ready to initiate Terraform.
+endif::tf-defaults[]

--- a/modules/rosa-cluster-enable-autoscaling-terraform.adoc
+++ b/modules/rosa-cluster-enable-autoscaling-terraform.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// * rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations-terraform.adoc
+//
+ifeval::["{context}" == "rosa-sts-creating-a-cluster-quickly-terraform"]
+:tf-defaults:
+endif::[]
+:_content-type: PROCEDURE
+[id="rosa-cluster-enable-autoscaling-terraform_{context}"]
+= Enabling autoscaling
+:source-highlighter: coderay
+
+By default, the Terraform files used in this guide create a cluster with autoscaling disabled. You can enable autoscaling by editing your `main.tf` and `terraform.tfvars` files.
+
+Enabling autoscaling requires you to set a maximum and minimum replicas range using the 'max_replicas' and 'min_replicas' variables.
+
+[IMPORTANT]
+====
+If autoscaling is enabled, you cannot configure the worker node replicas.
+====
+
+.Procedure
+
+. Edit your `main.tf` file so that `autoscaling_enabled`, `min_replicas`, and `max_replicas` point to your `terraform.tfvars` file.
++
+.Excerpt of a `main.tf` file with autoscaling enabled
++
+[source,terminal]
+----
+autoscaling_enabled  = var.autoscaling_enabled
+replicas             = local.worker_node_replicas
+min_replicas         = var.min_replicas
+max_replicas         = var.max_replicas
+----
+
+. Enable autoscaling and set a maximum and minimum replicas range in your `terraform.tfvars` file. 
+
++
+Maximum and minimum replicas must be in multiples of 3 for multiple availability zone clusters.
++
+.Excerpt of a `terraform.tfvars` file with autoscaling enabled
++
+[source,terminal]
+----
+autoscaling_enabled = "true"
+worker_node_replicas = null
+min_replicas = "<minimum_replicas>"
+max_replicas = "<maximum_replicas>"
+----
++
+.Example input
++
+[source,terminal]
+----
+autoscaling_enabled = "true"
+worker_node_replicas = null
+min_replicas = "6"
+max_replicas = "15"
+----
+
+ifndef::tf-defaults[]
+You are ready to initiate Terraform.
+endif::tf-defaults[]
+
+ifeval::["{context}" == "rosa-sts-creating-a-cluster-quickly-terraform"]
+:!tf-defaults:
+endif::[]

--- a/modules/rosa-sts-cluster-terraform-file-creation.adoc
+++ b/modules/rosa-sts-cluster-terraform-file-creation.adoc
@@ -164,7 +164,7 @@ ifndef::tf-defaults[]
 +
 [NOTE]
 ====
-Copy and then edit this file _before_ running the command to build your cluster.
+Copy and edit this file _before_ running the command to build your cluster.
 ====
 +
 [source,terminal]
@@ -360,7 +360,7 @@ ifndef::tf-defaults[]
 +
 [NOTE]
 ====
-Copy and then edit this file _before_ running the command to build your cluster.
+Copy and edit this file _before_ running the command to build your cluster.
 ====
 endif::tf-defaults[]
 +
@@ -479,13 +479,13 @@ module "vpc" {
 EOF
 ----
 
-. *Optional*: Create the `terraform.tfvars` file by running the following command:
+. Create the `terraform.tfvars` file by running the following command:
 +
 [NOTE]
 ====
-You can use the `terraform.tfvars` file to change your variables in one place without touching the rest of your Terraform files. If you do not create a `terraform.tfvars` file, you will be prompted for the required variables during cluster creation.
+Use the `terraform.tfvars` file to change variables in one place without modifying the rest of your Terraform files when customizing your cluster. If you do not create a `terraform.tfvars` file, you are prompted for the required variables during cluster creation.
 
-Copy and then edit this file _before_ running the command to build your cluster.
+Copy and edit this file _before_ running the command to build your cluster.
 ====
 +
 [source,terminal]
@@ -533,8 +533,10 @@ EOF
 ----
 endif::tf-defaults[]
 
+ifdef::tf-defaults[]
 You are ready to initiate Terraform.
+endif::tf-defaults[]
 
 ifeval::["{context}" == "rosa-sts-creating-a-cluster-quickly-terraform"]
-:tf-defaults:
+:!tf-defaults:
 endif::[]

--- a/rosa_install_access_delete_clusters/terraform/rosa-sts-creating-a-cluster-with-customizations-terraform.adoc
+++ b/rosa_install_access_delete_clusters/terraform/rosa-sts-creating-a-cluster-with-customizations-terraform.adoc
@@ -28,7 +28,7 @@ The cluster creation process outlined below shows how to use Terraform to create
 
 [NOTE]
 ====
-Clusters are customized by editing the default `main.tf`, `variables.tf`, and `terraform.tfvar` files. Cluster customizations must be performed *before* cluster creation. To customize, copy the default Terraform file from the procedure below and make the desired changes.
+You edit the default `main.tf`, `variables.tf`, and `terraform.tfvars` files to customize a cluster. Cluster customizations must be performed before you create a cluster. To customize, copy the default Terraform file from the procedure below and make the desired changes.
 ====
 
 include::modules/rosa-sts-cluster-terraform-setup.adoc[leveloffset=+2]
@@ -37,9 +37,10 @@ include::modules/rosa-sts-cluster-terraform-file-creation.adoc[leveloffset=+2]
 [id="rosa-sts-creating-a-cluster-with-customizations-terraform-customizing"]
 == Terraform customization options
 
-The following sections detail individual customizations you can add to your `main.tf`, `variables.tf`, and `terraform.tfvar` files.
+The following sections detail individual customizations you can add to your `main.tf`, `variables.tf`, and `terraform.tfvars` files.
 
 include::modules/rosa-cluster-cluster-role-name-change.adoc[leveloffset=+2]
+include::modules/rosa-cluster-enable-autoscaling-terraform.adoc[leveloffset=+2]
 include::modules/rosa-sts-cluster-terraform-execute.adoc[leveloffset=+1]
 include::modules/rosa-sts-cluster-terraform-destroy.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[OSDOCS-9249](https://issues.redhat.com//browse/OSDOCS-9249): Create an installation guide for enabling autoscaling on a cluster with Terraform

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-9249

Link to docs preview:
https://71112--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/terraform/rosa-sts-creating-a-cluster-quickly-terraform

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
