### PR TITLE
added -v with mv to have better verbosity, apart from this I've added…

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -62,7 +62,7 @@ You do not need to stop the static pods on the recovery host.
 +
 [source,terminal]
 ----
-$ sudo mv /etc/kubernetes/manifests/etcd-pod.yaml /tmp
+$ sudo mv -v /etc/kubernetes/manifests/etcd-pod.yaml /tmp
 ----
 
 .. Verify that the `etcd` pods are stopped by using:
@@ -78,7 +78,7 @@ If the output of this command is not empty, wait a few minutes and check again.
 +
 [source,terminal]
 ----
-$ sudo mv /etc/kubernetes/manifests/kube-apiserver-pod.yaml /tmp
+$ sudo mv -v /etc/kubernetes/manifests/kube-apiserver-pod.yaml /tmp
 ----
 
 .. Verify that the `kube-apiserver` containers are stopped by running:
@@ -94,7 +94,7 @@ If the output of this command is not empty, wait a few minutes and check again.
 +
 [source,terminal]
 ----
-$ sudo mv /etc/kubernetes/manifests/kube-controller-manager-pod.yaml /tmp
+$ sudo mv -v /etc/kubernetes/manifests/kube-controller-manager-pod.yaml /tmp
 ----
 
 .. Verify that the `kube-controller-manager` containers are stopped by running:
@@ -109,7 +109,7 @@ If the output of this command is not empty, wait a few minutes and check again.
 +
 [source,terminal]
 ----
-$ sudo mv /etc/kubernetes/manifests/kube-scheduler-pod.yaml /tmp
+$ sudo mv -v /etc/kubernetes/manifests/kube-scheduler-pod.yaml /tmp
 ----
 
 .. Verify that the `kube-scheduler` containers are stopped by using:
@@ -124,7 +124,7 @@ If the output of this command is not empty, wait a few minutes and check again.
 +
 [source,terminal]
 ----
-$ sudo mv /var/lib/etcd/ /tmp
+$ sudo mv -v /var/lib/etcd/ /tmp
 ----
 
 .. If the `/etc/kubernetes/manifests/keepalived.yaml` file exists, follow these steps:
@@ -133,7 +133,7 @@ $ sudo mv /var/lib/etcd/ /tmp
 +
 [source,terminal]
 ----
-$ sudo mv /etc/kubernetes/manifests/keepalived.yaml /tmp
+$ sudo mv -v /etc/kubernetes/manifests/keepalived.yaml /tmp
 ----
 
 ... Verify that any containers managed by the `keepalived` daemon are stopped:
@@ -183,7 +183,7 @@ You can check whether the proxy is enabled by reviewing the output of `oc get pr
 +
 [source,terminal]
 ----
-$ sudo -E /usr/local/bin/cluster-restore.sh /home/core/backup
+$ sudo -E /usr/local/bin/cluster-restore.sh /home/core/assets/backup
 ----
 +
 .Example script output


### PR DESCRIPTION
added -v with mv to have better verbosity, apart from this I've added the correct path: "/home/core/assets/backup"

As mentioned in [this documentation](https://docs.openshift.com/container-platform/4.14/backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.html#backing-up-etcd-data_backup-etcd) in the point number 4 it is mentioned that the backup is under assets directory.

`sh-4.4# /usr/local/bin/cluster-backup.sh /home/core/assets/backup`

4.14 and it should be fixed in all.

Preview: https://72098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state#dr-scenario-2-restoring-cluster-state_dr-restoring-cluster-state