### PR TITLE
OCPBUGS-23427-revert: Reverted original change but placed new content in api-server part

### DIFF
--- a/modules/installation-load-balancing-user-infra.adoc
+++ b/modules/installation-load-balancing-user-infra.adoc
@@ -180,20 +180,20 @@ defaults
 listen api-server-6443 <1>
   bind *:6443
   mode tcp
-  server bootstrap bootstrap.ocp4.example.com:6443 check inter 1s backup <2>
-  server control-plane0 control-plane0.ocp4.example.com:6443 check inter 1s
-  server control-plane1 control-plane1.ocp4.example.com:6443 check inter 1s
-  server control-plane2 control-plane2.ocp4.example.com:6443 check inter 1s
-listen machine-config-server-22623 <3>
-  bind *:22623
-  mode tcp
   option  httpchk GET /readyz HTTP/1.0
   option  log-health-checks
   balance roundrobin
   server bootstrap bootstrap.ocp4.example.com:6443 verify none check check-ssl inter 10s fall 2 rise 3 backup <2>
-  server control-plane0 control-plane0.ocp4.example.com:6443 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
-  server control-plane1 control-plane1.ocp4.example.com:6443 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
-  server control-plane2 control-plane2.ocp4.example.com:6443 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
+  server master0 master0.ocp4.example.com:6443 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
+  server master1 master1.ocp4.example.com:6443 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
+  server master2 master2.ocp4.example.com:6443 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
+listen machine-config-server-22623 <3>
+  bind *:22623
+  mode tcp
+  server bootstrap bootstrap.ocp4.example.com:22623 check inter 1s backup <2>
+  server master0 master0.ocp4.example.com:22623 check inter 1s
+  server master1 master1.ocp4.example.com:22623 check inter 1s
+  server master2 master2.ocp4.example.com:22623 check inter 1s
 listen ingress-router-443 <4>
   bind *:443
   mode tcp


### PR DESCRIPTION
Version(s):
4.15 to 4.12

Issue:
[OCPBUGS-23427](https://issues.redhat.com/browse/OCPBUGS-23427)

Link to docs preview:
* [Example load balancer configuration for user-provisioned clusters - Bare metal](https://71287--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal#installation-load-balancing-user-infra-example_installing-bare-metal)
* [Example load balancer configuration for user-provisioned clusters - Agnostic](https://71287--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_platform_agnostic/installing-platform-agnostic#installation-load-balancing-user-infra_installing-platform-agnostic)
* [Example load balancer configuration for user-provisioned clusters - IBM Z](https://71287--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z#installation-load-balancing-user-infra_installing-ibm-z)
* [Example load balancer configuration for user-provisioned clusters - IBM Power](https://71287--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_power/installing-ibm-power#installation-load-balancing-user-infra_installing-ibm-power)
* [Example load balancer configuration for user-provisioned clusters - OpenStack](https://71287--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-custom#installation-load-balancing-user-infra-example_installing-openstack-installer-custom)

SME review
- [x] SME has approved this change.

QE review:
- [x] QE has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
