### PR TITLE
OCPBUGS#29369: Update naming syntax for Operator groups

### DIFF
--- a/modules/olm-operatorgroups-rbac.adoc
+++ b/modules/olm-operatorgroups-rbac.adoc
@@ -11,13 +11,13 @@ When an Operator group is created, three cluster roles are generated. Each conta
 |===
 |Cluster role |Label to match
 
-|`<operatorgroup_name>-admin`
+|`olm.og.<operatorgroup_name>-admin-<hash_value>`
 |`olm.opgroup.permissions/aggregate-to-admin: <operatorgroup_name>`
 
-|`<operatorgroup_name>-edit`
+|`olm.og.<operatorgroup_name>-edit-<hash_value>`
 |`olm.opgroup.permissions/aggregate-to-edit: <operatorgroup_name>`
 
-|`<operatorgroup_name>-view`
+|`olm.og.<operatorgroup_name>-view-<hash_value>`
 |`olm.opgroup.permissions/aggregate-to-view: <operatorgroup_name>`
 |===
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUGS-29369](https://issues.redhat.com/browse/OCPBUGS-29369)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://71496--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/understanding/olm/olm-understanding-operatorgroups#olm-operatorgroups-rbac_olm-understanding-operatorgroups
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change. (Acked in the JIRA ticket https://issues.redhat.com/browse/OCPBUGS-29369)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
