### PR TITLE
CNV-35121: Add MetalLB Operator to network post-install config

### DIFF
--- a/virt/post_installation_configuration/virt-post-install-network-config.adoc
+++ b/virt/post_installation_configuration/virt-post-install-network-config.adoc
@@ -16,26 +16,17 @@ endif::openshift-rosa,openshift-dedicated[]
 == Installing networking Operators
 
 ifndef::openshift-rosa,openshift-dedicated[]
-You must install the xref:../../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#k8s-nmstate-about-the-k8s-nmstate-operator[Kubernetes NMState Operator] to configure a Linux bridge network for live migration or external access to virtual machines (VMs).
-endif::openshift-rosa,openshift-dedicated[]
-ifdef::openshift-rosa,openshift-dedicated[]
-// hide link until Networking docs are ported: xref:  ../../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#k8s-nmstate-about-the-k8s-nmstate-operator
-You must install the Kubernetes NMState Operator for live migration or external access to virtual machines (VMs).
+You must install the xref:../../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#k8s-nmstate-about-the-k8s-nmstate-operator[Kubernetes NMState Operator] to configure a Linux bridge network for live migration or external access to virtual machines (VMs). For installation instructions, see xref:../../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#installing-the-kubernetes-nmstate-operator-cli[Installing the Kubernetes NMState Operator by using the web console].
 endif::openshift-rosa,openshift-dedicated[]
 
 ifndef::openshift-rosa,openshift-dedicated[]
-You can install the xref:../../networking/hardware_networks/about-sriov.adoc#about-sriov[SR-IOV Operator] to manage SR-IOV network devices and network attachments.
+You can install the xref:../../networking/hardware_networks/about-sriov.adoc#about-sriov[SR-IOV Operator] to manage SR-IOV network devices and network attachments. For installation instructions, see xref:../../networking/hardware_networks/installing-sriov-operator.adoc#installing-sriov-operator[Installing the SR-IOV Network Operator].
 endif::openshift-rosa,openshift-dedicated[]
 
-include::modules/k8s-nmstate-installing-the-kubernetes-nmstate-operator.adoc[leveloffset=+2]
-
-// Hiding in ROSA/OSD as dedicated-admin user cannot create the required namespace
 ifndef::openshift-rosa,openshift-dedicated[]
-include::modules/nw-sriov-installing-operator.adoc[leveloffset=+2]
+You can add the xref:../../networking/metallb/about-metallb.adoc#about-metallb[MetalLB Operator] to manage the lifecycle for an instance of MetalLB on your cluster. For installation instructions, see xref:../../networking/metallb/metallb-operator-install.adoc#metallb-operator-install[Installing the MetalLB Operator from the OperatorHub using the web console].
 endif::openshift-rosa,openshift-dedicated[]
 
-// Hiding in ROSA/OSD as dedicated-admin user cannot create the required "nodenetworkconfigurationpolicies" resource
-ifndef::openshift-rosa,openshift-dedicated[]
 [id="configuring-linux-bridge-network"]
 == Configuring a Linux bridge network
 
@@ -45,8 +36,10 @@ include::modules/virt-creating-linux-bridge-nncp.adoc[leveloffset=+2]
 
 include::modules/virt-creating-linux-bridge-nad-web.adoc[leveloffset=+2]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 .Next steps
 * xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-attaching-vm-secondary-network-cli_virt-connecting-vm-to-linux-bridge[Attaching a virtual machine (VM) to a Linux bridge network]
+endif::openshift-rosa,openshift-dedicated[]
 
 [id="configuring-network-live-migration"]
 == Configuring a network for live migration
@@ -56,9 +49,7 @@ After you have configured a Linux bridge network, you can configure a dedicated 
 include::modules/virt-configuring-secondary-network-vm-live-migration.adoc[leveloffset=+2]
 
 include::modules/virt-selecting-migration-network-ui.adoc[leveloffset=+2]
-endif::openshift-rosa,openshift-dedicated[]
 
-// Hiding in ROSA/OSD as dedicated-admin user cannot create the required namespace
 ifndef::openshift-rosa,openshift-dedicated[]
 [id="configuring-sriov-network"]
 == Configuring an SR-IOV network
@@ -75,4 +66,3 @@ include::modules/nw-sriov-network-attachment.adoc[leveloffset=+2]
 endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/virt-enabling-load-balancer-service-web.adoc[leveloffset=+1]
-


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/CNV-35121

OCP 4.12+

Preview: https://71820--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-post-install-network-config#installing-operators

