### PR TITLE
OSDOCS-9692: adds edit and delete network policy to MicroShift docs

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -409,6 +409,10 @@ Topics:
     File: microshift-network-policy-index
   - Name: Creating network policies
     File: microshift-creating-network-policy
+  - Name: Editing network policies
+    File: microshift-editing-network-policy
+  - Name: Deleting network policies
+    File: microshift-deleting-network-policy
 - Name: Firewall configuration
   File: microshift-firewall
 - Name: Networking settings for fully disconnected hosts

--- a/microshift_networking/microshift-network-policy/microshift-deleting-network-policy.adoc
+++ b/microshift_networking/microshift-network-policy/microshift-deleting-network-policy.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="microshift-deleting-network-policy"]
+= Deleting a network policy
+include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-microshift.adoc[]
+:context: microshift-deleting-network-policy
+
+toc::[]
+
+You can delete a network policy from a namespace.
+
+include::modules/nw-networkpolicy-delete-cli.adoc[leveloffset=+1]

--- a/microshift_networking/microshift-network-policy/microshift-editing-network-policy.adoc
+++ b/microshift_networking/microshift-network-policy/microshift-editing-network-policy.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="microshift-editing-network-policy"]
+= Editing a network policy
+include::_attributes/attributes-microshift.adoc[]
+include::_attributes/common-attributes.adoc[]
+:context: microshift-editing-network-policy
+
+toc::[]
+
+You can edit an existing network policy for a namespace. Typical edits might include changes to the pods to which the policy applies, allowed ingress traffic, and the destination ports on which to accept traffic. The `apiVersion`, `kind`, and `name` fields must not be changed when editing `NetworkPolicy` objects, as these define the resource itself.
+
+//OCP modules, edit using conditionals
+include::modules/nw-networkpolicy-edit.adoc[leveloffset=+1]
+
+include::modules/nw-networkpolicy-object.adoc[leveloffset=+1]

--- a/modules/nw-networkpolicy-delete-cli.adoc
+++ b/modules/nw-networkpolicy-delete-cli.adoc
@@ -2,6 +2,7 @@
 //
 // * networking/network_policy/deleting-network-policy.adoc
 // * networking/multiple_networks/configuring-multi-network-policy.adoc
+// * microshift_networking/microshift-network-policy/microshift-editing-network-policy.adoc
 
 :name: network
 :role: admin
@@ -17,18 +18,21 @@ endif::[]
 
 You can delete a {name} policy in a namespace.
 
-ifndef::multi[]
+ifndef::multi,microshift[]
 [NOTE]
 ====
 If you log in with a user with the `cluster-admin` role, then you can delete any network policy in the cluster.
 ====
-endif::multi[]
+endif::multi,microshift[]
 
 .Prerequisites
-
+ifndef::microshift[]
 * Your cluster uses a network plugin that supports `NetworkPolicy` objects, such as the OVN-Kubernetes network plugin or the OpenShift SDN network plugin with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
+endif::microshift[]
 * You installed the OpenShift CLI (`oc`).
+ifndef::microshift[]
 * You are logged in to the cluster with a user with `{role}` privileges.
+endif::microshift[]
 * You are working in the namespace where the {name} policy exists.
 
 .Procedure
@@ -64,7 +68,9 @@ endif::multi[]
 :!name:
 :!role:
 
+ifndef::microshift[]
 [NOTE]
 ====
 If you log in to the web console with `cluster-admin` privileges, you have a choice of deleting a network policy in any namespace in the cluster directly in YAML or from the policy in the web console through the *Actions* menu.
 ====
+endif::microshift[]

--- a/modules/nw-networkpolicy-edit.adoc
+++ b/modules/nw-networkpolicy-edit.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * networking/network_policy/editing-network-policy.adoc
+// * microshift_networking/microshift-network-policy/microshift-editing-network-policy.adoc
 
 :name: network
 :role: admin
@@ -16,18 +17,21 @@ endif::[]
 
 You can edit a {name} policy in a namespace.
 
-ifndef::multi[]
+ifndef::multi,microshift[]
 [NOTE]
 ====
 If you log in with a user with the `cluster-admin` role, then you can edit a network policy in any namespace in the cluster.
 ====
-endif::multi[]
+endif::multi,microshift[]
 
 .Prerequisites
-
+ifndef::microshift[]
 * Your cluster uses a network plugin that supports `NetworkPolicy` objects, such as the OVN-Kubernetes network plugin or the OpenShift SDN network plugin with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
+endif::microshift[]
 * You installed the OpenShift CLI (`oc`).
+ifndef::microshift[]
 * You are logged in to the cluster with a user with `{role}` privileges.
+endif::microshift[]
 * You are working in the namespace where the {name} policy exists.
 
 .Procedure
@@ -95,7 +99,9 @@ endif::multi[]
 :!name:
 :!role:
 
+ifndef::microshift[]
 [NOTE]
 ====
 If you log in to the web console with `cluster-admin` privileges, you have a choice of editing a network policy in any namespace in the cluster directly in YAML or from the policy in the web console through the *Actions* menu.
 ====
+endif::microshift[]

--- a/modules/nw-networkpolicy-object.adoc
+++ b/modules/nw-networkpolicy-object.adoc
@@ -5,6 +5,7 @@
 // * networking/network_policy/editing-network-policy.adoc
 // * post_installation_configuration/network-configuration.adoc
 // * microshift_networking/microshift-creating-network-policy.adoc
+// * microshift_networking/microshift-network-policy/microshift-editing-network-policy.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="nw-networkpolicy-object_{context}"]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-9692](https://issues.redhat.com/browse/OSDOCS-9692)

Link to docs preview:
[Editing network policies](https://71854--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-network-policy/microshift-editing-network-policy)
[Deleting network policies](https://71854--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-network-policy/microshift-deleting-network-policy)

_OCP preview for Docs team reviewers:_
[Editing and deleting network policy](https://71854--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_policy/editing-network-policy)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Content port with conditionals
[Create network policy](https://github.com/openshift/openshift-docs/pull/71808)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
