### PR TITLE
[OCPBUGS-29455] The 22623 shall be used to backend as declared in same 

### DIFF
--- a/modules/installation-load-balancing-user-infra.adoc
+++ b/modules/installation-load-balancing-user-infra.adoc
@@ -190,10 +190,10 @@ listen machine-config-server-22623 <3>
   option  httpchk GET /readyz HTTP/1.0
   option  log-health-checks
   balance roundrobin
-  server bootstrap bootstrap.ocp4.example.com:6443 verify none check check-ssl inter 10s fall 2 rise 3 backup <2>
-  server control-plane0 control-plane0.ocp4.example.com:6443 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
-  server control-plane1 control-plane1.ocp4.example.com:6443 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
-  server control-plane2 control-plane2.ocp4.example.com:6443 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
+  server bootstrap bootstrap.ocp4.example.com:22623 verify none check check-ssl inter 10s fall 2 rise 3 backup <2>
+  server control-plane0 control-plane0.ocp4.example.com:22623 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
+  server control-plane1 control-plane1.ocp4.example.com:22623 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
+  server control-plane2 control-plane2.ocp4.example.com:22623 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
 listen ingress-router-443 <4>
   bind *:443
   mode tcp


### PR DESCRIPTION
Fixing https://issues.redhat.com/browse/OCPBUGS-29455 

In the sample config the current config shall listen to 22623 where they are binded for machine-config-server.

The current config is as,
~~~
listen machine-config-server-22623 
  bind *:22623
  mode tcp
  option  httpchk GET /readyz HTTP/1.0
  option  log-health-checks
  balance roundrobin
  server bootstrap bootstrap.ocp4.example.com:6443 verify none check check-ssl inter 10s fall 2 rise 3 backup 
  server master0 master0.ocp4.example.com:6443 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
  server master1 master1.ocp4.example.com:6443 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
  server master2 master2.ocp4.example.com:6443 weight 1 verify none check check-ssl inter 10s fall 2 rise 3    
~~~

This shall be like below instead.

~~~
listen machine-config-server-22623 
  bind *:22623
  mode tcp
  option  httpchk GET /readyz HTTP/1.0
  option  log-health-checks
  balance roundrobin
  server bootstrap bootstrap.ocp4.example.com:22623 verify none check check-ssl inter 10s fall 2 rise 3 backup 
  server master0 master0.ocp4.example.com:22623 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
  server master1 master1.ocp4.example.com:22623 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
  server master2 master2.ocp4.example.com:22623 weight 1 verify none check check-ssl inter 10s fall 2 rise 3    
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
Enterprise 4.11 and above till 4.15 I can see the docbug

Issue: [enterprise-4.15] Issue in file installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc 
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
