### PR TITLE
[ROX-22409] Add automatic cert rotation info from 4.3.4 RNs to docs

### DIFF
--- a/configuration/reissue-internal-certificates.adoc
+++ b/configuration/reissue-internal-certificates.adoc
@@ -7,8 +7,8 @@ toc::[]
 
 [role="_abstract"]
 Each component of {product-title} uses an X.509 certificate to authenticate itself to other components.
-These certificates have expiration dates, and you must reissue them before they expire.
-You can view the certificate expiry dates in the *Platform Configuration* -> *Clusters* view from the RHACS portal.
+These certificates have expiration dates, and you must reissue, or rotate, certificates before they expire.
+You can view the certificate expiration dates by selecting *Platform Configuration* -> *Clusters* in the {product-title-short} portal and viewing the *Credential Expiration* column.
 
 //Add link to role based permissions and resources
 

--- a/modules/reissue-internal-certificates-central.adoc
+++ b/modules/reissue-internal-certificates-central.adoc
@@ -7,21 +7,31 @@
 
 Central uses a built-in server certificate for authentication when communicating with other {product-title} services.
 This certificate is unique to your Central installation.
-The RHACS portal shows an information banner when the Central certificate is about to expire.
+The {product-title-short} portal shows an information banner when the Central certificate is about to expire.
 
 [NOTE]
 ====
-The information banner only appears 15 days before the certificate expiry date.
+The information banner only appears 15 days before the certificate expiration date.
 ====
+
+For Operator-based installations, beginning with {product-title-short} version 4.3.4, the Operator will automatically rotate all Central components' service transport layer security (TLS) certificates 6 months before they expire. The following conditions apply:
+
+* The rotation of certificates in the secrets does not trigger the components to automatically reload them. However, reloads typically occur when the pod is replaced as part of an {product-title-short} upgrade or as a result of node reboots. If neither of those events happens at least every 6 months, you must restart the pods before the old (in-memory) service certificates expire. For example, you can delete the pods with an `app` label that contains one of the values of `central`, `central-db`, `scanner`, or `scanner-db`.
+
+* CA certificates are not updated. They are valid for 5 years.
+
+* The service certificates in the init bundles used by secured cluster components are not updated. You must rotate the init bundles at regular intervals.
+
+For non-Operator based installations, you must manually rotate TLS certificates. Instructions for manually rotating certificates are included in the following section.
 
 .Prerequisites
 
-* To reissue certificates, you must have `write` permission for the `ServiceIdentity` resource.
+* To reissue, or rotate, certificates, you must have `write` permission for the `ServiceIdentity` resource.
 
 .Procedure
 
-. Click on the link in the banner to download a YAML configuration file, which contains a new {ocp} secret, including the certificate and key values.
-. Apply the new YAML configuration file to the cluster where you have installed Central.
+. In the {product-title-short} portal, click on the link in the banner that announces the certificate expiration to download a YAML configuration file, which contains a new secret. The secret includes the certificate and key values.
+. Apply the new YAML configuration file to the cluster where you have installed Central by running the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):

4.3+

[Issue](https://issues.redhat.com/browse/ROX-22409)

[Link to docs preview
](https://71445--docspreview.netlify.app/openshift-acs/latest/configuration/reissue-internal-certificates)

QE review:
- [x] QE has approved this change. **ACS has no QE, approved by SME**
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
