### PR TITLE
CNV#38629: KI for qemu-kvm bug

### DIFF
--- a/virt/release_notes/virt-4-15-release-notes.adoc
+++ b/virt/release_notes/virt-4-15-release-notes.adoc
@@ -250,6 +250,15 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 [discrete]
 [id="virt-4-15-ki-virtualization"]
 ==== Virtualization
+
+// new for 4.15
+* A critical bug in `qemu-kvm` causes VMs to hang and experience I/O errors after xref:../../virt/virtual_machines/virtual_disks/virt-hot-plugging-virtual-disks.adoc#virt-hot-plugging-virtual-disks[disk hot plug] operations. This issue can also affect the operating system disk and other disks that were not involved in the hot plug operations. If the operating system disk stops working, the root file system shuts down. For more information, see link:https://access.redhat.com/solutions/7055333[Virtual Machine loses access to its disks after hot-plugging some extra disks] in the Red Hat Knowledgebase.
++
+[IMPORTANT]
+====
+Due to package versioning, this bug might reappear after updating {VirtProductName} from 4.13.z or 4.14.z to 4.15.0.
+====
+
 //4.15 still unresolved
 * When adding a virtual Trusted Platform Module (vTPM) device to a Windows VM, the BitLocker Drive Encryption system check passes even if the vTPM device is not persistent. This is because a vTPM device that is not persistent stores and recovers encryption keys using ephemeral storage for the lifetime of the `virt-launcher` pod. When the VM migrates or is shut down and restarts, the vTPM data is lost. (link:https://issues.redhat.com/browse/CNV-36448[*CNV-36448*])
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15 only (RN)
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-38629](https://issues.redhat.com//browse/CNV-38629)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [approximate link - see Virtualization section of Known Issues](https://72066--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-15-release-notes#virt-4-15-known-issues:~:text=the%20VM%20clones.-,Virtualization,-A%20critical%20bug)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
