### PR TITLE
OADP 3306- VolumeSnapshoClass-deletion policy-retain removed

### DIFF
--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-pvs-csi-doc.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-pvs-csi-doc.adoc
@@ -19,6 +19,7 @@ For more information, see xref:../../../backup_and_restore/application_backup_an
 
 * Add the `metadata.labels.velero.io/csi-volumesnapshot-class: "true"` key-value pair to the `VolumeSnapshotClass` CR:
 +
+.Example configuration file
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: snapshot.storage.k8s.io/v1
@@ -26,9 +27,16 @@ kind: VolumeSnapshotClass
 metadata:
   name: <volume_snapshot_class_name>
   labels:
-    velero.io/csi-volumesnapshot-class: "true"
+    velero.io/csi-volumesnapshot-class: "true" <1>
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: true <2>
 driver: <csi_driver>
-deletionPolicy: Retain
+deletionPolicy: <deletion_policy_type> <3>
 ----
+<1> Must be set to `true`.
+<2> Must be set to `true`.
+<3> OADP supports the `Retain` and `Delete` deletion policy types for CSI and Data Mover backup and restore. For the OADP 1.2 Data Mover, set the deletion policy type to `Retain`.
 
-You can now create a `Backup` CR.
+.Next steps
+
+* You can now create a `Backup` CR.

--- a/backup_and_restore/application_backup_and_restore/installing/oadp-12-data-mover-ceph-doc.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/oadp-12-data-mover-ceph-doc.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 [id="oadp-12-data-mover-ceph-doc"]
 = Using OADP 1.2 Data Mover with Ceph storage
 include::_attributes/common-attributes.adoc[]
@@ -5,13 +6,13 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can use OADP 1.2 Data Mover to backup and restore application data for clusters that use CephFS, CephRBD, or both.
+You can use OADP 1.2 Data Mover to back up and restore application data for clusters that use CephFS, CephRBD, or both.
 
 OADP 1.2 Data Mover leverages Ceph features that support large-scale environments. One of these is the shallow copy method, which is available for {product-title} 4.12 and later. This feature supports backing up and restoring `StorageClass` and `AccessMode` resources other than what is found on the source persistent volume claim (PVC).
 
 [IMPORTANT]
 ====
-The CephFS shallow copy feature is a back up feature. It is not part of restore operations.
+The CephFS shallow copy feature is a backup feature. It is not part of restore operations.
 ====
 
 include::modules/oadp-ceph-prerequisites.adoc[leveloffset=+1]
@@ -45,7 +46,7 @@ include::modules/oadp-ceph-cephfs-restore.adoc[leveloffset=+2]
 [id="oadp-ceph-split"]
 == Backing up and restoring data using OADP 1.2 Data Mover and split volumes (CephFS and Ceph RBD)
 
-You can use OpenShift API for Data Protection (OADP) 1.2 Data Mover to back up and restore data in an environment that has _split volumes_, that is, an environment that uses both CephFS and CephRBD.
+You can use OpenShift API for Data Protection (OADP) 1.2 Data Mover to backup and restore data in an environment that has _split volumes_, that is, an environment that uses both CephFS and CephRBD.
 
 include::snippets/oadp-ceph-cr-prerequisites.adoc[]
 
@@ -60,3 +61,5 @@ include::modules/oadp-ceph-cephfs-restore.adoc[leveloffset=+2]
 :context: !split
 
 :context: backing-up-applications
+
+include::modules/oadp-deletion-policy-1-2.adoc[leveloffset=+1]

--- a/backup_and_restore/application_backup_and_restore/installing/oadp-backup-restore-csi-snapshots.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/oadp-backup-restore-csi-snapshots.adoc
@@ -12,5 +12,4 @@ include::modules/oadp-1-3-backing-csi-snapshots.adoc[leveloffset=+1]
 
 include::modules/oadp-1-3-restoring-csi-snapshots.adoc[leveloffset=+1]
 
-
-
+include::modules/oadp-deletion-policy-1-3.adoc[leveloffset=+1]

--- a/modules/oadp-backing-up-pvs-csi.adoc
+++ b/modules/oadp-backing-up-pvs-csi.adoc
@@ -18,6 +18,7 @@ You back up persistent volumes with Container Storage Interface (CSI) snapshots 
 
 * Add the `metadata.labels.velero.io/csi-volumesnapshot-class: "true"` key-value pair to the `VolumeSnapshotClass` CR:
 +
+.Example configuration file
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: snapshot.storage.k8s.io/v1
@@ -25,9 +26,16 @@ kind: VolumeSnapshotClass
 metadata:
   name: <volume_snapshot_class_name>
   labels:
-    velero.io/csi-volumesnapshot-class: "true"
+    velero.io/csi-volumesnapshot-class: "true" <1>
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: true <2>
 driver: <csi_driver>
-deletionPolicy: Retain
+deletionPolicy: <deletion_policy_type> <3>
 ----
+<1> Must be set to `true`.
+<2> Must be set to `true`.
+<3> OADP supports the `Retain` and `Delete` deletion policy types for CSI and Data Mover backup and restore. For the OADP 1.2 Data Mover, set the deletion policy type to `Retain`.
 
-You can now create a `Backup` CR.
+.Next steps
+
+* You can now create a `Backup` CR.

--- a/modules/oadp-ceph-cephfs-back-up-dba.adoc
+++ b/modules/oadp-ceph-cephfs-back-up-dba.adoc
@@ -10,7 +10,7 @@ You must create a Data Protection Application (DPA) CR before you use the OpenSh
 
 .Procedure
 
-. Verify that the `deletionPolicy` field of the `VolumeSnapshotClass` CR is set to `Retain` by running the following command:
+. For the OADP 1.2 Data Mover, you must verify that the `deletionPolicy` field of the `VolumeSnapshotClass` CR is set to `Retain` by running the following command:
 +
 [source,terminal]
 ----
@@ -55,8 +55,8 @@ spec:
         objectStorage:
           bucket: <my_bucket>
           prefix: velero
-       provider: aws
-    configuration:
+        provider: aws
+  configuration:
       restic:
         enable: false  <1>
       velero:
@@ -65,7 +65,7 @@ spec:
           - aws
           - csi
           - vsm
-    features:
+  features:
       dataMover:
         credentialName: <restic_secret_name> <2>
         enable: true <3>

--- a/modules/oadp-ceph-preparing-cephfs-crs.adoc
+++ b/modules/oadp-ceph-preparing-cephfs-crs.adoc
@@ -17,7 +17,7 @@ When you install {rh-storage-first}, it automatically creates a default CephFS `
 [source,yaml]
 ----
 apiVersion: snapshot.storage.k8s.io/v1
-deletionPolicy: Retain <1>
+deletionPolicy: <deletion_policy_type> <1>
 driver: openshift-storage.cephfs.csi.ceph.com
 kind: VolumeSnapshotClass
 metadata:
@@ -31,7 +31,7 @@ parameters:
   csi.storage.k8s.io/snapshotter-secret-name: rook-csi-cephfs-provisioner
   csi.storage.k8s.io/snapshotter-secret-namespace: openshift-storage
 ----
-<1> Must be set to `Retain`.
+<1> OADP supports the `Retain` and `Delete` deletion policy types for CSI and Data Mover backup and restore. For the OADP 1.2 Data Mover, set the deletion policy type to `Retain`.
 <2> Must be set to `true`.
 <3> Must be set to `true`.
 

--- a/modules/oadp-ceph-preparing-cephrbd-crs.adoc
+++ b/modules/oadp-ceph-preparing-cephrbd-crs.adoc
@@ -17,7 +17,7 @@ When you install {rh-storage-first}, it automatically creates a default CephRBD 
 [source,yaml]
 ----
 apiVersion: snapshot.storage.k8s.io/v1
-deletionPolicy: Retain <1>
+deletionPolicy: <deletion_policy_type> <1>
 driver: openshift-storage.rbd.csi.ceph.com
 kind: VolumeSnapshotClass
 metadata:
@@ -29,7 +29,7 @@ parameters:
   csi.storage.k8s.io/snapshotter-secret-name: rook-csi-rbd-provisioner
   csi.storage.k8s.io/snapshotter-secret-namespace: openshift-storage
 ----
-<1> Must be set to `Retain`.
+<1> OADP supports the `Retain` and `Delete` deletion policy types for CSI and Data Mover backup and restore. For the OADP 1.2 Data Mover, set the deletion policy type to `Retain`.
 <2> Must be set to `true`.
 
 . Define the `StorageClass` CR as in the following example:

--- a/modules/oadp-deletion-policy-1-2.adoc
+++ b/modules/oadp-deletion-policy-1-2.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="oadp-deletion-policy-1-2_{context}"]
+= Deletion policy for OADP 1.2
+
+The deletion policy determines rules for removing data from a system, specifying when and how deletion occurs based on factors such as retention periods, data sensitivity, and compliance requirements. It manages data removal effectively while meeting regulations and preserving valuable information.
+
+[id="oadp-deletion-policy-guidelines-1-2_{context}"]
+== Deletion policy guidelines for OADP 1.2
+
+Review the following deletion policy guidelines for the OADP 1.2:
+
+* To use OADP 1.2.x Data Mover to backup and restore, set the `deletionPolicy` field to `Retain` in the `VolumeSnapshotClass` custom resource (CR).
+
+* In OADP 1.2.x, to use CSI backup and restore, you can set the `deletionPolicy` field to either `Retain` or `Delete` in the `VolumeSnapshotClass` CR.
+
+[IMPORTANT]
+====
+OADP 1.2.x Data Mover to backup and restore is a Technology Preview feature and is not supported without a support exception.
+====

--- a/modules/oadp-deletion-policy-1-3.adoc
+++ b/modules/oadp-deletion-policy-1-3.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="oadp-deletion-policy-1-3_{context}"]
+= Deletion policy for OADP 1.3
+
+The deletion policy determines rules for removing data from a system, specifying when and how deletion occurs based on factors such as retention periods, data sensitivity, and compliance requirements. It manages data removal effectively while meeting regulations and preserving valuable information.
+
+[id="oadp-deletion-policy-guidelines-1-3_{context}"]
+== Deletion policy guidelines for OADP 1.3
+
+Review the following deletion policy guidelines for the OADP 1.3:
+
+* In OADP 1.3.x, when using any type of backup and restore methods, you can set the `deletionPolicy` field to `Retain` or `Delete` in the `VolumeSnapshotClass` custom resource (CR).

--- a/modules/oadp-using-data-mover-for-csi-snapshots.adoc
+++ b/modules/oadp-using-data-mover-for-csi-snapshots.adoc
@@ -44,8 +44,6 @@ Red Hat recommends that customers who use OADP 1.2 Data Mover in order to back u
 In {product-title} version 4.12 or later, verify that this is the only default `volumeSnapshotClass`.
 ====
 
-* You have verified that `deletionPolicy` of the `VolumeSnapshotClass` CR is set to `Retain`.
-
 * You have verified that only one `storageClass` CR has the annotation `storageclass.kubernetes.io/is-default-class: true`.
 
 * You have included the label `{velero-domain}/csi-volumesnapshot-class: 'true'` in your `VolumeSnapshotClass` CR.


### PR DESCRIPTION
OADP 1.3.1

OCP 4.13+

Resolves - https://issues.redhat.com/browse/OADP-3306

Deploy preview - 

https://71474--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-pvs-csi-doc

https://71474--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/oadp-using-data-mover-for-csi-snapshots-doc

https://71474--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/oadp-12-data-mover-ceph-doc#oadp-ceph-preparing-cephfs-crs_backing-up-applications

https://71474--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/oadp-12-data-mover-ceph-doc#oadp-ceph-preparing-cephrbd-crs_backing-up-applications

https://71474--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/oadp-12-data-mover-ceph-doc#oadp-ceph-cephfs-back-up-dba_cephfs

https://71474--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/oadp-12-data-mover-ceph-doc#oadp-deletion-policy

https://71474--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/oadp-backup-restore-csi-snapshots#oadp-deletion-policy-1-3_oadp-backup-restore-csi-snapshots
