### PR TITLE
[WIP] OSDOCS#8321: Adjusting preferred auth config order

### DIFF
--- a/modules/builds-creating-secrets.adoc
+++ b/modules/builds-creating-secrets.adoc
@@ -26,6 +26,7 @@ For example, you can create a secret from your local `.docker/config.json` file:
 +
 [source,terminal]
 ----
+// TODO: check
 $ oc create secret generic dockerhub \
     --from-file=.dockerconfigjson=<path/to/.docker/config.json> \
     --type=kubernetes.io/dockerconfigjson

--- a/modules/builds-docker-credentials-private-registries.adoc
+++ b/modules/builds-docker-credentials-private-registries.adoc
@@ -6,6 +6,7 @@
 [id="builds-docker-credentials-private-registries_{context}"]
 = Using docker credentials for private registries
 
+// TODO: check
 You can supply builds with a .`docker/config.json` file with valid credentials for private container registries. This allows you to push the output image into a private container image registry or pull a builder image from the private container image registry that requires authentication.
 
 You can supply credentials for multiple repositories within the same registry, each with credentials specific to that registry path.

--- a/modules/cluster-samples-operator.adoc
+++ b/modules/cluster-samples-operator.adoc
@@ -47,6 +47,8 @@ endif::[]
 ifdef::operator-ref[]
 The Cluster Samples Operator deployment is contained within the `openshift-cluster-samples-operator` namespace. On start up, the install pull secret is used by the image stream import logic in the {product-registry} and API server to authenticate with `registry.redhat.io`. An administrator can create any additional secrets in the `openshift` namespace if they change the registry used for the sample image streams. If created, those secrets contain the content of a `config.json` for `docker` needed to facilitate image import.
 
+// TODO: check
+
 The image for the Cluster Samples Operator contains image stream and template definitions for the associated {product-title} release. After the Cluster Samples Operator creates a sample, it adds an annotation that denotes the {product-title} version that it is compatible with. The Operator uses this annotation to ensure that each sample matches the compatible release version. Samples outside of its inventory are ignored, as are skipped samples.
 
 Modifications to any samples that are managed by the Operator are allowed as long as the version annotation is not modified or deleted. However, on an upgrade, as the version annotation will change, those modifications can get replaced as the sample will be updated with the newer version. The Jenkins images are part of the image payload from the installation and are tagged into the image streams directly.

--- a/modules/connected-to-disconnected-config-registry.adoc
+++ b/modules/connected-to-disconnected-config-registry.adoc
@@ -6,8 +6,8 @@
 = Configuring the cluster for the mirror registry
 
 After creating and mirroring the images to the mirror registry, you must modify your cluster so that pods can pull images from the mirror registry.
- 
-You must: 
+
+You must:
 
 * Add the mirror registry credentials to the global pull secret.
 * Add the mirror registry server certificate to the cluster.
@@ -99,7 +99,7 @@ imagecontentsourcepolicy.operator.openshift.io/mirror-ocp created
 
 . Verify that the credentials, CA, and ICSP for mirror registry were added:
 
-.. Log into a node: 
+.. Log into a node:
 +
 [source,terminal]
 ----
@@ -119,6 +119,8 @@ sh-4.4# chroot /host
 ----
 sh-4.4# cat /var/lib/kubelet/config.json
 ----
++
+// TODO: check ^
 +
 .Example output
 [source,terminal]
@@ -179,7 +181,7 @@ unqualified-search-registries = ["registry.access.redhat.com", "docker.io"]
     location = "mirror.registry.com:443/ocp/release"
 ----
 +
-The `registry.mirror` parameters indicate that the mirror registry is searched before the original registry. 
+The `registry.mirror` parameters indicate that the mirror registry is searched before the original registry.
 
 .. Exit the node.
 +
@@ -187,4 +189,3 @@ The `registry.mirror` parameters indicate that the mirror registry is searched b
 ----
 sh-4.4# exit
 ----
-

--- a/modules/coreos-layering-configuring.adoc
+++ b/modules/coreos-layering-configuring.adoc
@@ -48,6 +48,8 @@ Instructions on how to create a Containerfile are beyond the scope of this docum
 
 * Because the process for building a custom layered image is performed outside of the cluster, you must use the `--authfile /path/to/pull-secret` option with Podman or Buildah. Alternatively, to have the pull secret read by these tools automatically, you can add it to one of the default file locations: `~/.docker/config.json`, `$XDG_RUNTIME_DIR/containers/auth.json`, `~/.docker/config.json`, or `~/.dockercfg`. Refer to the `containers-auth.json` man page for more information.
 
+// TODO: check ^
+
 * You must push the custom layered image to a repository that your cluster can access.
 
 .Procedure
@@ -204,4 +206,3 @@ Deployments:
 * ostree-unverified-registry:quay.io/my-registry/...
                    Digest: sha256:...
 ----
-

--- a/modules/images-allow-pods-to-reference-images-from-secure-registries.adoc
+++ b/modules/images-allow-pods-to-reference-images-from-secure-registries.adoc
@@ -6,6 +6,8 @@
 [id="images-allow-pods-to-reference-images-from-secure-registries_{context}"]
 = Allowing pods to reference images from other secured registries
 
+// TODO: check
+
 The `.dockercfg` `$HOME/.docker/config.json` file for Docker clients is a Docker credentials file that stores your authentication information if you have previously logged into a secured or insecure registry.
 
 To pull a secured container image that is not from {product-registry}, you must create a pull secret from your Docker credentials and add it to your service account.

--- a/modules/insights-operator-manual-upload.adoc
+++ b/modules/insights-operator-manual-upload.adoc
@@ -18,6 +18,8 @@ You can manually upload an Insights Operator archive to link:https://console.red
 
 .Procedure
 
+// TODO: check
+
 . Download the `dockerconfig.json` file:
 +
 [source,terminal]

--- a/modules/installation-adding-registry-pull-secret.adoc
+++ b/modules/installation-adding-registry-pull-secret.adoc
@@ -104,6 +104,8 @@ ifdef::update-oc-mirror[]
 endif::[]
 endif::[]
 
+// TODO: check ^
+
 . Generate the base64-encoded user name and password or token for your mirror registry:
 +
 [source,terminal]

--- a/modules/nodes-pods-secrets-creating-docker.adoc
+++ b/modules/nodes-pods-secrets-creating-docker.adoc
@@ -12,6 +12,8 @@ As an administrator, you can create a Docker configuration secret, which allows 
 
 * `kubernetes.io/dockerconfigjson`. Use this secret type to store your local Docker configuration JSON file. The `data` parameter of the `secret` object must contain the contents of a `.docker/config.json` file encoded in the base64 format.
 
+// TODO: check ^
+
 .Procedure
 
 . Create a `Secret` object in a YAML file on a control plane node.
@@ -62,4 +64,3 @@ $ oc create -f <filename>.yaml
 .. Update the pod's service account to reference the secret, as shown in the "Understanding how to create secrets" section.
 
 .. Create the pod, which consumes the secret as an environment variable or as a file (using a `secret` volume), as shown in the "Understanding how to create secrets" section.
-

--- a/modules/olm-accessing-images-private-registries.adoc
+++ b/modules/olm-accessing-images-private-registries.adoc
@@ -42,6 +42,8 @@ $ podman login <registry>:<port>
 [NOTE]
 ====
 The file path of your registry credentials can be different depending on the container tool used to log in to the registry. For the `podman` CLI, the default location is `${XDG_RUNTIME_DIR}/containers/auth.json`. For the `docker` CLI, the default location is `/root/.docker/config.json`.
+
+// TODO: check ^
 ====
 
 .. It is recommended to include credentials for only one registry per secret, and manage credentials for multiple registries in separate secrets. Multiple secrets can be included in a `CatalogSource` object in later steps, and {product-title} will merge the secrets into a single virtual credentials file for use during an image pull.

--- a/modules/olmv1-creating-a-pull-secret-for-catalogd.adoc
+++ b/modules/olmv1-creating-a-pull-secret-for-catalogd.adoc
@@ -62,6 +62,9 @@ $ oc create secret generic redhat-cred \
     --type=kubernetes.io/dockerconfigjson \
     --namespace=openshift-catalogd
 ----
+
+// TODO: check
+
 ====
 * If you do not have a Docker configuration file with login credentials for the secure registry, create a pull secret by running the following command:
 +

--- a/modules/samples-operator-overview.adoc
+++ b/modules/samples-operator-overview.adoc
@@ -16,6 +16,8 @@ itself and then creates the sample image streams and templates, including quick 
 To facilitate image stream imports from other registries that require credentials, a cluster administrator can create any additional secrets that contain the content of a Docker `config.json` file in the `openshift` namespace needed for image import.
 ====
 
+// TODO: check ^
+
 The Cluster Samples Operator configuration is a cluster-wide resource, and the deployment is contained within the `openshift-cluster-samples-operator` namespace.
 
 The image for the Cluster Samples Operator contains image stream and template definitions

--- a/modules/ztp-precaching-downloading-artifacts.adoc
+++ b/modules/ztp-precaching-downloading-artifacts.adoc
@@ -91,6 +91,8 @@ $ mkdir /root/.docker
 
 .. Copy the valid pull in the `config.json` file to the previously created `.docker/` folder:
 +
+// TODO: check
++
 [source,terminal]
 ----
 $ cp config.json /root/.docker/config.json <1>


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

* https://72168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/cicd/builds/creating-build-inputs#builds-creating-secrets_creating-build-inputs
* https://72168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/cicd/builds/creating-build-inputs#builds-docker-credentials-private-registries_creating-build-inputs
* https://72168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator-reference#cluster-samples-operator_cluster-operators-ref
* https://72168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/connected-to-disconnected#connected-to-disconnected-config-registry_connected-to-disconnected
* https://72168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/coreos-layering#coreos-layering-configuring_coreos-layering
* https://72168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/openshift_images/image-streams-manage#images-allow-pods-to-reference-images-from-secure-registries_image-streams-managing
* https://72168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/remote-health-reporting-from-restricted-network#insights-operator-manual-upload_remote-health-reporting-from-restricted-network
* https://72168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-disconnected#installation-adding-registry-pull-secret_installing-mirroring-disconnected
* https://72168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets#nodes-pods-secrets-creating-docker_nodes-pods-secrets
* https://72168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs#olm-accessing-images-private-registries_olm-managing-custom-catalogs
* https://72168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/olm_v1/olmv1-installing-an-operator-from-a-catalog#olmv1-creating-a-pull-secret-for-catalogs-secure-registry_olmv1-installing-operator
* https://72168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/openshift_images/configuring-samples-operator#samples-operator-overview_configuring-samples-operator
* https://72168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-precaching-tool#ztp-preparing-ocp-images_pre-caching

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
