### PR TITLE
OSDOCS#8971: Docs for change in secret generation behavior when the i…

### DIFF
--- a/installing/cluster-capabilities.adoc
+++ b/installing/cluster-capabilities.adoc
@@ -111,6 +111,7 @@ include::modules/cluster-image-registry-operator.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 * xref:../registry/configuring-registry-operator.adoc#configuring-registry-operator[Image Registry Operator in {product-title}]
+* xref:../nodes/pods/nodes-pods-secrets.adoc#auto-generated-sa-token-secrets_nodes-pods-secrets[Automatically generated secrets]
 
 [role="_additional-resources"]
 [id="additional-resources_{context}"]

--- a/modules/cluster-image-registry-operator.adoc
+++ b/modules/cluster-image-registry-operator.adoc
@@ -34,6 +34,13 @@ If insufficient information is available to define a complete `image-registry` r
 The Cluster Image Registry Operator runs in the `openshift-image-registry` namespace and it also manages the registry instance in that location. All configuration and workload resources for the registry reside in that namespace.
 
 ifdef::cluster-caps[]
+In order to integrate the image registry into the cluster's user authentication and authorization system, a service account token secret and an image pull secret are generated for each service account in the cluster.
+
+[IMPORTANT]
+====
+If you disable the `ImageRegistry` capability or if you disable the integrated {product-registry} in the Cluster Image Registry Operator's configuration, the service account token secret and image pull secret are not generated for each service account.
+====
+
 If you disable the `ImageRegistry` capability, you can reduce the overall resource footprint of {product-title} in Telco environments. Depending on your deployment, you can disable this component if you do not need it.
 endif::[]
 

--- a/modules/service-account-auto-secret-removed.adoc
+++ b/modules/service-account-auto-secret-removed.adoc
@@ -5,10 +5,13 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="auto-generated-sa-token-secrets_{context}"]
-= About automatically generated service account token secrets
+= Automatically generated secrets
 
-When a service account is created, a service account token secret is automatically generated for it. This service account token secret, along with an automatically generated docker configuration secret, is used to authenticate to the internal {product-title} registry. Do not rely on these automatically generated secrets for your own use; they might be removed in a future {product-title} release.
+By default, {product-title} creates the following secrets for each service account:
 
+* A dockercfg image pull secret
+* A service account token secret
++
 [NOTE]
 ====
 Prior to {product-title} 4.11, a second service account token secret was generated when a service account was created. This service account token secret was used to access the Kubernetes API.
@@ -16,6 +19,15 @@ Prior to {product-title} 4.11, a second service account token secret was generat
 Starting with {product-title} 4.11, this second service account token secret is no longer created. This is because the `LegacyServiceAccountTokenNoAutoGeneration` upstream Kubernetes feature gate was enabled, which stops the automatic generation of secret-based service account tokens to access the Kubernetes API.
 
 After upgrading to {product-version}, any existing service account token secrets are not deleted and continue to function.
+====
+
+This service account token secret and docker configuration image pull secret are necessary to integrate the {product-registry} into the cluster's user authentication and authorization system.
+
+However, if you do not enable the `ImageRegistry` capability or if you disable the integrated {product-registry} in the Cluster Image Registry Operator's configuration, these secrets are not generated for each service account.
+
+[WARNING]
+====
+Do not rely on these automatically generated secrets for your own use; they might be removed in a future {product-title} release.
 ====
 
 Workloads are automatically injected with a projected volume to obtain a bound service account token. If your workload needs an additional service account token, add an additional projected volume in your workload manifest. Bound service account tokens are more secure than service account token secrets for the following reasons:


### PR DESCRIPTION
…nternal registry is disabled

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-8971

Link to docs preview:
* https://71256--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/cluster-capabilities#cluster-image-registry-operator_cluster-capabilities
* https://71256--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets#auto-generated-sa-token-secrets_nodes-pods-secrets

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
