### PR TITLE
WINC-511: Use RuntimeClass in e2e tests

### DIFF
--- a/modules/creating-runtimeclass.adoc
+++ b/modules/creating-runtimeclass.adoc
@@ -17,7 +17,7 @@ Using a `RuntimeClass` object simplifies the use of scheduling mechanisms like t
 apiVersion: node.k8s.io/v1beta1
 kind: RuntimeClass
 metadata:
-  name: <runtime_class_name> <1>
+  name: windows2019 <1>
 handler: 'runhcs-wcow-process'
 scheduling:
   nodeSelector: <2>
@@ -28,10 +28,16 @@ scheduling:
   - effect: NoSchedule
     key: os
     operator: Equal
+    value: "windows"
+  - effect: NoSchedule
+    key: os
+    operator: Equal
     value: "Windows"
 ----
 <1> Specify the `RuntimeClass` object name, which is defined in the pods you want to be managed by this runtime class.
 <2> Specify labels that must be present on nodes that support this runtime class. Pods using this runtime class can only be scheduled to a node matched by this selector. The node selector of the runtime class is merged with the existing node selector of the pod. Any conflicts prevent the pod from being scheduled to the node.
+* For Windows 2019, specify the `node.kubernetes.io/windows-build: '10.0.17763'` label.
+* For Windows 2022, specify the `node.kubernetes.io/windows-build: '10.0.20348'` label.
 <3> Specify tolerations to append to pods, excluding duplicates, running with this runtime class during admission. This combines the set of nodes tolerated by the pod and the runtime class.
 
 . Create the `RuntimeClass` object:
@@ -57,7 +63,7 @@ kind: Pod
 metadata:
   name: my-windows-pod
 spec:
-  runtimeClassName: <runtime_class_name> <1>
-...
+  runtimeClassName: windows2019 <1>
+# ...
 ----
 <1> Specify the runtime class to manage the scheduling of your pod.

--- a/modules/sample-windows-workload-deployment.adoc
+++ b/modules/sample-windows-workload-deployment.adoc
@@ -51,29 +51,26 @@ spec:
         app: win-webserver
       name: win-webserver
     spec:
-      tolerations:
-      - key: "os"
-        value: "Windows"
-        Effect: "NoSchedule"
       containers:
       - name: windowswebserver
-        image: mcr.microsoft.com/windows/servercore:ltsc2019
+        image: mcr.microsoft.com/windows/servercore:ltsc2019 <1>
         imagePullPolicy: IfNotPresent
         command:
-        - powershell.exe
+        - powershell.exe <2>
         - -command
         - $listener = New-Object System.Net.HttpListener; $listener.Prefixes.Add('http://*:80/'); $listener.Start();Write-Host('Listening at http://*:80/'); while ($listener.IsListening) { $context = $listener.GetContext(); $response = $context.Response; $content='<html><body><H1>Red Hat OpenShift + Windows Container Workloads</H1></body></html>'; $buffer = [System.Text.Encoding]::UTF8.GetBytes($content); $response.ContentLength64 = $buffer.Length; $response.OutputStream.Write($buffer, 0, $buffer.Length); $response.Close(); };
         securityContext:
           runAsNonRoot: false
           windowsOptions:
             runAsUserName: "ContainerAdministrator"
-      nodeSelector:
-        kubernetes.io/os: windows
       os:
-        name: windows
+        name: "windows"
+      runtimeClassName: windows2019 <3>
 ----
-
-[NOTE]
-====
-When using the `mcr.microsoft.com/powershell:<tag>` container image, you must define the command as `pwsh.exe`. If you are using the `mcr.microsoft.com/windows/servercore:<tag>` container image, you must define the command as `powershell.exe`. For more information, see Microsoft's documentation.
-====
+<1> Specify the container image to use: `mcr.microsoft.com/powershell:<tag>` or `mcr.microsoft.com/windows/servercore:<tag>`. The container image must match the Windows version running on the node.
+* For Windows 2019, use the `ltsc2019` tag.
+* For Windows 2022, use the `ltsc2022` tag. 
+<2> Specify the commands to execute on the container. 
+* For the `mcr.microsoft.com/powershell:<tag>` container image, you must define the command as `pwsh.exe`. 
+* For the `mcr.microsoft.com/windows/servercore:<tag>` container image, you must define the command as `powershell.exe`. 
+<3> Specify the runtime class you created for the Windows operating system variant on your cluster.


### PR DESCRIPTION
Documents:  [WINC-511: Use RuntimeClass in e2e tests](https://github.com/openshift/windows-machine-config-operator/pull/2040)  

Update Windows runtime and deployment for 2019 and 2012

4.12+

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
