### PR TITLE
OSDOCS-9527: Added sa-east-1 region

### DIFF
--- a/modules/rosa-sdpolicy-am-regions-az.adoc
+++ b/modules/rosa-sdpolicy-am-regions-az.adoc
@@ -67,7 +67,9 @@ endif::rosa-with-hcp[]
 * me-south-1 (Bahrain, AWS opt-in required)
 ifndef::rosa-with-hcp[]
 * me-central-1 (UAE, AWS opt-in required)
+endif::rosa-with-hcp[]
 * sa-east-1 (São Paulo)
+ifndef::rosa-with-hcp[]
 * us-gov-east-1 (AWS GovCloud - US-East)
 * us-gov-west-1 (AWS GovCloud - US-West)
 endif::rosa-with-hcp[]


### PR DESCRIPTION
Version(s):
`enterprise-4.14+`

Issue:
[OSDOCS-9527](https://issues.redhat.com/browse/OSDOCS-9527)

Link to docs preview:
* [Regions and availability zones](http://file.rdu.redhat.com/eponvell/OSDOCS-9527_sa-east-1/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-regions-az_rosa-service-definition) for ROSA Classic
* [Regions and availability zones](http://file.rdu.redhat.com/eponvell/OSDOCS-9527_sa-east-1/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-regions-az_rosa-hcp-service-definition) for ROSA with HCP

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added the `sa-east-1` region to ROSA with HCP docs.