### PR TITLE
Update IPsec release note to state IPv4 support for E-W

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -607,7 +607,7 @@ For more information, see xref:../operators/operator_sdk/token_auth/osdk-cco-azu
 [id="ocp-4-15-networking-ovn-kubernetes-ipsec-support-for-external-traffic"]
 ==== OVN-Kubernetes network plugin support for IPsec encryption of external traffic general availability (GA)
 
-{product-title} now supports encryption of external traffic, also known as _north-south traffic_. IPsec already supports encryption of network traffic between pods, known as _east-west traffic_. You can use both features together to provide full in-transit encryption for {product-title} clusters.
+{product-title} now supports encryption of IPv4 external traffic, also known as _north-south traffic_. IPsec already supports encryption of network traffic between pods, known as _east-west traffic_. You can use both features together to provide full in-transit encryption for {product-title} clusters.
 
 This feature is supported on the following platforms:
 


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-6863
- https://github.com/openshift/openshift-docs/pull/70288#issuecomment-1967307997

@anuragthehatter 

This is an attempt to clarify IPv4 for N-S. We only describe how to configure N-S with nmstate, so for all intents and purposes, only IPv4 is supported, even if IPv6 actually works. At least, that's my understanding of it. This might be a fine needle to thread. I don't want to get too elaborate with it, but we can revise this to whatever seems best.