### PR TITLE
[OSDOCS-9703]:Issue in file osd_install_access_delete_cluster/creating-an-aws-cluster

### DIFF
--- a/modules/osd-create-cluster-ccs.adoc
+++ b/modules/osd-create-cluster-ccs.adoc
@@ -88,7 +88,7 @@ endif::osd-on-gcp[]
 . On the *Create an OpenShift cluster* page, select *Create cluster* in the *Red Hat OpenShift Dedicated* row.
 
 . Under *Billing model*, configure the subscription type and infrastructure type:
-.. Select a subscription type. For information about {product-title} subscription options, see link:https://access.redhat.com/documentation/en-us/openshift_cluster_manager/2022/html-single/managing_clusters/index#subscribing-osd-cluster_assembly-cluster-subscriptions[Managing OpenShift Dedicated cluster subscriptions] in the {cluster-manager} documentation.
+.. Select a subscription type. For information about {product-title} subscription options, see link:https://access.redhat.com/documentation/en-us/openshift_cluster_manager/1-latest/html-single/managing_clusters/index#assembly-cluster-subscriptions[Cluster subscriptions and registration] in the {cluster-manager} documentation.
 +
 [NOTE]
 ====

--- a/modules/osd-create-cluster-red-hat-account.adoc
+++ b/modules/osd-create-cluster-red-hat-account.adoc
@@ -38,7 +38,7 @@ using a standard cloud provider account owned by Red Hat.
 . Under *Billing model*, configure the subscription type and infrastructure type:
 .. Select the *Annual* subscription type. Only the *Annual* subscription type is available when you deploy a cluster using a Red Hat cloud account.
 +
-For information about {product-title} subscription options, see link:https://access.redhat.com/documentation/en-us/openshift_cluster_manager/2022/html-single/managing_clusters/index#subscribing-osd-cluster_assembly-cluster-subscriptions[Managing OpenShift Dedicated cluster subscriptions] in the {cluster-manager} documentation.
+For information about {product-title} subscription options, see link:https://access.redhat.com/documentation/en-us/openshift_cluster_manager/1-latest/html-single/managing_clusters/index#assembly-cluster-subscriptions[Cluster subscriptions and registration] in the {cluster-manager} documentation.
 +
 [NOTE]
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-9703
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://71814--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-an-aws-cluster#osd-create-aws-cluster-ccs_osd-creating-a-cluster-on-aws

https://71814--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-an-aws-cluster#osd-create-aws-cluster-red-hat-account_osd-creating-a-cluster-on-aws

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
QE NA. Doc change was redirecting links to specific subject matter. Previous link(s) were not location-specific enough. 
Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
