### PR TITLE
OSDOCS#9456: Adds ODC release notes

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -82,6 +82,33 @@ You can now install a cluster on {ibm-cloud-name} in an environment with limited
 [id="ocp-4-15-web-console"]
 === Web console
 
+[id="ocp-4-15-developer-perspective"]
+==== Developer Perspective
+
+With this release, there are several updates to the *Developer* perspective of the web console.
+
+* Pipeline history and logs based on the data from Tekton Results are available in the dashboard without requiring PipelineRun CRs on the cluster.
+
+[id="ocp-4-15-software-supply-chain-enhancements"]
+===== Software Supply Chain Enhancements
+
+The *PipelineRun Details* page in the *Developer* or *Administrator* perspective of the web console provides an enhanced visual representation of PipelineRuns within a Project.
+
+For more information, see link:https://docs.openshift.com/pipelines/latest/about/understanding-openshift-pipelines.html[{pipelines-title}].
+
+[id="ocp-4-15-red-hat-developer-hub"]
+===== {rh-dev-hub} in the web console
+With this update, a quick start is now available for you to learn more about how to install and use the developer hub.
+
+For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_developer_hub/1.0[Product Documentation for {rh-dev-hub}].
+
+[id="ocp-4-15-builds-support"]
+===== builds for {product-title} is supported in the web console
+
+With this update, builds for {product-title} 1.0 is supported in the web console. Builds is an extensible build framework based on the link:https://shipwright.io/[Shipwright project]. You can use builds for {product-title} to build container images on an {product-title} cluster.
+
+For more information, see link:https://docs.openshift.com/builds/1.0/about/overview-openshift-builds.html[builds for {product-title}].
+
 [id="ocp-4-15-openshift-cli"]
 === OpenShift CLI (oc)
 


### PR DESCRIPTION
Adds ODC release notes

Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-9456

Link to docs preview:
https://71590--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-developer-perspective

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
