### PR TITLE
OSDOCS#9575: Release notes for clusters with multi-architecture compu…

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -126,6 +126,15 @@ You can now move etcd from a root volume (Cinder) to a dedicated ephemeral local
 
 //For more information, see < insert link to Deploying OpenStack with rootVolume and etcd on local disk when docs merge>.
 
+[id="ocp-4.15-postinstallation-configuration"]
+=== Postinstallation configuration 
+
+[id="ocp-4.15-postinstallation-configuration-multi-arch-compute-machines"]
+
+==== {product-title} clusters with multi-architecture compute machines
+
+On {product-title} {product-version} clusters with multi-architecture compute machines, you can now enable 64k page sizes in the {op-system-first} kernel on the 64-bit ARM compute machines in your cluster. For more information on setting this parameter, see xref:../post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-compute-managing.adoc#multi-architecture-enabling-64k-pages_multi-architecture-compute-managing[Enabling 64k pages on the {op-system-first} kernel].
+
 [id="ocp-4-15-web-console"]
 === Web console
 


### PR DESCRIPTION
**Version(s):** 4.15
**Issue:** [OSDOCS-9575](https://issues.redhat.com//browse/OSDOCS-9575)

**Link to docs preview:**

- [Postinstallation configuration -> OpenShift Container Platform clusters with multi-architecture compute machines](https://71265--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4.15-postinstallation-configuration)

**QE review:**
- [x] QE has approved this change.
