### PR TITLE
OSDOCS#9638: Adds  extension

### DIFF
--- a/modules/dynamic-plugin-sdk-extensions.adoc
+++ b/modules/dynamic-plugin-sdk-extensions.adoc
@@ -1024,6 +1024,37 @@ component to be rendered when the model matches
 |===
 
 [discrete]
+== `console.resource/details-item`
+
+Adds a new details item to the default resource summary on the details page.
+
+[cols=".^2,.^3a,.^3a,.^3a",options="header"]
+|===
+|Name |Value Type |Optional |Description
+|`model` |`ExtensionK8sModel` |no |The subject resource's API group, version, and kind.
+
+|`id`
+|`string` |no |A unique identifier.
+
+|`column`
+|`DetailsItemColumn` |no |Determines if the item will appear in the 'left' or 'right' column of the resource summary on the details page. Default: 'right'
+
+|`title`
+|`string` |no |The details item title.
+
+|`path`
+|`string` |yes |An optional, fully-qualified path to a resource property to used as the details item value. Only link:https://developer.mozilla.org/en-US/docs/Glossary/Primitive[primitive type] values can be rendered directly. Use the component property to handle other data types.
+
+|`component`
+|`CodeRef<React.ComponentType<DetailsItem
+ComponentProps<K8sResourceCommon, any>>>` |yes |An optional React component that will render the details item value.
+
+|`sortWeight`
+|`number` |yes |An optional sort weight, relative to all other details items in the same column. Represented by any valid link:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#number_type[JavaScriptNumber]. Items in each column are sorted independently, lowest to highest. Items without sort weightsare sorted after items with sort weights.
+
+|===
+
+[discrete]
 == `console.storage-class/provisioner`
 
 Adds a new storage class provisioner as an option during storage class creation.


### PR DESCRIPTION
OSDOCS#9638: Adds  `console.resource/details-item` extension

Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-9638

Link to docs preview:
https://71494--ocpdocs-pr.netlify.app/openshift-enterprise/latest/web_console/dynamic-plugin/dynamic-plugins-reference#dynamic-plugin-sdk-extensions_dynamic-plugins-reference 
Scroll or search to find `console.resource/details-item`

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Note to docs peer reviewer that these are from https://github.com/openshift/console/blob/master/frontend/packages/console-dynamic-plugin-sdk/docs/console-extensions.md#consoleresourcedetails-item
