### PR TITLE
Added hyper link of Cluster Operators reference in The Cluster CAPI Operator section in openshift document.

### DIFF
--- a/modules/cluster-api-architecture.adoc
+++ b/modules/cluster-api-architecture.adoc
@@ -15,7 +15,7 @@ The Cluster CAPI Operator is an {product-title} Operator that maintains the life
 
 If a cluster is configured correctly to allow the use of the Cluster API, the Cluster CAPI Operator installs the Cluster API components on the cluster.
 
-For more information, see the entry for the Cluster CAPI Operator in the _Cluster Operators reference_ content.
+For more information, see the entry for the Cluster CAPI Operator in the link:https://docs.openshift.com/container-platform/4.15/operators/operator-reference.html[Cluster Operators reference] content.
 
 [id="capi-arch-resources"]
 == Primary resources


### PR DESCRIPTION
Added hyper link of Cluster Operators reference in The Cluster CAPI Operator section in openshift document.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->    4.15,4.14,4.13,4.12

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-29907

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://docs.openshift.com/container-platform/4.15/machine_management/capi-machine-management.html#capi-arch-operator

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
