### PR TITLE
Adding/modifying content to trigger Vale CI review comments

### DIFF
--- a/modules/cnf-performing-end-to-end-tests-disconnected-mode.adoc
+++ b/modules/cnf-performing-end-to-end-tests-disconnected-mode.adoc
@@ -8,6 +8,8 @@
 
 Adding the error term GIT to trigger a Vale alert.
 
+Making a third commit. Hopefully only one more comment. GIT.
+
 The CNF tests image can run tests in a disconnected cluster that is not able to reach external registries. This requires two steps:
 
 . Mirroring the `cnf-tests` image to the custom disconnected registry.

--- a/modules/cnf-performing-end-to-end-tests-disconnected-mode.adoc
+++ b/modules/cnf-performing-end-to-end-tests-disconnected-mode.adoc
@@ -3,7 +3,7 @@
 // * scalability_and_performance/cnf-performing-platform-verification-latency-tests.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="cnf-performing-end-to-end-tests-disconnected-mode_{context}"]
+[id="cnf-performing-end-to-end-tests-disconnected-mode_{context}]
 = Running latency tests in a disconnected cluster
 
 The CNF tests image can run tests in a disconnected cluster that is not able to reach external registries. This requires two steps:

--- a/modules/cnf-performing-end-to-end-tests-disconnected-mode.adoc
+++ b/modules/cnf-performing-end-to-end-tests-disconnected-mode.adoc
@@ -3,8 +3,10 @@
 // * scalability_and_performance/cnf-performing-platform-verification-latency-tests.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="cnf-performing-end-to-end-tests-disconnected-mode_{context}]
+[id="cnf-performing-end-to-end-tests-disconnected-mode_{context}"]
 = Running latency tests in a disconnected cluster
+
+Adding the error term GIT to trigger a Vale alert.
 
 The CNF tests image can run tests in a disconnected cluster that is not able to reach external registries. This requires two steps:
 

--- a/modules/private-clusters-about-gcp.adoc
+++ b/modules/private-clusters-about-gcp.adoc
@@ -23,7 +23,7 @@ The internal load balancer relies on instance groups rather than the target pool
 
 * The cluster IP address is internal only.
 * One forwarding rule manages both the Kubernetes API and machine config server ports.
-* The backend service is comprised of each zone's instance group and, while it exists, the bootstrap instance group.
+* Editing this sentence should trigger a vale error. The backend service is comprised of each zone's instance group and, while it exists, the bootstrap instance group.
 * The firewall uses a single rule that is based on only internal source ranges.
 
 [id="private-clusters-limitations-gcp_{context}"]

--- a/modules/virt-creating-linux-bridge-nad-web.adoc
+++ b/modules/virt-creating-linux-bridge-nad-web.adoc
@@ -8,7 +8,9 @@
 [id="virt-creating-linux-bridge-nad-web_{context}"]
 = Creating a Linux bridge NAD by using the web console
 
-You can create a network attachment definition (NAD) to provide layer-2 networking to pods and virtual machines by using the {product-title} web console.
+You can create a network attachment definition (NAD) to provide layer-2 networking to pods and virtual machines by using the {product-title} web console. The word provide flags as a Vale suggestion to instead use "give or offer". No Vale review comment here.
+
+However, if I use the term white hat hacker, this triggers a Vale error comment.
 
 A Linux bridge network attachment definition is the most efficient method for connecting a virtual machine to a VLAN.
 

--- a/modules/virt-creating-storage-pool-pvc-template.adoc
+++ b/modules/virt-creating-storage-pool-pvc-template.adoc
@@ -46,7 +46,7 @@ spec:
 ----
 <1> The `storagePools` stanza is an array that can contain both basic and PVC template storage pools.
 <2> Specify the storage pool directories under this node path.
-<3> Optional: The `volumeMode` parameter can be either `Block` or `Filesystem` as long as it matches the provisioned volume format. If no value is specified, the default is `Filesystem`. If the `volumeMode` is `Block`, the mounting pod creates an XFS file system on the block volume before mounting it.
+<3> Optional: The `volumeMode` parameter can be either `Block` or `Filesystem` as long as it matches the provisioned volume format. If no value is specified, the default is `Filesystem`. If the `volumeMode` is `Block`, the mounting pod creates an XFS file system on the block volume before mounting it. Editing this sentence to trigger a vale error.
 <4> If the `storageClassName` parameter is omitted, the default storage class is used to create PVCs. If you omit `storageClassName`, ensure that the HPP storage class is not the default storage class.
 <5> You can specify statically or dynamically provisioned storage. In either case, ensure the requested storage size is appropriate for the volume you want to virtually divide or the PVC cannot be bound to the large PV. If the storage class you are using uses dynamically provisioned storage, pick an allocation size that matches the size of a typical request.
 


### PR DESCRIPTION
Proof of concept (POC) for running Vale in the Prow CI. All feedback welcome.

- Vale review runs on any modified or changed content only.
- Runs on the latest commit every time you push.
- Review comments are added for any error level (`level: error`) Vale [rules](https://github.com/redhat-documentation/vale-at-red-hat/tree/main/.vale/styles). 
- It does not fail the build
- Doesn't duplicate a comment if a comment already exists
- POC implementation takes about 30 seconds

Test it out by PR'ing the prow-test-2 branch with content that will trigger an error level Vale rule. For example, use the term "[hyperthreading](https://github.com/redhat-documentation/vale-at-red-hat/blob/c56f7414b69a490de0a13d1a8731126d454349cd/.vale/styles/RedHat/CaseSensitiveTerms.yml#L146)" in content. 