### PR TITLE
OSSM-5900 Update v2 to match v1 change request from outside OSSM

### DIFF
--- a/modules/ossm-add-project-using-label-selectors-cli.adoc
+++ b/modules/ossm-add-project-using-label-selectors-cli.adoc
@@ -21,10 +21,11 @@ You can use label selectors to add a project to the {SMProductShortName} with th
 +
 [source,terminal]
 ----
-$ oc edit smmr -n <controlplane_project>
+$ oc edit smmr default -n istio-system
 ----
 +
-The previous example uses `<controlplane_project>` as an example. You can deploy the {SMProductShortName} control plane to any project as long as it is separate from the project that contains your services.
+You can deploy the {SMProductShortName} control plane to any project provided that it is separate from the project that contains your services.
+
 
 . Modify the YAML file to include namespace label selectors in the `spec.memberSelectors` field of the `ServiceMeshMemberRoll` resource.
 +


### PR DESCRIPTION
Update v2 to match v1 change request from outside OSSM

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSSM-5900 

Link to docs preview:
https://71419--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-create-mesh#ossm-adding-project-using-label-selectors-cli_ossm-create-mesh

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Update sample as change suggested in v1 docs applies to v2.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
