### PR TITLE
WINC add redirect for 4.15 -- WMCO 10.15.0

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -176,9 +176,6 @@ AddType text/vtt                            vtt
     RewriteRule ^(rosa|dedicated)/logging/config/cluster-logging-moving-nodes.html /$1/logging/scheduling_resources/logging-node-selectors.html [NE,R=302]
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/logging/config/cluster-logging-log-store.html /container-platform/$1/logging/log_storage/logging-config-es-store.html [NE,R=302]
 
-    # Redirects for observability rework per https://github.com/openshift/openshift-docs/pull/71248
-    RewriteRule ^container-platform/4.14/power_monitoring/(.*)$ /container-platform/4.14/observability/power_monitoring/$1 [NE,R=302,L]
-
     # Redirect for log collection forwarding per https://github.com/openshift/openshift-docs/pull/64406
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/logging/config/cluster-logging-collector.html /container-platform/$1/logging/log_collection_forwarding/cluster-logging-collector.html [NE,R=302]
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/logging/cluster-logging-eventrouter.html /container-platform/$1/logging/log_collection_forwarding/cluster-logging-eventrouter.html [NE,R=302]
@@ -290,7 +287,7 @@ AddType text/vtt                            vtt
 
     # Pipelines handling unversioned and latest links
     RewriteRule ^pipelines/?$ /pipelines/latest [R=302]
-    RewriteRule ^pipelines/latest/?(.*)$ /pipelines/1\.14/$1 [NE,R=302]
+    RewriteRule ^pipelines/latest/?(.*)$ /pipelines/1\.13/$1 [NE,R=302]
 
     # Pipelines landing page
 
@@ -318,7 +315,7 @@ AddType text/vtt                            vtt
     RewriteRule ^container-platform/(4\.10|4\.11|4\.12|4\.13|4\.14)/cicd/pipelines/securing-webhooks-with-event-listeners.html /pipelines/latest/secure/securing-webhooks-with-event-listeners.html [L,R=302]
 
     # redirect top-level without filespec to the about file
-    RewriteRule ^pipelines/(1\.10|1\.11|1\.12|1\.13|1\.14)/?$ /pipelines/$1/about/understanding-openshift-pipelines.html [L,R=302]
+    RewriteRule ^pipelines/(1\.10|1\.11|1\.12|1\.13)/?$ /pipelines/$1/about/understanding-openshift-pipelines.html [L,R=302]
 
 
     # OSD redirects for new content
@@ -434,22 +431,22 @@ AddType text/vtt                            vtt
     RewriteRule ^container-platform/(4\.4|4\.5)/authentication/(allowing-javascript-access-api-server|encrypting-etcd|certificate-types-descriptions)\.html$ /container-platform/$1/security/$2\.html [NE,R=301]
 
 
-    # The following rule prevents an infinite redirect loop when browsing to /container-platform/4.15/virt/about_virt/about-virt.html
-    RewriteRule ^container-platform/4\.15/virt/about_virt/about-virt.html$ - [L]
+    # The following rule prevents an infinite redirect loop when browsing to /container-platform/4.14/virt/about_virt/about-virt.html
+    # RewriteRule ^container-platform/4\.14/virt/about_virt/about-virt.html$ - [L]
 
     # OpenShift Virtualization (CNV) catchall redirect; use when CNV releases asynchronously from OCP. Do not change the 302 to a 301.
     # When uncommented, this redirects all `virt` directory traffic to the about-virt page.
     # Pay mind to the redirect directly above this which prevents redirect loops.
     # To activate the redirects, uncomment the next and previous lines and update the version number to the pending release.
 
-    RewriteRule container-platform/4\.15/virt/(?!about-virt\.html)(.+)$ /container-platform/4.15/virt/about_virt/about-virt.html [NE,R=302]
+    # RewriteRule container-platform/4\.14/virt/(?!about-virt\.html)(.+)$ /container-platform/4.14/virt/about_virt/about-virt.html [NE,R=302]
 
 
     # Red Hat OpenShift support for Windows Containers (WMCO) catchall redirect; use when WMCO releases asynchronously from OCP. Do not change the 302 to a 301.
     # When uncommented, this redirects all `windows_containers` directory traffic to the /windows_containers/index.html page.
     # To activate the redirects, uncomment the next line and update the version number to the pending release.
-    # RewriteRule container-platform/4\.14/windows_containers/(?!index\.html)(.+)$ /container-platform/4.14/windows_containers/index.html [NE,R=302]
-    # RewriteRule ^container-platform/4\.14/support/troubleshooting/troubleshooting-windows-container-workload-issues\.html(.*)$ /container-platform/4.14/windows_containers/index.html [NE,R=302]
+    RewriteRule container-platform/4\.15/windows_containers/(?!index\.html)(.+)$ /container-platform/4.15/windows_containers/index.html [NE,R=302]
+    RewriteRule ^container-platform/4\.15/support/troubleshooting/troubleshooting-windows-container-workload-issues\.html(.*)$ /container-platform/4.15/windows_containers/index.html [NE,R=302]
 
     # Serverless Redirects
     RewriteRule container-platform/(4\.5|4\.6)/serverless/knative_eventing/(serverless-subscriptions\.html|serverless-channels\.html|serverless-subscriptions\.html) /container-platform/$1/serverless/event_workflows/serverless-channels.html [NE,R=301]

--- a/.s2i/httpd-cfg/01-community.conf
+++ b/.s2i/httpd-cfg/01-community.conf
@@ -159,20 +159,20 @@ AddType text/vtt                            vtt
     RewriteRule ^latest/install_config/upgrades\.html(.*)$ /latest/install_config/upgrading/index.html$1 [NE,R=301]
     RewriteRule ^latest/install_config/upgrading/(.*)$ /latest/upgrading/$1 [NE,R=301]
 
-    # The following rule prevents an infinite redirect loop when browsing to /(latest|4\.15)/virt/about_virt/about-virt.html
-    RewriteRule ^(latest|4\.15)/virt/about_virt/about-virt.html$ - [L]
+    # The following rule prevents an infinite redirect loop when browsing to /(latest|4\.14)/virt/about_virt/about-virt.html
+    # RewriteRule ^(latest|4\.14)/virt/about_virt/about-virt.html$ - [L]
 
     # OpenShift Virtualization (CNV) catchall redirect; use when CNV releases asynchronously from OCP. Do not change the 302 to a 301.
     # When uncommented, this redirects all `virt` directory traffic to the about-virt page.
     # Pay mind to the redirect directly above this which prevents redirect loops.
     # To activate the redirects, uncomment the next and previous lines and update the version number to the pending release.
-    RewriteRule ^(latest|4\.15)/virt/(?!about-virt\.html)(.+)$ /$1/virt/about_virt/about-virt.html [NE,R=302]
+    # RewriteRule ^(latest|4\.14)/virt/(?!about-virt\.html)(.+)$ /$1/virt/about_virt/about-virt.html [NE,R=302]
 
     # Red Hat OpenShift support for Windows Containers (WMCO) catchall redirect; use when WMCO releases asynchronously from OCP. Do not change the 302 to a 301.
     # When uncommented, this redirects all `windows_containers` directory traffic to the /windows_containers/index.html page.
     # To activate the redirects, uncomment the next line and update the version number to the pending release.
-    # RewriteRule ^(latest|4\.14)/windows_containers/(?!index\.html)(.+)$ /$1/windows_containers/index.html [NE,R=302]
-    # RewriteRule ^(latest|4\.14)/support/troubleshooting/troubleshooting-windows-container-workload-issues\.html(.*)$ /$1/windows_containers/index.html [NE,R=302]
+    RewriteRule ^(latest|4\.15)/windows_containers/(?!index\.html)(.+)$ /$1/windows_containers/index.html [NE,R=302]
+    RewriteRule ^(latest|4\.15)/support/troubleshooting/troubleshooting-windows-container-workload-issues\.html(.*)$ /$1/windows_containers/index.html [NE,R=302]
 
   </Directory>
 </IfModule>

--- a/windows_containers/index.adoc
+++ b/windows_containers/index.adoc
@@ -6,6 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+
+Documentation for {productwinc} will be available for {product-title} {product-version} in the near future.
+
+////
 {productwinc} is a feature providing the ability to run Windows compute nodes in an {product-title} cluster. This is possible by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes. With a Red Hat subscription, you can get support for running Windows workloads in {product-title}. Windows instances deployed by the WMCO are configured with the containerd container runtime. For more information, see the xref:../windows_containers/windows-containers-release-notes-6-x.adoc#windows-containers-release-notes-6-x[release notes].
 
 You can add Windows nodes either by creating a xref:../windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc#creating-windows-machineset-aws[compute machine set] or by specifying existing Bring-Your-Own-Host (BYOH) Window instances through a xref:../windows_containers/byoh-windows-instance.adoc#byoh-windows-instance[configuration map].
@@ -33,3 +37,4 @@ You can xref:../windows_containers/disabling-windows-container-workloads.adoc#di
 
 * Uninstalling the Windows Machine Config Operator
 * Deleting the Windows Machine Config Operator namespace
+////


### PR DESCRIPTION
If the WMCO 10.15.0 releases asynchronously from OCP 4.15, this PR creates redirects that effectively hide the WINC content without removing the Windows Container book from the TOC.

Merge to **_main_**. No need to cherrypick to 4.15.
To be reverted when WMCO 10.15.1 is released.

Preview: https://72186--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/

No QE needed

