### PR TITLE
OCPBUGS-25695: gingko timeout update

### DIFF
--- a/modules/cnf-measuring-latency.adoc
+++ b/modules/cnf-measuring-latency.adoc
@@ -23,7 +23,7 @@ oslat:: Behaves similarly to a CPU-intensive DPDK application and measures all t
 The tests introduce the following environment variables:
 
 .Latency test environment variables
-[cols="1,3", options="header"]
+[cols="1,3a", options="header"]
 |====
 |Environment variables
 |Description
@@ -36,6 +36,11 @@ The tests introduce the following environment variables:
 
 |`LATENCY_TEST_RUNTIME`
 |Specifies the amount of time in seconds that the latency test must run. The default value is 300 seconds.
+
+[NOTE]
+====
+To prevent the Ginkgo 2.0 test suite from timing out before the latency tests complete, set the `-ginkgo.timeout` flag to a value greater than `LATENCY_TEST_RUNTIME` + 2 minutes. If you also set a `LATENCY_TEST_DELAY` value then you must set `-ginkgo.timeout` to a value greater than `LATENCY_TEST_RUNTIME` + `LATENCY_TEST_DELAY` + 2 minutes. The default timeout value for the Ginkgo 2.0 test suite is 1 hour.
+====
 
 |`HWLATDETECT_MAXIMUM_LATENCY`
 |Specifies the maximum acceptable hardware latency in microseconds for the workload and operating system. If you do not set the value of `HWLATDETECT_MAXIMUM_LATENCY` or `MAXIMUM_LATENCY`, the tool compares the default expected threshold (20μs) and the actual maximum latency in the tool itself. Then, the test fails or succeeds accordingly.

--- a/modules/cnf-performing-end-to-end-tests-disconnected-mode.adoc
+++ b/modules/cnf-performing-end-to-end-tests-disconnected-mode.adoc
@@ -41,7 +41,7 @@ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 -e IMAGE_REGISTRY="<disconnected_registry>" \
 -e CNF_TESTS_IMAGE="cnf-tests-rhel8:v{product-version}" \
 -e LATENCY_TEST_RUNTIME=<time_in_seconds> \
-<disconnected_registry>/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh --ginkgo.v
+<disconnected_registry>/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh --ginkgo.v --ginkgo.timeout="24h"
 ----
 
 [discrete]
@@ -58,7 +58,7 @@ $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 -e IMAGE_REGISTRY="<custom_image_registry>" \
 -e CNF_TESTS_IMAGE="<custom_cnf-tests_image>" \
 -e LATENCY_TEST_RUNTIME=<time_in_seconds> \
-registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh --ginkgo.v
+registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh --ginkgo.v --ginkgo.timeout="24h"
 ----
 +
 where:
@@ -144,7 +144,7 @@ registry.redhat.io/openshift4/cnf-tests-rhel8:{product-version} \
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 -e LATENCY_TEST_RUNTIME=<time_in_seconds> \
--e IMAGE_REGISTRY=image-registry.openshift-image-registry.svc:5000/cnftests cnf-tests-local:latest /usr/bin/test-run.sh --ginkgo.v
+-e IMAGE_REGISTRY=image-registry.openshift-image-registry.svc:5000/cnftests cnf-tests-local:latest /usr/bin/test-run.sh --ginkgo.v --ginkgo.timeout="24h"
 ----
 
 [discrete]

--- a/modules/cnf-performing-end-to-end-tests-running-cyclictest.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-cyclictest.adoc
@@ -30,7 +30,7 @@ When executing `podman` commands as a non-root or non-privileged user, mounting 
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 -e LATENCY_TEST_CPUS=10 -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20 \
 registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
-/usr/bin/test-run.sh --ginkgo.focus="cyclictest" --ginkgo.v
+/usr/bin/test-run.sh --ginkgo.focus="cyclictest" --ginkgo.v --ginkgo.timeout="24h"
 ----
 +
 The command runs the `cyclictest` tool for 10 minutes (600 seconds). The test runs successfully when the maximum observed latency is lower than `MAXIMUM_LATENCY` (in this example, 20 μs). Latency spikes of 20 μs and above are generally not acceptable for {rds} workloads.

--- a/modules/cnf-performing-end-to-end-tests-running-hwlatdetect.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-hwlatdetect.adoc
@@ -28,7 +28,7 @@ When executing `podman` commands as a non-root or non-privileged user, mounting 
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20 \
 registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
-/usr/bin/test-run.sh --ginkgo.focus="hwlatdetect" --ginkgo.v
+/usr/bin/test-run.sh --ginkgo.focus="hwlatdetect" --ginkgo.v --ginkgo.timeout="24h"
 ----
 +
 The `hwlatdetect` test runs for 10 minutes (600 seconds). The test runs successfully when the maximum observed latency is lower than `MAXIMUM_LATENCY` (20 μs).

--- a/modules/cnf-performing-end-to-end-tests-running-in-single-node-cluster.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-in-single-node-cluster.adoc
@@ -29,7 +29,7 @@ When executing `podman` commands as a non-root or non-privileged user, mounting 
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 -e LATENCY_TEST_RUNTIME=<time_in_seconds> registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
-/usr/bin/test-run.sh --ginkgo.v
+/usr/bin/test-run.sh --ginkgo.v --ginkgo.timeout="24h"
 ----
 +
 [NOTE]

--- a/modules/cnf-performing-end-to-end-tests-running-oslat.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-oslat.adoc
@@ -27,7 +27,7 @@ When executing `podman` commands as a non-root or non-privileged user, mounting 
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 -e LATENCY_TEST_CPUS=10 -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20 \
 registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
-/usr/bin/test-run.sh --ginkgo.focus="oslat" --ginkgo.v
+/usr/bin/test-run.sh --ginkgo.focus="oslat" --ginkgo.v --ginkgo.timeout="24h"
 ----
 +
 `LATENCY_TEST_CPUS` specifies the number of CPUs to test with the `oslat` command.

--- a/modules/cnf-performing-end-to-end-tests-running-the-tests.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-the-tests.adoc
@@ -27,12 +27,14 @@ $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 -e LATENCY_TEST_RUNTIME=<time_in_seconds>\
 -e MAXIMUM_LATENCY=<time_in_microseconds> \
 registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh \
---ginkgo.v
+--ginkgo.v --ginkgo.timeout="24h"
 ----
 
 . Optional: Append `--ginkgo.dryRun` flag to run the latency tests in dry-run mode. This is useful for checking what commands the tests run.
 
 . Optional: Append `--ginkgo.v` flag to run the tests with increased verbosity.
+
+. Optional: Append `--ginkgo.timeout="24h"` flag to ensure the Ginkgo 2.0 test suite does not timeout before the latency tests complete.
 +
 [IMPORTANT]
 ====


### PR DESCRIPTION
OCPBUGS#25695: Ginkgo test suite now times out in 1hr. Setting flag to 24hr to accommodate latency tests that typically take 12hrs+

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OCPBUGS-25695

Link to docs preview:
https://72146--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-performing-platform-verification-latency-tests

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
