### PR TITLE
OSDOCS-9545: Documented the 4.12.49 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -4430,3 +4430,28 @@ $ oc adm release info 4.12.48 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+
+[id="ocp-4-12-49"]
+=== RHSA-2024:0664 - {product-title} 4.12.49 bug fix and security update
+
+Issued: 2024-02-09
+
+{product-title} release 4.12.49, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:0664[RHSA-2024:0664] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0666[RHSA-2024:0666] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.49 --pullspecs
+----
+
+[id="ocp-4-12-49-bug-fixes"]
+==== Bug fixes
+
+* Previously, pods assigned an IP from the pool created by the Whereabouts CNI plugin were getting stuck in `ContainerCreating` state after a node force reboot. With this release, the Whereabouts CNI plugin issue associated with the IP allocation after a node force reboot is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-16008[*OCPBUGS-16008*])
+
+[id="ocp-4-12-49-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.12

Issue:
* [OSDOCS-9545](https://issues.redhat.com/browse/OSDOCS-9545)

Link to docs preview:
[4.12.49 z-stream release notes](https://71282--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes#ocp-4-12-49)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
