### PR TITLE
OBSDOCS-280: Update internal log store refs

### DIFF
--- a/logging/log_collection_forwarding/configuring-log-forwarding.adoc
+++ b/logging/log_collection_forwarding/configuring-log-forwarding.adoc
@@ -7,12 +7,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-By default, the {logging} sends container and infrastructure logs to the default internal log store defined in the `ClusterLogging` custom resource. However, it does not send audit logs to the internal store because it does not provide secure storage. If this default configuration meets your needs, you do not need to configure the Cluster Log Forwarder.
-
-[NOTE]
-====
-To send audit logs to the internal Elasticsearch log store, use the Cluster Log Forwarder as described in xref:../../logging/log_storage/logging-config-es-store.adoc#cluster-logging-elasticsearch-audit_logging-config-es-store[Forwarding audit logs to the log store].
-====
+include::snippets/audit-logs-default.adoc[]
 
 include::modules/cluster-logging-collector-log-forwarding-about.adoc[leveloffset=+1]
 

--- a/modules/cluster-logging-collector-log-forwarding-about.adoc
+++ b/modules/cluster-logging-collector-log-forwarding-about.adoc
@@ -27,15 +27,9 @@ _Secret_:: A `key:value map` that contains confidential data such as user creden
 
 Note the following:
 
-* If a `ClusterLogForwarder` CR object exists, logs are not forwarded to the default Elasticsearch instance, unless there is a pipeline with the `default` output.
-
-* By default, the {logging} sends container and infrastructure logs to the default internal Elasticsearch log store defined in the `ClusterLogging` custom resource. However, it does not send audit logs to the internal store because it does not provide secure storage. If this default configuration meets your needs, do not configure the Log Forwarding API.
-
 * If you do not define a pipeline for a log type, the logs of the undefined types are dropped. For example, if you specify a pipeline for the `application` and `audit` types, but do not specify a pipeline for the `infrastructure` type, `infrastructure` logs are dropped.
 
 * You can use multiple types of outputs in the `ClusterLogForwarder` custom resource (CR) to send logs to servers that support different protocols.
-
-* The internal {product-title} Elasticsearch instance does not provide secure storage for audit logs. We recommend you ensure that the system to which you forward audit logs is compliant with your organizational and governmental regulations and is properly secured. The {logging} does not comply with those regulations.
 
 The following example forwards the audit logs to a secure external Elasticsearch instance, the infrastructure logs to an insecure external Elasticsearch instance, the application logs to a Kafka broker, and the application logs from the `my-apps-logs` project to the internal Elasticsearch instance.
 

--- a/modules/cluster-logging-elasticsearch-audit.adoc
+++ b/modules/cluster-logging-elasticsearch-audit.adoc
@@ -6,14 +6,7 @@
 [id="cluster-logging-elasticsearch-audit_{context}"]
 = Forwarding audit logs to the log store
 
-By default, OpenShift Logging does not store audit logs in the internal {product-title} Elasticsearch log store. You can send audit logs to this log store so, for example, you can view them in Kibana.
-
-To send the audit logs to the default internal Elasticsearch log store, for example to view the audit logs in Kibana, you must use the Log Forwarding API.
-
-[IMPORTANT]
-====
-The internal {product-title} Elasticsearch log store does not provide secure storage for audit logs. Verify that the system to which you forward audit logs complies with your organizational and governmental regulations and is properly secured. {logging-uc} does not comply with those regulations.
-====
+include::snippets/audit-logs-default.adoc[]
 
 .Procedure
 

--- a/snippets/audit-logs-default.adoc
+++ b/snippets/audit-logs-default.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies and modules:
+//
+// * logging/log_collection_forwarding/configuring-log-forwarding.adoc
+//
+// * modules/cluster-logging-elasticsearch-audit.adoc
+
+In a {logging} deployment, container and infrastructure logs are forwarded to the internal log store defined in the `ClusterLogging` custom resource (CR) by default.
+
+Audit logs are not forwarded to the internal log store by default because this does not provide secure storage. You are responsible for ensuring that the system to which you forward audit logs is compliant with your organizational and governmental regulations, and is properly secured.
+
+If this default configuration meets your needs, you do not need to configure a `ClusterLogForwarder` CR. If a `ClusterLogForwarder` CR exists, logs are not forwarded to the internal log store unless a pipeline is defined that contains the `default` output.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OBSDOCS-280

Link to docs preview:
- https://71711--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_collection_forwarding/configuring-log-forwarding
- https://71711--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_storage/logging-config-es-store#cluster-logging-elasticsearch-audit_logging-config-es-store

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
