### PR TITLE
Include ROSA customer-initiated incident documentation

### DIFF
--- a/modules/rosa-policy-incident.adoc
+++ b/modules/rosa-policy-incident.adoc
@@ -109,6 +109,13 @@ When managing a new incident, Red Hat uses the following general workflow:
 . The incident is documented and a root cause analysis (RCA) is performed within 5 business days of the incident.
 . An RCA draft document will be shared with the customer within 7 business days of the incident.
 
+Red Hat also assists with customer incidents raised through support cases. 
+Red Hat can assist with activities including but not limited to:
+
+* Forensic gathering, including isolating virtual compute
+* Guiding compute image collection
+* Providing collected audit logs
+
 [id="rosa-policy-notifications_{context}"]
 == Notifications
 Platform notifications are configured using email. Some customer notifications are also sent to an account's corresponding Red Hat account team, including a Technical Account Manager, if applicable.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
`enterprise-4.14+`

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Incident Management](https://71403--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix#rosa-policy-incident-management_rosa-policy-responsibility-matrix)
- [Cluster capacity](https://71403--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix#rosa-policy-cluster-capacity_rosa-policy-responsibility-matrix)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
