### PR TITLE
OCPBUGS-14987: fix Nutanix creds extraction in 4.12

### DIFF
--- a/modules/manually-configure-iam-nutanix.adoc
+++ b/modules/manually-configure-iam-nutanix.adoc
@@ -37,13 +37,22 @@ credentials:
 <2> Specify the Prism Central credentials.
 <3> Optional: Specify the Prism Element credentials.
 
+. Set a `$RELEASE_IMAGE` variable with the release image from your installation file by running the following command:
++
+[source,terminal]
+----
+$ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}')
+----
+
 . Extract the list of `CredentialsRequest` custom resources (CRs) from the {product-title} release image by running the following command:
 +
 [source,terminal]
 ----
-$ oc adm release extract --credentials-requests --cloud=nutanix \//
---to=<path_to_directory_with_list_of_credentials_requests>/credrequests \ <1>
-quay.io/<path_to>/ocp-release:<version>
+$ oc adm release extract \
+  --from=$RELEASE_IMAGE \
+  --credentials-requests \
+  --cloud=nutanix \
+  --to=<path_to_directory_with_list_of_credentials_requests>/credrequests <1>
 ----
 +
 <1> Specify the path to the directory that contains the files for the component `CredentialsRequests` objects. If the specified directory does not exist, this command creates it.


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OCPBUGS-14987](https://issues.redhat.com//browse/OCPBUGS-14987)

Link to docs preview:
[Configuring IAM for Nutanix](https://72169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned#manually-create-iam-nutanix_installing-nutanix-installer-provisioned)

QE review:
- [x] QE has approved this change.

Additional information:
Catching 4.12 up to 4.13+