### PR TITLE
OCPBUGS-8764: Release note for BMO enhancement

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -925,6 +925,9 @@ To generate the `junit` report, the `--ginkgo.junit-report` flag replaces `--jun
 
 For more information, see xref:../scalability_and_performance/cnf-performing-platform-verification-latency-tests.adoc[Performing latency tests for platform verification].
 
+[id="ocp-4-15-bare-metal-operator"]
+==== Bare Metal Operator
+For {product-title} {product-version}, when the Bare Metal Operator removes a host from the cluster it also powers off the host. This enhancement streamlines hardware maintenance and management.
 
 [id="ocp-4-15-hcp"]
 === Hosted control planes


### PR DESCRIPTION
Adds a brief release note about an enhancement to the Bare Metal Operator.

Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-8764
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://184.23.213.161:8080/OCPBUGS-8764-4.15/release_notes/ocp-4-15-release-notes.html#ocp-4-15-bare-metal-operator

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
