### PR TITLE
OCPBUGS-25260 - Add missing disable-cluster-proxy-addon.json patch step to enterprise-4.12

### DIFF
--- a/modules/ztp-preparing-the-hub-cluster-for-ztp.adoc
+++ b/modules/ztp-preparing-the-hub-cluster-for-ztp.adoc
@@ -65,6 +65,14 @@ where:
 
 ====
 
+. In {rh-rhacm} 2.7 and later, the multicluster engine enables the `cluster-proxy-addon` feature by default.
+To disable this feature, apply the following patch to disable and remove the relevant hub cluster and managed cluster pods that are responsible for this add-on.
++
+[source,terminal]
+----
+$ oc patch multiclusterengines.multicluster.openshift.io multiclusterengine --type=merge --patch-file out/argocd/deployment/disable-cluster-proxy-addon.json
+----
+
 . Apply the pipeline configuration to your hub cluster by using the following command:
 +
 [source,terminal]


### PR DESCRIPTION
Add missing disable-cluster-proxy-addon.json patch step to enterprise-4.12

Version(s):
enterprise-4.12

Issue:
https://issues.redhat.com/browse/OCPBUGS-25260

Link to docs preview:
https://71542--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster#ztp-configuring-hub-cluster-with-argocd_ztp-preparing-the-hub-cluster

QE review:
- [ ] QE has reviewed this change

