### PR TITLE
copies 'Contributing' intro from README to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,16 +1,5 @@
-= OpenShift documentation
-
-* https://www.okd.io/[OKD]
-* https://www.openshift.com/products/online/[OpenShift Online]
-* https://www.openshift.com/products/container-platform/[OpenShift Container Platform]
-* https://www.openshift.com/products/dedicated/[OpenShift Dedicated]
-
-All OpenShift documentation is sourced in https://asciidoc.org/[AsciiDoc] and transformed into HTML/CSS and other formats through automation that is based on https://asciidoctor.org/[AsciiDoctor].
-
-The documentation published from these source files can be viewed at https://docs.openshift.com.
-
-== Contributing to OpenShift documentation
-// NOTE: This text is mirrored in ./CONTRIBUTING.adoc
+= Contributing to OpenShift documentation
+// NOTE: This text mirrors the "Contributing to OpenShift documentation" section in ./README.adoc
 // If you update one, update both.
 
 If you are interested in contributing to OpenShift technical documentation, you can view all our link:./contributing_to_docs[resources] that will help you get set up and provide more information.
@@ -36,9 +25,3 @@ The following table provides quick links to help you get started.
 |See the link:/contributing_to_docs/create_or_edit_content.adoc[create or edit content] topic to get started.
 
 |===
-
-== Contacts
-
-For questions or comments about OpenShift documentation:
-
-* Send an email to the OpenShift documentation team at openshift-docs@redhat.com.


### PR DESCRIPTION
Version(s):
main

Issue:
N/A

Link to docs preview:
[Files changed](https://github.com/openshift/openshift-docs/pull/72189/files) > [...] > View file

QE review:
N/A

Additional information:
* Noticed that [this page](https://github.com/openshift/openshift-docs/community) expects a contributing guide in `./CONTRIBUTING.md` (though I think it will take .adoc too, since it can see `README.adoc`)
* Figured I would just steal [this](https://github.com/openshift/openshift-docs/tree/main?tab=readme-ov-file#contributing-to-openshift-documentation) instead of reinventing the wheel.