### PR TITLE
OSDOCS-8517 Storage & etcd bugs 4.15 GA

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -1290,6 +1290,8 @@ See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API de
 [id="ocp-4-15-cloud-etcd-operator-bug-fixes"]
 ==== etcd Cluster Operator
 
+* Previously, the `cluster-backup.sh` script cached the `etcdctl` binary on the local machine indefinitely, making updates impossible. With this update, the `cluster-backup.sh` script pulls the latest `etcdctl` binary each time it is run. (link:https://issues.redhat.com/browse/OCPBUGS-19052[*OCPBUGS-19052*])
+
 
 [discrete]
 [id="ocp-4-15-hosted-control-plane-bug-fixes"]
@@ -1503,6 +1505,10 @@ This update adds the optional `operatorframework.io/bundle-unpack-min-retry-inte
 * Prior to this release, if the default device class was not present on all selected nodes, {lvms} failed to set up the `LVMCluster` CR. With this release, {lvms} detects all the default device classes even if the default device class is present only on one of the selected nodes. With this update, you can define the default device class only on one of the selected nodes. (link:https://issues.redhat.com/browse/OCPBUGS-23181[*OCPBUGS-23181*])
 
 * Prior to this release, upon deleting the worker node in the single-node OpenShift (SNO) and worker node topology, the `LVMCluster` CR still included the configuration of the deleted worker node. This resulted in the `LVMCluster` CR remaining in `Progressing` state. With this release, upon deleting the worker node in the SNO and worker node topology, {lvms} deletes the worker node configuration in the `LVMCluster` CR, and updates the `LVMCluster` CR state to `Ready`. (link:https://issues.redhat.com/browse/OCPBUGS-13558[*OCPBUGS-13558*])
+
+* Previously, CPU limits for the AWS EFS CSI driver container could cause performance degradation of volumes managed by the AWS EFS CSI Driver Operator. With this release, the CPU limits from the AWS EFS CSI driver container have been removed to help prevent potential performance degradation. (link:https://issues.redhat.com/browse/OCPBUGS-28645[*OCPBUGS-28645*])
+
+* Previously, if you used the `performancePlus` parameter in the Azure Disk CSI driver and provisioned volumes 512 GiB or smaller, you would receive an error from the driver that you need a disk size of at least 512 GiB. With this release, if you use the `performancePlus` parameter and provision volumes 512 GiB or smaller, the Azure Disk CSI driver automatically resizes volumes to be 513 GiB. (link:https://issues.redhat.com/browse/OCPBUGS-17542[*OCPBUGS-17542*])
 
 [discrete]
 [id="ocp-4-15-windows-containers-bug-fixes"]


### PR DESCRIPTION
Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-8517](https://issues.redhat.com/browse/OSDOCS-8517)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Preview](https://71857--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-bug-fixes). One bug in etcd and 2 in Storage
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
Not needed
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
