### PR TITLE
OSDOCS-6894-rnote: Documented the 4.15 vSphere CPMS note

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -515,6 +515,13 @@ If the following conditions are true, the feature is enabled by default:
 [id="ocp-4-15-machine-api"]
 === Machine API
 
+[id="ocp-4-15-machine-api-and-update-vsphere-cpms"]
+==== Defining a VMware vSphere failure domain for a control plane machine set (Technology Preview)
+
+By using a vSphere failure domain resource, you can use a control plane machine set to deploy control plane machines on hardware that is separate from the primary VMware vSphere infrastructure. A control plane machine set helps balance control plane machines across defined failure domains to provide fault tolerance capabilities to your infrastructure.
+
+For more information, see xref:../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-yaml-failure-domain-vsphere_cpmso-configuration[Sample VMware vSphere failure domain configuration] and xref:../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-platform-matrix_cpmso-getting-started[Supported cloud providers].
+
 [id="ocp-4-15-nodes"]
 === Nodes
 
@@ -1444,6 +1451,11 @@ In the following tables, features are marked with the following statuses:
 |Managing machines with the Cluster API
 |Technology Preview
 |Technology Preview
+|Technology Preview
+
+|Defining a vSphere failure domain for a control plane machine set
+|Not Available
+|Not Available
 |Technology Preview
 
 |Cloud controller manager for Alibaba Cloud


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-9584](https://issues.redhat.com/browse/OSDOCS-9584)

Link to docs preview:
[Defining a VMware vSphere failure domain for a control plane machine set (Technology Preview)](https://71309--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-machine-api-and-update-vsphere-cpms)

QE review:
- [X] SME approved
- [x] QE approved


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
