### PR TITLE
Minor fixes: Node -> node & Remove FCOS acronym

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -612,7 +612,7 @@ Topics:
 - Name: Red Hat Enterprise Linux CoreOS image layering
   File: coreos-layering
   Distros: openshift-enterprise
-- Name: Fedora CoreOS (FCOS) image layering
+- Name: Fedora CoreOS image layering
   File: coreos-layering
   Distros: openshift-origin
 - Name: AWS Local Zone tasks

--- a/security/container_security/security-hardening.adoc
+++ b/security/container_security/security-hardening.adoc
@@ -41,7 +41,7 @@ include::modules/security-hardening-how.adoc[leveloffset=+1]
 * xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installation-user-infra-generate-k8s-manifest-ignition_installing-bare-metal[Creating the Kubernetes manifest and Ignition config files]
 * xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installation-user-infra-machines-iso_installing-bare-metal[Installing {op-system} by using an ISO image]
 * xref:../../installing/install_config/installing-customizing.adoc#installing-customizing[Customizing nodes]
-* xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-kernel-arguments_nodes-nodes-managing[Adding kernel arguments to Nodes]
+* xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-kernel-arguments_nodes-nodes-managing[Adding kernel arguments to nodes]
 ifndef::openshift-origin[]
 * xref:../../installing/installing_aws/installing-aws-customizations.adoc#installation-configuration-parameters_installing-aws-customizations[Installation configuration parameters] - see `fips`
 * xref:../../installing/installing-fips.adoc#installing-fips[Support for FIPS cryptography]


### PR DESCRIPTION
security-hardening: Node -> node

---

topic_map: Remove FCOS acronym

Unify with other mentions of Fedora CoreOS

---

Version(s):
Latest only should be fine.

Issue:
N/A

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
N/A