### PR TITLE
OSDOCS#9604: Create new installation options table for multi-arch com…

### DIFF
--- a/post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-configuration.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-configuration.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-An {product-title} cluster with multi-architecture compute machines is a cluster that supports compute machines with different architectures. Clusters with multi-architecture compute machines are available only on Amazon Web Services (AWS) or Microsoft Azure installer-provisioned infrastructures and bare metal, {ibm-power-name}, and {ibm-z-name} user-provisioned infrastructures with x86_64 control plane machines.
+An {product-title} cluster with multi-architecture compute machines is a cluster that supports compute machines with different architectures. Clusters with multi-architecture compute machines are available only on Amazon Web Services (AWS) or Microsoft Azure installer-provisioned infrastructures and bare metal, {ibm-power-name}, and {ibm-z-name} user-provisioned infrastructures with 64-bit x86 control plane machines.
 
 [NOTE]
 ====
@@ -22,21 +22,75 @@ For information on migrating your single-architecture cluster to a cluster that 
 
 == Configuring your cluster with multi-architecture compute machines
 
-To create a cluster with multi-architecture compute machines for various platforms, you can use the documentation in the following sections:
+To create a cluster with multi-architecture compute machines with different installation options and platforms, you can use the documentation in the following table:
 
-* xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-azure.adoc#creating-multi-arch-compute-nodes-azure[Creating a cluster with multi-architecture compute machines on Azure]
+.Cluster with multi-architecture compute machine installation options
+[cols="3,1,1,1,1,1",options="header"]
+|===
+|Documentation section |Platform |User-provisioned installation |Installer-provisioned installation |Control Plane |Compute node
 
-* xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-aws.adoc#creating-multi-arch-compute-nodes-aws[Creating a cluster with multi-architecture compute machines on AWS]
+|xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-azure.adoc#creating-multi-arch-compute-nodes-azure[Creating a cluster with multi-architecture compute machines on Azure]
+|Microsoft Azure
+|
+|&#10003;
+|`x84_64`
+|`aarch64`
 
-* xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-gcp.adoc#creating-multi-arch-compute-nodes-gcp[Creating a cluster with multi-architecture compute machines on GCP]
+|xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-aws.adoc#creating-multi-arch-compute-nodes-aws[Creating a cluster with multi-architecture compute machines on AWS]
+|Amazon Web Services (AWS)
+|
+|&#10003;
+|`x84_64`
+|`aarch64`
 
-* xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-bare-metal.adoc#creating-multi-arch-compute-nodes-bare-metal[Creating a cluster with multi-architecture compute machines on bare metal]
+|xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-gcp.adoc#creating-multi-arch-compute-nodes-gcp[Creating a cluster with multi-architecture compute machines on GCP]
+|Google Cloud Platform (GCP)
+|
+|&#10003;
+|`x84_64`
+|`aarch64`
 
-* xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z.adoc#creating-multi-arch-compute-nodes-ibm-z[Creating a cluster with multi-architecture compute machines on {ibm-z-name} and {ibm-linuxone-name} with z/VM]
+.3+|xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-bare-metal.adoc#creating-multi-arch-compute-nodes-bare-metal[Creating a cluster with multi-architecture compute machines on bare metal, {ibm-power-title}, or {ibm-z-title}]
+|Bare metal
+|&#10003;
+|
+|`x84_64`
+|`aarch64`
 
-* xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z-kvm.adoc#creating-multi-arch-compute-nodes-ibm-z-kvm[Creating a cluster with multi-architecture compute machines on {ibm-z-name} and {ibm-linuxone-name} with {op-system-base} KVM]
+|{ibm-power-title}
+|&#10003;
+|
+|`x84_64` or `ppc64le`
+|`x84_64`, `ppc64le`
 
-* xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-power.adoc#creating-multi-arch-compute-nodes-ibm-power[Creating a cluster with multi-architecture compute machines on {ibm-power-name}]
+|{ibm-z-title}
+|&#10003;
+|
+|`x84_64` or `s390x`
+|`x84_64`, `s390x`
+
+|xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z.adoc#creating-multi-arch-compute-nodes-ibm-z[Creating a cluster with multi-architecture compute machines on {ibm-z-name} and {ibm-linuxone-name} with z/VM]
+|{ibm-z-name} and {ibm-linuxone-name}
+|&#10003;
+|
+|`x84_64`
+|`x84_64`, `s390x`
+
+|xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z-kvm.adoc#creating-multi-arch-compute-nodes-ibm-z-kvm[Creating a cluster with multi-architecture compute machines on {ibm-z-name} and {ibm-linuxone-name} with {op-system-base} KVM]
+|{ibm-z-name} and {ibm-linuxone-name}
+|&#10003;
+|
+|`x84_64`
+|`x84_64`, `s390x`
+
+|xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-power.adoc#creating-multi-arch-compute-nodes-ibm-power[Creating a cluster with multi-architecture compute machines on {ibm-power-name}]
+|{ibm-power-name}
+|&#10003;
+|
+|`x84_64`
+|`x84_64`, `ppc64le`
+
+|===
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
**Version(s):** 4.15+
**Issue:** [OSDOCS-9604](https://issues.redhat.com//browse/OSDOCS-9604)

**Link to docs preview:**

- [About clusters with multi-architecture compute machines -> Configuring your cluster with multi-architecture compute machines](https://71394--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-configuration#configuring-your-cluster-with-multi-architecture-compute-machines)

**QE review:**
- [x] QE has approved this change.

