### PR TITLE
HCIDOCS-18: Added known issue from 4.14 back to 4.13

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -2910,6 +2910,90 @@ $ oc adm taint nodes <node_name> node.cloudprovider.kubernetes.io/uninitialized:
 +
 (link:https://issues.redhat.com/browse/OCPBUGS-20049[*OCPBUGS-20049*])
 
+* When installing an {product-title} cluster with static IP addressing and Tang encryption, nodes start without network settings. This condition prevents nodes from accessing the Tang server, causing installation to fail. To address this condition, you must set the network settings for each node as `ip` installer arguments.
++
+. For installer-provisioned infrastructure, before installation provide the network settings as `ip` installer arguments for each node by executing the following steps. 
+
+.. Create the manifests.
+
+.. For each node, modify the `BareMetalHost` custom resource with annotations to include the network settings. For example:
++
+[source,terminal]
+----
+$ cd ~/clusterconfigs/openshift
+$ vim openshift-worker-0.yaml
+----
++
+[source,yaml]
+----
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  annotations:
+    bmac.agent-install.openshift.io/installer-args: '["--append-karg", "ip=<static_ip>::<gateway>:<netmask>:<hostname_1>:<interface>:none", "--save-partindex", "1", "-n"]' <1> <2> <3> <4> <5>
+    inspect.metal3.io: disabled
+    bmac.agent-install.openshift.io/hostname: <fqdn> <6>
+    bmac.agent-install.openshift.io/role: <role> <7>
+
+  generation: 1
+  name: openshift-worker-0
+  namespace: mynamespace
+spec:
+  automatedCleaningMode: disabled
+  bmc:
+    address: idrac-virtualmedia://<bmc_ip>/redfish/v1/Systems/System.Embedded.1 <8>
+    credentialsName: bmc-secret-openshift-worker-0
+    disableCertificateVerification: true
+  bootMACAddress: 94:6D:AE:AB:EE:E8
+  bootMode: "UEFI"
+  rootDeviceHints:
+    deviceName: /dev/sda
+----
+For the `ip` settings, replace:
+<1> `<static_ip>` with the static IP address for the node, for example, `192.168.1.100`
+<2> `<gateway>` with the IP address of your network's gateway, for example, `192.168.1.1`
+<3> `<netmask>` with the network mask, for example, `255.255.255.0`
+<4> `<hostname_1>` with the node's hostname, for example, `node1.example.com`
+<5> `<interface>` with the name of the network interface, for example, `eth0`
+<6> `<fqdn>` with the fully qualified domain name of the node
+<7> `<role>` with `worker` or `master` to reflect the node's role
+<8> `<bmc_ip>` with with the BMC IP address and the protocol and path of the BMC, as needed.
+
+.. Save the file to the `clusterconfigs/openshift` directory.
+
+.. Create the cluster.
+
+. When installing with the {ai-full}, before installation modify each node's installer arguments using the API to append the network settings as `ip` installer arguments. For example:
++
+[source,bash]
+----
+$ curl https://api.openshift.com/api/assisted-install/v2/infra-envs/${infra_env_id}/hosts/${host_id}/installer-args \
+-X PATCH \
+-H "Authorization: Bearer ${API_TOKEN}" \
+-H "Content-Type: application/json" \
+-d '
+    {
+      "args": [
+        "--append-karg",
+        "ip=<static_ip>::<gateway>:<netmask>:<hostname_1>:<interface>:none", <1> <2> <3> <4> <5>
+        "--save-partindex",
+        "1",
+        "-n"
+      ]
+    }
+  ' | jq
+----
+For the previous network settings, replace:
+<1> `<static_ip>` with the static IP address for the node, for example, `192.168.1.100`
+<2> `<gateway>` with the IP address of your network's gateway, for example, `192.168.1.1`
+<3> `<netmask>` with the network mask, for example, `255.255.255.0`
+<4> `<hostname_1>` with the node's hostname, for example, `node1.example.com`
+<5> `<interface>` with the name of the network interface, for example, `eth0`. 
+
+Contact Red Hat Support for additional details and assistance.
+
+(link:https://issues.redhat.com/browse/OCPBUGS-23119[*OCPBUGS-23119*])
+
 [id="ocp-4-13-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
This PR is a cherry pick of https://github.com/openshift/openshift-docs/pull/68702. There are no text changes.

Version(s): 4.13

Issue: https://issues.redhat.com/browse/HCIDOCS-18

Link to docs preview: http://184.23.213.161:8080/HCIDOCS-18-4.13/release_notes/ocp-4-13-release-notes.html#ocp-4-13-asynchronous-errata-updates <--scroll up to last bullet of known issues.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
