### PR TITLE
Fix vale template

### DIFF
--- a/.vale/templates/bot-comment-output.tmpl
+++ b/.vale/templates/bot-comment-output.tmpl
@@ -1,18 +1,49 @@
-{{- $githubCommitID := "githubID" -}}
-{{- range .Files }}
-  {{- $filePath := .Path }}
-  {{- range .Alerts }}
-    {{- $severity := "" -}}
-    {{- if eq .Severity "error" -}}
-        {{- $severity = "error" -}}
-    {{- else if eq .Severity "warning" -}}
-        {{- $severity = "warning" -}}
-    {{- else -}}
-        {{- $severity = "suggestion" -}}
-    {{- end -}}
+{{- /* Modify Vale's output https://docs.errata.ai/vale/cli#--output */ -}}
 
-    {{- $loc := printf "%d:%d" .Line (index .Span 0) -}}
-    {{- $body := printf "{\"body\":\"%s\",\"path\":\"%s\",\"line\":%d}" .Message $filePath .Line }}
-    {{- $body }}
-  {{- end }}
-{{- end }}
+{{- /* Keep track of our various counts */ -}}
+
+{{- $e := 0 -}}
+{{- $w := 0 -}}
+{{- $s := 0 -}}
+
+{{- /* Range over the linted files */ -}}
+
+[
+{{- range $jdx, $file := .Files -}}
+
+{{- $path := .Path -}}
+
+{{- /* Range over the file's alerts */ -}}
+
+{{- if $jdx -}},{{- end -}}
+{{- range $idx, $a := .Alerts -}}
+
+{{- $error := "" -}}
+{{- if eq .Severity "error" -}}
+    {{- $error = "error" -}}
+    {{- $e = add1 $e  -}}
+{{- else if eq .Severity "warning" -}}
+    {{- $error = "warning" -}}
+    {{- $w = add1 $w -}}
+{{- else -}}
+    {{- $error = "suggestion" -}}
+    {{- $s = add1 $s -}}
+{{- end}}
+
+{{- /* Variables setup */ -}}
+
+{{- $loc := printf "%d" .Line -}}
+{{- $check := printf "%s" .Check -}}
+{{- $message := printf "%s" .Message -}}
+{{- if $idx -}},{{- end -}}
+
+{{- /* Output */ -}}
+
+  {
+    "body": "[{{ $error }}] {{$check}}: {{ $message }}",
+    "path": "{{ $path }}",
+    "line": {{ $loc }}
+  }
+{{end -}}
+{{end -}}
+]


### PR DESCRIPTION
Updated the vale template to produce valid JSON.

```cmd
$ vale --minAlertLevel=suggestion --output=.vale/templates/bot-comment-output.tmpl /home/aireilly/openshift-docs/nodes/cma/nodes-cma-autoscaling-custom-pausing.adoc | jq
```

produces:
```json
[
  {
    "body": "[warning] RedHat.Spelling: Use correct American English spelling. Did you really mean 'autoscaler'?",
    "path": "/home/aireilly/openshift-docs/nodes/cma/nodes-cma-autoscaling-custom-pausing.adoc",
    "line": 4
  },
  {
    "body": "[warning] RedHat.Spelling: Use correct American English spelling. Did you really mean 'autoscaling'?",
    "path": "/home/aireilly/openshift-docs/nodes/cma/nodes-cma-autoscaling-custom-pausing.adoc",
    "line": 10
  },
  {
    "body": "[warning] RedHat.Spelling: Use correct American English spelling. Did you really mean 'autoscaling'?",
    "path": "/home/aireilly/openshift-docs/nodes/cma/nodes-cma-autoscaling-custom-pausing.adoc",
    "line": 12
  }
]
```