### PR TITLE
OSDOCS-9565: configuring AWS Outposts postinstallation

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -633,6 +633,8 @@ Topics:
 - Name: Adding failure domains to an existing Nutanix cluster
   File: adding-nutanix-failure-domains
   Distros: openshift-origin,openshift-enterprise
+- Name: Extending an AWS VPC cluster into an AWS Outpost
+  File: configuring-aws-outposts
 ---
 Name: Updating clusters
 Dir: updating

--- a/installing/installing_aws/installing-aws-outposts.adoc
+++ b/installing/installing_aws/installing-aws-outposts.adoc
@@ -9,3 +9,5 @@ toc::[]
 In {product-title} version 4.14, you could install a cluster on Amazon Web Services (AWS) with compute nodes running in AWS Outposts as a Technology Preview. As of {product-title} version 4.15, this installation method is no longer supported.
 
 Instead, you can xref:../../installing/installing_aws/installing-aws-vpc.adoc#installing-aws-vpc[install a cluster on AWS into an existing VPC] and provision compute nodes on AWS Outposts as a postinstallation configuration task.
+
+For more information, see xref:../../post_installation_configuration/configuring-aws-outposts.adoc#configuring-aws-outposts[Extending an AWS VPC cluster into an AWS Outpost]

--- a/installing/installing_aws/installing-aws-vpc.adoc
+++ b/installing/installing_aws/installing-aws-vpc.adoc
@@ -121,3 +121,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
 * If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+* After installing a cluster on AWS into an existing VPC, you can xref:../../post_installation_configuration/configuring-aws-outposts.adoc#configuring-aws-outposts[extend the AWS VPC cluster into an AWS Outpost].

--- a/modules/aws-outposts-environment-info-aws.adoc
+++ b/modules/aws-outposts-environment-info-aws.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/configuring-aws-outposts.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="aws-outposts-environment-info-aws_{context}"]
+= Obtaining information from your AWS account
+
+You can use the AWS CLI (`aws`) to obtain information from your AWS account.
+
+[TIP]
+====
+You might find it convenient to store some or all of these values as environment variables by using the `export` command.
+====
+
+.Prerequisites
+
+* You have an AWS Outposts site with the required hardware setup complete.
+
+* Your Outpost is connected to your AWS account.
+
+* You have access to your AWS account by using the AWS CLI (`aws`) as a user with permissions to perform the required tasks.
+
+.Procedure
+
+. List the Outposts that are connected to your AWS account by running the following command:
++
+[source,terminal]
+----
+$ aws outposts list-outposts
+----
+
+. Retain the following values from the output of the `aws outposts list-outposts` command:
+
+** The Outpost ID.
+
+** The Amazon Resource Name (ARN) for the Outpost.
+
+** The Outpost availability zone.
++
+[NOTE]
+====
+The output of the `aws outposts list-outposts` command includes two values related to the availability zone: `AvailabilityZone` and `AvailabilityZoneId`. You use the `AvailablilityZone` value to configure a compute machine set that creates compute machines in your Outpost.
+====
+
+. Using the value of the Outpost ID, show the instance types that are available in your Outpost by running the following command. Retain the values of the available instance types.
++
+[source,terminal]
+----
+$ aws outposts get-outpost-instance-types \
+  --outpost-id <outpost_id_value>
+----
+
+. Using the value of the Outpost ARN, show the subnet ID for the Outpost by running the following command. Retain this value.
++
+[source,terminal]
+----
+$ aws ec2 describe-subnets \
+  --filters Name=outpost-arn,Values=<outpost_arn_value>
+----

--- a/modules/aws-outposts-environment-info-oc.adoc
+++ b/modules/aws-outposts-environment-info-oc.adoc
@@ -1,0 +1,66 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/configuring-aws-outposts.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="aws-outposts-environment-info-oc_{context}"]
+= Obtaining information from your {product-title} cluster
+
+You can use the {oc-first} to obtain information from your {product-title} cluster.
+
+[TIP]
+====
+You might find it convenient to store some or all of these values as environment variables by using the `export` command.
+====
+
+.Prerequisites
+
+* You have installed an {product-title} cluster into a custom VPC on AWS.
+
+* You have access to the cluster using an account with `cluster-admin` permissions.
+
+* You have installed the {oc-first}.
+
+.Procedure
+
+. List the infrastructure ID for the cluster by running the following command. Retain this value.
++
+[source,terminal]
+----
+$ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructures.config.openshift.io cluster
+----
+
+. Obtain details about the compute machine sets that the installation program created by running the following commands:
+
+.. List the compute machine sets on your cluster:
++
+[source,terminal]
+----
+$ oc get machinesets.machine.openshift.io -n openshift-machine-api
+----
++
+.Example output
+[source,text]
+----
+NAME                           DESIRED   CURRENT   READY   AVAILABLE   AGE
+<compute_machine_set_name_1>   1         1         1       1           55m
+<compute_machine_set_name_2>   1         1         1       1           55m
+----
+
+.. Display the Amazon Machine Image (AMI) ID for one of the listed compute machine sets. Retain this value.
++
+[source,terminal]
+----
+$ oc get machinesets.machine.openshift.io <compute_machine_set_name_1> \
+  -n openshift-machine-api \
+  -o jsonpath='{.spec.template.spec.providerSpec.value.ami.id}'
+----
+
+.. Display the subnet ID for the AWS VPC cluster. Retain this value.
++
+[source,terminal]
+----
+$ oc get machinesets.machine.openshift.io <compute_machine_set_name_1> \
+  -n openshift-machine-api \
+  -o jsonpath='{.spec.template.spec.providerSpec.value.subnet.id}'
+----

--- a/modules/aws-outposts-load-balancer-clb.adoc
+++ b/modules/aws-outposts-load-balancer-clb.adoc
@@ -1,0 +1,123 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/configuring-aws-outposts.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="aws-outposts-load-balancer-clb_{context}"]
+= Using AWS Classic Load Balancers in an AWS VPC cluster extended into an Outpost
+
+AWS Outposts racks cannot run AWS Classic Load Balancers, but Classic Load Balancers in the AWS VPC cluster can target edge compute nodes in the Outpost if edge and cloud-based subnets are in the same availability zone.
+As a result, Classic Load Balancers on the VPC cluster might schedule pods on either of these node types.
+
+Scheduling the workloads on edge compute nodes is supported, but can introduce latency.
+If you want to prevent a Classic Load Balancer in the VPC cluster from targeting Outpost edge compute nodes, you can apply labels to the cloud-based compute nodes and configure the Classic Load Balancer to only schedule on nodes with the applied labels.
+
+[NOTE]
+====
+If you do not need to prevent a Classic Load Balancer in the VPC cluster from targeting Outpost edge compute nodes, you do not need to complete these steps.
+====
+
+.Prerequisites
+
+* You have extended an AWS VPC cluster into an Outpost.
+
+* You have access to the cluster using an account with `cluster-admin` permissions.
+
+* You have installed the {oc-first}.
+
+* You have created a user workload in the Outpost with tolerations that match the taints for your edge compute machines.
+
+.Procedure
+
+. Optional: Verify that the edge compute nodes have the `location=outposts` label by running the following command and verifying that the output includes only the edge compute nodes in your Outpost:
++
+[source,terminal]
+----
+$ oc get nodes -l location=outposts
+----
+
+. Label the cloud-based compute nodes in the VPC cluster with a key-value pair by running the following command:
++
+[source,terminal]
+----
+$ for NODE in $(oc get node -l node-role.kubernetes.io/worker --no-headers | grep -v outposts | awk '{print$1}'); do oc label node $NODE <key_name>=<value>; done
+----
++
+where `<key_name>=<value>` is the label you want to use to distinguish cloud-based compute nodes.
++
+.Example output
+[source,text]
+----
+node1.example.com labeled
+node2.example.com labeled
+node3.example.com labeled
+----
+
+. Optional: Verify that the cloud-based compute nodes have the specified label by running the following command and confirming that the output includes all cloud-based compute nodes in your VPC cluster:
++
+[source,terminal]
+----
+$ oc get nodes -l <key_name>=<value>
+----
++
+.Example output
+[source,terminal]
+----
+NAME                   STATUS    ROLES     AGE       VERSION
+node1.example.com      Ready     worker    7h        v1.28.5
+node2.example.com      Ready     worker    7h        v1.28.5
+node3.example.com      Ready     worker    7h        v1.28.5
+----
+
+. Configure the Classic Load Balancer service by adding the cloud-based subnet information to the `annotations` field of the `Service` manifest:
++
+.Example service configuration
+[source,yaml]
+----
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: <application_name>
+  name: <application_name>
+  namespace: <application_namespace>
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-subnets: <aws_subnet> # <1>
+    service.beta.kubernetes.io/aws-load-balancer-target-node-labels: <key_name>=<value> # <2>
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: <application_name>
+  type: LoadBalancer
+----
+<1> Specify the subnet ID for the AWS VPC cluster.
+<2> Specify the key-value pair that matches the pair in the node label.
+
+. Create the `Service` CR by running the following command:
++
+[source,terminal]
+----
+$ oc create -f <file_name>.yaml
+----
+
+.Verification
+
+. Verify the status of the `service` resource to show the host of the provisioned Classic Load Balancer by running the following command:
++
+[source,terminal]
+----
+$ HOST=$(oc get service <application_name> -n <application_namespace> --template='{{(index .status.loadBalancer.ingress 0).hostname}}')
+----
+
+. Verify the status of the provisioned Classic Load Balancer host by running the following command:
++
+[source,terminal]
+----
+$ curl $HOST
+----
+
+. In the AWS console, verify that only the labeled instances appear as the targeted instances for the load balancer.

--- a/modules/aws-outposts-machine-set.adoc
+++ b/modules/aws-outposts-machine-set.adoc
@@ -1,0 +1,219 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/configuring-aws-outposts.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="aws-outposts-machine-set_{context}"]
+= Creating a compute machine set that deploys edge compute machines on an Outpost
+
+To create edge compute machines on AWS Outposts, you must create a new compute machine set with a compatible configuration.
+
+.Prerequisites
+
+* You have an AWS Outposts site.
+
+* You have installed an {product-title} cluster into a custom VPC on AWS.
+
+* You have access to the cluster using an account with `cluster-admin` permissions.
+
+* You have installed the {oc-first}.
+
+.Procedure
+
+. List the compute machine sets in your cluster by running the following command:
++
+[source,terminal]
+----
+$ oc get machinesets.machine.openshift.io -n openshift-machine-api
+----
++
+.Example output
+[source,text]
+----
+NAME                            DESIRED   CURRENT   READY   AVAILABLE   AGE
+<original_machine_set_name_1>   1         1         1       1           55m
+<original_machine_set_name_2>   1         1         1       1           55m
+----
+
+. Record the names of the existing compute machine sets.
+
+. Create a YAML file that contains the values for a new compute machine set custom resource (CR) by using one of the following methods:
+
+** Copy an existing compute machine set configuration into a new file by running the following command:
++
+[source,terminal]
+----
+$ oc get machinesets.machine.openshift.io <original_machine_set_name_1> \
+  -n openshift-machine-api -o yaml > <new_machine_set_name_1>.yaml
+----
++
+You can edit this YAML file with your preferred text editor.
+
+** Create an empty YAML file named `<new_machine_set_name_1>.yaml` with your preferred text editor and include the required values for your new compute machine set.
++
+If you are not sure which value to set for a specific field, you can view values of an existing compute machine set CR by running the following command:
++
+[source,terminal]
+----
+$ oc get machinesets.machine.openshift.io <original_machine_set_name_1> \
+  -n openshift-machine-api -o yaml
+----
++
+--
+.Example output
+[source,yaml]
+----
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id> # <1>
+  name: <infrastructure_id>-<role>-<availability_zone> # <2>
+  namespace: openshift-machine-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<availability_zone>
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+        machine.openshift.io/cluster-api-machine-role: <role>
+        machine.openshift.io/cluster-api-machine-type: <role>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<availability_zone>
+    spec:
+      providerSpec: # <3>
+# ...
+----
+<1> The cluster infrastructure ID.
+<2> A default node label. For AWS Outposts, you use the `outposts` role.
+<3> The omitted `providerSpec` section includes values that must be configured for your Outpost.
+--
+
+. Configure the new compute machine set to create edge compute machines in the Outpost by editing the `<new_machine_set_name_1>.yaml` file:
++
+--
+.Example compute machine set for AWS Outposts
+[source,yaml]
+----
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id> # <1>
+  name: <infrastructure_id>-outposts-<availability_zone> # <2>
+  namespace: openshift-machine-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-outposts-<availability_zone>
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+        machine.openshift.io/cluster-api-machine-role: outposts
+        machine.openshift.io/cluster-api-machine-type: outposts
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-outposts-<availability_zone>
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/outposts: ""
+          location: outposts
+      providerSpec:
+        value:
+          ami:
+            id: <ami_id> # <3>
+          apiVersion: machine.openshift.io/v1beta1
+          blockDevices:
+            - ebs:
+                volumeSize: 120
+                volumeType: gp2 # <4>
+          credentialsSecret:
+            name: aws-cloud-credentials
+          deviceIndex: 0
+          iamInstanceProfile:
+            id: <infrastructure_id>-worker-profile
+          instanceType: m5.xlarge # <5>
+          kind: AWSMachineProviderConfig
+          placement:
+            availabilityZone: <availability_zone>
+            region: <region> # <6>
+          securityGroups:
+            - filters:
+              - name: tag:Name
+                values:
+                  - <infrastructure_id>-worker-sg
+          subnet:
+            id: <subnet_id> # <7>
+          tags:
+            - name: kubernetes.io/cluster/<infrastructure_id>
+              value: owned
+          userDataSecret:
+            name: worker-user-data
+      taints: # <8>
+        - key: node-role.kubernetes.io/outposts
+          effect: NoSchedule
+----
+<1> Specifies the cluster infrastructure ID.
+<2> Specifies the name of the compute machine set. The name is composed of the cluster infrastructure ID, the `outposts` role name, and the Outpost availability zone.
+<3> Specifies the Amazon Machine Image (AMI) ID.
+<4> Specifies the EBS volume type. AWS Outposts requires gp2 volumes.
+<5> Specifies the AWS instance type. You must use an instance type that is configured in your Outpost.
+<6> Specifies the AWS region in which the Outpost availability zone exists.
+<7> Specifies the dedicated subnet for your Outpost.
+<8> Specifies a taint to prevent user workloads from being scheduled on nodes that have the `node-role.kubernetes.io/outposts` label.
+--
+
+. Save your changes.
+
+. Create a compute machine set CR by running the following command:
++
+[source,terminal]
+----
+$ oc create -f <new_machine_set_name_1>.yaml
+----
+
+.Verification
+
+* To verify that the compute machine set is created, list the compute machine sets in your cluster by running the following command:
++
+[source,terminal]
+----
+$ oc get machinesets.machine.openshift.io -n openshift-machine-api
+----
++
+.Example output
+[source,text]
+----
+NAME                            DESIRED   CURRENT   READY   AVAILABLE   AGE
+<new_machine_set_name_1>        1         1         1       1           4m12s
+<original_machine_set_name_1>   1         1         1       1           55m
+<original_machine_set_name_2>   1         1         1       1           55m
+----
+
+* To list the machines that are managed by the new compute machine set, run the following command:
++
+[source,terminal]
+----
+$ oc get -n openshift-machine-api machines.machine.openshift.io \
+  -l machine.openshift.io/cluster-api-machineset=<new_machine_set_name_1>
+----
++
+.Example output
+[source,text]
+----
+NAME                             PHASE          TYPE        REGION      ZONE         AGE
+<machine_from_new_1>             Provisioned    m5.xlarge   us-east-1   us-east-1a   25s
+<machine_from_new_2>             Provisioning   m5.xlarge   us-east-1   us-east-1a   25s
+----
+
+* To verify that a machine created by the new compute machine set has the correct configuration, examine the relevant fields in the CR for one of the new machines by running the following command:
++
+[source,terminal]
+----
+$ oc describe machine <machine_from_new_1> -n openshift-machine-api
+----

--- a/modules/aws-outposts-requirements-limitations.adoc
+++ b/modules/aws-outposts-requirements-limitations.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/configuring-aws-outposts.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="aws-outposts-requirements-limitations_{context}"]
+= AWS Outposts on {product-title} requirements and limitations
+
+You can manage the resources on your Outpost similarly to those on a cloud-based AWS cluster if you configure your {product-title} cluster to accommodate the following requirements and limitations:
+
+* To extend an {product-title} cluster on AWS into an Outpost, you must have installed the cluster into an existing VPC.
+
+* {product-title} clusters on AWS include the `gp3-csi` and `gp2-csi` storage classes.
+These classes correspond to Amazon Elastic Block Store (EBS) gp3 and gp2 volumes.
+{product-title} clusters use the `gp3-csi` storage class by default, but AWS Outposts does not support EBS gp3 volumes.
+
+* An Outpost is an extension of an availability zone associated with an AWS region and has a dedicated subnet.
+Edge compute machines deployed into an Outpost must use the Outpost availability zone and subnet.
+
+* AWS Outposts does not support AWS Network Load Balancers or Classic Load Balancers.
+To manages Ingress objects for your edge compute resources, you must install the AWS Load Balancer Operator so that you can use AWS Application Load Balancers in the AWS Outposts environment.
+If your cluster contains both edge and cloud-based compute instances that share workloads, additional configuration is required.
+
+* To create a volume in the Outpost, the CSI driver requires the Outpost Amazon Resource Name (ARN).
+The driver uses the topology keys stored on the `CSINode` objects to determine the Outpost ARN.
+To ensure that the driver uses the correct topology values, you must set the volume binding mode to `WaitForConsumer` and avoid setting allowed topologies on any new storage classes that you create.
+
+* When you extend an AWS VPC cluster into an Outpost, you have two types of compute resources.
+The Outpost has edge compute nodes, while the VPC has cloud-based compute nodes.
+The cloud-based AWS Elastic Block volume cannot attach to Outpost edge compute nodes, and the Outpost volumes cannot attach to cloud-based compute nodes.
++
+As a result, you cannot use CSI snapshots to migrate applications that use persistent storage from cloud-based compute nodes to edge compute nodes or directly use the original persistent volume.
+To migrate persistent storage data for applications, you must perform a manual backup and restore operation.

--- a/modules/create-user-workloads-aws-edge.adoc
+++ b/modules/create-user-workloads-aws-edge.adoc
@@ -1,0 +1,135 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/configuring-aws-outposts.adoc
+
+//To-do: reintegrate installation-extend-edge-nodes-aws-local-zones.adoc with create-user-workloads-aws-edge.adoc. Requires global repo update of any xrefs/includes.
+
+:_mod-docs-content-type: PROCEDURE
+[id="create-user-workloads-aws-edge_{context}"]
+= Creating user workloads in an Outpost
+
+After you extend an {product-title} in an AWS VPC cluster into an Outpost, you can use edge compute nodes with the label `node-role.kubernetes.io/outposts` to create user workloads in the Outpost.
+
+.Prerequisites
+
+* You have extended an AWS VPC cluster into an Outpost.
+
+* You have access to the cluster using an account with `cluster-admin` permissions.
+
+* You have installed the {oc-first}.
+
+* You have created a compute machine set that deploys edge compute machines compatible with the Outpost environment.
+
+.Procedure
+
+. Configure a `Deployment` resource file for an application that you want to deploy to the edge compute node in the edge subnet.
++
+.Example `Deployment` manifest
+[source,yaml]
+----
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: <application_name> # <1>
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: <application_name>
+  namespace: <application_namespace> # <2>
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: gp2-csi # <3>
+  volumeMode: Filesystem
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: <application_name>
+  namespace: <application_namespace>
+spec:
+  selector:
+    matchLabels:
+      app: <application_name>
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: <application_name>
+        location: outposts # <4>
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector: # <5>
+        node-role.kubernetes.io/outpost: ''
+      tolerations: # <6>
+      - key: "node-role.kubernetes.io/outposts"
+        operator: "Equal"
+        value: ""
+        effect: "NoSchedule"
+      containers:
+        - image: openshift/origin-node
+          command:
+           - "/bin/socat"
+          args:
+            - TCP4-LISTEN:8080,reuseaddr,fork
+            - EXEC:'/bin/bash -c \"printf \\\"HTTP/1.0 200 OK\r\n\r\n\\\"; sed -e \\\"/^\r/q\\\"\"'
+          imagePullPolicy: Always
+          name: <application_name>
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - mountPath: "/mnt/storage"
+              name: data
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: <application_name>
+----
+<1> Specify a name for your application.
+<2> Specify a namespace for your application. The application namespace can be the same as the application name.
+<3> Specify the storage class name. For an edge compute configuration, you must use the `gp2-csi` storage class.
+<4> Specify a label to identify workloads deployed in the Outpost.
+<5> Specify the node selector label that targets edge compute nodes.
+<6> Specify tolerations that match the `key` and `effects` taints in the compute machine set for your edge compute machines. Set the `value` and `operator` tolerations as shown.
+
+. Create the `Deployment` resource by running the following command:
++
+[source,terminal]
+----
+$ oc create -f <application_deployment>.yaml
+----
+
+. Configure a `Service` object that exposes a pod from a targeted edge compute node to services that run inside your edge network.
++
+.Example `Service` manifest
+[source,yaml]
+----
+apiVersion: v1
+kind: Service # <1>
+metadata:
+  name:  <application_name>
+  namespace: <application_namespace>
+spec:
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+  type: NodePort
+  selector: # <2>
+    app: <application_name>
+----
+<1> Defines the `service` resource.
+<2> Specify the label type to apply to managed pods.
+
+. Create the `Service` CR by running the following command:
++
+[source,terminal]
+----
+$ oc create -f <application_service>.yaml
+----

--- a/modules/installation-cloudformation-subnet-localzone.adoc
+++ b/modules/installation-cloudformation-subnet-localzone.adoc
@@ -1,14 +1,20 @@
 // Module included in the following assemblies:
 //
-// * installing/installing-aws-localzone.adoc (Installing a cluster on AWS with worker nodes on AWS Local Zones) 
-// * installing/installing-aws-wavelength-zone.adoc (Installing a cluster on AWS with compute nodes on AWS Wavelength Zones) 
+// * installing/installing-aws-localzone.adoc (Installing a cluster on AWS with worker nodes on AWS Local Zones)
+// * installing/installing-aws-wavelength-zone.adoc (Installing a cluster on AWS with compute nodes on AWS Wavelength Zones)
 // * post_installation_configuration/aws-compute-edge-zone-tasks.adoc (AWS zone tasks)
+// * post_installation_configuration/configuring-aws-outposts.adoc
+
+ifeval::["{context}" == "configuring-aws-outposts"]
+:outposts:
+endif::[]
 
 :_mod-docs-content-type: REFERENCE
 [id="installation-cloudformation-subnet-localzone_{context}"]
-= CloudFormation template for the VPC Subnet
+= CloudFormation template for the VPC subnet
 
-You can use the following CloudFormation template to deploy the private and public subnets in a zone on {zone-type} infrastructure.
+ifndef::outposts[You can use the following CloudFormation template to deploy the private and public subnets in a zone on {zone-type} infrastructure.]
+ifdef::outposts[You can use the following CloudFormation template to deploy the Outpost subnet.]
 
 .CloudFormation template for VPC subnets
 [%collapsible]
@@ -20,43 +26,59 @@ Description: Template for Best Practice Subnets (Public and Private)
 
 Parameters:
   VpcId:
-    Description: VPC ID that comprises all the target subnets
+    Description: VPC ID that comprises all the target subnets.
     Type: String
     AllowedPattern: ^(?:(?:vpc)(?:-[a-zA-Z0-9]+)?\b|(?:[0-9]{1,3}\.){3}[0-9]{1,3})$
     ConstraintDescription: VPC ID must be with valid name, starting with vpc-.*.
   ClusterName:
-    Description: ClusterName or PrefixName prepends to the Name tag for each subnet
+    Description: Cluster name or prefix name to prepend the Name tag for each subnet.
     Type: String
     AllowedPattern: ".+"
-    ConstraintDescription: ClusterName parameter must be specified
+    ConstraintDescription: ClusterName parameter must be specified.
   ZoneName:
-    Description: ZoneName that will be used to create the subnets, such as us-west-2-lax-1a
+    Description: Zone Name to create the subnets, such as us-west-2-lax-1a.
     Type: String
     AllowedPattern: ".+"
-    ConstraintDescription: ZoneName parameter must be specified
+    ConstraintDescription: ZoneName parameter must be specified.
   PublicRouteTableId:
-    Description: The PublicRouteTableID that associates with the public subnet
+    Description: Public Route Table ID to associate the public subnet.
     Type: String
     AllowedPattern: ".+"
-    ConstraintDescription: PublicRouteTableId parameter must be specified
+    ConstraintDescription: PublicRouteTableId parameter must be specified.
   PublicSubnetCidr:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-4]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-24
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-24.
     Default: 10.0.128.0/20
-    Description: CIDR block for public subnet
+    Description: CIDR block for public subnet.
     Type: String
-
   PrivateRouteTableId:
-    Description: PublicRouteTableID that associates to the {zone-type} subnet
+    Description: Private Route Table ID to associate the private subnet.
     Type: String
     AllowedPattern: ".+"
-    ConstraintDescription: PublicRouteTableId parameter must be specified
+    ConstraintDescription: PrivateRouteTableId parameter must be specified.
   PrivateSubnetCidr:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-4]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-24
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-24.
     Default: 10.0.128.0/20
-    Description: CIDR block for the public subnet
+    Description: CIDR block for private subnet.
     Type: String
+ifdef::outposts[]
+  PrivateSubnetLabel:
+    Default: "private"
+    Description: Subnet label to be added when building the subnet name.
+    Type: String
+  PublicSubnetLabel:
+    Default: "public"
+    Description: Subnet label to be added when building the subnet name.
+    Type: String
+  OutpostArn:
+    Default: ""
+    Description: OutpostArn when creating subnets on AWS Outpost.
+    Type: String
+
+Conditions:
+  OutpostEnabled: !Not [!Equals [!Ref "OutpostArn", ""]]
+endif::outposts[]
 
 Resources:
   PublicSubnet:
@@ -65,9 +87,19 @@ Resources:
       VpcId: !Ref VpcId
       CidrBlock: !Ref PublicSubnetCidr
       AvailabilityZone: !Ref ZoneName
+ifdef::outposts[]
+      OutpostArn: !If [ OutpostEnabled, !Ref OutpostArn, !Ref "AWS::NoValue"]
+endif::outposts[]
       Tags:
       - Key: Name
+ifndef::outposts[]
         Value: !Join ['-', [!Ref ClusterName, "public", !Ref ZoneName]]
+endif::outposts[]
+ifdef::outposts[]
+        Value: !Join ['-', [ !Ref ClusterName, !Ref PublicSubnetLabel, !Ref ZoneName]]
+      - Key: kubernetes.io/cluster/unmanaged
+        Value: true
+endif::outposts[]
 
   PublicSubnetRouteTableAssociation:
     Type: "AWS::EC2::SubnetRouteTableAssociation"
@@ -81,9 +113,19 @@ Resources:
       VpcId: !Ref VpcId
       CidrBlock: !Ref PrivateSubnetCidr
       AvailabilityZone: !Ref ZoneName
+ifdef::outposts[]
+      OutpostArn: !If [ OutpostEnabled, !Ref OutpostArn, !Ref "AWS::NoValue"]
+endif::outposts[]
       Tags:
       - Key: Name
+ifndef::outposts[]
         Value: !Join ['-', [!Ref ClusterName, "private", !Ref ZoneName]]
+endif::outposts[]
+ifdef::outposts[]
+        Value: !Join ['-', [!Ref ClusterName, !Ref PrivateSubnetLabel, !Ref ZoneName]]
+      - Key: kubernetes.io/cluster/unmanaged
+        Value: true
+endif::outposts[]
 
   PrivateSubnetRouteTableAssociation:
     Type: "AWS::EC2::SubnetRouteTableAssociation"
@@ -93,13 +135,17 @@ Resources:
 
 Outputs:
   PublicSubnetId:
-    Description: Subnet ID for the public subnets
+    Description: Subnet ID of the public subnets.
     Value:
       !Join ["", [!Ref PublicSubnet]]
 
   PrivateSubnetId:
-    Description: Subnet ID for the private subnets
+    Description: Subnet ID of the private subnets.
     Value:
       !Join ["", [!Ref PrivateSubnet]]
 ----
 ====
+
+ifeval::["{context}" == "configuring-aws-outposts"]
+:!outposts:
+endif::[]

--- a/modules/installation-creating-aws-vpc-subnets-edge.adoc
+++ b/modules/installation-creating-aws-vpc-subnets-edge.adoc
@@ -1,12 +1,17 @@
 // Module included in the following assemblies:
 //
-// * post_installation_configuration//aws-compute-edge-zone-tasks..adoc (AWS Local Zone or Wavelength Zone tasks) 
+// * post_i// * post_installation_configuration/configuring-aws-outposts.adoc
+
+ifeval::["{context}" == "configuring-aws-outposts"]
+:outposts:
+endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="installation-creating-aws-vpc-subnets-edge_{context}"]
-= Creating subnets in AWS Local Zones or Wavelength Zones
+= Creating subnets for AWS edge compute services
 
-Before you configure a machine set for edge compute nodes in your {product-title} cluster, you must create the subnets in {zone-type}. Complete the following procedure for each Wavelength Zone that you want to deploy compute nodes to.
+Before you configure a machine set for edge compute nodes in your {product-title} cluster, you must create a subnet in {zone-type}.
+ifndef::outposts[Complete the following procedure for each Wavelength Zone that you want to deploy compute nodes to.]
 
 You can use the provided CloudFormation template and create a CloudFormation stack. You can then use this stack to custom provision a subnet.
 
@@ -19,7 +24,8 @@ If you do not use the provided CloudFormation template to create your AWS infras
 
 * You configured an AWS account.
 * You added your AWS keys and region to your local AWS profile by running `aws configure`.
-* You opted in to the {zone-type} group.
+ifndef::outposts[* You opted in to the {zone-type} group.]
+ifdef::outposts[* You have obtained the required information about your environment from your {product-title} cluster, Outpost, and AWS account.]
 
 .Procedure
 
@@ -29,32 +35,40 @@ If you do not use the provided CloudFormation template to create your AWS infras
 +
 [source,terminal]
 ----
-$ aws cloudformation create-stack --stack-name <stack_name> \ <1>
+$ aws cloudformation create-stack --stack-name <stack_name> \// <1>
   --region ${CLUSTER_REGION} \
-  --template-body file://<template>.yaml \ <2>
+  --template-body file://<template>.yaml \// <2>
   --parameters \
-    ParameterKey=VpcId,ParameterValue="${VPC_ID}" \ <3>
-    ParameterKey=ClusterName,ParameterValue="${CLUSTER_NAME}" \ <4>
-    ParameterKey=ZoneName,ParameterValue="${ZONE_NAME}" \ <5>
-    ParameterKey=PublicRouteTableId,ParameterValue="${ROUTE_TABLE_PUB}" \ <6>
-    ParameterKey=PublicSubnetCidr,ParameterValue="${SUBNET_CIDR_PUB}" \ <7>
-    ParameterKey=PrivateRouteTableId,ParameterValue="${ROUTE_TABLE_PVT}" \ <8>
-    ParameterKey=PrivateSubnetCidr,ParameterValue="${SUBNET_CIDR_PVT}" <9>
+    ParameterKey=VpcId,ParameterValue="${VPC_ID}" \// <3>
+    ParameterKey=ClusterName,ParameterValue="${CLUSTER_NAME}" \// <4>
+    ParameterKey=ZoneName,ParameterValue="${ZONE_NAME}" \// <5>
+    ParameterKey=PublicRouteTableId,ParameterValue="${ROUTE_TABLE_PUB}" \// <6>
+    ParameterKey=PublicSubnetCidr,ParameterValue="${SUBNET_CIDR_PUB}" \// <7>
+    ParameterKey=PrivateRouteTableId,ParameterValue="${ROUTE_TABLE_PVT}" \// <8>
+ifndef::outposts[    ParameterKey=PrivateSubnetCidr,ParameterValue="${SUBNET_CIDR_PVT}" <9>]
+ifdef::outposts[]
+    ParameterKey=PrivateSubnetCidr,ParameterValue="${SUBNET_CIDR_PVT}" \// <9>
+    ParameterKey=PrivateSubnetLabel,ParameterValue="private-outpost" \
+    ParameterKey=PublicSubnetLabel,ParameterValue="public-outpost" \
+    ParameterKey=OutpostArn,ParameterValue="${OUTPOST_ARN}" <10>
+endif::outposts[]
 ----
-<1> `<stack_name>` is the name for the CloudFormation stack, such as `cluster-wl-<local_zone_shortname>` for Local Zones and `cluster-wl-<wavelength_zone_shortname>` for Wavelength Zones. You need the name of this stack if you remove the cluster.
-<2> `<template>` is the relative path and the name of the CloudFormation template
-YAML file that you saved.
+ifndef::outposts[<1> `<stack_name>` is the name for the CloudFormation stack, such as `cluster-wl-<local_zone_shortname>` for Local Zones and `cluster-wl-<wavelength_zone_shortname>` for Wavelength Zones. You need the name of this stack if you remove the cluster.]
+ifdef::outposts[<1> `<stack_name>` is the name for the CloudFormation stack, such as `cluster-<outpost_name>`.]
+<2> `<template>` is the relative path and the name of the CloudFormation template YAML file that you saved.
 <3> `${VPC_ID}` is the VPC ID, which is the value `VpcID` in the output of the CloudFormation template for the VPC.
 <4> `${CLUSTER_NAME}` is the value of *ClusterName* to be used as a prefix of the new AWS resource names.
 <5> `${ZONE_NAME}` is the value of {zone-type} name to create the subnets.
-<6> `${ROUTE_TABLE_PUB}` is the *PublicRouteTableId* extracted from the CloudFormation template. For Local Zones, the public route table is extracted from the VPC CloudFormation Stack. For Wavelength Zones, the value must be extracted from the output of the VPC's carrier gateway CloudFormation stack.
+ifndef::outposts[<6> `${ROUTE_TABLE_PUB}` is the Public Route Table Id extracted from the CloudFormation template. For Local Zones, the public route table is extracted from the VPC CloudFormation Stack. For Wavelength Zones, the value must be extracted from the output of the VPC's carrier gateway CloudFormation stack.]
+ifdef::outposts[<6> `${ROUTE_TABLE_PUB}` is the Public Route Table ID created in the `${VPC_ID}` used to associate the public subnets on Outposts. Specify the public route table to associate the Outpost subnet created by this stack.]
 <7> `${SUBNET_CIDR_PUB}` is a valid CIDR block that is used to create the public subnet. This block must be part of the VPC CIDR block `VpcCidr`.
-<8> `${ROUTE_TABLE_PVT}` is the *PrivateRouteTableId* extracted from the output of the VPC's CloudFormation stack.
+ifndef::outposts[<8> `${ROUTE_TABLE_PVT}` is the *PrivateRouteTableId* extracted from the output of the VPC's CloudFormation stack.]
+ifdef::outposts[<8> `${ROUTE_TABLE_PVT}` is the Private Route Table ID created in the `${VPC_ID}` used to associate the private subnets on Outposts. Specify the private route table to associate the Outpost subnet created by this stack.]
 <9> `${SUBNET_CIDR_PVT}` is a valid CIDR block that is used to create the private subnet. This block must be part of the VPC CIDR block `VpcCidr`.
-
+ifdef::outposts[<10> `${OUTPOST_ARN}` is the Amazon Resource Name (ARN) for the Outpost.]
++
 .Example output
-
-[source,terminal]
+[source,text]
 ----
 arn:aws:cloudformation:us-east-1:123456789012:stack/<stack_name>/dbedae40-820e-11eb-2fd3-12a48460849f
 ----
@@ -68,8 +82,16 @@ arn:aws:cloudformation:us-east-1:123456789012:stack/<stack_name>/dbedae40-820e-1
 $ aws cloudformation describe-stacks --stack-name <stack_name>
 ----
 +
-After the `StackStatus` displays `CREATE_COMPLETE`, the output displays values for the following parameters. Ensure that you provide these parameter values to the other CloudFormation templates that you run to create for your cluster.
+After the `StackStatus` displays `CREATE_COMPLETE`, the output displays values for the following parameters:
 +
+--
 [horizontal]
 `PublicSubnetId`:: The IDs of the public subnet created by the CloudFormation stack.
 `PrivateSubnetId`:: The IDs of the private subnet created by the CloudFormation stack.
+--
++
+Ensure that you provide these parameter values to the other CloudFormation templates that you run to create for your cluster.
+
+ifeval::["{context}" == "configuring-aws-outposts"]
+:!outposts:
+endif::[]

--- a/modules/nw-aws-load-balancer-with-outposts.adoc
+++ b/modules/nw-aws-load-balancer-with-outposts.adoc
@@ -1,27 +1,42 @@
 // Module included in the following assemblies:
 // * networking/aws_load_balancer_operator/understanding-aws-load-balancer-operator.adoc
+// * post_installation_configuration/configuring-aws-outposts.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-aws-load-balancer-with-outposts_{context}"]
-= AWS Load Balancer Operator and AWS Outposts
+= Using the AWS Load Balancer Operator in an AWS VPC cluster extended into an Outpost
 
-AWS Load Balancer Operator can work with AWS Outposts. Application Load Balancer is supported. Network Load balancer is not, so AWS Load Balancer Operator does not provision it on AWS Outposts subnets. Ingress resources must be annotated with the either outposts or regular subnets (but not both).
+You can configure the AWS Load Balancer Operator to provision an AWS Application Load Balancer in an AWS VPC cluster extended into an Outpost.
+AWS Outposts does not support AWS Network Load Balancers.
+As a result, the AWS Load Balancer Operator cannot provision Network Load Balancers in an Outpost.
+
+You can create an AWS Application Load Balancer either in the cloud subnet or in the Outpost subnet.
+An Application Load Balancer in the cloud can attach to cloud-based compute nodes and an Application Load Balancer in the Outpost can attach to edge compute nodes.
+You must annotate Ingress resources with the Outpost subnet or the VPC subnet, but not both.
+
+.Prerequisites
+
+* You have extended an AWS VPC cluster into an Outpost.
+
+* You have installed the {oc-first}.
+
+* You have installed the AWS Load Balancer Operator and created the AWS Load Balancer Controller.
 
 .Procedure
 
-* Configure the Ingress resource to use a specified subnet:
+* Configure the `Ingress` resource to use a specified subnet:
 +
-.Example Ingress resource configuration
+.Example `Ingress` resource configuration
 [source,yaml]
 ----
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: echoserver
+  name: <application_name>
   annotations:
-    alb.ingress.kubernetes.io/subnets: <outposts_subnet_id> # <1>
+    alb.ingress.kubernetes.io/subnets: <subnet_id> # <1>
 spec:
-  ingressClassName: alb 
+  ingressClassName: alb
   rules:
     - http:
         paths:
@@ -29,9 +44,13 @@ spec:
             pathType: Exact
             backend:
               service:
-                name: echoserver
+                name: <application_name>
                 port:
                   number: 80
 ----
-<1> Specifies the subnet to use. To use the Application Load Balancer in an Outpost, specify the Outpost subnet ID.
-
+<1> Specifies the subnet to use.
++
+--
+* To use the Application Load Balancer in an Outpost, specify the Outpost subnet ID.
+* To use the Application Load Balancer in the cloud, you must specify at least two subnets in different availability zones.
+--

--- a/modules/nw-cluster-mtu-change.adoc
+++ b/modules/nw-cluster-mtu-change.adoc
@@ -2,6 +2,7 @@
 //
 // * networking/changing-cluster-network-mtu.adoc
 // * post_installation_configuration/aws-compute-edge-zone-tasks.adoc
+// * post_installation_configuration/configuring-aws-outposts.adoc
 
 ifeval::["{context}" == "aws-compute-edge-tasks-local-zone"]
 :local-zone:
@@ -12,24 +13,38 @@ endif::[]
 ifeval::["{context}" == "aws-compute-edge-zone-tasks"]
 :post-aws-zones:
 endif::[]
+ifeval::["{context}" == "configuring-aws-outposts"]
+:outposts:
+endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-cluster-mtu-change_{context}"]
-= Changing the cluster network MTU
+ifndef::outposts[= Changing the cluster network MTU]
+ifdef::outposts[= Changing the cluster network MTU to support AWS Outposts]
 
-As a cluster administrator, you can change the maximum transmission unit (MTU) for your cluster network. The migration is disruptive and nodes in your cluster might be temporarily unavailable as the MTU update takes effect.
+ifdef::outposts[]
+During installation, the maximum transmission unit (MTU) for the cluster network is detected automatically based on the MTU of the primary network interface of nodes in the cluster.
+You might need to decrease the MTU value for the cluster network to support an AWS Outposts subnet.
+endif::outposts[]
 
-ifndef::local-zone,wavelength-zone,post-aws-zones[]
+ifndef::outposts[As a cluster administrator, you can increase or decrease the maximum transmission unit (MTU) for your cluster.]
+
+[IMPORTANT]
+====
+The migration is disruptive and nodes in your cluster might be temporarily unavailable as the MTU update takes effect.
+====
+
+ifdef::outposts[For more details about the migration process, including important service interruption considerations, see "Changing the MTU for the cluster network" in the additional resources for this procedure.]
+
+ifndef::local-zone,wavelength-zone,post-aws-zones,outposts[]
 The following procedure describes how to change the cluster network MTU by using either machine configs, Dynamic Host Configuration Protocol (DHCP), or an ISO image. If you use either the DHCP or ISO approaches, you must refer to configuration artifacts that you kept after installing your cluster to complete the procedure.
-endif::local-zone,wavelength-zone,post-aws-zones[]
-
-To increase or decrease the MTU for the cluster network, complete the steps in the following procedure.
+endif::local-zone,wavelength-zone,post-aws-zones,outposts[]
 
 .Prerequisites
 
-* You installed the OpenShift CLI (`oc`).
-* You are logged in to the cluster with `cluster-admin` privileges.
-* You identified the target MTU for your cluster. The correct MTU for the OVN-Kubernetes network plugin must be set to `100` less than the lowest hardware MTU value in your cluster.
+* You have installed the {oc-first}.
+* You have access to the cluster using an account with `cluster-admin` permissions.
+* You have identified the target MTU for your cluster. The MTU for the OVN-Kubernetes network plugin must be set to `100` less than the lowest hardware MTU value in your cluster.
 
 .Procedure
 
@@ -55,7 +70,7 @@ Status:
 ...
 ----
 
-ifndef::local-zone,wavelength-zone,post-aws-zones[]
+ifndef::local-zone,wavelength-zone,post-aws-zones,outposts[]
 . Prepare your configuration for the hardware MTU:
 
 ** If your hardware MTU is specified with DHCP, update your DHCP configuration such as with the following dnsmasq configuration:
@@ -170,7 +185,7 @@ $ for manifest in control-plane-interface worker-interface; do
     butane --files-dir . $manifest.bu > $manifest.yaml
   done
 ----
-endif::local-zone,wavelength-zone,post-aws-zones[]
+endif::local-zone,wavelength-zone,post-aws-zones,outposts[]
 
 . To begin the MTU migration, specify the migration configuration by entering the following command. The Machine Config Operator performs a rolling reboot of the nodes in the cluster in preparation for the MTU change.
 +
@@ -184,29 +199,39 @@ $ oc patch Network.operator.openshift.io cluster --type=merge --patch \
 where:
 
 `<overlay_from>`:: Specifies the current cluster network MTU value.
-`<overlay_to>`:: Specifies the target MTU for the cluster network. This value is set relative to the value for `<machine_to>` and for OVN-Kubernetes must be `100` or less.
+`<overlay_to>`:: Specifies the target MTU for the cluster network. This value is set relative to the value of `<machine_to>`. For OVN-Kubernetes, this value must be `100` less than the value of `<machine_to>`.
 `<machine_to>`:: Specifies the MTU for the primary network interface on the underlying host network.
 --
 +
+ifndef::outposts[]
 .Example that increases the cluster MTU
 [source,terminal]
 ----
 $ oc patch Network.operator.openshift.io cluster --type=merge --patch \
   '{"spec": { "migration": { "mtu": { "network": { "from": 1400, "to": 9000 } , "machine": { "to" : 9100} } } } }'
 ----
+endif::outposts[]
+ifdef::outposts[]
+.Example that decreases the cluster MTU
+[source,terminal]
+----
+$ oc patch Network.operator.openshift.io cluster --type=merge --patch \
+  '{"spec": { "migration": { "mtu": { "network": { "from": 1400, "to": 1000 } , "machine": { "to" : 1100} } } } }'
+----
+endif::outposts[]
 
-. As the MCO updates machines in each machine config pool, it reboots each node one by one. You must wait until all the nodes are updated. Check the machine config pool status by entering the following command:
+. As the Machine Config Operator updates machines in each machine config pool, it reboots each node one by one. You must wait until all the nodes are updated. Check the machine config pool status by entering the following command:
 +
 [source,terminal]
 ----
-$ oc get mcp
+$ oc get machineconfigpools
 ----
 +
 A successfully updated node has the following status: `UPDATED=true`, `UPDATING=false`, `DEGRADED=false`.
 +
 [NOTE]
 ====
-By default, the MCO updates one machine per pool at a time, causing the total time the migration takes to increase with the size of the cluster.
+By default, the Machine Config Operator updates one machine per pool at a time, causing the total time the migration takes to increase with the size of the cluster.
 ====
 
 . Confirm the status of the new machine configuration on the hosts:
@@ -227,8 +252,8 @@ machineconfiguration.openshift.io/desiredConfig: rendered-master-c53e221d9d24e1c
 machineconfiguration.openshift.io/reason:
 machineconfiguration.openshift.io/state: Done
 ----
-+
-Verify that the following statements are true:
+
+.. Verify that the following statements are true:
 +
 --
 * The value of `machineconfiguration.openshift.io/state` field is `Done`.
@@ -251,7 +276,7 @@ The machine config must include the following update to the systemd configuratio
 ExecStart=/usr/local/bin/mtu-migration.sh
 ----
 
-ifndef::local-zone,wavelength-zone,post-aws-zones[]
+ifndef::local-zone,wavelength-zone,post-aws-zones,outposts[]
 . Update the underlying network interface MTU value:
 
 ** If you are specifying the new MTU with a NetworkManager connection configuration, enter the following command. The MachineConfig Operator automatically performs a rolling reboot of the nodes in your cluster.
@@ -265,18 +290,18 @@ $ for manifest in control-plane-interface worker-interface; do
 
 ** If you are specifying the new MTU with a DHCP server option or a kernel command line and PXE, make the necessary changes for your infrastructure.
 
-. As the MCO updates machines in each machine config pool, it reboots each node one by one. You must wait until all the nodes are updated. Check the machine config pool status by entering the following command:
+. As the Machine Config Operator updates machines in each machine config pool, it reboots each node one by one. You must wait until all the nodes are updated. Check the machine config pool status by entering the following command:
 +
 [source,terminal]
 ----
-$ oc get mcp
+$ oc get machineconfigpools
 ----
 +
 A successfully updated node has the following status: `UPDATED=true`, `UPDATING=false`, `DEGRADED=false`.
 +
 [NOTE]
 ====
-By default, the MCO updates one machine per pool at a time, causing the total time the migration takes to increase with the size of the cluster.
+By default, the Machine Config Operator updates one machine per pool at a time, causing the total time the migration takes to increase with the size of the cluster.
 ====
 
 . Confirm the status of the new machine configuration on the hosts:
@@ -317,7 +342,7 @@ where `<config_name>` is the name of the machine config from the `machineconfigu
 If the machine config is successfully deployed, the previous output contains the `/etc/NetworkManager/system-connections/<connection_name>` file path.
 +
 The machine config must not contain the `ExecStart=/usr/local/bin/mtu-migration.sh` line.
-endif::local-zone,wavelength-zone,post-aws-zones[]
+endif::local-zone,wavelength-zone,post-aws-zones,outposts[]
 
 . To finalize the MTU migration, enter the following command for the OVN-Kubernetes network plugin:
 +
@@ -334,29 +359,27 @@ where:
 `<mtu>`:: Specifies the new cluster network MTU that you specified with `<overlay_to>`.
 --
 
-. After finalizing the MTU migration, each MCP node is rebooted one by one. You must wait until all the nodes are updated. Check the machine config pool status by entering the following command:
+. After finalizing the MTU migration, each machine config pool node is rebooted one by one. You must wait until all the nodes are updated. Check the machine config pool status by entering the following command:
 +
 [source,terminal]
 ----
-$ oc get mcp
+$ oc get machineconfigpools
 ----
 +
 A successfully updated node has the following status: `UPDATED=true`, `UPDATING=false`, `DEGRADED=false`.
 
 .Verification
 
-ifdef::local-zone,wavelength-zone,post-aws-zones[]
-* Verify that the node in your cluster uses the MTU that you specified in the previous procedure by entering the following command:
+ifdef::local-zone,wavelength-zone,post-aws-zones,outposts[]
+* Verify that the node in your cluster uses the MTU that you specified by entering the following command:
 +
 [source,terminal]
 ----
 $ oc describe network.config cluster
 ----
-endif::local-zone,wavelength-zone,post-aws-zones[]
+endif::local-zone,wavelength-zone,post-aws-zones,outposts[]
 
-ifndef::local-zone,wavelength-zone,post-aws-zones[]
-You can verify that a node in your cluster uses an MTU that you specified in the previous procedure.
-
+ifndef::local-zone,wavelength-zone,post-aws-zones,outposts[]
 . To get the current MTU for the cluster network, enter the following command:
 +
 [source,terminal]
@@ -364,7 +387,7 @@ You can verify that a node in your cluster uses an MTU that you specified in the
 $ oc describe network.config cluster
 ----
 
-. Get the current MTU for the primary network interface of a node.
+. Get the current MTU for the primary network interface of a node:
 
 .. To list the nodes in your cluster, enter the following command:
 +
@@ -392,7 +415,7 @@ where:
 ----
 ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8051
 ----
-endif::local-zone,wavelength-zone,post-aws-zones[]
+endif::local-zone,wavelength-zone,post-aws-zones,outposts[]
 
 ifeval::["{context}" == "aws-compute-edge-tasks-local-zone"]
 :!local-zone:
@@ -402,4 +425,7 @@ ifeval::["{context}" == "aws-compute-edge-tasks-wavelength-zone"]
 endif::[]
 ifeval::["{context}" == "aws-compute-edge-zone-tasks"]
 :!post-aws-zones:
+endif::[]
+ifeval::["{context}" == "configuring-aws-outposts"]
+:!outposts:
 endif::[]

--- a/post_installation_configuration/configuring-aws-outposts.adoc
+++ b/post_installation_configuration/configuring-aws-outposts.adoc
@@ -1,0 +1,84 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="configuring-aws-outposts"]
+= Extending an AWS VPC cluster into an AWS Outpost
+include::_attributes/common-attributes.adoc[]
+:context: configuring-aws-outposts
+:zone-type: AWS Outposts
+
+toc::[]
+
+After xref:../installing/installing_aws/installing-aws-vpc.adoc#installing-aws-vpc[installing a cluster on Amazon Web Services (AWS) into an existing Amazon Virtual Private Cloud (VPC)], you can create a compute machine set that deploys compute machines in AWS Outposts.
+AWS Outposts is an AWS edge compute service that enables using many features of a cloud-based AWS deployment with the reduced latency of an on-premise environment.
+For more information, see the link:https://docs.aws.amazon.com/outposts/[AWS Outposts documentation].
+
+//AWS Outposts on {product-title} requirements and limitations
+include::modules/aws-outposts-requirements-limitations.adoc[leveloffset=+1]
+
+[id="aws-outposts-environment-info_{context}"]
+== Obtaining information about your environment
+
+To extend an AWS VPC cluster to your Outpost, you must provide information about your {product-title} cluster and your Outpost environment.
+You use this information to complete network configuration tasks and configure a compute machine set that creates compute machines in your Outpost.
+You can use command-line tools to gather the required details.
+
+//Obtaining information from your {product-title} cluster
+include::modules/aws-outposts-environment-info-oc.adoc[leveloffset=+2]
+
+//Obtaining information from your AWS account
+include::modules/aws-outposts-environment-info-aws.adoc[leveloffset=+2]
+
+[id="aws-outposts-network-config_{context}"]
+== Configuring your network for your Outpost
+
+To extend your VPC cluster into an Outpost, you must complete the following network configuration tasks:
+
+* Change the Cluster Network MTU.
+* Create a subnet in your Outpost.
+
+//Changing the Cluster Network MTU to support AWS Outposts
+include::modules/nw-cluster-mtu-change.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+* xref:../networking/changing-cluster-network-mtu.adoc#changing-cluster-network-mtu[Changing the MTU for the cluster network]
+
+//Creating subnets for AWS edge compute services
+include::modules/installation-creating-aws-vpc-subnets-edge.adoc[leveloffset=+2]
+
+//CloudFormation template for the VPC Subnet
+include::modules/installation-cloudformation-subnet-localzone.adoc[leveloffset=+2]
+
+//Creating a compute machine set that deploys edge compute machines an Outpost
+include::modules/aws-outposts-machine-set.adoc[leveloffset=+1]
+
+//Creating user workloads in an Outpost
+include::modules/create-user-workloads-aws-edge.adoc[leveloffset=+1]
+//To-do: reintegrate installation-extend-edge-nodes-aws-local-zones.adoc with create-user-workloads-aws-edge.adoc. Requires global repo update of any xrefs/includes.
+
+[id="aws-outposts-network-scheduling-workloads_{context}"]
+== Scheduling workloads on edge and cloud-based AWS compute resources
+
+When you extend an AWS VPC cluster into an Outpost, the Outpost uses edge compute nodes and the VPC uses cloud-based compute nodes.
+The following load balancer considerations apply to an AWS VPC cluster extended into an Outpost:
+
+* Outposts cannot run AWS Network Load Balancers or AWS Classic Load Balancers, but a Classic Load Balancer for a VPC cluster extended into an Outpost can attach to the Outpost edge compute nodes.
+For more information, see xref:../post_installation_configuration/configuring-aws-outposts.adoc#aws-outposts-load-balancer-clb_configuring-aws-outposts[Using AWS Classic Load Balancers in an AWS VPC cluster extended into an Outpost].
+
+* To run a load balancer on an Outpost instance, you must use an AWS Application Load Balancer.
+You can use the AWS Load Balancer Operator to deploy an instance of the AWS Load Balancer Controller.
+The controller provisions AWS Application Load Balancers for Kubernetes Ingress resources.
+For more information, see xref:../post_installation_configuration/configuring-aws-outposts.adoc#nw-aws-load-balancer-with-outposts_configuring-aws-outposts[Using the AWS Load Balancer Operator in an AWS VPC cluster extended into an Outpost].
+
+//Using Classic Load Balancers in an AWS VPC cluster extended into an Outpost
+include::modules/aws-outposts-load-balancer-clb.adoc[leveloffset=+2]
+
+//Using the AWS Load Balancer Operator in an AWS VPC cluster extended into an Outpost
+include::modules/nw-aws-load-balancer-with-outposts.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../networking/aws_load_balancer_operator/create-instance-aws-load-balancer-controller.adoc#nw-creating-instance-aws-load-balancer-controller_create-instance-aws-load-balancer[Creating an instance of the AWS Load Balancer Controller using AWS Load Balancer Operator]
+
+[role="_additional-resources"]
+[id="additional-resources_configuring-aws-outposts"]
+== Additional resources
+* xref:../installing/installing_aws/installing-aws-vpc.adoc#installing-aws-vpc[Installing a cluster on AWS into an existing VPC]


### PR DESCRIPTION
Version(s):
4.15+

Issue:
[OSDOCS-9565](https://issues.redhat.com//browse/OSDOCS-9565)

Link to docs preview:
[Extending an AWS VPC cluster into an AWS Outpost](https://71263--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-aws-outposts)

QE review:
- [x] QE has approved this change.

Additional information: