### PR TITLE
OSDOCS-8517-CCO Cloud Credential Operator bug text for 4.15 RNs

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -1243,6 +1243,18 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 [id="ocp-4-15-cloud-cred-operator-bug-fixes"]
 ==== Cloud Credential Operator
 
+* Previously, the Cloud Credential Operator utility (`ccoctl`) created custom GCP roles at the cluster level, so each cluster contributed to the quota limit on the number of allowed custom roles. Because of GCP deletion policies, deleted custom roles continue to contribute to the quota limit for many days after they are deleted. With this release, custom roles are added at the project level instead of the cluster level to reduce the total number of custom roles created. Additionally, an option to clean up custom roles is now available when deleting the GCP resources that the `ccoctl` utility creates during installation. These changes can help avoid reaching the quota limit on the number of allowed custom roles. (link:https://issues.redhat.com/browse/OCPBUGS-28850[*OCPBUGS-28850*])
+
+* Previously, when the Cloud Credential Operator (CCO) was in default mode, CCO used an incorrect client for root credential queries. The CCO failed to find the intended secret and wrongly reported a `credsremoved` mode in the `cco_credentials_mode` metric. With this release, the CCO now uses the correct client to ensure accurate reporting of the `cco_credentials_mode` metric. (link:https://issues.redhat.com/browse/OCPBUGS-26510[*OCPBUGS-26510*])
+
+* Previously, buckets created by running the `ccoctl azure create` command were prohibited from allowing public blob access due to a change in the default behavior of Microsoft Azure buckets. With this release, buckets created by running the `ccoctl azure create` command are explicitly set to allow public blob access. (link:https://issues.redhat.com/browse/OCPBUGS-22369[*OCPBUGS-22369*])
+
+* Previously, an Azure Managed Identity role was omitted from the Cloud Controller Manager service account. As a result, the Cloud Controller Manager could not manage service type load balancers in environments deployed to existing VNets with a private publishing method. With this release, the missing role was added to the Cloud Credential Operator utility (`ccoctl`) and Azure Managed Identity installations into an existing VNet with private publishing is possible. (link:https://issues.redhat.com/browse/OCPBUGS-21745[*OCPBUGS-21745*])
+
+* Previously, the Cloud Credential Operator did not support updating the vCenter server value in the root secret `vshpere-creds` that is stored in the `kube-system` namespace. As a result, attempting to update this value caused both the old and new values to exist because the component secrets were not synchronized correctly. With this release, the Cloud Credential Operator resets the secret data during synchronization so that updating the vCenter server value is supported. (link:https://issues.redhat.com/browse/OCPBUGS-20478[*OCPBUGS-20478*])
+
+* Previously, the Cloud Credential Operator utility (`ccoctl`) failed to create AWS Security Token Service (STS) resources in China regions because the China region DNS suffix `.amazonaws.com.cn` differs from the suffix `.amazonaws.com` that is used in other regions. With this release, `ccoctl` can detect the correct DNS suffix and use it to create the required resources. (link:https://issues.redhat.com/browse/OCPBUGS-13597[*OCPBUGS-13597*])
+
 [discrete]
 [id="ocp-4-15-cluster-version-operator-bug-fixes"]
 ==== Cluster Version Operator


### PR DESCRIPTION
Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-8517](https://issues.redhat.com/browse/OSDOCS-8517)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Scroll to Cloud Credential Operator under Bug Fixes](https://71779--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-bug-fixes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
Not needed
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
