### PR TITLE
OSDOCS-9768: adds 4.15.0 async release note MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -12,7 +12,6 @@ toc::[]
 
 [id="microshift-4-15-about-this-release"]
 == About this release
-// TODO: Update with the relevant information closer to release.
 Version 4.15 of {product-title} includes new features and enhancements. {microshift-short} was introduced as Generally Available with {microshift-short} 4.14. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md[Kubernetes 1.28] with the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
 
 You can deploy {microshift-short} clusters to either on-premise, cloud, or disconnected environments.
@@ -20,8 +19,7 @@ You can deploy {microshift-short} clusters to either on-premise, cloud, or disco
 // Double check OP system versions
 {microshift-short} {product-version} is supported on {op-system-ostree-first} and {op-system-base-full} 9.2 and 9.3.
 
-//TODO: update link after GA; KCS article will not be live until then
-//For lifecycle information, see the link:https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle Policy].
+For lifecycle information, see the link:https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{product-title} Life Cycle Policy].
 
 [id="microshift-4-15-new-features-and-enhancements"]
 == New features and enhancements
@@ -109,7 +107,7 @@ Various networking documentation improvements are now available in the {microshi
 
 * *Network topology updates.* Extensive examples of the Network topology available in your {microshift-short} instance are also updated, see xref:../microshift_networking/microshift-cni.html#microshift-network-topology_microshift-about-ovn-k-plugin[Network topology].
 
-* *Auditing exposed ports examples.* The {microshift-short} documentation now includes procedures on auditing exposed network ports and viewing port log settings. The updated documentation can be viewed in xref:../microshift_networking/microshift-networking-settings.adoc#microshift-exposed-audit-ports_microshift-networking[Auditing exposed network ports]. 
+* *Auditing exposed ports examples.* The {microshift-short} documentation now includes procedures on auditing exposed network ports and viewing port log settings. The updated documentation can be viewed in xref:../microshift_networking/microshift-networking-settings.adoc#microshift-exposed-audit-ports_microshift-networking[Auditing exposed network ports].
 
 * *Adding and closing ports.* This release also improved the documentation for adding and closing ports and services in your {microshift-short} firewall, see xref:../microshift_networking/microshift-firewall.adoc#microshift-firewall-optional-settings_microshift-firewall[Using optional port settings].
 
@@ -120,30 +118,12 @@ Various networking documentation improvements are now available in the {microshi
 
 You can configure your network settings to run {microshift-short} on a fully disconnected host. This feature is also enabled in {microshift-short} version 4.14. For more information, see xref:../microshift_networking/microshift-disconnected-network-config.adoc[Configuring network settings for fully disconnected hosts].
 
-//[id="microshift-4-15-storage"]
-//=== Storage
-
-//[id="microshift-backup-and-restore"]
-//=== Backup and restore
-
 [id="microshift-4-15-running-apps"]
 === Running Applications
 
 [id="microshift-4-15-olm"]
 ==== Operator Lifecyle Manager
 With this release, you can use Operator Lifecyle Manager (OLM) to create, apply, and administer add-on Operators. See xref:../microshift_running_apps/microshift-operators-olm.adoc#microshift-operators-olm[Using Operator Lifecycle Manager with {microshift-short}].
-
-//[id="microshift-4-15-notable-technical-changes"]
-//== Notable technical changes
-
-//{microshift-short} {product-version} introduces the following notable technical changes.
-// Note: use [discrete] for these sub-headings.
-
-//[discrete]
-//[id="microshift-4-15-networking-changes"]
-//=== Networking changes
-
-//Networking updates to {microshift-short} {product-version} include ...
 
 [id="microshift-4-15-deprecated-and-removed"]
 == Deprecated and removed features
@@ -191,40 +171,16 @@ In the following tables, features are marked with the following statuses:
 
 * Previously, the Greenboot health check reported a `RED` status when the Logical Volume Manager Storage (LVMS) component was disabled because no volume groups (VGs) were present. Because volume groups are not required for {microshift-short}, the health check should report `GREEN` without VGs. Now, when LVMS is disabled, the Greenboot health check skips the check for the `openshift-storage` namespace and reports `GREEN` status. (link:https://issues.redhat.com/browse/OCPBUGS-25689[*OCPBUGS-25689*])
 
-//[discrete]
-//[id="microshift-4-15-updating-bug-fixes"]
-//==== Updating
-
 [discrete]
 [id="microshift-4-15-networking-bug-fixes"]
 ==== Networking
 * Whenever `advertiseAddress` is configured with an IP address, any network interfaces must also be configured. Previously, manually setting the `advertiseAddress` in the {microshift-short} `config.yaml` to the IP address value that is expected to be set by default, but not manually setting the same IP address for the `br-ex` network bridge on the host, caused the `ovnkube-master` container in the `ovnkube-master` pod to crash. With this release, the {microshift-short} service verifies whether `advertiseAddress` is set in the `config.yaml` and whether any interface has the same IP address set. If the two settings are not the same, {microshift-short} prints an error, for example, `Advertise address: %s not present in any interface, advertiseAddress` and fails. This helps ensure the proper configuration before the system starts. (link:https://issues.redhat.com/browse/OCPBUGS-27398[*OCPBUGS-27398*]
-
-//[discrete]
-//[id="microshift-4-15-configuring-bug-fixes"]
-//==== Configuring
-
-//[discrete]
-//[id="microshift-4-15-storage-bug-fixes"]
-//==== Storage
-
-//[discrete]
-//[id="microshift-4-15-running-applications-bug-fixes"]
-//==== Running applications
-
-//[discrete]
-//[id="microshift-4-15-backup-and-restore-bug-fixes"]
-//==== Backup and restore
 
 [discrete]
 [id="microshift-4-15-support-bug-fixes"]
 ==== Support
 * Previously, `sos` reports created journal logs in separate files, making it difficult to correlate {microshift-short} and the Greenboot health check. Now the {microshift-short} `sos` tool includes a full system journal with an aggregated view in the same log. With this update, you can see one log with a detailed report that shows all of the enabled plugins and data from the different components and applications.
 (link:https://issues.redhat.com/browse/OCPBUGS-19567[*OCPBUGS-19567*])
-
-//[id="microshift-4-15-known-issues"]
-//== Known issues
-
 
 [id="microshift-4-15-asynchronous-errata-updates"]
 == Asynchronous errata updates
@@ -240,12 +196,11 @@ Red Hat Customer Portal user accounts must have systems registered and consuming
 
 This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, will be detailed in the following subsections.
 
-//[id="microshift-4-15-0-dp"]
-//=== RHSA-2023:7200 - {microshift-short} 4.15.0 bug fix and security update advisory
+[id="microshift-4-15-0-dp"]
+=== RHSA-2023:7200 - {microshift-short} 4.15.0 bug fix and security update advisory
 
-//Issued: 2024-02-28
+Issued: 2024-02-27
 
-//{product-title} release 4.15.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:7200[RHSA-2023:7200] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7198[RHSA-2023:7198] advisory.
+{product-title} release 4.15.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:7200[RHSA-2023:7200] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7198[RHSA-2023:7198] advisory.
 
-//For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
-//check the lvms version
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-9768](https://issues.redhat.com/browse/OSDOCS-9768)

Link to docs preview:
[4.15.0 async relnote](https://72078--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes#microshift-4-15-0-dp)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
