### PR TITLE
[OSDOCS-9636]: ROSA docs is missing instructions related to the internal image backup

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-deploy-api-data-protection.adoc
+++ b/cloud_experts_tutorials/cloud-experts-deploy-api-data-protection.adoc
@@ -279,7 +279,7 @@ metadata:
  name: ${CLUSTER_NAME}-dpa
  namespace: openshift-adp
 spec:
- backupImages: false
+ backupImages: true
  features:
    dataMover:
      enable: false
@@ -321,7 +321,7 @@ metadata:
  name: ${CLUSTER_NAME}-dpa
  namespace: openshift-adp
 spec:
- backupImages: false
+ backupImages: true
  features:
    dataMover:
      enable: false
@@ -356,8 +356,7 @@ EOF
 
 [NOTE]
 ====
-* Container image backup and restore (`spec.backupImages=false`) is disabled and not supported in OADP 1.1.x
-or OADP 1.2.0 ROSA STS environments.
+* In OADP 1.1.x ROSA STS environments, the container image backup and restore (`spec.backupImages`) value must be set to `false` as it is not supported.
 * The Restic feature (`restic.enable=false`) is disabled and not supported in ROSA STS environments.
 * The DataMover feature (`dataMover.enable=false`) is disabled and not supported in ROSA STS environments.
 ====
@@ -367,7 +366,7 @@ or OADP 1.2.0 ROSA STS environments.
 
 [NOTE]
 ====
-The following sample hello-world application has no attached PV's.
+The following sample hello-world application has no attached persistent volumes.
 Either DPA configuration will work.
 ====
 

--- a/rosa_backing_up_and_restoring_applications/backing-up-applications.adoc
+++ b/rosa_backing_up_and_restoring_applications/backing-up-applications.adoc
@@ -28,7 +28,6 @@ include::modules/oadp-installing-oadp-rosa-sts.adoc[leveloffset=+1]
 .Restic, Kopia, and DataMover are not supported or recommended
 
 * link:https://issues.redhat.com/browse/OADP-1054[CloudStorage: openshift-adp-controller-manager crashloop seg fault with Restic enabled]
-* link:https://issues.redhat.com/browse/OADP-1057[Cloudstorage API: CSI Backup of an app with internal images partially fails with plugin panicked error]
 * (Affects OADP 1.1.x_ only): link:https://issues.redhat.com/browse/OADP-1055[CloudStorage: bucket is removed on CS CR delete, although it doesn't have "oadp.openshift.io/cloudstorage-delete": "true"]
 
 [role="_additional-resources"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.15+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-9636
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://71618--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-deploy-api-data-protection
https://71618--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_backing_up_and_restoring_applications/backing-up-applications#rosa-backing-up-applications-known-issues

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
QE approval in JIRA comment: https://issues.redhat.com/browse/OSDOCS-9636?focusedId=24186347&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-24186347
Additional information:
<!--- Optional: Include additional context or expand the description here.--->


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
