### PR TITLE
OSDOCS#8897: Docs for adding services and closing ports on MicroShift

### DIFF
--- a/microshift_networking/microshift-firewall.adoc
+++ b/microshift_networking/microshift-firewall.adoc
@@ -22,6 +22,12 @@ include::modules/microshift-firewall-req-settings.adoc[leveloffset=+1]
 
 include::modules/microshift-firewall-opt-settings.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_networking/using-and-configuring-firewalld_configuring-and-managing-networking#closing-unused-or-unnecessary-ports-to-enhance-network-security_controlling-network-traffic-using-firewalld[Closing unused or unnecessary ports to enhance network security]
+
+include::modules/microshift-firewall-add-services.adoc[leveloffset=+1]
+
 include::modules/microshift-firewall-allow-traffic.adoc[leveloffset=+1]
 
 include::modules/microshift-firewall-apply-settings.adoc[leveloffset=+1]

--- a/modules/microshift-firewall-add-services.adoc
+++ b/modules/microshift-firewall-add-services.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * microshift_networking/microshift-firewall.adoc
+
+:_mod-docs-content-type: Procedure
+[id="microshift-firewall-add-services_{context}"]
+= Adding services to open ports
+
+On a {microshift-short} instance, you can open services on ports by using the `firewall-cmd` command. 
+
+.Procedure 
+
+. Optional: You can view all predefined services in firewalld by running the following command
++
+[source,terminal]
+----
+$ sudo firewall-cmd --get-services
+----
+
+. To open a service that you want on a default port, run the following example command: 
++
+[source,terminal]
+----
+$ sudo firewall-cmd --add-service=mdns
+----

--- a/modules/microshift-firewall-opt-settings.adoc
+++ b/modules/microshift-firewall-opt-settings.adoc
@@ -49,7 +49,7 @@ $ sudo firewall-cmd --permanent --zone=public --add-port=<port number>/<port pro
 
 The following are examples of commands used when requiring external access through the firewall to services running on {microshift-short}, such as port 6443 for the API server, for example, ports 80 and 443 for applications exposed through the router.
 
-.Example commands
+.Example command
 
 * Configuring a port for the {microshift-short} API server:
 +
@@ -58,15 +58,4 @@ The following are examples of commands used when requiring external access throu
 $ sudo firewall-cmd --permanent --zone=public --add-port=6443/tcp
 ----
 
-* Configuring ports for applications exposed through the router:
-+
-[source,terminal]
-----
-$ sudo firewall-cmd --permanent --zone=public --add-port=80/tcp
-----
-+
-[source,terminal]
-----
-$ sudo firewall-cmd --permanent --zone=public --add-port=443/tcp
-----
-
+To close unnecessary ports in your {microshift-short} instance, follow the procedure in "Closing unused or unnecessary ports to enhance network security". 


### PR DESCRIPTION
**Version(s):** 4.14+
**Issue:** [OSDOCS-8897](https://issues.redhat.com//browse/OSDOCS-8897)

**Link to docs preview:**

Firewall configuration:
- [Using optional port settings](https://71221--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-firewall#microshift-firewall-optional-settings_microshift-firewall)
- [Adding services to open ports](https://71221--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-firewall#microshift-firewall-add-services_microshift-firewall)

**QE review:**
- [x] QE has approved this change.
