### PR TITLE
CNV#29261 - Document OVN network in UI

### DIFF
--- a/modules/virt-creating-nad-l2-overlay-console.adoc
+++ b/modules/virt-creating-nad-l2-overlay-console.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-creating-nad-l2-overlay-console_{context}"]
+= Creating a NAD for layer 2 topology by using the web console
+
+You can create a network attachment definition (NAD) that describes how to attach a pod to the layer 2 overlay network.
+
+.Prerequisites
+* You have access to the cluster as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Go to *Networking* -> *NetworkAttachmentDefinitions* in the web console.
+
+. Click *Create Network Attachment Definition*. The network attachment definition must be in the same namespace as the pod or virtual machine using it.
+
+. Enter a unique *Name* and optional *Description*.
+
+. Select *OVN Kubernetes L2 overlay network* from the *Network Type* list.
+
+. Click *Create*.

--- a/modules/virt-creating-nad-localnet-console.adoc
+++ b/modules/virt-creating-nad-localnet-console.adoc
@@ -9,6 +9,7 @@
 You can create a network attachment definition (NAD) to connect workloads to a physical network by using the {product-title} web console.
 
 .Prerequisites
+* You have access to the cluster as a user with `cluster-admin` privileges.
 * Use `nmstate` to configure the localnet to OVS bridge mappings.
 
 .Procedure

--- a/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc
+++ b/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc
@@ -48,6 +48,7 @@ include::modules/virt-creating-localnet-nad-cli.adoc[leveloffset=+2]
 You can attach a virtual machine (VM) to the OVN-Kubernetes secondary network interface by using the {product-title} web console or the CLI.
 
 include::modules/virt-attaching-vm-to-ovn-secondary-nw-cli.adoc[leveloffset=+2]
+include::modules/virt-creating-nad-l2-overlay-console.adoc[leveloffset=+2]
 include::modules/virt-creating-nad-localnet-console.adoc[leveloffset=+2]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/CNV-29261

Link to docs preview:
https://71923--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network#virt-creating-nad-l2-overlay-console_virt-connecting-vm-to-ovn-secondary-network

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
