### PR TITLE
OSDOCS-9787: Improved the reference to the RHCOS vSphere image

### DIFF
--- a/installing/installing_openstack/installing-openstack-installer-restricted.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-restricted.adoc
@@ -31,7 +31,7 @@ include::modules/cluster-entitlements.adoc[leveloffset=+1]
 include::modules/installation-osp-enabling-swift.adoc[leveloffset=+1]
 include::modules/installation-osp-describing-cloud-parameters.adoc[leveloffset=+1]
 include::modules/installation-osp-setting-cloud-provider-options.adoc[leveloffset=+1]
-include::modules/installation-creating-image-restricted.adoc[leveloffset=+1]
+include::modules/installation-downloading-image-restricted.adoc[leveloffset=+1]
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc
+++ b/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc
@@ -37,7 +37,7 @@ include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
-include::modules/installation-creating-image-restricted.adoc[leveloffset=+1]
+include::modules/installation-downloading-image-restricted.adoc[leveloffset=+1]
 
 include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
 

--- a/modules/installation-downloading-image-restricted.adoc
+++ b/modules/installation-downloading-image-restricted.adoc
@@ -11,8 +11,8 @@ ifeval::["{context}" == "installing-restricted-networks-installer-provisioned-vs
 endif::[]
 
 :_mod-docs-content-type: PROCEDURE
-[id="installation-creating-image-restricted_{context}"]
-= Creating the {op-system} image for restricted network installations
+[id="installation-downloading-image-restricted_{context}"]
+= Downloading the {op-system} image for restricted network installations
 
 Download the {op-system-first} image to install {product-title} on a restricted network
 ifdef::osp[{rh-openstack-first}]
@@ -22,9 +22,12 @@ environment.
 .Prerequisites
 
 * Obtain the {product-title} installation program. For a restricted network installation, the program is on your mirror registry host.
+ifndef::vsphere[]
+* You have an HTTP server that can be accessed from your computer, and from the machines that you create.
+endif::vsphere[]
 
 .Procedure
-
+ifndef::vsphere[]
 . Log in to the Red Hat Customer Portal's https://access.redhat.com/downloads/content/290[Product Downloads page].
 
 . Under *Version*, select the most recent release of {product-title} {product-version} for RHEL 8.
@@ -36,12 +39,55 @@ You must download images with the highest version that is less than or equal to
 the {product-title} version that you install. Use the image versions that match
 your {product-title} version if they are available.
 ====
-
+endif::vsphere[]
 ifdef::osp[]
 . Download the *{op-system-first} - OpenStack Image (QCOW)* image.
 endif::osp[]
 ifdef::vsphere[]
-. Download the *{op-system-first} - vSphere* image.
+. Download the {op-system-first} OVA image by completing the following steps:
++
+.. Change to the directory that contains the installation program and run the following command:
++
+[source,terminal]
+----
+$ ./openshift-install coreos print-stream-json
+----
++
+.. Use the output of the command to find the location of the `rhcos-vmware` OVA image, and click the outputted link to download the image.
++
+.Example output
+[source,json,terminal,subs="attributes+"]
+----
+"vsphere": {
+  "release": "<rhcos_image_release_number>",
+  "formats": {
+    "qcow2": {
+      "disk": {
+        "location": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/{product-version}/latest/rhcos-vmware.<architecture>.ova",
+        "sha256": <sha_256_checksum>
+      }
+    }
+  }
+}
+----
++
+[IMPORTANT]
+====
+Note the location of the downloaded image.
+====
+////
+.. Make the image available through an internal HTTP server.
+////
++
+.. Before deploying the cluster, update the platform section in the installation configuration file (`install-config.yaml`) with the downloaded image’s location.
++
+.Example configuration
+[source,yaml]
+----
+platform:
+  vsphere:
+    clusterOSImage: http://<internal_http_server>/rhcos-<version>-vmware.<architecture>.ova
+----
 endif::vsphere[]
 
 ifdef::osp[]
@@ -51,14 +97,15 @@ ifdef::osp[]
 ====
 You must decompress the image before the cluster can use it. The name of the downloaded file might not contain a compression extension, like `.gz` or `.tgz`. To find out if or how the file is compressed, in a command line, enter:
 
+[source,terminal]
 ----
 $ file <name_of_downloaded_file>
 ----
-
 ====
 
 . Upload the image that you decompressed to a location that is accessible from the bastion server, like Glance. For example:
 +
+[source,terminal]
 ----
 $ openstack image create --file rhcos-44.81.202003110027-0-openstack.x86_64.qcow2 --disk-format qcow2 rhcos-${RHCOS_VERSION}
 ----
@@ -74,7 +121,8 @@ If the installation program finds multiple images with the same name, it chooses
 ====
 endif::osp[]
 ifdef::vsphere[]
-. Upload the image you downloaded to a location that is accessible from the bastion server.
+. Deploy your cluster. See the "Deploying the cluster" section. When deploying your cluster on a VMware vCenter, the installation program uploads the `rhcos-vmware` OVA image to a vCenter datastore. You can now create a template from the uploaded OVA image.
+//. Upload the image you downloaded to a location that is accessible from the bastion server.
 endif::vsphere[]
 
 The image is now available for a restricted installation. Note the image name or location for use in {product-title} deployment.

--- a/modules/installation-vsphere-machines.adoc
+++ b/modules/installation-vsphere-machines.adoc
@@ -79,7 +79,7 @@ If you plan to add more compute machines to your cluster after you finish instal
 ====
 
 ifndef::openshift-origin[]
-. Obtain the {op-system} OVA image. Images are available from the link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.15/[{op-system} image mirror] page.
+. Obtain the {op-system} OVA image. Images are available from the link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/{product-version}/\\[{op-system} image mirror] page.
 +
 [IMPORTANT]
 ====


### PR DESCRIPTION
Version(s):
4.12 to 4.16

Issue:
[OSDOCS-9787](https://issues.redhat.com/browse/OSDOCS-9787)

Link to docs preview:
[Downloading the RHCOS image for restricted network installations](https://72164--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere#installation-downloading-image-restricted_installing-restricted-networks-installer-provisioned-vsphere)

- [ ] SME has approved this change.
- [ ] QE has approved this change.

Additional information:
* [Slack thread](https://redhat-internal.slack.com/archives/C68TNFWA2/p1708967367207739)
* Image details taken from https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.14/latest/
* [platform.g for 4.13 and 4.12](https://github.com/openshift/installer/blob/b8d567115ff6a93ad048808fa4c8a52eb78fe954/pkg/types/vsphere/platform.go#L73-L74)
* [platform.go 4.14+](https://github.com/openshift/installer/blob/b6c1765278cb4082db715da7641b5d318c9d3f90/pkg/types/vsphere/platform.go#L208-L214)
* [Customer docs `template` example](https://docs.openshift.com/container-platform/4.15/installing/installing_vsphere/installation-config-parameters-vsphere.html#:~:text=Specify%20the%20absolute%20path%20to%20a%20pre%2Dexisting)

Feedback to consider:

Well the cache is “internal” behavior, I assume the openshift-install download first the ova to upload lather. When you deploy a OVA from vcenter you have 2 options get a ova from a datastore or set an URL,  the openshift-install decided to use the ova from the datastore and make the template. from there create the VMs.  Use the cache is more a trick than official procedure to use local ova

Add. Resources
* [Installing RHCOS and starting the OpenShift Container Platform bootstrap process](https://72164--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/installing-vsphere-network-customizations)
