### PR TITLE
Updating for 4.14.12 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -2258,6 +2258,11 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
+|Dual Intel E810 Westport Channel NICs as PTP grandmaster clock
+|Not Available
+|Not Available
+|Technology Preview
+
 |Ingress Node Firewall Operator
 |Technology Preview
 |Technology Preview
@@ -3212,7 +3217,7 @@ The following feature is included in this z-stream release:
 * You can now configure `linuxptp` services as grandmaster clock (T-GM) for dual Intel E810 Westport Channel NICs by creating a `PtpConfig` custom resource (CR) that configures both NICs.
 The host system clock is synchronized from the NIC that is connected to the GNSS time source.
 The second NIC is synced to the 1PPS timing output provided by the NIC that is connected to GNSS.
-For more information see, xref:../networking/ptp/configuring-ptp.adoc#configuring-linuxptp-services-as-grandmaster-clock-dual-nic_configuring-ptp[Configuring linuxptp services as a grandmaster clock for dual E810 Westport Channel NICs]. (link:https://issues.redhat.com/browse/TELCODOCS-1480[*TELCODOCS-1480*])
+For more information see, xref:../networking/ptp/configuring-ptp.adoc#configuring-linuxptp-services-as-grandmaster-clock-dual-nic_configuring-ptp[Configuring linuxptp services as a grandmaster clock for dual E810 Westport Channel NICs].
 
 [id="ocp-4-14-12-bug-fixes"]
 ==== Bug Fixes


### PR DESCRIPTION
Two small fixes for 4.14.12 z-stream release notes

1. Adds missing 2WPC feature to Networking TP table
2. Removes incorrect JIRA link

Version(s):
enterprise-4.14

Issue:
https://issues.redhat.com/browse/TELCODOCS-1480


Link to docs preview:
https://71603--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-12

QE review:
- [x] QE not required.
