### PR TITLE
OCPBUGS29602: OCP documentation wrong disk type for Control Plane node on GCP

### DIFF
--- a/modules/machineset-gcp-pd-disk-types.adoc
+++ b/modules/machineset-gcp-pd-disk-types.adoc
@@ -38,9 +38,19 @@ spec:
       providerSpec:
         value:
           disks:
+ifndef::cpmso[]
             type: <pd-disk-type> <1>
+endif::cpmso[]
+ifdef::cpmso[]
+            type: pd-ssd <1>
+endif::cpmso[]
 ----
-<1> Specify the disk persistent type. Valid values are `pd-ssd`, `pd-standard`, and `pd-balanced`. The default value is `pd-standard`.
+ifndef::cpmso[]
+<1> Specify the persistent disk type. Valid values are `pd-ssd`, `pd-standard`, and `pd-balanced`. The default value is `pd-standard`.
+endif::cpmso[]
+ifdef::cpmso[]
+<1>  Control plane nodes must use the `pd-ssd` disk type.
+endif::cpmso[]
 
 .Verification
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-29602

 Control plane nodes must use the pd-ssd disk type.
 
 Preview:
Machine management -> Manage compute machines -> Creating a compute machine set on GCP -> [Configuring persistent disk types by using machine sets](https://71754--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp#machineset-gcp-pd-disk-types_creating-machineset-gcp). Code block has a variable for persistent disk type and callout lists three options. 
Machine management -> Managing control plane machines -> Using control plane machine sets -> [Configuring persistent disk types by using machine sets](https://71754--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-using#machineset-gcp-pd-disk-types_cpmso-using). Code block has `pd-ssd` for persistent disk type and callout mentions this requirement. 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
