### PR TITLE
TELCODOCS-1729 Document disconnected mirror registry configuration for assisted wrt to ZTP

### DIFF
--- a/modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc
+++ b/modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc
@@ -12,7 +12,7 @@ You can configure the hub cluster to use a disconnected mirror registry for a di
 
 * You have a disconnected hub cluster installation with {rh-rhacm-first} {rh-rhacm-version} installed.
 
-* You have hosted the `rootfs` and `iso` images on an HTTP server.
+* You have hosted the `rootfs` and `iso` images on an HTTP server. See the _Additional resources_ section for guidance about _Mirroring the OpenShift Container Platform image repository_.
 
 [WARNING]
 ====


### PR DESCRIPTION
[TELCODOCS-1729]: Document disconnected mirror registry configuration for assisted

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13, 4.14, 4.15 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-1729
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://71742--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.html#ztp-configuring-the-cluster-for-a-disconnected-environment_ztp-preparing-the-hub-cluster
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
