### PR TITLE
OBSDOCS-814: Fixing typo in CLI install

### DIFF
--- a/modules/logging-loki-cli-install.adoc
+++ b/modules/logging-loki-cli-install.adoc
@@ -27,12 +27,6 @@ metadata:
   name: loki-operator
   namespace: openshift-operators-redhat <1>
 spec:
-  charsion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: loki-operator
-  namespace: openshift-operators-redhat <1>
-spec:
   channel: stable <2>
   name: loki-operator
   source: redhat-operators <3>


### PR DESCRIPTION
OCPBUGS#29250: Fixing typo in CLI install: Fixing broken Loki CLI Install example

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OBSDOCS-814

Link to docs preview:
https://71372--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_storage/installing-log-storage#logging-loki-cli-install_installing-log-storage

QE review:
- [x] QE has approved this change.
