### PR TITLE
OCPBUGS-25260 - enterprise-4.13 formatting fix 

### DIFF
--- a/modules/ztp-preparing-the-hub-cluster-for-ztp.adoc
+++ b/modules/ztp-preparing-the-hub-cluster-for-ztp.adoc
@@ -50,7 +50,7 @@ $ oc patch argocd openshift-gitops \
 
 . In {rh-rhacm} 2.7 and later, the multicluster engine enables the `cluster-proxy-addon` feature by default.
 To disable this feature, apply the following patch to disable and remove the relevant hub cluster and managed cluster pods that are responsible for this add-on.
-
++
 [source,terminal]
 ----
 $ oc patch multiclusterengines.multicluster.openshift.io multiclusterengine --type=merge --patch-file out/argocd/deployment/disable-cluster-proxy-addon.json


### PR DESCRIPTION
Formatting typo

Version(s):
enterprise-4.13

Issue:
https://issues.redhat.com/browse/OCPBUGS-25260

Link to docs preview:
https://71538--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster#ztp-configuring-hub-cluster-with-argocd_ztp-preparing-the-hub-cluster

QE review:
- [x] QE review not required.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

