### PR TITLE
OSDOCS-9602: Documented the 4.13.33 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -3755,3 +3755,31 @@ The following feature is included in this z-stream release:
 [id="ocp-4-13-32-updating"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+
+[id="ocp-4-13-33"]
+=== RHSA-2024:0741 - {product-title} 4.13.33 bug fix and security update
+
+Issued: 2024-02-14
+
+{product-title} release 4.13.33, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:0741[RHSA-2024:0741] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:0743[RHBA-2024:0743] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.33 --pullspecs
+----
+
+[id="ocp-4-13-33-bug-fixes"]
+==== Bug fixes
+
+* Previously, upgrading {product-title} could lead to DNS queries failing due to upstream returning a payload larger than 512 bytes for non-EDNS queries using CoreDNS 1.10.1. With this release, clusters with a noncompliant upstream can retry with TCP upon overflow errors which can prevent disruption of function when upgrading. (link:https://issues.redhat.com/browse/OCPBUGS-28205[*OCPBUGS-28205*])
+
+*  Previously, CPU limits applied on the Amazon Elastic File System (EFS) Container Storage Interface (CSI) driver container caused performance degradation issues for I/O operations to EFS volumes. Now, the CPU limits for the EFS CSI driver are removed so the performance degradation issue no longer exist. (link:https://issues.redhat.com/browse/OCPBUGS-28979[*OCPBUGS-28979*])
+
+[id="ocp-4-13-33-updating"]
+==== Updating
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OSDOCS-9602](https://issues.redhat.com/browse/OSDOCS-9602)

Link to docs preview:
[4.13.33 z-stream release notes](https://71547--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes#ocp-4-13-33)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
