### PR TITLE
Adds image registry doc text to 4.15 release notes

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -975,6 +975,13 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 [id="ocp-4-15-image-registry-bug-fixes"]
 ==== Image Registry
 
+* Previously, the Image Registry pruner relied on a cluster role that was managed by the OpenShift API server. This could cause the pruner job to intermittently fail during an upgrade. Now, the Image Registry Operator is responsible for creating the pruner cluster role, which resolves the issue. (link:https://issues.redhat.com/browse/OCPBUGS-18969[*OCPBUGS-18969*])
+
+* The Image Registry Operator makes API calls to the storage account list endpoint as part of obtaining access keys. In projects with several {product-title} clusters, this might lead to API limits being reached. As a result, `429` errors were returned when attempting to create new clusters. With this update, the time between calls has been increased from 5 minutes to 20 minutes, and API limits are no longer reached. (link:https://issues.redhat.com/browse/OCPBUGS-18469[*OCPBUGS-18469*])
+
+* Previously, the default low settings for QPS and Burst caused the image registry to return with a gateway timeout error when API server requests were not returned in an appropriate time. To resolve this issue, users had to restart the image registry. With this update, the default settings for QPS and Burst have been increased, and this issue no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-18999[*OCPBUGS-18999*])
+
+* Previously, when creating the deployment resource for the Cluster Image Registry Operator, error handling used a pointer variable without checking if the value was `nil` first. Consequently, when the pointer value was `nil`, a panic was reported in the logs. With this update, a nil check was added so that the panic is no longer reported in the logs. (link:https://issues.redhat.com/browse/OCPBUGS-18103[*OCPBUGS-18103*])
 
 [discrete]
 [id="ocp-4-15-installer-bug-fixes"]


### PR DESCRIPTION
Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OCPBUGS-18969

https://issues.redhat.com/browse/OCPBUGS-18469

https://issues.redhat.com/browse/OCPBUGS-18999

https://issues.redhat.com/browse/OCPBUGS-18103

Link to docs preview:
https://71487--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-bug-fixes


