### PR TITLE
OSDOCS-9265: adds 4.14.13 relnotes MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -441,3 +441,17 @@ Issued: 2024-02-13
 {product-title} release 4.14.12, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0737[RHBA-2024:0737] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0735[RHSA-2024:0735] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-14-13-dp"]
+=== RHBA-2024:0839 - {microshift-short} 4.14.13 bug fix update and security advisory
+
+Issued: 2024-02-20
+
+{product-title} release 4.14.13, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RRHBA-2024:0839[RHBA-2024:0839] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0837[RHSA-2024:0837] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-14-13-bug-fixes"]
+==== Enhancement and bug fix
+
+* Previously, the CoreDNS `bufsize` setting was configured as 512 bytes. With this release, the maximum size of the buffer for {microshift-short} CoreDNS is 1232 bytes. This modification enhances DNS performance by reducing the occurrence of DNS truncations and retries. (link:https://issues.redhat.com/browse/OCPBUGS-29372[*OCPBUGS-29372*])


### PR DESCRIPTION
Version(s):
4.14 only

Issue:
[OSDOCS-9265](https://issues.redhat.com/browse/OSDOCS-9265)

Link to docs preview:
[4.14.13 Release Note](https://71734--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes#microshift-4-14-13-dp)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
