### PR TITLE
Removing  --all-namespaces from command "oc get imagecontentsourcepolicy"

### DIFF
--- a/modules/oc-mirror-updating-cluster-manifests.adoc
+++ b/modules/oc-mirror-updating-cluster-manifests.adoc
@@ -47,7 +47,7 @@ If you are mirroring Operators instead of clusters, you do not need to run `$ oc
 +
 [source,terminal]
 ----
-$ oc get imagecontentsourcepolicy --all-namespaces
+$ oc get imagecontentsourcepolicy
 ----
 
 . Verify that the `CatalogSource` resources were successfully installed by running the following command:

--- a/modules/oc-mirror-updating-restricted-cluster-manifests.adoc
+++ b/modules/oc-mirror-updating-restricted-cluster-manifests.adoc
@@ -35,7 +35,7 @@ $ oc apply -f ./oc-mirror-workspace/results-<id>/
 +
 [source,terminal]
 ----
-$ oc get imagecontentsourcepolicy --all-namespaces
+$ oc get imagecontentsourcepolicy
 ----
 
 . Verify that the `CatalogSource` resources were successfully installed:


### PR DESCRIPTION

Removing  --all-namespaces while listing imagecontentsourcepolicy since it's cluster wide resource hence no need to mentioned --all-namespaces

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.13, 4.12, 4.11, 4.14, 4.15

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-29903
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://docs.openshift.com/container-platform/4.15/installing/disconnected_install/installing-mirroring-disconnected.html#oc-mirror-updating-cluster-manifests_installing-mirroring-disconnected
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
  
  target 4.12+ versions.
