### PR TITLE
Revert "OSDOCS#9210 Enabling userProvisionedDNS for GCP installations"

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -2122,12 +2122,6 @@ Additional GCP configuration parameters are described in the following table:
 
 |platform:
   gcp:
-    userProvisionedDNS:
-|Enables user-provisioned DNS instead of the default cluster-provisioned DNS solution. If you want to use this feature, you must set the `featureSet` parameter to `TechPreviewNoUpgrade`. Alternatively, you can set `featureSet` to `CustomNoUpgrade` and `featureGates` to `- GCPClusterHostedDNS=true`.
-|`Enabled` or `Disabled`. The default value is `Disabled`.
-
-|platform:
-  gcp:
     region:
 |The name of the GCP region that hosts your cluster.
 |Any valid region name, such as `us-central1`.

--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -47,7 +47,6 @@ The following Technology Preview features are enabled by this feature set:
 ** `managedBootImages`
 ** `onClusterBuild`
 ** `signatureStores`
-** `userProvisionedDNS`
 --
 
 ////

--- a/nodes/clusters/nodes-cluster-enabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-enabling-features.adoc
@@ -25,9 +25,7 @@ For more information about the features activated by the `TechPreviewNoUpgrade` 
 ** xref:../../storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc#persistent-storage-csi-sc-manage[Managing the default storage class]
 
 
-** xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Pod security admission enforcement]
-
-** xref:../../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp[Installation configuration parameters for GCP]
+** xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Pod security admission enforcement].
 
 include::modules/nodes-cluster-enabling-features-install.adoc[leveloffset=+1]
 


### PR DESCRIPTION
This reverts commit 387f8bcea25a70df48f0c6384bca320455a96e29.

Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-9210
https://issues.redhat.com/browse/OCPBUGS-29741

Link to docs preview:
[Installation configuration parameters](https://71993--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installation-config-parameters-gcp.html#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp)
[Enabling feature gates](https://71993--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-about_nodes-cluster-enabling)

QE review:
- [ ] QE has approved this change.

Additional information:
Reverting due to failed QE tests. Will re-add as a 4.15 z stream