### PR TITLE
OSDOCS#9616: adding link to Software Supply Chain Security doc

### DIFF
--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -206,9 +206,7 @@ xref:../operators/operator_sdk/helm/osdk-helm-support.adoc#osdk-helm-support[Hel
 - **Reference the xref:../rest_api/index.adoc#api-index[REST API index]**: Learn about {product-title} application programming interface endpoints.
 
 // Need to provide a link closer to 4.15 GA
-- **Software Supply Chain Security enhancements**: The PipelineRun *details* page in the *Developer* or *Administrator* perspective of the web console provides a visual representation of identified vulnerabilities, which are categorized by severity. Additionally, these enhancements provide an option to download or view Software Bill of Materials (SBOMs) for enhanced transparency and control within your supply chain. Learn about setting up OpenShift Pipelines in the web console to view Software Supply Chain Security elements. 
-
-//When doc available, add a link to /openshift-pipelines/latest/secure/setting-up-openshift-pipelines-to-view-software-supply-chain-security-elements[Setting up OpenShift Pipelines in the web console to view Software Supply Chain Security elements]
+- **Software Supply Chain Security enhancements**: The PipelineRun *details* page in the *Developer* or *Administrator* perspective of the web console provides a visual representation of identified vulnerabilities, which are categorized by severity. Additionally, these enhancements provide an option to download or view Software Bill of Materials (SBOMs) for enhanced transparency and control within your supply chain. Learn about link:https://docs.openshift.com/pipelines/1.13/secure/setting-up-openshift-pipelines-to-view-software-supply-chain-security-elements.html[setting up OpenShift Pipelines in the web console to view Software Supply Chain Security elements].
 
 endif::openshift-enterprise,openshift-webscale,openshift-origin[]
 endif::openshift-rosa,openshift-dedicated,openshift-dpu,microshift[]
@@ -339,8 +337,8 @@ ifdef::openshift-enterprise[]
 ** link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/clusters/cluster_mce_overview#hosting-service-cluster-configure-aws[Configuring the hosting cluster on AWS (Technology Preview)]
 ** link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/clusters/cluster_mce_overview#config-hosted-service-ibmpower[Configuring the hosting cluster on a 64-bit x86 {product-title} cluster to create hosted control planes for {ibm-power-name} compute nodes (Technology Preview)]
 ** link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/clusters/cluster_mce_overview#configuring-hosting-service-cluster-ibmz[Configuring the hosted cluster on 64-bit x86 bare metal for {ibm-z-name} compute nodes (Technology Preview)]
-// CHECK IN WITH SERVESHA CLOSER TO 4.15 GA ON THE FOLLOWING FEATURE: 
-// **  Using the Agent-based Installer to provision non-bare-metal machines. 
+// CHECK IN WITH SERVESHA CLOSER TO 4.15 GA ON THE FOLLOWING FEATURE:
+// **  Using the Agent-based Installer to provision non-bare-metal machines.
 
 * **link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/clusters/cluster_mce_overview#enable-or-disable-hosted-control-planes[Enabling or disabling the hosted control planes feature]**: The hosted control planes feature is now enabled by default.
 endif::openshift-enterprise[]


### PR DESCRIPTION
Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-9616

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://72069--ocpdocs-pr.netlify.app/openshift-enterprise/latest/welcome/#developer-activities
It's at the bottom of the section.

QE review:
- [n/a] QE has approved this change.

Additional information:
This topic was in-flight when the welcome page was created but has since been merged. The preview link was [this](https://70231--docspreview.netlify.app/openshift-pipelines/latest/secure/setting-up-openshift-pipelines-to-view-software-supply-chain-security-elements). The live docs are [here](https://docs.openshift.com/pipelines/latest/secure/setting-up-openshift-pipelines-to-view-software-supply-chain-security-elements.html).