### PR TITLE
[RHACS] ROX-19798: CO-RE BPF migration

### DIFF
--- a/configuration/configure-proxy.adoc
+++ b/configuration/configure-proxy.adoc
@@ -13,7 +13,7 @@ When you use a proxy with {product-title}:
 * All outgoing HTTP, HTTPS, and other TCP traffic from Central and Scanner goes through the proxy.
 * Traffic between Central and Scanner does not go through the proxy.
 * The proxy configuration does not affect the other {product-title} components.
-* When you are not using the offline mode, and a Collector running in a secured cluster needs to download an additional eBPF probe or kernel module at runtime:
+* When you are not using the offline mode, and a Collector running in a secured cluster needs to download an additional eBPF probe at runtime:
 ** The collector attempts to download them by contacting Sensor.
 ** The Sensor then forwards this request to Central.
 ** Central uses the proxy to locate the module or probe at `\https://collector-modules.stackrox.io`.

--- a/modules/acs-quick-install-secured-cluster-using-helm.adoc
+++ b/modules/acs-quick-install-secured-cluster-using-helm.adoc
@@ -23,11 +23,6 @@ endif::[]
 [role="_abstract"]
 Use the following instructions to install the `secured-cluster-services` Helm chart to deploy the per-cluster and per-node components (Sensor, Admission controller, Collector, and Scanner-slim).
 
-[CAUTION]
-====
-To install Collector on systems that have Unified Extensible Firmware Interface (UEFI) and that have Secure Boot enabled, you must use eBPF probes because kernel modules are unsigned, and the UEFI firmware cannot load unsigned packages. Collector identifies Secure Boot status at the start and switches to eBPF probes if required.
-====
-
 .Prerequisites
 * You must have generated an {product-title-short} init bundle for your cluster.
 * You must have access to the Red Hat Container Registry and a pull secret for authentication. For information about downloading images from `registry.redhat.io`, see link:https://access.redhat.com/RegistryAuthentication[Red Hat Container Registry Authentication].

--- a/modules/default-requirements-secured-cluster-services.adoc
+++ b/modules/default-requirements-secured-cluster-services.adoc
@@ -97,11 +97,11 @@ By default, the admission control service runs 3 replicas. The following table l
 
 .2+| *Collector Container*
 | *Request*
-| 0.05 cores
+| 0.06 cores
 | 320 MiB
 
 | *Limit*
-| 0.75 cores
+| 0.9 cores
 | 1000 MiB
 
 .2+| *Compliance Container*

--- a/modules/install-secured-cluster-operator.adoc
+++ b/modules/install-secured-cluster-operator.adoc
@@ -14,11 +14,6 @@ endif::[]
 [role="_abstract"]
 You can install secured cluster services on your clusters by using the `SecuredCluster` custom resource. You must install the secured cluster services on every cluster in your environment that you want to monitor.
 
-[CAUTION]
-====
-When you install secured cluster services, Collector is also installed. To install Collector on systems that have Unified Extensible Firmware Interface (UEFI) and that have Secure Boot enabled, you must use eBPF probes because kernel modules are unsigned, and the UEFI firmware cannot load unsigned packages. Collector identifies Secure Boot status at the start and switches to eBPF probes if required.
-====
-
 .Prerequisites
 * If you are using {ocp}, you must install version {ocp-supported-version} or later.
 * You have installed the {product-title-short} Operator.

--- a/modules/install-secured-cluster-services-helm-chart.adoc
+++ b/modules/install-secured-cluster-services-helm-chart.adoc
@@ -7,11 +7,6 @@
 
 After you configure the `values-public.yaml` and `values-private.yaml` files, install the `secured-cluster-services` Helm chart to deploy the per-cluster and per-node components (Sensor, Admission controller, Collector, and Scanner-slim).
 
-[CAUTION]
-====
-To install Collector on systems that have Unified Extensible Firmware Interface (UEFI) and that have Secure Boot enabled, you must use eBPF probes because kernel modules are unsigned, and the UEFI firmware cannot load unsigned packages. Collector identifies Secure Boot status at the start and switches to eBPF probes if required.
-====
-
 .Prerequisites
 * You must have generated an {product-title-short} init bundle for your cluster.
 * You must have access to the Red Hat Container Registry and a pull secret for authentication. For information about downloading images from `registry.redhat.io`, see link:https://access.redhat.com/RegistryAuthentication[Red Hat Container Registry Authentication].

--- a/modules/secured-cluster-configuration-options-operator.adoc
+++ b/modules/secured-cluster-configuration-options-operator.adoc
@@ -162,16 +162,20 @@ Use image configuration settings when you are using a custom registry.
 Per node settings define the configuration settings for components that run on each node in a cluster to secure the cluster.
 These components are Collector and Compliance.
 
-[cols="1,3"]
+[cols="1,3a"]
 |===
 | Parameter | Description
 
 | `perNode.collector.collection`
 | The method for system-level data collection.
-The default value is `EBPF`.
-Red Hat recommends using `EBPF` for data collection.
+The default value is `CORE_BPF`.
+Red Hat recommends using `CORE_BPF` for data collection.
 If you select `NoCollection`, Collector does not report any information about the network activity and the process executions.
 Available options are `NoCollection`, `EBPF`, and `CORE_BPF`.
+[NOTE]
+====
+Red Hat has deprecated the `EBPF` option and will remove it from future versions. Use `CORE_BPF` instead.
+====
 
 | `perNode.collector.imageFlavor`
 | The image type to use for Collector. You can specify it as `Regular` or `Slim`.

--- a/modules/secured-cluster-services-config.adoc
+++ b/modules/secured-cluster-services-config.adoc
@@ -69,7 +69,7 @@
 | Tag of `collector` image to use.
 
 | `collector.collectionMethod`
-| Either `EBPF`, `CORE_BPF`, or `NO_COLLECTION`.
+| Either `CORE_BPF`, `EBPF` (deprecated), or `NO_COLLECTION`.
 
 | `collector.imagePullPolicy`
 | Image pull policy for the Collector container.
@@ -188,7 +188,7 @@ If you do not create this account, you must complete future upgrades manually if
 
 | `collector.slimMode`
 | Specify `true` if you want to use a slim Collector image for deploying Collector.
-Using slim Collector images requires Central to provide the matching eBPF probe or kernel module.
+Using slim Collector images with the EBPF collection method requires Central to provide the matching eBPF probe.
 If you are running {product-title} in offline mode, you must download a kernel support package from link:https://install.stackrox.io/collector/support-packages/index.html[stackrox.io] and upload it to Central for slim Collectors to function.
 Otherwise, you must ensure that Central can access the online probe repository hosted at link:https://collector-modules.stackrox.io/[https://collector-modules.stackrox.io/].
 //TODO: Change these links when new links are alive.

--- a/modules/update-kernel-support-packages.adoc
+++ b/modules/update-kernel-support-packages.adoc
@@ -7,7 +7,7 @@
 
 Collector monitors the runtime activity for each node in your secured clusters.
 To monitor the activities, Collector requires probes.
-These probes are eBPF programs or kernel modules specific to the Linux kernel version installed on the host.
+These probes are eBPF programs specific to the Linux kernel version installed on the host.
 The Collector image contains a set of built-in probes.
 
 When {product-title} runs in normal mode (connected to the internet), Collector automatically downloads a new probe if the required probe is not built in.


### PR DESCRIPTION
CO-RE BPF is going to be a new default collection method, represent this in the documentation. eBPF is marked everywhere as deprecated, and few instances of using kernel modules are removed (should they be kept for any kind of backward compatibility reasons?).

The resources requirements are updated as well, based on the current performance evaluation.

Cherrypick in `rhacs-docs-4.4`