### PR TITLE
OADP 3356 - fixed Local self-signed CA certificates

### DIFF
--- a/modules/oadp-self-signed-certificate.adoc
+++ b/modules/oadp-self-signed-certificate.adoc
@@ -39,3 +39,58 @@ spec:
 ----
 <1> Specify the Base64-encoded CA certificate string.
 <2> The `insecureSkipTLSVerify` configuration can be set to either `"true"` or `"false"`. If set to `"true"`, SSL/TLS security is disabled. If set to `"false"`, SSL/TLS security is enabled.
+
+[id="oadp-using-ca-certificates-with-velero-command-aliased-for-velero-deployment_{context}"]
+== Using CA certificates with the velero command aliased for Velero deployment
+
+You might want to use the Velero CLI without installing it locally on your system by creating an alias for it.
+
+.Prerequisites
+
+* You must be logged in to the OpenShift Container Platform cluster as a user with the `cluster-admin` role.
+* You must have the OpenShift CLI (`oc`) installed.
+
+. To use an aliased Velero command, run the following command:
++
+[source,terminal]
+----
+$ alias velero='oc -n openshift-adp exec deployment/velero -c velero -it -- ./velero'
+----
+. Check that the alias is working by running the following command:
++
+[source,terminal]
+.Example
+----
+$ velero version
+Client:
+	Version: v1.12.1-OADP
+	Git commit: -
+Server:
+	Version: v1.12.1-OADP
+----
+
+. To use a CA certificate with this command, you can add a certificate to the Velero deployment by running the following commands:
++
+[source,terminal]
+----
+$ CA_CERT=$(oc -n openshift-adp get dataprotectionapplications.oadp.openshift.io <dpa-name> -o jsonpath='{.spec.backupLocations[0].velero.objectStorage.caCert}')
+
+$ [[ -n $CA_CERT ]] && echo "$CA_CERT" | base64 -d | oc exec -n openshift-adp -i deploy/velero -c velero -- bash -c "cat > /tmp/your-cacert.txt" || echo "DPA BSL has no caCert"
+----
++
+[source,terminal]
+----
+$ velero -n openshift-adp describe backup <backup-name> --details --cacert /tmp/your-cacert.txt
+----
++
+. If the Velero pod restarts, the `/tmp/your-cacert.txt` file disappears, and you must re-create the `/tmp/your-cacert.txt` file by re-running the commands from the previous step.
+
+. You can check if the `/tmp/your-cacert.txt` file still exists, in the file location where you stored it, by running the following command:
++
+[source,terminal]
+----
+$ oc exec -n openshift-adp -i deploy/velero -c velero -- bash -c "ls /tmp/your-cacert.txt"
+/tmp/your-cacert.txt
+----
+
+In a future release of OpenShift API for Data Protection (OADP), we plan to mount the certificate to the Velero pod so that this step is not required.


### PR DESCRIPTION
OADP 1.3.1

OCP 4.13+

Resolves - https://issues.redhat.com/browse/OADP-3356

Deploy preview - https://71473--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws#oadp-self-signed-certificate_installing-oadp-aws

https://71473--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure#oadp-self-signed-certificate_installing-oadp-azure

https://71473--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp#oadp-self-signed-certificate_installing-oadp-gcp

https://71473--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg#oadp-self-signed-certificate_installing-oadp-mcg

https://71473--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs#oadp-self-signed-certificate_installing-oadp-ocs


