### PR TITLE
Telcodocs 1602: Updates to TELCODOCS-1010

### DIFF
--- a/modules/kmm-preflight-validation-stages-per-module.adoc
+++ b/modules/kmm-preflight-validation-stages-per-module.adoc
@@ -9,5 +9,7 @@
 Preflight runs the following validations on every KMM Module present in the cluster:
 
 . Image validation stage
+
 . Build validation stage
+
 . Sign validation stage

--- a/modules/kmm-validation-status.adoc
+++ b/modules/kmm-validation-status.adoc
@@ -39,7 +39,7 @@ type CRStatus struct {
 
 The following fields apply to each module:
 
-<1> `VerificationStatus` - `true` or `false`, validated or not.
+<1> `VerificationStatus` - `true` or `false`, validated or not validated.
 
 <2> `StatusReason` - Verbal explanation regarding the status.
 

--- a/updating/preparing_for_updates/kmm-preflight-validation.adoc
+++ b/updating/preparing_for_updates/kmm-preflight-validation.adoc
@@ -12,7 +12,9 @@ WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to 
 To do: Remove this comment once 4.13 docs are EOL.
 ////
 
-Before performing an upgrade on the cluster with applied KMM modules, the administrator must verify that kernel modules installed using KMM are able to be installed on the nodes after the cluster upgrade and possible kernel upgrade. Preflight attempts to validate every `Module` loaded in the cluster, in parallel. Preflight does not wait for validation of one `Module` to complete before starting validation of another `Module`.
+// Updated via TELCODOCS-1602
+
+Before performing an upgrade on the cluster with applied KMM modules, the administrator must verify that kernel modules installed using KMM are able to be installed on the nodes after the cluster upgrade and possible kernel upgrade. Preflight attempts to validate every `Module` loaded in the cluster, in parallel. This means that preflight does not wait for validation of one `Module` to complete before starting validation of another `Module`.
 
 :FeatureName: Kernel Module Management Operator Preflight validation
 


### PR DESCRIPTION
D/S PreflightValidationOCP should document no-push and signing ([MGMT-13303](https://issues.redhat.com//browse/MGMT-13303))

Peer reviewer: Note that this is a minor update to existing documention here: https://docs.openshift.com/container-platform/4.14/updating/preparing_for_updates/kmm-preflight-validation.html

OCP version: openshift-4.15

Version: [KMMO 1.0]
Issue: https://issues.redhat.com/browse/TELCODOCS-1602

Link to docs preview:  https://71179--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/kmm-preflight-validation

SME review: [@quba](https://redhat-internal.slack.com/team/U02GW51L0GZ) @bthurber 
QE review: [@Costi](https://redhat-internal.slack.com/team/ULP4MT9GB)