### PR TITLE
CNV#36464: network latency tests in UI

### DIFF
--- a/virt/release_notes/virt-4-15-release-notes.adoc
+++ b/virt/release_notes/virt-4-15-release-notes.adoc
@@ -116,6 +116,8 @@ This release adds new features and enhancements related to the following compone
 //CNV-36603: Mark bootable volumes as favorite
 
 //CNV-36464: Run a test that shows that the SR-IOV settings are correct
+* You can run a VM xref:../../virt/monitoring/virt-running-cluster-checkups.adoc#virt-measuring-latency-vm-secondary-network_virt-running-cluster-checkups[latency checkup] by using the web console. From the side menu, click *Virtualization* -> *Checkups* -> *Network latency*.
+To run your first checkup, click *Install permissions* and then click *Run checkup*.
 
 //CNV-34697: Instance types is now GA. Move the 4.14 RN from the TP section to here.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15 only (RN)
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-36464](https://issues.redhat.com//browse/CNV-36464)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://71938--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-15-release-notes#virt-4-15-web
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: RN-only due to capacity constraints, so there is more procedural info in this note than is usually necessary.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
