### PR TITLE
OCPBUGS#25247: External gateway is on default network

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1441,7 +1441,7 @@ Topics:
     File: logging-network-policy
   - Name: Configuring IPsec encryption
     File: configuring-ipsec-ovn
-  - Name: Configure an external gateway through a secondary network interface
+  - Name: Configure an external gateway on the default network
     File: configuring-secondary-external-gateway
   - Name: Configuring an egress firewall for a project
     File: configuring-egress-firewall-ovn

--- a/modules/nw-secondary-ext-gw-configure.adoc
+++ b/modules/nw-secondary-ext-gw-configure.adoc
@@ -6,7 +6,7 @@
 [id="nw-secondary-ext-gw-configure_{context}"]
 = Configure a secondary external gateway
 
-You can configure a secondary external gateway for a namespace in your cluster.
+You can configure an external gateway on the default network for a namespace in your cluster.
 
 .Prerequisites
 

--- a/modules/nw-secondary-ext-gw-status.adoc
+++ b/modules/nw-secondary-ext-gw-status.adoc
@@ -4,9 +4,9 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-secondary-ext-gw-status_{context}"]
-= View the status of a secondary external gateway
+= View the status of an external gateway
 
-You can view the status of a secondary external gateway that is configured for your cluster. The `status` field for the `AdminPolicyBasedExternalRoute` custom resource reports recent status messages whenever you update the resource, subject to a few limitations:
+You can view the status of an external gateway that is configured for your cluster. The `status` field for the `AdminPolicyBasedExternalRoute` custom resource reports recent status messages whenever you update the resource, subject to a few limitations:
 
 - Namespaces impacted are not reported in status messages
 - Pods selected as part of a dynamic next hop configuration do not trigger status updates as a result of pod lifecycle events, such as pod termination

--- a/networking/ovn_kubernetes_network_provider/configuring-secondary-external-gateway.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-secondary-external-gateway.adoc
@@ -1,12 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="configuring-secondary-external-gateway"]
-= Configure an external gateway through a secondary network interface
+= Configure an external gateway on the default network
 include::_attributes/common-attributes.adoc[]
 :context: configuring-secondary-external-gateway
 
 toc::[]
 
-As a cluster administrator, you can configure an external gateway on a secondary network.
+As a cluster administrator, you can configure an external gateway on the default network.
 
 This feature offers the following benefits:
 


### PR DESCRIPTION
- https://issues.redhat.com/browse/OCPBUGS-25247

Changing of words.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://71228--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-secondary-external-gateway
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
