### PR TITLE
ER-OBSDOCS-795: Fix rendering issue for power monitoing docs

### DIFF
--- a/modules/power-monitoring-hardware-virtualization-support.adoc
+++ b/modules/power-monitoring-hardware-virtualization-support.adoc
@@ -6,7 +6,7 @@
 [id="power-monitoring-hardware-virtualization-support_{context}"]
 = {PM-kepler} hardware and virtualization support
 
-{PM-kepler} is the key component of {PM-shortname} that collects real-time power consumption data from a node through one of the following power estimation methods:
+{PM-kepler} is the key component of {PM-shortname} that collects real-time power consumption data from a node through one of the following methods:
 
 Kernel Power Management Subsystem (preferred)::
 * `rapl-sysfs`: This requires access to the `/sys/class/powercap/intel-rapl` host file.

--- a/power_monitoring/power-monitoring-release-notes.adoc
+++ b/power_monitoring/power-monitoring-release-notes.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="power-monitoring-release-notes"]
-= {PM-title-c} release notes
 include::_attributes/common-attributes.adoc[]
+= {PM-title-c} release notes
 :context: power-monitoring-release-notes
 
 toc::[]


### PR DESCRIPTION
**OCP version(s)**: 4.14+

**Issue**: [OBSDOCS-795](https://issues.redhat.com/browse/OBSDOCS-795)

**Preview link**: https://71115--ocpdocs-pr.netlify.app/openshift-enterprise/latest/power_monitoring/power-monitoring-release-notes

- [x] **SME review**: @vimalk78 
- [x] **QE review**: @vprashar2929 
- [x] **Peer review**: @Srivaralakshmi 

**Additional information**: the issue can be seen on customer portal: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/power_monitoring/power-monitoring-release-notes