### PR TITLE
Updating existing steps description with extra information 

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -127,7 +127,7 @@ If the output of this command is not empty, wait a few minutes and check again.
 $ sudo mv /var/lib/etcd/ /tmp
 ----
 
-.. If the `/etc/kubernetes/manifests/keepalived.yaml` file exists, follow these steps:
+.. If the `/etc/kubernetes/manifests/keepalived.yaml` file exists and the node is deleted, follow these steps:
 
 ... Move the `/etc/kubernetes/manifests/keepalived.yaml` file out of the kubelet manifest directory:
 +


### PR DESCRIPTION
Added an extra information to follow the step:

New : If the /etc/kubernetes/manifests/keepalived.yaml file exists and the node is deleted, follow these steps:

Old : If the /etc/kubernetes/manifests/keepalived.yaml file exists, follow these steps:

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> ---> 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. --> 4.12, 4.13, 4.14

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->  https://issues.redhat.com/browse/OCPBUGS-29908

Link to docs preview:
https://72103--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html#dr-scenario-2-restoring-cluster-state_dr-restoring-cluster-state

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
