### PR TITLE
Updating errata link for RHBA-2024:0734 in 4.14.12 z-stream release notes 

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3218,6 +3218,7 @@ The following feature is included in this z-stream release:
 The host system clock is synchronized from the NIC that is connected to the GNSS time source.
 The second NIC is synced to the 1PPS timing output provided by the NIC that is connected to GNSS.
 For more information see, xref:../networking/ptp/configuring-ptp.adoc#configuring-linuxptp-services-as-grandmaster-clock-dual-nic_configuring-ptp[Configuring linuxptp services as a grandmaster clock for dual E810 Westport Channel NICs].
+(link:https://access.redhat.com/errata/RHBA-2024:0734[*RHBA-2024:0734*])
 
 [id="ocp-4-14-12-bug-fixes"]
 ==== Bug Fixes


### PR DESCRIPTION
Adding https://access.redhat.com/errata/RHBA-2024:0734 to 4.14.12 z-stream release notes for new PTP feature added in this release

Preview: https://71610--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-12