### PR TITLE
CNV#29983 - RN: free page reporting enabled by default

### DIFF
--- a/virt/release_notes/virt-4-15-release-notes.adoc
+++ b/virt/release_notes/virt-4-15-release-notes.adoc
@@ -77,6 +77,7 @@ This release adds new features and enhancements related to the following compone
 === Virtualization
 
 //CNV-29983: Free page reporting
+* Free page reporting is enabled by default.
 
 //CNV-28880: KSM configuration
 * You can configure {VirtProductName} to xref:../../virt/virtual_machines/advanced_vm_management/virt-activating-ksm.adoc#virt-activating-ksm[activate kernel samepage merging (KSM)] when a node is overloaded.


### PR DESCRIPTION
Version(s):
4.15

Issue:
https://issues.redhat.com/browse/CNV-29983

Link to docs preview:
https://71710--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-15-release-notes#virt-4-15-virtualization

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
