### PR TITLE
OCPBUGS25485 Remove infra nodes subscription information from OCP documentation

### DIFF
--- a/modules/infrastructure-components.adoc
+++ b/modules/infrastructure-components.adoc
@@ -1,21 +1,21 @@
 // Module included in the following assemblies:
 //
 // * machine_management/creating-infrastructure-machinesets.adoc
-// * post_installation_configuration/cluster-tasks.adoc
 // * nodes-nodes-creating-infrastructure-nodes.adoc
 
 [id="infrastructure-components_{context}"]
 = {product-title} infrastructure components
 
-The following infrastructure workloads do not incur {product-title} worker subscriptions:
+Each self-managed Red{nbsp}Hat OpenShift subscription includes entitlements for {product-title} and other OpenShift-related components. These entitlements are included for running {product-title} control plane and infrastructure workloads and do not need to be accounted for during sizing.
 
-* Kubernetes and {product-title} control plane services that run on masters
+To qualify as an infrastructure node and use the included entitlement, only components that are supporting the cluster, and not part of an end-user application, can run on those instances. Examples include the following components:
+
+* Kubernetes and {product-title} control plane services
 * The default router
 * The integrated container image registry
 * The HAProxy-based Ingress Controller
 * The cluster metrics collection, or monitoring service, including components for monitoring user-defined projects
 * Cluster aggregated logging
-* Service brokers
 * Red Hat Quay
 * {rh-storage-first}
 * Red Hat Advanced Cluster Manager


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-25485

The request was to remove the "information about what workloads are acceptable to be executed on infra nodes" as the info is in the subscription guide.

However, per @kalexand-rh we are leaving the section. This PR updates the list slightly, adds the introductory wording from the subscription guide. 

Preview:
[OpenShift Container Platform infrastructure components](https://71777--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-creating-infrastructure-nodes#infrastructure-components_creating-infrastructure-nodes) -- Added text from subscription guide to first to paragraphs.