### PR TITLE
WMCO 10 RN Add live ID errata link

### DIFF
--- a/windows_containers/windows-containers-release-notes-10-15-x.adoc
+++ b/windows_containers/windows-containers-release-notes-10-15-x.adoc
@@ -31,7 +31,7 @@ endif::openshift-origin[]
 [id="wmco-10-15-0"]
 == Release notes for Red{nbsp}Hat Windows Machine Config Operator 10.15.0
 
-This release of the WMCO provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.15.0 were released in {UPDATE WHEN AVAILABLE} link:https://access.redhat.com/errata/RHSA-2023:4025[RHSA-2023:4025] {UPDATE WHEN AVAILABLE}
+This release of the WMCO provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.15.0 were released in link:https://access.redhat.com/errata/RHSA-2024:0954-09[RHSA-2024:0954-09].
 
 === New features and improvements
 [id="wmco-10-15-0-node-certificates"]


### PR DESCRIPTION
Adding Live ID to release notes

Preview:
[Release notes for Red Hat Windows Machine Config Operator 10.15.0](https://72096--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-10-15-x#wmco-10-15-0) -- Link to the errata RHSA-2024:0954-09 in the first paragraph. Link will not work until the errata is published. 