### PR TITLE
OSDOCS#4348: Adding xref to IBM Cloud restricted installs release note

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -77,7 +77,7 @@ For more information, see xref:../installing/installing_ibm_cloud_public/user-ma
 
 You can now install a cluster on {ibm-cloud-name} in an environment with limited internet access, such as a disconnected or restricted network cluster. With this type of installation, you create a registry that mirrors the contents of the {product-title} installation images. You can create this registry on a mirror host, which can access both the internet and your restricted network.
 
-// For more information see <insert links to restricted install assembly after docs merge>.
+For more information, see xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc#installing-ibm-cloud-restricted[Installing a cluster on IBM Cloud in a restricted network].
 
 [id="ocp-4-15-installation-and-update-nutanix-failure-domains"]
 ==== Nutanix and fault tolerant deployments


### PR DESCRIPTION
Version(s):
4.15

Issue:
This PR addresses [osdocs-4348](https://issues.redhat.com/browse/OSDOCS-4348) and updates the IBM Cloud restricted installs release note with a cross reference to the docs.

Link to docs preview:



QE review:
- [N/A] QE has approved this change.
This PR is only adding an xref. The release note was approved by QE in https://github.com/openshift/openshift-docs/pull/70636.
