### PR TITLE
CNV#21920: RN - Move instancetype API from v1alpha2 to v1beta1

### DIFF
--- a/virt/release_notes/virt-4-15-release-notes.adoc
+++ b/virt/release_notes/virt-4-15-release-notes.adoc
@@ -70,7 +70,8 @@ This release adds new features and enhancements related to the following compone
 [id="virt-4-15-infrastructure"]
 === Infrastructure
 
-//CNV-29987: Move instancetype API from v1alpha2 to v1beta1. As of 01/03/2024, this is an In Progress TP RN for 4.14 (CNV-21920).
+//CNV-21920: Move instancetype API from v1alpha2 to v1beta1
+* The `instanceType` API now uses a more stable `v1beta1` version.
 
 //CNV-31433: virtio-serial channel for SAP
 


### PR DESCRIPTION
Version(s):
4.15

Issue:
https://issues.redhat.com/browse/CNV-21920

Link to docs preview:
https://72052--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-15-release-notes#virt-4-15-infrastructure

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
