### PR TITLE
OCPBUGS-17656 (16019) 412 Multiple cni-sysctl-allowlist-ds were created in openshift-multus namespace

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -4087,6 +4087,12 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.12.32 --pullspecs
 ----
 
+[id="ocp-4-12-32-bug-fixes"]
+==== Bug fix
+
+* Previously, an issue was observed in {product-title} with some pods getting stuck in the `terminating` state. This affected the reconciliation loop of the allowlist controller, which resulted in unwanted retries that caused the creation of multiple pods.
+With this update, the allowlist controller only inspects pods that belong to the current daemon set. As a result, retries no longer occur when one or more pods are not ready. (link:https://issues.redhat.com/browse/OCPBUGS-16019[*OCPBUGS-16019*])
+
 [id="ocp-4-12-32-updating"]
 ==== Updating
 


### PR DESCRIPTION
[OCPBUGS-17656]: Multiple cni-sysctl-allowlist-ds were created in openshift-multus namespace

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13 
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-17656
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://71729--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes#ocp-4-12-32-bug-fixes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Copy of https://github.com/openshift/openshift-docs/pull/71694 for 4.12 zstream
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

