### PR TITLE
OSDOCS-9549: Add metadata to snippet

### DIFF
--- a/snippets/rosa-classic-support.adoc
+++ b/snippets/rosa-classic-support.adoc
@@ -1,3 +1,13 @@
+// Text snippet included in the following assemblies: (1)
+//
+// * rosa_cluster_admin/rosa-configuring-pid-limits.adoc
+//
+// Text snippet included in the following modules:    (2)
+//
+// * modules/setting-higher-pid-limit-on-existing-cluster.adoc
+
+:_mod-docs-content-type: SNIPPET
+
 // When including this file, ensure that {FeatureName} is set immediately before
 // the include. Otherwise it will result in an incorrect replacement.
 


### PR DESCRIPTION
Add the required metadata to the ROSA classic support statement.

Version(s):
* enterprise-4.14+
