### PR TITLE
OSDOCS#9566: Removing Assisted Installer references from failure doma…

### DIFF
--- a/installing/installing_nutanix/nutanix-failure-domains.adoc
+++ b/installing/installing_nutanix/nutanix-failure-domains.adoc
@@ -18,9 +18,6 @@ The {product-title} installation method determines how and when you configure fa
 
 * If you deploy using installer-provisioned infrastructure, you can configure failure domains in the installation configuration file before deploying the cluster. For more information, see xref:../../installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc#installation-configuring-nutanix-failure-domains_installing-nutanix-installer-provisioned[Configuring failure domains].
 +
-You can also configure failure domains after the cluster is deployed.
-* If you deploy using the {ai-full}, you configure failure domains after the cluster is deployed.
-+
-For more information about configuring failure domains post-installation, see xref:../../post_installation_configuration/adding-nutanix-failure-domains.adoc#adding-failure-domains-to-an-existing-nutanix-cluster[Adding failure domains to an existing Nutanix cluster].
+You can also configure failure domains after the cluster is deployed. For more information about configuring failure domains post-installation, see xref:../../post_installation_configuration/adding-nutanix-failure-domains.adoc#adding-failure-domains-to-an-existing-nutanix-cluster[Adding failure domains to an existing Nutanix cluster].
 
 * If you deploy using infrastructure that you manage (user-provisioned infrastructure) no additional configuration is required. After the cluster is deployed, you can manually distribute control plane and compute machines across failure domains.

--- a/post_installation_configuration/adding-nutanix-failure-domains.adoc
+++ b/post_installation_configuration/adding-nutanix-failure-domains.adoc
@@ -13,11 +13,6 @@ A failure domain represents a single Prism Element instance to which:
 * New control plane and compute machines can be deployed.
 * Existing control plane and compute machines can be distributed.
 
-[IMPORTANT]
-====
-If you deployed the {product-title} cluster using the {ai-full}, be sure that the postinstallation steps have been completed. Completing the {product-title} integration with Nutanix is required to add failure domains. For more information, see the {ai-full} documentation for link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2024/html/installing_openshift_container_platform_with_the_assisted_installer/assembly_installing-on-nutanix#nutanix-post-installation-configuration_assembly_installing-on-nutanix[Nutanix postinstallation configuration].
-====
-
 include::modules/installation-nutanix-failure-domains-req.adoc[leveloffset=+1]
 
 include::modules/post-installation-configuring-nutanix-failure-domains.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.15+

Issue:
This PR addresses [osdocs-9566](https://issues.redhat.com/browse/OSDOCS-9566).

Link to docs preview:

- [Installation method and failure domain configuration](https://71230--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/nutanix-failure-domains#installation-method-and-failure-domain-configuration) (reference to Assisted Installer removed)
- [Adding failure domains to an existing Nutanix cluster](https://71230--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/adding-nutanix-failure-domains) (Admonition about completing the post-installation steps for the Assisted installer has been removed)

QE review:
- [x] QE has approved this change.