### PR TITLE
OCPBUGS-29234 Add in link to correct section

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3209,7 +3209,7 @@ The following feature is included in this z-stream release:
 [id="ocp-4-14-11-wherabouts-cron-schedule"]
 ===== Enabling configuration of whereabouts cron schedule
 
-* The Whereabouts reconciliation schedule was hard-coded to run once per day and could not be reconfigured. With this release, a ConfigMap has enabled the configuration of the whereabouts cron schedule. xref:../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-creating-whereabouts-reconciler-daemon-set_configuring-additional-network[Creating a Whereabouts reconciler daemon set].
+* The Whereabouts reconciliation schedule was hard-coded to run once per day and could not be reconfigured. With this release, a `ConfigMap` has enabled the configuration of the whereabouts cron schedule. For more information, see xref:../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-configuring-whereabouts-ip-reconciler-schedule_configuring-additional-network[Configuring the Whereabouts IP reconciler schedule].
 
 [id="ocp-4-14-11-bug-fixes"]
 ==== Bug fixes


### PR DESCRIPTION
[OCPBUGS-29234]: Updating link in "Enabling configuration of whereabouts cron schedule" z-stream

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-29234
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://71414--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-11-wherabouts-cron-schedule
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Content already present in 4.14 z-stream, this PR updates the link to point to the correct section. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
