### PR TITLE
[OSDOCS-7500] multi-architecture IBM Power and IBM Z control planes

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -568,7 +568,7 @@ Topics:
     File: creating-multi-arch-compute-nodes-aws
   - Name: Creating a cluster with multi-architecture compute machines on GCP
     File: creating-multi-arch-compute-nodes-gcp
-  - Name: Creating a cluster with multi-architecture compute machines on bare metal
+  - Name: Creating a cluster with multi-architecture compute machines on bare metal, IBM Power, or IBM Z
     File: creating-multi-arch-compute-nodes-bare-metal
   - Name: Creating a cluster with multi-architecture compute machines on IBM Z and IBM LinuxONE with z/VM
     File: creating-multi-arch-compute-nodes-ibm-z

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-bare-metal.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-bare-metal.adoc
@@ -1,16 +1,20 @@
 :_mod-docs-content-type: ASSEMBLY
 :context: creating-multi-arch-compute-nodes-bare-metal
 [id="creating-multi-arch-compute-nodes-bare-metal"]
-= Creating a cluster with multi-architecture compute machine on bare metal
+= Creating a cluster with multi-architecture compute machines on bare metal, {ibm-power-title}, or {ibm-z-title}
 include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-To create a cluster with multi-architecture compute machines on bare metal, you must have an existing single-architecture bare metal cluster. For more information on bare metal installations, see xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[Installing a user provisioned cluster on bare metal]. You can then add 64-bit ARM compute machines to your {product-title} cluster on bare metal.
+To create a cluster with multi-architecture compute machines on bare metal (`x86_64`), {ibm-power-name} (`ppc64le`), or {ibm-z-name} (`s390x`) you must have an existing single-architecture cluster on one of these platforms. Follow the installations procedures for your platform:
 
-Before you can add 64-bit ARM nodes to your bare metal cluster, you must upgrade your cluster to one that uses the multi-architecture payload. For more information on migrating to the multi-architecture payload, see xref:../../updating/updating_a_cluster/migrating-to-multi-payload.adoc#migrating-to-multi-payload[Migrating to a cluster with multi-architecture compute machines].
+* xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[Installing a user provisioned cluster on bare metal]. You can then add 64-bit ARM compute machines to your {product-title} cluster on bare metal.
+* xref:../../installing/installing_ibm_power/preparing-to-install-on-ibm-power.adoc#preparing-to-install-on-ibm-power[Installing a cluster on {ibm-power-name}]. You can then add `x86_64` compute machines to your {product-title} cluster on {ibm-power-name}.
+* xref:../../installing/installing_ibm_z/preparing-to-install-on-ibm-z.adoc#preparing-to-install-on-ibm-z[Installing a cluster on {ibm-z-name} and {ibm-linuxone-name}]. You can then add `x86_64` compute machines to your {product-title} cluster on {ibm-z-name} and {ibm-linuxone-name}.
 
-The following procedures explain how to create a {op-system} compute machine using an ISO image or network PXE booting. This will allow you to add ARM64 nodes to your bare metal cluster and deploy a cluster with multi-architecture compute machines.
+Before you can add additional compute nodes to your cluster, you must upgrade your cluster to one that uses the multi-architecture payload. For more information on migrating to the multi-architecture payload, see xref:../../updating/updating_a_cluster/migrating-to-multi-payload.adoc#migrating-to-multi-payload[Migrating to a cluster with multi-architecture compute machines].
+
+The following procedures explain how to create a {op-system} compute machine using an ISO image or network PXE booting. This will allow you to add additional nodes to your cluster and deploy a cluster with multi-architecture compute machines.
 
 include::modules/multi-architecture-verifying-cluster-compatibility.adoc[leveloffset=+1]
 

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-power.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-power.adoc
@@ -15,6 +15,13 @@ Before you can add `ppc64le` nodes to your cluster, you must upgrade your cluste
 
 The following procedures explain how to create a {op-system} compute machine using an ISO image or network PXE booting. This will allow you to add `ppc64le` nodes to your cluster and deploy a cluster with multi-architecture compute machines.
 
+[NOTE]
+====
+To create an {ibm-power-name} (`ppc64le`) cluster with multi-architecture compute machines on `x86_64`, follow the instructions for
+xref:../../installing/installing_ibm_power/preparing-to-install-on-ibm-power.adoc#preparing-to-install-on-ibm-power[Installing a cluster on {ibm-power-name}]. You can then add `x86_64` compute machines as described in xref:./creating-multi-arch-compute-nodes-bare-metal.adoc#creating-multi-arch-compute-nodes-bare-metal[Creating a cluster with multi-architecture compute machines on bare metal, {ibm-power-title}, or {ibm-z-title}].
+====
+
+
 include::modules/multi-architecture-verifying-cluster-compatibility.adoc[leveloffset=+1]
 
 include::modules/machine-user-infra-machines-iso.adoc[leveloffset=+1]

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z-kvm.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z-kvm.adoc
@@ -12,6 +12,12 @@ Before you can add `s390x` nodes to your cluster, you must upgrade your cluster 
 
 The following procedures explain how to create a {op-system} compute machine using a {op-system-base} KVM instance. This will allow you to add `s390x` nodes to your cluster and deploy a cluster with multi-architecture compute machines.
 
+[NOTE]
+====
+To create an {ibm-z-name} or {ibm-linuxone-name} (`s390x`) cluster with multi-architecture compute machines on `x86_64`, follow the instructions for
+xref:../../installing/installing_ibm_z/preparing-to-install-on-ibm-z.adoc#preparing-to-install-on-ibm-z[Installing a cluster on {ibm-z-name} and {ibm-linuxone-name}]. You can then add `x86_64` compute machines as described in xref:./creating-multi-arch-compute-nodes-bare-metal.adoc#creating-multi-arch-compute-nodes-bare-metal[Creating a cluster with multi-architecture compute machines on bare metal, {ibm-power-title}, or {ibm-z-title}].
+====
+
 include::modules/multi-architecture-verifying-cluster-compatibility.adoc[leveloffset=+1]
 
 include::modules/machine-user-infra-machines-ibm-z-kvm.adoc[leveloffset=+1]

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z.adoc
@@ -12,6 +12,12 @@ Before you can add `s390x` nodes to your cluster, you must upgrade your cluster 
 
 The following procedures explain how to create a {op-system} compute machine using a z/VM instance. This will allow you to add `s390x` nodes to your cluster and deploy a cluster with multi-architecture compute machines.
 
+[NOTE]
+====
+To create an {ibm-z-name} or {ibm-linuxone-name} (`s390x`) cluster with multi-architecture compute machines on `x86_64`, follow the instructions for
+xref:../../installing/installing_ibm_z/preparing-to-install-on-ibm-z.adoc#preparing-to-install-on-ibm-z[Installing a cluster on {ibm-z-name} and {ibm-linuxone-name}]. You can then add `x86_64` compute machines as described in xref:./creating-multi-arch-compute-nodes-bare-metal.adoc#creating-multi-arch-compute-nodes-bare-metal[Creating a cluster with multi-architecture compute machines on bare metal, {ibm-power-title}, or {ibm-z-title}].
+====
+
 include::modules/multi-architecture-verifying-cluster-compatibility.adoc[leveloffset=+1]
 
 include::modules/machine-user-infra-machines-ibm-z.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-7500
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://71418--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-bare-metal
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: related to this PR: https://github.com/openshift/openshift-docs/pull/71394
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
