### PR TITLE
PR for SRVKS-1180: Update the information about `secret filtering` for net-istio and net-kourier

### DIFF
--- a/modules/serverless-ossm-secret-filtering-net-istio.adoc
+++ b/modules/serverless-ossm-secret-filtering-net-istio.adoc
@@ -6,11 +6,13 @@
 [id="serverless-ossm-secret-filtering-net-istio_{context}"]
 = Improving net-istio memory usage by using secret filtering for {SMProductShortName}
 
-By default, the link:https://aly.arriqaaq.com/kubernetes-informers/[informers] implementation for the Kubernetes `client-go` library fetches all resources of a particular type. This can lead to a substantial overhead when many resources are available, which can cause the Knative `net-istio` ingress controller to fail on large clusters due to memory leaking. However, a filtering mechanism is available for the Knative `net-istio` ingress controller, which enables the controller to only fetch Knative related secrets. You can enable this mechanism by adding an annotation to the `KnativeServing` custom resource (CR).
+By default, the link:https://aly.arriqaaq.com/kubernetes-informers/[informers] implementation for the Kubernetes `client-go` library fetches all resources of a particular type. This can lead to a substantial overhead when many resources are available, which can cause the Knative `net-istio` ingress controller to fail on large clusters due to memory leaking. However, a filtering mechanism is available for the Knative `net-istio` ingress controller, which enables the controllers to only fetch Knative related secrets.
+
+The secret filtering is enabled by default on the {ServerlessOperatorName} side. An environment variable, `ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID=true`, is added by default to the `net-istio` controller pods.
 
 [IMPORTANT]
 ====
-If you enable secret filtering, all of your secrets need to be labeled with  `networking.internal.knative.dev/certificate-uid: "<id>"`. Otherwise, Knative Serving does not detect them, which leads to failures. You must label both new and existing secrets.
+If you enable secret filtering, you must label all of your secrets with  `networking.internal.knative.dev/certificate-uid: "<id>"`. Otherwise, Knative Serving does not detect them, which leads to failures. You must label both new and existing secrets.
 ====
 
 .Prerequisites
@@ -22,10 +24,8 @@ If you enable secret filtering, all of your secrets need to be labeled with  `ne
 * Install the {ServerlessOperatorName} and Knative Serving.
 * Install the OpenShift CLI (`oc`).
 
-.Procedure
+You can disable the secret filtering by setting the `ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID` variable to `false` by using the  `workloads` field in the `KnativeServing` custom resource (CR).
 
-* Add the `serverless.openshift.io/enable-secret-informer-filtering` annotation to the `KnativeServing` CR:
-+
 .Example KnativeServing CR
 [source,yaml]
 ----
@@ -34,25 +34,14 @@ kind: KnativeServing
 metadata:
   name: knative-serving
   namespace: knative-serving
-  annotations:
-    serverless.openshift.io/enable-secret-informer-filtering: "true" <1>
 spec:
-  ingress:
-    istio:
-      enabled: true
-  deployments:
-    - annotations:
-        sidecar.istio.io/inject: "true"
-        sidecar.istio.io/rewriteAppHTTPProbers: "true"
-      name: activator
-    - annotations:
-        sidecar.istio.io/inject: "true"
-        sidecar.istio.io/rewriteAppHTTPProbers: "true"
-      name: autoscaler
+...
+  workloads:
+    - env:
+        - container: controller
+          envVars:
+            - name: ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID
+              value: 'false'
+      name: net-istio-controller
 ----
-<1> Adding this annotation injects an environment variable, `ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID=true`, to the `net-istio` controller pod.
-+
-[NOTE]
-====
-This annotation is ignored if you set a different value by overriding deployments.
-====
+

--- a/modules/serverless-ossm-secret-filtering-net-kourier.adoc
+++ b/modules/serverless-ossm-secret-filtering-net-kourier.adoc
@@ -6,7 +6,9 @@
 [id="serverless-ossm-secret-filtering-net-kourier_{context}"]
 = Improving net-kourier memory usage by using secret filtering
 
-By default, the link:https://aly.arriqaaq.com/kubernetes-informers/[informers] implementation for the Kubernetes `client-go` library fetches all resources of a particular type. This can lead to a substantial overhead when many resources are available, which can cause the Knative `net-kourier` ingress controller to fail on large clusters due to memory leaking. However, a filtering mechanism is available for the Knative `net-kourier` ingress controller, which enables the controller to only fetch Knative related secrets. You can enable this mechanism by setting an environment variable to the `KnativeServing` custom resource (CR).
+By default, the link:https://aly.arriqaaq.com/kubernetes-informers/[informers] implementation for the Kubernetes `client-go` library fetches all resources of a particular type. This can lead to a substantial overhead when many resources are available, which can cause the Knative `net-kourier` ingress controller to fail on large clusters due to memory leaking. However, a filtering mechanism is available for the Knative `net-kourier` ingress controller, which enables the controller to only fetch Knative related secrets.
+
+The secret filtering is enabled by default on the {ServerlessOperatorName} side. An environment variable, `ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID=true`, is added by default to the `net-kourier` controller pods.
 
 [IMPORTANT]
 ====
@@ -21,24 +23,23 @@ If you enable secret filtering, all of your secrets need to be labeled with  `ne
 * Install the {ServerlessOperatorName} and Knative Serving.
 * Install the OpenShift CLI (`oc`).
 
-.Procedure
+You can disable the secret filtering by setting the `ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID` variable to `false` by using the  `workloads` field in the `KnativeServing` custom resource (CR).
 
-* Set the `ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID` variable to `true` for `net-kourier-controller` in the `KnativeServing` CR:
-+
 .Example KnativeServing CR
 [source,yaml]
 ----
 apiVersion: operator.knative.dev/v1beta1
 kind: KnativeServing
 metadata:
- name: knative-serving
- namespace: knative-serving
+  name: knative-serving
+  namespace: knative-serving
 spec:
- deployments:
-   - env:
-     - container: controller
-       envVars:
-       - name: ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID
-         value: 'true'
-     name: net-kourier-controller
+...
+  workloads:
+    - env:
+        - container: controller
+          envVars:
+            - name: ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID
+              value: 'false'
+      name: net-kourier-controller
 ----


### PR DESCRIPTION
**Affected cherry-picking versions:** serverless-docs 1.32

**Associated JIRA:** https://issues.redhat.com/browse/SRVKS-1180

**Doc preview and description:**

I have updated the information about `secret filtering` for net-istio and net-kourier as per the JIRA description.

- [Improving net-istio memory usage by using secret filtering for Service Mesh](https://71721--docspreview.netlify.app/openshift-serverless/latest/integrations/serverless-ossm-setup#serverless-ossm-secret-filtering-net-istio_serverless-ossm-setup)

- [Improving net-kourier memory usage by using secret filtering](https://71721--docspreview.netlify.app/openshift-serverless/latest/knative-serving/config-custom-domains/domain-mapping-custom-tls-cert#serverless-ossm-secret-filtering-net-kourier_domain-mapping-custom-tls-cert)