### PR TITLE
OSDOCS9297: Using /dev/fuse to access faster builds

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2477,6 +2477,8 @@ Topics:
     File: nodes-containers-port-forwarding
   - Name: Using sysctls in containers
     File: nodes-containers-sysctls
+  - Name: Accessing faster builds with /dev/fuse
+    File: nodes-containers-dev-fuse
 - Name: Working with clusters
   Dir: clusters
   Topics:

--- a/modules/nodes-containers-dev-fuse-configuring.adoc
+++ b/modules/nodes-containers-dev-fuse-configuring.adoc
@@ -1,0 +1,66 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes-containers-dev-fuse.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nodes-containers-dev-fuse-configuring_{context}"]
+= Configuring /dev/fuse on unprivileged pods
+
+As an alternative to the virtual filesystem, you can configure the `/dev/fuse` device to the `io.kubernetes.cri-o.Devices` annotation to access faster builds within unprivileged pods. Using `/dev/fuse` is secure, efficient, and scalable, and allows unprivileged users to mount an overlay filesystem as if the unprivileged pod was privileged. 
+
+.Procedure
+
+. Create the pod.
++
+[source,terminal]
+----
+$ oc exec -ti no-priv -- /bin/bash
+----
++
+[source,terminal]
+----
+$ cat >> Dockerfile <<EOF
+FROM registry.access.redhat.com/ubi9
+EOF
+----
++
+[source,terminal]
+----
+$ podman build .
+----
+
+. Implement `/dev/fuse` by adding the `/dev/fuse` device to the `io.kubernetes.cri-o.Devices` annotation.
++
+[source,yaml]
+----
+io.kubernetes.cri-o.Devices: "/dev/fuse"
+----
++
+For example:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: podman-pod
+  annotations:
+    io.kubernetes.cri-o.Devices: "/dev/fuse"
+----
+
+. Configure the `/dev/fuse` device in your pod specifications.
++
+[source,yaml]
+----
+spec:
+  containers:
+  - name: podman-container
+    image: quay.io/podman/stable
+    args:
+    - sleep
+    - "1000000"
+    securityContext:
+      runAsUser: 1000
+----
+
+

--- a/nodes/containers/nodes-containers-dev-fuse.adoc
+++ b/nodes/containers/nodes-containers-dev-fuse.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: ASSEMBLY
+:context: nodes-containers-dev-fuse
+[id="nodes-containers-dev-fuse"]
+= Accessing faster builds with /dev/fuse
+include::_attributes/common-attributes.adoc[]
+
+toc::[]
+
+You can configure your pods with the `/dev/fuse` device to access faster builds.
+
+include::modules/nodes-containers-dev-fuse-configuring.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-9297](https://issues.redhat.com/browse/OSDOCS-9297), [OSDOCS-9298](https://issues.redhat.com/browse/OSDOCS-9298), [OSDOCS-9299](https://issues.redhat.com//browse/OSDOCS-9299)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://71401--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-dev-fuse
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
