### PR TITLE
Remove TE note from IPI on PowerVS documentation

### DIFF
--- a/installing/installing_ibm_powervs/creating-ibm-power-vs-workspace.adoc
+++ b/installing/installing_ibm_powervs/creating-ibm-power-vs-workspace.adoc
@@ -4,9 +4,6 @@
 include::_attributes/common-attributes.adoc[]
 :context: creating-ibm-power-vs-workspace
 
-:FeatureName: {ibm-power-server-name} using installer-provisioned infrastructure
-include::snippets/technology-preview.adoc[]
-
 include::modules/creating-ibm-power-vs-workspace-procedure.adoc[leveloffset=+1]
 
 

--- a/installing/installing_ibm_powervs/installing-ibm-cloud-account-power-vs.adoc
+++ b/installing/installing_ibm_powervs/installing-ibm-cloud-account-power-vs.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 Before you can install {product-title}, you must configure an {ibm-cloud-name} account.
 
-:FeatureName: {ibm-power-server-title} using installer-provisioned infrastructure
-include::snippets/technology-preview.adoc[]
-
 [id="prerequisites_installing-ibm-cloud-account-power-vs"]
 == Prerequisites
 

--- a/installing/installing_ibm_powervs/installing-ibm-power-vs-customizations.adoc
+++ b/installing/installing_ibm_powervs/installing-ibm-power-vs-customizations.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 In {product-title} version {product-version}, you can install a customized cluster on infrastructure that the installation program provisions on {ibm-power-server-title}. To customize the installation, you modify parameters in the `install-config.yaml` file before you install the cluster.
 
-:FeatureName: {ibm-power-server-title} using installer-provisioned infrastructure
-include::snippets/technology-preview.adoc[]
-
 [id="prerequisites_installing-ibm-powervs-customizations"]
 == Prerequisites
 

--- a/installing/installing_ibm_powervs/installing-ibm-power-vs-private-cluster.adoc
+++ b/installing/installing_ibm_powervs/installing-ibm-power-vs-private-cluster.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 In {product-title} version {product-version}, you can install a private cluster into an existing VPC and {ibm-power-server-name} Workspace. The installation program provisions the rest of the required infrastructure, which you can further customize. To customize the installation, you modify parameters in the `install-config.yaml` file before you install the cluster.
 
-:FeatureName: {ibm-power-server-name} using installer-provisioned infrastructure
-include::snippets/technology-preview.adoc[]
-
 [id="prerequisites_installing-ibm-power-vs-private-cluster"]
 == Prerequisites
 

--- a/installing/installing_ibm_powervs/installing-ibm-powervs-vpc.adoc
+++ b/installing/installing_ibm_powervs/installing-ibm-powervs-vpc.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 In {product-title} version {product-version}, you can install a cluster into an existing Virtual Private Cloud (VPC) on {ibm-cloud-name}. The installation program provisions the rest of the required infrastructure, which you can then further customize. To customize the installation, you modify parameters in the `install-config.yaml` file before you install the cluster.
 
-:FeatureName: {ibm-power-server-name} using installer-provisioned infrastructure
-include::snippets/technology-preview.adoc[]
-
 [id="prerequisites_installing-ibm-powervs-vpc"]
 == Prerequisites
 

--- a/installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.adoc
+++ b/installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 In {product-title} {product-version}, you can install a cluster on {ibm-cloud-name} in a restricted network by creating an internal mirror of the installation release content on an existing Virtual Private Cloud (VPC) on {ibm-cloud-name}.
 
-:FeatureName: {ibm-power-server-name} using installer-provisioned infrastructure
-include::snippets/technology-preview.adoc[]
-
 [id="prerequisites_installing-ibm-power-vs-restricted"]
 == Prerequisites
 

--- a/installing/installing_ibm_powervs/preparing-to-install-on-ibm-power-vs.adoc
+++ b/installing/installing_ibm_powervs/preparing-to-install-on-ibm-power-vs.adoc
@@ -15,9 +15,6 @@ The installation workflows documented in this section are for {ibm-power-server-
 
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 
-:FeatureName: {ibm-power-server-name} using installer-provisioned infrastructure
-include::snippets/technology-preview.adoc[]
-
 [id="requirements-for-installing-ocp-on-ibm-power-vs"]
 == Requirements for installing {product-title} on {ibm-power-server-title}
 


### PR DESCRIPTION
Version(s): 4.15

Issue: https://issues.redhat.com/browse/MULTIARCH-4115

Link to docs preview:
- https://71553--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/preparing-to-install-on-ibm-power-vs
- https://71553--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/installing-ibm-cloud-account-power-vs
- https://71553--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/creating-ibm-power-vs-workspace
- https://71553--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/installing-ibm-power-vs-customizations
- https://71553--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/installing-ibm-powervs-vpc
- https://71553--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/installing-ibm-power-vs-private-cluster
- https://71553--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs

QE review:
- [x] QE has approved this change.

Additional information:
