### PR TITLE
OADP-3522: ROSA docs is missing instructions related to the internal image backup

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.adoc
@@ -28,6 +28,7 @@ This process is performed in the following two stages:
 include::modules/preparing-aws-credentials-for-oadp.adoc[leveloffset=+1]
 
 include::modules/installing-oadp-rosa-sts.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 .Additional resources
 
@@ -38,4 +39,5 @@ include::modules/installing-oadp-rosa-sts.adoc[leveloffset=+1]
 == Example: Backing up workload on OADP ROSA STS, with an optional cleanup
 
 include::modules/performing-a-backup-oadp-rosa-sts.adoc[leveloffset=+2]
+
 include::modules/cleanup-a-backup-oadp-rosa-sts.adoc[leveloffset=+2]

--- a/modules/cleanup-a-backup-oadp-rosa-sts.adoc
+++ b/modules/cleanup-a-backup-oadp-rosa-sts.adoc
@@ -16,33 +16,39 @@ If you need to uninstall the {oadp-first} Operator together with the backups and
 ----
 $ oc delete ns hello-world
 ----
+
 . Delete the Data Protection Application (DPA) by running the following command:
 +
 [source,terminal]
 ----
 $ oc -n openshift-adp delete dpa ${CLUSTER_NAME}-dpa
 ----
+
 . Delete the cloud storage by running the following command:
 +
 [source,terminal]
 ----
 $ oc -n openshift-adp delete cloudstorage ${CLUSTER_NAME}-oadp
 ----
+
 +
 [WARNING]
 ====
 If this command hangs, you might need to delete the finalizer by running the following command:
+
 [source,terminal]
 ----
 $ oc -n openshift-adp patch cloudstorage ${CLUSTER_NAME}-oadp -p '{"metadata":{"finalizers":null}}' --type=merge
 ----
 ====
+
 . If the Operator is no longer required, remove it by running the following command:
 +
 [source,terminal]
 ----
 $ oc -n openshift-adp delete subscription oadp-operator
 ----
+
 . Remove the namespace from the Operator:
 +
 [source,terminal]
@@ -51,25 +57,26 @@ $ oc delete ns openshift-adp
 ----
 
 . If the backup and restore resources are no longer required, remove them from the cluster by running the following command:
-
 +
 [source,terminal]
 ----
 $ oc delete backup hello-world
 ----
-+
+
 . To delete backup, restore and remote objects in {aws-short} S3 run the following command:
 +
 [source,terminal]
 ----
 $ velero backup delete hello-world
 ----
+
 . If you no longer need the Custom Resource Definitions (CRD), remove them from the cluster by running the following command:
 +
 [source,terminal]
 ----
 $ for CRD in `oc get crds | grep velero | awk '{print $1}'`; do oc delete crd $CRD; done
 ----
+
 . Delete the {aws-short} S3 bucket by running the following commands:
 +
 [source,terminal]
@@ -81,13 +88,14 @@ $ aws s3 rm s3://${CLUSTER_NAME}-oadp --recursive
 ----
 $ aws s3api delete-bucket --bucket ${CLUSTER_NAME}-oadp
 ----
+
 . Detach the policy from the role by running the following command:
 +
 [source,terminal]
 ----
-$ aws iam detach-role-policy --role-name "${ROLE_NAME}" \
-  --policy-arn "${POLICY_ARN}"
+$ aws iam detach-role-policy --role-name "${ROLE_NAME}"  --policy-arn "${POLICY_ARN}"
 ----
+
 . Delete the role by running the following command:
 +
 [source,terminal]

--- a/modules/installing-oadp-rosa-sts.adoc
+++ b/modules/installing-oadp-rosa-sts.adoc
@@ -155,7 +155,7 @@ $ cat << EOF | oc create -f -
     name: ${CLUSTER_NAME}-dpa
     namespace: openshift-adp
   spec:
-    backupImages: false
+    backupImages: true <1>
     features:
       dataMover:
         enable: false
@@ -166,6 +166,7 @@ $ cat << EOF | oc create -f -
         credential:
           key: credentials
           name: cloud-credentials
+        prefix: velero
         default: true
         config:
           region: ${REGION}
@@ -179,6 +180,8 @@ $ cat << EOF | oc create -f -
         enable: false
 EOF
 ----
+<1> ROSA supports internal image backup. Set this field to `false` if you do not want to use image backup.
+
 // . Create the `DataProtectionApplication` resource, which is used to configure the connection to the storage where the backups and volume snapshots are stored:
 
 .. If you are using CSI or non-CSI volumes, deploy a Data Protection Application by entering the following command:
@@ -192,6 +195,10 @@ $ cat << EOF | oc create -f -
     name: ${CLUSTER_NAME}-dpa
     namespace: openshift-adp
   spec:
+    backupImages: true <1>
+    features:
+      dataMover:
+         enable: false
     backupLocations:
     - bucket:
         cloudStorageRef:
@@ -199,6 +206,7 @@ $ cat << EOF | oc create -f -
         credential:
           key: credentials
           name: cloud-credentials
+        prefix: velero
         default: true
         config:
           region: ${REGION}
@@ -207,24 +215,25 @@ $ cat << EOF | oc create -f -
         defaultPlugins:
         - openshift
         - aws
-      nodeAgent: <1>
+      nodeAgent: <2>
         enable: false
         uploaderType: restic
     snapshotLocations:
       - velero:
           config:
-            credentialsFile: /tmp/credentials/openshift-adp/cloud-credentials-credentials <2>
-            enableSharedConfig: "true" <3>
-            profile: default <4>
-            region: ${REGION} <5>
+            credentialsFile: /tmp/credentials/openshift-adp/cloud-credentials-credentials <3>
+            enableSharedConfig: "true" <4>
+            profile: default <5>
+            region: ${REGION} <6>
           provider: aws
 EOF
 ----
-<1> See the following note.
-<2> The `credentialsFile` field is the mounted location of the bucket credential on the pod.
-<3> The `enableSharedConfig` field allows the `snapshotLocations` to share or reuse the credential defined for the bucket.
-<4> Use the profile name set in the {aws-short} credentials file.
-<5> Specify `region` as your {aws-short} region. This must be the same as the cluster region.
+<1> ROSA supports internal image backup. Set this field to false if you do not want to use image backup.
+<2> See the following note.
+<3> The `credentialsFile` field is the mounted location of the bucket credential on the pod.
+<4> The `enableSharedConfig` field allows the `snapshotLocations` to share or reuse the credential defined for the bucket.
+<5> Use the profile name set in the {aws-short} credentials file.
+<6> Specify `region` as your {aws-short} region. This must be the same as the cluster region.
 +
 You are now ready to back up and restore {product-title} applications, as described in _Backing up applications_.
 
@@ -233,8 +242,8 @@ You are now ready to back up and restore {product-title} applications, as descri
 The `enable` parameter of `restic` is set to `false` in this configuration, because OADP does not support Restic in ROSA environments.
 
 If you use OADP 1.2, replace this configuration:
-[source,terminal]
 
+[source,terminal]
 ----
 nodeAgent:
   enable: false


### PR DESCRIPTION
### JIRA

* [OADP-3522](https://issues.redhat.com/browse/OADP-3522)

### PREVIEW

* [OADP ROSA docs](https://72112--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications)

### VERSIONS

* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16


### QE review:
- [X ] QE has approved this change. Prasad approved

![image](https://github.com/openshift/openshift-docs/assets/106804821/20a49a78-8ede-425e-a5d1-aeb597f2f516)


<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
