### PR TITLE
OSDOCS-9782: Worker Node Instance types on ROSA/OSD i4i instances

### DIFF
--- a/modules/rosa-sdpolicy-am-aws-compute-types.adoc
+++ b/modules/rosa-sdpolicy-am-aws-compute-types.adoc
@@ -265,6 +265,8 @@
 - p3.16xlarge (64 vCPU, 488 GiB)
 - p3dn.24xlarge (96 vCPU, 768 GiB)
 - p4d.24xlarge (96 vCPU, 1,152 GiB)
+- p4de.24xlarge (96 vCPU, 1,152 GiB)
+- p5.48xlarge (192 vCPU, 2,048 GiB)
 - g4dn.xlarge (4 vCPU, 16 GiB)
 - g4dn.2xlarge (8 vCPU, 32 GiB)
 - g4dn.4xlarge (16 vCPU, 64 GiB)

--- a/modules/sdpolicy-am-aws-compute-types-ccs.adoc
+++ b/modules/sdpolicy-am-aws-compute-types-ccs.adoc
@@ -264,6 +264,8 @@
 - p3.16xlarge (64 vCPU, 488 GiB)
 - p3dn.24xlarge (96 vCPU, 768 GiB)
 - p4d.24xlarge (96 vCPU, 1,152 GiB)
+- p4de.24xlarge (96 vCPU, 1,152 GiB)
+- p5.48xlarge (192 vCPU, 2,048 GiB)
 - g4dn.xlarge (4 vCPU, 16 GiB)
 - g4dn.2xlarge (8 vCPU, 32 GiB)
 - g4dn.4xlarge (16 vCPU, 64 GiB)


### PR DESCRIPTION
[OSDOCS-9782](https://issues.redhat.com//browse/OSDOCS-9782): Worker Node Instance types on ROSA/OSD i4i instances

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-9782

Link to docs preview:
ROSA: https://72129--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition#rosa-sdpolicy-instance-types_rosa-service-definition
OSD: https://72129--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-service-definition#instance-types_osd-service-definition

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
