### PR TITLE
OSDOCS-9571 machine pools in hcp clusters

### DIFF
--- a/modules/machine-pools-hcp.adoc
+++ b/modules/machine-pools-hcp.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="machine_pools_hcp_{context}"]
+= Machine pools in Red Hat OpenShift Service on AWS (ROSA) with Hosted Control Plane (HCP) clusters
+
+In {hcp-title} clusters, the hosted control plane spans all three of the Availability Zones (AZ) in the installed cloud region. Each machine pool in a {hcp-title} cluster deploys in a single subnet within a single AZ. Additionally, machine Pools in {hcp-title} clusters each upgrade independently and the versions of the machine pools must remain within two minor (Y-stream) versions of the Control Plane. 

--- a/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.adoc
+++ b/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.adoc
@@ -58,6 +58,9 @@ You can override this default setting and create a machine pool in a Single-AZ o
 Similarly, deleting a machine pool will delete it from all zones.
 Due to this multiplicative effect, using machine pools in Multi-AZ cluster can consume more of your project's quota for a specific region when creating machine pools.
 
+// ROSA HCP content applies to the following subsection 
+include::modules/machine-pools-hcp.adoc[leveloffset=+1]
+
 == Additional resources
 ifdef::openshift-rosa[]
 * xref:../../rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc#rosa-managing-worker-nodes[Managing compute nodes]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Added a module to describe Machine pool differences in HCP clusters. 
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14+ 
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://71625--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about#machine_pools_hcp_rosa-nodes-machinepools-about



QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
