### PR TITLE
Adding AWS outposts day 0 -> day 2 change to 4.15 RNs

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -114,6 +114,13 @@ You can customize the MTU for a cluster by specifying the networking.clusterNetw
 
 For more information, see xref:../installing/installing_aws/installing-aws-localzone.adoc#installation-aws-cluster-network-mtu_installing-aws-localzone[Customizing the cluster network MTU].
 
+[id="ocp-4-15-installing-aws-outposts"]
+==== Installing a cluster on AWS with compute nodes on AWS Outposts
+
+In {product-title} version 4.14, you could install a cluster on AWS with compute nodes running in AWS Outposts as a Technology Preview. In {product-title} 4.15, you can install a cluster on AWS into an existing VPC and provision compute nodes on AWS Outposts as a postinstallation configuration task.
+
+For more information, see xref:../installing/installing_aws/installing-aws-vpc.adoc[Installing a cluster on AWS into an existing VPC].
+
 [id="ocp-4-15-installation-and-update-nutanix-failure-domains"]
 ==== Nutanix and fault tolerant deployments
 


### PR DESCRIPTION
Adding RN to move outposts from day 0 to day 2.

Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-9286

Link to docs preview:
https://72113--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-installing-aws-outposts

QE review:
- [x] QE has approved this change.

Link to post-install config procedure can be added after https://github.com/openshift/openshift-docs/pull/71263 merges