### PR TITLE
OSDOCS-6863: Clarify IPv6 support

### DIFF
--- a/modules/nw-ovn-ipsec-external.adoc
+++ b/modules/nw-ovn-ipsec-external.adoc
@@ -30,4 +30,5 @@ If your cluster uses hosted control planes for Red Hat {product-title}, configur
 
 Ensure that the following prohibitions are observed:
 
+* IPv6 configuration is not currently supported by the NMState Operator when configuring IPsec for external traffic.
 * Certificate common names (CN) in the provided certificate bundle must not begin with the `ovs_` prefix, because this naming can conflict with pod-to-pod IPsec CN names in the Network Security Services (NSS) database of each node.


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-6863
- https://github.com/openshift/openshift-docs/pull/70288#issuecomment-1967307997

@anuragthehatter @yuvalk 

This PR attempts to clarify that IPv6 for N-S isn't supported with NMState Operator at this time.

Preview: https://72188--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn#ipsec-external-limitations_configuring-ipsec-ovn