### PR TITLE
SRVCOM-2923: Adds Serverless 1.32 to distro file

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -321,6 +321,9 @@ openshift-serverless:
     serverless-docs-1.31:
       name: '1.31'
       dir: serverless/1.31
+    serverless-docs-1.32:
+      name: '1.32'
+      dir: serverless/1.32
 openshift-gitops:
   name: Red Hat OpenShift GitOps
   author: OpenShift documentation team <openshift-docs@redhat.com>


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: [SRVCOM-2923](https://issues.redhat.com//browse/SRVCOM-2923) Update _distro_map.yml

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[SRVCOM-2923](https://issues.redhat.com/browse/SRVCOM-2923)

Link to docs preview:
https://71236--ocpdocs-pr.netlify.app/

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
