### PR TITLE
TELCODOCS-1767  Add a link to existing KMM Preflight topic 

### DIFF
--- a/hardware_enablement/kmm-kernel-module-management.adoc
+++ b/hardware_enablement/kmm-kernel-module-management.adoc
@@ -15,6 +15,7 @@ include::modules/kmm-installation.adoc[leveloffset=+1]
 include::modules/kmm-installing-using-web-console.adoc[leveloffset=+2]
 include::modules/kmm-installing-using-cli.adoc[leveloffset=+2]
 include::modules/kmm-installing-older-versions.adoc[leveloffset=+2]
+
 // Added for TELCODOCS-1309
 include::modules/kmm-uninstalling-kmm.adoc[leveloffset=+1]
 include::modules/kmm-uninstalling-kmmo-red-hat-catalog.adoc[leveloffset=+2]
@@ -25,13 +26,11 @@ include::modules/kmm-creating-module-cr.adoc[leveloffset=+2]
 
 // Added for TELCODOCS-1280
 include::modules/kmm-setting-soft-dependencies-between-kernel-modules.adoc[leveloffset=+2]
-
 include::modules/kmm-security.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-
-* xref:../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Understanding and managing pod security admission].
+* xref:../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Understanding and managing pod security admission]
 
 // Added for TELCODOCS-1279
 include::modules/kmm-replacing-in-tree-modules-with-out-of-tree-modules.adoc[leveloffset=+1]
@@ -48,23 +47,25 @@ include::modules/kmm-running-depmod.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../hardware_enablement/psap-driver-toolkit.adoc#driver-toolkit[Driver Toolkit].
+* xref:../hardware_enablement/psap-driver-toolkit.adoc#driver-toolkit[Driver Toolkit]
 
 include::modules/kmm-building-in-cluster.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../cicd/builds/build-configuration.adoc#build-configuration[Build configuration resources].
+* xref:../cicd/builds/build-configuration.adoc#build-configuration[Build configuration resources]
+// Added for TELCODOCS-1767
+* xref:../updating/preparing_for_updates/kmm-preflight-validation.adoc[Preflight validation for Kernel Module Management (KMM) Modules]
 
 include::modules/kmm-using-driver-toolkit.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../hardware_enablement/psap-driver-toolkit.adoc#driver-toolkit[Driver Toolkit].
+* xref:../hardware_enablement/psap-driver-toolkit.adoc#driver-toolkit[Driver Toolkit]
 
-//Deploying kernel modules (Might just leave this short intro in the assembly and put further module below it)
+// Deploying kernel modules (Might just leave this short intro in the assembly and put further module below it)
 //    * Running ModuleLoader images (CONCEPT, or could be included in the assembly with the intro)
 //    * Using the device plugin (CONCEPT, or could be included in the assembly with the intro)
 //  * Creating the Module Custom Resource (PROCEDURE? Seems like not a process the user does after reading it. Maybe a REFERENCE)
@@ -81,7 +82,7 @@ include::modules/kmm-signing-a-prebuilt-driver-container.adoc[leveloffset=+1]
 include::modules/kmm-building-and-signing-a-moduleloader-container-image.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
-For information on creating a service account, see link:https://docs.openshift.com/container-platform/4.12/authentication/understanding-and-creating-service-accounts.html#service-accounts-managing_understanding-service-accounts[Creating service accounts].
+* link:https://docs.openshift.com/container-platform/4.12/authentication/understanding-and-creating-service-accounts.html#service-accounts-managing_understanding-service-accounts[Creating service accounts]
 
 // Added for TELCODOCS-1109
 include::modules/kmm-hub-hub-and-spoke.adoc[leveloffset=+1]
@@ -104,7 +105,6 @@ include::modules/kmm-hub-installing-kmm-hub-creating-resources.adoc[leveloffset=
 
 include::modules/kmm-hub-using-the-managedclustermodule.adoc[leveloffset=+2]
 include::modules/kmm-hub-running-kmm-on-the-spoke.adoc[leveloffset=+2]
-
 
 // Added for TELCODOCS-1277
 include::modules/kmm-customizing-upgrades-for-kernel-modules.adoc[leveloffset=+1]
@@ -136,12 +136,12 @@ include::modules/kmm-debugging-and-troubleshooting.adoc[leveloffset=+1]
 include::modules/kmm-firmware-support.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
-* xref:../hardware_enablement/kmm-kernel-module-management.adoc#kmm-creating-moduleloader-image_kernel-module-management-operator[Creating a ModuleLoader image].
+* xref:../hardware_enablement/kmm-kernel-module-management.adoc#kmm-creating-moduleloader-image_kernel-module-management-operator[Creating a ModuleLoader image]
 
 include::modules/kmm-configuring-the-lookup-path-on-nodes.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
-* xref:../post_installation_configuration/machine-configuration-tasks.adoc#understanding-the-machine-config-operator[Machine Config Operator].
+* xref:../post_installation_configuration/machine-configuration-tasks.adoc#understanding-the-machine-config-operator[Machine Config Operator]
 
 include::modules/kmm-building-a-moduleloader-image.adoc[leveloffset=+2]
 include::modules/kmm-tuning-the-module-resource.adoc[leveloffset=+2]


### PR DESCRIPTION
D/S PreflightValidationOCP should document no-push and signing ([MGMT-13303](https://issues.redhat.com//browse/MGMT-13303))

Adding a link in the **Building in the cluster -Additional resources** section. 

OCP version: openshift-4.14

Version: [KMMO 1.0]
Issue: https://issues.redhat.com/browse/TELCODOCS-1767

Peer reviewer: Note that this is only adding a link to an existing topic. I also did some housekeeping and removed periods from **Additional resources** links. No technical changes, so no QE Ack should be needed.

OCP version: openshift-4.14, openshift-4.15

Link to docs preview: https://71316--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management#kmm-building-in-cluster_kernel-module-management-operator

SME: @qbarrand 