### PR TITLE
OSDOCS-9210-RN Enabling userProvisionedDNS for GCP

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -58,6 +58,13 @@ This release adds improvements related to the following components and concepts.
 [id="ocp-4-15-installation-and-update"]
 === Installation and update
 
+[id="ocp-4-15-GCP-custom-dns"]
+==== Installing a cluster on Google Cloud Platform (GCP) with customer managed DNS (Tech Preview)
+
+You can now install a cluster on GCP with a custom DNS solution that you manage. If you enable the `TechPreviewNoUpgrade` flag during installation, you can enable this feature. If your organization's security policies do not allow the use of public DNS services like Google Cloud DNS, you can use your own DNS service with this feature.
+
+For more information, see xref:../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp[Installation configuration parameters].
+
 [id="ocp-4-15-CAPO-tech-preview-no-upgrade"]
 ==== CAPO integration into the cluster CAPI Operator (Tech Preview)
 


### PR DESCRIPTION
Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-9210

Link to docs preview:
https://71410--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-GCP-custom-dns

QE review:
- [ ] QE has approved this change.
