### PR TITLE
TRACING-3922 | Configure OTEL to scrape in-cluster monitoring stack

### DIFF
--- a/modules/otel-config-receive-metrics-monitoring-stack.adoc
+++ b/modules/otel-config-receive-metrics-monitoring-stack.adoc
@@ -1,0 +1,85 @@
+// Module included in the following assemblies:
+//
+// * otel/deploying-otel.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="configuration-for-receiving-metrics-from-the-monitoring-stack_{context}"]
+= Configuration for receiving metrics from the monitoring stack
+
+The OpenTelemetry Collector custom resource (CR) can configure Prometheus receiver to scrape metrics from the in-cluster monitoring stack.
+
+.Example of the OpenTelemetry Collector custom resource to scrape metrics from in-cluster monitoring stack.
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otel-collector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view # <1>
+subjects:
+  - kind: ServiceAccount
+    name: otel-collector
+    namespace: observability
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cabundle
+  namespce: observability
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true" # <2>
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel
+  namespace: observability
+spec:
+  volumeMounts:
+    - name: cabundle-volume
+      mountPath: /etc/pki/ca-trust/source/service-ca
+      readOnly: true
+  volumes:
+    - name: cabundle-volume
+      configMap:
+        name: cabundle
+  mode: deployment
+  config: |
+    receivers:
+      prometheus: # <3>
+        config:
+          scrape_configs:
+            - job_name: 'federate'
+              scrape_interval: 15s
+              scheme: https
+              tls_config:
+                ca_file: /etc/pki/ca-trust/source/service-ca/service-ca.crt
+              bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              honor_labels: true
+              params:
+                'match[]':
+                  - '{__name__="<metric_name>"}' # <4>
+              metrics_path: '/federate'
+              static_configs:
+                - targets:
+                  - "prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
+
+    exporters:
+      debug: # <5>
+        verbosity: detailed
+
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          processors: []
+          exporters: [debug]
+----
+<1> Give OpenTelemetry collector service account `cluster-monitoring-view` cluster role to access metric data.
+<2> Inject OpenShift service CA for configuring TLS in the Prometheus receiver.
+<3> Configure Prometheus receiver to scrape the federate endpoint from in-cluster monitoring stack.
+<4> Use the Prometheus query language to select metrics which should be scraped. Refer to the in-cluster monitoring documentation for more details and limitations of the federate endpoint.
+<5> Configure debug exporter to print the metrics to the standard output.

--- a/otel/otel-configuring.adoc
+++ b/otel/otel-configuring.adoc
@@ -11,6 +11,7 @@ The {OTELName} Operator uses a custom resource definition (CRD) file that define
 include::modules/otel-config-collector.adoc[leveloffset=+1]
 include::modules/otel-config-multicluster.adoc[leveloffset=+1]
 include::modules/otel-config-send-metrics-monitoring-stack.adoc[leveloffset=+1]
+include::modules/otel-config-receive-metrics-monitoring-stack.adoc[leveloffset=+1]
 
 [id="setting-up-monitoring-for-otel"]
 == Setting up monitoring for the {OTELShortName}
@@ -25,3 +26,4 @@ include::modules/otel-configuring-otelcol-metrics.adoc[leveloffset=+2]
 [id="additional-resources_deploy-otel"]
 == Additional resources
 * xref:../monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
+* xref:../monitoring/accessing-third-party-monitoring-apis.adoc#monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus_accessing-third-party-monitoring-apis[Querying metrics by using the federation endpoint for Prometheus]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->


<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

4.12, 4.13, 4.14, 4.15, 4.16

This should be released as part of RHOSDT 3.2

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->


https://issues.redhat.com/browse/TRACING-3922

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://71580--ocpdocs-pr.netlify.app/openshift-enterprise/latest/otel/otel-configuring#configuration-for-receiving-metrics-from-the-monitoring-stack_otel-configuring

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
