### PR TITLE
OSDOCS-9549: Add ROSA HCP support statement for kubeletconfig

### DIFF
--- a/modules/setting-higher-pid-limit-on-existing-cluster.adoc
+++ b/modules/setting-higher-pid-limit-on-existing-cluster.adoc
@@ -15,6 +15,12 @@ Changing the `podPidsLimit` on an existing cluster will trigger non-control plan
 
 .Prerequisites
 
+* You have a ROSA Classic cluster.
++
+--
+:FeatureName: Configuring the maximum number of PIDs
+include::snippets/rosa-classic-support.adoc[]
+--
 * You have installed the OpenShift CLI (`oc`).
 * You have logged in to your Red Hat account by using the ROSA CLI.
 

--- a/rosa_cluster_admin/rosa-configuring-pid-limits.adoc
+++ b/rosa_cluster_admin/rosa-configuring-pid-limits.adoc
@@ -19,7 +19,10 @@ toc::[]
 
 A process identifier (PID) is a unique identifier assigned by the Linux kernel to each process or thread currently running on a system. The number of processes that can run simultaneously on a system is limited to 4,194,304 by the Linux kernel. This number might also be affected by limited access to other system resources such as memory, CPU, and disk space.
 
-In {product-title} 4.11 and later, by default, a pod can have a maximum of 4,096 PIDs. If your workload requires more than that, you can increase the allowed maximum number of PIDs.
+In {product-title} 4.11 and later, by default, a pod can have a maximum of 4,096 PIDs. If your workload requires more than that, you can increase the allowed maximum number of PIDs by configuring a `KubeletConfig` object.
+
+:FeatureName: Configuring the maximum number of PIDs
+include::snippets/rosa-classic-support.adoc[]
 
 // Understanding process ID limits
 include::modules/sd-understanding-process-id-limits.adoc[leveloffset=+1]

--- a/snippets/rosa-classic-support.adoc
+++ b/snippets/rosa-classic-support.adoc
@@ -1,0 +1,10 @@
+// When including this file, ensure that {FeatureName} is set immediately before
+// the include. Otherwise it will result in an incorrect replacement.
+
+[IMPORTANT]
+====
+[subs="attributes+"]
+{FeatureName} is not supported on {hcp-title-first}.
+====
+// Undefine {FeatureName} attribute, so that any mistakes are easily spotted
+:!FeatureName:


### PR DESCRIPTION
Version(s):
* enterprise-4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-9549

Link to docs preview:
* https://71278--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa-configuring-pid-limits
* https://71278--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa-configuring-pid-limits#setting-higher-pid-limit-on-existing-cluster_rosa-configuring-pid-limits

QE review:
- [ ] QE has approved this change.
