### PR TITLE
OSDOCS 9556: Release note udate about the default channel in mirror operator catalog packages

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -1146,6 +1146,22 @@ With this update, the Ingress Operator no longer adds the `clientca-configmap` f
 ==== OpenShift CLI (oc)
 
 [discrete]
+[id="ocp-4-15-openshift-oc-mirror-bug-fixes"]
+==== oc-mirror
+
+Prior to this release, to filter operator packages by channel, for example, `mirror.operators.catalog.packages.channels`, you had to specify the default channel for the package, even if you did not intend to use the packages from that channel. Based on this information, the resulting catalog is considered invalid if the `imageSetConfig` does not contain the default channel for the package.
+
+[WARNING]
+====
+Modifying the default channel can have an impact on the Operator's upgrade paths. The use of `defaultChannel` is the responsibility of the end user.
+====
+
+This update introduces the `defaultChannel` field in the `mirror.operators.catalog.packages` section. You can now select a default channel. This action enables `oc-mirror` to build a new catalog that defines the selected channel in the `defaultChannel` field as the default for the package. 
+
+For example, if you are interested in a specific channel, such as `stable-4.14`, and not the default channel, you can add the required default channel to the `imageSetConfig` under the `defaultChannel` field of the package. This action overrides the previous default channel, that is, `stable-4.15`.
+(link:https://issues.redhat.com/browse/OCPBUGS-385[OCPBUGS-385])
+
+[discrete]
 [id="ocp-4-15-olm-bug-fixes"]
 ==== Operator Lifecycle Manager (OLM)
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:[OSDOCS-9556](https://issues.redhat.com//browse/OSDOCS-9556)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Doc Preview](https://71528--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-bug-fixes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
