### PR TITLE
OCPBUGS#9372: Modified the overriding the default Kubelet node IP selection logic procedure

### DIFF
--- a/modules/nw-how-nw-iface-selected.adoc
+++ b/modules/nw-how-nw-iface-selected.adoc
@@ -6,7 +6,7 @@
 [id="nw-how-nw-iface-selected_{context}"]
 = How the network interface is selected
 
-For installations on bare metal or with virtual machines that have more than one network interface controller (NIC), the NIC that {product-title} uses for communication with the Kubernetes API server is determined by the `nodeip-configuration.service` service unit that is run by systemd when the node boots. The `nodeip-configuration.service` selects the IP from the interface associated with the default route.
+For installations on bare metal or with virtual machines that have more than one network interface controller (NIC), the NIC that {product-title} uses for communication with the Kubernetes API server is determined by the `nodeip-configuration.service` service unit that is run by `systemd` when the node boots. The `nodeip-configuration.service` selects the IP from the interface associated with the default route.
 
 After the `nodeip-configuration.service` service determines the correct NIC, the service creates the `/etc/systemd/system/kubelet.service.d/20-nodenet.conf` file. The `20-nodenet.conf` file sets the `KUBELET_NODE_IP` environment variable to the IP address that the service selected.
 
@@ -17,3 +17,21 @@ If hardware or networking is reconfigured after installation, or if there is a n
 If network communication is disrupted or misconfigured because a different NIC is selected, you might receive the following error: `EtcdCertSignerControllerDegraded`. You can create a hint file that includes the `NODEIP_HINT` variable to override the default IP selection logic. For more information, see Optional: Overriding the default node IP selection logic.
 
 // Link to info for creating a machine config.
+
+By default, the nodeip-configuration service on a cluster host will select the IP address from the interface the default route uses. If multiple default routes are present, the service will select the route with the lowest metric value. This works for the majority of deployments, but in some cases the deployment may depend on the less well-defined behavior in the Kubelet itself that was used prior to {product-title} {version 4.6}. Some less common network layouts may also find the default logic problematic. In these instances, it is necessary to override the node IP address selection logic.
+
+.Creating a Hint file
+
+In {product-title}, a new interface is added to the `nodeip-configuration` that allows for a hint file. This hint file contains a variable named `KUBELET_NODEIP_HINT`.
+
+. Set the node's IP address by setting an IP address from the subnet to the `KUBELET_NODEIP_HINT` variable.
+
+. The hint filename must be `/etc/default/nodeip-configuration` and the output should look like the following example:
++
+.Sample output
++
+[source,terminal]
+----
+KUBELET_NODEIP_HINT=192.0.2.1
+----
+


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUG-9372](https://issues.redhat.com/browse/OCPBUGS-9372)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Preview](https://72135--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/troubleshooting/troubleshooting-network-issues#nw-how-nw-iface-selected_troubleshooting-network-issues)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
