### PR TITLE
OCPBUG26050: Added a section for day2 operator for azure disk encryption sets.

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -251,6 +251,8 @@ Topics:
     File: preparing-to-install-on-azure
   - Name: Configuring an Azure account
     File: installing-azure-account
+  - Name: Enabling user-managed encryption for Azure
+    File: enabling-user-managed-encryption-azure
   - Name: Installer-provisioned infrastructure
     Dir: ipi
     Distros: openshift-origin,openshift-enterprise

--- a/installing/installing_azure/enabling-user-managed-encryption-azure.adoc
+++ b/installing/installing_azure/enabling-user-managed-encryption-azure.adoc
@@ -1,0 +1,32 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="enabling-user-managed-encryption-azure"]
+= Enabling user-managed encryption for Azure
+include::_attributes/common-attributes.adoc[]
+:context: enabling-user-managed-encryption-azure
+
+toc::[]
+
+In {product-title} version {product-version}, you can install a cluster with a user-managed encryption key in {azure-first}. To enable this feature, you can prepare an {azure-short} `DiskEncryptionSet` before installation, modify the `install-config.yaml` file, and then complete the installation.
+
+// Preparing an Azure Disk Encryption Set
+include::modules/installation-azure-preparing-diskencryptionsets.adoc[leveloffset=+1]
+
+// Preparing an Azure Disk Encryption Set for Day2 Operator
+include::modules/installation-azure-day2-operations-diskencryptionsets.adoc[leveloffset=+1]
+
+[id="enabling-disk-encrytpion-additional-resources"]
+== Additional resources
+
+* link:https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-cli#prerequisites[Use the {azure-short} portal to enable end-to-end encryption using encryption at host] ({azure-full} documentation)
+
+* xref:../../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-evacuating_nodes-nodes-working[Understanding how to evacuate pods on nodes]
+
+[id="enabling-disk-encryption-sets-azure-next-steps"]
+== Next steps
+
+* Depending on your infrastructure preferences, install an {product-title} cluster by completing the instructions in one of the following documents:
+** xref:../../installing/installing_azure/ipi/installing-azure-customizations.adoc#installing-azure-customizations[Install a cluster with customizations on installer-provisioned infrastructure]
+** xref:../../installing/installing_azure/ipi/installing-azure-network-customizations.adoc#installing-azure-network-customizations[Install a cluster with network customizations on installer-provisioned infrastructure]
+** xref:../../installing/installing_azure/ipi/installing-azure-vnet.adoc#installing-azure-vnet[Install a cluster into an existing VNet on installer-provisioned infrastructure]
+** xref:../../installing/installing_azure/ipi/installing-azure-private.adoc#installing-azure-private[Install a private cluster on installer-provisioned infrastructure]
+** xref:../../installing/installing_azure/ipi/installing-azure-government-region.adoc#installing-azure-government-region[Install a cluster into an government region on installer-provisioned infrastructure]

--- a/modules/installation-azure-day2-operations-diskencryptionsets.adoc
+++ b/modules/installation-azure-day2-operations-diskencryptionsets.adoc
@@ -1,0 +1,83 @@
+//Module included in the following assemblies:
+//
+// * installing/installing_azure/enabling-disk-encryption-sets-azure.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="preparing-disk-encryption-sets-day2-operator_{context}"]
+= Preparing an Azure Disk Encryption Set for Day2 Operator
+
+The {product-title} installation program can use an existing Disk Encryption Set with a user-managed key. To enable this feature, create a `DiskEncryptionSet` in Azure and provide the key to the installation program. 
+
+.Prerequisite
+
+* You enabled the `EncryptionAtHost` feature in your {ausre-short} subscription. For more information, see "Use the Azure portal to enable end-to-end encryption using encryption at host".
+
+.Procedure
+
+. Mark the node from the `encyptionAtHost` cluster resource group as unschedulable by using the following command:
++
+[source,terminal]
+----
+$ oc adm cordon <node_name>
+----
+
+. Evacuate the pods from the compute node. There are several ways to do this. For example, you can evacuate all the pods or the selected pods on a node: 
++
+[source,terminal]
+----
+$ oc adm drain <compute_node> [--pod-selector=<pod_selector>]
+----
++
+[NOTE]
+====
+For other options to evacuate pods from a node, see the "Understanding how to evacuate pods on nodes" section. 
+====
+
+. De-allocate the node by running the following command:
++
+[source,terminal]
+----
+$ az vm deallocate -n <node_name> -g <cluster_resource_group>
+----
+
+. Set the `encryptionAtHost` property to `true` by running the following command:
++
+[source,terminal]
+----
+$ az vm update -n <node_name> -g <cluster_resource_group> --set securityProfile.encryptionAtHost=true
+----
+
+. Start the node by running the following commands:
++
+[source,terminal]
+----
+$ az vm start -n <node_name> -g <cluster_resource_group>
+----
+
+. Mark the node as schedulable by using the following command:
++
+[source,terminal]
+----
+$ oc adm uncordon <node_name>
+----
+
+. Verify that all cluster Operators are available:
++
+[source,terminal]
+----
+$ oc get clusteroperators
+----
++
+All Operators should show `AVAILABLE=True`, `PROGRESSING=False`, and `DEGRADED=False`.
+
+. Repeat the above steps on all the nodes that run `encryptionAtHost`.
+
+[NOTE]
+====
+If you want to enable encryption for your host during cluster installation, specify the following parameters in the `install-config.yaml` file:
+
+* `compute.platform.azure.encryptionAtHost`
+* `controlPlane.platform.azure.encryptionAtHost`
+* `platform.azure.defaultMachinePlatform.encryptionAtHost`
+
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUG-26050](https://issues.redhat.com/browse/OCPBUGS-26050)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Preview](https://72130--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/enabling-user-managed-encryption-azure.html#preparing-disk-encryption-sets-day2-operator_enabling-user-managed-encryption-azure)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
