### PR TITLE
OSDOCS#9760: Adds management console known issue to 4.15 RNs

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2591,8 +2591,11 @@ If NMEA sentences are lost on their way to the e810 NIC, the T-GM cannot synchro
 A proposed fix is to report a `FREERUN` event when the NMEA string is lost.
 (link:https://issues.redhat.com/browse/OCPBUGS-19838[*OCPBUGS-19838*])
 
+* Currently, the *YAML* tab of some pages in the web console stops unexpectedly on some browsers when the multicluster engine for Kubernetes operator (MCE) is installed. The following message is displayed: "Oh no! Something went wrong." (link:https://issues.redhat.com/browse/OCPBUGS-29812[*OCPBUGS-29812*])
+
 //[id="ocp-telco-ran-4-15-known-issues"]
 //
+
 [id="ocp-telco-core-4-15-known-issues"]
 
 * Currently, defining a `sysctl` value for a setting with a slash in its name, such as for bond devices, in the `profile` field of a Tuned resource might not work. Values with a slash in the `sysctl` option name are not mapped correctly to the `/proc` filesystem. As a workaround, create a `MachineConfig` resource that places a configuration file with the required values in the `/etc/sysctl.d` node directory. (link:https://issues.redhat.com/browse/RHEL-3707[*RHEL-3707*])


### PR DESCRIPTION
Adds management console known issue https://issues.redhat.com/browse/OCPBUGS-29812 to 4.15 RNs

Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-9760

Link to docs preview:
https://72060--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-known-issues

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
