### PR TITLE
OSDOCS-9661 Adding date and errata links to the 4.15.0 section

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2432,11 +2432,11 @@ For any {product-title} release, always review the instructions on xref:../updat
 
 //Update with relevant advisory information
 [id="ocp-4-15-0-ga"]
-=== RHSA-2024:XXXX - {product-title} {product-version}.0 image release, bug fix, and security update advisory
+=== RHSA-2023:7198 - {product-title} {product-version}.0 image release, bug fix, and security update advisory
 
-Issued: TBD
+Issued: 2024-2-27
 
-{product-title} release {product-version}.0, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:XXXX[RHSA-2024:XXXX] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:XXXX[RHSA-2024:XXXX] advisory.
+{product-title} release {product-version}.0, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:7198[RHSA-2023:7198] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7201[RHSA-2023:7201] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory.
 


### PR DESCRIPTION
Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-9661](https://issues.redhat.com/browse/OSDOCS-9661)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to [docs preview:](https://71988--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-0-ga)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
Not needed, per Kathryn on Slack.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
