### PR TITLE
Adding prow smoke-test script

### DIFF
--- a/scripts/prow-smoke-test.sh
+++ b/scripts/prow-smoke-test.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+#================================================================
+# HEADER
+#================================================================
+#%
+#%OVERVIEW 📑
+#+    ./scripts/prow-smoke-test.sh [--validate --preview]
+#%
+#%DESCRIPTION 💡
+#%    Validates openshift-docs AsciiDoc source files using the same tools that run in the Prow CI
+#%
+#%OPTIONS ⚙️
+#%    -v, --validate                                    Validate the AsciiDoc source
+#%    -p, --preview $DISTRO "$PRODUCT_NAME" $VERSION    Use --preview to run with default options
+#%    -h, --help                                        Print this help
+#%
+#%EXAMPLES 🤔
+#%    ./scripts/prow-smoke-test.sh --validate
+#%    ./scripts/prow-smoke-test.sh --preview
+#%    ./scripts/prow-smoke-test.sh --preview openshift-rosa
+#%    ./scripts/prow-smoke-test.sh --preview openshift-pipelines "Red Hat OpenShift Pipelines" 1.14
+#================================================================
+# END_OF_HEADER
+#================================================================
+
+set -e
+
+TEST=$1
+DISTRO=$2
+PRODUCT_NAME=$3
+VERSION=$4
+CONTAINER_IMAGE=quay.io/redhat-docs/openshift-docs-asciidoc
+SCRIPT_HEADSIZE=$(head -30 ${0} |grep -n "^# END_OF_HEADER" | cut -f1 -d:)
+
+if [[ "$1" == "--help" || "$1" == "-h" ]]; then
+    usage
+fi
+
+# Assign default variables
+: ${PRODUCT_NAME:="OpenShift Container Platform"}
+: ${VERSION:="4.16"}
+: ${DISTRO:="openshift-enterprise"}
+
+# Allow podman or docker
+if hash podman 2>/dev/null; then
+    CONTAINER_ENGINE=podman
+elif hash docker 2>/dev/null; then
+    CONTAINER_ENGINE=docker
+else
+    echo >&2 "Container engine not installed. Install Podman or Docker and run the script again."
+    exit 1
+fi
+
+echo "CONTAINER_ENGINE=$CONTAINER_ENGINE 🐳"
+
+# Get the default container $WORKDIR
+CONTAINER_WORKDIR=$($CONTAINER_ENGINE run --rm $CONTAINER_IMAGE /bin/bash -c 'echo $PWD')
+
+# Grep the commented script preamble and return it as help
+display_help() { head -${SCRIPT_HEADSIZE:-99} ${0} | grep -e "^#[%+-]" | sed -e "s/^#[%+-]//g" ; }
+
+# Exit and show the help if no parameters are passed
+if [ $# -eq 0 ]; then
+    display_help
+fi
+
+if [[ "$TEST" == "--preview" || "$TEST" == "-p" ]] && [[ -z "$DISTRO" ]]; then
+    echo ""
+    echo "🚧 Building with openshift-enterprise distro..."
+    $CONTAINER_ENGINE run --rm -it -v "$(pwd)":${CONTAINER_WORKDIR}:Z $CONTAINER_IMAGE asciibinder build -d "$DISTRO"
+
+elif [[ "$TEST" == "--preview" || "$TEST" == "-p" ]] && [[ -n "$DISTRO" ]]; then
+    echo ""
+    echo "🚧 Building $DISTRO distro..."
+    $CONTAINER_ENGINE run --rm -it -v "$(pwd)":${CONTAINER_WORKDIR}:Z $CONTAINER_IMAGE asciibinder build -d "$DISTRO"
+
+elif [[ "$TEST" == "--validate" || "$TEST" == "-v" ]]; then
+    echo ""
+    echo "🚧 Validating the docs..."
+  $CONTAINER_ENGINE run --rm -it -v "$(pwd)":${CONTAINER_WORKDIR}:Z $CONTAINER_IMAGE sh -c 'scripts/check-asciidoctor-build.sh && python3 build_for_portal.py --distro '${DISTRO}' --product "'"${PRODUCT_NAME}"'" --version '${VERSION}' --no-upstream-fetch && python3 makeBuild.py'
+fi


### PR DESCRIPTION
Adding a prow-smoke-test script to cut down on PR churn. This allows you to run the Prow tests locally :partying_face: 

You must have docker or podman installed. There are no other dependencies. Underneath the hood, the script pulls the `quay.io/redhat-docs/openshift-docs-asciidoc` container that we use in Prow.

* To build the preview output, run `./scripts/prow-smoke-test.sh --preview`
* To run the validation jobs, run `./scripts/prow-smoke-test.sh --validate`

Run the script from the root of the /openshift-docs repo.