### PR TITLE
OBSDOCS-798: add missing monitoring-plugin info to in-cluster monitoring docs

### DIFF
--- a/modules/monitoring-configurable-monitoring-components.adoc
+++ b/modules/monitoring-configurable-monitoring-components.adoc
@@ -27,6 +27,7 @@ ifndef::openshift-dedicated,openshift-rosa[]
 |Prometheus |`prometheusK8s` |`prometheus`
 |Alertmanager |`alertmanagerMain` | `alertmanager`
 |kube-state-metrics |`kubeStateMetrics` |
+|monitoring-plugin | `monitoringPlugin` |
 |openshift-state-metrics |`openshiftStateMetrics` |
 |Telemeter Client |`telemeterClient` |
 |Prometheus Adapter |`k8sPrometheusAdapter` |

--- a/modules/monitoring-default-monitoring-components.adoc
+++ b/modules/monitoring-default-monitoring-components.adoc
@@ -29,14 +29,18 @@ By default, the {product-title} {product-version} monitoring stack includes thes
 |Alertmanager
 |The Alertmanager service handles alerts received from Prometheus. Alertmanager is also responsible for sending the alerts to external notification systems.
 
-|`kube-state-metrics` agent
-|The `kube-state-metrics` exporter agent (KSM in the preceding diagram) converts Kubernetes objects to metrics that Prometheus can use.
+|kube-state-metrics agent
+|The kube-state-metrics exporter agent (KSM in the preceding diagram) converts Kubernetes objects to metrics that Prometheus can use.
 
-|`openshift-state-metrics` agent
-|The `openshift-state-metrics` exporter (OSM in the preceding diagram) expands upon `kube-state-metrics` by adding metrics for {product-title}-specific resources.
+|monitoring-plugin
+|The monitoring-plugin dynamic plugin component deploys the monitoring pages in the *Observe* section of the {product-title} web console. 
+You can use Cluster Monitoring Operator (CMO) config map settings to manage monitoring-plugin resources for the web console pages.
 
-|`node-exporter` agent
-|The `node-exporter` agent (NE in the preceding diagram) collects metrics about every node in a cluster. The `node-exporter` agent is deployed on every node.
+|openshift-state-metrics agent
+|The openshift-state-metrics exporter (OSM in the preceding diagram) expands upon kube-state-metrics by adding metrics for {product-title}-specific resources.
+
+|node-exporter agent
+|The node-exporter agent (NE in the preceding diagram) collects metrics about every node in a cluster. The node-exporter agent is deployed on every node.
 
 |Thanos Querier
 |Thanos Querier aggregates and optionally deduplicates core {product-title} metrics and metrics for user-defined projects under a single, multi-tenant interface.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-798
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://71143--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack#configurable-monitoring-components_configuring-the-monitoring-stack
- https://71143--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/monitoring-overview#default-monitoring-components_monitoring-overview
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR adds missing monitoring-plugin component information to the in-cluster monitoring docs.

It also includes a tiny fix to remove incorrect backtick formatting from some of the component names in the table
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
