### PR TITLE
[SRVCOM-1561] Add the Serverless operator resource requirements doc

### DIFF
--- a/install/install-serverless-operator.adoc
+++ b/install/install-serverless-operator.adoc
@@ -8,6 +8,10 @@ toc::[]
 
 Installing the {ServerlessOperatorName} enables you to install and use Knative Serving, Knative Eventing, and the Knative broker for Apache Kafka on a {ocp-product-title} cluster. The {ServerlessOperatorName} manages Knative custom resource definitions (CRDs) for your cluster and enables you to configure them without directly modifying individual config maps for each component.
 
+
+// operator resource requirements doc
+include::modules/serverless-operator-installation-resource-requirements.adoc[leveloffset=+1]
+
 // universal install doc
 include::modules/serverless-install-web-console.adoc[leveloffset=+1]
 

--- a/modules/serverless-operator-installation-resource-requirements.adoc
+++ b/modules/serverless-operator-installation-resource-requirements.adoc
@@ -1,0 +1,91 @@
+// Module included in the following assemblies:
+//
+// * install/install-serverless-operator.adoc
+
+:_content-type: REFERENCE
+[id="serverless-operator-resource-requirements_{context}"]
+= {ServerlessOperatorName} resource requirements
+
+The following sample setup might help you to estimate the minimum resource requirements for your {ServerlessOperatorName} installation. Your specific requirements might be significantly different, and might grow as your use of {ServerlessProductName} increases.
+
+The test suite used in the sample setup has the following parameters:
+
+* An {ocp-product-title} cluster with:
+** 10 workers (8 vCPU, 16GiB memory)
+** 3 workers dedicated to Kafka
+** 2 workers dedicated to Prometheus
+** 5 workers remaining for both {ServerlessProductShortName} and test deployments
+
+* 89 test scenarios running in parallel, mainly focused on using the control plane. Testing scenarios typically have a Knative Service sending events through an in-memory channel, a Kafka channel, an in-memory broker, or a Kafka broker to either a Deployment or a Knative Service.
+
+* 48 re-creation scenarios, where the testing scenario is repeatedly being deleted and re-created.
+
+* 41 stable scenarios, where events are sent throughout the test run slowly but continuously.
+
+* The test setup contains, in total:
+** 170 Knative Services
+** 20 In-Memory Channels
+** 24 Kafka Channels
+** 52 Subscriptions
+** 42 Brokers
+** 68 Triggers
+
+The following table details the minimal resource requirements for a Highly-Available (HA) setup discovered by the test suite:
+
+[cols=3,options="header"]
+|===
+|Component
+|RAM resources
+|CPU resources
+
+|{ServerlessOperatorName}
+|1GB
+|0.2 core
+
+|Knative Serving
+|5GB
+|2.5 cores
+
+|Knative Eventing
+|2GB
+|0.5 core
+
+|Knative broker for Apache Kafka
+|6GB
+|1 core
+
+|Sum
+|14GB
+|4.2 cores
+
+|===
+
+The following table details the minimal resource requirements for a non-HA setup discovered by the test suite:
+
+[cols=3,options="header"]
+|===
+|Component
+|RAM resources
+|CPU resources
+
+|{ServerlessOperatorName}
+|1GB
+|0.2 core
+
+|Knative Serving
+|2.5GB
+|1.2 cores
+
+|Knative Eventing
+|1GB
+|0.2 core
+
+|Knative broker for Apache Kafka
+|6GB
+|1 core
+
+|Sum
+|10.5GB
+|2.6 cores
+
+|===


### PR DESCRIPTION
Version(s):
`serverless-docs-1.32` +

Issue:
https://issues.redhat.com/browse/SRVCOM-1561

Link to docs preview:
https://71573--docspreview.netlify.app/openshift-serverless/latest/install/install-serverless-operator#serverless-operator-resource-requirements_install-serverless-operator

QE review:
- [ ] QE has approved this change.