### PR TITLE
[RHACS] ROX-22231: cloud source integrations

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -293,6 +293,8 @@ Topics:
   File: integrate-with-jira
 - Name: Integrating with Email
   File: integrate-with-email
+- Name: Integrating with cloud management platforms
+  File: integrate-with-cloud-management-platforms
 ---
 Name: Backup and restore
 Dir: backup_and_restore

--- a/integration/integrate-with-cloud-management-platforms.adoc
+++ b/integration/integrate-with-cloud-management-platforms.adoc
@@ -1,0 +1,31 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="integrate-with-cloud-management-platforms"]
+= Integrating with cloud management platforms
+include::modules/common-attributes.adoc[]
+:context: integrate-with-cloud-management-platforms
+
+toc::[]
+
+[role="_abstract"]
+You can integrate {rh-rhacs-first} with different cloud management platforms to discover potential clusters to secure. The cluster discovery aims to gain a detailed overview of the cluster assets already or not yet secured by {product-title-short}.
+
+The clusters discovered from a cloud management platform are accessible from the *Platform Configuration* -> *Clusters* -> *Discovered clusters* page.
+
+{product-title-short} matches the discovered clusters against already secured clusters. Based on the result of the matching, a discovered cluster has one of the following statuses:
+
+* *Secured*: The cluster is secured by {product-title-short}.
+* *Unsecured*: The cluster is not secured by {product-title-short}.
+* *Undetermined*: The metadata collected from secured clusters is not enough for a unique match. The cluster is either secured or unsecured.
+
+For successful cluster matching, ensure that the following conditions are met:
+
+* Sensors running on secured clusters have been updated to the latest version.
+* link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#allow-access-to-tags-in-IMDS[Access to instance tags via the metadata service] has been granted for secured clusters running on AWS. Sensors require access to the AWS EC2 instance tags to determine the cluster status.
+
+You can integrate {product-title-short} with the following cloud management platforms:
+
+* link:https://paladincloud.io/[Paladin Cloud]
+* link:https://console.redhat.com/openshift/[OpenShift Cluster Manager]
+
+include::modules/cloud-management-platforms-paladin-cloud.adoc[leveloffset=+1]
+include::modules/cloud-management-platforms-ocm.adoc[leveloffset=+1]

--- a/modules/cloud-management-platforms-ocm.adoc
+++ b/modules/cloud-management-platforms-ocm.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * integration/integrate-with-cloud-management-platforms.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="cloud-management-platforms-ocm.adoc_{context}"]
+= Configuring Red Hat OpenShift Cluster Manager integration
+
+To discover cluster assets from Red Hat OpenShift Cluster Manager, create a new integration in {product-title}.
+
+.Prerequisites
+* A Red Hat account.
+* An link:https://console.redhat.com/openshift/token[Red Hat OpenShift Cluster Manager API token].
+
+.Procedure
+. On the {product-title-short} portal, go to *Platform Configuration* -> *Integrations*.
+. Scroll down to the *Cloud source integrations* section and select *Red Hat OpenShift Cluster Manager*.
+. Click *New integration*.
+. Enter a name for *Integration name*.
+. Enter the Red Hat OpenShift Cluster Manager API endpoint for *Endpoint*. The default is `\https://api.openshift.com`.
+. Enter the Red Hat OpenShift Cluster Manager API token for *API token*.
+. Select *Test* to confirm that authentication is working.
+. Select *Create* to create the configuration.
+
+Once configured, {product-title} discovers cluster assets from your connected Red Hat account.

--- a/modules/cloud-management-platforms-paladin-cloud.adoc
+++ b/modules/cloud-management-platforms-paladin-cloud.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * integration/integrate-with-cloud-management-platforms.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="cloud-management-platforms-paladin-cloud_{context}"]
+= Configuring Paladin Cloud integration
+
+To discover cluster assets from Paladin Cloud, create a new integration in {product-title}.
+
+.Prerequisites
+* A Paladin Cloud account.
+* A Paladin Cloud API token.
+
+.Procedure
+. On the {product-title-short} portal, go to *Platform Configuration* -> *Integrations*.
+. Scroll down to the *Cloud source integrations* section and select *Paladin Cloud*.
+. Click *New integration*.
+. Enter a name for *Integration name*.
+. Enter the Paladin Cloud API endpoint for *Paladin Cloud endpoint*. The default is `\https://api.paladincloud.io`.
+. Enter the Paladin Cloud API token for *Paladin Cloud token*.
+. Select *Test* to confirm that authentication is working.
+. Select *Create* to create the configuration.
+
+Once configured, {product-title} discovers cluster assets from your connected Paladin Cloud account.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.4

Cherrypick to `rhacs-docs-4.4`
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/ROX-22231
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://71977--docspreview.netlify.app/openshift-acs/latest/integration/integrate-with-cloud-sources
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
Added documentation for the new cloud source integration type. I added the pages under the `Integrating` section. I was also looking for a general docs page for the regular *Clusters* page to add a note about the discovered clusters button, but I didn't find such page.
I believe the discovered clusters page itself is essentially self-evident, I would personally opt to avoid documentation a la "to filter by status, click the status filter". Please let me know if I should rather be a bit more verbose and/or add a dedicated section for the discovered clusters page.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

<img width="1253" alt="Screenshot 2024-02-22 at 04 00 10" src="https://github.com/openshift/openshift-docs/assets/55607356/7eb869c6-322a-41f2-8cf5-f03b2bdd6865">

<img width="1271" alt="SCR-20240222-ekwh" src="https://github.com/openshift/openshift-docs/assets/55607356/50d87865-4b57-4fc4-af92-a92526c7f5f8">

<img width="1253" alt="Screenshot 2024-02-22 at 03 59 35" src="https://github.com/openshift/openshift-docs/assets/55607356/b5485db9-0628-471b-9fae-de162be67bb0">
