### PR TITLE
OBSDOCS-850: update CLI commands to access metrics outside the cluster for UWM

### DIFF
--- a/modules/accessing-metrics-outside-cluster.adoc
+++ b/modules/accessing-metrics-outside-cluster.adoc
@@ -8,44 +8,50 @@
 
 Learn how to query Prometheus statistics from the command line when monitoring your own services. You can access monitoring data from outside the cluster with the `thanos-querier` route.
 
+This access only supports using a Bearer Token for authentication.
+
 .Prerequisites
 
-* You deployed your own service, following the _Enabling monitoring for user-defined projects_ procedure.
+* You have deployed your own service, following the "Enabling monitoring for user-defined projects" procedure.
+* You are logged in to an account with the `cluster-monitoring-view` cluster role, which provides permission to access the Thanos Querier API.
+* You are logged in to an account that has permission to get the Thanos Querier API route.
++
+[NOTE]
+====
+If your account does not have permission to get the Thanos Querier API route, a cluster administrator can provide the URL for the route.
+====
 
 .Procedure
 
-. Extract a token to connect to Prometheus:
+. Extract an authentication token to connect to Prometheus by running the following command:
 +
 [source,terminal]
 ----
-$ SECRET=`oc get secret -n openshift-user-workload-monitoring | grep  prometheus-user-workload-token | head -n 1 | awk '{print $1 }'`
-----
-+
-[source,terminal]
-----
-$ TOKEN=`echo $(oc get secret $SECRET -n openshift-user-workload-monitoring -o json | jq -r '.data.token') | base64 -d`
+$ TOKEN=$(oc whoami -t)
 ----
 
-. Extract your route host:
+. Extract the `thanos-querier` API route URL by running the following command:
 +
 [source,terminal]
 ----
-$ THANOS_QUERIER_HOST=`oc get route thanos-querier -n openshift-monitoring -o json | jq -r '.spec.host'`
+$ HOST=$(oc -n openshift-monitoring get route thanos-querier -ojsonpath={.spec.host})
 ----
 
-. Query the metrics of your own services in the command line. For example:
+. Set the namespace to the namespace in which your service is running by using the following command:
 +
 [source,terminal]
 ----
 $ NAMESPACE=ns1
 ----
+
+. Query the metrics of your own services in the command line by running the following command:
 +
 [source,terminal]
 ----
-$ curl -X GET -kG "https://$THANOS_QUERIER_HOST/api/v1/query?" --data-urlencode "query=up{namespace='$NAMESPACE'}" -H "Authorization: Bearer $TOKEN"
+$ curl -H "Authorization: Bearer $TOKEN" -k "https://$HOST/api/v1/query?" --data-urlencode "query=up{namespace='$NAMESPACE'}"
 ----
 +
-The output will show you the duration that your application pods have been up.
+The output shows the status for each application pod that Prometheus is scraping:
 +
 .Example output
 [source,terminal]

--- a/monitoring/enabling-monitoring-for-user-defined-projects.adoc
+++ b/monitoring/enabling-monitoring-for-user-defined-projects.adoc
@@ -31,6 +31,11 @@ include::modules/monitoring-granting-users-permission-to-configure-monitoring-fo
 // Accessing metrics from outside the cluster for custom applications
 include::modules/accessing-metrics-outside-cluster.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects_enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
+
 // Excluding a user-defined project from monitoring
 include::modules/monitoring-excluding-a-user-defined-project-from-monitoring.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-850
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://72176--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/enabling-monitoring-for-user-defined-projects#accessing-metrics-from-outside-cluster_enabling-monitoring-for-user-defined-projects
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR updates CLI commands for accessing metrics outside the cluster for user workload monitoring because the old commands no longer work in OCP 4.15+.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
