### PR TITLE
WMCO 8.1.2 release notes

### DIFF
--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -7,10 +7,12 @@
 
 The following information details the supported platform versions, Windows Server versions, and networking configurations for the Windows Machine Config Operator. See the vSphere documentation for any information that is relevant to only that platform.
 
-[id="wmco-prerequisites-supported-8.1.1_{context}"]
-== WMCO 8.1.1 supported platforms and Windows Server versions
-
 The following table lists the link:https://docs.microsoft.com/en-us/windows/release-health/windows-server-release-info[Windows Server versions] that are supported by WMCO 8.1.1, based on the applicable platform. Windows Server versions not listed are not supported, and attempting to use them will cause errors. To prevent these errors, use only an appropriate version for your platform.
+
+[id="wmco-prerequisites-supported-8.1.2_{context}"]
+== WMCO 8.1.x supported platforms and Windows Server versions
+
+The following table lists the link:https://docs.microsoft.com/en-us/windows/release-health/windows-server-release-info[Windows Server versions] that are supported by WMCO 8.1.x, based on the applicable platform. Windows Server versions not listed are not supported and attempting to use them will cause errors. To prevent these errors, use only an appropriate version for your platform.
 
 [cols="3,7",options="header"]
 |===

--- a/windows_containers/windows-containers-release-notes-8-x.adoc
+++ b/windows_containers/windows-containers-release-notes-8-x.adoc
@@ -28,6 +28,20 @@ For more information, see the Red Hat OpenShift Container Platform Life Cycle Po
 If you do not have this additional Red Hat subscription, you can use the Community Windows Machine Config Operator, a distribution that lacks official support.
 endif::openshift-origin[]
 
+[id="wmco-8-1-2"]
+== Release notes for Red{nbsp}Hat Windows Machine Config Operator 8.1.2
+
+This release of the WMCO provides new features and bug fixes for running Windows compute nodes in an {product-title} cluster. The components of WMCO 8.1.2 were released in link:https://access.redhat.com/errata/RHSA-2024:1477[RHSA-2024:1477].
+
+[id="wmco-8-1-2-bug-fixes"]
+=== Bug fixes
+
+// Also in 10.15.0
+* Previously, because of bad logic in the networking configuration script, the WICD was incorrectly reading carriage returns in the CNI configuration file as changes, and identified the file as modified. This caused the CNI configuration to be unnecessarily reloaded, potentially resulting in container restarts and brief network outages. With this fix, the WICD now reloads the CNI configuration only when the CNI configuration is actually modified. (link:https://issues.redhat.com/browse/OCPBUGS-27046[*OCPBUGS-27046*])
+
+// Also in 10.15.0
+* Previously, because of a lack of synchronization between Windows machine set nodes and BYOH instances, during an update the machine set nodes and the BYOH instances could update simultaneously. This could impact running workloads. This fix introduces a locking mechanism so that machine set nodes and BYOH instances update individually. (link:https://issues.redhat.com/browse/OCPBUGS-23016[*OCPBUGS-23016*])
+
 [id="wmco-8-1-1"]
 == Release notes for Red Hat Windows Machine Config Operator 8.1.1
 


### PR DESCRIPTION
Errata: https://errata.devel.redhat.com/docs/show/125566

**PEER REVIEWER**
The bug texts were already QE- and peer- reviewed along with the [10.15.0 release notes](https://github.com/openshift/openshift-docs/pull/71436). 

Previews
[Release notes for Red Hat Windows Machine Config Operator 8.1.2](https://71485--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-8-x#wmco-8-1-2)
[WMCO 8.1.2 supported platforms and Windows Server versions](https://71485--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-8-x#wmco-prerequisites-supported-8.1.2_windows-containers-release-notes)
