### PR TITLE
OSDOCS-9519: Added eu-south-1 region to ROSA docs

### DIFF
--- a/modules/rosa-hcp-classic-comparison.adoc
+++ b/modules/rosa-hcp-classic-comparison.adoc
@@ -57,6 +57,7 @@
 * Europe - Frankfurt (eu-central-1)
 * Europe - Ireland (eu-west-1)
 * Europe - London (eu-west-2)
+* Europe - Milan (eu-south-1)
 * US East - N. Virginia (us-east-1)
 * US East - Ohio (us-east-2)
 * US West - Oregon (us-west-2)

--- a/modules/rosa-sdpolicy-am-regions-az.adoc
+++ b/modules/rosa-sdpolicy-am-regions-az.adoc
@@ -55,7 +55,9 @@ endif::rosa-with-hcp[]
 ifndef::rosa-with-hcp[]
 * eu-central-2 (Zurich, AWS opt-in required)
 * eu-north-1 (Stockholm)
+endif::rosa-with-hcp[]
 * eu-south-1 (Milan, AWS opt-in required)
+ifndef::rosa-with-hcp[]
 * eu-south-2 (Spain, AWS opt-in required)
 endif::rosa-with-hcp[]
 * eu-west-1 (Ireland)


### PR DESCRIPTION
Version(s):
`enterprise-4.14+`

Issue:
[OSDOCS-9519](https://issues.redhat.com/browse/OSDOCS-9519)

Link to docs preview:
* [Regions and availability zones](https://file.rdu.redhat.com/eponvell/OSDOCS-9519_eu-south-1-region/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-regions-az_rosa-service-definition) for ROSA Classic
* [Regions and availability zones](https://file.rdu.redhat.com/eponvell/OSDOCS-9519_eu-south-1-region/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-regions-az_rosa-hcp-service-definition) for ROSA with HCP
* [Comparing ROSA with hosted control planes and ROSA Classic](https://file.rdu.redhat.com/eponvell/OSDOCS-9519_eu-south-1-region/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html#rosa-hcp-classic-comparison_rosa-hcp-sts-creating-a-cluster-quickly)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added the `eu-south-1` region to ROSA with HCP docs.