### PR TITLE
OSDOCS#9649: Release notes for networking doc enhancements

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -92,8 +92,33 @@ Previously, you could not query for the etcd version included with {microshift-s
 //==== Administrator Perspective
 //admin perspectives go here
 
-//[id="microshift-4-15-networking"]
-//=== Networking
+//[id="microshift-4-15-security"]
+//=== Security and compliance
+//
+// This content will be added post-GA, as it is asynchronous content.
+
+[id="microshift-4-15-networking"]
+=== Networking
+
+[id="microshift-4-15-networking-doc-enhancements"]
+==== Networking documentation enhancements
+
+Various networking documentation improvements are now available in the {microshift-short} release.
+
+* *Network features with their customization status.* A new detailed table of the networking features and their customizations that are accessible in a {microshift-short} instance are described in xref:../microshift_networking/microshift-cni.adoc#microshift-nw-customization-matrix_microshift-about-ovn-k-plugin[{microshift-short} networking customization matrix].
+
+* *Network topology updates.* Extensive examples of the Network topology available in your {microshift-short} instance are also updated, see xref:../microshift_networking/microshift-cni.html#microshift-network-topology_microshift-about-ovn-k-plugin[Network topology].
+
+* *Auditing exposed ports examples.* The {microshift-short} documentation now includes procedures on auditing exposed network ports and viewing port log settings. The updated documentation can be viewed in xref:../microshift_networking/microshift-networking-settings.adoc#microshift-exposed-audit-ports_microshift-networking[Auditing exposed network ports]. 
+
+* *Adding and closing ports.* This release also improved the documentation for adding and closing ports and services in your {microshift-short} firewall, see xref:../microshift_networking/microshift-firewall.adoc#microshift-firewall-optional-settings_microshift-firewall[Using optional port settings].
+
+* *Network policies introduction.* With this release, an introduction to setting network policies has been added to the {microshift-short} documentation. More details are expected to follow in z-stream releases, see xref:../microshift_networking/microshift-network-policy/microshift-network-policy-index.adoc#microshift-network-policy-index[Setting network policies].
+
+[id="microshift-4-15-networking-disconnected"]
+==== Configuring {microshift-short} on disconnected hosts
+
+You can configure your network settings to run {microshift-short} on a fully disconnected host. This feature is also enabled in {microshift-short} version 4.14. For more information, see xref:../microshift_networking/microshift-disconnected-network-config.adoc[Configuring network settings for fully disconnected hosts].
 
 //[id="microshift-4-15-storage"]
 //=== Storage


### PR DESCRIPTION
**Version(s):** 4.15
**Issue:** [OSDOCS-9649](https://issues.redhat.com//browse/OSDOCS-9649)

**Description:** Creating documentation to show the doc enhancements that were created in the MicroShift Networking docs. This was a customer request, which is why we wanted to add it to the release notes

**Link to docs preview:**
[Red Hat build of MicroShift Branch Build release notes -> Networking](https://71631--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes#microshift-4-15-networking)

**QE review:**
- QE not needed


