### PR TITLE
OSDOCS#8459: non-tested platform guidelines for Agent

### DIFF
--- a/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
@@ -50,6 +50,11 @@ include::modules/agent-install-networking.adoc[leveloffset=+1]
 
 This section describes the requirements for an Agent-based {product-title} installation that is configured to use the platform `none` option.
 
+[IMPORTANT]
+====
+Review the information in the link:https://access.redhat.com/articles/4207611[guidelines for deploying {product-title} on non-tested platforms] before you attempt to install an {product-title} cluster in virtualized or cloud environments.
+====
+
 //Platform "none" DNS requirements
 include::modules/agent-install-dns-none.adoc[leveloffset=+2]
 

--- a/modules/understanding-agent-install.adoc
+++ b/modules/understanding-agent-install.adoc
@@ -66,5 +66,9 @@ The following platforms are supported:
 +
 [IMPORTANT]
 ====
-The `none` option requires the provision of DNS name resolution and load balancing infrastructure in your cluster. See the _Requirements for a cluster using the platform "none" option_ section for more information.
+For platform `none`:
+
+* The `none` option requires the provision of DNS name resolution and load balancing infrastructure in your cluster. See _Requirements for a cluster using the platform "none" option_ in the "Additional resources" section for more information.
+
+* Review the information in the link:https://access.redhat.com/articles/4207611[guidelines for deploying {product-title} on non-tested platforms] before you attempt to install an {product-title} cluster in virtualized or cloud environments.
 ====


### PR DESCRIPTION
[OSDOCS-8459](https://issues.redhat.com/browse/OSDOCS-8459)

Version(s):
4.14+

This PR adds links in Agent "Platform none" sections to guidelines about deploying OCP on non-tested platforms. This is a verbatim copy of the same warning in the install section for agnostic platform installs.

QE review:
- [x] QE has approved this change.

Preview:

- [Recommended resources for topologies](https://71617--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer#recommended-resources-for-topologies)
- [Requirements for a cluster using the platform "none" option](https://71617--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer#installation-requirements-platform-none_preparing-to-install-with-agent-based-installer)