### PR TITLE
OSDOCS#9585: Added oc registry info as deprecated

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -829,6 +829,13 @@ The ability to enable dedicated service monitors by configuring the `dedicatedSe
 To replace this feature, Prometheus functionality has been improved in order to ensure that alerts and time aggregations are accurate.
 This improved functionality is active by default and makes the dedicated service monitors feature obsolete.
 
+[id="ocp-4-15-deprecated-oc-registry-info"]
+==== oc registry info command is deprecated
+
+With this release, the experimental `oc registry info` command is deprecated.
+
+To view information about the integrated {product-registry}, run  `oc get imagestream -n openshift` and check the `IMAGE REPOSITORY` column.
+
 [id="ocp-4-15-removed-features"]
 === Removed features
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-9585

Link to docs preview:
https://71314--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-deprecated-features

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
