### PR TITLE
OSDOCS-9659: Worker Node Instance types on ROSA/OSD i4i instances

### DIFF
--- a/modules/rosa-sdpolicy-am-aws-compute-types.adoc
+++ b/modules/rosa-sdpolicy-am-aws-compute-types.adoc
@@ -89,6 +89,30 @@
 - m6id.16xlarge (64 vCPU, 256 GiB)
 - m6id.24xlarge (96 vCPU, 384 GiB)
 - m6id.32xlarge (128 vCPU, 512 GiB)
+- m7i.xlarge (4 vCPU, 16 GiB)	 
+- m7i.2xlarge (8 vCPU, 32 GiB)	 
+- m7i.4xlarge (16 vCPU, 64 GiB) 
+- m7i.8xlarge (32 vCPU, 128 GiB) 
+- m7i.12xlarge (48 vCPU, 192 GiB)	 
+- m7i.16xlarge (64 vCPU, 256 GiB)	 
+- m7i.24xlarge (96 vCPU, 384 GiB) 
+- m7i.48xlarge (192 vCPU, 768 GiB)	 
+- m7i.metal-24xl (96 vCPU, 384 GiB)
+- m7i.metal-48xl (192 vCPU, 768 GiB)
+- m7i-flex.xlarge (4 vCPU, 16 GiB) 
+- m7i-flex.2xlarge (8 vCPU, 32 GiB)	 
+- m7i-flex.4xlarge (16 vCPU, 64 GiB)	 
+- m7i-flex.8xlarge (32 vCPU, 128 GiB)
+- m7a.xlarge (4 vCPU, 16 GiB)	 
+- m7a.2xlarge (8 vCPU, 32 GiB)
+- m7a.4xlarge (16 vCPU, 64 GiB)	 
+- m7a.8xlarge (32 vCPU, 128 GiB)	 
+- m7a.12xlarge (48 vCPU, 192 GiB)	 
+- m7a.16xlarge (64 vCPU, 256 GiB)	 
+- m7a.24xlarge (96 vCPU, 384 GiB)	 
+- m7a.32xlarge (128 vCPU, 512 GiB)	 
+- m7a.48xlarge (192 vCPU, 768 GiB)	 
+- m7a.metal-48xl (192 vCPU, 768 GiB)
 
 &#8224; These instance types provide 96 logical processors on 48 physical cores. They run on single servers with two physical Intel sockets.
 ====
@@ -219,6 +243,15 @@
 - z1d.3xlarge (12 vCPU, 96 GiB)
 - z1d.6xlarge (24 vCPU, 192 GiB)
 - z1d.12xlarge (48 vCPU, 384 GiB)
+- r7iz.xlarge (4 vCPU, 32 GiB)	 
+- r7iz.2xlarge (8 vCPU, 64 GiB)	 
+- r7iz.4xlarge (16 vCPU, 128 GiB)	 
+- r7iz.8xlarge (32 vCPU, 256 GiB)	 
+- r7iz.12xlarge (48 vCPU, 384 GiB)	 
+- r7iz.16xlarge (64 vCPU, 512 GiB)	 
+- r7iz.32xlarge (128 vCPU, 1024 GiB)	 
+- r7iz.metal-16xl (64 vCPU, 512 GiB)
+- r7iz.metal-32xl (128 vCPU, 1024 GiB)
 
 &#8224; These instance types provide 96 logical processors on 48 physical cores. They run on single servers with two physical Intel sockets.
 
@@ -337,6 +370,15 @@ Support for the GPU instance type software stack is provided by AWS. Ensure that
 - i3en.6xlarge (24 vCPU, 192 GiB)
 - i3en.12xlarge (48 vCPU, 384 GiB)
 - i3en.24xlarge (96 vCPU, 768 GiB)
+- i4i.xlarge (4 vCPU, 32 GiB)	 
+- i4i.2xlarge (8 vCPU, 64 GiB)	 
+- i4i.4xlarge (16 vCPU, 128 GiB)	 
+- i4i.8xlarge (32 vCPU, 256 GiB)	 
+- i4i.12xlarge (48 vCPU, 384 GiB)	 
+- i4i.16xlarge (64 vCPU, 512 GiB)	 
+- i4i.24xlarge (96 vCPU, 768 GiB) 
+- i4i.32xlarge (128 vCPU, 1024 GiB)	 
+- i4i.metal (128 vCPU, 1024 GiB)
 
 &#8224; This instance type provides 72 logical processors on 36 physical cores.
 ====

--- a/modules/sdpolicy-am-aws-compute-types-ccs.adoc
+++ b/modules/sdpolicy-am-aws-compute-types-ccs.adoc
@@ -88,6 +88,30 @@
 - m6id.16xlarge (64 vCPU, 256 GiB)
 - m6id.24xlarge (96 vCPU, 384 GiB)
 - m6id.32xlarge (128 vCPU, 512 GiB)
+- m7i.xlarge (4 vCPU, 16 GiB)	 
+- m7i.2xlarge (8 vCPU, 32 GiB)	 
+- m7i.4xlarge (16 vCPU, 64 GiB) 
+- m7i.8xlarge (32 vCPU, 128 GiB) 
+- m7i.12xlarge (48 vCPU, 192 GiB)	 
+- m7i.16xlarge (64 vCPU, 256 GiB)	 
+- m7i.24xlarge (96 vCPU, 384 GiB) 
+- m7i.48xlarge (192 vCPU, 768 GiB)	 
+- m7i.metal-24xl (96 vCPU, 384 GiB)
+- m7i.metal-48xl (192 vCPU, 768 GiB)
+- m7i-flex.xlarge (4 vCPU, 16 GiB) 
+- m7i-flex.2xlarge (8 vCPU, 32 GiB)	 
+- m7i-flex.4xlarge (16 vCPU, 64 GiB)	 
+- m7i-flex.8xlarge (32 vCPU, 128 GiB)
+- m7a.xlarge (4 vCPU, 16 GiB)	 
+- m7a.2xlarge (8 vCPU, 32 GiB)
+- m7a.4xlarge (16 vCPU, 64 GiB)	 
+- m7a.8xlarge (32 vCPU, 128 GiB)	 
+- m7a.12xlarge (48 vCPU, 192 GiB)	 
+- m7a.16xlarge (64 vCPU, 256 GiB)	 
+- m7a.24xlarge (96 vCPU, 384 GiB)	 
+- m7a.32xlarge (128 vCPU, 512 GiB)	 
+- m7a.48xlarge (192 vCPU, 768 GiB)	 
+- m7a.metal-48xl (192 vCPU, 768 GiB)
 
 &#8224; These instance types provide 96 logical processors on 48 physical cores. They run on single servers with two physical Intel sockets.
 ====
@@ -218,6 +242,15 @@
 - z1d.3xlarge (12 vCPU, 96 GiB)
 - z1d.6xlarge (24 vCPU, 192 GiB)
 - z1d.12xlarge (48 vCPU, 384 GiB)
+- r7iz.xlarge (4 vCPU, 32 GiB)	 
+- r7iz.2xlarge (8 vCPU, 64 GiB)	 
+- r7iz.4xlarge (16 vCPU, 128 GiB)	 
+- r7iz.8xlarge (32 vCPU, 256 GiB)	 
+- r7iz.12xlarge (48 vCPU, 384 GiB)	 
+- r7iz.16xlarge (64 vCPU, 512 GiB)	 
+- r7iz.32xlarge (128 vCPU, 1024 GiB)	 
+- r7iz.metal-16xl (64 vCPU, 512 GiB)
+- r7iz.metal-32xl (128 vCPU, 1024 GiB)
 
 &#8224; These instance types provide 96 logical processors on 48 physical cores. They run on single servers with two physical Intel sockets.
 
@@ -336,6 +369,15 @@ Support for the GPU instance type software stack is provided by AWS. Ensure that
 - i3en.6xlarge (24 vCPU, 192 GiB)
 - i3en.12xlarge (48 vCPU, 384 GiB)
 - i3en.24xlarge (96 vCPU, 768 GiB)
+- i4i.xlarge (4 vCPU, 32 GiB)	 
+- i4i.2xlarge (8 vCPU, 64 GiB)	 
+- i4i.4xlarge (16 vCPU, 128 GiB)	 
+- i4i.8xlarge (32 vCPU, 256 GiB)	 
+- i4i.12xlarge (48 vCPU, 384 GiB)	 
+- i4i.16xlarge (64 vCPU, 512 GiB)	 
+- i4i.24xlarge (96 vCPU, 768 GiB) 
+- i4i.32xlarge (128 vCPU, 1024 GiB)	 
+- i4i.metal (128 vCPU, 1024 GiB)
 
 &#8224; This instance type provides 72 logical processors on 36 physical cores.
 ====


### PR DESCRIPTION
[OSDOCS-9659](https://issues.redhat.com//browse/OSDOCS-9659): Worker Node Instance types on ROSA/OSD i4i instances

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-9659

Link to docs preview:
ROSA: https://71770--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition#rosa-sdpolicy-instance-types_rosa-service-definition
OSD: https://71770--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-service-definition#instance-types_osd-service-definition

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
