### PR TITLE
[WIP] RHDEVDOCS-5801 Update _distro_map.yml

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -340,6 +340,9 @@ openshift-gitops:
     gitops-docs-1.11:
       name: '1.11'
       dir: gitops/1.11
+    gitops-docs-1.12:
+      name: '1.12'
+      dir: gitops/1.12
 openshift-pipelines:
   name: Red Hat OpenShift Pipelines
   author: OpenShift documentation team <openshift-docs@redhat.com>


### PR DESCRIPTION
**Version(s):** `main` only

**Issue:**
-  [RHDEVDOCS 5801](https://issues.redhat.com/browse/RHDEVDOCS-5801)

**Link to docs preview:** Not applicable

**SME and QE review:** Not applicable


**Additional information:** This PR updates the distro map in main for the 1.12 GitOps standalone doc and enables building a new version of a standalone documentation set on docs.openshift.com. This PR does not alter any documentation content, so no documentation preview is available. 
