### PR TITLE
OSDOCS-9665: backports relnote to 4.14 MicroShift docs

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -363,6 +363,8 @@ For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers
 
 * Previously, a backup was created every time the {microshift-short} service started. These backups caused system backups to fail. Now, automated backups only occur on full system starts. (link:https://issues.redhat.com/browse/OCPBUGS-23076[*OCPBUGS-23076*])
 
+* Previously, {microshift-short} created a backup on application restarts without a host restart. This prevented a proper backup from being created on system restarts because {microshift-short} does not update a current-boot backup. Now, {microshift-short} only creates a backup when the system has been restarted. This ensures that a backup is taken every time the system is restarted. (link:https://issues.redhat.com/browse/OCPBUGS-22322[*OCPBUGS-22322*])
+
 [id="microshift-4-14-5-dp"]
 === RHBA-2023:7601 - {microshift-short} 4.14.5 bug fix update advisory
 
@@ -375,7 +377,7 @@ For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers
 [id="microshift-4-14-5-bug-fixes"]
 ==== Bug fixes
 
-* Previously, when {microshift-short} was installed on a non-ostree system, an error was logged during greenboot health check stating that the ostree directory did not exist. {microshift-short} still started normally. Now, the system properly logs the ostree status as “not an ostree system” and an error message is not produced.
+* Previously, the Greenboot health check script printed an error message when installed on a non `rpm-ostree` system. The installation was still successful with {microshift-short} starting normally. Now, the error message is not present in the `greenboot-healthcheck` output on non `rpm-ostree`-based systems. (link:https://issues.redhat.com/browse/OCPBUGS-22858[*OCPBUGS-22858*])
 
 [id="microshift-4-14-6-dp"]
 === RHBA-2023:7684 - {microshift-short} 4.14.6 bug fix update advisory


### PR DESCRIPTION
Version(s):
4.14 only

Issue:
[OSDOCS-9665](https://issues.redhat.com/browse/OSDOCS-9665)

Link to docs preview:
[4.14.4 Bug fix #2](https://71669--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes#microshift-4-14-4-dp)

QE review:
- N/A, fix already landed; docs work only
- SME of bug approved

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
