### PR TITLE
[enterprise-4.15] Add 4.15 RN for OLM/Azure & v0 dep

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -186,6 +186,13 @@ For more information, see xref:../web_console/dynamic-plugin/dynamic-plugins-ref
 
 For more information about `console.resource/details-item`, see xref:../web_console/dynamic-plugin/dynamic-plugins-reference.adoc#dynamic-plugin-sdk-extensions_dynamic-plugins-reference[{product-title} console API].
 
+[id="ocp-4-15-console-supports-azure-sts-detection"]
+===== OperatorHub support for {azure-id}
+
+With this release, OperatorHub detects when a {product-title} cluster running on Azure is configured for {azure-id}. When detected, a "Cluster in Workload Identity / Federated Identity Mode" notification is displayed with additional instructions before installing an Operator to ensure it runs correctly. The *Operator Installation* page is also modified to add fields for the required Azure credentials information.
+
+For the updated step for the *Install Operator* page, see xref:../operators/admin/olm-adding-operators-to-cluster.adoc#olm-installing-from-operatorhub-using-web-console_olm-adding-operators-to-a-cluster[Installing from OperatorHub using the web console].
+
 [id="ocp-4-15-developer-perspective"]
 ==== Developer Perspective
 
@@ -581,6 +588,13 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 [id="ocp-4-15-auth"]
 === Authentication and authorization
 
+[id="ocp-4-15-auth-olm-azure-sts"]
+==== OLM-based Operator support for {azure-id}
+
+With this release, some Operators managed by Operator Lifecycle Manager (OLM) on Azure clusters can use the Cloud Credential Operator (CCO) in manual mode with {azure-id}. These Operators authenticate with short-term credentials that are managed outside the cluster.
+
+For more information, see xref:../operators/operator_sdk/token_auth/osdk-cco-azure.adoc#osdk-cco-azure[CCO-based workflow for OLM-managed Operators with Azure AD Workload Identity].
+
 [id="ocp-4-15-networking"]
 === Networking
 
@@ -802,8 +816,22 @@ include::snippets/olmv1-cli-only.adoc[]
 
 For more information, see xref:../operators/olm_v1/index.adoc#olmv1-about[About Operator Lifecycle Manager 1.0].
 
+[id="ocp-4-15-deprecation"]
+==== Deprecation schema for Operator catalogs
+
+The optional `olm.deprecations` schema defines deprecation information for Operator packages, bundles, and channels in a file-based catalog. Operator authors can use this schema in a `deprecations.yaml` file to provide relevant messages about their Operators, such as support status and recommended upgrade paths, to users running those Operators from a catalog. After the Operator is installed, any specified messages can be viewed as status conditions on the related `Subscription` object.
+
+For information on the `olm.deprecations` schema, see xref:../operators/understanding/olm-packaging-format.adoc#olm-deprecations-schema_olm-packaging-format[Operator Framework packaging format].
+
 [id="ocp-4-15-osdk"]
 === Operator development
+
+[id="ocp-4-15-osdk-cco-azure"]
+==== Token authentication for Operators on cloud providers: {azure-id}
+
+With this release, Operators managed by Operator Lifecycle Manager (OLM) can support token authentication when running on Azure clusters configured for {azure-id}. Updates to the Cloud Credential Operator (CCO) enable semi-automated provisioning of certain short-term credentials, provided that the Operator author has enabled their Operator to support {azure-id}.
+
+For more information, see xref:../operators/operator_sdk/token_auth/osdk-cco-azure.adoc#osdk-cco-azure[CCO-based workflow for OLM-managed Operators with Azure AD Workload Identity].
 
 [id="ocp-4-15-builds"]
 === Builds


### PR DESCRIPTION
Release notes for:

* https://github.com/openshift/openshift-docs/pull/70222
* https://github.com/openshift/openshift-docs/pull/70898

Preview:

* _Web console_ feature: [OperatorHub support for Azure AD Workload Identity](https://72071--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-console-supports-azure-sts-detection) (cc @opayne1)
* _Authentication and authorization_ feature: [OLM-based Operator support for Azure AD Workload Identity](https://72071--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-auth-olm-azure-sts) (cc @jeana-redhat)
* _Operator development_ feature: [Token authentication for Operators on cloud providers: Azure AD Workload Identity](https://72071--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-osdk-cco-azure)
* _Operator lifecycle_ feature: [Deprecation schema for Operator catalogs](https://72071--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-deprecation)