### PR TITLE
cluster logging redirect

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -174,6 +174,7 @@ AddType text/vtt                            vtt
     RewriteRule ^(rosa|dedicated)/logging/config/cluster-logging-tolerations.html /$1/logging/scheduling_resources/logging-taints-tolerations.html [NE,R=302]
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/logging/config/cluster-logging-moving-nodes.html /container-platform/$1/logging/scheduling_resources/logging-node-selectors.html [NE,R=302]
     RewriteRule ^(rosa|dedicated)/logging/config/cluster-logging-moving-nodes.html /$1/logging/scheduling_resources/logging-node-selectors.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/logging/config/cluster-logging-log-store.html /container-platform/$1/logging/log_storage/logging-config-es-store.html [NE,R=302]
 
     # Redirect for log collection forwarding per https://github.com/openshift/openshift-docs/pull/64406
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/logging/config/cluster-logging-collector.html /container-platform/$1/logging/log_collection_forwarding/cluster-logging-collector.html [NE,R=302]


### PR DESCRIPTION
Redirecting [https://docs.openshift.com/container-platform/4.11/logging/config/cluster-logging-log-store.html](https://docs.openshift.com/container-platform/4.13/logging/config/cluster-logging-log-store.html) to https://docs.openshift.com/container-platform/4.11/logging/log_storage/logging-config-es-store.html for all active versions. 

Main only.