### PR TITLE
add eu-south-1 region availability for hcp

### DIFF
--- a/modules/rosa-hcp-classic-comparison.adoc
+++ b/modules/rosa-hcp-classic-comparison.adoc
@@ -56,6 +56,7 @@
 |
 * Europe - Frankfurt (eu-central-1)
 * Europe - Ireland (eu-west-1)
+* Europe - Milan (eu-south-1)
 * US East - N. Virginia (us-east-1)
 * US East - Ohio (us-east-2)
 * US West - Oregon (us-west-2)

--- a/modules/rosa-sdpolicy-am-regions-az.adoc
+++ b/modules/rosa-sdpolicy-am-regions-az.adoc
@@ -52,10 +52,10 @@ endif::rosa-with-hcp[]
 * ap-southeast-4 (Melbourne, AWS opt-in required)
 * ca-central-1 (Central Canada)
 * eu-central-1 (Frankfurt)
+* eu-south-1 (Milan, AWS opt-in required)
 ifndef::rosa-with-hcp[]
 * eu-central-2 (Zurich, AWS opt-in required)
 * eu-north-1 (Stockholm)
-* eu-south-1 (Milan, AWS opt-in required)
 * eu-south-2 (Spain, AWS opt-in required)
 endif::rosa-with-hcp[]
 * eu-west-1 (Ireland)


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
Add `eu-south-1` region to HCP

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
