### PR TITLE
CNV-26981: Reversing redirect to allow CNV content to go live on GA

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -435,14 +435,14 @@ AddType text/vtt                            vtt
 
 
     # The following rule prevents an infinite redirect loop when browsing to /container-platform/4.15/virt/about_virt/about-virt.html
-    RewriteRule ^container-platform/4\.15/virt/about_virt/about-virt.html$ - [L]
+    # RewriteRule ^container-platform/4\.15/virt/about_virt/about-virt.html$ - [L]
 
     # OpenShift Virtualization (CNV) catchall redirect; use when CNV releases asynchronously from OCP. Do not change the 302 to a 301.
     # When uncommented, this redirects all `virt` directory traffic to the about-virt page.
     # Pay mind to the redirect directly above this which prevents redirect loops.
     # To activate the redirects, uncomment the next and previous lines and update the version number to the pending release.
 
-    RewriteRule container-platform/4\.15/virt/(?!about-virt\.html)(.+)$ /container-platform/4.15/virt/about_virt/about-virt.html [NE,R=302]
+    # RewriteRule container-platform/4\.15/virt/(?!about-virt\.html)(.+)$ /container-platform/4.15/virt/about_virt/about-virt.html [NE,R=302]
 
 
     # Red Hat OpenShift support for Windows Containers (WMCO) catchall redirect; use when WMCO releases asynchronously from OCP. Do not change the 302 to a 301.

--- a/.s2i/httpd-cfg/01-community.conf
+++ b/.s2i/httpd-cfg/01-community.conf
@@ -160,13 +160,13 @@ AddType text/vtt                            vtt
     RewriteRule ^latest/install_config/upgrading/(.*)$ /latest/upgrading/$1 [NE,R=301]
 
     # The following rule prevents an infinite redirect loop when browsing to /(latest|4\.15)/virt/about_virt/about-virt.html
-    RewriteRule ^(latest|4\.15)/virt/about_virt/about-virt.html$ - [L]
+    # RewriteRule ^(latest|4\.15)/virt/about_virt/about-virt.html$ - [L]
 
     # OpenShift Virtualization (CNV) catchall redirect; use when CNV releases asynchronously from OCP. Do not change the 302 to a 301.
     # When uncommented, this redirects all `virt` directory traffic to the about-virt page.
     # Pay mind to the redirect directly above this which prevents redirect loops.
     # To activate the redirects, uncomment the next and previous lines and update the version number to the pending release.
-    RewriteRule ^(latest|4\.15)/virt/(?!about-virt\.html)(.+)$ /$1/virt/about_virt/about-virt.html [NE,R=302]
+    # RewriteRule ^(latest|4\.15)/virt/(?!about-virt\.html)(.+)$ /$1/virt/about_virt/about-virt.html [NE,R=302]
 
     # Red Hat OpenShift support for Windows Containers (WMCO) catchall redirect; use when WMCO releases asynchronously from OCP. Do not change the 302 to a 301.
     # When uncommented, this redirects all `windows_containers` directory traffic to the /windows_containers/index.html page.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): No CP
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-26981](https://issues.redhat.com//browse/CNV-26981)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: N/A
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: N/A
<!--- [ ] QE has approved this change. --->
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: To be merged at CNV 4.14 GA (after merging placeholder reversal https://github.com/openshift/openshift-docs/pull/72121)
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
