### PR TITLE
OSDOCS-9524: Added the ap-northeast-2 region

### DIFF
--- a/modules/rosa-hcp-classic-comparison.adoc
+++ b/modules/rosa-hcp-classic-comparison.adoc
@@ -58,6 +58,8 @@
 * US East - Ohio (us-east-2)
 * US West - Oregon (us-west-2)
 * Africa - Cape Town (af-south-1)
+* Asia Pacific - Tokyo (ap-northeast-1)
+* Asia Pacific - Seoul (ap-northeast-2)
 * Asia Pacific - Hyderabad (ap-south-2)
 * Asia Pacific - Jakarta (ap-southeast-3)
 * Asia Pacific - Melbourne (ap-southeast-4)

--- a/modules/rosa-sdpolicy-am-regions-az.adoc
+++ b/modules/rosa-sdpolicy-am-regions-az.adoc
@@ -38,11 +38,7 @@ GovCloud (US) regions are only supported on ROSA Classic clusters.
 * us-east-1 (N. Virginia)
 * us-east-2 (Ohio)
 ifndef::rosa-with-hcp[]
-* us-gov-east-1 - (AWS GovCloud - US-East)
-* us-gov-west-1 - (AWS GovCloud - US-West)
 * us-west-1 (N. California)
-* us-gov-east-1 - (AWS GovCloud - US-East)
-* us-gov-west-1 - (AWS GovCloud - US-West)
 endif::rosa-with-hcp[]
 * us-west-2 (Oregon)
 * af-south-1 (Cape Town, AWS opt-in required)
@@ -55,8 +51,8 @@ endif::rosa-with-hcp[]
 * ap-south-1 (Mumbai)
 ifndef::rosa-with-hcp[]
 * ap-northeast-3 (Osaka)
-* ap-northeast-2 (Seoul)
 endif::rosa-with-hcp[]
+* ap-northeast-2 (Seoul)
 * ap-southeast-1 (Singapore)
 * ap-southeast-2 (Sydney)
 * ap-northeast-1 (Tokyo)
@@ -68,11 +64,15 @@ endif::rosa-with-hcp[]
 ifndef::rosa-with-hcp[]
 * eu-west-3 (Paris)
 * eu-south-2 (Spain, AWS opt-in required)
+endif::rosa-with-hcp[]
 * eu-north-1 (Stockholm)
+ifndef::rosa-with-hcp[]
 * eu-central-2 (Zurich, AWS opt-in required)
 * me-south-1 (Bahrain, AWS opt-in required)
 * me-central-1 (UAE, AWS opt-in required)
 * sa-east-1 (São Paulo)
+* us-gov-east-1 (AWS GovCloud - US-East)
+* us-gov-west-1 (AWS GovCloud - US-West)
 endif::rosa-with-hcp[]
 ====
 


### PR DESCRIPTION
Version(s):
`enterprise-4.15+`

Issue:
[OSDOCS-9524](https://issues.redhat.com/browse/OSDOCS-9524)

Link to docs preview:
* [Regions and availability zones](http://file.rdu.redhat.com/eponvell/OSDOCS-9524_ap-northeast-2/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-regions-az_rosa-service-definition) for ROSA Classic
* [Regions and availability zones](http://file.rdu.redhat.com/eponvell/OSDOCS-9524_ap-northeast-2/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-regions-az_rosa-hcp-service-definition) for ROSA with HCP
* [Comparing ROSA with hosted control planes and ROSA Classic](http://file.rdu.redhat.com/eponvell/OSDOCS-9524_ap-northeast-2/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html#rosa-hcp-classic-comparison_rosa-hcp-sts-creating-a-cluster-quickly)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added the `ap-northeast-2` region to ROSA with HCP docs.