### PR TITLE
OSDOCS-9551: Further clarify CPMS non-IPI incompatibility

### DIFF
--- a/machine_management/control_plane_machine_management/cpmso-about.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-about.adoc
@@ -18,29 +18,8 @@ Control plane machine sets provide for control plane machines similar management
 //Control Plane Machine Set Operator overview
 include::modules/cpmso-overview.adoc[leveloffset=+1]
 
-[id="cpmso-limitations_{context}"]
-== Limitations
-
-The Control Plane Machine Set Operator has the following limitations:
-
-* The Operator requires the Machine API Operator to be operational and is therefore not supported on clusters with manually provisioned machines. When installing a {product-title} cluster with manually provisioned machines for a platform that creates an active generated `ControlPlaneMachineSet` custom resource (CR), you must remove the Kubernetes manifest files that define the control plane machine set as instructed in the installation process.
-
-* Only Amazon Web Services (AWS), Google Cloud Platform (GCP), {ibm-power-server-name}, Microsoft Azure, Nutanix, VMware vSphere, and {rh-openstack-first} clusters are supported.
-
-* Only clusters with three control plane machines are supported.
-
-* Horizontal scaling of the control plane is not supported.
-
-* Deploying Azure control plane machines on Ephemeral OS disks increases risk for data loss and is not supported.
-
-* Deploying control plane machines as AWS Spot Instances, GCP preemptible VMs, or Azure Spot VMs is not supported.
-+
-[IMPORTANT]
-====
-Attempting to deploy control plane machines as AWS Spot Instances, GCP preemptible VMs, or Azure Spot VMs might cause the cluster to lose etcd quorum. A cluster that loses all control plane machines simultaneously is unrecoverable.
-====
-
-* Making changes to the control plane machine set during or prior to installation is not supported. You must make any changes to the control plane machine set only after installation.
+//Control Plane Machine Set Operator limitations
+include::modules/cpmso-limitations.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources_cpmso-about"]

--- a/modules/cpmso-limitations.adoc
+++ b/modules/cpmso-limitations.adoc
@@ -1,0 +1,54 @@
+// Module included in the following assemblies:
+//
+// * machine_management/cpmso-about.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="cpmso-limitations_{context}"]
+= Control Plane Machine Set Operator limitations
+
+The Control Plane Machine Set Operator has the following limitations:
+
+* Only Amazon Web Services (AWS), Google Cloud Platform (GCP), {ibm-power-server-name}, Microsoft Azure, Nutanix, VMware vSphere, and {rh-openstack-first} clusters are supported.
+
+* Clusters that do not have preexisting machines that represent the control plane nodes cannot use a control plane machine set or enable the use of a control plane machine set after installation. Generally, preexisting control plane machines are only present if a cluster was installed using infrastructure provisioned by the installation program.
++
+To determine if a cluster has the required preexisting control plane machines, run the following command as a user with administrator privileges:
++
+[source,terminal]
+----
+$ oc get machine \
+  -n openshift-machine-api \
+  -l machine.openshift.io/cluster-api-machine-role=master
+----
++
+.Example output showing preexisting control plane machines
+[source,text]
+----
+NAME                    PHASE     TYPE         REGION      ZONE         AGE
+<cluster_id>-master-0   Running   m6i.xlarge   us-west-1   us-west-1a   5h19m
+<cluster_id>-master-1   Running   m6i.xlarge   us-west-1   us-west-1b   5h19m
+<cluster_id>-master-2   Running   m6i.xlarge   us-west-1   us-west-1a   5h19m
+----
++
+.Example output missing preexisting control plane machines
+[source,text]
+----
+No resources found in openshift-machine-api namespace.
+----
+
+* The Operator requires the Machine API Operator to be operational and is therefore not supported on clusters with manually provisioned machines. When installing a {product-title} cluster with manually provisioned machines for a platform that creates an active generated `ControlPlaneMachineSet` custom resource (CR), you must remove the Kubernetes manifest files that define the control plane machine set as instructed in the installation process.
+
+* Only clusters with three control plane machines are supported.
+
+* Horizontal scaling of the control plane is not supported.
+
+* Deploying Azure control plane machines on Ephemeral OS disks increases risk for data loss and is not supported.
+
+* Deploying control plane machines as AWS Spot Instances, GCP preemptible VMs, or Azure Spot VMs is not supported.
++
+[IMPORTANT]
+====
+Attempting to deploy control plane machines as AWS Spot Instances, GCP preemptible VMs, or Azure Spot VMs might cause the cluster to lose etcd quorum. A cluster that loses all control plane machines simultaneously is unrecoverable.
+====
+
+* Making changes to the control plane machine set during or prior to installation is not supported. You must make any changes to the control plane machine set only after installation.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-9551](https://issues.redhat.com//browse/OSDOCS-9551)

Link to docs preview:
[Limitations](https://71212--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-about.html#cpmso-limitations_cpmso-about)

QE review:
- [x] QE has approved this change.

Additional information: