### PR TITLE
OSDOCS-8914: Explaining upgrades for ROSA with HCP clusters.

### DIFF
--- a/modules/rosa-hcp-upgrading-cli-tutorial.adoc
+++ b/modules/rosa-hcp-upgrading-cli-tutorial.adoc
@@ -1,0 +1,106 @@
+// Module included in the following assemblies:
+//
+// * upgrading/rosa-hcp-upgrading.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-hcp-upgrading-cli_{context}"]
+= Upgrading with the ROSA CLI
+
+You can manually upgrade a {hcp-title} cluster by using the ROSA CLI. This method schedules the cluster for an immediate upgrade if a more recent version is available.
+
+[NOTE]
+====
+Your control plane only supports machine pools within two minor Y-stream versions. For example, a {hcp-title} cluster with a control plane using version 4.15.z supports machine pools with version 4.13.z and 4.14.z, but the control plane does not support machine pools using version 4.12.z.
+====
+
+.Prerequisites
+
+* You have installed and configured the latest version of the ROSA CLI.
+
+.Procedure
+
+. Verify the current version of your cluster by running the following command:
++
+[source,terminal]
+----
+$ rosa describe cluster --cluster=<cluster_name_or_id> <1>
+----
+<1> Replace `<cluster_name_or_id>` with the cluster name or the cluster ID.
+
+. List the versions that you can upgrade your control plane and machine pools to by running the following commands:
++
+.. For the control plane versions, run the following command:
++
+[source,terminal]
+----
+$ rosa list upgrade --cluster=<cluster_name|cluster_id>
+----
++
+The command returns a list of available updates, including the recommended version.
++
+.Example output
++
+[source,terminal]
+----
+VERSION  NOTES
+4.14.8   recommended
+4.14.7
+4.14.6
+----
++
+.. For the machine pool versions, run the following command:
++
+[source,terminal]
+----
+$ rosa list upgrade --cluster <cluster-name> --machinepool <machinepool_name>
+----
++
+The command returns a list of available updates, including the recommended version.
++
+.Example output
++
+[source,terminal]
+----
+VERSION  NOTES
+4.14.5   recommended
+4.14.4
+4.14.3
+4.14.2
+4.14.1
+----
++
+[NOTE]
+====
+The latest available update for machine pools is limited to the current current version of the control plane. Ensure your control plane is up to date first.
+====
+
+. Upgrade your cluster with one of the following options:
+** Upgrade the cluster's hosted control plane by running the following command:
++
+[source,terminal]
+----
+$ rosa upgrade cluster -c <cluster_name> --control-plane [--schedule-date=XX --schedule-time=XX] [--version <version_number>]
+----
++
+Your hosted control plane is now scheduled for an upgrade.
+
+** Upgrade a specific machine pool on your cluster by running the following command:
++
+[source,terminal]
+----
+$ rosa upgrade machinepool -c <cluster_name> <your_machine_pool_id> [--schedule-date=XX --schedule-time=XX] [--version <version_number>]
+----
++
+Your machine pool is now scheduled for an upgrade.
+//
+// ** Upgrade both the hosted control plane and all attached machine pools by running the following command:
+// +
+// [source,terminal]
+// ----
+// $ rosa upgrade cluster -c <cluster_name> [--schedule-date=XX --schedule-time=XX] [--version <version_number>]
+// ----
+// +
+// Your hosted control plane and machine pools are now scheduled for an upgrade.
+
+.Troubleshooting
+* Sometimes a scheduled upgrade does not initiate. See link:https://access.redhat.com/solutions/6648291[Upgrade maintenance cancelled] for more information.

--- a/upgrading/rosa-hcp-upgrading.adoc
+++ b/upgrading/rosa-hcp-upgrading.adoc
@@ -6,20 +6,24 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-[id="rosa-hcp-lifecycle-policy_{context}"]
-== Life cycle policies and planning
+You can upgrade {hcp-title-first} clusters by individually upgrading the hosted control plane and the machine pools with the ROSA command line interface (CLI), `rosa`.
 
-To plan an upgrade, review the xref:../rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc#rosa-life-cycle[{product-title} update life cycle]. The life cycle page includes release definitions, support and upgrade requirements, installation policy information and life cycle dates.
+Use one of the following methods to upgrade your HCP clusters:
 
-You can manually upgrade your cluster. Red Hat Site Reliability Engineers (SREs) monitor upgrade progress and remedy any issues encountered.
+* Upgrade only your hosted control plane. This does not impact your worker nodes.
+* Upgrade only your machine pool. This initiates a rolling reboot of a specific machine pool and temporarily impacts the worker nodes on the specific machine pool. It does not impact all your worker nodes if you have multiple machine pools.
+* Upgrade your hosted control plane first and then your machine pool.
++
+[NOTE]
+====
+If you want to upgrade both your hosted control plane and your machine pool to the same version, you must upgrade the the hosted control plane first.
+====
 
-[id="rosa-hcp-upgrading-a-cluster"]
-== Upgrading a ROSA cluster
-You can upgrade {hcp-title-first} clusters by using individual upgrades through the {product-title} (ROSA) CLI, `rosa`.
+To plan an upgrade, review the xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.adoc#rosa-hcp-life-cycle[{hcp-title} update life cycle] documentation. The life cycle page includes release definitions, support and upgrade requirements, installation policy information, and life cycle dates.
 
 [NOTE]
 ====
-When following a scheduled upgrade policy, there might be a delay of no more than thirty minutes before the upgrade process begins, even if it is an immediate upgrade. Additionally, the duration of the upgrade might vary based on your workload configuration and with machine pool upgrades, the number of worker nodes.
+Hosted control plane upgrade duration varies based on your workload configuration, and machine pool upgrade duration varies based on the number of worker nodes.
 ====
 
-include::modules/rosa-upgrading-cli-tutorial.adoc[leveloffset=+2]
+include::modules/rosa-hcp-upgrading-cli-tutorial.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
`enterprise-4.14+`

Issue:
**[OSDOCS-8914](https://issues.redhat.com/browse/OSDOCS-8914)**

Link to docs preview:
* [Upgrading ROSA with HCP](https://file.rdu.redhat.com/eponvell/OSDOCS-8914_HCP-Upgrades/upgrading/rosa-hcp-upgrading.html)
* [ROSA with HCP update life cycle](https://file.rdu.redhat.com/eponvell/OSDOCS-8914_HCP-Upgrades/rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Elaborating on the various ways to update ROSA with HCP clusters.