### PR TITLE
Re-adding removed RTT overview info

### DIFF
--- a/network_observability/observing-network-traffic.adoc
+++ b/network_observability/observing-network-traffic.adoc
@@ -26,6 +26,11 @@ include::modules/network-observability-dns-overview.adoc[leveloffset=+2]
 * xref:../network_observability/observing-network-traffic.adoc#network-observability-dns-tracking_nw-observe-network-traffic[Working with DNS tracking]
 * xref:../network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network Observability metrics]
 
+include::modules/network-observability-RTT-overview.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../network_observability/observing-network-traffic.adoc#network-observability-RTT_nw-observe-network-traffic[Working with RTT tracing]
 
 //Traffic flows
 include::modules/network-observability-trafficflow.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
This Overview was added in this [PR](https://github.com/openshift/openshift-docs/pull/67540/files#diff-5ce817ed3c947d24778aa12ef7969e116e48fe749d177303cd1dcf87f06fbdaf) and removed accidentally when I rebased this [PR](https://github.com/openshift/openshift-docs/pull/69106/files#diff-21cba4b9eea6286345ee8e2ad7b3cc0e4dc6ac125a47623a7df9f52f2f2506aaL27-L31). So this PR is to add the info back where it belongs. 

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://71399--docspreview.netlify.app/openshift-enterprise/latest/network_observability/observing-network-traffic#network-observability-RTT-overview_nw-observe-network-traffic

QE review:
- QE is not required as this content has already been QE approved for the Network Observability 1.5 release but was mistakenly removed when I merged another feature PR that touches a similar file. 
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
