### PR TITLE
Remove TE note from CSI Driver Operator documentation

### DIFF
--- a/storage/container_storage_interface/persistent-storage-csi-ibm-powervs-block.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-ibm-powervs-block.adoc
@@ -16,9 +16,6 @@ The {ibm-power-server-name} Block CSI Driver will be installed through {ibm-powe
 
 {product-title} can provision persistent volumes (PVs) by using the Container Storage Interface (CSI) driver for {ibm-power-server-name} Block Storage.
 
-:FeatureName: {ibm-power-server-title} Block CSI Driver Operator
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 Familiarity with xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] and xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[configuring CSI volumes] is helpful when working with a CSI Operator and driver.
 
 To create CSI-provisioned PVs that mount to {ibm-power-server-name} Block storage assets, {product-title} installs the {ibm-power-server-name} Block CSI Driver Operator and the {ibm-power-server-name} Block CSI driver by default in the `openshift-cluster-csi-drivers` namespace.


### PR DESCRIPTION
Version(s): 4.15

Issue: https://issues.redhat.com/browse/MULTIARCH-4115

Link to docs preview: https://71551--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-ibm-powervs-block

QE review:
- [x] QE has approved this change.

Additional information:

