### PR TITLE
CNV#36930: DR link to kbase and assembly stub updates

### DIFF
--- a/modules/virt-about-dr-methods.adoc
+++ b/modules/virt-about-dr-methods.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * virt/backup_restore/virt-disaster-recovery.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="virt-about-dr-methods_{context}"]
+= About disaster recovery methods
+
+For an overview of disaster recovery (DR) concepts, architecture, and planning considerations, see the link:https://access.redhat.com/articles/7041594[Red Hat {VirtProductName} disaster recovery guide] in the Red Hat Knowledgebase.
+
+The two primary DR methods for {VirtProductName} are Metropolitan Disaster Recovery (Metro-DR) and Regional-DR.
+
+Metro-DR::
+
+Metro-DR uses synchronous replication. It writes to storage at both the primary and secondary sites so that the data is always synchronized between sites. Because the storage provider is responsible for ensuring that the synchronization succeeds, the environment must meet the throughput and latency requirements of the storage provider.
+
+Regional-DR::
+
+Regional-DR uses asynchronous replication. The data in the primary site is synchronized with the secondary site at regular intervals. For this type of replication, you can have a higher latency connection between the primary and secondary sites.
+
+[id="metro-dr_{context}"]
+== Metro-DR for {rh-storage-first}
+
+{VirtProductName} supports the link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.14/html-single/configuring_openshift_data_foundation_disaster_recovery_for_openshift_workloads/index#metro-dr-solution[Metro-DR solution for {rh-storage}], which provides two-way synchronous data replication between managed {VirtProductName} clusters installed on primary and secondary sites. This solution combines {rh-rhacm-first}, Red Hat Ceph Storage, and {rh-storage} components.
+
+Use this solution during a site disaster to fail applications from the primary to the secondary site, and to relocate the application back to the primary site after restoring the disaster site. 
+
+This synchronous solution is only available to metropolitan distance data centers with a 10 millisecond latency or less. 
+
+For more information about using the Metro-DR solution for {rh-storage} with {VirtProductName}, see link:https://access.redhat.com/articles/7053115[the Red Hat Knowledgebase].

--- a/virt/backup_restore/virt-disaster-recovery.adoc
+++ b/virt/backup_restore/virt-disaster-recovery.adoc
@@ -2,11 +2,10 @@
 [id="virt-disaster-recovery"]
 = Disaster recovery
 include::_attributes/common-attributes.adoc[]
-:context: virt-about-dr
+:context: virt-disaster-recovery
 
 toc::[]
 
-The disaster recovery documentation provides information for administrators on how to recover from certain disaster scenarios that might occur with an {product-title} cluster. As an administrator, you must plan your {VirtProductName} deployment in advance in order to take advantage of disaster recovery.
+{VirtProductName} supports using disaster recovery (DR) solutions to ensure that your environment can recover after a site outage. To use these methods, you must plan your {VirtProductName} deployment in advance.
 
-Metropolitan Disaster Recovery (Metro-DR)::
-Metro-DR provides two-way synchronous data replication between managed {VirtProductName} clusters installed on primary and secondary sites. Use Metro-DR during a site disaster to fail applications from the primary to the secondary site, and to relocate the application back to the primary site after restoring the disaster site. This synchronous solution is only available to metropolitan distance data centers with a 10 millisecond latency or less. For more information, see https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.14/html-single/configuring_openshift_data_foundation_disaster_recovery_for_openshift_workloads/index#metro-dr-solution[Metro-DR solution for OpenShift Data Foundation].
+include::modules/virt-about-dr-methods.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-36930](https://issues.redhat.com//browse/CNV-36930)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://71987--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-disaster-recovery
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: My main objective was to add the kbase link to a stub assembly. It turned out that the DR stub assembly already existed, so I modularized it and added a little more info from the kbase. I also clarified that metro-DR support statements are referring to ODF metro-DR.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
