### PR TITLE
OSDOCS#8947: Adds RHDH instructions

### DIFF
--- a/modules/rhdh-install-web-console.adoc
+++ b/modules/rhdh-install-web-console.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * capabilities_products-web-console.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="rhdh-install-web-console_{context}"]
+=  Installing the {rh-dev-hub} using the {product-title} web console
+
+The web console provides a quick start with instructions on how to install the {rh-dev-hub} Operator.
+
+.Prerequisites
+* You must be logged in to the {product-title} web console with `admin` privileges.
+
+.Procedure
+. On the *Overview* page of the Administrator perspective, click *Install {rh-dev-hub} (RHDH) with an Operator* in the *Getting started resources* tile.
+. A quick start pane is displayed with instructions for you to install the {rh-dev-hub} with an Operator. Follow the quick start for instructions on how to install the Operator, create a {rh-dev-hub} instance, and add your instance to the *OpenShift Console Application* menu.
+
+.Verification
+. You can click the *Application launcher* link that is displayed to verify your *Application* tab is available.
+. Verify your Janus IDP instance can be opened.

--- a/modules/rhdh-web-console.adoc
+++ b/modules/rhdh-web-console.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * products-web-console.adoc
+// * capabilities_products-web-console.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="rhdh-web-console_{context}"]

--- a/web_console/capabilities_products-web-console.adoc
+++ b/web_console/capabilities_products-web-console.adoc
@@ -34,6 +34,7 @@ include::modules/serverless-web-console.adoc[leveloffset=+1]
 
 //RHDH
 include::modules/rhdh-web-console.adoc[leveloffset=+1]
+include::modules/rhdh-install-web-console.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
Adds procedure to access RHDH quick start

Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-8947
https://issues.redhat.com/browse/OSDOCS-9644

Link to docs preview:
https://71338--ocpdocs-pr.netlify.app/openshift-enterprise/latest/web_console/capabilities_products-web-console#rhdh-install-web-console_capabilities-web-console

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

