### PR TITLE
PR for SRVCOM-2630: Removed the deprecated "deployment" attribute and replaced it with "workloads" in Serving, Eventing sections. 

### DIFF
--- a/eventing/tuning/overriding-config-eventing.adoc
+++ b/eventing/tuning/overriding-config-eventing.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can override the default configurations for some specific deployments by modifying the `deployments` spec in the `KnativeEventing` custom resource (CR). Currently, overriding default configuration settings is supported for the `eventing-controller`, `eventing-webhook`, and `imc-controller` fields, as well as for the `readiness` and `liveness` fields for probes.
+You can override the default configurations for some specific deployments by modifying the `workloads` spec in the `KnativeEventing` custom resource (CR). Currently, overriding default configuration settings is supported for the `eventing-controller`, `eventing-webhook`, and `imc-controller` fields, as well as for the `readiness` and `liveness` fields for probes.
 
 [IMPORTANT]
 ====

--- a/knative-serving/tuning-serving-configuration/overriding-config-serving.adoc
+++ b/knative-serving/tuning-serving-configuration/overriding-config-serving.adoc
@@ -4,7 +4,7 @@
 include::_attributes/common-attributes.adoc[]
 :context: overriding-config-serving
 
-You can override the default configurations for some specific deployments by modifying the `deployments` spec in the `KnativeServing` custom resources (CRs).
+You can override the default configurations for some specific deployments by modifying the `workloads` spec in the `KnativeServing` custom resources (CRs).
 
 include::modules/knative-serving-CR-system-deployments.adoc[leveloffset=+1]
 

--- a/modules/knative-eventing-CR-system-deployments.adoc
+++ b/modules/knative-eventing-CR-system-deployments.adoc
@@ -31,7 +31,7 @@ metadata:
   name: knative-eventing
   namespace: knative-eventing
 spec:
-  deployments:
+  workloads:
   - name: eventing-controller
     readinessProbes: <1>
       - container: controller

--- a/modules/knative-serving-CR-system-deployments.adoc
+++ b/modules/knative-serving-CR-system-deployments.adoc
@@ -33,7 +33,7 @@ metadata:
 spec:
   high-availability:
     replicas: 2
-  deployments:
+  workloads:
   - name: net-kourier-controller
     readinessProbes: <1>
       - container: controller


### PR DESCRIPTION
**Affected cherry-picking versions:**
serverless-docs 1.31
serverless-docs 1.32

**Associated JIRA:** https://issues.redhat.com/browse/SRVCOM-2630

**Doc preview and description:**

Check the following sections I have removed the deprecated "**deployment**" attribute and replaced it with "**workloads**".
- [Overriding Knative Eventing system deployment configurations](https://71279--docspreview.netlify.app/openshift-serverless/latest/eventing/tuning/overriding-config-eventing)
- [Overriding Knative Serving system deployment configurations](https://71279--docspreview.netlify.app/openshift-serverless/latest/knative-serving/tuning-serving-configuration/overriding-config-serving)