### PR TITLE
OCPBUGS-29468 SR-IOV operator non existing 4.14/4.15 channel

### DIFF
--- a/modules/nw-sriov-installing-operator.adoc
+++ b/modules/nw-sriov-installing-operator.adoc
@@ -52,18 +52,7 @@ spec:
 EOF
 ----
 
-. Subscribe to the SR-IOV Network Operator.
-
-.. Run the following command to get the {product-title} major and minor version. It is required for the `channel` value in the next
-step.
-+
-[source,terminal]
-----
-$ OC_VERSION=$(oc version -o yaml | grep openshiftVersion | \
-    grep -o '[0-9]*[.][0-9]*' | head -1)
-----
-
-.. To create a Subscription CR for the SR-IOV Network Operator, enter the following command:
+. To create a Subscription CR for the SR-IOV Network Operator, enter the following command:
 +
 [source,terminal]
 ----
@@ -74,7 +63,7 @@ metadata:
   name: sriov-network-operator-subscription
   namespace: openshift-sriov-network-operator
 spec:
-  channel: "${OC_VERSION}"
+  channel: stable
   name: sriov-network-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
[OCPBUGS-28813]: SRIOV operator] Non existing 4.14/4.15 channel should read stable 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):main, 4.15. 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-28813
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://71670--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/installing-sriov-operator.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
