### PR TITLE
PR for SRVKE-1444: Update more information about the channels used for development, non-development, and production environment use in the "Channels and subscriptions" section. 

### DIFF
--- a/eventing/channels/serverless-channels.adoc
+++ b/eventing/channels/serverless-channels.adoc
@@ -37,7 +37,7 @@ The backing channel acts as a proxy that copies its subscriptions to the user-cr
 [id="serverless-channels-implementations"]
 == Channel implementation types
 
-`InMemoryChannel` and `KafkaChannel` channel implementations can be used with {ServerlessProductName} for development use.
+{ServerlessProductName} supports the `InMemoryChannel` and `KafkaChannel` channels implementations. The `InMemoryChannel` channel is recommended for development use only due to its limitations. You can use the `KafkaChannel` channel for a production environment.
 
 The following are limitations of `InMemoryChannel` type channels:
 


### PR DESCRIPTION
**Affected cherry-picking versions:** serverless-docs 1.32

**Associated JIRA:** https://issues.redhat.com/browse/SRVKE-1444

**Doc preview and description:**

Please check the following "Channel implementation types" section, I have updated more information about the channels used for development, non-development, and production environment use. 

[Channel implementation types](https://71529--docspreview.netlify.app/openshift-serverless/latest/eventing/channels/serverless-channels#serverless-channels-implementations)