### PR TITLE
OSDOCS#9555: Refactor of pre-installation tasks for a UPI installation

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -493,6 +493,8 @@ Topics:
     Topics:
     - Name: vSphere installation requirements
       File: upi-vsphere-installation-reqs
+    - Name: Preparing to install a cluster
+      File: upi-vsphere-preparing-to-install
     - Name: Installing a cluster
       File: installing-vsphere
     - Name: Installing a cluster with network customizations

--- a/installing/installing_vsphere/upi/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/upi/installing-restricted-networks-vsphere.adoc
@@ -18,6 +18,7 @@ The steps for performing a user-provisioned infrastructure installation are prov
 
 == Prerequisites
 
+* You have completed the tasks in xref:../../../installing/installing_vsphere/upi/upi-vsphere-preparing-to-install.adoc#upi-vsphere-preparing-to-install[Preparing to install a cluster using user-provisioned infrastructure].
 * You reviewed your VMware platform licenses. Red{nbsp}Hat does not place any restrictions on your VMware licenses, but some VMware infrastructure components require licensing.
 * You reviewed details about the xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
@@ -41,12 +42,6 @@ Be sure to also review this site list if you are configuring a proxy.
 include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
-
-include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
-
-include::modules/installation-user-provisioned-validating-dns.adoc[leveloffset=+1]
-
-include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 //You extract the installation program from the mirrored content.
 

--- a/installing/installing_vsphere/upi/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/upi/installing-vsphere-network-customizations.adoc
@@ -25,6 +25,7 @@ The steps for performing a user-provisioned infrastructure installation are prov
 
 == Prerequisites
 
+* You have completed the tasks in xref:../../../installing/installing_vsphere/upi/upi-vsphere-preparing-to-install.adoc#upi-vsphere-preparing-to-install[Preparing to install a cluster using user-provisioned infrastructure].
 * You reviewed your VMware platform licenses. Red{nbsp}Hat does not place any restrictions on your VMware licenses, but some VMware infrastructure components require licensing.
 * You reviewed details about the xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
@@ -33,12 +34,6 @@ The steps for performing a user-provisioned infrastructure installation are prov
 * If you use a firewall, you xref:../../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
-
-include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
-
-include::modules/installation-user-provisioned-validating-dns.adoc[leveloffset=+1]
-
-include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
 
@@ -52,8 +47,6 @@ include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
 * xref:../../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration-sc-vsphere_persistent-storage-csi-migration[vSphere automatic migration]
 
 * xref:../../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-top-aware_persistent-storage-csi-vsphere[VMware vSphere CSI Driver Operator]
-
-include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 

--- a/installing/installing_vsphere/upi/installing-vsphere.adoc
+++ b/installing/installing_vsphere/upi/installing-vsphere.adoc
@@ -19,6 +19,7 @@ The steps for performing a user-provisioned infrastructure installation are prov
 
 == Prerequisites
 
+* You have completed the tasks in xref:../../../installing/installing_vsphere/upi/upi-vsphere-preparing-to-install.adoc#upi-vsphere-preparing-to-install[Preparing to install a cluster using user-provisioned infrastructure].
 * You reviewed your VMware platform licenses. Red{nbsp}Hat does not place any restrictions on your VMware licenses, but some VMware infrastructure components require licensing.
 * You reviewed details about the xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
@@ -34,12 +35,6 @@ Be sure to also review this site list if you are configuring a proxy.
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
-include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
-
-include::modules/installation-user-provisioned-validating-dns.adoc[leveloffset=+1]
-
-include::modules/ssh-agent-using.adoc[leveloffset=+1]
-
 include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -52,8 +47,6 @@ include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
 * xref:../../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration-sc-vsphere_persistent-storage-csi-migration[vSphere automatic migration]
 
 * xref:../../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-top-aware_persistent-storage-csi-vsphere[VMware vSphere CSI Driver Operator]
-
-include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 
@@ -80,8 +73,6 @@ include::modules/machine-vsphere-machines.adoc[leveloffset=+1]
 include::modules/installation-disk-partitioning.adoc[leveloffset=+1]
 
 include::modules/architecture-rhcos-updating-bootloader.adoc[leveloffset=+1]
-
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/installation-installing-bare-metal.adoc[leveloffset=+1]
 

--- a/installing/installing_vsphere/upi/upi-vsphere-preparing-to-install.adoc
+++ b/installing/installing_vsphere/upi/upi-vsphere-preparing-to-install.adoc
@@ -1,0 +1,35 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="upi-vsphere-preparing-to-install"]
+= Preparing to install a cluster using user-provisioned infrastructure
+include::_attributes/common-attributes.adoc[]
+:context: upi-vsphere-preparing-to-install
+
+toc::[]
+
+You prepare to install an {product-title} cluster on vSphere by completing the following steps:
+
+* Downloading the installation program.
++
+[NOTE]
+====
+If you are installing in a disconnected environment, you extract the installation program from the mirrored content. For more information, see xref:../../../installing/disconnected_install/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Mirroring images for a disconnected installation].
+====
+* Installing the {oc-first}.
++
+[NOTE]
+====
+If you are installing in a disconnected environment, install `oc` to the mirror host.
+====
+* Generating an SSH key pair. You can use this key pair to authenticate into the {product-title} cluster's nodes after it is deployed.
+* Preparing the user-provisioned infrastructure.
+* Validating DNS resolution.
+
+include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
+
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
+include::modules/ssh-agent-using.adoc[leveloffset=+1]
+
+include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
+
+include::modules/installation-user-provisioned-validating-dns.adoc[leveloffset=+1]

--- a/modules/cli-installing-cli.adoc
+++ b/modules/cli-installing-cli.adoc
@@ -34,7 +34,6 @@
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-private.adoc
 // * installing/install_config/installing-restricted-networks-preparations.adoc
-// * installing/installing_vsphere/installing-vsphere.adoc
 // * installing/installing_ibm_z/installing-ibm-z.adoc
 // * openshift_images/samples-operator-alt-registry.adoc
 // * updating/updating-restricted-network-cluster/mirroring-image-repository.adoc
@@ -48,6 +47,7 @@
 // * installing/installing-restricted-networks-azure-installer-provisioned.adoc
 // * installing/installing_azure/installing-restricted-networks-azure-user-provisioned.adoc
 // * installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc
+// * installing/installing_vsphere/upi/upi-vsphere-preparing-to-install.adoc
 // AMQ docs link to this; do not change anchor
 
 ifeval::["{context}" == "mirroring-ocp-image-repository"]

--- a/modules/installation-infrastructure-user-infra.adoc
+++ b/modules/installation-infrastructure-user-infra.adoc
@@ -3,14 +3,12 @@
 // * installing/installing_bare_metal/installing-bare-metal.adoc
 // * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
 // * installing/installing_platform_agnostic/installing-platform-agnostic.adoc
-// * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
 // * installing/installing_ibm_z/installing-ibm-z.adoc
 // * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
 // * installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
 // * installing/installing_ibm_z/installing-ibm-power.adoc
 // * installing/installing_ibm_z/installing-restricted-networks-ibm-power.adoc
+// * installing/installing_vsphere/upi/upi-vsphere-preparing-to-install.adoc
 
 ifeval::["{context}" == "installing-ibm-z"]
 :ibm-z:

--- a/modules/installation-obtaining-installer.adoc
+++ b/modules/installation-obtaining-installer.adoc
@@ -33,13 +33,12 @@
 // * installing/installing_platform_agnostic/installing-platform-agnostic.adoc
 // * installing/installing_ibm_powervs/installing-ibm-power-vs-private-cluster.adoc
 // * installing/installing_ibm_powervs/installing-ibm-powervs-vpc.adoc
-// * installing/installing_vsphere/installing-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
 // * installing/installing_ibm_z/installing-ibm-z.adoc
 // * installing/installing_ibm_z/installing-ibm-z-kvm.adoc
 // * installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
 // * installing/installing_azure/installing-restricted-networks-azure-user-provisioned.adoc
 // * installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc
+// * installing/installing_vsphere/upi/upi-vsphere-preparing-to-install.adoc
 
 
 ifeval::["{context}" == "installing-ibm-z"]

--- a/modules/installation-user-provisioned-validating-dns.adoc
+++ b/modules/installation-user-provisioned-validating-dns.adoc
@@ -12,9 +12,7 @@
 // * installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
 // * installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc
 // * installing/installing_vmc/installing-vmc-user-infra.adoc
-// * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
-// * installing/installing_vsphere/installing-vsphere.adoc
+// * installing/installing_vsphere/upi/upi-vsphere-preparing-to-install.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="installation-user-provisioned-validating-dns_{context}"]

--- a/modules/ssh-agent-using.adoc
+++ b/modules/ssh-agent-using.adoc
@@ -40,9 +40,6 @@
 // * installing/installing_aws/installing-restricted-networks-aws.adoc
 // * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
 // * installing/installing_platform_agnostic/installing-platform-agnostic.adoc
-// * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
 // * installing/installing_ibm_z/installing-ibm-z.adoc
 // * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
 // * installing/installing_ibm_z/installing-ibm-z-kvm.adoc
@@ -53,11 +50,8 @@
 // * installing/installing_azure/installing-restricted-networks-azure-installer-provisioned.adoc
 // * installing/installing_azure/installing-restricted-networks-azure-user-provisioned.adoc
 // * installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc
+// * installing/installing_vsphere/upi/upi-vsphere-preparing-to-install.adoc
 
-
-ifeval::["{context}" == "installing-restricted-networks-vsphere"]
-:user-infra:
-endif::[]
 ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
 :user-infra:
 endif::[]
@@ -94,9 +88,6 @@ endif::[]
 ifeval::["{context}" == "installing-bare-metal"]
 :user-infra:
 endif::[]
-ifeval::["{context}" == "installing-vsphere"]
-:user-infra:
-endif::[]
 ifeval::["{context}" == "installing-aws-user-infra"]
 :user-infra:
 endif::[]
@@ -125,6 +116,9 @@ ifeval::["{context}" == "installing-platform-agnostic"]
 :user-infra:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-azure-user-provisioned"]
+:user-infra:
+endif::[]
+ifeval::["{context}" == "upi-vsphere-preparing-to-install"]
 :user-infra:
 endif::[]
 
@@ -239,9 +233,6 @@ ifdef::user-infra[]
 If you install a cluster on infrastructure that you provision, you must provide the key to the installation program.
 endif::user-infra[]
 
-ifeval::["{context}" == "installing-restricted-networks-vsphere"]
-:!user-infra:
-endif::[]
 ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
 :!user-infra:
 endif::[]
@@ -278,9 +269,6 @@ endif::[]
 ifeval::["{context}" == "installing-bare-metal"]
 :!user-infra:
 endif::[]
-ifeval::["{context}" == "installing-vsphere"]
-:!user-infra:
-endif::[]
 ifeval::["{context}" == "installing-aws-user-infra"]
 :!user-infra:
 endif::[]
@@ -309,5 +297,8 @@ ifeval::["{context}" == "installing-platform-agnostic"]
 :!user-infra:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-azure-user-provisioned"]
+:!user-infra:
+endif::[]
+ifeval::["{context}" == "upi-vsphere-preparing-to-install"]
 :!user-infra:
 endif::[]


### PR DESCRIPTION
Version(s):
4.15+

Issue:
This PR addresses [osdocs-9555](https://issues.redhat.com//browse/osdocs-9555) and implements refactored vSphere pre-installation tasks for a UPI installation, which is detailed in this Miro [board](https://miro.com/app/board/uXjVNbUhuKQ=/). This refactor has been approved by Stephanie Stout (CS) and Ju Lim (Senior Manager, Product Management).

Link to docs preview:

[Preparing to install a cluster using user-provisioned infrastructure](https://71164--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/upi-vsphere-preparing-to-install)

QE review:
- [x] QE has approved this change.
