### PR TITLE
OSDOCS#8972: Noting that the deployer service account isn't created i…

### DIFF
--- a/modules/deployment-config-capability.adoc
+++ b/modules/deployment-config-capability.adoc
@@ -13,5 +13,11 @@ The `DeploymentConfig` capability enables and manages the `DeploymentConfig` API
 
 [IMPORTANT]
 ====
-If the `DeploymentConfig` capability is disabled, the cluster cannot use `DeploymentConfig` resources. Disable the capability only if `DeploymentConfig` resources are not required in the cluster.
+
+If you disable the `DeploymentConfig` capability, the following resources will not be available in the cluster:
+
+* `DeploymentConfig` resources
+* The `deployer` service account
+
+Disable the `DeploymentConfig` capability only if you do not require `DeploymentConfig` resources and the `deployer` service account in the cluster.
 ====

--- a/modules/service-accounts-default.adoc
+++ b/modules/service-accounts-default.adoc
@@ -18,7 +18,7 @@ cluster-wide:
 
 [cols="1,3",options="header"]
 |====
-|Service Account |Description
+|Service account |Description
 
 |`replication-controller`
 |Assigned the `system:replication-controller` role
@@ -51,9 +51,9 @@ policyConfig:
 
 Three service accounts are automatically created in each project:
 
-[options="header",cols="1,3"]
+[options="header",cols="1,3a"]
 |===
-|Service Account |Usage
+|Service account |Usage
 
 |`builder`
 |Used by build pods. It is given the `system:image-builder` role, which allows
@@ -64,10 +64,15 @@ registry.
 |Used by deployment pods and given the `system:deployer` role, which allows
 viewing and modifying replication controllers and pods in the project.
 
+[NOTE]
+====
+The `deployer` service account is not created if the `DeploymentConfig` cluster capability is not enabled.
+====
+
 |`default`
 |Used to run all other pods unless they specify a different service account.
 |===
 
 All service accounts in a project are given the `system:image-puller` role,
-which allows pulling images from any imagestream in the project using the
+which allows pulling images from any image stream in the project using the
 internal container image registry.


### PR DESCRIPTION
…f the DeploymentConfig capability is disabled

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-8972

Link to docs preview:
* https://71442--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/cluster-capabilities#deployment-config-capability_cluster-capabilities
* https://71442--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/using-service-accounts-in-applications#default-service-accounts-and-roles_using-service-accounts

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
