### PR TITLE
OCPBUGS18194: OVN-Kubernetes hybrid network overlay configuration after the cluster installation

### DIFF
--- a/windows_containers/enabling-windows-container-workloads.adoc
+++ b/windows_containers/enabling-windows-container-workloads.adoc
@@ -22,7 +22,7 @@ Dual NIC is not supported on WMCO-managed Windows instances.
 
 * You have installed your cluster using installer-provisioned infrastructure, or using user-provisioned infrastructure with the `platform: none` field set in your `install-config.yaml` file.
 
-* You have configured hybrid networking with OVN-Kubernetes for your cluster. This must be completed during the installation of your cluster. For more information, see xref:../networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc#configuring-hybrid-ovnkubernetes[Configuring hybrid networking].
+* You have configured hybrid networking with OVN-Kubernetes for your cluster. For more information, see xref:../networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc#configuring-hybrid-ovnkubernetes[Configuring hybrid networking].
 
 * You are running an {product-title} cluster version 4.6.8 or later.
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-18194

4.13+ 

Preview: [Enabling Windows container workloads -> Prerequisites](https://71706--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/enabling-windows-container-workloads) -- Bullet 4. 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
