### PR TITLE
OSDOCS-9587: Documented the AWS WZ Day 0 and Day 2 release note

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -79,6 +79,24 @@ You can now install a cluster on {ibm-cloud-name} in an environment with limited
 
 For more information, see xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc#installing-ibm-cloud-restricted[Installing a cluster on IBM Cloud in a restricted network].
 
+[id="ocp-4-15-installation-and-update-aws-wavelength-zones"]
+==== Installing a cluster on AWS to extend nodes to Wavelength Zones
+
+You can quickly install an {product-title} cluster in Amazon Web Services (AWS) Wavelength Zones by setting the zone names in the edge compute pool of the `install-config.yaml` file, or install a cluster in an existing VPC with Wavelength Zone subnets.
+
+You can also perform post-installation tasks to extend an existing {product-title} cluster on AWS to use AWS Wavelength Zones.
+
+For more information, see xref:../installing/installing_aws/installing-aws-wavelength-zone.adoc#installing-aws-wavelength-zone[Installing a cluster on AWS with compute nodes on AWS Wavelength Zones] and xref:../post_installation_configuration/aws-compute-edge-zone-tasks.adoc#aws-compute-edge-zone-tasks[Extend existing clusters to use AWS Local Zones or Wavelength Zones].
+
+[id="ocp-4-15-installation-customize-cluster-network-mtu-aws"]
+==== Customizing the cluster network MTU on AWS deployments
+
+Before you deploy a cluster on AWS Local Zones infrastructure, you can customize the cluster network maximum transmission unit (MTU) for your cluster network to meet the needs of your infrastructure. 
+
+You can customize the MTU for a cluster by specifying the networking.clusterNetworkMTU parameter in the `install-config.yaml` configuration file.
+
+For more information, see xref:../installing/installing_aws/installing-aws-localzone.adoc#installation-aws-cluster-network-mtu_installing-aws-localzone[Customizing the cluster network MTU].
+
 [id="ocp-4-15-installation-and-update-nutanix-failure-domains"]
 ==== Nutanix and fault tolerant deployments
 


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-9587](https://issues.redhat.com/browse/OSDOCS-9587)

Link to docs preview:
* [Installing a cluster on AWS to extend nodes to Wavelength Zones](https://71333--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-installation-and-update-aws-wavelength-zones)
* [Customizing the cluster network MTU on AWS deployments](https://71333--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-installation-customize-cluster-network-mtu-aws)

QE review:
- [x] SME has approved this change.
- [x] QE on PTO, but Yunfei (QE) approved the feature doc. Stephanie added a LGTM to confirm. This release note is urgent as I am on PTO next week.

Additional information:
https://github.com/openshift/openshift-docs/pull/69537
