### PR TITLE
CNV-36164: Document creating VMs with persistent iSCSI reservation - UI

### DIFF
--- a/modules/virt-configuring-disk-sharing-lun-cli.adoc
+++ b/modules/virt-configuring-disk-sharing-lun-cli.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-configuring-disk-sharing-lun-cli_{context}"]
+= Configuring disk sharing by using LUN and the command line
+
+You can use the command line to configure disk sharing by using LUN.
+
+.Procedure
+
+. Edit or create the `VirtualMachine` manifest for your VM to set the required values, as shown in the following example:
++
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: vm-0
+spec:
+  template:
+    spec:
+      domain:
+        devices:
+          disks:
+          - disk:
+              bus: sata
+            name: rootdisk
+          - errorPolicy: report
+            lun: <1>
+              bus: scsi
+              reservation: true <2>
+            name: na-shared
+            serial: shared1234
+      volumes:
+      - dataVolume:
+          name: vm-0
+        name: rootdisk
+      - name: na-shared
+        persistentVolumeClaim:
+          claimName: pvc-na-share
+----
+<1> Identifies a LUN disk.
+<2> Identifies that the persistent reservation is enabled.
+
+. Save the `VirtualMachine` manifest file to apply your changes.

--- a/modules/virt-configuring-disk-sharing-lun-web.adoc
+++ b/modules/virt-configuring-disk-sharing-lun-web.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-configuring-disk-sharing-lun-web_{context}"]
+= Configuring disk sharing by using LUN and the web console
+
+You can use the {product-title} web console to configure disk sharing by using LUN.
+
+.Prerequisites
+
+*  The cluster administrator must enable the `persistentreservation` feature gate setting.
+
+.Procedure
+
+. Click *Virtualization* -> *VirtualMachines* in the web console.
+
+. Select a VM to open the *VirtualMachine details* page.
+
+. Expand *Storage*.
+
+. On the *Disks* tab, click *Add disk*.
+
+. Specify the *Name*, *Source*, *Size*, *Interface*, and *Storage Class*.
+
+. Select *LUN* as the *Type*.
+
+. Select *Shared access (RWX)* as the *Access Mode*.
+
+. Select *Block* as the *Volume Mode*.
+
+. Expand *Advanced Settings*, and select both checkboxes.
+
+. Click *Save*.

--- a/modules/virt-configuring-disk-sharing-lun.adoc
+++ b/modules/virt-configuring-disk-sharing-lun.adoc
@@ -14,6 +14,8 @@ You reserve a LUN through the SCSI persistent reserve options to protect data on
 
 .Prerequisites
 
+* You must have cluster administrator privileges to configure the feature gate option.
+
 * The volume access mode must be `ReadWriteMany` (RWX) if the VMs that are sharing disks are running on different nodes.
 +
 If the VMs that are sharing disks are running on the same node, `ReadWriteOnce` (RWO) volume access mode is sufficient.

--- a/modules/virt-enabling-persistentreservation-feature-gate-cli.adoc
+++ b/modules/virt-enabling-persistentreservation-feature-gate-cli.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * * virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-enabling-persistentreservation-feature-gate-cli_{context}"]
+= Enabling the PersistentReservation feature gate by using the command line
+
+You enable the `persistentReservation` feature gate by using the command line. Enabling the feature gate requires cluster administrator privileges.
+
+.Procedure
+
+. Enable the `persistentReservation` feature gate by running the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
+  --type json -p '[{"op":"replace","path":"/spec/featureGates/persistentReservation", "value": true}]'
+----

--- a/modules/virt-enabling-persistentreservation-feature-gate-web.adoc
+++ b/modules/virt-enabling-persistentreservation-feature-gate-web.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * * virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-enabling-persistentreservation-feature-gate-web_{context}"]
+= Enabling the PersistentReservation feature gate by using the web console
+
+You must enable the PersistentReservation feature gate to allow a LUN-backed block mode virtual machine (VM) disk to be shared among multiple virtual machines. Enabling the feature gate requires cluster administrator privileges.
+
+.Procedure
+
+. Click *Virtualization* -> *Overview* in the web console.
+
+. Click the *Settings* tab.
+
+. Select *Cluster*.
+
+. Expand *SCSI persistent reservation* and set *Enable persistent reservation* to on.

--- a/modules/virt-enabling-persistentreservation-feature-gate.adoc
+++ b/modules/virt-enabling-persistentreservation-feature-gate.adoc
@@ -2,26 +2,16 @@
 //
 // * * virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="virt-enabling-persistentreservation-feature-gate_{context}"]
 = Enabling the PersistentReservation feature gate
 
 You can enable the SCSI `persistentReservation` feature gate and allow a LUN-backed block mode virtual machine (VM) disk to be shared among multiple virtual machines.
 
-The `persistentReservation` feature gate is disabled by default.
+The `persistentReservation` feature gate is disabled by default. You can enable the `persistentReservation` feature gate by using the web console or the command line.
 
 .Prerequisites
 
 * Cluster administrator privileges are required.
 * The volume access mode `ReadWriteMany` (RWX) is required if the VMs that are sharing disks are running on different nodes. If the VMs that are sharing disks are running on the same node, the `ReadWriteOnce` (RWO) volume access mode is sufficient.
 * The storage provider must support a Container Storage Interface (CSI) driver that uses the SCSI protocol.
-
-.Procedure
-
-. Enable the `persistentReservation` feature gate by running the following command:
-+
-[source,terminal,subs="attributes+"]
-----
-$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
-  --type json -p '[{"op":"replace","path":"/spec/featureGates/persistentReservation", "value": true}]'
-----

--- a/virt/getting_started/virt-web-console-overview.adoc
+++ b/virt/getting_started/virt-web-console-overview.adoc
@@ -97,7 +97,7 @@ The *Overview* page displays resources, metrics, migration progress, and cluster
 |The *Settings* tab contains the *Cluster* tab, *User* tab, and *Preview features* tab.
 
 |*Settings* -> xref:../../virt/getting_started/virt-web-console-overview.adoc#overview-settings-cluster_virt-web-console-overview[*Cluster* tab]
-|{VirtProductName} version, update status, live migration, templates project, preview features, and load balancer service settings.
+|{VirtProductName} version, update status, live migration, templates project, load balancer service, guest management, resource management, and SCSI persistent reservation settings.
 
 |*Settings* -> xref:../../virt/getting_started/virt-web-console-overview.adoc#overview-settings-user_virt-web-console-overview[*User* tab]
 |Public SSH keys, user permissions, and welcome information settings.
@@ -226,7 +226,7 @@ The *Settings* tab displays cluster-wide settings.
 |Description
 
 |xref:../../virt/getting_started/virt-web-console-overview.adoc#overview-settings-cluster_virt-web-console-overview[*Cluster* tab]
-|{VirtProductName} version and update status, live migration, templates project, and load balancer service settings.
+|{VirtProductName} version, update status, live migration, templates project, load balancer service, guest management, resource management, and SCSI persistent reservation settings.
 
 |xref:../../virt/getting_started/virt-web-console-overview.adoc#overview-settings-user_virt-web-console-overview[*User* tab]
 |Public SSH key management, user permissions, and welcome information settings.
@@ -286,6 +286,9 @@ The cluster must have a load balancer configured.
 |Expand this section to select a project for Red Hat templates. The default project is `openshift`.
 
 To store Red Hat templates in multiple projects, xref:../../virt/getting_started/virt-web-console-overview.adoc#templates-page_virt-web-console-overview[clone the template] and then select a project for the cloned template.
+
+|*SCSI persistent reservation* section
+|Expand this section to enable persistent reservation for cluster-aware applications.
 |====
 =====
 
@@ -398,7 +401,7 @@ include::snippets/technology-preview.adoc[]
 |Project in which bootable volumes are stored. The default is `openshift-virtualization-os-images`.
 
 |*Add volume* button
-|Click to upload a new volume or to use an existing persistent volume claim.
+|Click to upload a volume or to use an existing persistent volume claim, volume snapshot, or data source.
 
 |*Filter* field
 |Filter boot sources by operating system or resource.

--- a/virt/virtual_machines/virt-edit-vms.adoc
+++ b/virt/virtual_machines/virt-edit-vms.adoc
@@ -10,6 +10,8 @@ You can update a virtual machine (VM) configuration by using the {product-title}
 
 You can also edit a VM by using the command line.
 
+To edit a VM to configure disk sharing by using virtual disks or LUN, see xref:../../virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc#virt-configuring-shared-volumes-for-vms[Configuring shared volumes for virtual machines].
+
 include::modules/virt-editing-vm-cli.adoc[leveloffset=+1]
 
 include::modules/virt-add-disk-to-vm.adoc[leveloffset=+1]

--- a/virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc
@@ -3,6 +3,7 @@
 = Configuring shared volumes for virtual machines
 include::_attributes/common-attributes.adoc[]
 :context: virt-configuring-shared-volumes-for-vms
+
 toc::[]
 
 You can configure shared disks to allow multiple virtual machines (VMs) to share the same underlying storage. A shared disk's volume must be block mode.
@@ -16,7 +17,15 @@ include::modules/virt-configuring-vm-disk-sharing.adoc[leveloffset=+1]
 
 include::modules/virt-configuring-disk-sharing-lun.adoc[leveloffset=+1]
 
+include::modules/virt-configuring-disk-sharing-lun-web.adoc[leveloffset=+2]
+
+include::modules/virt-configuring-disk-sharing-lun-cli.adoc[leveloffset=+2]
+
 include::modules/virt-enabling-persistentreservation-feature-gate.adoc[leveloffset=+1]
+
+include::modules/virt-enabling-persistentreservation-feature-gate-web.adoc[leveloffset=+2]
+
+include::modules/virt-enabling-persistentreservation-feature-gate-cli.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
Version(s): 4.15+

Issue: [CNV-36164](https://issues.redhat.com/browse/CNV-36164)

Links to docs previews:
[Configuring disk sharing by using LUN](https://71462--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms#virt-configuring-disk-sharing-lun_virt-configuring-shared-volumes-for-vms)
[Configuring disk sharing by using LUN and the web console](https://71462--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms#virt-configuring-disk-sharing-lun-web_virt-configuring-shared-volumes-for-vms)
[Configuring disk sharing by using LUN and the command line](https://71462--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms#virt-configuring-disk-sharing-lun-cli_virt-configuring-shared-volumes-for-vms)
[Enabling the persistentreservation feature gate](https://71462--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms#virt-enabling-persistentreservation-feature-gate_virt-configuring-shared-volumes-for-vms)
[Enabling the persistentreservation feature gate by using the web console](https://71462--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms#virt-enabling-persistentreservation-feature-gate-web_virt-configuring-shared-volumes-for-vms)
[Enabling the persistentreservation feature gate by using the command line](https://71462--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms#virt-enabling-persistentreservation-feature-gate-cli_virt-configuring-shared-volumes-for-vms)
[Editing virtual machines](https://71462--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-edit-vms)


Links to web console doc previews:
[Overview page>Settings tab>Cluster tab](https://71462--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/getting_started/virt-web-console-overview#overview-page_virt-web-console-overview) 
[Settings tab>Cluster tab](https://71462--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/getting_started/virt-web-console-overview#overview-settings_virt-web-console-overview)
[Cluster tab>SCSI persistent reservation section](https://71462--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/getting_started/virt-web-console-overview#overview-settings-cluster_virt-web-console-overview)


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


