### PR TITLE
TELCODOCS-1582: Remove incorrect note from removing a managed cluster ZTP docs

### DIFF
--- a/modules/ztp-site-cleanup.adoc
+++ b/modules/ztp-site-cleanup.adoc
@@ -23,8 +23,3 @@ When you run the {ztp} pipeline again, the generated CRs are removed.
 . Optional: If you want to permanently remove a site, you should also remove the `SiteConfig` and site-specific `PolicyGenTemplate` files from the Git repository.
 
 . Optional: If you want to remove a site temporarily, for example when redeploying a site, you can leave the `SiteConfig` and site-specific `PolicyGenTemplate` CRs in the Git repository.
-
-[NOTE]
-====
-After removing the `SiteConfig` file from the Git repository, if the corresponding clusters get stuck in the detach process, check {rh-rhacm-first} on the hub cluster for information about cleaning up the detached cluster.
-====


### PR DESCRIPTION
Removing a managed cluster site from the GitOps ZTP pipeline topic has a note that goes against GitOps principles. 

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1582

Link to docs preview:
https://71743--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites#ztp-site-cleanup_ztp-deploying-far-edge-sites

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
