### PR TITLE
OSDOCS-9559: Added OIDC provider note to prereqs

### DIFF
--- a/rosa_planning/rosa-cloud-expert-prereq-checklist.adoc
+++ b/rosa_planning/rosa-cloud-expert-prereq-checklist.adoc
@@ -28,9 +28,14 @@ This is a high level checklist and your implementation can vary.
 Before running the installation process, verify that you deploy this from a machine that has access to:
 
 * The API services for the cloud to which you provision.
-* Access to `api.openshift.com` and `sso.redhat.com`.
+* Access to `api.openshift.com`, `oidc.op1.openshiftapps.com`, and `sso.redhat.com`.
 * The hosts on the network that you provision.
 * The internet to obtain installation media.
+
+[IMPORTANT]
+====
+Starting with version 1.2.7 of the ROSA CLI, all OIDC provider endpoint URLs on new clusters use Amazon CloudFront and the link:http://oidc.op1.openshiftapps.com/[oidc.op1.openshiftapps.com] domain. This change improves access speed, reduces latency, and improves resiliency for new clusters created with the ROSA CLI 1.2.7 or later. There are no supported migration paths for existing OIDC provider configurations.
+====
 
 == Accounts and CLIs Prerequisites
 


### PR DESCRIPTION
Version(s):
`enterprise-4.14+`

Issue:
[OSDOCS-9559](https://issues.redhat.com/browse/OSDOCS-9559)

Link to docs preview:
- [Prerequisites checklist for deploying ROSA using STS](https://file.rdu.redhat.com/eponvell/OSDOCS-9559_OIDC-Note/rosa_planning/rosa-cloud-expert-prereq-checklist.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added [a note from the What's New topic](https://docs.openshift.com/rosa/rosa_release_notes/rosa-release-notes.html#rosa-q1-2023_rosa-whats-new) into the AWS Prereqs topic.
