### PR TITLE
OCPBUGS-25719: Add OpenStack as supported for IPv6 clusters

### DIFF
--- a/modules/nw-ovn-kubernetes-matrix.adoc
+++ b/modules/nw-ovn-kubernetes-matrix.adoc
@@ -64,7 +64,7 @@ endif::[]
 
 2. Egress router for OVN-Kubernetes supports only redirect mode.
 
-3. IPv6 is supported only on bare metal, vSphere, {ibm-power-name}, and {ibm-z-name} clusters.
+3. IPv6 is supported only on bare metal, vSphere, {ibm-power-name}, {ibm-z-name}, and Red Hat OpenStack clusters.
 
-4. IPv6 single stack is not supported on {ibm-power-name} and {ibm-z-name} clusters.
+4. IPv6 single stack is not supported on {ibm-power-name}, {ibm-z-name}, and Red Hat OpenStack clusters.
 --


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
OpenStack is being added as a platform that supports dual-stack network consequently IPv6 networks as well, we need to address that in the docs. Also it does not support single stack IPv6.
context https://issues.redhat.com/browse/OSASINFRA-3210
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
