### PR TITLE
OCPBUGS-11325-4.11: Supported access table is modified for Fibre C…

### DIFF
--- a/modules/storage-persistent-storage-pv.adoc
+++ b/modules/storage-persistent-storage-pv.adoc
@@ -160,17 +160,17 @@ ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 //|Ceph RBD  | ✅ | ✅ |  -
 //|CephFS  | ✅ | ✅ |  ✅
 |Cinder  | ✅ | - |  -
-|Fibre Channel  | ✅ | ✅ |  -
+|Fibre Channel  | ✅ | ✅ |  ✅ ^[3]^
 |GCE Persistent Disk  | ✅ | - |  -
 //|GlusterFS  | ✅ | ✅ | ✅
 |HostPath  | ✅ | - |  -
 |IBM VPC Disk | ✅ | - |  -
-|iSCSI  | ✅ | ✅ |  -
+|iSCSI  | ✅ | ✅ |  ✅ ^[3]^
 |Local volume | ✅ | - |  -
 |NFS  | ✅ | ✅ | ✅
 |OpenStack Manila  | - | - | ✅
 |{rh-storage-first}  | ✅ | - | ✅
-|VMware vSphere | ✅ | - | ✅ ^[3]^
+|VMware vSphere | ✅ | - | ✅ ^[4]^
 endif::[]
 
 |===
@@ -178,7 +178,8 @@ endif::[]
 --
 1. ReadWriteOnce (RWO) volumes cannot be mounted on multiple nodes. If a node fails, the system does not allow the attached RWO volume to be mounted on a new node because it is already assigned to the failed node. If you encounter a multi-attach error message as a result, force delete the pod on a shutdown or crashed node to avoid data loss in critical workloads, such as when dynamic persistent volumes are attached.
 2. Use a recreate deployment strategy for pods that rely on AWS EBS.
-3. If the underlying vSphere environment supports the vSAN file service, then the vSphere Container Storage Interface (CSI) Driver Operator installed by
+3. Only raw block volumes support the ReadWriteMany (RWX) access mode for Fibre Channel and iSCSI. For more information, see "Block volume support".
+4. If the underlying vSphere environment supports the vSAN file service, then the vSphere Container Storage Interface (CSI) Driver Operator installed by
 {product-title} supports provisioning of ReadWriteMany (RWX) volumes. If you do not have vSAN file service configured, and you request RWX, the volume fails to get created and an error is logged. For more information, see "Using Container Storage Interface" -> "VMware vSphere CSI Driver Operator".
 // GCE Persistent Disks, or Openstack Cinder PVs.
 --


### PR DESCRIPTION
Version(s):
4.11

Issue:
[OCPBUGS-11325](https://issues.redhat.com/browse/OCPBUGS-11325)

Link to docs preview:


QE review:
- [x] QE has approved this change.
repeating the changes for 4.11 from the PR https://github.com/openshift/openshift-docs/pull/70560
