### PR TITLE
OCPBUGS-27948 Adding late breaking issue re performance profile

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2473,7 +2473,7 @@ This issue affects CPU load balancing features because these features depend on 
 
 * When a node reboot occurs all pods are restarted in a random order. In this scenario it is possible that `tuned` pod started after the workload pods. This means the workload pods start with partial tuning, which can affect performance or even cause the workload to fail. (link:https://issues.redhat.com/browse/OCPBUGS-26400[*OCPBUGS-26400*])
 
-* Currently, applying a performance profile at day-0 is not supported. (link:https://issues.redhat.com/browse/OCPBUGS-18640[*OCPBUGS-18640*])
+* The installation of {product-title} might fail when a performance profile is present in the extra manifests folder and targets the master or worker pools. This is caused by the internal install ordering that processes the performance profile before the default master and worker `MachineConfigPools` are created. It is possible to workaround this issue by including a copy of the stock master or worker `MachineConfigPools` in the extra manifests folder. (link:https://issues.redhat.com/browse/OCPBUGS-27948[*OCPBUGS-27948*]) (link:https://issues.redhat.com/browse/OCPBUGS-18640[*OCPBUGS-18640*])
 
 [id="ocp-4-15-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
[OCPBUGS-27948]: PerformanceProfile render fails at Day-0 because the master/worker pools are not yet presen 
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15RN
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-27948
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://72012--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-known-issues
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
