### PR TITLE
removing OSO link

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -51,16 +51,6 @@ openshift-origin:
     enterprise-3.11:
       name: '3.11'
       dir: '3.11'
-openshift-online:
-  name: OpenShift Online
-  author: OpenShift Documentation Project <openshift-docs@redhat.com>
-  site: commercial
-  site_name: Documentation
-  site_url: https://docs.openshift.com/
-  branches:
-    enterprise-3.11:
-      name: 'Pro'
-      dir: online/pro
 openshift-enterprise:
   name: OpenShift Container Platform
   author: OpenShift Documentation Project <openshift-docs@redhat.com>

--- a/index-commercial.html
+++ b/index-commercial.html
@@ -164,9 +164,9 @@
 <div class="landing">
   <div class="container">
     <div class="row">
-      <div class="col-md-10 col-centered">
+      <div class="col-md-12 col-centered">
         <div class="row">
-          <div class="col-sm-3 text-center">
+          <div class="col-sm-4 text-center">
             <h2>OpenShift Container Platform</h2>
             <div class="list-group">
               <p class="list-group-item-text">Red Hat's private, on-premise cloud application deployment and hosting platform.</p>
@@ -202,7 +202,7 @@
               </div>
             </div>
           </div>
-          <div class="col-sm-3 text-center">
+          <div class="col-sm-4 text-center">
             <h2>OpenShift Dedicated</h2>
             <div class="list-group">
               <p class="list-group-item-text">Red Hat's managed public cloud application deployment and hosting service.</p>
@@ -212,7 +212,7 @@
 
             </div>
           </div>
-          <div class="col-sm-3 text-center">
+          <div class="col-sm-4 text-center">
             <h2>Red Hat OpenShift Service on AWS</h2>
             <div class="list-group">
               <p class="list-group-item-text">Red Hat OpenShift Service on AWS (ROSA) is a fully-managed OpenShift service, jointly managed and supported by Red Hat and Amazon Web Services (AWS).</p>
@@ -221,7 +221,7 @@
           </div>
         </div>
         <div class="row">
-          <div class="col-sm-3 text-center">
+          <div class="col-sm-4 text-center">
 
             <h2>Azure Red Hat OpenShift</h2>
             <div class="list-group">
@@ -234,7 +234,7 @@
 
           </div>
 
-          <div class="col-sm-3 text-center">
+          <div class="col-sm-4 text-center">
 
             <h2>Red Hat Advanced Cluster Security for Kubernetes</h2>
             <div class="list-group">
@@ -259,41 +259,18 @@
                 </ul>
               </div>
             </div>
-
-
-
           </div>
-
-
-
-
-          <div class="col-sm-3 text-center">
-
-            <h2>OpenShift Online</h2>
-            <div class="list-group">
-              <p class="list-group-item-text">Red Hat's public cloud application deployment and hosting platform.</p>
-                <p><a role="button" class="btn btn-primary" href="online/pro/welcome/index.html"><i class="fa fa-arrow-circle-o-right"></i> Pro</a></p>
-
-
-          </div>
-
-        </div>
-        <div class="col-sm-3 text-center">
-
-            <div class="list-group">
-
-          <h2>OpenShift Kubernetes Engine</h2>
+          <div class="col-sm-4 text-center">
+            <h2>OpenShift Kubernetes Engine</h2>
           <div class="list-group">
             <p class="list-group-item-text">The OpenShift Kubernetes Engine is the core of the OpenShift Container Platform. Use OpenShift Container Platform docs links for OpenShift Kubernetes Engine documentation.</p>
             Read more about <a href="/container-platform/4.14/welcome/oke_about.html">OKE</a>.
           </div>
-
-        </div>
-
+          </div>
         </div>
       </div>
       <div class="row">
-        <div class="col-sm-3 text-center">
+        <div class="col-sm-4 text-center">
             <h2>OpenShift Container Platform <font size="-1">(日本語翻訳)</font></h2>
           <div class="list-group">
             <p class="list-group-item-text">Red Hat のプライベート、オンプレミスクラウドアプリケーションのデプロイメントおよびホスティングプラットフォーム。</p>
@@ -315,7 +292,7 @@
             </div>
           </div>
         </div>
-        <div class="col-sm-3 text-center">
+        <div class="col-sm-4 text-center">
           <h2>OpenShift Container Platform <font size="-1">(中文文档)</font></h2>
           <div class="list-group">
             <p class="list-group-item-text">红帽的私有内部云应用程序部署和托管平台。</p>
@@ -337,7 +314,7 @@
           </div>
         </div>
 
-        <div class="col-sm-3 text-center">
+        <div class="col-sm-4 text-center">
           <h2>OpenShift Container Platform <font size="-1">(한국어 문서)</font></h2>
           <div class="list-group">
             <p class="list-group-item-text">Red Hat의 프라이빗 온프레미스 클라우드 애플리케이션 배포 및 호스팅 플랫폼입니다.</p>


### PR DESCRIPTION
OSO has been EOL and inaccesible since late last year. Removing the distro and link from the homepage.