### PR TITLE
OSDOCS-9487: Doc ROSA CLI kubeletconfig commands

### DIFF
--- a/modules/rosa-create-objects.adoc
+++ b/modules/rosa-create-objects.adoc
@@ -493,6 +493,37 @@ Add an ingress with a route selector label match.
 $ rosa create ingress --cluster=mycluster --label-match=foo=bar,bar=baz
 ----
 
+[id="rosa-create-kubeletconfig_{context}"]
+== create kubeletconfig
+
+Create a custom `KubeletConfig` object for the cluster.
+
+.Syntax
+[source,terminal]
+----
+$ rosa create kubeletconfig --cluster=<cluster_name|cluster_id> --pod-pids-limit=<number> [flags]
+----
+
+.Flags
+[cols="30,70"]
+|===
+|Option |Definition
+
+|--pod-pids-limit <number>
+|Required. The maximum number of PIDs for the cluster.
+
+a|-c, --cluster <cluster_name>\|<cluster_id>
+|Required. The name or ID of the cluster for which the `KubeletConfig` object will be created.
+
+|-i, --interactive
+|Enable interactive mode.
+
+|-h, --help
+|Shows help for this command.
+|===
+
+For more information about setting the PID limit for the cluster, see _Configuring PID limits_.
+
 [id="rosa-create-machinepool_{context}"]
 == create machinepool
 

--- a/modules/rosa-delete-objects.adoc
+++ b/modules/rosa-delete-objects.adoc
@@ -214,6 +214,34 @@ Delete a secondary ingress with the subdomain name `apps2` from a cluster named 
 $ rosa delete ingress --cluster=mycluster apps2
 ----
 
+[id="rosa-delete-kubeletconfig_{context}"]
+== delete kubeletconfig
+
+Delete a custom `KubeletConfig` object from a cluster.
+
+.Syntax
+[source,terminal]
+----
+$ rosa delete kubeletconfig --cluster=<cluster_name|cluster_id> [flags]
+----
+
+.Flags
+[cols="30,70"]
+|===
+|Option |Definition
+
+a|-c, --cluster <cluster_name>\|<cluster_id>
+|Required. The name or ID of the cluster for which you want to delete the `KubeletConfig` object.
+
+|-h, --help
+|Shows help for this command.
+
+|-y, --yes
+|Automatically answers `yes` to confirm the operation.
+
+|===
+
+
 [id="rosa-delete-machinepool_{context}"]
 == delete machinepool
 

--- a/modules/rosa-edit-objects.adoc
+++ b/modules/rosa-edit-objects.adoc
@@ -161,6 +161,37 @@ Update the load balancer type of the `apps2` ingress.
 $ rosa edit ingress --lb-type=nlb --cluster=mycluster apps2
 ----
 
+[id="rosa-edit-kubeletconfig_{context}"]
+== edit kubeletconfig
+
+Edit a custom `KubeletConfig` object in a cluster.
+
+.Syntax
+[source,terminal]
+----
+$ rosa edit kubeletconfig --cluster=<cluster_name|cluster_id> --pod-pids-limit=<number> [flags]
+----
+
+.Flags
+[cols="30,70"]
+|===
+|Option |Definition
+
+a|-c, --cluster <cluster_name>\|<cluster_id>
+|Required. The name or ID of the cluster for which the `KubeletConfig` object will be edited.
+
+|-i, --interactive
+|Enable interactive mode.
+
+|--pod-pids-limit <number>
+|Required. The maximum number of PIDs for the cluster.
+
+|-h, --help
+|Shows help for this command.
+|===
+
+For more information about setting the PID limit for the cluster, see _Configuring PID limits_.
+
 [id="rosa-edit-machinepool_{context}"]
 == edit machinepool
 

--- a/modules/rosa-list-objects.adoc
+++ b/modules/rosa-list-objects.adoc
@@ -523,6 +523,33 @@ Describe a cluster named `mycluster`.
 $ rosa describe cluster --cluster=mycluster
 ----
 
+[id="rosa-describe-kubeletconfig_{context}"]
+== describe kubeletconfig
+
+Show the details of a custom `KubeletConfig` object.
+
+.Syntax
+[source,terminal]
+----
+$ rosa describe kubeletconfig --cluster=<cluster_name|cluster_id> [flags]
+----
+
+.Flags
+[cols="30,70"]
+|===
+|Option |Definition
+
+a|-c, --cluster <cluster_name>\|<cluster_id>
+|Required. The name or ID of the cluster for which you want to view the `KubeletConfig` object.
+
+|-h, --help
+|Shows help for this command.
+
+|-o, --output string    
+|The output format. You can specify either `json` or `yaml`.
+
+|===
+
 [id="rosa-describe-machinepool_{context}"]
 == describe machinepool
 


### PR DESCRIPTION
Version(s):
* enterprise-4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-9487

Link to docs preview:
* https://71328--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli#rosa-create-kubeletconfig_rosa-managing-objects-cli
* https://71328--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli#rosa-edit-kubeletconfig_rosa-managing-objects-cli
* https://71328--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli#rosa-delete-kubeletconfig_rosa-managing-objects-cli
* https://71328--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli#rosa-describe-kubeletconfig_rosa-managing-objects-cli

QE review:
- [x] QE has approved this change.

