### PR TITLE
Update the Tang Operator release notes with 1.0.1

### DIFF
--- a/security/nbde_tang_server_operator/nbde-tang-server-operator-release-notes.adoc
+++ b/security/nbde_tang_server_operator/nbde-tang-server-operator-release-notes.adoc
@@ -10,6 +10,7 @@ toc::[]
 The following release notes track the development of the Security Profiles Operator in the OpenShift Container Platform.
 
 * link:https://access.redhat.com/errata/RHEA-2023:7491[RHEA-2023:7491 - Release of the NBDE Tang Server Operator 1.0]
+* link:https://access.redhat.com/errata/RHEA-2024:0854[RHEA-2024:0854 - NBDE Tang Server Operator 1.0.1 has been moved from the "alpha" channel to the "stable" channel]
 
 ////
 A template for a future use


### PR DESCRIPTION
Just a new line for a new minor change (the advisory published on Feb 19)

Version(s):
4.13, 4.14, 4.15

Issue: https://issues.redhat.com/browse/SECENGSP-5588

Link to docs preview:
https://71822--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/nbde_tang_server_operator/nbde-tang-server-operator-release-notes

QE review:
- [x] QE review not required (this change does not impact the meaning of the docs)
