### PR TITLE
OSDOCS-9494: ROSA drain/cordon/uncordon worker nodes

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1262,6 +1262,8 @@ Topics:
   Topics:
   - Name: Viewing and listing the nodes in your cluster
     File: nodes-nodes-viewing
+  - Name: Working with nodes
+    File: nodes-nodes-working
 # cannot use oc adm cordon; cannot patch resource "machinesets"; cannot patch resource "nodes"
 #  - Name: Working with nodes
 #    File: nodes-nodes-working

--- a/nodes/nodes/nodes-nodes-working.adoc
+++ b/nodes/nodes/nodes-nodes-working.adoc
@@ -2,23 +2,33 @@
 [id="nodes-nodes-working"]
 = Working with nodes
 include::_attributes/common-attributes.adoc[]
+
 :context: nodes-nodes-working
 
 toc::[]
 
 As an administrator, you can perform several tasks to make your clusters more efficient.
+ifdef::openshift-rosa[]
+You can use the `oc adm` command to cordon, uncordon, and drain a specific node. This is available for both ROSA Classic and ROSA with HCP clusters.
+
+[NOTE]
+====
+Cordoning and draining are only allowed on worker nodes that are part of {cluster-manager-first} machine pools.
+====
+endif::openshift-rosa[]
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
 // modules required to cover the user story. You can also include other
 // assemblies.
 
+ifdef::openshift-enterprise,openshift-rosa[]
 include::modules/nodes-nodes-working-evacuating.adoc[leveloffset=+1]
+endif::openshift-enterprise,openshift-rosa[]
 
+ifndef::openshift-rosa[]
 include::modules/nodes-nodes-working-updating.adoc[leveloffset=+1]
-
 include::modules/nodes-nodes-working-marking.adoc[leveloffset=+1]
-
 include::modules/sno-clusters-reboot-without-drain.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -36,3 +46,4 @@ include::modules/nodes-nodes-working-deleting.adoc[leveloffset=+2]
 * xref:../../machine_management/manually-scaling-machineset.adoc#machineset-manually-scaling-manually-scaling-machineset[Manually scaling a compute machine set]
 
 include::modules/nodes-nodes-working-deleting-bare-metal.adoc[leveloffset=+2]
+endif::openshift-rosa[]

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -22,6 +22,8 @@ toc::[]
 
 * **Additional Security Groups for {hcp-title}.** Starting with ROSA CLI version 1.2.37, you can now use the `--additional-security-group-ids <sec_group_id>` when creating machine pools on {hcp-title} clusters. For more information, see xref:../rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html#creating_machine_pools_cli_rosa-managing-worker-nodes[Creating a machine pool using the ROSA CLI] and the xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.html#rosa-create-machinepool_rosa-managing-objects-cli[create machinepool] section of the ROSA CLI reference.
 
+* **Node management improvements.** Now, you can perform specific tasks to make clusters more efficient. You can cordon, uncordon, and drain a specific node. For more information, see xref:../nodes/nodes/nodes-nodes-working.adoc[Working with nodes].
+
 [id="rosa-q1-2024_{context}"]
 === Q1 2024
 


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-9494](https://issues.redhat.com/browse/OSDOCS-9494)

Link to docs preview:
[Working with nodes](https://71663--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/nodes/nodes-nodes-working)

[What's new](https://71663--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
