### PR TITLE
OBSDOCS-768: Add docs for syslog input receiver

### DIFF
--- a/logging/log_collection_forwarding/cluster-logging-collector.adoc
+++ b/logging/log_collection_forwarding/cluster-logging-collector.adoc
@@ -20,4 +20,7 @@ include::modules/cluster-logging-collector-pod-location.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-collector-limits.adoc[leveloffset=+1]
 
+//include::modules/log-collector-rsyslog-server.adoc[leveloffset=+1]
+// uncomment for 5.9 release
+
 include::modules/cluster-logging-collector-tuning.adoc[leveloffset=+1]

--- a/modules/log-collector-rsyslog-server.adoc
+++ b/modules/log-collector-rsyslog-server.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * logging/log_collection_forwarding/cluster-logging-collector.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="log-collector-rsyslog-server_{context}"]
+= Configuring the collector to listen for connections as a syslog server
+
+In {logging} version 5.9 and newer versions, you can configure your log collector to collect journal format infrastructure logs from outside the cluster by specifying `syslog` as a receiver input in the `ClusterLogForwarder` custom resource (CR). This enables you to use a single common log store for journal format infrastructure logs that are collected from both inside and outside of your {product-title} cluster.
+
+.Prerequisites
+
+* You have administrator permissions.
+* You have installed the {oc-first}.
+* You have installed the {clo}.
+* You have created a `ClusterLogForwarder` CR.
+
+.Procedure
+
+. Modify the `ClusterLogForwarder` CR to add configuration for the `syslog` receiver input:
++
+[source,yaml]
+----
+apiVersion: logging.openshift.io/v1beta1
+kind: ClusterLogForwarder
+metadata:
+# ...
+spec:
+  serviceAccountName: <service_account_name>
+  inputs:
+    - name: syslog-receiver # <1>
+      receiver:
+        type: syslog # <2>
+        syslog:
+          port: 10514 # <3>
+  pipelines: # <4>
+    - name: syslog-pipeline
+      inputRefs:
+        - syslog-receiver
+# ...
+----
+<1> Specify a name for your input receiver.
+<2> Specify the input receiver type as `syslog`.
+<3> Optional: Specify the port that the input receiver listens on. This must be a value between `1024` and `65535`. The default value is `10514` if this is not specified.
+<4> Configure a pipeline for your input receiver.
+
+. Apply the changes to the `ClusterLogForwarder` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----


### PR DESCRIPTION
Version(s):
4.13+

**Note: This is for logging 5.9 which releases in April. The docs must be commented out for merging until this goes live.**

Issue:
https://issues.redhat.com/browse/OBSDOCS-768

Link to docs preview:
https://71744--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_collection_forwarding/cluster-logging-collector#log-collector-rsyslog-server_cluster-logging-collector

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
