### PR TITLE
OSDOCS-9521: Added ap-south-1 region

### DIFF
--- a/modules/rosa-hcp-classic-comparison.adoc
+++ b/modules/rosa-hcp-classic-comparison.adoc
@@ -54,20 +54,21 @@
 
 | *Regional Availability*
 |
+* US East - N. Virginia (us-east-1)
+* US East - Ohio (us-east-2)
+* US West - Oregon (us-west-2)
+* Asia Pacific - Hyderabad (ap-south-2)
+* Asia Pacific - Jakarta (ap-southeast-3)
+* Asia Pacific - Melbourne (ap-southeast-4)
+* Asia Pacific - Mumbai (ap-south-1)
+* Asia Pacific - Singapore (ap-southeast-1)
+* Asia Pacific - Sydney (ap-southeast-2)
+* Asia Pacific - Tokyo (ap-northeast-1)
+* Canada - Central (ca-central-1)
 * Europe - Frankfurt (eu-central-1)
 * Europe - Ireland (eu-west-1)
 * Europe - London (eu-west-2)
 * Europe - Milan (eu-south-1)
-* US East - N. Virginia (us-east-1)
-* US East - Ohio (us-east-2)
-* US West - Oregon (us-west-2)
-* Asia Pacific - Tokyo (ap-northeast-1)
-* Asia Pacific - Hyderabad (ap-south-2)
-* Asia Pacific - Singapore (ap-southeast-1)
-* Asia Pacific - Sydney (ap-southeast-2)
-* Asia Pacific - Jakarta (ap-southeast-3)
-* Asia Pacific - Melbourne (ap-southeast-4)
-* Canada - Central (ca-central-1)
 | For AWS Region availability, see link:https://docs.aws.amazon.com/general/latest/gr/rosa.html[Red Hat OpenShift Service on AWS endpoints and quotas] in the AWS documentation.
 
 | *Compliance*

--- a/modules/rosa-sdpolicy-am-regions-az.adoc
+++ b/modules/rosa-sdpolicy-am-regions-az.adoc
@@ -35,47 +35,43 @@ GovCloud (US) regions are only supported on ROSA Classic clusters.
 .AWS Regions
 [%collapsible]
 ====
+* us-east-1 (N. Virginia)
+* us-east-2 (Ohio)
+ifndef::rosa-with-hcp[]
+* us-west-1 (N. California)
+* us-gov-east-1 - (AWS GovCloud - US-East)
+* us-gov-west-1 - (AWS GovCloud - US-West)
+endif::rosa-with-hcp[]
+* us-west-2 (Oregon)
 ifndef::rosa-with-hcp[]
 * af-south-1 (Cape Town, AWS opt-in required)
 * ap-east-1 (Hong Kong, AWS opt-in required)
 endif::rosa-with-hcp[]
-* ap-northeast-1 (Tokyo)
-ifndef::rosa-with-hcp[]
-* ap-northeast-2 (Seoul)
-* ap-northeast-3 (Osaka)
-* ap-south-1 (Mumbai)
-endif::rosa-with-hcp[]
 * ap-south-2 (Hyderabad, AWS opt-in required)
-* ap-southeast-1 (Singapore)
-* ap-southeast-2 (Sydney)
 * ap-southeast-3 (Jakarta, AWS opt-in required)
 * ap-southeast-4 (Melbourne, AWS opt-in required)
+* ap-south-1 (Mumbai)
+ifndef::rosa-with-hcp[]
+* ap-northeast-3 (Osaka)
+* ap-northeast-2 (Seoul)
+endif::rosa-with-hcp[]
+* ap-southeast-1 (Singapore)
+* ap-southeast-2 (Sydney)
+* ap-northeast-1 (Tokyo)
 * ca-central-1 (Central Canada)
 * eu-central-1 (Frankfurt)
-ifndef::rosa-with-hcp[]
-* eu-central-2 (Zurich, AWS opt-in required)
-* eu-north-1 (Stockholm)
-endif::rosa-with-hcp[]
-* eu-south-1 (Milan, AWS opt-in required)
-ifndef::rosa-with-hcp[]
-* eu-south-2 (Spain, AWS opt-in required)
-endif::rosa-with-hcp[]
 * eu-west-1 (Ireland)
 * eu-west-2 (London)
+* eu-south-1 (Milan, AWS opt-in required)
 ifndef::rosa-with-hcp[]
 * eu-west-3 (Paris)
-* me-central-1 (UAE, AWS opt-in required)
+* eu-south-2 (Spain, AWS opt-in required)
+* eu-north-1 (Stockholm)
+* eu-central-2 (Zurich, AWS opt-in required)
 * me-south-1 (Bahrain, AWS opt-in required)
+* me-central-1 (UAE, AWS opt-in required)
 * sa-east-1 (São Paulo)
 endif::rosa-with-hcp[]
-* us-east-1 (N. Virginia)
-* us-east-2 (Ohio)
-ifndef::rosa-with-hcp[]
-* us-gov-east-1 - (AWS GovCloud - US-East)
-* us-gov-west-1 - (AWS GovCloud - US-West)
-* us-west-1 (N. California)
-endif::rosa-with-hcp[]
-* us-west-2 (Oregon)
 ====
 
 Multiple availability zone clusters can only be deployed in regions with at least 3 availability zones. For more information, see the link:https://aws.amazon.com/about-aws/global-infrastructure/regions_az/[Regions and Availability Zones] section in the AWS documentation.


### PR DESCRIPTION
Version(s):
`enterprise-4.14+`

Issue:
[OSDOCS-9521](https://issues.redhat.com/browse/OSDOCS-9521)

Link to docs preview:
* [Regions and availability zones](http://file.rdu.redhat.com/eponvell/OSDOCS-9521_ap-south-1-region/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-regions-az_rosa-service-definition) for ROSA Classic
* [Regions and availability zones](http://file.rdu.redhat.com/eponvell/OSDOCS-9521_ap-south-1-region/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-regions-az_rosa-hcp-service-definition) for ROSA with HCP
* [Comparing ROSA with hosted control planes and ROSA Classic](http://file.rdu.redhat.com/eponvell/OSDOCS-9521_ap-south-1-region/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html#rosa-hcp-classic-comparison_rosa-hcp-sts-creating-a-cluster-quickly)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added the `ap-south-1` region to ROSA with HCP docs.