### PR TITLE
OCPBUGS-29085: added shiftstack known issue to 4.15 release notes

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -1694,6 +1694,8 @@ In the following tables, features are marked with the following statuses:
 
 * When running a cluster with FIPS enabled, you might receive the following error when running an older version of the OpenShift CLI (`oc`) on a {op-system-base} 9 system: `FIPS mode is enabled, but the required OpenSSL backend is unavailable`. As a workaround, use the `oc` binary provided with the {product-title} cluster. (link:https://issues.redhat.com/browse/OCPBUGS-23386[*OCPBUGS-23386*])
 
+* In {product-version} with IPv6 networking running on {rh-openstack-first} environments, `IngressController` objects configured with the `endpointPublishingStrategy.type=LoadBalancerService` YAML attribute will not function correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2263550[*BZ#2263550*], link:https://bugzilla.redhat.com/show_bug.cgi?id=2263552[*BZ#2263552*])
+
 [id="ocp-telco-ran-4-15-known-issues"]
 
 [id="ocp-4-15-asynchronous-errata-updates"]


### PR DESCRIPTION
Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OCPBUGS-29085

Link to docs preview (VPN required):
[Known Issues](https://file.rdu.redhat.com/antaylor/OCPBUGS-29085/release_notes/ocp-4-15-release-notes.html#ocp-4-15-known-issues) (fourth one down)
