### PR TITLE
OCPBUGS-29465: updating SDN deprecation statement in 4.14

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -1642,6 +1642,11 @@ In the following tables, features are marked with the following statuses:
 |Deprecated
 |Deprecated
 
+|OpenShift SDN network plugin
+|General Availability
+|General Availability
+|Deprecated
+
 |====
 
 //[discrete]
@@ -1715,6 +1720,11 @@ In the following tables, features are marked with the following statuses:
 [id="ocp-4-14-deprecated-features"]
 === Deprecated features
 
+[id="ocp-4-14-deprecation-sdn"]
+==== Deprecation of the OpenShift SDN network plugin
+
+OpenShift SDN CNI is deprecated as of {product-title} {product-version}. It is currently planned that the network plugin will not be an option for new installations in the next minor release of {product-title}. In a subsequent future release, the OpenShift SDN network plugin is planned to be be removed and no longer supported. Red{nbsp}Hat will provide bug fixes and support for this feature until removed, but this feature will no longer receive enhancements. As an alternative to OpenShift SDN CNI, you can use OVN Kubernetes CNI instead.
+
 [id="ocp-4-14-deployment-config-deprecated"]
 ==== DeploymentConfig resources are now deprecated
 
@@ -1786,14 +1796,6 @@ As of {product-title} {product-version}, support for the `LatencySensitive` feat
 ==== oc registry login no longer stores credentials in Docker configuration file locations
 
 As of {product-title} {product-version}, the `oc registry login` command no longer stores registry credentials in the Docker file locations, such as `~/.docker/config.json`. The `oc registry login` command now stores credentials in the Podman configuration file locations, such as `${XDG_RUNTIME_DIR}/containers/auth.json`.
-
-[id="ocp-4-14-future-deprecation"]
-=== Notice of future deprecation
-
-[id="ocp-4-14-future-deprecation-sdn"]
-==== Future deprecation of the OpenShift SDN network plugin
-
-It is currently planned that the OpenShift SDN CNI network plugin will not be an option for new installations in the next minor release of {product-title}. However, at that time, it is planned to be supported in clusters that were previously installed with the OpenShift SDN network plugin. In a subsequent future release, the OpenShift SDN network plugin will be removed and no longer supported.
 
 [id="ocp-4-14-bug-fixes"]
 == Bug fixes


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OCPBUGS-29465

Link to docs preview:
https://71650--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-deprecated-features


QE review:
- [ ] QE has approved this change.

