### PR TITLE
HCIDOCS-125: Updating AI docs location in OCP docs.

### DIFF
--- a/installing/installing_sno/install-sno-installing-sno.adoc
+++ b/installing/installing_sno/install-sno-installing-sno.adoc
@@ -15,6 +15,8 @@ ifndef::openshift-origin[]
 
 To install {product-title} on a single node, use the web-based Assisted Installer wizard to guide you through the process and manage the installation.
 
+See the link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/[Assisted Installer for {product-title}] documentation for details and configuration options.
+
 include::modules/install-sno-generating-the-discovery-iso-with-the-assisted-installer.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -29,9 +31,7 @@ include::modules/install-sno-installing-with-the-assisted-installer.adoc[levelof
 .Additional resources
 
 * xref:../../installing/installing_sno/install-sno-installing-sno.adoc#installing-with-usb-media_install-sno-installing-sno-with-the-assisted-installer[Creating a bootable ISO image on a USB drive]
-
 * xref:../../installing/installing_sno/install-sno-installing-sno.adoc#install-booting-from-an-iso-over-http-redfish_install-sno-installing-sno-with-the-assisted-installer[Booting from an HTTP-hosted ISO image using the Redfish API]
-
 * xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno} clusters]
 
 endif::openshift-origin[]
@@ -55,9 +55,7 @@ include::modules/install-sno-monitoring-the-installation-manually.adoc[leveloffs
 .Additional resources
 
 * xref:../../installing/installing_sno/install-sno-installing-sno.adoc#installing-with-usb-media_install-sno-installing-sno-with-the-assisted-installer[Creating a bootable ISO image on a USB drive]
-
 * xref:../../installing/installing_sno/install-sno-installing-sno.adoc#install-booting-from-an-iso-over-http-redfish_install-sno-installing-sno-with-the-assisted-installer[Booting from an HTTP-hosted ISO image using the Redfish API]
-
 * xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno} clusters]
 
 [id="install-sno-installing-sno-on-cloud-providers"]
@@ -70,10 +68,10 @@ include::modules/install-sno-supported-cloud-providers-for-single-node-openshift
 include::modules/installation-aws_con_installing-sno-on-aws.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
+
 .Additional resources
 
 * xref:../../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-customizations[Installing a cluster on AWS with customizations]
-
 
 include::modules/install-sno-installing-sno-on-azure.adoc[leveloffset=+2]
 
@@ -82,14 +80,12 @@ include::modules/install-sno-installing-sno-on-azure.adoc[leveloffset=+2]
 
 * xref:../../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-customizations[Installing a cluster on Azure with customizations]
 
-
 include::modules/install-sno-installing-sno-on-gcp.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[Installing a cluster on GCP with customizations]
-
 
 include::modules/install-sno-installing-with-usb-media.adoc[leveloffset=+1]
 
@@ -122,7 +118,6 @@ You can use dedicated or shared IFLs to assign sufficient compute resources. Res
 .Additional resources
 
 * xref:../../installing/installing_ibm_z/installing-ibm-z.adoc#installing-ibm-z[Installing a cluster with z/VM on {ibm-z-name} and {ibm-linuxone-name}]
-
 * xref:../../installing/installing_ibm_z/installing-ibm-z-kvm.adoc#installing-ibm-z-kvm[Installing a cluster with {op-system-base} KVM on {ibm-z-name} and{ibm-linuxone-name}]
 
 include::modules/install-sno-ibm-z.adoc[leveloffset=+2]


### PR DESCRIPTION
Fixes: [HCIDOCS-125](https://issues.redhat.com/browse/HCIDOCS-125)

For: Version 4.14

Preview [here](https://71277--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-installing-sno)

Signed-off-by: Katie Drake kdrake@redhat.com