### PR TITLE
OCPBUGS-27961-RN-415-NF RN Description for whereabouts schedule

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -405,6 +405,12 @@ Previously, if one pod (`Pod X`) was deleted, and a second pod (`Pod Y`) was cre
 
 With this update, pods created using the macvlan CNI plugin, where the IP address management CNI plugin has assigned IPs, now send IPv6 unsolicited neighbor advertisements by default onto the network. This enhancement notifies the network fabric of the new pod's MAC address for a particular IP to refresh IPv6 neighbor caches.
 
+
+[id="ocp-4-15-configuring-whereabouts-IP-reconciler-schedule"]
+==== Configuring the Whereabouts IP reconciler schedule
+
+The Whereabouts reconciliation schedule was hard-coded to run once per day and could not be reconfigured. With this release, a `ConfigMap` object has enabled the configuration of the Whereabouts cron schedule. For more information, see xref:../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-configuring-whereabouts-ip-reconciler-schedule_configuring-additional-network[Configuring the Whereabouts IP reconciler schedule].
+
 [id="ocp-4-15-egressfirewall-updates-status-management"]
 ==== Status management updates for EgressFirewall and AdminPolicyBasedExternalRoute CR
 


### PR DESCRIPTION
[OCPBUGS-27961]: Configuring the Whereabouts IP reconciler schedule

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-27961
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://71413--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-configuring-whereabouts-IP-reconciler-schedule
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
