### PR TITLE
Tuning etcd latency tolerances to 4.15 RNs as Tech Preview

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -922,6 +922,7 @@ The Network Observability Operator releases updates independently from the {prod
 
 [id="ocp-4-15-scalability-and-performance"]
 === Scalability and performance
+You can set the control plane hardware speed to one of `"Standard"`, `"Slower"`, or the default, `""`, which allows the system to decide which speed to use. This is a Technology Preview feature. For more information, see xref:../scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.adoc#etcd-tuning-parameters_recommended-etcd-practices[Setting tuning parameters for etcd].
 
 [id="ocp-4-15-hub-side-templating-policygentemplate"]
 ==== Hub-side templating for PolicyGenTemplate CRs


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:  This PR brings forward release note text from 4.14 that must also be in 4.15.  SME and QE approvals rcvd.
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://72068--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-scalability-and-performance
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Refer to PR [71126](https://github.com/openshift/openshift-docs/pull/71126)
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
