### PR TITLE
WMCO 10.15.1 release notes

### DIFF
--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -8,9 +8,9 @@
 The following information details the supported platform versions, Windows Server versions, and networking configurations for the Windows Machine Config Operator. See the vSphere documentation for any information that is relevant to only that platform.
 
 [id="wmco-prerequisites-supported-10.15.0_{context}"]
-== WMCO 10.15.0 supported platforms and Windows Server versions
+== WMCO 10.y supported platforms and Windows Server versions
 
-The following table lists the link:https://docs.microsoft.com/en-us/windows/release-health/windows-server-release-info[Windows Server versions] that are supported by WMCO 10.15.0, based on the applicable platform. Windows Server versions not listed are not supported and attempting to use them will cause errors. To prevent these errors, use only an appropriate version for your platform.
+The following table lists the link:https://docs.microsoft.com/en-us/windows/release-health/windows-server-release-info[Windows Server versions] that are supported by WMCO 10.y, based on the applicable platform. Windows Server versions not listed are not supported and attempting to use them will cause errors. To prevent these errors, use only an appropriate version for your platform.
 
 [cols="3,7",options="header"]
 |===

--- a/windows_containers/windows-containers-release-notes-10-15-x.adoc
+++ b/windows_containers/windows-containers-release-notes-10-15-x.adoc
@@ -28,36 +28,39 @@ For more information, see the Red{nbsp}Hat OpenShift Container Platform Life Cyc
 If you do not have this additional Red{nbsp}Hat subscription, you can use the Community Windows Machine Config Operator, a distribution that lacks official support.
 endif::openshift-origin[]
 
-[id="wmco-10-15-0"]
-== Release notes for Red{nbsp}Hat Windows Machine Config Operator 10.15.0
+[id="about-windows-containers-numbering"]
+== WMCO numbering
 
-This release of the WMCO provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.15.0 were released in link:https://access.redhat.com/errata/RHSA-2024:0954-09[RHSA-2024:0954-09].
+Starting with this release, y-stream releases of the WMCO will be in step with {product-title}, with only z-stream releases between {product-title} releases. The WMCO numbering reflects the associated {product-title} version in the y-stream position. For example, the current release of WMCO is associated with {product-title} version 4.15. Thus, the numbering is WMCO 10.15.z.
+
+
+[id="wmco-10-15-1"]
+== Release notes for Red{nbsp}Hat Windows Machine Config Operator 10.15.1
+
+This release of the WMCO provides new features and bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.15.1 were released in link:https://access.redhat.com/errata/RHBA-2024:1191[RHBA-2024:1191].
+
+Due to an internal issue, the planned WMCO 10.15.0 could not be released. Multiple bug and security fixes, described below, were included in WMCO 10.15.0. These fixes are included in WMCO 10.15.1. For specific details about these bug and security fixes, see the link:https://access.redhat.com/errata/RHSA-2024:0954[RHSA-2024:0954] errata.
 
 === New features and improvements
-[id="wmco-10-15-0-node-certificates"]
+[id="wmco-10-15-1-node-certificates"]
 
-[id="wmco-10-15-0-numbering"]
-==== New WMCO numbering
-
-Starting with this release, y-stream releases of the WMCO will be in step with {product-title}, with only z-stream releases between {product-title} releases. The WMCO numbering will reflect the associated {product-title} version in the y-stream position. For example, the current release of WMCO is associated with {product-title} version 4.15. Thus, the numbering is WMCO 10.15.z.
-
-[id="wmco-10-15-0-operator-metrics"]
+[id="wmco-10-15-1-operator-metrics"]
 ==== CPU and memory usage metrics are now available
 
 //https://issues.redhat.com/browse/WINC-1181
 CPU and memory usage metrics for Windows pods are now available in Prometheus. The metrics are shown in the {product-title} web console on the *Metrics* tab for each Windows pod and can be queried by users.
 
-[id="wmco-10-15-0-operator-sdk"]
+[id="wmco-10-15-1-operator-sdk"]
 ==== Operator SDK upgrade
 
 The WMCO now uses the Operator SDK version 1.32.0.
 
-[id="wmco-10-15-0-operator-kube"]
+[id="wmco-10-15-1-operator-kube"]
 ==== Kubernetes upgrade
 
 The WMCO now uses Kubernetes 1.28.
 
-[id="wmco-10-15-0-bug-fixes"]
+[id="wmco-10-15-1-bug-fixes"]
 === Bug fixes
 
 * Previously, there was a flaw in the handling of multiplexed streams in the HTTP/2 protocol, which is utilized by the WMCO. A client could repeatedly make a request for a new multiplex stream and then immediately send an `RST_STREAM` frame to cancel those requests. This activity created additional work for the server by setting up and dismantling streams, but avoided any server-side limitations on the maximum number of active streams per connection. As a result, a denial of service occurred due to server resource consumption. This issue has been fixed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2243296[*BZ-2243296*])


### PR DESCRIPTION
WMCO 10.15.0 needed to be dropped. WMCO 10.15.1 replaces it.

Errata:

Preview:
https://72190--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-10-15-x#wmco-10-15-1