### PR TITLE
OCPBUGS-24557: Explain spec.clusterImageSetNameRef and spec.clusters.clusterImageSetNameRef in SiteConfig CR

### DIFF
--- a/modules/ztp-precaching-ztp-config.adoc
+++ b/modules/ztp-precaching-ztp-config.adoc
@@ -25,11 +25,11 @@ spec:
   baseDomain: "example.domain.redhat.com"
   pullSecretRef:
     name: "assisted-deployment-pull-secret"
-  clusterImageSetNameRef: "img4.9.10-x86-64-appsub"
+  clusterImageSetNameRef: "img4.9.10-x86-64-appsub" <1>
   sshPublicKey: "ssh-rsa ..."
   clusters:
   - clusterName: "sno-worker-0"
-    clusterImageSetNameRef: "eko4-img4.11.5-x86-64-appsub"
+    clusterImageSetNameRef: "eko4-img4.11.5-x86-64-appsub" <2>
     clusterLabels:
       group-du-sno: ""
       common-411: true
@@ -75,6 +75,8 @@ spec:
             - name: "ens1f0"
               macAddress: "AA:BB:CC:11:22:33"
 ----
+<1> Specifies the cluster image set used for deployment, unless you specify a different image set in the `spec.clusters.clusterImageSetNameRef` field.
+<2> Specifies the cluster image set used to deploy an individual cluster. If defined, it overrides the `spec.clusterImageSetNameRef` at the site level.
 
 [id="ztp-pre-caching-config-clusters-ignitionconfigoverride_{context}"]
 == Understanding the clusters.ignitionConfigOverride field

--- a/modules/ztp-sno-siteconfig-config-reference.adoc
+++ b/modules/ztp-sno-siteconfig-config-reference.adoc
@@ -24,8 +24,8 @@ Configuring workload partitioning by using the `cpuPartitioningMode` field in th
 |`metadata.name`
 |Set `name` to `assisted-deployment-pull-secret` and create the `assisted-deployment-pull-secret` CR in the same namespace as the `SiteConfig` CR.
 
-|`clusterImageSetNameRef`
-|Configure the image set available on the hub cluster.
+|`spec.clusterImageSetNameRef`
+|Configure the image set available on the hub cluster for all the clusters in the site.
 To see the list of supported versions on your hub cluster, run `oc get clusterimagesets`.
 
 |`installConfigOverrides`
@@ -35,6 +35,9 @@ a|Set the `installConfigOverrides` field to enable or disable optional component
 Use the reference configuration as specified in the example `SiteConfig` CR.
 Adding additional components back into the system might require additional reserved CPU capacity.
 ====
+
+|`spec.clusters.clusterImageSetNameRef`
+|Specifies the cluster image set used to deploy an individual cluster. If defined, it overrides the `spec.clusterImageSetNameRef` at site level.
 
 |`spec.clusters.clusterLabels`
 |Configure cluster labels to correspond to the `bindingRules` field in the `PolicyGenTemplate` CRs that you define.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12, 4.13, 4.14, 4.15, 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-24557
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 
* [Single-node OpenShift SiteConfig CR installation reference](https://71724--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites#ztp-sno-siteconfig-config-reference_ztp-deploying-far-edge-sites)
* [Pre-caching images in GitOps ZTP](https://71724--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-precaching-tool#ztp-pre-caching-config-con_pre-caching)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
