### PR TITLE
OSDOCS-8707: clarification for external gateway

### DIFF
--- a/modules/nw-secondary-ext-gw-about.adoc
+++ b/modules/nw-secondary-ext-gw-about.adoc
@@ -6,7 +6,11 @@
 [id="nw-secondary-ext-gw-about_{context}"]
 = How {product-title} determines the external gateway IP address
 
-You configure a secondary external gateway with the `AdminPolicyBasedExternalRoute` custom resource from the the `k8s.ovn.org` API group. The custom resource (CR) supports static and dynamic approaches to specifying an external gateway's IP address. Each namespace that a `AdminPolicyBasedExternalRoute` CR targets cannot be selected by any other `AdminPolicyBasedExternalRoute` CR. A namespace cannot have concurrent secondary external gateways.
+You configure a secondary external gateway with the `AdminPolicyBasedExternalRoute` custom resource (CR) from the the `k8s.ovn.org` API group. The CR supports static and dynamic approaches to specifying an external gateway's IP address.
+
+Each namespace that a `AdminPolicyBasedExternalRoute` CR targets cannot be selected by any other `AdminPolicyBasedExternalRoute` CR. A namespace cannot have concurrent secondary external gateways.
+
+Changes to policies are isolated in the controller. If a policy fails to apply, changes to other policies do not trigger a retry of other policies. Policies are only re-evaluated, applying any differences that might have occurred by the change, when updates to the policy itself or related objects to the policy such as target namespaces, pod gateways, or namespaces hosting them from dynamic hops are made.
 
 Static assignment:: You specify an IP address directly.
 Dynamic assignment:: You specify an IP address indirectly, with namespace and pod selectors, and an optional network attachment definition.

--- a/modules/nw-secondary-ext-gw-object.adoc
+++ b/modules/nw-secondary-ext-gw-object.adoc
@@ -32,7 +32,7 @@ from:
       kubernetes.io/metadata.name: novxlan-externalgw-ecmp-4059
 ----
 
-A namespace can be targeted by only one `AdminPolicyBasedExternalRoute` CR. If a namespace is selected by more than one `AdminPolicyBasedExternalRoute` CR, a `failed` error status occurs on the second and subsequent CRs targeting the same namespace.
+A namespace can only be targeted by one `AdminPolicyBasedExternalRoute` CR. If a namespace is selected by more than one `AdminPolicyBasedExternalRoute` CR, a `failed` error status occurs on the second and subsequent CRs that target the same namespace. To apply updates, you must change the policy itself or related objects to the policy such as target namespaces, pod gateways, or namespaces hosting them from dynamic hops in order for the policy to be re-evaluated and your changes to be applied.
 
 |`spec.nextHops`
 |`object`


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-8707
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://71305--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-secondary-external-gateway
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Related to https://issues.redhat.com/browse/OCPBUGS-22706
PTAL @tshefi @jordigilh 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
