### PR TITLE
OCPBUGS25190: Fix repeated sentence

### DIFF
--- a/nodes/clusters/nodes-cluster-worker-latency-profiles.adoc
+++ b/nodes/clusters/nodes-cluster-worker-latency-profiles.adoc
@@ -16,8 +16,6 @@ toc::[]
 
 include::snippets/worker-latency-profile-intro.adoc[]
 
-You can configure worker latency profiles when installing a cluster or at any time you notice increased latency in your cluster network.
-
 include::modules/nodes-cluster-worker-latency-profiles-about.adoc[leveloffset=+1]
 
 include::modules/nodes-cluster-worker-latency-profiles-using.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-25190


The below sentence is appearing two times on this "https://docs.openshift.com/container-platform/4.13/nodes/clusters/nodes-cluster-worker-latency-profiles.html" article page:
~~~
You can configure worker latency profiles when installing a cluster or at any time you notice increased latency in your cluster network.
~~~

Preview
[Improving cluster stability in high latency environments using worker latency profiles](https://71658--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-worker-latency-profiles.html) --  The final sentence in the intro (_You can configure worker latency profiles..._) was repeated,  once in the `worker-latency-profile-intro.adoc` and once in the assembly. Removed from the assembly. 

No QE needed