### PR TITLE
OSDOCS-9706: Deprecation status of SDN for 4.15 release notes

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -1105,6 +1105,11 @@ In the following tables, features are marked with the following statuses:
 |Deprecated
 |Removed
 
+|OpenShift SDN network plugin
+|General Availability
+|Deprecated
+|Deprecated
+
 |====
 
 [discrete]
@@ -1192,6 +1197,11 @@ In the following tables, features are marked with the following statuses:
 
 [id="ocp-4-15-deprecated-features"]
 === Deprecated features
+
+[id="ocp-4-15-deprecation-sdn"]
+==== Deprecation of the OpenShift SDN network plugin
+
+OpenShift SDN CNI is deprecated as of {product-title} 4.14. As of {product-title} {product-version}, the network plugin is not an option for new installations. In a subsequent future release, the OpenShift SDN network plugin is planned to be removed and no longer supported. Red{nbsp}Hat will provide bug fixes and support for this feature until it is removed, but this feature will no longer receive enhancements. As an alternative to OpenShift SDN CNI, you can use OVN Kubernetes CNI instead.
 
 [id="ocp-4-15-bmer"]
 ==== Bare Metal Event Relay Operator


### PR DESCRIPTION
Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-9706

Link to docs previews:

(deprecation statement)  https://71848--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-deprecation-sdn

(deprecation table) https://71848--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-deprecated-removed-features


QE review:
- [x] QE has approved this change.
