### PR TITLE
Telcodocs 1729 412 Adding same change made in 4.14 here in 4.12

### DIFF
--- a/modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc
+++ b/modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc
@@ -12,7 +12,7 @@ You can configure the hub cluster to use a disconnected mirror registry for a di
 
 * You have a disconnected hub cluster installation with {rh-rhacm-first} {rh-rhacm-version} installed.
 
-* You have hosted the `rootfs` and `iso` images on an HTTP server.
+* You have hosted the `rootfs` and `iso` images on an HTTP server. See the _Additional resources_ section for guidance about _Mirroring the OpenShift Container Platform image repository_.
 
 [WARNING]
 ====

--- a/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc
@@ -34,6 +34,11 @@ include::modules/ztp-enabling-assisted-installer-service-on-bare-metal.adoc[leve
 
 include::modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/disconnected_install/installing-mirroring-installation-images.adoc#installation-mirror-repository_installing-mirroring-installation-images[Mirroring the OpenShift Container Platform image repository]
+
 include::modules/ztp-configuring-the-hub-cluster-to-use-unauthenticated-registries.adoc[leveloffset=+1]
 
 include::modules/ztp-preparing-the-hub-cluster-for-ztp.adoc[leveloffset=+1]


### PR DESCRIPTION
[TELCODOCS-1729]: Document disconnected mirror registry configuration for assisted

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-1729
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://71749--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.html#ztp-configuring-the-cluster-for-a-disconnected-environment_ztp-preparing-the-hub-cluster
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This is the same update as https://github.com/openshift/openshift-docs/pull/71742 with the addition of the Additional resources section to the assembly so all 4.13 > are in sync with 4.12
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
