### PR TITLE
OADP 3511 - removing OADP 1.1 Data Mover references

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3103,7 +3103,7 @@ Topics:
     Topics:
     - Name: Backing up applications on ROSA STS using OADP
       File: oadp-rosa-backing-up-applications
-  - Name: OADP Data Mover
+  - Name: OADP 1.2 Data Mover
     Dir: installing
     Topics:
     - Name: Introduction to OADP Data Mover
@@ -3112,8 +3112,6 @@ Topics:
       File: oadp-using-data-mover-for-csi-snapshots-doc
     - Name: Using OADP 1.2 Data Mover with Ceph storage
       File: oadp-12-data-mover-ceph-doc
-    - Name: Cleaning up after a backup using OADP 1.1 Data Mover
-      File: oadp-cleaning-up-after-data-mover-1-1-backup-doc
   - Name: OADP 1.3 Data Mover
     Dir: installing
     Topics:

--- a/backup_and_restore/application_backup_and_restore/installing/data-mover-intro.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/data-mover-intro.adoc
@@ -8,20 +8,12 @@ toc::[]
 
 OADP Data Mover allows you to restore stateful applications from the store if a failure, accidental deletion, or corruption of the cluster occurs.
 
-[NOTE]
-====
-The OADP 1.1 Data Mover is a Technology Preview feature.
-
-The OADP 1.2 Data Mover has significantly improved features and performances, but is still a Technology Preview feature.
-====
-:FeatureName: The OADP Data Mover
+:FeatureName: The OADP 1.2 Data Mover
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
 * You can use OADP Data Mover to back up Container Storage Interface (CSI) volume snapshots to a remote object store. See xref:../../../backup_and_restore/application_backup_and_restore/installing/oadp-using-data-mover-for-csi-snapshots-doc.adoc#oadp-using-data-mover-for-csi-snapshots-doc[Using Data Mover for CSI snapshots].
 
-* You can use OADP 1.2 Data Mover to backup and restore application data for clusters that use CephFS, CephRBD, or both. See xref:../../../backup_and_restore/application_backup_and_restore/installing/oadp-using-data-mover-for-csi-snapshots-doc.adoc#oadp-using-data-mover-for-csi-snapshots-doc[Using OADP 1.2 Data Mover with Ceph storage].
-
-* You must perform a data cleanup after you perform a backup, if you are using OADP 1.1 Data Mover. See xref:../../../backup_and_restore/application_backup_and_restore/installing/oadp-cleaning-up-after-data-mover-1-1-backup-doc.adoc#oadp-cleaning-up-after-data-mover-1-1-backup-doc[Cleaning up after a backup using OADP 1.1 Data Mover].
+* You can use OADP 1.2 Data Mover to back up and restore application data for clusters that use CephFS, CephRBD, or both. See xref:../../../backup_and_restore/application_backup_and_restore/installing/oadp-using-data-mover-for-csi-snapshots-doc.adoc#oadp-using-data-mover-for-csi-snapshots-doc[Using OADP 1.2 Data Mover with Ceph storage].
 
 include::snippets/snip-post-mig-hook[]
 

--- a/backup_and_restore/application_backup_and_restore/installing/oadp-using-data-mover-for-csi-snapshots-doc.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/oadp-using-data-mover-for-csi-snapshots-doc.adoc
@@ -21,13 +21,7 @@ Data Mover supports backup and restore of CSI volume snapshots only.
 In OADP 1.2 Data Mover `VolumeSnapshotBackups` (VSBs) and `VolumeSnapshotRestores` (VSRs) are queued using the VolumeSnapshotMover (VSM). The VSM's performance is improved by specifying a concurrent number of VSBs and VSRs simultaneously `InProgress`. After all async plugin operations are complete, the backup is marked as complete.
 
 
-[NOTE]
-====
-The OADP 1.1 Data Mover is a Technology Preview feature.
-
-The OADP 1.2 Data Mover has significantly improved features and performances, but is still a Technology Preview feature.
-====
-:FeatureName: The OADP Data Mover
+:FeatureName: The OADP 1.2 Data Mover
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
 [NOTE]
@@ -63,8 +57,6 @@ In {product-title} version 4.12 or later, verify that this is the only default `
 +
 [NOTE]
 ====
-In OADP 1.1 the above setting is mandatory.
-
 In OADP 1.2 the `privileged-movers` setting is not required in most scenarios. The restoring container permissions should be adequate for the Volsync copy. In some user scenarios, there may be permission errors that the `privileged-mover`= `true` setting should resolve.
 ====
 
@@ -131,15 +123,15 @@ spec:
         - openshift
         - aws
         - csi
-        - vsm <1>
+        - vsm
   features:
     dataMover:
       credentialName: restic-secret
       enable: true
-      maxConcurrentBackupVolumes: "3" <2>
-      maxConcurrentRestoreVolumes: "3" <3>
-      pruneInterval: "14" <4>
-      volumeOptions: <5>
+      maxConcurrentBackupVolumes: "3" <1>
+      maxConcurrentRestoreVolumes: "3" <2>
+      pruneInterval: "14" <3>
+      volumeOptions: <4>
       sourceVolumeOptions:
           accessMode: ReadOnlyMany
           cacheAccessMode: ReadWriteOnce
@@ -155,11 +147,10 @@ spec:
         provider: aws
 
 ----
-<1> OADP 1.2 only.
-<2> OADP 1.2 only. Optional: Specify the upper limit of the number of snapshots allowed to be queued for backup. The default value is 10.
-<3> OADP 1.2 only. Optional: Specify the upper limit of the number of snapshots allowed to be queued for restore. The default value is 10.
-<4> OADP 1.2 only. Optional: Specify the number of days, between running Restic pruning on the repository. The prune operation repacks the data to free space, but it can also generate significant I/O traffic as a part of the process. Setting this option allows a trade-off between storage consumption, from no longer referenced data, and access costs.
-<5> OADP 1.2 only. Optional: Specify VolumeSync volume options for backup and restore.
+<1> Optional: Specify the upper limit of the number of snapshots allowed to be queued for backup. The default value is `10`.
+<2> Optional: Specify the upper limit of the number of snapshots allowed to be queued for restore. The default value is `10`.
+<3> Optional: Specify the number of days between running Restic pruning on the repository. The prune operation repacks the data to free space, but it can also generate significant I/O traffic as a part of the process. Setting this option allows a trade-off between storage consumption, from no longer referenced data, and access costs.
+<4> Optional: Specify VolumeSync volume options for backup and restore.
 
 +
 The OADP Operator installs two custom resource definitions (CRDs), `VolumeSnapshotBackup` and `VolumeSnapshotRestore`.

--- a/modules/oadp-using-data-mover-for-csi-snapshots.adoc
+++ b/modules/oadp-using-data-mover-for-csi-snapshots.adoc
@@ -18,13 +18,7 @@ Data Mover supports backup and restore of CSI volume snapshots only.
 
 In OADP 1.2 Data Mover, `VolumeSnapshotBackups` (VSBs) and `VolumeSnapshotRestores` (VSRs) are queued by using the VolumeSnapshotMover (VSM). The VSM's performance is improved by specifying a concurrent number of VSBs and VSRs simultaneously `InProgress`. After all async plugin operations are complete, the backup is marked as complete.
 
-[NOTE]
-====
-The OADP 1.1 Data Mover is a Technology Preview feature.
-
-The OADP 1.2 Data Mover has significantly improved features and performances, but is still a Technology Preview feature.
-====
-:FeatureName: The OADP Data Mover
+:FeatureName: The OADP 1.2 Data Mover
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
 [NOTE]
@@ -57,11 +51,6 @@ In {product-title} version 4.12 or later, verify that this is the only default `
 * You have included the label `{velero-domain}/csi-volumesnapshot-class: 'true'` in your `VolumeSnapshotClass` CR.
 
 * You have verified that the `OADP namespace` has the annotation `oc annotate --overwrite namespace/openshift-adp volsync.backube/privileged-movers='true'`.
-+
-[NOTE]
-====
-In OADP 1.1 the above setting is mandatory.
-====
 
 * You have installed the VolSync Operator by using Operator Lifecycle Manager (OLM).
 +
@@ -139,14 +128,12 @@ spec:
         - openshift
         - aws
         - csi
-        - vsm <5>
+        - vsm
 ----
-<1> OADP 1.2 only. Optional: Specify the upper limit of the number of snapshots allowed to be queued for backup. The default value is 10.
-<2> OADP 1.2 only. Optional: Specify the upper limit of the number of snapshots allowed to be queued for restore. The default value is 10.
-<3> OADP 1.2 only. Optional: Specify the number of days, between running Restic pruning on the repository. The prune operation repacks the data to free space, but it can also generate significant I/O traffic as a part of the process. Setting this option allows a trade-off between storage consumption, from no longer referenced data, and access costs.
-<4> OADP 1.2 only. Optional: Specify VolumeSync volume options for backup and restore.
-<5> OADP 1.2 only.
-
+<1> Optional: Specify the upper limit of the number of snapshots allowed to be queued for backup. The default value is `10`.
+<2> Optional: Specify the upper limit of the number of snapshots allowed to be queued for restore. The default value is `10`.
+<3> Optional: Specify the number of days between running Restic pruning on the repository. The prune operation repacks the data to free space, but it can also generate significant I/O traffic as a part of the process. Setting this option allows a trade-off between storage consumption, from no longer referenced data, and access costs.
+<4> Optional: Specify VolumeSync volume options for backup and restore.
 +
 The OADP Operator installs two custom resource definitions (CRDs), `VolumeSnapshotBackup` and `VolumeSnapshotRestore`.
 +

--- a/snippets/snip-post-mig-hook
+++ b/snippets/snip-post-mig-hook
@@ -4,7 +4,7 @@
 ====
 Post-migration hooks are not likely to work well with the OADP 1.3 Data Mover.
 
-The OADP 1.1 and OADP 1.2 Data Movers use synchronous processes to back up and restore application data. Because the processes are synchronous, users can be sure that any post-restore hooks start only after the persistent volumes (PVs) of the related pods are released by the persistent volume claim (PVC) of the Data Mover.
+The OADP 1.2 Data Mover uses synchronous processes to back up and restore application data. Because the processes are synchronous, users can be sure that any post-restore hooks start only after the persistent volumes (PVs) of the related pods are released by the persistent volume claim (PVC) of the Data Mover.
 
 However, the OADP 1.3 Data Mover uses an asynchronous process. As a result of this difference in sequencing, a post-restore hook might be called before the related PVs were released by the PVC of the Data Mover. If this happens, the pod remains in `Pending` status and cannot run the hook. The hook attempt might time out before the pod is released, leading to a `PartiallyFailed` restore operation.
 ====


### PR DESCRIPTION
OADP 1.3.1

OCP - 4.13+

Resolves - https://issues.redhat.com/browse/OADP-3511

Deploy preview - 

https://71790--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/data-mover-intro

(Intro Data Mover)

https://71790--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/oadp-using-data-mover-for-csi-snapshots-doc

(Using Data Mover for CSI)
