### PR TITLE
Do not emphasize disabling SELinux in examples

### DIFF
--- a/modules/installation-special-config-kargs.adoc
+++ b/modules/installation-special-config-kargs.adoc
@@ -12,14 +12,15 @@ installation. Here are some reasons you might want
 to add kernel arguments during cluster installation so they take effect before
 the systems first boot up:
 
-* You want to disable a feature, such as SELinux, so it has no impact on the systems when they first come up.
+* You need to do some low-level network configuration before the systems start.
 
+* You want to disable a feature, such as SELinux, so it has no impact on the systems when they first come up.
++
 [WARNING]
 ====
-Disabling SELinux on {op-system} is not supported.
+Disabling SELinux on {op-system} in production is not supported.
+Once SELinux has been disabled on a node, it must be re-provisioned before re-inclusion in a production cluster.
 ====
-
-* You need to do some low-level network configuration before the systems start.
 
 To add kernel arguments to master or worker nodes, you can create a `MachineConfig` object
 and inject that object into the set of manifest files used by Ignition during

--- a/modules/nodes-nodes-kernel-arguments.adoc
+++ b/modules/nodes-nodes-kernel-arguments.adoc
@@ -16,8 +16,6 @@ Improper use of kernel arguments can result in your systems becoming unbootable.
 
 Examples of kernel arguments you could set include:
 
-* **enforcing=0**: Configures Security Enhanced Linux (SELinux) to run in permissive mode. In permissive mode, the system acts as if SELinux is enforcing the loaded security policy, including labeling objects and emitting access denial entries in the logs, but it does not actually deny any operations. While not supported for production systems, permissive mode can be helpful for debugging.
-
 * **nosmt**: Disables symmetric multithreading (SMT) in the kernel. Multithreading allows multiple logical threads for each CPU. You could consider `nosmt` in multi-tenant environments to reduce risks from potential cross-thread attacks. By disabling SMT, you essentially choose security over performance.
 
 ifndef::openshift-origin[]
@@ -32,6 +30,14 @@ ifdef::openshift-origin[]
 cgroup v2 is enabled by default. To disable cgroup v2, use the `systemd.unified_cgroup_hierarchy=0` kernel argument, as shown in the following procedure.
 ====
 endif::openshift-origin[]
+
+* **enforcing=0**: Configures Security Enhanced Linux (SELinux) to run in permissive mode. In permissive mode, the system acts as if SELinux is enforcing the loaded security policy, including labeling objects and emitting access denial entries in the logs, but it does not actually deny any operations. While not supported for production systems, permissive mode can be helpful for debugging.
++
+[WARNING]
+====
+Disabling SELinux on {op-system} in production is not supported.
+Once SELinux has been disabled on a node, it must be re-provisioned before re-inclusion in a production cluster.
+====
 
 See link:https://www.kernel.org/doc/Documentation/admin-guide/kernel-parameters.txt[Kernel.org kernel parameters] for a list and descriptions of kernel arguments.
 


### PR DESCRIPTION
Update examples to mention SELinux last and ensure that we clearly mention that disabling it in production is unsupported and needs node to be re-provisionned.

Version(s):
All versions.

Issue:
N/A

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
