### PR TITLE
OCPBUGS28387: Warning about containerRuntimeSearchRegistries not clear about default behavior

### DIFF
--- a/modules/images-configuration-shortname.adoc
+++ b/modules/images-configuration-shortname.adoc
@@ -21,7 +21,7 @@ Using image short names with public registries is strongly discouraged because t
 
 Red Hat internal or private registries typically support the use of image short names.
 
-If you list public registries under the `containerRuntimeSearchRegistries` parameter, you expose your credentials to all the registries on the list and you risk network and registry attacks.
+If you list public registries under the `containerRuntimeSearchRegistries` parameter (including the `registry.redhat.io`, `docker.io`, and `quay.io` registries), you expose your credentials to all the registries on the list, and you risk network and registry attacks. Because you can only have one pull secret for pulling images, as defined by the global pull secret, that secret is used to authenticate against every registry in that list. Therefore, if you include public registries in the list, you introduce a security risk.
 
 You cannot list multiple public registries under the `containerRuntimeSearchRegistries` parameter if each public registry requires different credentials and a cluster does not list the public registry in the global pull secret.
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-28387

Issue: If you list public registries under the containerRuntimeSearchRegistries parameter, you expose your credentials to all the registries on the list and you risk network and registry attacks. It is however unclear what happens when using only the Red Hat ones and docker.io, that is the default configuration.

Resolution: The RH and docker registries are public, so the warning applies. Added information to clarify that these are public and highlight why the risk exists. 

Link to docs preview:
[Adding registries that allow image short names](https://71888--ocpdocs-pr.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration#images-configuration-shortname_image-configuration) -- Third paragraph in the Warning.

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

