### PR TITLE
OCPBUGS16709 oc delete MutatingWebhookConfiguration vpa-webhook-config

### DIFF
--- a/modules/nodes-pods-vertical-autoscaler-uninstall.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-uninstall.adoc
@@ -64,6 +64,13 @@ Deleting the CRDs removes the associated roles, cluster roles, and role bindings
 This action removes from the cluster all user-created VPA CRs. If you re-install the VPA, you must create these objects again.
 ====
 
+.. Delete the `MutatingWebhookConfiguration` object by running the following command:
++
+[source,terminal]
+----
+$ oc delete MutatingWebhookConfiguration vpa-webhook-config
+----
+
 .. Delete the VPA Operator:
 +
 [source,terminal]


### PR DESCRIPTION
We tried to remove the VPA Operator following the steps in the documentation, but the MutatingWebhookConfiguration was not removed, it was necessary to remove it manually, is it possible to include this step in the documentation?

https://issues.redhat.com/browse/OCPBUGS-16709

Preview: [Uninstalling the Vertical Pod Autoscaler Operator](https://71639--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler#nodes-pods-vertical-autoscaler-uninstall_nodes-pods-vertical-autoscaler) -- New step 6c.