### PR TITLE
[enterprise-4.13] OCPBUGS17080: Description for the InsightsConfigAPI feature is not correct

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -25,7 +25,7 @@ The following Technology Preview features are enabled by this feature set:
 ** CSI volumes. Enables CSI volume support for the {product-title} build system. (`BuildCSIVolumes`)
 ** Swap memory on nodes. Enables swap memory use for {product-title} workloads on a per-node basis. (`NodeSwap`)
 ** OpenStack Machine API Provider. This gate has no effect and is planned to be removed from this feature set in a future release. (`MachineAPIProviderOpenStack`)
-** Insights Operator. Enables the Insights Operator, which gathers {product-title} configuration data and sends it to Red Hat. (`InsightsConfigAPI`)
+** Insights Operator. Enables the `InsightsDataGather` CRD, which allows users to configure some Insights data gathering options.
 ** Pod topology spread constraints. Enables the `matchLabelKeys` parameter for pod topology constraints. The parameter is list of pod label keys to select the pods over which spreading will be calculated. (`MatchLabelKeysInPodTopologySpread`)
 ** Retroactive Default Storage Class. Enables {product-title} to retroactively assign the default storage class to PVCs if there was no default storage class when the PVC was created.(`RetroactiveDefaultStorageClass`)
 ** Pod disruption budget (PDB) unhealthy pod eviction policy. Enables support for specifying how unhealthy pods are considered for eviction when using PDBs. (`PDBUnhealthyPodEvictionPolicy`)

--- a/nodes/clusters/nodes-cluster-enabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-enabling-features.adoc
@@ -18,7 +18,9 @@ For more information about the features activated by the `TechPreviewNoUpgrade` 
 
 ** xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-swap-memory_nodes-nodes-managing[Swap memory on nodes]
 
-** xref:../../support/remote_health_monitoring/using-insights-operator.adoc#using-insights-operator[Using Insights Operator]
+** xref:../../support/remote_health_monitoring/using-insights-operator.adoc#disabling-insights-operator-gather_using-insights-operator[Disabling the Insights Operator gather operations]
+
+** xref:../../support/remote_health_monitoring/using-insights-operator.adoc#enabling-insights-operator-gather_using-insights-operator[Enabling the Insights Operator gather operations]
 
 ** xref:../../machine_management/capi-machine-management.adoc#capi-machine-management[Managing machines with the Cluster API]
 


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/71636