### PR TITLE
OSDOCS#9264: MicroShift z-stream release note 4.14.12

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -430,3 +430,12 @@ Issued: 2024-02-07
 {product-title} release 4.14.11, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0644[RHBA-2024:0644] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0642[RHSA-2024:0642] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-14-12-dp"]
+=== RHBA-2024:0737 - {microshift-short} 4.14.12 bug fix update and security advisory
+
+Issued: 2024-02-13
+
+{product-title} release 4.14.12, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0737[RHBA-2024:0737] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0735[RHSA-2024:0735] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
**Version(s):** 4.14 
**Issue:** [OSDOCS-9264](https://issues.redhat.com//browse/OSDOCS-9264)

**Link to docs preview:**

- [Red Hat build of MicroShift Branch Build release notes -> RHBA-2024:0737 - MicroShift 4.14.12 bug fix update and security advisory
](https://71439--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes#microshift-4-14-12-dp)

**QE review:**
- No QE required for this update