### PR TITLE
OSDOCS-8643: RN for CoreDNS metrics deprecation and removal

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -455,6 +455,12 @@ With this update, you can now create multi-network policies for IPv6 networks. F
 ==== Ingress Operator metrics dashboard available
 With this release, Ingress networking metrics are now viewable from within the {product-title} web console. See xref:../networking/networking-dashboards.adoc#ingress-dashboards[Ingress Operator dashboard] for more information.
 
+[id="ocp-4-15-CoreDNS-filtration-externalname-service-queries"]
+==== CoreDNS metrics deprecation and removal
+As of {product-title} {product-version}, CoreDNS has been updated from 1.10.1 to 1.11.1.
+
+This update to CoreDNS resulted in the deprecation and removal of certain metrics that have been relocated, including the metrics `coredns_forward_healthcheck_failures_total`, `coredns_forward_requests_total`, `coredns_forward_responses_total`, and `coredns_forward_request_duration_seconds`. See link:https://coredns.io/plugins/forward/#metrics[CoreDNS Metrics] for more information.
+
 [id="ocp-4-15-registry"]
 === Registry
 


### PR DESCRIPTION
**Fixes:** [OSDOCS-8643](https://issues.redhat.com/browse/OSDOCS-8643)

**For:** Version 4.15 

**Signed-off-by:** Katie Drake kdrake@redhat.com

**QE review:**
- [x] QE has approved this change.