### PR TITLE
TELCODOCS#1759: Adding must gather image for LVM Storage

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -78,6 +78,9 @@ endif::openshift-dedicated[]
 |`registry.redhat.io/openshift4/ose-csi-driver-shared-resource-mustgather-rhel8:v<installed_version_secret_store>`
 |Data collection for the {secrets-store-operator}.
 
+|`registry.redhat.io/lvms4/lvms-must-gather-rhel9:v<installed_version_LVMS>`
+|Data collection for the LVM Operator.
+
 |===
 
 [NOTE]

--- a/modules/lvms-uninstalling-logical-volume-manager-operator-using-openshift-web-console.adoc
+++ b/modules/lvms-uninstalling-logical-volume-manager-operator-using-openshift-web-console.adoc
@@ -4,9 +4,9 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="lvms-unstalling-lvms-with-web-console_{context}"]
-= Uninstalling {lvms} installed using the OpenShift Web Console
+= Uninstalling {lvms} using the web console
 
-You can unstall {lvms} using the Red Hat OpenShift Container Platform Web Console.
+You can uninstall {lvms} using the {product-title} web console.
 
 .Prerequisites
 


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[TELCODOCS-1759](https://issues.redhat.com/browse/TELCODOCS-1759)

Link to docs preview:

- https://71114--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data#gathering-data-specific-features_gathering-cluster-data
- [Uninstalling LVM Storage using the web console](https://71114--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms#lvms-unstalling-lvms-with-web-console_logical-volume-manager-storage)

QE review:
- [x] QE has approved this change.