### PR TITLE
OSSM-5904 Troubleshooting your service mesh has a typo 

### DIFF
--- a/modules/ossm-about-collecting-ossm-data.adoc
+++ b/modules/ossm-about-collecting-ossm-data.adoc
@@ -2,6 +2,7 @@
 //
 // * service_mesh/v1x/servicemesh-release-notes.adoc
 // * service_mesh/v2x/servicemesh-release-notes.adoc
+// * service_mesh/v2x/ossm-troubleshooting-istio.adoc
 
 
 :_mod-docs-content-type: CONCEPT
@@ -38,5 +39,5 @@ This creates a local directory that contains the following items:
 * All control plane namespaces and their children objects
 * All namespaces and their children objects that belong to any service mesh
 * All Istio custom resource definitions (CRD)
-* All Istio CRD objectsm such as VirtualServices in a given namespace
+* All Istio CRD objects, such as VirtualServices, in a given namespace
 * All Istio webhooks


### PR DESCRIPTION
[OSSM-5904](https://issues.redhat.com//browse/OSSM-5904) Troubleshooting your service mesh has a typo: "m" should be a comma

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSSM-5904

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
QE is not required as this change does not impact the meaning of the docs.

Additional information:
Fixing a typo, and adding the assembly to which it belongs. Why it wasn't added before is unknown.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
