### PR TITLE
TELCODOCS-1655 - Update set of `MachineConfig` CRs for telco ZTP

### DIFF
--- a/.vale/styles/config/vocabularies/OpenShiftDocs/accept.txt
+++ b/.vale/styles/config/vocabularies/OpenShiftDocs/accept.txt
@@ -28,5 +28,6 @@ NICs?
 Operators?
 pmc
 ubxtool
+vDUs?
 VFs?
 Westport

--- a/modules/ztp-recommended-cluster-mc-crs.adoc
+++ b/modules/ztp-recommended-cluster-mc-crs.adoc
@@ -21,24 +21,10 @@ a|`01-container-mount-ns-and-kubelet-conf-master.yaml`
 `01-container-mount-ns-and-kubelet-conf-worker.yaml`
 |Configures the container mount namespace and kubelet configuration.
 
-|`02-workload-partitioning.yaml`
-a|Configures workload partitioning for the cluster. Apply this `MachineConfig` CR when you install the cluster.
-[NOTE]
-====
-If you use the `cpuPartitioningMode` field in the `SiteConfig` CR to configure workload partitioning, you do not need to use the `02-workload-partitioning.yaml` CR.
-Using the `cpuPartitioningMode` field is a Technology Preview feature in {product-title} 4.13.
-For more information, see "Workload partitioning in {sno} with {ztp}".
-====
-
 a|`03-sctp-machine-config-master.yaml`
 
 `03-sctp-machine-config-worker.yaml`
 |Loads the SCTP kernel module. These `MachineConfig` CRs are optional and can be omitted if you do not require this kernel module.
-
-a|`04-accelerated-container-startup-master.yaml`
-
-`04-accelerated-container-startup-worker.yaml`
-|Configures accelerated startup for the cluster.
 
 a|`05-kdump-config-master.yaml`
 
@@ -49,8 +35,36 @@ a|`05-kdump-config-master.yaml`
 `06-kdump-worker.yaml`
 |Configures kdump crash reporting for the cluster.
 
+a|`07-sriov-related-kernel-args-master.yaml`
+|Configures SR-IOV kernel arguments in the cluster.
+
+a|`08-set-rcu-normal-master.yaml`
+
+`08-set-rcu-normal-worker.yaml`
+|Disables `rcu_expedited` mode after the cluster has rebooted.
+
 a|`99-crio-disable-wipe-master.yaml`
 
 `99-crio-disable-wipe-worker.yaml`
 |Disables the automatic CRI-O cache wipe following cluster reboot.
+
+a|`99-sync-time-once-master.yaml`
+
+`99-sync-time-once-worker.yaml`
+|Configures the one-time check and adjustment of the system clock by the Chrony service.
+
+a|`enable-crun-master.yaml`
+
+`enable-crun-worker.yaml`
+|Enables the `crun` OCI container runtime.
+
+a|`extra-manifest/enable-cgroups-v1.yaml`
+
+`source-crs/extra-manifest/enable-cgroups-v1.yaml`
+|Enables cgroups v1 during cluster installation and when generating {rh-rhacm} cluster policies.
 |====
+
+[NOTE]
+====
+In {product-title} 4.14 and later, you configure workload partitioning with the `cpuPartitioningMode` field in the `SiteConfig` CR.
+====

--- a/scalability_and_performance/ztp_far_edge/ztp-vdu-validating-cluster-tuning.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-vdu-validating-cluster-tuning.adoc
@@ -11,7 +11,9 @@ Before you can deploy virtual distributed unit (vDU) applications, you need to t
 [role="_additional-resources"]
 .Additional resources
 
-* For more information about {sno} clusters tuned for vDU application deployments, see xref:../../scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc#sno-configure-for-vdu[Reference configuration for deploying vDUs on {sno}].
+* xref:../../scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-workload-partitioning-sno_sno-configure-for-vdu[Workload partitioning in {sno} with {ztp}]
+
+* xref:../../scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc#sno-configure-for-vdu[Reference configuration for deploying vDUs on {sno}]
 
 include::modules/ztp-du-firmware-config-reference.adoc[leveloffset=+1]
 
@@ -24,6 +26,8 @@ include::modules/ztp-recommended-cluster-mc-crs.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
+
+* xref:../../scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-workload-partitioning-sno_sno-configure-for-vdu[Workload partitioning in {sno} with {ztp}]
 
 * xref:../../scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc#ztp-preparing-the-ztp-git-repository_ztp-preparing-the-hub-cluster[Extracting source CRs from the ztp-site-generate container]
 


### PR DESCRIPTION
Update `MachineConfig` CRs for telco ZTP

Version(s):
enterprise-4.14+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1655

Link to docs preview:
https://71543--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-vdu-validating-cluster-tuning#ztp-recommended-cluster-mc-crs_vdu-config-ref

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
