### PR TITLE
OSDOCS-9690: adds create network policy to MicroShift

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -405,13 +405,14 @@ Topics:
 - Name: Network policies
   Dir: microshift-network-policy
   Topics:
-  - Name: Setting network policies
+  - Name: About network policies
     File: microshift-network-policy-index
+  - Name: Creating network policies
+    File: microshift-creating-network-policy
 - Name: Firewall configuration
   File: microshift-firewall
 - Name: Networking settings for fully disconnected hosts
   File: microshift-disconnected-network-config
-
 ---
 Name: Storage
 Dir: microshift_storage

--- a/microshift_networking/microshift-network-policy/microshift-creating-network-policy.adoc
+++ b/microshift_networking/microshift-network-policy/microshift-creating-network-policy.adoc
@@ -1,0 +1,23 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="microshift-creating-network-policy"]
+= Creating network policies
+include::_attributes/attributes-microshift.adoc[]
+include::_attributes/common-attributes.adoc[]
+:context: microshift-creating-network-policy
+
+toc::[]
+
+You can create a network policy for a namespace.
+
+//OCP modules, edit using conditions and with care (check OCP previews, too)
+include::modules/nw-networkpolicy-object.adoc[leveloffset=+1]
+
+include::modules/nw-networkpolicy-create-cli.adoc[leveloffset=+1]
+
+include::modules/nw-networkpolicy-deny-all-allowed.adoc[leveloffset=+1]
+
+include::modules/nw-networkpolicy-allow-external-clients.adoc[leveloffset=+1]
+
+include::modules/nw-networkpolicy-allow-application-all-namespaces.adoc[leveloffset=+1]
+
+include::modules/nw-networkpolicy-allow-application-particular-namespace.adoc[leveloffset=+1]

--- a/microshift_networking/microshift-network-policy/microshift-network-policy-index.adoc
+++ b/microshift_networking/microshift-network-policy/microshift-network-policy-index.adoc
@@ -1,11 +1,11 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="microshift-network-policies"]
-= Setting network policies
+= About network policies
 include::_attributes/attributes-microshift.adoc[]
 :context: microshift-network-policies
 toc::[]
 
-Learn how to apply network policies to restrict or allow network traffic to pods in your cluster.
+Learn how network policies work for {microshift-short} to restrict or allow network traffic to pods in your cluster.
 
 include::modules/microshift-nw-network-policy-intro.adoc[leveloffset=+1]
 

--- a/modules/nw-networkpolicy-allow-application-all-namespaces.adoc
+++ b/modules/nw-networkpolicy-allow-application-all-namespaces.adoc
@@ -2,6 +2,7 @@
 //
 // * networking/multiple_networks/configuring-multi-network-policy.adoc
 // * networking/network_policy/creating-network-policy.adoc
+// * microshift_networking/microshift-creating-network-policy.adoc
 
 :name: network
 :role: admin
@@ -15,18 +16,23 @@ endif::[]
 [id="nw-networkpolicy-allow-traffic-from-all-applications_{context}"]
 = Creating a {name} policy allowing traffic to an application from all namespaces
 
+ifndef::microshift[]
 [NOTE]
 ====
 If you log in with a user with the `cluster-admin` role, then you can create a network policy in any namespace in the cluster.
 ====
+endif::microshift[]
 
 Follow this procedure to configure a policy that allows traffic from all pods in all namespaces to a particular application.
 
 .Prerequisites
-
+ifndef::microshift[]
 * Your cluster uses a network plugin that supports `NetworkPolicy` objects, such as the OVN-Kubernetes network plugin or the OpenShift SDN network plugin with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
+endif::microshift[]
 * You installed the OpenShift CLI (`oc`).
+ifndef::microshift[]
 * You are logged in to the cluster with a user with `{role}` privileges.
+endif::microshift[]
 * You are working in the namespace that the {name} policy applies to.
 
 .Procedure

--- a/modules/nw-networkpolicy-allow-application-particular-namespace.adoc
+++ b/modules/nw-networkpolicy-allow-application-particular-namespace.adoc
@@ -2,6 +2,7 @@
 //
 // * networking/multiple_networks/configuring-multi-network-policy.adoc
 // * networking/network_policy/creating-network-policy.adoc
+// * microshift_networking/microshift-creating-network-policy.adoc
 
 :name: network
 :role: admin
@@ -15,10 +16,12 @@ endif::[]
 [id="nw-networkpolicy-allow-traffic-from-a-namespace_{context}"]
 = Creating a {name} policy allowing traffic to an application from a namespace
 
+ifndef::microshift[]
 [NOTE]
 ====
 If you log in with a user with the `cluster-admin` role, then you can create a network policy in any namespace in the cluster.
 ====
+endif::microshift[]
 
 Follow this procedure to configure a policy that allows traffic to a pod with the label `app=web` from a particular namespace. You might want to do this to:
 
@@ -26,10 +29,13 @@ Follow this procedure to configure a policy that allows traffic to a pod with th
 * Enable monitoring tools deployed to a particular namespace to scrape metrics from the current namespace.
 
 .Prerequisites
-
+ifndef::microshift[]
 * Your cluster uses a network plugin that supports `NetworkPolicy` objects, such as the OVN-Kubernetes network plugin or the OpenShift SDN network plugin with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
+endif::microshift[]
 * You installed the OpenShift CLI (`oc`).
+ifndef::microshift[]
 * You are logged in to the cluster with a user with `{role}` privileges.
+endif::microshift[]
 * You are working in the namespace that the {name} policy applies to.
 
 .Procedure

--- a/modules/nw-networkpolicy-allow-external-clients.adoc
+++ b/modules/nw-networkpolicy-allow-external-clients.adoc
@@ -17,18 +17,29 @@ endif::[]
 
 With the `deny-by-default` policy in place you can proceed to configure a policy that allows traffic from external clients to a pod with the label `app=web`.
 
+ifndef::microshift[]
 [NOTE]
 ====
 If you log in with a user with the `cluster-admin` role, then you can create a network policy in any namespace in the cluster.
 ====
+endif::microshift[]
+ifdef::microshift[]
+[NOTE]
+====
+Firewalld rules run before any `NetworkPolicy` is enforced.
+====
+endif::microshift[]
 
 Follow this procedure to configure a policy that allows external service from the public Internet directly or by using a Load Balancer to access the pod. Traffic is only allowed to a pod with the label `app=web`.
 
 .Prerequisites
-
+ifndef::microshift[]
 * Your cluster uses a network plugin that supports `NetworkPolicy` objects, such as the OVN-Kubernetes network plugin or the OpenShift SDN network plugin with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
+endif::microshift[]
 * You installed the OpenShift CLI (`oc`).
+ifndef::microshift[]
 * You are logged in to the cluster with a user with `{role}` privileges.
+endif::microshift[]
 * You are working in the namespace that the {name} policy applies to.
 
 .Procedure
@@ -80,10 +91,11 @@ ifdef::multi[]
 multinetworkpolicy.k8s.cni.cncf.io/web-allow-external created
 endif::multi[]
 ----
-
+ifndef::microshift[]
 This policy allows traffic from all resources, including external traffic as illustrated in the following diagram:
 
 image::292_OpenShift_Configuring_multi-network_policy_1122.png[Allow traffic from external clients]
+endif::microshift[]
 
 ifdef::multi[]
 :!multi:

--- a/modules/nw-networkpolicy-create-cli.adoc
+++ b/modules/nw-networkpolicy-create-cli.adoc
@@ -3,6 +3,7 @@
 // * networking/multiple_networks/configuring-multi-network-policy.adoc
 // * networking/network_policy/creating-network-policy.adoc
 // * post_installation_configuration/network-configuration.adoc
+// * microshift_networking/microshift-creating-network-policy.adoc
 
 :name: network
 :role: admin
@@ -18,18 +19,21 @@ endif::[]
 
 To define granular rules describing ingress or egress network traffic allowed for namespaces in your cluster, you can create a {name} policy.
 
-ifndef::multi[]
+ifndef::multi,microshift[]
 [NOTE]
 ====
 If you log in with a user with the `cluster-admin` role, then you can create a network policy in any namespace in the cluster.
 ====
-endif::multi[]
+endif::multi,microshift[]
 
 .Prerequisites
-
+ifndef::microshift[]
 * Your cluster uses a network plugin that supports `NetworkPolicy` objects, such as the OVN-Kubernetes network plugin or the OpenShift SDN network plugin with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
+endif::microshift[]
 * You installed the OpenShift CLI (`oc`).
+ifndef::microshift[]
 * You are logged in to the cluster with a user with `{role}` privileges.
+endif::microshift[]
 * You are working in the namespace that the {name} policy applies to.
 
 .Procedure
@@ -235,7 +239,9 @@ endif::multi[]
 :!name:
 :!role:
 
+ifndef::microshift[]
 [NOTE]
 ====
 If you log in to the web console with `cluster-admin` privileges, you have a choice of creating a network policy in any namespace in the cluster directly in YAML or from a form in the web console.
 ====
+endif::microshift[]

--- a/modules/nw-networkpolicy-deny-all-allowed.adoc
+++ b/modules/nw-networkpolicy-deny-all-allowed.adoc
@@ -2,6 +2,7 @@
 //
 // * networking/multiple_networks/configuring-multi-network-policy.adoc
 // * networking/network_policy/creating-network-policy.adoc
+// * microshift_networking/microshift-creating-network-policy.adoc
 
 :name: network
 :role: admin
@@ -17,16 +18,21 @@ endif::[]
 
 This is a fundamental policy, blocking all cross-pod networking other than network traffic allowed by the configuration of other deployed network policies. This procedure enforces a default `deny-by-default` policy.
 
+ifndef::microshift[]
 [NOTE]
 ====
 If you log in with a user with the `cluster-admin` role, then you can create a network policy in any namespace in the cluster.
 ====
+endif::microshift[]
 
 .Prerequisites
-
+ifndef::microshift[]
 * Your cluster uses a network plugin that supports `NetworkPolicy` objects, such as the OVN-Kubernetes network plugin or the OpenShift SDN network plugin with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
+endif::microshift[]
 * You installed the OpenShift CLI (`oc`).
+ifndef::microshift[]
 * You are logged in to the cluster with a user with `{role}` privileges.
+endif::microshift[]
 * You are working in the namespace that the {name} policy applies to.
 
 .Procedure

--- a/modules/nw-networkpolicy-object.adoc
+++ b/modules/nw-networkpolicy-object.adoc
@@ -4,6 +4,7 @@
 // * networking/network_policy/viewing-network-policy.adoc
 // * networking/network_policy/editing-network-policy.adoc
 // * post_installation_configuration/network-configuration.adoc
+// * microshift_networking/microshift-creating-network-policy.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="nw-networkpolicy-object_{context}"]
@@ -31,7 +32,9 @@ spec:
       port: 27017
 ----
 <1> The name of the NetworkPolicy object.
-<2> A selector that describes the pods to which the policy applies. The policy object can
-only select pods in the project that defines the NetworkPolicy object.
+<2> A selector that describes the pods to which the policy applies.
+ifndef::microshift[]
+The policy object can only select pods in the project that defines the NetworkPolicy object.
+endif::microshift[]
 <3> A selector that matches the pods from which the policy object allows ingress traffic. The selector matches pods in the same namespace as the NetworkPolicy.
 <4> A list of one or more destination ports on which to accept traffic.


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-9690](https://issues.redhat.com/browse/OSDOCS-9690)

Link to docs preview:
[Creating network policies](https://71808--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-network-policy/microshift-creating-network-policy)

_For docs-team reviewers_
[OCP assembly for docs-reviewer reference](https://71808--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_policy/creating-network-policy)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Content port with conditionals.
[Edit and delete network policies](https://github.com/openshift/openshift-docs/pull/71854)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
