### PR TITLE
OBSDOCS-212: Add docs for http server receiver input

### DIFF
--- a/logging/log_collection_forwarding/cluster-logging-collector.adoc
+++ b/logging/log_collection_forwarding/cluster-logging-collector.adoc
@@ -23,4 +23,10 @@ include::modules/cluster-logging-collector-limits.adoc[leveloffset=+1]
 //include::modules/log-collector-rsyslog-server.adoc[leveloffset=+1]
 // uncomment for 5.9 release
 
+include::modules/log-collector-http-server.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../logging/log_collection_forwarding/configuring-log-forwarding.adoc#logging-audit-filtering_configuring-log-forwarding[Overview of API audit filter]
+
 include::modules/cluster-logging-collector-tuning.adoc[leveloffset=+1]

--- a/modules/log-collector-http-server.adoc
+++ b/modules/log-collector-http-server.adoc
@@ -1,0 +1,54 @@
+// Module included in the following assemblies:
+//
+// * logging/log_collection_forwarding/cluster-logging-collector.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="log-collector-http-server_{context}"]
+= Configuring the collector to receive audit logs as an HTTP server
+
+You can configure your log collector to listen for HTTP connections and receive audit logs as an HTTP server by specifying `http` as a receiver input in the `ClusterLogForwarder` custom resource (CR). This enables you to use a common log store for audit logs that are collected from both inside and outside of your {product-title} cluster.
+
+.Prerequisites
+
+* You have administrator permissions.
+* You have installed the {oc-first}.
+* You have installed the {clo}.
+* You have created a `ClusterLogForwarder` CR.
+
+.Procedure
+
+. Modify the `ClusterLogForwarder` CR to add configuration for the `http` receiver input:
++
+[source,yaml]
+----
+apiVersion: logging.openshift.io/v1beta1
+kind: ClusterLogForwarder
+metadata:
+# ...
+spec:
+  serviceAccountName: <service_account_name>
+  inputs:
+    - name: http-receiver # <1>
+      receiver:
+        type: http # <2>
+        http:
+          format: kubeAPIAudit # <3>
+          port: 8443 # <4>
+  pipelines: # <5>
+    - name: http-pipeline
+      inputRefs:
+        - http-receiver
+# ...
+----
+<1> Specify a name for your input receiver.
+<2> Specify the input receiver type as `http`.
+<3> Currently, only the the `kube-apiserver` webhook format is supported for `http` input receivers.
+<4> Optional: Specify the port that the input receiver listens on. This must be a value between `1024` and `65535`. The default value is `8443` if this is not specified.
+<5> Configure a pipeline for your input receiver.
+
+. Apply the changes to the `ClusterLogForwarder` CR:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----

--- a/modules/logging-audit-log-filtering.adoc
+++ b/modules/logging-audit-log-filtering.adoc
@@ -2,7 +2,7 @@
 //logging/log_collection_forwarding/configuring-log-forwarding.adoc
 //
 :_mod-docs-content-type: CONCEPT
-[id="logging_audit_filtering_{context}"]
+[id="logging-audit-filtering_{context}"]
 = Overview of API audit filter
 OpenShift API servers generate audit events for each API call, detailing the request, response, and the identity of the requester, leading to large volumes of data. The API Audit filter uses rules to enable the exclusion of non-essential events and the reduction of event size, facilitating a more manageable audit trail. Rules are checked in order, checking stops at the first match. How much data is included in an event is determined by the value of the `level` field:
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OBSDOCS-212

Link to docs preview:
https://71780--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_collection_forwarding/cluster-logging-collector#log-collector-http-server_cluster-logging-collector

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
