### PR TITLE
OSDOCS-9525: Added eu-north-1 region

### DIFF
--- a/modules/rosa-hcp-classic-comparison.adoc
+++ b/modules/rosa-hcp-classic-comparison.adoc
@@ -69,6 +69,7 @@
 * Europe - Ireland (eu-west-1)
 * Europe - London (eu-west-2)
 * Europe - Milan (eu-south-1)
+* Europe - Stockholm (eu-north-1)
 | For AWS Region availability, see link:https://docs.aws.amazon.com/general/latest/gr/rosa.html[Red Hat OpenShift Service on AWS endpoints and quotas] in the AWS documentation.
 
 | *Compliance*

--- a/modules/rosa-sdpolicy-am-regions-az.adoc
+++ b/modules/rosa-sdpolicy-am-regions-az.adoc
@@ -22,7 +22,7 @@ endif::rosa-with-hcp[]
 
 [NOTE]
 ====
-China regions are not supported, regardless of their support on OpenShift 4.
+Regions in China are not supported, regardless of their support on OpenShift 4.
 ====
 
 [NOTE]
@@ -60,13 +60,20 @@ endif::rosa-with-hcp[]
 * ap-northeast-1 (Tokyo)
 * ca-central-1 (Central Canada)
 * eu-central-1 (Frankfurt)
+ifndef::rosa-with-hcp[]
+* eu-central-2 (Zurich, AWS opt-in required)
+* eu-south-1 (Milan, AWS opt-in required)
+* eu-south-2 (Spain, AWS opt-in required)
+endif::rosa-with-hcp[]
 * eu-west-1 (Ireland)
 * eu-west-2 (London)
 * eu-south-1 (Milan, AWS opt-in required)
 ifndef::rosa-with-hcp[]
 * eu-west-3 (Paris)
 * eu-south-2 (Spain, AWS opt-in required)
+endif::rosa-with-hcp[]
 * eu-north-1 (Stockholm)
+ifndef::rosa-with-hcp[]
 * eu-central-2 (Zurich, AWS opt-in required)
 * me-south-1 (Bahrain, AWS opt-in required)
 * me-central-1 (UAE, AWS opt-in required)


### PR DESCRIPTION
Version(s):
`enterprise-4.14+`

Issue:
[OSDOCS-9525](https://issues.redhat.com/browse/OSDOCS-9525)

Link to docs preview:
* [Regions and availability zones](http://file.rdu.redhat.com/eponvell/OSDOCS-9525_eu-north-1-region/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-regions-az_rosa-service-definition) for ROSA Classic
* [Regions and availability zones](http://file.rdu.redhat.com/eponvell/OSDOCS-9525_eu-north-1-region/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-regions-az_rosa-hcp-service-definition) for ROSA with HCP
* [Comparing ROSA with hosted control planes and ROSA Classic](http://file.rdu.redhat.com/eponvell/OSDOCS-9525_eu-north-1-region/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html#rosa-hcp-classic-comparison_rosa-hcp-sts-creating-a-cluster-quickly)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added the `eu-north-1` region to ROSA with HCP docs.