### PR TITLE
fix variable problem in header

### DIFF
--- a/installing/acs-high-level-overview.adoc
+++ b/installing/acs-high-level-overview.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="acs-high-level-overview"]
-= High-level {product-title-short} installation overview
 include::modules/common-attributes.adoc[]
+= High-level {product-title-short} installation overview
 :context: acs-high-level-overview
 
 toc::[]


### PR DESCRIPTION
Version(s):

4.2+

Issue: none
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://71693--docspreview.netlify.app/openshift-acs/latest/installing/acs-high-level-overview
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: (**N/A**)
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Variables not showing up correctly in heading in customer portal: https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/4.3/html/installing/acs-high-level-overview

The problem is caused by the processor that converts the source looking for the file that contains the variable definition before it is actually included. Moving the include above the title should fix this.
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
