### PR TITLE
OSDOCS#9645: Updating the descheduler to be not supported in OKE

### DIFF
--- a/welcome/oke_about.adoc
+++ b/welcome/oke_about.adoc
@@ -5,6 +5,8 @@
 include::_attributes/common-attributes.adoc[]
 :context: oke-about
 
+toc::[]
+
 As of 27 April 2020, Red Hat has decided to rename Red Hat OpenShift Container Engine to Red Hat {oke}
 to better communicate what value the product offering delivers.
 
@@ -254,7 +256,7 @@ The following table is a summary of the feature availability in {oke} and {produ
 | File Integrity Operator | Included | Included | File Integrity Operator
 | Gatekeeper Operator | Not Included - Requires separate subscription | Not Included - Requires separate subscription | Gatekeeper Operator
 | Klusterlet | Not Included - Requires separate subscription | Not Included - Requires separate subscription | N/A
-| {descheduler-operator} provided by Red Hat | Included | Included | {descheduler-operator}
+| {descheduler-operator} provided by Red Hat | Not Included | Included | {descheduler-operator}
 | Local Storage provided by Red Hat | Included | Included | Local Storage Operator
 | Node Feature Discovery provided by Red Hat | Included | Included | Node Feature Discovery Operator
 | Performance Profile controller | Included | Included | N/A


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-9645

Link to docs preview:
https://71557--ocpdocs-pr.netlify.app/openshift-enterprise/latest/welcome/oke_about#feature-summary

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
