### PR TITLE
HCIDOCS-228: [enterprise-4.13] Issue in file networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc

### DIFF
--- a/modules/virt-example-vlan-nncp.adoc
+++ b/modules/virt-example-vlan-nncp.adoc
@@ -39,7 +39,7 @@ spec:
 <1> Name of the policy.
 <2> Optional: If you do not include the `nodeSelector` parameter, the policy applies to all nodes in the cluster.
 <3> This example uses a `hostname` node selector.
-<4> Name of the interface.
+<4> Name of the interface. When deploying on bare metal, only the `<interface_name>.<vlan_number>` VLAN format is supported.
 <5> Optional: Human-readable description of the interface.
 <6> The type of interface. This example creates a VLAN.
 <7> The requested state for the interface after creation.


### PR DESCRIPTION
Clarified the callout to more specifically note that the format for VLAN is <interface_name>.<vlan_number>.

Fixes: [HCIDOCS-228](https://issues.redhat.com//browse/HCIDOCS-228)

See https://issues.redhat.com/browse/HCIDOCS-228 for additional details.

Preview URL: http://184.23.213.161:8080/HCIDOCS-228/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#virt-example-vlan-nncp_k8s_nmstate-updating-node-network-config

For release(s): 4.16, 4.15, 4.14, 4.13, 4.12, 4.11
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
