### PR TITLE
OSDOCS-9536: updated microshift documents

### DIFF
--- a/microshift_getting_started/microshift-architecture.adoc
+++ b/microshift_getting_started/microshift-architecture.adoc
@@ -18,7 +18,6 @@ For example, {microshift-short} contains only the following Kubernetes cluster c
 * Networking
 * Ingress
 * Storage
-* Helm
 
 {microshift-short} also provides the following Kubernetes functions:
 
@@ -79,3 +78,4 @@ include::modules/microshift-k8s-apis.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 * xref:../microshift_rest_api/index.adoc#api-index[API index]
+* link:https://www.redhat.com/en/technologies/cloud-computing/openshift/kubernetes-engine[{oke}]

--- a/microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc
+++ b/microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc
@@ -32,5 +32,5 @@ include::modules/microshift-creating-ostree-iso.adoc[leveloffset=+2]
 == Additional resources
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_a_customized_rhel_system_image/assembly_pushing-a-container-to-a-register-and-embedding-it-into-a-image_composing-a-customized-rhel-system-image#con_the-container-registry-credentials_assembly_pushing-a-container-to-a-register-and-embedding-it-into-a-image[Pushing a container to a registry and embedding it into an image]
-* link:https://www.osbuild.org/guides/image-builder-on-premises/container-auth.html[Container registry credentials]
+* link:https://osbuild.org/docs/on-premises/installation/container-auth[Container registry credentials]
 * xref:../microshift_networking/microshift-disconnected-network-config.adoc#microshift-disconnected-network-config[Configuring network settings for fully disconnected hosts]

--- a/microshift_install/microshift-embed-in-rpm-ostree.adoc
+++ b/microshift_install/microshift-embed-in-rpm-ostree.adoc
@@ -60,8 +60,8 @@ include::modules/microshift-download-iso-prep-for-use.adoc[leveloffset=+1]
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/composing-a-rhel-for-edge-image-using-image-builder-command-line_composing-installing-managing-rhel-for-edge-images[Creating a {op-system-ostree} Container blueprint using image builder CLI]
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/composing-a-rhel-for-edge-image-using-image-builder-command-line_composing-installing-managing-rhel-for-edge-images#image-customizations_composing-a-rhel-for-edge-image-using-image-builder-command-line[Supported image customizations]
-* link:https://www.osbuild.org/guides/image-builder-on-premises/building-ostree-images.html#building-ostree-image[Building ostree images]
-* link:https://www.osbuild.org/guides/image-builder-on-premises/blueprint-reference.html[Blueprint reference]
+* link:https://osbuild.org/docs/on-premises/commandline/building-ostree-images[Building OSTree image]
+* link:https://osbuild.org/docs/user-guide/blueprint-reference[Blueprint Reference]
 * link:https://podman.io/docs/installation[Installing podman]
 
 include::modules/microshift-provisioning-ostree.adoc[leveloffset=+1]

--- a/microshift_running_apps/microshift-embedded-apps-on-rhel-edge.adoc
+++ b/microshift_running_apps/microshift-embedded-apps-on-rhel-edge.adoc
@@ -12,7 +12,7 @@ You can embed microservices-based workloads and applications in a {op-system-ost
 == Adding application RPMs to an rpm-ostree image
 If you have an application that includes APIs, container images, and configuration files for deployment such as manifests, you can build application RPMs. You can then add the RPMs to your {op-system-ostree} system image.
 
-The following is an outline of the procedures to embed applications or workloads in an fully self-contained operating system image:
+The following is an outline of the procedures to embed applications or workloads in a fully self-contained operating system image:
 
 * Build your own RPM that includes your application manifest.
 * Add the RPM to the blueprint you used to install {product-title}.

--- a/modules/microshift-accessing-cluster-remotely.adoc
+++ b/modules/microshift-accessing-cluster-remotely.adoc
@@ -16,7 +16,7 @@ The `user@workstation` login is used to access the host machine remotely. The `<
 
 * You have installed the `oc` binary.
 
-* The `@user@microshift` has opened the firewall from the local host.
+* The `user@microshift` has opened the firewall from the local host.
 
 .Procedure
 

--- a/modules/microshift-cri-o-container-runtime.adoc
+++ b/modules/microshift-cri-o-container-runtime.adoc
@@ -6,7 +6,7 @@
 [id="microshift-CRI-O-container-engine_{context}"]
 = Using a proxy in the CRI-O container runtime
 
-To use an HTTP(S) proxy in `CRI-O`, you must add a `Service` section to the configuration file and set the `HTTP_PROXY` and `HTTPS_PROXY` environment variables. You can also set the `NO_PROXY` variable to exclude a list of hosts from being proxied.
+To use an HTTP or HTTPS proxy in `CRI-O`, you must add a `Service` section to the configuration file and set the `HTTP_PROXY` and `HTTPS_PROXY` environment variables. You can also set the `NO_PROXY` variable to exclude a list of hosts from being proxied.
 
 .Procedure
 

--- a/modules/microshift-http-proxy.adoc
+++ b/modules/microshift-http-proxy.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="microshift-http-proxy_{context}"]
-= Deploying {microshift-short} behind an HTTP(S) proxy
+= Deploying {microshift-short} behind an HTTP or HTTPS proxy
 
-Deploy a {microshift-short} cluster behind an HTTP(S) proxy when you want to add basic anonymity and security measures to your pods.
+Deploy a {microshift-short} cluster behind an HTTP or HTTPS proxy when you want to add basic anonymity and security measures to your pods.
 
-You must configure the host operating system to use the proxy service with all components initiating HTTP(S) requests when deploying {microshift-short} behind a proxy.
+You must configure the host operating system to use the proxy service with all components initiating HTTP or HTTPS requests when deploying {microshift-short} behind a proxy.
 
 All the user-specific workloads or pods with egress traffic, such as accessing cloud services, must be configured to use the proxy. There is no built-in transparent proxying of egress traffic in {microshift-short}.

--- a/modules/microshift-provisioning-ostree.adoc
+++ b/modules/microshift-provisioning-ostree.adoc
@@ -22,7 +22,7 @@ If you are using a Kickstart such as the {op-system-ostree} Installer (ISO) imag
 
 .Prerequisites
 
-. You have created an {op-system-ostree} Installer (ISO) image containing your {op-system-ostree} commit with {product-title}.
+. You have created a {op-system-ostree} Installer (ISO) image containing your {op-system-ostree} commit with {product-title}.
 .. This requirement includes the steps of composing an RFE Container image, creating the RFE Installer blueprint, starting the RFE container, and composing the RFE Installer image.
 . Create a Kickstart file or use an existing one. In the Kickstart file, you must include:
 .. Detailed instructions about how to create a user.

--- a/modules/microshift-rpm-ostree-https.adoc
+++ b/modules/microshift-rpm-ostree-https.adoc
@@ -4,9 +4,9 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="microshift-rpm-ostree-https_{context}"]
-= Using the RPM-OStree HTTP(S) proxy
+= Using the RPM-OStree HTTP or HTTPS proxy
 
-To use the HTTP(S) proxy in RPM-OStree, you must add a `Service` section to the configuration file and set the `http_proxy environment` variable for the `rpm-ostreed` service.
+To use the HTTP or HTTPS proxy in RPM-OStree, you must add a `Service` section to the configuration file and set the `http_proxy environment` variable for the `rpm-ostreed` service.
 
 .Procedure
 


### PR DESCRIPTION
Version(s):
4.15+

Issue:
[OSDOCS-9536](https://issues.redhat.com/browse/OSDOCS-9536)

Link to docs preview:
[getting started - Architecture](https://71659--ocpdocs-pr.netlify.app/microshift/latest/microshift_getting_started/microshift-architecture)
[networking](https://71659--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-networking-settings#microshift-http-proxy_microshift-networking)
[installing](https://71659--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree#microshift-download-iso-prep-for-use_microshift-embed-in-rpm-ostree)
[installing](https://71659--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree-offline-use#additional-resources_microshift-embed-microshift-offline-deployments_microshift-embed-rpm-ostree-offline-use)
[running applications](https://71659--ocpdocs-pr.netlify.app/microshift/latest/microshift_running_apps/microshift-embedded-apps-on-rhel-edge#microshift-add-app-RPMs-to-rpm-ostree-image_microshift-embedded-apps-on-rhel-edge)

QE review:
- N/A docs work, no technical changes
