### PR TITLE
OSDOCS#8830:Updated OCM and HCC attributes and references to them in ROSA docs

### DIFF
--- a/_attributes/attributes-openshift-dedicated.adoc
+++ b/_attributes/attributes-openshift-dedicated.adoc
@@ -9,10 +9,11 @@
 :op-system-first: Red Hat Enterprise Linux CoreOS (RHCOS)
 :cluster-manager-first: Red Hat OpenShift Cluster Manager
 :cluster-manager: OpenShift Cluster Manager
-:cluster-manager-url: link:https://console.redhat.com/openshift[OpenShift Cluster Manager Hybrid Cloud Console]
-:cluster-manager-url-pull: link:https://console.redhat.com/openshift/install/pull-secret[pull secret from the Red Hat OpenShift Cluster Manager]
+:cluster-manager-url: link:https://console.redhat.com/openshift[OpenShift Cluster Manager]
+:cluster-manager-url-pull: link:https://console.redhat.com/openshift/install/pull-secret[pull secret from Red Hat OpenShift Cluster Manager]
 :hybrid-console: Red Hat Hybrid Cloud Console
 :hybrid-console-second: Hybrid Cloud Console
+:hybrid-console-url: link:https://console.redhat.com[Red Hat Hybrid Cloud Console]
 :AWS: Amazon Web Services (AWS)
 :GCP: Google Cloud Platform (GCP)
 :product-registry: OpenShift image registry

--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -36,11 +36,12 @@ endif::openshift-origin[]
 :ai-full: Assisted Installer
 :cluster-manager-first: Red Hat OpenShift Cluster Manager
 :cluster-manager: OpenShift Cluster Manager
-:cluster-manager-url: link:https://console.redhat.com/openshift[OpenShift Cluster Manager Hybrid Cloud Console]
-:cluster-manager-url-pull: link:https://console.redhat.com/openshift/install/pull-secret[pull secret from the Red Hat OpenShift Cluster Manager]
+:cluster-manager-url: link:https://console.redhat.com/openshift[OpenShift Cluster Manager]
+:cluster-manager-url-pull: link:https://console.redhat.com/openshift/install/pull-secret[pull secret from Red Hat OpenShift Cluster Manager]
 :insights-advisor-url: link:https://console.redhat.com/openshift/insights/advisor/[Insights Advisor]
 :hybrid-console: Red Hat Hybrid Cloud Console
 :hybrid-console-second: Hybrid Cloud Console
+:hybrid-console-url: link:https://console.redhat.com[Red Hat Hybrid Cloud Console]
 // OADP attributes
 :oadp-first: OpenShift API for Data Protection (OADP)
 :oadp-full: OpenShift API for Data Protection

--- a/modules/deploy-app.adoc
+++ b/modules/deploy-app.adoc
@@ -20,15 +20,21 @@ From the {product-title} web console, you can deploy a test application from the
 ifndef::quickstart[]
 .Prerequisites
 
-* You logged in to {cluster-manager-url}.
-* You created an {product-title} cluster.
+* You logged in to the {hybrid-console-url}.
+* You created a {product-title} cluster.
 * You configured an identity provider for your cluster.
 * You added your user account to the configured identity provider.
 endif::[]
 
 .Procedure
 
-. From the {cluster-manager} {hybrid-console-second}, click *Open console*.
+. Go to the *Clusters* page in {cluster-manager-url}. 
+
+. Click the options icon (&#8942;) next to the cluster you want to view.
+
+. Click *Open console*.
+
+. Your cluster console opens in a new browser window. Login to your Red Hat account with your configured identity provider credentials.
 
 . In the *Administrator* perspective, select *Home* -> *Projects* -> *Create Project*.
 
@@ -57,7 +63,7 @@ You might need to click *Clear All Filters* to display the *Node.js* option.
 
 . Click *Create* to deploy the application. It will take a few minutes for the pods to deploy.
 
-. Optional: Check the status of the pods in the *Topology* pane by selecting your *nodejs* app and reviewing its sidebar. You must wait for the `nodejs` build to complete and for the `nodejs` pod to be in a *Running* state before continuing.
+. Optional: Check the status of the pods in the *Topology* pane by selecting your *Node.js* app and reviewing its sidebar. You must wait for the `nodejs` build to complete and for the `nodejs` pod to be in a *Running* state before continuing.
 
 . When the deployment is complete, click the route URL for the application, which has a format similar to the following:
 +

--- a/modules/rosa-sts-associating-your-aws-account.adoc
+++ b/modules/rosa-sts-associating-your-aws-account.adoc
@@ -20,7 +20,7 @@ ifeval::["{context}" == "rosa-sts-creating-a-cluster-quickly"]
 :rosa-standalone:
 endif::[]
 
-Before using the {cluster-manager-first} {hybrid-console-second} to create
+Before using {cluster-manager-first} on the {hybrid-console-url} to create
 ifdef::rosa-hcp[]
 {hcp-title} clusters
 endif::rosa-hcp[]
@@ -99,7 +99,7 @@ $ rosa create ocm-role
 +
 Select the default values at the prompts to quickly create and link the role.
 +
-. Create a user role and link it to your {cluster-manager} user account:
+. Create a user role and link it to your Red Hat user account:
 +
 [source,terminal]
 ----

--- a/modules/rosa-sts-creating-a-cluster-using-defaults-ocm.adoc
+++ b/modules/rosa-sts-creating-a-cluster-using-defaults-ocm.adoc
@@ -5,7 +5,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="rosa-sts-creating-a-cluster-using-defaults-ocm_{context}"]
-= Creating a cluster with the default options using {cluster-manager} {hybrid-console-second}
+= Creating a cluster with the default options using {cluster-manager} 
 
 ifeval::["{context}" == "rosa-sts-creating-a-cluster-quickly"]
 :quick-install:
@@ -14,7 +14,7 @@ ifeval::["{context}" == "rosa-quickstart"]
 :quickstart:
 endif::[]
 
-When using the {cluster-manager-first} {hybrid-console-second} to create a {product-title} (ROSA) cluster that uses the AWS Security Token Service (STS), you can select the default options to create the cluster quickly. You can also use the admin {cluster-manager} IAM role to enable automatic deployment of the cluster-specific Operator roles and the OpenID Connect (OIDC) provider.
+When using {cluster-manager-first} on the {hybrid-console-url} to create a {product-title} (ROSA) cluster that uses the AWS Security Token Service (STS), you can select the default options to create the cluster quickly. You can also use the admin {cluster-manager} IAM role to enable automatic deployment of the cluster-specific Operator roles and the OpenID Connect (OIDC) provider.
 
 ifdef::quick-install[]
 .Prerequisites
@@ -43,7 +43,7 @@ If your AWS account ID is not listed, check that you have successfully associate
 
 . Click *Next*.
 
-. On the *Cluster details* page, provide a *Cluster name*. Leave the default values in the remaining fields and click *Next*.
+. On the *Cluster details* page, enter a *Cluster name*. Leave the default values in the remaining fields and click *Next*.
 
 . To deploy a cluster quickly, leave the default options in the *Cluster settings*, *Networking*, *Cluster roles and policies*, and *Cluster updates* pages and click *Next* on each page.
 
@@ -51,7 +51,7 @@ If your AWS account ID is not listed, check that you have successfully associate
 
 .Verification
 
-* You can monitor the progress of the installation in the *Overview* page for your cluster. You can view the installation logs on the same page. Your cluster is ready when the *Status* in the *Details* section of the page is listed as *Ready*.
+* You can check the progress of the installation in the *Overview* page for your cluster. You can view the installation logs on the same page. Your cluster is ready when the *Status* in the *Details* section of the page is listed as *Ready*.
 +
 [NOTE]
 ====

--- a/modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc
+++ b/modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc
@@ -123,7 +123,7 @@ endif::rosa-hcp[]
 +
 [NOTE]
 ====
-For installations using the {cluster-manager} {hybrid-console-second}, the `auto` mode requires an admin-privileged {cluster-manager} role.
+For installations that use {cluster-manager} on the {hybrid-console-second}, the `auto` mode requires an admin-privileged {cluster-manager} role.
 ====
 ifdef::rosa-terraform[]
 * Default Operator role prefix: `rosa-<6-digit-alphanumeric-string>`

--- a/modules/rosa-sts-understanding-aws-account-association.adoc
+++ b/modules/rosa-sts-understanding-aws-account-association.adoc
@@ -24,7 +24,7 @@ endif::[]
 [id="rosa-sts-understanding-aws-account-association_{context}"]
 = Understanding AWS account association
 
-Before you can use the {cluster-manager-first} {hybrid-console-second} to create
+Before you can use {cluster-manager-first} on the {hybrid-console-url} to create
 ifdef::rosa-hcp[]
 {hcp-title}
 endif::rosa-hcp[]
@@ -35,7 +35,7 @@ clusters that use the AWS Security Token Service (STS), you must associate your 
 
 {cluster-manager} role:: Create an {cluster-manager} IAM role and link it to your Red Hat organization.
 +
-You can apply basic or administrative permissions to the {cluster-manager} role. The basic permissions enable cluster maintenance using the {cluster-manager} {hybrid-console-second}. The administrative permissions enable automatic deployment of the cluster-specific Operator roles and the OpenID Connect (OIDC) provider using the {cluster-manager} {hybrid-console-second}.
+You can apply basic or administrative permissions to the {cluster-manager} role. The basic permissions enable cluster maintenance using {cluster-manager}. The administrative permissions enable automatic deployment of the cluster-specific Operator roles and the OpenID Connect (OIDC) provider using {cluster-manager}.
 ifdef::quick-install[]
 +
 You can use the administrative permissions with the {cluster-manager} role to deploy a cluster quickly.

--- a/rosa_getting_started/rosa-quickstart-guide-ui.adoc
+++ b/rosa_getting_started/rosa-quickstart-guide-ui.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="rosa-quickstart-guide-ui"]
-= {product-title} quickstart guide
+= {product-title} quick start guide
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-quickstart-guide-ui
 
@@ -8,10 +8,10 @@ toc::[]
 
 [NOTE]
 ====
-If you are looking for a comprehensive getting started guide for ROSA, see xref:../rosa_getting_started/rosa-getting-started.adoc#rosa-getting-started[Comprehensive guide to getting started with {product-title}]. For additional information on ROSA installation, see link:https://www.redhat.com/en/products/interactive-walkthrough/install-rosa[Installing Red Hat OpenShift Service on AWS (ROSA) interactive walkthrough].
+If you are looking for a comprehensive getting started guide for {product-title} (ROSA), see xref:../rosa_getting_started/rosa-getting-started.adoc#rosa-getting-started[Comprehensive guide to getting started with {product-title}]. For additional information on ROSA installation, see link:https://www.redhat.com/en/products/interactive-walkthrough/install-rosa[Installing Red Hat OpenShift Service on AWS (ROSA) interactive walkthrough].
 ====
 
-Follow this guide to quickly create a {product-title} (ROSA) cluster using the {cluster-manager-first} {hybrid-console-second}, grant user access, deploy your first application, and learn how to revoke user access and delete your cluster.
+Follow this guide to quickly create a {product-title} (ROSA) cluster using {cluster-manager-first} on the {hybrid-console-url}, grant user access, deploy your first application, and learn how to revoke user access and delete your cluster.
 
 The procedures in this document enable you to create a cluster that uses AWS Security Token Service (STS). For more information about using AWS STS with ROSA clusters, see xref:../rosa_architecture/rosa-understanding.adoc#rosa-understanding-aws-sts_rosa-understanding[Using the AWS Security Token Service].
 
@@ -47,7 +47,8 @@ include::modules/rosa-getting-started-install-configure-cli-tools.adoc[leveloffs
 [id="rosa-quickstart-creating-a-cluster"]
 == Creating a ROSA cluster with AWS STS using the default auto mode
 
-The procedures in this document use the `auto` modes in the {cluster-manager} {hybrid-console-second} to immediately create the required Identity and Access Management (IAM) resources using the current AWS account. The required resources include the account-wide IAM roles and policies, cluster-specific Operator roles and policies, and OpenID Connect (OIDC) identity provider.
+{cluster-manager-first} is a managed service on the {hybrid-console-url} where you can install, modify, operate, and upgrade your Red Hat OpenShift clusters. This service allows you to work with all of your organization’s clusters from a single dashboard.
+The procedures in this document use the `auto` modes in {cluster-manager} to immediately create the required Identity and Access Management (IAM) resources using the current AWS account. The required resources include the account-wide IAM roles and policies, cluster-specific Operator roles and policies, and OpenID Connect (OIDC) identity provider.
 
 //This content is pulled from rosa-sts-creating-a-cluster-quickly-ocm.adoc
 When using the {cluster-manager} {hybrid-console-second} to create a {product-title} (ROSA) cluster that uses the STS, you can select the default options to create the cluster quickly.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+

Issue:
[OSDOCS-8830](https://issues.redhat.com/browse/OSDOCS-8830)

Link to docs preview:

- [Red Hat OpenShift Service on AWS quick start guide](https://71722--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-quickstart-guide-ui)
- [Creating a ROSA cluster with AWS STS using the default auto mode](https://71722--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-quickstart-guide-ui#rosa-quickstart-creating-a-cluster)
- [Deploying an application from the Developer Catalog](https://71722--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-quickstart-guide-ui#deploy-app_rosa-quickstart-guide-ui)
- [Overview of the default cluster specifications](https://71722--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly#rosa-sts-overview-of-the-default-cluster-specifications_rosa-hcp-sts-creating-a-cluster-quickly)

QE review:
- [x] QE has approved this change.

Peer review:
- [x] Peer reviewer has approved this change.

SME review:
- [x] SME has approved this change.

