### PR TITLE
OBSDOCS-830: add xref to 4.15 monitoring RNs

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -639,7 +639,7 @@ This release introduces a Technology Preview option to add a Metrics Server comp
 As a Technology Preview feature, Metrics Server is automatically installed instead of Prometheus Adapter if the `FeatureGate` custom resource is configured with the `TechPreviewNoUpgrade` option.
 If installed, Metrics Server collects resource metrics and exposes them in the `metrics.k8s.io` Metrics API service for use by other tools and APIs.
 Using Metrics Server instead of Prometheus Adapter frees the core platform Prometheus stack from handling this functionality.
-For more information, see xref:../monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc#metricsserverconfig[MetricsServerConfig] in the config map API reference for the Cluster Monitoring Operator.
+For more information, see xref:../monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc#metricsserverconfig[MetricsServerConfig] in the config map API reference for the Cluster Monitoring Operator and xref:../nodes/clusters/nodes-cluster-enabling-features.adoc[Enabling features using feature gates].
 
 [id="ocp-4-15-monitoring-new-feature-to-send-exemplar-data-to-remote-write-storage-for-user-defined-projects"]
 ==== New feature to send exemplar data to remote write storage for user-defined projects


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15 only
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-830
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://71677--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-monitoring-new-metrics-server-to-access-metrics-API-technology-preview
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: This PR only adds an xref, and no technical content is changing or being added. Therefore no QE approval is required for this PR.

<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Adds an xref to the Metrics Server new feature description in the 4.15 monitoring RNs.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
