### PR TITLE
ROX#21157: update installation docs for init bundle changes and other issues

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -111,13 +111,13 @@ Topics:
   Topics:
   - Name: Installing Central services for RHACS on Red Hat OpenShift
     File: install-central-ocp
-  - Name: Optional - Configuring Central configuration options for RHACS using the Operator
+  - Name: Configuring Central configuration options for RHACS using the Operator
     File: install-central-config-options-ocp
   - Name: Generating and applying an init bundle for RHACS on Red Hat OpenShift
     File: init-bundle-ocp
-  - Name: Installing secured cluster services for RHACS on Red Hat OpenShift
+  - Name: Installing Secured Cluster services for RHACS on Red Hat OpenShift
     File: install-secured-cluster-ocp
-  - Name: Optional - Configuring Secured cluster configuration options for RHACS using the Operator
+  - Name: Configuring Secured Cluster services options for RHACS using the Operator
     File: install-secured-cluster-config-options-ocp
   - Name: Verifying installation of RHACS on Red Hat OpenShift
     File: verify-installation-rhacs-ocp
@@ -131,7 +131,7 @@ Topics:
     File: install-central-other
   - Name: Generating and applying an init bundle for RHACS on other platforms
     File: init-bundle-other
-  - Name: Installing secured cluster services for RHACS on other platforms
+  - Name: Installing Secured Cluster services for RHACS on other platforms
     File: install-secured-cluster-other
   - Name: Verifying installation of RHACS on other platforms
     File: verify-installation-rhacs-other
@@ -344,7 +344,7 @@ Topics:
   - Name: roxctl cluster
     File: roxctl-cluster
   - Name: roxctl collector
-    File: roxctl-collector   
+    File: roxctl-collector
   - Name: roxctl completion
     File: roxctl-completion
   - Name: roxctl declarative-config
@@ -352,9 +352,9 @@ Topics:
   - Name: roxctl deployment
     File: roxctl-deployment
   - Name: roxctl helm
-    File: roxctl-helm   
+    File: roxctl-helm
   - Name: roxctl image
-    File: roxctl-image   
+    File: roxctl-image
   - Name: roxctl netpol
     File: roxctl-netpol
   - Name: roxctl scanner
@@ -362,7 +362,7 @@ Topics:
   - Name: roxctl sensor
     File: roxctl-sensor
   - Name: roxctl version
-    File: roxctl-version  
+    File: roxctl-version
 ---
 Name: Troubleshooting Collector
 Dir: troubleshooting

--- a/cloud_service/getting-started-rhacs-cloud-ocp.adoc
+++ b/cloud_service/getting-started-rhacs-cloud-ocp.adoc
@@ -56,7 +56,7 @@ To secure Kubernetes clusters, perform the following steps:
 . Verify that the clusters you want to secure meet the xref:../cloud_service/acscs-default-requirements.adoc#acscs-default-requirements[requirements].
 . In the {cloud-console}, xref:../cloud_service/installing_cloud_other/cloud-create-instance-other.adoc#cloud-create-instance-other[create an *ACS Instance*].
 . In the ACS Console, xref:../cloud_service/installing_cloud_other/init-bundle-cloud-other-generate.adoc#init-bundle-cloud-other-generate[create an init bundle]. The init bundle contains secrets that allow communication between {product-title-managed-short} secured clusters and the ACS Console.
-. On each Kubernetes cluster, xref:../cloud_service/installing_cloud_other/init-bundle-cloud-other-apply#init-bundle-cloud-other-apply[apply the init bundle] by using it to create resources.
+. On each Kubernetes cluster, xref:../cloud_service/installing_cloud_other/init-bundle-cloud-other-apply.adoc#init-bundle-cloud-other-apply[apply the init bundle] by using it to create resources.
 . On each Kubernetes cluster, xref:../cloud_service/installing_cloud_other/install-secured-cluster-cloud-other.adoc#install-secured-cluster-cloud-other[install secured cluster resources] by using Helm charts or the `roxctl` CLI.
 . xref:../cloud_service/installing_cloud_other/verify-installation-cloud-other.adoc#verify-installation-cloud-other[Verify installation] by ensuring that your secured clusters can communicate with the ACS instance.
 

--- a/installing/acs-high-level-overview.adoc
+++ b/installing/acs-high-level-overview.adoc
@@ -41,7 +41,7 @@ Not all installation methods are supported for all platforms. See the link:https
 |{osp} Dedicated (OSD)
 .4+d|Operator (recommended), Helm charts, or `roxctl` CLI ^[1]^
 .4+a| * xref:../installing/installing_ocp/install-central-ocp.adoc#install-central-ocp[Installing Central services for {product-title-short} on {osp}]
-* xref:../installing/installing_ocp/install-secured-cluster-ocp.adoc#install-secured-cluster-ocp[Installing secured cluster services for {product-title-short} on {osp}]
+* xref:../installing/installing_ocp/install-secured-cluster-ocp.adoc#install-secured-cluster-ocp[Installing Secured Cluster services for {product-title-short} on {osp}]
 
 |Azure {osp} (ARO)
 
@@ -53,7 +53,7 @@ Not all installation methods are supported for all platforms. See the link:https
 .3+d|Helm charts (recommended), or `roxctl` CLI ^[1]^
 
 .3+a| * xref:../installing/installing_other/install-central-other.adoc#install-central-other[Installing Central services for {product-title-short} on other platforms]
-* xref:../installing/installing_other/install-secured-cluster-other.adoc#install-secured-cluster-other[Installing secured cluster services for {product-title-short} on other platforms]
+* xref:../installing/installing_other/install-secured-cluster-other.adoc#install-secured-cluster-other[Installing Secured Cluster services for {product-title-short} on other platforms]
 
 |Google Kubernetes Engine (Google GKE)
 
@@ -63,7 +63,7 @@ Not all installation methods are supported for all platforms. See the link:https
 |Red Hat {ocp} ({ocp-short})
 .2+d|Operator (recommended), Helm charts, or `roxctl` CLI ^[1]^
 .2+a| * xref:../installing/installing_ocp/install-central-ocp.adoc#install-central-ocp[Installing Central services for {product-title-short} on {osp}]
-* xref:../installing/installing_ocp/install-secured-cluster-ocp.adoc#install-secured-cluster-ocp[Installing secured cluster services for {product-title-short} on {osp}]
+* xref:../installing/installing_ocp/install-secured-cluster-ocp.adoc#install-secured-cluster-ocp[Installing Secured Cluster services for {product-title-short} on {osp}]
 
 |{osp} Kubernetes Engine (OKE)
 |===
@@ -76,3 +76,6 @@ Not all installation methods are supported for all platforms. See the link:https
 include::modules/installation-methods-for-different-architectures.adoc[leveloffset=+1]
 
 //browser support info removed - this info is in the support matrix
+
+include::modules/installing-rhacs-ocp-steps.adoc[leveloffset=+1]
+include::modules/installing-rhacs-kubernetes-steps.adoc[leveloffset=+1]

--- a/installing/installing_ocp/install-central-config-options-ocp.adoc
+++ b/installing/installing_ocp/install-central-config-options-ocp.adoc
@@ -1,13 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="install-central-config-options-ocp"]
-= Optional - Configuring Central configuration options for RHACS using the Operator
+= Configuring Central configuration options for RHACS using the Operator
 :context: install-central-config-options-ocp
 include::modules/common-attributes.adoc[]
 
 toc::[]
 
 [role="_abstract"]
-This topic provides information about optional configuration options that you can configure using the Operator.
+When installing the Central instance by using the Operator, you can configure optional settings.
 
 include::modules/central-configuration-options-operator.adoc[leveloffset=+1]
 include::modules/customize-installation-operator-overlays.adoc[leveloffset=+1]

--- a/installing/installing_ocp/install-secured-cluster-config-options-ocp.adoc
+++ b/installing/installing_ocp/install-secured-cluster-config-options-ocp.adoc
@@ -1,13 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="install-secured-cluster-config-options-ocp"]
-= Optional - Configuring Secured cluster configuration options for RHACS using the Operator
+= Configuring Secured Cluster services options for RHACS using the Operator
 :context: install-secured-cluster-config-options-ocp
 include::modules/common-attributes.adoc[]
 
 toc::[]
 
 [role="_abstract"]
-This topic provides information about optional configuration settings that you can make using the Operator.
+When installing Secured Cluster services by using the Operator, you can configure optional settings.
 
 include::modules/secured-cluster-configuration-options-operator.adoc[leveloffset=+1]
 include::modules/customize-installation-operator-overlays.adoc[leveloffset=+1]

--- a/installing/installing_ocp/install-secured-cluster-ocp.adoc
+++ b/installing/installing_ocp/install-secured-cluster-ocp.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="install-secured-cluster-ocp"]
-= Installing secured cluster services for RHACS on Red Hat OpenShift
+= Installing Secured Cluster services for RHACS on Red Hat OpenShift
 include::modules/common-attributes.adoc[]
 :context: install-secured-cluster-ocp
 
@@ -8,13 +8,11 @@ toc::[]
 
 [role="_abstract"]
 
-This section describes the installation procedure for installing {product-title} on your secured clusters.
-
 You can install {product-title-short} on your secured clusters by using one of the following methods:
 
-* Install using the Operator
-* Install using Helm charts
-* Install using the `roxctl` CLI (do not use this method unless you have a specific installation need that requires using it)
+* Install by using the Operator
+* Install by using Helm charts
+* Install by using the `roxctl` CLI (do not use this method unless you have a specific installation need that requires using it)
 
 [id="installing-sc-operator"]
 == Installing {product-title-short} on secured clusters by using the Operator
@@ -67,10 +65,16 @@ include::modules/change-config-options-after-deployment.adoc[leveloffset=+2]
 [id="installing-sc-roxctl"]
 == Installing {product-title-short} on secured clusters by using the roxctl CLI
 
-To install {product-title-short} on secured clusters by using the CLI, perform the following steps:
+This method is also referred to as the manifest installation method.
 
-. Install the `roxctl` CLI
-. Install Sensor.
+.Prerequisites
+
+* If you plan to use the `roxctl` CLI command to generate the files used by the sensor installation script, you have installed the `roxctl` CLI.
+* You have generated the files that will be used by the sensor installation script.
+
+.Procedure
+
+* On the {ocp} secured cluster, deploy the Sensor component by running the sensor installation script.
 
 [id="installing-roxctl-cli-sc"]
 === Installing the roxctl CLI

--- a/installing/installing_other/install-secured-cluster-other.adoc
+++ b/installing/installing_other/install-secured-cluster-other.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="install-secured-cluster-other"]
-= Installing secured cluster services for RHACS on other platforms
+= Installing Secured Cluster services for RHACS on other platforms
 include::modules/common-attributes.adoc[]
 :context: install-secured-cluster-other
 

--- a/modules/acs-quick-install-secured-cluster-using-helm.adoc
+++ b/modules/acs-quick-install-secured-cluster-using-helm.adoc
@@ -41,8 +41,8 @@ ifndef::openshift[]
 ----
 $ helm install -n stackrox --create-namespace \
     stackrox-secured-cluster-services rhacs/secured-cluster-services \
-    -f <path_to_cluster_init_bundle.yaml> \ <1>
-    -f <path_to_pull_secret.yaml> \ <2>
+    -f <path_to_cluster_init_bundle.yaml> \// <1>
+    -f <path_to_pull_secret.yaml> \// <2>
     --set clusterName=<name_of_the_secured_cluster> \
     --set centralEndpoint=<endpoint_of_central_service> <3>
 ifdef::cloud-svc[]
@@ -67,8 +67,8 @@ ifndef::cloud-svc,k8[]
 ----
 $ helm install -n stackrox --create-namespace \
     stackrox-secured-cluster-services rhacs/secured-cluster-services \
-    -f <path_to_cluster_init_bundle.yaml> \ <1>
-    -f <path_to_pull_secret.yaml> \ <2>
+    -f <path_to_cluster_init_bundle.yaml> \// <1>
+    -f <path_to_pull_secret.yaml> \// <2>
     --set clusterName=<name_of_the_secured_cluster> \
     --set centralEndpoint=<endpoint_of_central_service> <3>
     --set scanner.disable=false <4>

--- a/modules/acs-quick-install-using-helm.adoc
+++ b/modules/acs-quick-install-using-helm.adoc
@@ -19,8 +19,8 @@ Use the following instructions to install the `central-services` Helm chart to d
 ----
 $ helm install -n stackrox \
   --create-namespace stackrox-central-services rhacs/central-services \
-  --set imagePullSecrets.username=<username> \ <1>
-  --set imagePullSecrets.password=<password> \ <2>
+  --set imagePullSecrets.username=<username> \// <1>
+  --set imagePullSecrets.password=<password> \// <2>
   --set central.exposure.route.enabled=true
 ----
 <1> Include the user name for your pull secret for Red Hat Container Registry authentication.
@@ -32,8 +32,8 @@ $ helm install -n stackrox \
 ----
 $ helm install -n stackrox \
   --create-namespace stackrox-central-services rhacs/central-services \
-  --set imagePullSecrets.username=<username> \ <1>
-  --set imagePullSecrets.password=<password> \ <2>
+  --set imagePullSecrets.username=<username> \// <1>
+  --set imagePullSecrets.password=<password> \// <2>
   --set central.exposure.loadBalancer.enabled=true
 ----
 <1> Include the user name for your pull secret for Red Hat Container Registry authentication.
@@ -45,7 +45,7 @@ $ helm install -n stackrox \
 ----
 $ helm install -n stackrox \
   --create-namespace stackrox-central-services rhacs/central-services \
-  --set imagePullSecrets.username=<username> \ <1>
+  --set imagePullSecrets.username=<username> \// <1>
   --set imagePullSecrets.password=<password>  <2>
 ----
 <1> Include the user name for your pull secret for Red Hat Container Registry authentication.

--- a/modules/change-config-options-after-deployment-central-service.adoc
+++ b/modules/change-config-options-after-deployment-central-service.adoc
@@ -16,9 +16,12 @@ You can make changes to any configuration options after you have deployed the `c
 ----
 $ helm upgrade -n stackrox \
   stackrox-central-services rhacs/central-services \
+  --reuse-values \// <1>
+  -f <path_to_init_bundle_file \
   -f <path_to_values_public.yaml> \
   -f <path_to_values_private.yaml>
 ----
+<1> If you have modified values that are not included in the `values_public.yaml` and `values_private.yaml` files, include the `--reuse-values` parameter.
 +
 [NOTE]
 ====

--- a/modules/change-config-options-after-deployment.adoc
+++ b/modules/change-config-options-after-deployment.adoc
@@ -16,11 +16,11 @@ You can make changes to any configuration options after you have deployed the `s
 ----
 $ helm upgrade -n stackrox \
   stackrox-secured-cluster-services rhacs/secured-cluster-services \
-  --reuse-values \ <1>
+  --reuse-values \// <1>
   -f <path_to_values_public.yaml> \
   -f <path_to_values_private.yaml>
 ----
-<1> You must specify the `--reuse-values` parameter, otherwise the Helm upgrade command resets all previously configured settings.
+<1> If you have modified values that are not included in the `values_public.yaml` and `values_private.yaml` files, include the `--reuse-values` parameter.
 +
 [NOTE]
 ====

--- a/modules/create-resource-init-bundle.adoc
+++ b/modules/create-resource-init-bundle.adoc
@@ -36,17 +36,17 @@ endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="create-resource-init-bundle_{context}"]
-= Creating resources by using the init bundle
+= Applying the init bundle on the secured cluster
 
 //Do not show for ACSCS
 ifndef::cloud[]
-Before you install secured clusters, you must use the init bundle to create the required resources on the cluster that will allow the services on the secured clusters to communicate with Central.
-endif::[]
+Before you configure a secured cluster, you must apply the init bundle by using it to create the required resources on the cluster. Applying the init bundle allows the services on the secured cluster to communicate with Central.
+endif::cloud[]
 
 //Show for ACSCS
 ifdef::cloud[]
-Before you install secured clusters, you must use the init bundle to create the required resources on the cluster that will allow the services on the secured clusters to communicate with {product-title-managed-short}.
-endif::[]
+Before you configure a secured cluster, you must apply the init bundle by using it to create the required resources on the secured cluster. Applying the init bundle allows the services on the secured cluster to communicate with {product-title-managed-short}.
+endif::cloud[]
 
 [NOTE]
 ====
@@ -56,37 +56,67 @@ If you are installing by using Helm charts, do not perform this step. Complete t
 
 .Prerequisites
 * You must have generated an init bundle containing secrets.
+* You must have created the `stackrox` project, or namespace, on the cluster where secured cluster services will be installed. Using `stackrox` for the project is not required, but ensures that vulnerabilities for {product-title-short} processes are not reported when scanning your clusters.
 
 .Procedure
+//Show for OpenShift
 ifdef::openshift[]
-To create resources, perform one of the following steps:
+To create resources, perform only one of the following steps:
 
-* In the {ocp} web console, in the top menu, click *+* to open the *Import YAML* page. You can drag the init bundle file or copy and paste its contents into the editor, and then click *Create*.
+* Create resources using the {ocp} web console: In the {ocp} web console, make sure that you are in the `stackrox` namespace. In the top menu, click *+* to open the *Import YAML* page. You can drag the init bundle file or copy and paste its contents into the editor, and then click *Create*. When the command is complete, the display shows that the `collector-tls`, `sensor-tls`, and admission-control-tls` resources were created.
 
-* Using the {osp} CLI, run the following command to create the resources:
+* Create resources using the {osp} CLI: Using the {osp} CLI, run the following command to create the resources:
 +
 [source,terminal]
 ----
-$ oc create -f <init_bundle>.yaml \ <1>
+$ oc create -f <init_bundle>.yaml \// <1>
   -n <stackrox> <2>
 ----
 <1> Specify the file name of the init bundle containing the secrets.
 <2> Specify the name of the project where Central services are installed.
-endif::[]
+endif::openshift[]
+//Show for Kubernetes
 ifdef::kube[]
 * Using the `kubectl` CLI, run the following commands to create the resources:
 +
 [source,terminal]
 ----
 $ kubectl create namespace stackrox <1>
-$ kubectl create -f <init_bundle>.yaml \ <2>
+$ kubectl create -f <init_bundle>.yaml \// <2>
   -n <stackrox> <3>
 ----
 <1> Create the project where secured cluster resources will be installed. This example uses `stackrox`.
 <2> Specify the file name of the init bundle containing the secrets.
 <3> Specify the project name that you created. This example uses `stackrox`.
-endif::[]
-
+endif::kube[]
 
 .Next Step
 * Install {product-title-short} secured cluster services in all clusters that you want to monitor.
+
+ifeval::["{context}" == "init-bundle-cloud-ocp"]
+:!openshift:
+endif::[]
+
+ifeval::["{context}" == "init-bundle-ocp"]
+:!openshift:
+endif::[]
+
+ifeval::["{context}" == "init-bundle-other"]
+:!kube:
+endif::[]
+
+ifeval::["{context}" == "init-bundle-cloud-other-apply"]
+:!kube:
+endif::[]
+
+ifeval::["{context}" == "init-bundle-cloud-other-apply"]
+:!cloud:
+endif::[]
+
+ifeval::["{context}" == "init-bundle-cloud-ocp-apply"]
+:!openshift:
+endif::[]
+
+ifeval::["{context}" == "init-bundle-cloud-ocp-apply"]
+:!cloud:
+endif::[]

--- a/modules/custom-cert-existing.adoc
+++ b/modules/custom-cert-existing.adoc
@@ -42,8 +42,13 @@ central:
 +
 [source,terminal]
 ----
-$ helm upgrade -n stackrox --create-namespace stackrox-central-services rhacs/central-services -f values-private.yaml
+
+$ helm upgrade -n stackrox --create-namespace stackrox-central-services \
+ rhacs/central-services --reuse-values \//<1>
+ -f values-private.yaml
+
 ----
+<1> You must use this parameter because the `values-private.yaml` file does not contain all of the required configuration values.
 * If you have installed {product-title} using the `roxctl` CLI:
 ** Create and apply a TLS secret from the PEM-encoded key and certificate files:
 +

--- a/modules/install-acs-operator.adoc
+++ b/modules/install-acs-operator.adoc
@@ -42,4 +42,4 @@ If you choose manual updates, you must update the {product-title-short} Operator
 * After the installation completes, navigate to *Operators* -> *Installed Operators* to verify that the {product-title} Operator is listed with the status of *Succeeded*.
 
 .Next Step
-* Install, configure, and deploy the `Central` custom resource.
+* You installed the Operator into the *rhacs-operator* project. Using that Operator, install, configure, and deploy the `Central` custom resource into the `stackrox` project.

--- a/modules/install-central-operator-external-db.adoc
+++ b/modules/install-central-operator-external-db.adoc
@@ -39,7 +39,7 @@ When you install {product-title} for the first time, you must first install the 
 +
 [source,terminal]
 ----
-$ oc create secret generic external-db-password \ <1>
+$ oc create secret generic external-db-password \// <1>
   --from-file=password=<password.txt> <2>
 ----
 <1> If you use Kubernetes, enter `kubectl` instead of `oc`.
@@ -67,7 +67,7 @@ spec:
 . For *Administrator Password* specify the referenced secret as `external-db-password` (or the secret name of the password created previously).
 . For *Connection String* specify the connection string in `keyword=value` format, for example, `host=<host> port=5432 database=stackrox user=stackrox sslmode=verify-ca`
 . For *Persistence* -> *PersistentVolumeClaim* -> *Claim Name*, remove `central-db`.
-. If necessary, you can specify a Certificate Authority so that there is trust between the data base certificate and Central. To add this, go to the YAML view and add a TLS block under the top-level spec, as shown in the following example:
+. If necessary, you can specify a Certificate Authority so that there is trust between the database certificate and Central. To add this, go to the YAML view and add a TLS block under the top-level spec, as shown in the following example:
 +
 [source,yaml]
 ----

--- a/modules/install-secured-cluster-operator.adoc
+++ b/modules/install-secured-cluster-operator.adoc
@@ -12,33 +12,40 @@ ifeval::["{context}" == "install-secured-cluster-cloud-ocp"]
 endif::[]
 
 [role="_abstract"]
-You can install secured cluster services on your clusters by using the `SecuredCluster` custom resource. You must install the secured cluster services on every cluster in your environment that you want to monitor.
+You can install Secured Cluster services on your clusters by using the Operator, which creates the `SecuredCluster` custom resource. You must install the Secured Cluster services on every cluster in your environment that you want to monitor.
 
 .Prerequisites
 * If you are using {ocp}, you must install version {ocp-supported-version} or later.
-* You have installed the {product-title-short} Operator.
+* You have installed the {product-title-short} Operator on the cluster that you want to secure, called the secured cluster.
 * You have generated an init bundle and applied it to the cluster.
 
 .Procedure
-. On the {ocp} web console, navigate to the *Operators* -> *Installed Operators* page.
+. On the {ocp} web console for the secured cluster, navigate to the *Operators* -> *Installed Operators* page.
 . Click the {product-title-short} Operator.
 . Click *Secured Cluster* from the central navigation menu in the *Operator details* page.
 . Click *Create SecuredCluster*.
 . Select one of the following options in the *Configure via* field:
 * *Form view*: Use this option if you want to use the on-screen fields to configure the secured cluster and do not need to change any other fields.
-* *YAML view*: Use this view to set up the secured cluster using the YAML file. The YAML file is displayed in the window and you can edit fields in it. If you select this option, when you are finished editing the file, click *Create*.
+* *YAML view*: Use this view to set up the secured cluster by using the YAML file. The YAML file is displayed in the window and you can edit fields in it. If you select this option, when you are finished editing the file, click *Create*.
 . If you are using *Form view*, enter the new project name by accepting or editing the default name. The default value is *stackrox-secured-cluster-services*.
 . Optional: Add any labels for the cluster.
 . Enter a unique name for your `SecuredCluster` custom resource.
-. For *Central Endpoint*, enter the address and port number of your Central instance. For example, if Central is available at `\https://central.example.com`, then specify the central endpoint as `central.example.com:443`. The default value of `central.stackrox.svc:443` only works when you install secured cluster services and Central in the same cluster. Do not use the default value when you are configuring multiple clusters. Instead, use the hostname when configuring the *Central Endpoint* value for each cluster.
+. For *Central Endpoint*, enter the address and port number of your Central instance. For example, if Central is available at `\https://central.example.com`, then specify the central endpoint as `central.example.com:443`.
 ifdef::cloud-svc[]
 *  For {product-title-managed-short} use the *Central API Endpoint*, including the address and the port number. You can view this information by choosing *Advanced Cluster Security* -> *ACS Instances* from the cloud console navigation menu, then clicking the ACS instance you created.
 endif::cloud-svc[]
-* Only if you are installing secured cluster services and Central in the same cluster, use `central.stackrox.svc:443`.
-. Accept the default values or configure custom values if needed. For example, you may need to configure TLS if you are using custom certificates or untrusted CAs.
-//Add a link for customization options
+* Use the default value of `central.stackrox.svc:443` _only_ if you are installing secured cluster services in the same cluster where Central is installed.
+* Do not use the default value when you are configuring multiple clusters. Instead, use the hostname when configuring the *Central Endpoint* value for each cluster.
+. For the remaining fields, accept the default values or configure custom values if needed. For example, you might need to configure TLS if you are using custom certificates or untrusted CAs. See "Configuring Secured Cluster services options for {product-title-short} using the Operator" for more information.
 . Click *Create*.
+. After a brief pause, the *SecuredClusters* page displays the status of `stackrox-secured-cluster-services`. You might see the following conditions:
+* *Conditions: Deployed, Initialized*: The secured cluster services have been installed and the secured cluster is communicating with Central.
+* *Conditions: Initialized, Irreconcilable*: The secured cluster is not communicating with Central. Make sure that you applied the init bundle you created in the {product-title-short} web portal to the secured cluster.
 
-.Next step
-. Optional: Configure additional secured cluster settings.
+.Next steps
+. Configure additional secured cluster settings (optional).
 . Verify installation.
+
+ifeval::["{context}" == "install-secured-cluster-cloud-ocp"]
+:!cloud-svc:
+endif::[]

--- a/modules/install-secured-cluster-services-helm-chart.adoc
+++ b/modules/install-secured-cluster-services-helm-chart.adoc
@@ -26,8 +26,8 @@ endif::[]
 $ helm install -n stackrox \
   --create-namespace stackrox-secured-cluster-services rhacs/secured-cluster-services \
   -f <name_of_cluster_init_bundle.yaml> \
-  -f <path_to_values_public.yaml> -f <path_to_values_private.yaml> \ <1>
-  --set imagePullSecrets.username=<username> \ <2>
+  -f <path_to_values_public.yaml> -f <path_to_values_private.yaml> \// <1>
+  --set imagePullSecrets.username=<username> \// <2>
   --set imagePullSecrets.password=<password> <3>
 ----
 <1> Use the `-f` option to specify the paths for your YAML configuration files.

--- a/modules/install-sensor-roxctl.adoc
+++ b/modules/install-sensor-roxctl.adoc
@@ -18,16 +18,23 @@ ifeval::["{context}" == "install-secured-cluster-cloud-other"]
 :kube:
 endif::[]
 
-To monitor a cluster, you must deploy Sensor.
-You must deploy Sensor into each cluster that you want to monitor.
-The following steps describe adding Sensor by using the {product-title-short} portal.
+To monitor a cluster, you must deploy Sensor. You must deploy Sensor into each cluster that you want to monitor. This installation method is also called the manifest installation method.
+
+To perform an installation by using the manifest installation method, follow _only one_ of the following procedures:
+
+* Use the {product-title-short} web portal to download the cluster bundle, and then extract and run the sensor script.
+* Use the `roxctl` CLI to generate the required sensor configuration for your {ocp} cluster and associate it with your Central instance.
 
 .Prerequisites
 * You must have already installed Central services, or you can access Central services by selecting your *ACS instance* on {rh-rhacscs-first}.
 
+[id="installing-manifest-web-portal_{context}"]
+== Manifest installation method by using the web portal
+
 .Procedure
+
 . On your secured cluster, in the {product-title-short} portal, navigate to *Platform Configuration* -> *Clusters*.
-. Select *+ New Cluster*.
+. Select *Secure a cluster* -> *Legacy installation method*.
 . Specify a name for the cluster.
 . Provide appropriate values for the fields based on where you are deploying the Sensor.
 ifndef::cloud-svc[]
@@ -36,10 +43,10 @@ ifndef::cloud-svc[]
 ** If you are using a non-gRPC capable load balancer, such as HAProxy, AWS Application Load Balancer (ALB), or AWS Elastic Load Balancing (ELB), use the WebSocket Secure (`wss`) protocol. To use `wss`:
 *** Prefix the address with *`wss://`*.
 *** Add the port number after the address, for example, `wss://stackrox-central.example.com:443`.
-endif::[]
+endif::cloud-svc[]
 ifdef::cloud-svc[]
 ** Enter the Central API Endpoint, including the address and the port number. You can view this information again in the {cloud-console} by choosing *Advanced Cluster Security* -> *ACS Instances*, and then clicking the ACS instance you created.
-endif::[]
+endif::cloud-svc[]
 . Click *Next* to continue with the Sensor setup.
 . Click *Download YAML File and Keys* to download the cluster bundle (zip archive).
 +
@@ -48,7 +55,7 @@ endif::[]
 The cluster bundle zip archive includes unique configurations and keys for each cluster.
 Do not reuse the same files in another cluster.
 ====
-. From a system that has access to the monitored cluster, unzip and run the `sensor` script from the cluster bundle:
+. From a system that has access to the monitored cluster, extract and run the `sensor` script from the cluster bundle:
 +
 [source,terminal]
 ----
@@ -59,7 +66,35 @@ $ unzip -d sensor sensor-<cluster_name>.zip
 ----
 $ ./sensor/sensor.sh
 ----
-If you get a warning that you do not have the required permissions to deploy Sensor, follow the on-screen instructions, or contact your cluster administrator for assistance.
+If you get a warning that you do not have the required permissions to deploy Sensor, follow the on-screen instructions, or contact your cluster administrator for help.
+
+After Sensor is deployed, it contacts Central and provides cluster information.
+
+[id="manifest-roxctl_{context}"]
+== Manifest installation by using the roxctl CLI
+
+.Procedure
+
+. Generate the required sensor configuration for your {ocp} cluster and associate it with your Central instance by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ roxctl sensor generate openshift --openshift-version _<ocp_version>_ --name _<cluster_name>_ --central "$ROX_ENDPOINT" <1>
+----
++
+<1> For the `--openshift-version` option, specify the major {ocp} version number for your cluster. For example, specify `3` for {ocp} version `3.x` and specify `4` for {ocp} version `4.x`.
+. From a system that has access to the monitored cluster, extract and run the `sensor` script from the cluster bundle:
++
+[source,terminal]
+----
+$ unzip -d sensor sensor-<cluster_name>.zip
+----
++
+[source,terminal]
+----
+$ ./sensor/sensor.sh
+----
+If you get a warning that you do not have the required permissions to deploy Sensor, follow the on-screen instructions, or contact your cluster administrator for help.
 
 After Sensor is deployed, it contacts Central and provides cluster information.
 
@@ -84,3 +119,11 @@ $ kubectl get pod -n stackrox -w
 . Click *Finish* to close the window.
 
 After installation, Sensor starts reporting security information to {product-title-short} and the {product-title-short} portal dashboard begins showing deployments, images, and policy violations from the cluster on which you have installed the Sensor.
+
+ifeval::["{context}" == "install-secured-cluster-cloud-other"]
+:!cloud-svc:
+endif::[]
+
+ifeval::["{context}" == "install-secured-cluster-cloud-other"]
+:!kube:
+endif::[]

--- a/modules/installing-rhacs-kubernetes-steps.adoc
+++ b/modules/installing-rhacs-kubernetes-steps.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * installing/acs-high-level-overview
+:_mod-docs-content-type: CONCEPT
+[id="installing-rhacs-kubernetes-steps_{context}"]
+= Installation steps for RHACS on Kubernetes
+
+[id="installing-kube-helm-steps"]
+== Installing {product-title-short} on Kubernetes platforms by using Helm charts
+
+. Add the {product-title-short} Helm charts repository.
+. Install the `central-services` Helm chart on the cluster that will contain Central, called the Central cluster.
+. Log in to the {product-title-short} web console from the Central cluster and create an init bundle that you will install on the cluster that you want to secure, called the secured cluster.
+. For each secured cluster:
+.. Apply the init bundle you created with {product-title-short}. Log in to the secured cluster and run the `kubectl create -f <init_bundle>.yaml -n <stackrox>` command, specifying the path to the downloaded YAML file of the init bundle.
+.. Install the `secured-cluster-services` Helm chart on the secured cluster, specifying the path to the init bundle that you created earlier.
+
+[id="installing-kube-roxctl-steps"]
+== Installing {product-title-short} on Kubernetes platforms by using the `roxctl` CLI
+
+This installation method is also called the _manifest installation method_.
+
+. Install the `roxctl` CLI.
+. On the Kubernetes cluster that will contain Central, perform these steps:
+.. In the terminal window, run the interactive install command by using the `roxctl` CLI.
+.. Run the setup shell script.
+.. In the terminal window, create the Central resources by using the `kubectl create` command.
+. Perform one of the following actions:
+* In the {product-title-short} web console, create and download the sensor YAML file and keys.
+* On the cluster that you want to secure, called the secured cluster, use the `roxctl sensor generate openshift` command.
+. On the secured cluster, run the sensor installation script.
+

--- a/modules/installing-rhacs-ocp-steps.adoc
+++ b/modules/installing-rhacs-ocp-steps.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * installing/acs-high-level-overview
+:_mod-docs-content-type: CONCEPT
+[id="installing-rhacs-ocp-steps_{context}"]
+= Installation steps for RHACS on OpenShift Container Platform
+
+[id="installing-ocp-operator-steps"]
+== Installing {product-title-short} on {osp} by using the {product-title-short} Operator
+
+. On the {osp} cluster, install the {product-title-short} Operator into the `rhacs-operator` project, or namespace.
+. On the {osp} cluster that will contain Central, called the central cluster, use the {product-title-short} Operator to install Central services into the `stackrox` project. One central cluster can secure multiple clusters.
+. Log in to the {product-title-short} web console from the central cluster, and then create an init bundle and download it. The init bundle is then installed on the cluster that you want to secure, called the secured cluster.
+. For the secured cluster:
+.. Install the {product-title-short} Operator into the `rhacs-operator` namespace.
+.. On the secured cluster, apply the init bundle that you created in {product-title-short} by performing one of these steps:
+* Use the {ocp} web console to import the YAML file of the init bundle that you created. Make sure you are in the `stackrox` namespace.
+* In the terminal window, run the `oc create -f <init_bundle>.yaml -n <stackrox>` command, specifying the path to the downloaded YAML file of the init bundle.
+.. On the secured cluster, use the {product-title-short} Operator to install Secured Cluster services into the `stackrox` namespace. When creating these services, be sure to enter the address and port number of Central in the *Central Endpoint* field so that the secured cluster can communicate with Central.
+
+[id="installing-ocp-helm-steps"]
+== Installing {product-title-short} on {osp} by using Helm charts
+
+. Add the {product-title-short} Helm charts repository.
+. Install the `central-services` Helm chart on the {osp} cluster that will contain Central, called the central cluster.
+. Log in to the {product-title-short} web console on the Central cluster and create an init bundle.
+. For each cluster that you want to secure, log in to the secured cluster and perform the following steps:
+.. Apply the init bundle you created with {product-title-short}. To apply the init bundle on the secured cluster, perform one of these steps:
+* Use the {ocp} web console to import the YAML file of the init bundle that you created. Make sure you are in the `stackrox` namespace.
+* In the terminal window, run the `oc create -f <init_bundle>.yaml -n <stackrox>` command, specifying the path to the downloaded YAML file of the init bundle.
+.. Install the `secured-cluster-services` Helm chart on the secured cluster, specifying the path to the init bundle that you created.
+
+[id="installing-ocp-roxctl-steps"]
+== Installing {product-title-short} on {osp} by using the `roxctl` CLI
+
+This installation method is also called the _manifest installation method_.
+
+. Install the `roxctl` CLI.
+. On the {osp} cluster that will contain Central, perform these steps:
+.. In the terminal window, run the interactive install command by using the `roxctl` CLI.
+.. Run the setup shell script.
+.. In the terminal window, create the Central resources by using the `oc create` command.
+. Perform one of the following actions:
+* In the {product-title-short} web console, create and download the sensor YAML file and keys.
+* On the secured cluster, use the `roxctl sensor generate openshift` command.
+. On the secured cluster, run the sensor installation script.
+

--- a/modules/portal-generate-init-bundle.adoc
+++ b/modules/portal-generate-init-bundle.adoc
@@ -30,11 +30,11 @@ endif::[]
 
 ifndef::cloud-svc[]
 You can create an init bundle containing secrets by using the {product-title-short} portal.
-endif::[]
+endif::cloud-svc[]
 
 ifdef::cloud-svc[]
 You can create an init bundle containing secrets by using the {product-title-short} portal, also called the ACS Console.
-endif::[]
+endif::cloud-svc[]
 
 [NOTE]
 ====
@@ -44,41 +44,40 @@ You must have the `Admin` user role to create an init bundle.
 .Procedure
 
 ifndef::cloud-svc[]
-. Find the address of the {product-title-short} portal based on your exposure method:
-.. For a route:
+. Find the address of the {product-title-short} portal as described in "Verifying Central installation using the Operator method".
+endif::cloud-svc[]
+. Log in to the {product-title-short} portal.
+. If you do not have secured clusters, the *Platform Configuration* -> *Clusters* page appears.
+. Click *Create init bundle*.
+. Enter a name for the cluster init bundle.
+. Select your platform.
+. Select the installation method you will use for your secured clusters: *Operator* or *Helm chart*.
+. Click *Download* to generate and download the init bundle, which is created in the form of a YAML file. You can use one init bundle and its corresponding YAML file for all secured clusters if you are using the same installation method.
 +
-[source,terminal]
-----
-$ oc get route central -n stackrox
-----
-.. For a load balancer:
-+
-[source,terminal]
-----
-$ oc get service central-loadbalancer -n stackrox
-----
-.. For port forward:
-... Run the following command:
-+
-[source,terminal]
-----
-$ oc port-forward svc/central 18443:443 -n stackrox
-----
-... Navigate to `\https://localhost:18443/`.
-endif::[]
-. On the {product-title-short} portal, navigate to *Platform Configuration* -> *Integrations*.
-. Navigate to the *Authentication Tokens* section and click on *Cluster Init Bundle*.
-. Click *Generate bundle*.
-. Enter a name for the cluster init bundle and click *Generate*.
-.. If you are installing using Helm charts, click *Download Helm Values File* to download the generated bundle.
-.. If you are installing using the Operator, click *Download Kubernetes Secret File* to download the generated bundle.
-
-
 [IMPORTANT]
 ====
 Store this bundle securely because it contains secrets.
-You can use the same bundle to create multiple secured clusters.
 ====
 .Next steps
-. Apply the init bundle by creating a resource on the secured cluster.
+. Apply the init bundle by using it to create resources on the secured cluster.
 . Install secured cluster services on each cluster.
+
+ifeval::["{context}" == "init-bundle-cloud-other"]
+:!cloud-svc:
+endif::[]
+
+ifeval::["{context}" == "init-bundle-cloud-ocp"]
+:!cloud-svc:
+endif::[]
+
+ifeval::["{context}" == "init-bundle-cloud-ocp"]
+:!openshift:
+endif::[]
+
+ifeval::["{context}" == "init-bundle-ocp"]
+:!openshift:
+endif::[]
+
+ifeval::["{context}" == "init-bundle-ocp"]
+:!openshift:
+endif::[]

--- a/modules/provision-postgresql-database.adoc
+++ b/modules/provision-postgresql-database.adoc
@@ -6,7 +6,7 @@
 = Provisioning a database in your PostgreSQL instance
 
 [role="_abstract"]
-You can use your existing PostgreSQL infrastructure to provision a database for {product-title-short}. Use this intructions in this section for configuring a PostgreSQL database environment, creating a user, database, schema, role, and granting required permissions.
+This step is optional. You can use your existing PostgreSQL infrastructure to provision a database for {product-title-short}. Use the instructions in this section for configuring a PostgreSQL database environment, creating a user, database, schema, role, and granting required permissions.
 
 .Procedure
 . Create a new user:

--- a/modules/rollback-helm-upgrade.adoc
+++ b/modules/rollback-helm-upgrade.adoc
@@ -3,10 +3,10 @@
 // * upgrading/upgrade-helm.adoc
 :_mod-docs-content-type: PROCEDURE
 [id="rollback-helm-upgrade_{context}"]
-= Rolling back an Helm upgrade
+= Rolling back a Helm upgrade
 
 [role="_abstract"]
-You can roll back to a previous version of Central if the upgrade to a new version is unsuccessful.
+You can roll back to an earlier version of Central if the upgrade to a new version is unsuccessful.
 
 .Procedure
 

--- a/modules/secured-cluster-configuration-options-operator.adoc
+++ b/modules/secured-cluster-configuration-options-operator.adoc
@@ -3,7 +3,7 @@
 // * installing/install-ocp-operator.adoc
 :_mod-docs-content-type: CONCEPT
 [id="secured-cluster-configuration-options-operator_{context}"]
-= Secured cluster configuration options
+= Secured Cluster services configuration options
 
 When you create a Central instance, the Operator lists the following configuration options for the `Central` custom resource.
 
@@ -20,9 +20,9 @@ If using a non-gRPC capable load balancer, use the WebSocket protocol by prefixi
 If you do not specify a value for this parameter, Sensor attempts to connect to a Central instance running in the same namespace.
 
 | `clusterName`
-| The unique name of this cluster, which shows up in the RHACS portal.
-After the name is set by using this parameter, you cannot change it again.
-To change the name, you must delete and recreate the object.
+| The unique name of this cluster, which shows up in the {product-title-short} portal.
+After you set the name by using this parameter, you cannot change it again.
+To change the name, you must delete and re-create the object.
 
 |===
 

--- a/modules/upgrade-helm-chart.adoc
+++ b/modules/upgrade-helm-chart.adoc
@@ -9,7 +9,7 @@
 You can use the `helm upgrade` command to update {rh-rhacs-first}.
 
 .Prerequisites
-* You must have access to the `values-private.yaml` configuration file that you have used to install {rh-rhacs-first}. Otherwise, you must generate the `values-private.yaml` configuration file containg root certificates, before proceeding with the commands here.
+* You must have access to the `values-private.yaml` configuration file that you have used to install {rh-rhacs-first}. Otherwise, you must generate the `values-private.yaml` configuration file containing root certificates before proceeding with these commands.
 
 .Procedure
 * Run the helm upgrade command and specify the configuration files by using the `-f` option:
@@ -17,7 +17,7 @@ You can use the `helm upgrade` command to update {rh-rhacs-first}.
 [source,terminal]
 ----
 $ helm upgrade -n stackrox stackrox-central-services \
-  rhacs/central-services --version <current-rhacs-version> \ <1>
+  rhacs/central-services --version <current-rhacs-version> \// <1>
   -f values-private.yaml \
   --set central.db.password.generate=true \
   --set central.db.serviceTLS.generate=true \
@@ -26,7 +26,7 @@ $ helm upgrade -n stackrox stackrox-central-services \
 +
 [NOTE]
 ====
-You might use the `--reuse-values` option to preserve the previously configured Helm values during the upgrade. If you do that, you must turn off central-db creation before you upgrade to the next version. For example,
+You might use the `--reuse-values` option to preserve the previously configured Helm values during the upgrade. If you do that, you must turn off `central-db` creation before you upgrade to the next version. See the following command example:
 
 [source,terminal]
 ----


### PR DESCRIPTION
**Note: Does not contain Scanner V4 changes. Go [here](https://github.com/openshift/openshift-docs/pull/72452) for that.**

Version(s):
4.4+

[Issue](https://issues.redhat.com/browse/ROX-21157)

Links to docs previews:

**xref error fix:** (doc fix, no review needed)

- cloud_service/getting-started-rhacs-cloud-ocp.adoc: [Getting started with RHACS Cloud Service](https://71919--docspreview.netlify.app/openshift-acs/latest/cloud_service/getting-started-rhacs-cloud-ocp)

**Guidance added to the "high level overview" that provides general installation steps:** (reviewer: Draco team &#x2611;) 

- installing/acs-high-level-overview.adoc: [High-level RHACS installation overview](https://71919--docspreview.netlify.app/openshift-acs/latest/installing/acs-high-level-overview)
- modules/installing-rhacs-ocp-steps.adoc: [Installation steps for RHACS on OpenShift Container Platform](https://71919--docspreview.netlify.app/openshift-acs/latest/installing/acs-high-level-overview#installing-rhacs-ocp-steps_acs-high-level-overview)
- modules/installing-rhacs-kubernetes-steps.adoc: [Installation steps for RHACS on Kubernetes](https://71919--docspreview.netlify.app/openshift-acs/latest/installing/acs-high-level-overview#installing-rhacs-kubernetes-steps_acs-high-level-overview)

**Doc style change** (no review needed)

- installing/installing_ocp/install-central-config-options-ocp.adoc: [Configuring Central configuration options for RHACS using the Operator](https://71919--docspreview.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-config-options-ocp)
- installing/installing_ocp/install-secured-cluster-config-options-ocp.adoc: [Configuring secured cluster configuration options for RHACS using the Operator](https://71919--docspreview.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-config-options-ocp)

**Reuse values parameter guidance added to Helm command:** (reviewer: Draco team  &#x2611;)

- modules/change-config-options-after-deployment-central-service.adoc: https://71919--docspreview.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-ocp#change-config-options-after-deployment_install-secured-cluster-ocp
- modules/custom-cert-existing.adoc: https://71919--docspreview.netlify.app/openshift-acs/latest/configuration/add-custom-certificates#custom-cert-existing_add-custom-cert

**Updated init bundle info and steps:** (reviewer: Mark P  &#x2611;)

- modules/create-resource-init-bundle.adoc: [Generating and applying an init bundle for RHACS on Red Hat OpenShift](https://71919--docspreview.netlify.app/openshift-acs/latest/installing/installing_ocp/init-bundle-ocp)
- [Generating and applying an init bundle for RHACS on other platforms](https://71919--docspreview.netlify.app/openshift-acs/latest/installing/installing_other/init-bundle-other)

**Added missing steps to roxctl install for secured clusters:** (reviewer: Marcin  &#x2611;)

- modules/install-sensor-roxctl.adoc: [Installing sensor](https://71919--docspreview.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-ocp#install-sensor-roxctl_install-secured-cluster-ocp)

**Guidance update and typo fix:** (no reviewer needed, doc change)

- modules/install-acs-operator.adoc: [Installing the Red Hat Advanced Cluster Security for Kubernetes Operator](https://71919--docspreview.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-ocp#install-acs-operator_install-central-ocp)
- modules/install-secured-cluster-operator.adoc: [Installing Secured Cluster services](https://71919--docspreview.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-ocp#install-secured-cluster-operator_install-secured-cluster-ocp)
- modules/provision-postgresql-database.adoc: [Provisioning a database in your PostgreSQL instance](https://71919--docspreview.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-ocp#provision-postgresql-database_install-central-ocp)

QE review:
- [x] QE has approved this change. **ACS has no QE - approved by SMEs**

Additional information:
Opened a [separate Jira ticket](https://issues.redhat.com/browse/ROX-23001) to address inconsistencies in "Secured Cluster services/secured cluster" capitalization.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
