### PR TITLE
[rosa hcp] add eu-south-1 to list of regions supported for ROSA HCP

### DIFF
--- a/modules/rosa-hcp-classic-comparison.adoc
+++ b/modules/rosa-hcp-classic-comparison.adoc
@@ -56,6 +56,7 @@
 |
 * Europe - Frankfurt (eu-central-1)
 * Europe - Ireland (eu-west-1)
+* Europe - Milan (eu-south-1)
 * US East - N. Virginia (us-east-1)
 * US East - Ohio (us-east-2)
 * US West - Oregon (us-west-2)

--- a/modules/rosa-sdpolicy-am-regions-az.adoc
+++ b/modules/rosa-sdpolicy-am-regions-az.adoc
@@ -55,7 +55,9 @@ endif::rosa-with-hcp[]
 ifndef::rosa-with-hcp[]
 * eu-central-2 (Zurich, AWS opt-in required)
 * eu-north-1 (Stockholm)
+endif::rosa-with-hcp[]
 * eu-south-1 (Milan, AWS opt-in required)
+ifndef::rosa-with-hcp[]
 * eu-south-2 (Spain, AWS opt-in required)
 endif::rosa-with-hcp[]
 * eu-west-1 (Ireland)


### PR DESCRIPTION
Version(s): n/a
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: n/a
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: n/a
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
Add newly enabled opt-in `eu-south-1` region to list of regions supported for ROSA HCP

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

@EricPonvelle ptal if you have the chance
