### PR TITLE
Adds Tuning etcd latency tolerances to 4.14 RNs as Tech preview

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -1292,6 +1292,11 @@ With this release, you can remove the partitioning table before installation by 
 
 With this update, you can add the `nodeLabels` field in the `SiteConfig` CR to create custom roles for nodes in managed clusters. For more information about how to add custom labels, see xref:../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc#ztp-deploying-a-site_ztp-deploying-far-edge-sites[Deploying a managed cluster with SiteConfig and {ztp}], xref:../scalability_and_performance/ztp_far_edge/ztp-manual-install.adoc#ztp-generating-install-and-config-crs-manually_ztp-manual-install[Generating {ztp} installation and configuration CRs manually], and xref:../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc#ztp-sno-siteconfig-config-reference_ztp-deploying-far-edge-sites[{sno} SiteConfig CR installation reference].
 
+[id="ocp-4-14-tuning-etcd-latency-tolerances"]
+==== Support for tuning etcd latency tolerances (Technology Preview)
+
+With this release, you can set the control plane hardware speed to one of `"Standard"`, `"Slower"`, or the default, `""`, which allows the system to decide which speed to use. This is a Technology Preview feature. For more information, see xref:../scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.adoc#etcd-tuning-parameters_recommended-etcd-practices[Setting tuning parameters for etcd].
+
 [id="ocp-4-14-hcp"]
 === Hosted control planes
 
@@ -2591,6 +2596,11 @@ In the following tables, features are marked with the following statuses:
 [cols="4,1,1,1",options="header"]
 |====
 |Feature |4.12 |4.13 |4.14
+
+|Tuning etcd latency tolerances
+|Not Available
+|Not Available
+|Technology Preview
 
 |Hyperthreading-aware CPU manager policy
 |Technology Preview


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-9542

Link to docs preview:
https://71126--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-tuning-etcd-latency-tolerances

Requires change management:
Product experience: Eric Rich
QE:
Engineering: Allen Ray
Project Manager: Ju Lim
DPM: Kathryn Alexander
CS: Ashley Hardin

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
