### PR TITLE
OSSM-5998 [DOC] Update Kiali CR for user-workload-monitoring

### DIFF
--- a/modules/ossm-integrating-with-user-workload-monitoring.adoc
+++ b/modules/ossm-integrating-with-user-workload-monitoring.adoc
@@ -52,13 +52,15 @@ kind: Kiali
 metadata:
   name: kiali-user-workload-monitoring
   namespace: istio-system
-spec:
-  external_services:
-    istio:
-      url_service_version: 'http://istiod-basic.istio-system:15014/version'
-      config_map_name: istio-basic # <1>
-    prometheus:
-      auth:
+spec: 
+  external_services: 
+    istio: 
+      config_map_name: istio-<smcp-name>
+      istio_sidecar_injector_config_map_name: istio-sidecar-injector-<smcp-name>
+      istiod_deployment_name: istiod-<smcp-name>
+      url_service_version: 'http://istiod-<smcp-name>.istio-system:15014/version'
+    prometheus: 
+      auth: 
         token: secret:thanos-querier-web-token:token
         type: bearer
         use_kiali_token: false
@@ -69,7 +71,6 @@ spec:
       url: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
   version: v1.65
 ----
-<1> Set the `ServiceMeshControlPlane` name prefixed with `istio-`.
 
 . Configure the SMCP for external Prometheus:
 +
@@ -167,7 +168,9 @@ spec:
 ====
 If there is only one mesh using user-workload monitoring, then both the `mesh_id` relabeling and the `spec.prometheus.query_scope` field in the Kiali resource are optional (but the `query_scope` field given here should be removed if the `mesh_id` label is removed).
 
-If there might be multiple meshes using user-workload monitoring, then both the `mesh_id` relabelings and the `spec.prometheus.query_scope` field in the Kiali resource are required so that Kiali only sees metrics from its associated mesh. If Kiali is not being deployed, applying the `mesh_id` relabeling is still recommended so that metrics from different meshes can be distinguished from one another.
+If multiple mesh instances on the cluster may use user-workload monitoring, then both the `mesh_id` relabelings and the `spec.prometheus.query_scope` field in the Kiali resource are required. This ensures that Kiali only sees metrics from its associated mesh.
+
+If you are not deploying Kiali, you can still apply `mesh_id` relabeling so that metrics from different meshes can be distinguished from one another.
 ====
 
 . Apply a `PodMonitor` object to collect metrics from Istio proxies:
@@ -224,7 +227,9 @@ spec:
 ====
 If there is only one mesh using user-workload monitoring, then both the `mesh_id` relabeling and the `spec.prometheus.query_scope` field in the Kiali resource are optional (but the `query_scope` field given here should be removed if the `mesh_id` label is removed).
 
-If there might be multiple meshes using user-workload monitoring, then both the `mesh_id` relabelings and the `spec.prometheus.query_scope` field in the Kiali resource are required so that Kiali only sees metrics from its associated mesh. If Kiali is not being deployed, applying the `mesh_id` relabeling is still recommended so that metrics from different meshes can be distinguished from one another.
+If multiple mesh instances on the cluster may use user-workload monitoring, then both the `mesh_id` relabelings and the `spec.prometheus.query_scope` field in the Kiali resource are required. This ensures that Kiali only sees metrics from its associated mesh.
+
+If you are not deploying Kiali, you can still apply `mesh_id` relabeling so that metrics from different meshes can be distinguished from one another.
 ====
 
 . Open the {product-title} web console, and check that metrics are visible.


### PR DESCRIPTION
[OSSM-5998](https://issues.redhat.com//browse/OSSM-5998) [DOC] Update Kiali CR for user-workload-monitoring

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSSM-5998

Link to docs preview:
https://72162--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-observability#ossm-integrating-with-user-workload-monitoring_observability

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Update to code sample in Step 2 as originally described in the associated Jira. 

While skimming the rest of the content, and in conjunction with feedback from the OCP core docs team, also updated the NOTE to be  in line with current Red Hat style. Updating the NOTE is not part of the original Jira, just something I noticed and decided to address while already working in the file.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
