### PR TITLE
OCPBUGS17080: Description for the InsightsConfigAPI feature is not correct

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -24,7 +24,7 @@ The following Technology Preview features are enabled by this feature set:
 ** Shared Resources CSI Driver in OpenShift Builds. Enables the Container Storage Interface (CSI). (`CSIDriverSharedResource`)
 ** Swap memory on nodes. Enables swap memory use for {product-title} workloads on a per-node basis. (`NodeSwap`)
 ** OpenStack Machine API Provider. This gate has no effect and is planned to be removed from this feature set in a future release. (`MachineAPIProviderOpenStack`)
-** Insights Operator. Enables the Insights Operator, which gathers {product-title} configuration data and sends it to Red Hat. (`InsightsConfigAPI`)
+** Insights Operator. Enables the `InsightsDataGather` CRD, which allows users to configure some Insights data gathering options. The feature set also enables the `DataGather` CRD, which allows users to run Insights data gathering on-demand. (`InsightsConfigAPI`)
 ** Retroactive Default Storage Class. Enables {product-title} to retroactively assign the default storage class to PVCs if there was no default storage class when the PVC was created.(`RetroactiveDefaultStorageClass`)
 ** Dynamic Resource Allocation API. Enables a new API for requesting and sharing resources between pods and containers. This is an internal feature that most users do not need to interact with. (`DynamicResourceAllocation`)
 ** Pod security admission enforcement. Enables the restricted enforcement mode for pod security admission. Instead of only logging a warning, pods are rejected if they violate pod security standards. (`OpenShiftPodSecurityAdmission`)

--- a/nodes/clusters/nodes-cluster-enabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-enabling-features.adoc
@@ -20,10 +20,13 @@ For more information about the features activated by the `TechPreviewNoUpgrade` 
 
 ** xref:../../machine_management/capi-machine-management.adoc#capi-machine-management[Managing machines with the Cluster API]
 
-** xref:../../support/remote_health_monitoring/using-insights-operator.adoc#using-insights-operator[Using Insights Operator]
+** xref:../../support/remote_health_monitoring/using-insights-operator.adoc#disabling-insights-operator-gather_using-insights-operator[Disabling the Insights Operator gather operations]
+
+** xref:../../support/remote_health_monitoring/using-insights-operator.adoc#enabling-insights-operator-gather_using-insights-operator[Enabling the Insights Operator gather operations]
+
+** xref:../../support/remote_health_monitoring/using-insights-operator.adoc#running-insights-operator-gather_using-insights-operator[Running an Insights Operator gather operation]
 
 ** xref:../../storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc#persistent-storage-csi-sc-manage[Managing the default storage class]
-
 
 ** xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Pod security admission enforcement].
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-17080

Will likely need to manually CP to 4.13, 4.14.

Previews:
[Understanding feature gates -> Insights Operator bullet](https://71636--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features#nodes-cluster-enabling-features-about_nodes-cluster-enabling)