### PR TITLE
OSDOCS#3630: OTA etcd backup guidance

### DIFF
--- a/modules/update-etcd-backup.adoc
+++ b/modules/update-etcd-backup.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * updating/preparing_for_updates/updating-cluster-prepare.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="update-etcd-backup_{context}"]
+= etcd backups before cluster updates
+
+etcd backups record the state of your cluster and all of its resource objects.
+You can use backups to attempt restoring the state of a cluster in disaster scenarios where you cannot recover a cluster in its currently dysfunctional state.
+
+In the context of updates, you can attempt an etcd restoration of the cluster if an update introduced catastrophic conditions that cannot be fixed without reverting to the previous cluster version.
+etcd restorations might be destructive and destabilizing to a running cluster, use them only as a last resort.
+
+[WARNING]
+====
+Due to their high consequences, etcd restorations are not intended to be used as a rollback solution.
+Rolling your cluster back to a previous version is not supported.
+If your update is failing to complete, contact Red{nbsp}Hat support.
+====
+
+There are several factors that affect the viability of an etcd restoration.
+For more information, see "Backing up etcd data" and "Restoring to a previous cluster state".

--- a/updating/preparing_for_updates/updating-cluster-prepare.adoc
+++ b/updating/preparing_for_updates/updating-cluster-prepare.adoc
@@ -58,6 +58,16 @@ include::modules/update-preparing-conditional.adoc[leveloffset=+1]
 .Additional resources
 * xref:../../updating/understanding_updates/how-updates-work.adoc#update-evaluate-availability_how-updates-work[Evaluation of update availability]
 
+// etcd backups before cluster updates
+include::modules/update-etcd-backup.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[Backing up etcd]
+
+* xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[Restoring to a previous cluster state]
+
 // Best practices for cluster updates
 include::modules/update-best-practices.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[OSDOCS-3630](https://issues.redhat.com/browse/OSDOCS-3630)

Versions: 4.14+

This PR adds guidance in the OTA docs about how to utilize etcd backups in the context of updates. In its current form, the content mostly serves to tell users "don't use this as a rollback solution (unless you really, really, really need to)" and then points them towards existing content that explains more about backup and restore operations.

QE review:
- [x] QE has approved this change.

Preview: [etcd backups before cluster updates](https://71747--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare#update-etcd-backup_updating-cluster-prepare)
