### PR TITLE
OSDOCS#9491: Update back up and restore procedure for on-premise

### DIFF
--- a/hosted_control_planes/hcp-backup-restore-dr.adoc
+++ b/hosted_control_planes/hcp-backup-restore-dr.adoc
@@ -15,7 +15,6 @@ In hosted clusters, etcd pods run as part of a stateful set. The stateful set re
 
 include::modules/hosted-cluster-etcd-status.adoc[leveloffset=+2]
 include::modules/hosted-cluster-single-node-recovery.adoc[leveloffset=+2]
-include::modules/hosted-cluster-etcd-quorum-loss-recovery.adoc[leveloffset=+2]
 
 [id="hcp-backup-restore"]
 == Backing up and restoring etcd on a hosted cluster on {aws-short}
@@ -32,6 +31,9 @@ include::modules/backup-etcd-hosted-cluster.adoc[leveloffset=+2]
 
 // Restoring an etcd snapshot on a hosted cluster
 include::modules/restoring-etcd-snapshot-hosted-cluster.adoc[leveloffset=+2]
+
+// Backing up and restoring etcd on a hosted cluster in an on-premise environment
+include::modules/hosted-cluster-etcd-backup-restore-on-prem.adoc[leveloffset=+1]
 
 [id="hcp-dr-aws"]
 == Disaster recovery for a hosted cluster within an {aws-short} region

--- a/modules/hosted-cluster-etcd-backup-restore-on-prem.adoc
+++ b/modules/hosted-cluster-etcd-backup-restore-on-prem.adoc
@@ -3,10 +3,10 @@
 // * hcp-backup-restore-dr.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="hosted-cluster-etcd-quorum-loss-recovery_{context}"]
-= Recovering an etcd cluster from a quorum loss
+[id="hosted-cluster-etcd-backup-restore-on-prem_{context}"]
+= Backing up and restoring etcd on a hosted cluster in an on-premise environment
 
-If multiple members of the etcd cluster have lost data or return a `CrashLoopBackOff` status, it can cause an etcd quorum loss. You must restore your etcd cluster from a snapshot.
+By backing up and restoring etcd on a hosted cluster, you can fix failures, such as corrupted or missing data in an etcd member of a three node cluster. If multiple members of the etcd cluster encounter data loss or have a `CrashLoopBackOff` status, this approach helps prevent an etcd quorum loss.
 
 [IMPORTANT]
 ====
@@ -14,6 +14,7 @@ This procedure requires API downtime.
 ====
 
 .Prerequisites
+
 * The `oc` and `jq` binaries have been installed.
 
 .Procedure


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
This PR updates the current "Recovering an etcd cluster from a quorum loss" section to reflect that the procedure described in this section also covers the etcd backup and recovery on premises.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-9491
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://71173--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-backup-restore-dr#hcp-backup-restore-on-premise
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review:
- [x] SME has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
