### PR TITLE
Adds prereq section to changing hardware speed tolerance

### DIFF
--- a/modules/etcd-tuning-parameters.adoc
+++ b/modules/etcd-tuning-parameters.adoc
@@ -20,6 +20,9 @@ include::snippets/technology-preview.adoc[]
 
 To change the hardware speed tolerance for etcd, complete the following steps.
 
+.Prerequisites
+* You have edited the cluster instance to enable Technology Preview features. For more information, see "Understanding feature gates".
+
 .Procedure
 
 . Check to see what the current value is by entering the following command:

--- a/scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.adoc
+++ b/scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.adoc
@@ -24,3 +24,7 @@ include::modules/move-etcd-different-disk.adoc[leveloffset=+1]
 include::modules/etcd-defrag.adoc[leveloffset=+1]
 
 include::modules/etcd-tuning-parameters.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-about_nodes-cluster-enabling[Understanding feature gates]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-9542
Follow up to https://github.com/openshift/openshift-docs/pull/71126

Link to docs preview:
https://71219--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices#etcd-tuning-parameters_recommended-etcd-practices

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
