### PR TITLE
OSDOCS#9704: new 4.15 update channels

### DIFF
--- a/modules/understanding-update-channels.adoc
+++ b/modules/understanding-update-channels.adoc
@@ -8,6 +8,12 @@
 = Update channels
 
 ifndef::openshift-origin[]
+[NOTE]
+====
+{product-title} 4.15 introduced the `ga` and `fleet-approved` update channels.
+Functionally, the `ga` channel is the same as the `fast` channel and the `fleet-approved` channel is the same as the `stable` channel.
+====
+
 [id="fast-version-channel_{context}"]
 == fast-{product-version} channel
 The `fast-{product-version}` channel is updated with new versions of {product-title} {product-version} as soon as Red Hat declares the version as a general availability (GA) release. As such, these releases are fully supported and purposed to be used in production environments.

--- a/modules/update-availability-faq.adoc
+++ b/modules/update-availability-faq.adoc
@@ -6,7 +6,13 @@
 [id="update-availability_{context}"]
 = Common questions about update availability
 
-There are several factors that affect if and when an update is made available to an {product-title} cluster. The following list provides common questions regarding the availability of an update:
+There are several factors that affect if and when an update is made available to an {product-title} cluster. The following list provides common questions regarding the availability of an update.
+
+[NOTE]
+====
+{product-title} 4.15 introduced the `ga` and `fleet-approved` update channels.
+Functionally, the `ga` channel is the same as the `fast` channel and the `fleet-approved` channel is the same as the `stable` channel.
+====
 
 [id="channel-differences_{context}"]
 *What are the differences between each of the update channels?*

--- a/modules/update-upgrading-cli.adoc
+++ b/modules/update-upgrading-cli.adoc
@@ -13,6 +13,14 @@ You can find information about available {product-title} advisories and updates
 link:https://access.redhat.com/downloads/content/290[in the errata section]
 of the Customer Portal.
 
+ifndef::openshift-origin[]
+[NOTE]
+====
+{product-title} 4.15 introduced the `ga` and `fleet-approved` update channels.
+Functionally, the `ga` channel is the same as the `fast` channel and the `fleet-approved` channel is the same as the `stable` channel.
+====
+endif::openshift-origin[]
+
 .Prerequisites
 
 * Install the OpenShift CLI (`oc`) that matches the version for your updated version.
@@ -91,7 +99,7 @@ $ oc adm upgrade channel stable-{product-version}
 +
 [IMPORTANT]
 ====
-For production clusters, you must subscribe to a `stable-\*`, `eus-*`, or `fast-*` channel.
+For production clusters, you must subscribe to a `stable-\*`, `eus-\*`, `fast-\*`, `ga-\*`, or `fleet-approved-\*` channel.
 ====
 +
 [NOTE]

--- a/modules/update-upgrading-web.adoc
+++ b/modules/update-upgrading-web.adoc
@@ -16,6 +16,14 @@ If updates are available, you can update your cluster from the web console.
 You can find information about available {product-title} advisories and updates
 link:https://access.redhat.com/downloads/content/290[in the errata section] of the Customer Portal.
 
+ifndef::openshift-origin[]
+[NOTE]
+====
+{product-title} 4.15 introduced the `ga` and `fleet-approved` update channels.
+Functionally, the `ga` channel is the same as the `fast` channel and the `fleet-approved` channel is the same as the `stable` channel.
+====
+endif::openshift-origin[]
+
 .Prerequisites
 
 * Have access to the web console as a user with `cluster-admin` privileges.
@@ -39,7 +47,7 @@ ifndef::openshift-origin[]
 +
 [IMPORTANT]
 ====
-For production clusters, you must subscribe to a `stable-\*`, `eus-*` or `fast-*` channel.
+For production clusters, you must subscribe to a `stable-\*`, `eus-\*`, `fast-\*`, `ga-\*`, or `fleet-approved-\*` channel.
 ====
 endif::openshift-origin[]
 ifdef::openshift-origin[]

--- a/updating/understanding_updates/understanding-update-channels-release.adoc
+++ b/updating/understanding_updates/understanding-update-channels-release.adoc
@@ -14,6 +14,14 @@ To do: Remove this comment once 4.13 docs are EOL.
 
 Update channels are the mechanism by which users declare the {product-title} minor version they intend to update their clusters to. They also allow users to choose the timing and level of support their updates will have through the `fast`, `stable`, `candidate`, and `eus` channel options. The Cluster Version Operator uses an update graph based on the channel declaration, along with other conditional information, to provide a list of recommended and conditional updates available to the cluster.
 
+ifndef::openshift-origin[]
+[NOTE]
+====
+{product-title} 4.15 introduced the `ga` and `fleet-approved` update channels.
+Functionally, the `ga` channel is the same as the `fast` channel and the `fleet-approved` channel is the same as the `stable` channel.
+====
+endif::openshift-origin[]
+
 Update channels correspond to a minor version of {product-title}. The version number in the channel represents the target minor version that the cluster will eventually be updated to, even if it is higher than the cluster's current minor version.
 
 For instance, {product-title} 4.10 update channels provide the following recommendations:


### PR DESCRIPTION
[OSDOCS-9704](https://issues.redhat.com/browse/OSDOCS-9704)

Versions: 4.15+

This PR makes a cursory reference to new `ga` and `fleet-approved` channels being added to OCP 4.15. This docs request has been made after the docs freeze deadline, so this PR aims to achieve the minimum viable doc, and a more comprehensive coverage of these new channels will be added to 4.16+ docs.

QE review:
- [ ] QE has approved this change.

Previews:

- [Common questions about update availability](https://71838--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/understanding_updates/intro-to-updates#update-availability_understanding-openshift-updates)
- [Understanding update channels and releases](https://71838--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/understanding_updates/understanding-update-channels-release)
- [Updating a cluster by using the CLI](https://71838--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-cluster-cli#update-upgrading-cli_updating-cluster-cli)
- [Updating a cluster by using the web console](https://71838--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-cluster-web-console#update-upgrading-web_updating-cluster-web-console)