### PR TITLE
OCPBUGS#29106: Removing unnecessary Nutanix install step

### DIFF
--- a/modules/installation-nutanix-ccm.adoc
+++ b/modules/installation-nutanix-ccm.adoc
@@ -21,30 +21,6 @@ Installations on Nutanix require additional `ConfigMap` and `Secret` resources t
 $ cd <path_to_installation_directory>/manifests
 ----
 
-. Create a file with the name `openshift-cloud-controller-manager-nutanix-credentials-credentials.yaml` and add the following information:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: nutanix-credentials
-  namespace: openshift-cloud-controller-manager
-type: Opaque
-stringData:
-  credentials: "[{
-    \"type\":\"basic_auth\",
-    \"data\":{
-          \"prismCentral\":{
-            \"username\":\"<username_for_prism_central>\", <1>
-            \"password\":\"<password_for_prism_central>\"}, <2>
-            \"prismElements\":null
-          }
-    }]"
-----
-<1> Specify the Prism Central username.
-<2> Specify the Prism Central password.
-
 . Create the `cloud-conf` `ConfigMap` file with the name `openshift-cloud-controller-manager-cloud-config.yaml` and add the following information:
 +
 [source,yaml]


### PR DESCRIPTION
[OCPBUGS-29106](https://issues.redhat.com/browse/OCPBUGS-29106)

Versions: 4.13+

Per the issue description, step 2 of the procedure for [Adding config map and secret resources required for Nutanix CCM](https://docs.openshift.com/container-platform/4.14/installing/installing_nutanix/installing-nutanix-installer-provisioned.html#nutanix-ccm-config_installing-nutanix-installer-provisioned) is unnecessary because the file is generated when performing the procedure for [Configuring IAM for Nutanix](https://docs.openshift.com/container-platform/4.14/installing/installing_nutanix/installing-nutanix-installer-provisioned.html#manually-create-iam-nutanix_installing-nutanix-installer-provisioned). I've confirmed this with Yanhua Li over Slack.

QE review:
- [x] QE has approved this change.

Preview: [Adding config map and secret resources required for Nutanix CCM](https://71715--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned#nutanix-ccm-config_installing-nutanix-installer-provisioned)
