### PR TITLE
RuntimeClass example uses wrong API version

### DIFF
--- a/modules/creating-runtimeclass.adoc
+++ b/modules/creating-runtimeclass.adoc
@@ -14,7 +14,7 @@ Using a `RuntimeClass` object simplifies the use of scheduling mechanisms like t
 +
 [source,yaml]
 ----
-apiVersion: node.k8s.io/v1beta1
+apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
   name: <runtime_class_name> <1>


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-27036

Preview
[Creating a RuntimeClass object to encapsulate scheduling mechanisms](https://71716--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/scheduling-windows-workloads#creating-runtimeclass_scheduling-windows-workloads) -- Updated API in Step 1 code example.