### PR TITLE
[SRVKS-1040] Add the configuring Queue Proxy resources section

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -210,6 +210,8 @@ Topics:
   Topics:  
   - Name: Overriding system deployment configurations
     File: overriding-config-serving
+- Name: Configuring Queue Proxy resources
+  File: queue-proxy-resources
 ---
 # Eventing
 Name: Eventing

--- a/knative-serving/queue-proxy-resources.adoc
+++ b/knative-serving/queue-proxy-resources.adoc
@@ -1,0 +1,11 @@
+:_content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="queue-proxy-resources"]
+= Configuring Queue Proxy resources
+:context: queue-proxy-resources
+
+toc::[]
+
+The Queue Proxy is a sidecar container to each application container within a service. It improves managing Serverless workloads, ensuring efficient resource usage. You can configure the Queue Proxy.
+
+include::modules/configuring-queue-proxy.adoc[leveloffset=+1]

--- a/modules/configuring-queue-proxy.adoc
+++ b/modules/configuring-queue-proxy.adoc
@@ -1,0 +1,71 @@
+:_content-type: PROCEDURE
+[id="serverless-configuring-queue-proxy_{context}"]
+= Configuring Queue Proxy Resources for a Knative Service
+
+Apart from configuring the Queue Proxy resource requests and limits globally in the deployment configmap, you can set them at the service level using the corresponding annotations targeting CPU, memory, and ephemeral storage resource types.
+
+.Prerequisites
+
+* {pipelines-title} must be installed on your cluster.
+
+* You have installed the OpenShift (`oc`) CLI.
+
+* You have installed the Knative (`kn`) CLI.
+
+.Procedure
+
+* Modify the configmap of your service with resource requests and limits:
++
+[source,yaml]
+----
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: example-service
+  namespace: default
+spec:
+  template:
+    metadata:
+      annotations:
+        queue.sidecar.serving.knative.dev/cpu-resource-request: "1"
+        queue.sidecar.serving.knative.dev/cpu-resource-limit: "2"
+        queue.sidecar.serving.knative.dev/memory-resource-request: "1Gi"
+        queue.sidecar.serving.knative.dev/memory-resource-limit: "2Gi"
+        queue.sidecar.serving.knative.dev/ephemeral-storage-resource-request: "400Mi"
+        queue.sidecar.serving.knative.dev/ephemeral-storage-resource-limit: "450Mi"
+----
++
+Alternatively, you can use the special `queue.sidecar.serving.knative.dev/resource-percentage` annotation, which calculates the Queue Proxy resources as a percentage of the application container. When CPU and memory resource requirements are calculated from the application container requirements and they are outside the boundaries below, the values are adjusted to fit within the boundaries. In this case, the following minimum and maximum boundaries are applied to the CPU and memory resource requirements:
++
+.Resource requirements boundaries
+[cols="2,1,1",options="header"]
+|====
+|Resource requirements|Min|Max
+
+|CPU request
+|25m
+|100m
+
+|CPU limit
+|40m
+|500m
+
+|Memory request
+|50Mi
+|200Mi
+
+|Memory limit
+|200Mi
+|500Mi
+
+|====
++
+[NOTE]
+====
+If you simultaneously set a percentage annotation and a specific resource value using the corresponding resource annotation, then the latter takes precedence.
+====
++
+[WARNING]
+====
+The `queue.sidecar.serving.knative.dev/resource-percentage` annotation is now deprecated and will be removed in a future version of {ServerlessProductName}.
+====


### PR DESCRIPTION
Version(s):
`serverless-docs-1.32` +

Issue:
https://issues.redhat.com/browse/SRVKS-1040

Link to docs preview:
https://71556--docspreview.netlify.app/openshift-serverless/latest/knative-serving/queue-proxy-resources

QE review:
- [ ] QE has approved this change.