### PR TITLE
OCPBUGS-29605: OpenStack: Document dualstack known issue

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2438,6 +2438,8 @@ In the following tables, features are marked with the following statuses:
 
 * In {product-version} with IPv6 networking running on {rh-openstack-first} environments, health monitors created with IPv6 `ovn-octavia` load balancers will not function correctly. (link:https://issues.redhat.com/browse/OCPBUGS-29603[*OCPBUGS-29603*])
 
+* In {product-version} with IPv6 networking running on {rh-openstack-first} environments, sharing a IPv6 load balancer with multiple services is not allowed because of an issue that mistakenly marks IPv6 load balancer as internal to the cluster.(link:https://issues.redhat.com/browse/OCPBUGS-29605[*OCPBUGS-29605*])
+
 * When installing an {product-title} cluster with static IP addressing and Tang encryption, nodes start without network settings. This condition prevents nodes from accessing the Tang server, causing installation to fail. To address this condition, you must set the network settings for each node as `ip` installer arguments.
 +
 . For installer-provisioned infrastructure, before installation provide the network settings as `ip` installer arguments for each node by executing the following steps.


### PR DESCRIPTION
Document following issue:

https://issues.redhat.com/browse/OCPBUGS-29605

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
