### PR TITLE
[OCPBUGS#22683] Remove reference to BM control plane node for OpenStack

### DIFF
--- a/modules/installation-osp-deploying-bare-metal-machines.adoc
+++ b/modules/installation-osp-deploying-bare-metal-machines.adoc
@@ -14,7 +14,7 @@ endif::[]
 If you want your cluster to use bare metal machines, modify the
 ifdef::osp-ipi[`install-config.yaml`]
 ifndef::osp-ipi[`inventory.yaml`]
-file. Your cluster can have both control plane and compute machines running on bare metal, or just compute machines.
+file. Your cluster can have compute machines running on bare metal.
 
 [NOTE]
 ====
@@ -50,37 +50,29 @@ endif::osp-ipi[]
 
 ifdef::osp-ipi[]
 . In the `install-config.yaml` file, edit the flavors for machines:
-.. If you want to use bare-metal control plane machines, change the value of `controlPlane.platform.openstack.type` to a bare metal flavor.
 .. Change the value of `compute.platform.openstack.type` to a bare metal flavor.
-.. If you want to deploy your machines on a pre-existing network, change the value of `platform.openstack.machinesSubnet` to the {rh-openstack} subnet UUID of the network. Control plane and compute machines must use the same subnet.
+.. If you want to deploy your machines on a pre-existing network, change the value of `platform.openstack.machinesSubnet` to the {rh-openstack} subnet UUID of the network.
 +
 .An example bare metal `install-config.yaml` file
 [source,yaml]
 ----
-controlPlane:
-    platform:
-      openstack:
-        type: <bare_metal_control_plane_flavor> <1>
-...
-
 compute:
   - architecture: amd64
     hyperthreading: Enabled
     name: worker
     platform:
       openstack:
-        type: <bare_metal_compute_flavor> <2>
+        type: <bare_metal_compute_flavor> <1>
     replicas: 3
 ...
 
 platform:
     openstack:
-      machinesSubnet: <subnet_UUID> <3>
+      machinesSubnet: <subnet_UUID> <2>
 ...
 ----
-<1> If you want to have bare-metal control plane machines, change this value to a bare metal flavor.
-<2> Change this value to a bare metal flavor to use for compute machines.
-<3> If you want to use a pre-existing network, change this value to the UUID of the {rh-openstack} subnet.
+<1> Change this value to a bare metal flavor to use for compute machines.
+<2> If you want to use a pre-existing network, change this value to the UUID of the {rh-openstack} subnet.
 
 
 Use the updated `install-config.yaml` file to complete the installation process.
@@ -90,7 +82,6 @@ endif::osp-ipi[]
 
 ifndef::osp-ipi[]
 . In the `inventory.yaml` file, edit the flavors for machines:
-.. If you want to use bare-metal control plane machines, change the value of `os_flavor_master` to a bare metal flavor.
 .. Change the value of `os_flavor_worker` to a bare metal flavor.
 +
 .An example bare metal `inventory.yaml` file
@@ -104,14 +95,13 @@ all:
 
       # User-provided values
       os_subnet_range: '10.0.0.0/16'
-      os_flavor_master: 'my-bare-metal-flavor' <1>
-      os_flavor_worker: 'my-bare-metal-flavor' <2>
+      os_flavor_master: 'my-vm-flavor'
+      os_flavor_worker: 'my-bare-metal-flavor' <1>
       os_image_rhcos: 'rhcos'
       os_external_network: 'external'
 ...
 ----
-<1> If you want to have bare-metal control plane machines, change this value to a bare metal flavor.
-<2> Change this value to a bare metal flavor to use for compute machines.
+<1> Change this value to a bare metal flavor to use for compute machines.
 
 Use the updated `inventory.yaml` file to complete the installation process.
 Machines that are created during deployment use the flavor that you


### PR DESCRIPTION
The doc explicitly said that BM control plane nodes were supported on OpenStack platform while it's not. QE don't test it either.

We do however support BM compute nodes.

Related to OCPBUGS-22683.

Version(s):
All supported versions

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
