### PR TITLE
OSDOCS-9543: OSD/ROSA GA and EOL dates for 4.15

### DIFF
--- a/modules/life-cycle-dates.adoc
+++ b/modules/life-cycle-dates.adoc
@@ -15,9 +15,11 @@ endif::[]
 |===
 |Version    |General availability   |End of life
 ifdef::rosa-with-hcp[]
+|4.15       |Feb 27, 2024           |Jun 30, 2025
 |4.14       |Dec 4, 2023            |Feb 28, 2025
 endif::rosa-with-hcp[]
 ifndef::rosa-with-hcp[]
+|4.15       |Feb 27, 2024           |Jun 30, 2025
 |4.14       |Oct 31, 2023           |Feb 28, 2025
 |4.13       |May 17, 2023           |Sep 17, 2024
 |4.12       |Jan 17, 2023           |May 17, 2024


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-9543](https://issues.redhat.com/browse/OSDOCS-9543)

Link to docs preview:
[OSD Life cycle dates](https://71874--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-life-cycle#sd-life-cycle-dates_osd-life-cycle)
[ROSA Classic Life cycle dates](https://71874--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-life-cycle#sd-life-cycle-dates_rosa-life-cycle)
[ROSA HCP Life cycle dates](https://71874--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle#sd-life-cycle-dates_rosa-hcp-life-cycle)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
