### PR TITLE
TELCODOCS-1507 - Updates for AMQP EOL + HTTP transport

### DIFF
--- a/modules/nw-rfhe-introduction.adoc
+++ b/modules/nw-rfhe-introduction.adoc
@@ -6,7 +6,7 @@
 [id="nw-rfhe-introduction_{context}"]
 = How bare-metal events work
 
-The {redfish-operator} enables applications running on bare-metal clusters to respond quickly to Redfish hardware changes and failures such as breaches of temperature thresholds, fan failure, disk loss, power outages, and memory failure. These hardware events are delivered over a reliable low-latency transport channel based on Advanced Message Queuing Protocol (AMQP). The latency of the messaging service is between 10 to 20 milliseconds.
+The {redfish-operator} enables applications running on bare-metal clusters to respond quickly to Redfish hardware changes and failures such as breaches of temperature thresholds, fan failure, disk loss, power outages, and memory failure. These hardware events are delivered using an HTTP transport or AMQP mechanism. The latency of the messaging service is between 10 to 20 milliseconds.
 
 The {redfish-operator} provides a publish-subscribe service for the hardware events. Applications can use a REST API to subscribe to the events. The {redfish-operator} supports hardware that complies with Redfish OpenAPI v1.8 or later.
 

--- a/modules/ptp-reference-deployment-and-service-crs.adoc
+++ b/modules/ptp-reference-deployment-and-service-crs.adoc
@@ -8,13 +8,7 @@
 
 Use the following example `cloud-event-proxy` deployment and subscriber service CRs as a reference when deploying your PTP events consumer application.
 
-[NOTE]
-====
-Use HTTP transport instead of AMQP for PTP and bare-metal events where possible.
-AMQ Interconnect is EOL from 30 June 2024.
-Extended life cycle support (ELS) for AMQ Interconnect ends 30 November 2030.
-For more information see, link:https://access.redhat.com/support/policy/updates/jboss_notes#p_Interconnect[Red Hat AMQ Interconnect support status].
-====
+include::snippets/ptp-amq-interconnect-eol.adoc[]
 
 .Reference cloud-event-proxy deployment with HTTP transport
 [source,yaml]

--- a/modules/ztp-creating-hwevents-amqp.adoc
+++ b/modules/ztp-creating-hwevents-amqp.adoc
@@ -8,6 +8,8 @@
 
 You can configure bare-metal events that use AMQP transport on managed clusters that you deploy with the {ztp-first} pipeline.
 
+include::snippets/ptp-amq-interconnect-eol.adoc[]
+
 .Prerequisites
 
 * You have installed the OpenShift CLI (`oc`).

--- a/snippets/ptp-amq-interconnect-eol.adoc
+++ b/snippets/ptp-amq-interconnect-eol.adoc
@@ -1,5 +1,6 @@
 [NOTE]
 ====
+HTTP transport is the default transport for PTP and bare-metal events.
 Use HTTP transport instead of AMQP for PTP and bare-metal events where possible.
 AMQ Interconnect is EOL from 30 June 2024.
 Extended life cycle support (ELS) for AMQ Interconnect ends 29 November 2029.


### PR DESCRIPTION
HTTP transport is the default transport for PTP and bare metal events

Version(s):
enterprise-4.12+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1507

Link to docs preview:
https://72141--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ptp/using-ptp-events#cnf-about-ptp-and-clock-synchronization_using-ptp-hardware-fast-events-framework

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->