### PR TITLE
OSDOCS#8471: Updated AWS AMI image IDs

### DIFF
--- a/modules/installation-aws-user-infra-rhcos-ami.adoc
+++ b/modules/installation-aws-user-infra-rhcos-ami.adoc
@@ -23,91 +23,94 @@ ifndef::openshift-origin[]
 |AWS AMI
 
 |`af-south-1`
-|`ami-01860370941726bdd`
+|`ami-0493ec0f0a451f83b`
 
 |`ap-east-1`
-|`ami-05bc702cdaf7e4251`
+|`ami-050a6d164705e7f62`
 
 |`ap-northeast-1`
-|`ami-098932fd93c15690d`
+|`ami-00910c337e0f52cff`
 
 |`ap-northeast-2`
-|`ami-006f4e02d97910a36`
+|`ami-07e98d33de2b93ac0`
 
 |`ap-northeast-3`
-|`ami-0c4bd5b1724f82273`
+|`ami-09bc0a599f4b3c483`
 
 |`ap-south-1`
-|`ami-0cbf22b638724853d`
+|`ami-0ba603a7f9d41228e`
 
 |`ap-south-2`
-|`ami-031f4d165f4b429c4`
+|`ami-03130aecb5d7459cc`
 
 |`ap-southeast-1`
-|`ami-0dc3e381a731ab9fc`
+|`ami-026c056e0a25e5a04`
 
 |`ap-southeast-2`
-|`ami-032ae8d0f287a66a6`
+|`ami-0d471f504ff6d9a0f`
 
 |`ap-southeast-3`
-|`ami-0393130e034b86423`
+|`ami-0c1b9a0721cbb3291`
 
 |`ap-southeast-4`
-|`ami-0b38f776bded7d7d7`
+|`ami-0ef23bfe787efe11e`
 
 |`ca-central-1`
-|`ami-058ea81b3a1d17edd`
+|`ami-0163965a05b75f976`
 
 |`eu-central-1`
-|`ami-011010debd974a250`
+|`ami-01edb54011f870f0c`
 
 |`eu-central-2`
-|`ami-0623b105ae811a5e2`
+|`ami-0bc500d6056a3b104`
 
 |`eu-north-1`
-|`ami-0c4bb9ce04f3526d4`
+|`ami-0ab155e935177f16a`
 
 |`eu-south-1`
-|`ami-06c29eccd3d74df52`
+|`ami-051b4c06b21f5a328`
 
 |`eu-south-2`
-|`ami-00e0b5f3181a3f98b`
+|`ami-096644e5555c23b19`
 
 |`eu-west-1`
-|`ami-087bfa513dc600676`
+|`ami-0faeeeb3d2b1aa07c`
 
 |`eu-west-2`
-|`ami-0ebad59c0e9554473`
+|`ami-00bb1522dc71b604f`
 
 |`eu-west-3`
-|`ami-074e63b65eaf83f96`
+|`ami-01e5397bd2b795bd3`
+
+|`il-central-1`
+|`ami-0b32feb5d77c64e61`
 
 |`me-central-1`
-|`ami-0179d6ae1d908ace9`
+|`ami-0a5158a3e68ab7e88`
 
 |`me-south-1`
-|`ami-0b60c75273d3efcd7`
+|`ami-024864ad1b799dbba`
 
 |`sa-east-1`
-|`ami-0913cbfbfa9a7a53c`
+|`ami-0c402ffb0c4b7edc0`
 
 |`us-east-1`
-|`ami-0f71dcd99e6a1cd53`
+|`ami-057df4d0cb8cbae0d`
 
 |`us-east-2`
-|`ami-0545fae7edbbbf061`
+|`ami-07566e5da1fd297f8`
 
 |`us-gov-east-1`
-|`ami-081eabdc478e501e5`
+|`ami-0fe03a7e289354670`
 
 |`us-gov-west-1`
-|`ami-076102c394767f319`
+|`ami-06b7cc6445c5da732`
 
 |`us-west-1`
-|`ami-0609e4436c4ae5eff`
+|`ami-02d20001c5b9df1e9`
 
 |`us-west-2`
-|`ami-0c5d3e03c0ab9b19a`
+|`ami-0dfba457127fba98c`
 
 |===
 
@@ -120,91 +123,94 @@ ifndef::openshift-origin[]
 |AWS AMI
 
 |`af-south-1`
-|`ami-08dd66a61a2caa326`
+|`ami-06c7b4e42179544df`
 
 |`ap-east-1`
-|`ami-0232cd715f8168c34`
+|`ami-07b6a37fa6d2d2e99`
 
 |`ap-northeast-1`
-|`ami-0bc0b17618da96700`
+|`ami-056d2eef4a3638246`
 
 |`ap-northeast-2`
-|`ami-0ee505fb62eed2fd6`
+|`ami-0bd5a7684f0ff4e02`
 
 |`ap-northeast-3`
-|`ami-0462cd2c3b7044c77`
+|`ami-0fd08063da50de1da`
 
 |`ap-south-1`
-|`ami-0e0b4d951b43adc58`
+|`ami-08f1ae2cef8f9690e`
 
 |`ap-south-2`
-|`ami-06d457b151cc0e407`
+|`ami-020ba25cc1ec53b1c`
 
 |`ap-southeast-1`
-|`ami-0874e1640dfc15f17`
+|`ami-0020a1c0964ac8e48`
 
 |`ap-southeast-2`
-|`ami-05f215734ceb0f5ad`
+|`ami-07013a63289350c3c`
 
 |`ap-southeast-3`
-|`ami-073030df265c88b3f`
+|`ami-041d6ca1d57e3190f`
 
 |`ap-southeast-4`
-|`ami-043f4c40a6fc3238a`
+|`ami-06539e9cbefc28702`
 
 |`ca-central-1`
-|`ami-0840622f99a32f586`
+|`ami-0bb3991641f2b40f6`
 
 |`eu-central-1`
-|`ami-09a5e6ebe667ae6b5`
+|`ami-0908d117c26059e39`
 
 |`eu-central-2`
-|`ami-0835cb1bf387e609a`
+|`ami-0e48c82ffbde67ed2`
 
 |`eu-north-1`
-|`ami-069ddbda521a10a27`
+|`ami-016614599b38d515e`
 
 |`eu-south-1`
-|`ami-09c5cc21026032b4c`
+|`ami-01b6cc1f0fd7b431f`
 
 |`eu-south-2`
-|`ami-0c36ab2a8bbeed045`
+|`ami-0687e1d98e55e402d`
 
 |`eu-west-1`
-|`ami-0d2723c8228cb2df3`
+|`ami-0bf0b7b1cb052d68d`
 
 |`eu-west-2`
-|`ami-0abd66103d069f9a8`
+|`ami-0ba0bf567caa63731`
 
 |`eu-west-3`
-|`ami-08c7249d59239fc5c`
+|`ami-0eab6a7956a66deda`
+
+|`il-central-1`
+|`ami-03b3cb1f4869bf21d`
 
 |`me-central-1`
-|`ami-0685f33ebb18445a2`
+|`ami-0a6e1ade3c9e206a1`
 
 |`me-south-1`
-|`ami-0466941f4e5c56fe6`
+|`ami-0aa0775c68eac9f6f`
 
 |`sa-east-1`
-|`ami-08cdc0c8a972f4763`
+|`ami-07235eee0bb930c78`
 
 |`us-east-1`
-|`ami-0d461970173c4332d`
+|`ami-005808ca73e7b36ff`
 
 |`us-east-2`
-|`ami-0e9cdc0e85e0a6aeb`
+|`ami-0c5c9420f6b992e9e`
 
 |`us-gov-east-1`
-|`ami-0b896df727672ce09`
+|`ami-08c9b2b8d578caf92`
 
 |`us-gov-west-1`
-|`ami-0b896df727672ce09`
+|`ami-0bdff65422ba7d95d`
 
 |`us-west-1`
-|`ami-027b7cc5f4c74e6c1`
+|`ami-017ad4dd030a04233`
 
 |`us-west-2`
-|`ami-0b189d89b44bdfbf2`
+|`ami-068d0af5e3c08e618`
 
 |===
 endif::openshift-origin[]


### PR DESCRIPTION
Version(s):
4.15+

Issue:
This PR addresses [osdocs-8471](https://issues.redhat.com/browse/OSDOCS-8471).

Link to docs preview:

[RHCOS AMIs for the AWS infrastructure](https://71621--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-user-infra#installation-aws-user-infra-rhcos-ami_installing-aws-user-infra)

QE review:
- [x] QE has approved this change.