### PR TITLE
OCPBUGS-29514: Removed 2 lines from the BM external LB example

### DIFF
--- a/modules/installation-load-balancing-user-infra.adoc
+++ b/modules/installation-load-balancing-user-infra.adoc
@@ -180,8 +180,6 @@ defaults
 listen api-server-6443 <1>
   bind *:6443
   mode tcp
-  option  httpchk GET /readyz HTTP/1.0
-  option  log-health-checks
   balance roundrobin
   server bootstrap bootstrap.ocp4.example.com:6443 verify none check check-ssl inter 10s fall 2 rise 3 backup <2>
   server master0 master0.ocp4.example.com:6443 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
@@ -190,10 +188,10 @@ listen api-server-6443 <1>
 listen machine-config-server-22623 <3>
   bind *:22623
   mode tcp
-  server bootstrap bootstrap.ocp4.example.com:22623 check inter 1s backup <2>
-  server master0 master0.ocp4.example.com:22623 check inter 1s
-  server master1 master1.ocp4.example.com:22623 check inter 1s
-  server master2 master2.ocp4.example.com:22623 check inter 1s
+  server bootstrap bootstrap.ocp4.example.com:22623 verify none check check-ssl inter 10s fall 2 rise 3 backup <2>
+  server master0 master0.ocp4.example.com:22623 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
+  server master1 master1.ocp4.example.com:22623 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
+  server master2 master2.ocp4.example.com:22623 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
 listen ingress-router-443 <4>
   bind *:443
   mode tcp


### PR DESCRIPTION
Version(s):
4.12 to 4.16

Issue:
[OCPBUGS-29514](https://issues.redhat.com/browse/OCPBUGS-29514)
[OCPBUGS-29452](https://issues.redhat.com/browse/OCPBUGS-29452)
[OCPBUGS-29455](https://issues.redhat.com/browse/OCPBUGS-29455)

Link to docs preview:
[Example load balancer configuration for user-provisioned clusters](https://72117--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal#installation-load-balancing-user-infra-example_installing-bare-metal)

- [ ] SME has approved this change.
- [ ] QE has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
