### PR TITLE
OSDOCS-9223-RN removal of openshiftSDN from installer

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -1012,6 +1012,11 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.13 |4.14 |4.15
 
+|OpenShift SDN network plugin
+|General Availability
+|Deprecated
+|Removed ^[1]^
+
 |`--cloud` parameter for `oc adm release extract`
 |General Availability
 |Deprecated
@@ -1045,7 +1050,7 @@ In the following tables, features are marked with the following statuses:
 |====
 [.small]
 --
-1. For {product-title} {product-version}, you must install the {product-title} cluster on a VMware vSphere version 7.0 Update 2 or later instance, including VMware vSphere version 8.0, that meets the requirements for the components that you use.
+1. While the OpenShift SDN network plugin is no longer supported by the installation program in version 4.15, you can upgrade a cluster that uses the OpenShift SDN plugin from version 4.14 to version 4.15.
 --
 [discrete]
 === Updating clusters deprecated and removed features


### PR DESCRIPTION
Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-9223

Link to docs preview:
https://71411--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-deprecated-removed-features (under installer section)


QE review:
- [x] QE has approved this change.
