### PR TITLE
[OSDOCS-9608] Updating console/oauth/downloads doc

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-rosa-osd-change-default-domain.adoc
+++ b/cloud_experts_tutorials/cloud-experts-rosa-osd-change-default-domain.adoc
@@ -18,78 +18,106 @@ toc::[]
 //---
 
 //Footnote definitions
-:fn-supported-cli: footnote:[The example commands in this guide use the ROSA CLI, but similar commands with the same function are available in the OCM CLI version 0.1.68 and higher for OpenShift Dedicated clusters that run on Google Cloud Platform.]
-:fn-supported-versions: footnote:[Modifying these routes on ROSA and OSD versions prior to 4.14 is not typically supported. However, if you have a cluster using version 4.13, you can request for Red Hat Support to enable support for this feature on your version 4.13 cluster.]
-:fn-term-component-routes: footnote:[We use the term `component routes` to refer to the `OAuth`, `Console`, and `Downloads` routes that are provided when ROSA and OSD are first installed. The ROSA CLI also uses the term `cluster routes` to refer to these resources.]
+ifdef::openshift-dedicated[]
+:fn-supported-cli: footnote:[The example commands in this guide use the ROSA CLI, but similar commands with the same function are available in the OCM CLI version 0.1.68 and higher for {product-title} (OSD) clusters.]
+:fn-supported-versions: footnote:[Modifying these routes on OSD versions prior to 4.14 is not typically supported. However, if you have a cluster using version 4.13, you can request for Red Hat Support to enable support for this feature on your version 4.13 cluster by link:https://access.redhat.com/support/cases/new[opening a support case].]
+:fn-term-component-routes: footnote:[We use the term "component routes" to refer to the `OAuth`, `Console`, and `Downloads` routes that are provided when OSD are first installed.]
+endif::openshift-dedicated[]
+ifdef::openshift-rosa[]
+:fn-supported-versions: footnote:[Modifying these routes on {product-title} ROSA versions prior to 4.14 is not typically supported. However, if you have a cluster using version 4.13, you can request for Red Hat Support to enable support for this feature on your version 4.13 cluster by link:https://access.redhat.com/support/cases/new[opening a support case].]
+:fn-term-component-routes: footnote:[We use the term "component routes" to refer to the `OAuth`, `Console`, and `Downloads` routes that are provided when ROSA are first installed. The ROSA CLI also uses the term "cluster routes" to refer to these resources.]
+endif::openshift-rosa[]
+
 
 //Article text
-This guide demonstrates how to modify the Console, Downloads, OAuth domain, and TLS certificate keypair on Red Hat Openshift on AWS (ROSA) and Red Hat Openshift Dedicated (OSD) versions 4.14 and above. {fn-supported-versions}
+ifdef::openshift-dedicated[]
+This guide demonstrates how to modify the hostname and TLS certificate of the Web console, OAuth server, and Downloads component routes in {product-title} (OSD) version 4.14 and above.{fn-supported-versions}
+endif::openshift-dedicated[]
+ifdef::openshift-rosa[]
+This guide demonstrates how to modify the hostname and TLS certificate of the Web console, OAuth server, and Downloads component routes in {product-title} (ROSA) version 4.14 and above.{fn-supported-versions}
+endif::openshift-rosa[]
 
-//// 
-The changes that we make to the component routes {fn-term-component-routes} in this guide are described in greater detail in the following documentation:
-
-* link:https://docs.openshift.com/container-platform/latest/authentication/configuring-internal-oauth.html#customizing-the-oauth-server-url_configuring-internal-oauth[Customizing the internal OAuth server URL]
-* link:https://docs.openshift.com/container-platform/latest/web_console/customizing-the-web-console.html#customizing-the-console-route_customizing-web-console[Customizing the console route]
-* link:https://docs.openshift.com/container-platform/latest/web_console/customizing-the-web-console.html#customizing-the-download-route_customizing-web-console[Customizing the download route]
-//// 
+The changes that we make to the component routes{fn-term-component-routes} in this guide are described in greater detail in the customizing the link:https://docs.openshift.com/container-platform/latest/authentication/configuring-internal-oauth.html#customizing-the-oauth-server-url_configuring-internal-oauth[internal OAuth server URL], link:https://docs.openshift.com/container-platform/latest/web_console/customizing-the-web-console.html#customizing-the-console-route_customizing-web-console[console route], and link:https://docs.openshift.com/container-platform/latest/web_console/customizing-the-web-console.html#customizing-the-download-route_customizing-web-console[download route] OpenShift Container Platform documentation. 
 
 [id="prerequisites_{context}"]
 == Prerequisites
-
-* ROSA CLI (`rosa`) version 1.2.27 or higher {fn-supported-cli}
+ifdef::openshift-dedicated[]
+* OCM CLI (`rosa`) version 0.1.68 and higher
+* An OSD cluster
+endif::openshift-dedicated[]
+ifdef::openshift-rosa[]
+* ROSA CLI (`rosa`) version 1.2.27 or higher
 * AWS CLI (`aws`)
+* A ROSA cluster
+endif::openshift-rosa[]
 * OpenShift CLI (`oc`)
-* A ROSA or OSD cluster (STS, non-STS, or PrivateLink)
-* OpenSSL (for generating the demonstration SSL certificate), which can be downloaded and installed from link:https://www.openssl.org/source/[OpenSSL.org]
 * Access to the cluster as a user with the `cluster-admin` role.
+* A unique domain, such as `openshift.example.com`
+* `jq`
+* [Optional] OpenSSL (for generating the demonstration SSL certificate), which can be downloaded and installed from link:https://www.openssl.org/source/[OpenSSL.org]
+
+[id="environment-setup_{context}"]
+== Setting up your environment
+
+. Configure the following environment variables:
++
+[NOTE]
+====
+You must be logged in as an administrator.
+====
++
+[source,terminal]
+----
+$ export NEW_BASE_DOMAIN=openshift.example.com <1>
+$ export CLUSTER_NAME=$(oc get infrastructure cluster -o=jsonpath="{.status.infrastructureName}"  | sed 's/-[a-z0-9]\{5\}$//')
+$ export INGRESS_JSON=$(rosa list ingress -c ${CLUSTER_NAME} -o json)
+$ export INGRESS_ID=$(echo $INGRESS_JSON | jq -cr '.[] | select( .default == true ) | .id')
+$ export DEFAULT_BASE_DOMAIN=$(echo $INGRESS_JSON | jq -cr '.[] | select( .default == true ) | .dns_name')
+$ export SCRATCH="/tmp/${CLUSTER_NAME}/component-route-change"
+$ mkdir -p ${SCRATCH}
+----
+<1> The custom base domain you wish to use for your component routes.
+
+. Ensure all fields output correctly before moving to the next section:
++
+[source,terminal]
+----
+$ echo "Cluster: ${CLUSTER_NAME}, Default Base Domain: ${DEFAULT_BASE_DOMAIN}, New Base Domain: ${NEW_BASE_DOMAIN}, Ingress ID: ${INGRESS_ID}"
+----
++
+.Example output
++
+[source,text]
+----
+Cluster: my-rosa-cluster, Default Base Domain: apps.my-rosa-cluster.e2eg.p1.openshiftapps.com, New Base Domain: openshift.example.com, Ingress ID: k5p6
+----
 
 [id="find-current-routes_{context}"]
 == Find the current routes
 
-Before we make any configuration changes, we need to know the current routes in the cluster.
-
-* Verify that you can reach the component routes on their default hostnames.
-+
-You can find the hostnames by querying the lists of routes in `openshift-console` and `openshift-authentication`.
+. List the default component routes by getting the routes in `openshift-console` and `openshift-authentication`.
 +
 [source,bash]
 ----
 $ oc get routes -n openshift-console
-NAME        HOST/PORT                                                                          PATH       SERVICES    PORT    TERMINATION          WILDCARD
-console     console-openshift-console.apps.my-example-cluster-aws.z9a9.p1.openshiftapps.com    ... 1 more  console    https   reencrypt/Redirect   None
-downloads   downloads-openshift-console.apps.my-example-cluster-aws.z9a9.p1.openshiftapps.com  ... 1 more  downloads  http    edge/Redirect        None
-----
-+
-[source,bash]
-----
 $ oc get routes -n openshift-authentication
-NAME              HOST/PORT                                                             PATH        SERVICES          PORT   TERMINATION            WILDCARD
-oauth-openshift   oauth-openshift.apps.my-example-cluster-aws.z9a9.p1.openshiftapps.com ... 1 more  oauth-openshift   6443   passthrough/Redirect   None
 ----
 +
-From these commands you can see that our base hostname is `z9a9.p1.openshiftapps.com`.
-
-* Verify that the default ingress exists, and ensure that the base hostname matches that of the component routes.
+.Example output
 +
-[source,bash]
+[source,text]
 ----
-$ rosa list ingress -c <my-example-cluster-aws>
-ID    API ENDPOINT                                                   PRIVATE
-r3l6  https://apps.my-example-cluster-aws.z9a9.p1.openshiftapps.com  external  true
+NAME              HOST/PORT                                                                     PATH   SERVICES          PORT   TERMINATION            WILDCARD
+console           console-openshift-console.apps.my-rosa-cluster.e2eg.p1.openshiftapps.com             console           https  reencrypt/Redirect     None
+downloads         downloads-openshift-console.apps.my-rosa-cluster.e2eg.p1.openshiftapps.com           downloads         http   edge/Redirect          None
+NAME              HOST/PORT                                                                     PATH   SERVICES          PORT   TERMINATION            WILDCARD
+oauth-openshift   oauth-openshift.apps.my-rosa-cluster.e2eg.p1.openshiftapps.com                       oauth-openshift   6443   passthrough/Redirect   None
 ----
 +
-Our ingress route shares the base hostname of `z9a9.p1.openshiftapps.com`.
+As you can see from the example output, our routes shares the base domain of our default ingress: `apps.my-rosa-cluster.e2eg.p1.openshiftapps.com`.
 +
-Note the ID of the default ingress: `r316`. We will need this to set up new DNS records later.
-
-By running these commands you can see that the default component routes for our cluster are:
-
-* `console-openshift-console.apps.my-example-cluster-aws.z9a9.p1.openshiftapps.com` for Console
-* `downloads-openshift-console.apps.my-example-cluster-aws.z9a9.p1.openshiftapps.com` for Downloads
-* `oauth-openshift.apps.my-example-cluster-aws.z9a9.p1.openshiftapps.com` for OAuth
-
-We can use the `rosa edit ingress` command to change this base hostname and add a TLS certificate for all of our component routes. The relevant parameters are shown in this excerpt of the command line help for the `rosa edit ingress` command:
-
+We can use the `rosa edit ingress` command to change this base domain (and provide a matching TLS certificate) for all of our component routes. The relevant parameters are shown in this excerpt of the command line help for the `rosa edit ingress` command:
++
 [source,bash]
 ----
 $ rosa edit ingress -h
@@ -99,101 +127,119 @@ Edit a cluster ingress for a cluster. Usage:
   --cluster-routes-hostname string         Components route hostname for oauth, console, download.
   --cluster-routes-tls-secret-ref string   Components route TLS secret reference for oauth, console, download.
 ----
-
++
 Note that when we use this command to change the component routes, it will change the base domain for all three routes at the same time.
-
-If we choose a new base domain of `my-new-domain.dev`, our new component routes for our cluster will be:
-
-* `console-openshift-console.my-new-domain.dev` for Console
-* `downloads-openshift-console.my-new-domain.dev` for Downloads
-* `oauth-openshift.my-new-domain.dev` for OAuth
++
+If we choose a new base domain of `openshift.example.com`, our new component routes for our cluster will be:
++
+* _console-openshift-console.openshift.example.com_ for the Web console
+* _downloads-openshift-console.openshift.example.com_ for Downloads
+* _oauth-openshift.openshift.example.com_ for the OAuth server
 
 [id="create-tls-certificate-for-routes_{context}"]
 == Create a valid TLS certificate for each component route
 
-In this section, we create a self-signed certificate key pair and then trust it to verify that we can access our new component routes using a real web browser. This is for demonstration purposes only, and is not recommended as a solution for production workloads. Consult your certificate authority to understand how to create a certificate with similar attributes for your production workloads.
+[WARNING]
+====
+You must create three separate certificates for each component route to avoid problems with link:https://daniel.haxx.se/blog/2016/08/18/http2-connection-coalescing/[HTTP/2 connection coalescing]. Using a wildcard or SAN certificate for the component routes *will not work* and result in unexpected errors for most modern browsers.
+====
 
-To work correctly, the certificate we create needs the following:
+In this section, we create three separate self-signed certificates. This is for demonstration purposes only, and is *not recommended* as a solution for production workloads. Consult your certificate authority to understand how to create a certificate with similar attributes for your production workloads.
 
-* a Common Name (CN) that matches the **wildcard** DNS of the `--cluster-routes-hostname` parameter
-* a Subject Alternative Name (SAN) for each component route that **matches** the routes generated by our new hostname
+To work correctly, the certificates we create needs a Common Name (CN) that match each of the individual component routes.
 
-For a base domain of `my-new-domain.dev`, our certificate's subject (`-subj`) looks like this:
-
-----
-/CN=*.my-new-domain.dev
-----
-
-We also need a SAN for each of our component routes:
-
-----
-subjectAltName = DNS:console-openshift-console.my-new-domain.dev
-subjectAltName = DNS:downloads-openshift-console.my-new-domain.dev
-subjectAltName = DNS:oauth-openshift.my-new-domain.dev
-----
-
-We can generate our certificate by running the following `openssl` command:
-
+. To generate our certificates, we can run the following `openssl` commands:
++
 [source,bash]
 ----
-$ openssl req -newkey rsa:2048 -new -nodes -x509 -days 365 -keyout key-my-new-domain.pem -out cert-my-new-domain.pem -subj "/CN=*.my-new-domain.dev" -addext "subjectAltName = DNS:console-openshift-console.my-new-domain.dev, DNS:oauth-openshift.my-new-domain.dev, DNS:downloads-openshift-console.my-new-domain.dev"
+$ openssl req -newkey rsa:2048 -new -nodes -x509 -days 365 -keyout ${SCRATCH}/key-console.pem -out ${SCRATCH}/cert-console.pem -subj "/CN=console-openshift-console.${NEW_BASE_DOMAIN}"
+$ openssl req -newkey rsa:2048 -new -nodes -x509 -days 365 -keyout ${SCRATCH}/key-downloads.pem -out ${SCRATCH}/cert-downloads.pem -subj "/CN=downloads-openshift-console.${NEW_BASE_DOMAIN}"
+$ openssl req -newkey rsa:2048 -new -nodes -x509 -days 365 -keyout ${SCRATCH}/key-oauth.pem -out ${SCRATCH}/cert-oauth.pem -subj "/CN=oauth-openshift.${NEW_BASE_DOMAIN}"
 ----
-
-This generates two `.pem` files, `key-my-new-domain.pem` and `cert-my-new-domain.pem`.
++
+This will generate six `.pem` files, a certificate and key for each component route in our scratch directory.
++
+. Next, we need to concatenate both the keys and certificates into their own individual file. To do so, run the following command:
++
+[source,bash]
+----
+$ cat ${SCRATCH}/cert-console.pem ${SCRATCH}/cert-downloads.pem ${SCRATCH}/cert-oauth.pem > ${SCRATCH}/combined-certs.pem
+$ cat ${SCRATCH}/key-console.pem ${SCRATCH}/key-downloads.pem ${SCRATCH}/key-oauth.pem > ${SCRATCH}/combined-keys.pem
+----
 
 [id="add-certificate-as-cluster-secret_{context}"]
 == Add the certificate to the cluster as a secret
 
-. Log in to the cluster as a user with the `cluster-admin` role.
-
-. Generate a TLS secret in the `openshift-config` namespace.
+. Create a TLS secret in the `openshift-config` namespace that contains your concatenated.
 +
-This becomes your secret reference when you update the component routes later in this guide.
+The `custom-component-tls` secret becomes your secret reference when you update the component routes later in this guide.
 +
 [source,bash]
 ----
-$ oc create secret tls component-tls --cert=cert-my-new-domain.pem --key=key-my-new-domain.pem -n openshift-config
+$ oc -n openshift-config create secret tls custom-component-tls --cert=${SCRATCH}/combined-certs.pem --key=${SCRATCH}/combined-keys.pem
 ----
-
-[id="find-lb-hostname_{context}"]
-== Find the hostname of the load balancer in your cluster
-
-When you create a cluster, ROSA and OSD create a load balancer and generate a hostname for that load balancer. We need to know the load balancer hostname in order to create DNS records for our cluster.
-
-You can find the hostname by running the `oc get svc` command against the `openshift-ingress` namespace. The hostname of the load balancer is the `EXTERNAL-IP` associated with the `router-default` service in the `openshift-ingress` namespace.
-
-[source,bash]
-----
-$ oc get svc -n openshift-ingress
-NAME            TYPE          CLUSTER-IP     EXTERNAL-IP                                             PORT(S)                     AGE
-router-default  LoadBalancer  172.30.237.88  a234gsr3242rsfsfs-1342r624.us-east-1.elb.amazonaws.com  80:31175/TCP,443:31554/TCP  76d
-----
-
-In our case, the hostname is `a234gsr3242rsfsfs-1342r624.us-east-1.elb.amazonaws.com`.
-
-Save this value for later, as we will need it to configure DNS records for our new component route hostnames.
 
 [id="add-routes-to-dns_{context}"]
-== Add component route DNS records to your hosting provider
+== Add component route DNS records to your DNS provider
 
-In your hosting provider, add DNS records that map the `CNAME` of your new component route hostnames to the load balancer hostname we found in the previous step.
+When you create a ROSA cluster, ROSA automatically creates a load balancer. AWS generates a hostname for that load balancer that we need to be able to create DNS records for our cluster.
 
-//.Need an image for this
-//image::[Picture goes here]
+. To get the hostname of the default IngressController load balancer, run the following command:
++
+[source,bash]
+----
+$ export DEFAULT_INGRESS_LB=$(oc -n openshift-ingress get svc/router-default -o jsonpath='{.status.loadBalancer.ingress[].hostname}')
+$ echo "Load Balancer Domain: ${DEFAULT_INGRESS_LB}"
+----
++
+.Example output
+[source,text]
+----
+Load Balancer Domain: a188c08ca91714ce989a9096646d41f4-1955205717.us-west-2.elb.amazonaws.com
+----
++
+. At your domain's DNS provider, add three new CNAME DNS records that map each of your new component routes to the load balancer hostname we looked up in the previous step. The below command will output the records that you need to create:
++
+[source,bash]
+----
+$ echo "console-openshift-console.${NEW_BASE_DOMAIN}.  300  IN  CNAME ${DEFAULT_INGRESS_LB} "
+$ echo "downloads-openshift-console.${NEW_BASE_DOMAIN}.  300 IN  CNAME ${DEFAULT_INGRESS_LB}"
+$ echo "oauth-openshift.${NEW_BASE_DOMAIN}.  300 IN  CNAME ${DEFAULT_INGRESS_LB}"
+----
++
+[NOTE]
+====
+You can take the output of this command and import the records directly into link:https://aws.amazon.com/route53/[Amazon Route 53].
+====
++
+.Example output
+[source,text]
+----
+console-openshift-console.openshift.example.com. 300 IN CNAME a188c08ca91714ce989a9096646d41f4-1955205717.us-west-2.elb.amazonaws.com
+downloads-openshift-console.openshift.example.com. 300 IN CNAME a188c08ca91714ce989a9096646d41f4-1955205717.us-west-2.elb.amazonaws.com
+oauth-openshift.openshift.example.com. 300 IN CNAME a188c08ca91714ce989a9096646d41f4-1955205717.us-west-2.elb.amazonaws.com
+----
+
 
 [id="update-routes-tls-using-rosa-cli_{context}"]
 == Update the component routes and TLS secret using the ROSA CLI
 
-When your DNS records have been updated, you can use the ROSA CLI to change the component routes.
+Once your DNS records have been created, you can use the ROSA CLI to change the component routes.
 
-Use the `rosa edit ingress` command to update your default ingress route with the new base domain and the secret reference associated with it.
-
+. Use the `rosa edit ingress` command to update your default ingress with the new component routes and the secret (which contains the TLS cert/key) that we created earlier.
++
 [source,bash]
 ----
-$ rosa edit ingress -c <my-example-cluster-aws> r3l6 --cluster-routes-hostname="my-new-domain.dev" --cluster-routes-tls-secret-ref="component-tls"
-
-ID    APPLICATION ROUTER                                             PRIVATE  DEFAULT  [...]  LB-TYPE  [...]  WILDCARD POLICY      NAMESPACE OWNERSHIP  HOSTNAME           TLS SECRET REF
-r3l6  https://apps.my-example-cluster-aws.z9a9.p1.openshiftapps.com  yes      yes      [...]  nlb      [...]  WildcardsDisallowed  Strict               my-new-domain.dev  component-tls
+$ rosa edit ingress -c ${CLUSTER_NAME} ${INGRESS_ID} --cluster-routes-hostname="${NEW_BASE_DOMAIN}" --cluster-routes-tls-secret-ref="custom-component-tls"
+----
++
+[source,text]
+----
+Output coming when cluster creation finishes...
 ----
 
-Add your certificate to the trust store on your local system, then confirm that you can access your components at their new routes using your local web browser.
+// ID    APPLICATION ROUTER                                             PRIVATE  DEFAULT  [...]  LB-TYPE  [...]  WILDCARD POLICY      NAMESPACE OWNERSHIP  HOSTNAME           TLS SECRET REF
+// r3l6  https://apps.my-example-cluster-aws.z9a9.p1.openshiftapps.com  yes      yes      [...]  nlb      [...]  WildcardsDisallowed  Strict               my-new-domain.dev  component-tls
+// ----
+
+If you are using a self-signed certificate, you should temporarily add your certificate to the trust store on your local system to ensure you can successfully access the web console, OAuth server, and downloads components.


### PR DESCRIPTION
[OSDOCS-9608]: Updating the custom Console/OAuth/Downloads Doc to reflect new information

Version(s): `enterprise-4.14+`
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-9608
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://71412--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-rosa-osd-change-default-domain
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
