### PR TITLE
OCPBUGS-29242: Removed the in-tree driver reference from vSphere inst…

### DIFF
--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -37,10 +37,6 @@ You must ensure that the time on your ESXi hosts is synchronized before you inst
 |vSphere 7.0 Update 2 and later with virtual hardware version 15
 |This version is the minimum version that {op-system-first} supports. For more information about supported hardware on the latest version of {op-system-base-full} that is compatible with {op-system}, see link:https://catalog.redhat.com/hardware/search[Hardware] on the Red Hat Customer Portal.
 
-|Storage with in-tree drivers
-|vSphere 7.0 Update 2 and later
-|This plugin creates vSphere storage by using the in-tree storage drivers for vSphere included in {product-title}.
-
 |Optional: Networking (NSX-T)
 |vSphere 7.0 Update 2 and later
 |vSphere 7.0 Update 2 is required for {product-title}. For more information about the compatibility of NSX and {product-title}, see the Release Notes section of VMware's link:https://docs.vmware.com/en/VMware-NSX-Container-Plugin/index.html[NSX container plugin documentation].

--- a/modules/installation-vsphere-regions-zones.adoc
+++ b/modules/installation-vsphere-regions-zones.adoc
@@ -15,9 +15,9 @@ You can deploy an {product-title} cluster to multiple vSphere datacenters that r
 
 [IMPORTANT]
 ====
-The VMware vSphere region and zone enablement feature requires the vSphere Container Storage Interface (CSI) driver as the default storage driver in the cluster. As a result, the feature only available on a newly installed cluster.
+The VMware vSphere region and zone enablement feature requires the vSphere Container Storage Interface (CSI) driver as the default storage driver in the cluster. As a result, the feature is only available on a newly installed cluster.
 
-A cluster that was upgraded from a previous release defaults to using the in-tree vSphere driver, so you must enable CSI automatic migration for the cluster. You can then configure multiple regions and zones for the upgraded cluster.
+For a cluster that was upgraded from a previous release, you must enable CSI automatic migration for the cluster. You can then configure multiple regions and zones for the upgraded cluster.
 ====
 
 The default installation configuration deploys a cluster to a single vSphere datacenter. If you want to deploy a cluster to multiple vSphere datacenters, you must create an installation configuration file that enables the region and zone feature.


### PR DESCRIPTION
Version(s):
4.14, 4.15. and 4.16

Issue:
[OCPBUGS-29242](https://issues.redhat.com/browse/OCPBUGS-29242)

Link to docs preview:
* [VMware vSphere infrastructure requirements](https://71448--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs)
* [VMware vSphere infrastructure requirements](https://71448--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/upi-vsphere-installation-reqs)

SME review: 
- [X] SME has approved this change.
QE review:
- [x] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
