### PR TITLE
OADP-3525: Remove the name field from snapshotLocations spec

### DIFF
--- a/modules/oadp-installing-dpa-1-2-and-earlier.adoc
+++ b/modules/oadp-installing-dpa-1-2-and-earlier.adoc
@@ -83,8 +83,7 @@ spec:
           key: cloud
           name: {credentials} <7>
   snapshotLocations: <8>
-    - name: default
-      velero:
+    - velero:
         provider: {provider}
         config:
           region: <region> <9>

--- a/modules/oadp-secrets-for-different-credentials.adoc
+++ b/modules/oadp-secrets-for-different-credentials.adoc
@@ -63,8 +63,7 @@ spec:
           key: cloud
           name: {credentials}
   snapshotLocations:
-    - name: default
-      velero:
+    - velero:
         provider: {provider}
         config:
           region: us-west-2
@@ -131,7 +130,6 @@ spec:
           resourceGroup: <azure_resource_group>
           subscriptionId: <azure_subscription_id>
           incremental: "true"
-        name: default
         provider: {provider}
 ----
 <1> Backup location `Secret` with custom name.


### PR DESCRIPTION
### JIRA

* [OADP-3525](https://issues.redhat.com/browse/OADP-3525)

### VERSIONS

* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16


<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->



### Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

* [Installing the Data Protection Application 1.2 and earlier](https://72144--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws#oadp-installing-dpa-1-2-and-earlier_installing-oadp-aws) - module included elsewhere but preview will be valid for all assemblies

* [Creating profiles for different credentials](https://72144--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws#oadp-creating-default-secret_installing-oadp-aws) - module included elsewhere but preview will be valid for all assemblies


### QE review:
- [X] [QE has approved this change](https://github.com/openshift/openshift-docs/pull/72144#issuecomment-1982619664).
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
