### PR TITLE
Fixing bad xref in Virt Post-install

### DIFF
--- a/virt/post_installation_configuration/virt-post-install-config.adoc
+++ b/virt/post_installation_configuration/virt-post-install-config.adoc
@@ -12,7 +12,7 @@ The following procedures are typically performed after {VirtProductName} is inst
 
 * xref:../../virt/post_installation_configuration/virt-node-placement-virt-components.adoc#virt-node-placement-virt-components[Node placement rules for {VirtProductName} Operators, workloads, and controllers]
 
-* xref:../../virt/post_installation_configuration/./.virt-network-config.adoc#virt-post-install-network-config[Network configuration]:
+* xref:../../virt/post_installation_configuration/virt-post-install-network-config.adoc#virt-post-install-network-config[Network configuration]:
 
 ** Installing the Kubernetes NMState and SR-IOV Operators
 ** Configuring a Linux bridge network for external access to virtual machines (VMs)


### PR DESCRIPTION
Noticed a bad link in the Virtualization -> -> Post-install -> Network configuration page. This PR is to fix that link. 

4.14+.  Assembly not in prior versions.

No associated issue

No QE required 