### PR TITLE
OSDOCS-9520: Added the  eu-west-2 region

### DIFF
--- a/modules/rosa-hcp-classic-comparison.adoc
+++ b/modules/rosa-hcp-classic-comparison.adoc
@@ -56,6 +56,7 @@
 |
 * Europe - Frankfurt (eu-central-1)
 * Europe - Ireland (eu-west-1)
+* Europe - London (eu-west-2)
 * US East - N. Virginia (us-east-1)
 * US East - Ohio (us-east-2)
 * US West - Oregon (us-west-2)

--- a/modules/rosa-sdpolicy-am-regions-az.adoc
+++ b/modules/rosa-sdpolicy-am-regions-az.adoc
@@ -27,9 +27,9 @@ China regions are not supported, regardless of their support on OpenShift 4.
 
 [NOTE]
 ====
-For GovCloud (US) regions, you must submit an link:https://console.redhat.com/openshift/create/rosa/govcloud[Access request for Red Hat OpenShift Service on AWS (ROSA) FedRAMP]. 
+For GovCloud (US) regions, you must submit an link:https://console.redhat.com/openshift/create/rosa/govcloud[Access request for Red Hat OpenShift Service on AWS (ROSA) FedRAMP].
 
-GovCloud (US) regions are only supported on ROSA Classic clusters. 
+GovCloud (US) regions are only supported on ROSA Classic clusters.
 ====
 
 .AWS Regions
@@ -59,8 +59,8 @@ ifndef::rosa-with-hcp[]
 * eu-south-2 (Spain, AWS opt-in required)
 endif::rosa-with-hcp[]
 * eu-west-1 (Ireland)
-ifndef::rosa-with-hcp[]
 * eu-west-2 (London)
+ifndef::rosa-with-hcp[]
 * eu-west-3 (Paris)
 * me-central-1 (UAE, AWS opt-in required)
 * me-south-1 (Bahrain, AWS opt-in required)
@@ -70,7 +70,7 @@ endif::rosa-with-hcp[]
 * us-east-2 (Ohio)
 ifndef::rosa-with-hcp[]
 * us-gov-east-1 - (AWS GovCloud - US-East)
-* us-gov-west-1 - (AWS GovCloud - US-West)	
+* us-gov-west-1 - (AWS GovCloud - US-West)
 * us-west-1 (N. California)
 endif::rosa-with-hcp[]
 * us-west-2 (Oregon)


### PR DESCRIPTION
Version(s):
`enterprise-4.14+`

Issue:
[OSDOCS-9520](https://issues.redhat.com/browse/OSDOCS-9520)

Link to docs preview:
* [Regions and availability zones](http://file.rdu.redhat.com/eponvell/OSDOCS-9520_eu-west-2-region/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-regions-az_rosa-service-definition) for ROSA Classic
* [Regions and availability zones](http://file.rdu.redhat.com/eponvell/OSDOCS-9520_eu-west-2-region/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-regions-az_rosa-hcp-service-definition) for ROSA with HCP
* [Comparing ROSA with hosted control planes and ROSA Classic](http://file.rdu.redhat.com/eponvell/OSDOCS-9520_eu-west-2-region/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html#rosa-hcp-classic-comparison_rosa-hcp-sts-creating-a-cluster-quickly)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added the `eu-west-2` region to ROSA with HCP docs.