### PR TITLE
OSDOCS-9526: Added me-south-1 region

### DIFF
--- a/modules/rosa-hcp-classic-comparison.adoc
+++ b/modules/rosa-hcp-classic-comparison.adoc
@@ -58,12 +58,11 @@
 * US East - Ohio (us-east-2)
 * US West - Oregon (us-west-2)
 * Africa - Cape Town (af-south-1)
-* Asia Pacific - Tokyo (ap-northeast-1)
-* Asia Pacific - Seoul (ap-northeast-2)
 * Asia Pacific - Hyderabad (ap-south-2)
 * Asia Pacific - Jakarta (ap-southeast-3)
 * Asia Pacific - Melbourne (ap-southeast-4)
 * Asia Pacific - Mumbai (ap-south-1)
+* Asia Pacific - Seoul (ap-northeast-2)
 * Asia Pacific - Singapore (ap-southeast-1)
 * Asia Pacific - Sydney (ap-southeast-2)
 * Asia Pacific - Tokyo (ap-northeast-1)
@@ -73,6 +72,7 @@
 * Europe - London (eu-west-2)
 * Europe - Milan (eu-south-1)
 * Europe - Stockholm (eu-north-1)
+* Middle East - Bahrain (me-south-1)
 | For AWS Region availability, see link:https://docs.aws.amazon.com/general/latest/gr/rosa.html[Red Hat OpenShift Service on AWS endpoints and quotas] in the AWS documentation.
 
 | *Compliance*

--- a/modules/rosa-sdpolicy-am-regions-az.adoc
+++ b/modules/rosa-sdpolicy-am-regions-az.adoc
@@ -63,12 +63,9 @@ endif::rosa-with-hcp[]
 * eu-south-1 (Milan, AWS opt-in required)
 ifndef::rosa-with-hcp[]
 * eu-west-3 (Paris)
-* eu-south-2 (Spain, AWS opt-in required)
 endif::rosa-with-hcp[]
-* eu-north-1 (Stockholm)
-ifndef::rosa-with-hcp[]
-* eu-central-2 (Zurich, AWS opt-in required)
 * me-south-1 (Bahrain, AWS opt-in required)
+ifndef::rosa-with-hcp[]
 * me-central-1 (UAE, AWS opt-in required)
 * sa-east-1 (São Paulo)
 * us-gov-east-1 (AWS GovCloud - US-East)


### PR DESCRIPTION
Version(s):
`enterprise-4.14+`

Issue:
[OSDOCS-9526](https://issues.redhat.com/browse/OSDOCS-9526)

Link to docs preview:
* [Regions and availability zones](http://file.rdu.redhat.com/eponvell/OSDOCS-9526_me-south-1-region/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-regions-az_rosa-service-definition) for ROSA Classic
* [Regions and availability zones](http://file.rdu.redhat.com/eponvell/OSDOCS-9526_me-south-1-region/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-regions-az_rosa-hcp-service-definition) for ROSA with HCP
* [Comparing ROSA with hosted control planes and ROSA Classic](http://file.rdu.redhat.com/eponvell/OSDOCS-9526_me-south-1-region/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html#rosa-hcp-classic-comparison_rosa-hcp-sts-creating-a-cluster-quickly)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added the `me-south-1` region to ROSA with HCP docs.