### PR TITLE
OSDOCS#9574: Release notes for OCP on ARM 4.15

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -86,6 +86,12 @@ By default, the installation program installs control plane and compute machines
 
 For more information, see xref:../installing/installing_nutanix/nutanix-failure-domains.adoc#nutanix-failure-domains[Fault tolerant deployments using multiple Prism Elements].
 
+[id="ocp-4-15-installation-and-update-OCP-on-ARM"]
+
+==== {product-title} on 64-bit ARM 
+
+{product-title} {product-version} now supports the ability to enable 64k page sizes in the {op-system} kernel using the Machine Config Operator (MCO). This setting is exclusive to machines with 64-bit ARM architectures. For more information, see the xref:../post_installation_configuration/machine-configuration-tasks.adoc#machine-configuration-tasks[Machine configuration tasks] documentation.  
+
 [id="ocp-4-15-web-console"]
 === Web console
 


### PR DESCRIPTION
**Version(s):** 4.15

**Issue:** [OSDOCS-9574](https://issues.redhat.com//browse/OSDOCS-9574)

**Link to docs preview:**

- [Installation and upgrade -> OpenShift container platform on 64-bit ARM](https://71255--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-installation-and-update)

**QE review:**
- [x] QE has approved this change.