### PR TITLE
OSDOCS-8833: Fixing backup lifecycle info for Kubernetes.

### DIFF
--- a/modules/rosa-policy-disaster-recovery.adoc
+++ b/modules/rosa-policy-disaster-recovery.adoc
@@ -30,9 +30,8 @@ One multi-zone cluster will not provide disaster avoidance or recovery in the ev
 |Virtual Storage management
 |**Red Hat**
 
-- For ROSA clusters created with IAM user credentials, back up all Kubernetes objects on the cluster through hourly, daily, and weekly volume snapshots.
+- For ROSA clusters created with IAM user credentials, back up all Kubernetes objects on the cluster through hourly, daily, and weekly volume snapshots. Hourly backups are retained for 24 hrs (1 day), daily backups are retained for 168 hrs (1 week), and weekly backups are retained for 720 hrs (30 days).
 
-- For ROSA clusters created with IAM user credentials, back up persistent volumes on the cluster through daily and weekly volume snapshots.
 
 |- Back up customer applications and application data.
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-8833](https://issues.redhat.com/browse/OSDOCS-8833)

Link to docs preview:
[Virtual Storage management row in the Disaster Recovery table](https://71661--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix#rosa-policy-disaster-recovery_rosa-policy-responsibility-matrix)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
