### PR TITLE
OCPBUGS-25398: update Azure machine set YAML sample

### DIFF
--- a/modules/cpmso-yaml-provider-spec-azure.adoc
+++ b/modules/cpmso-yaml-provider-spec-azure.adoc
@@ -39,7 +39,7 @@ spec:
             image: <2>
               offer: ""
               publisher: ""
-              resourceID: /resourceGroups/<cluster_id>-rg/providers/Microsoft.Compute/galleries/gallery_<cluster_id>/images/<cluster_id>-gen2/        versions/412.86.20220930 <3>
+              resourceID: /resourceGroups/<cluster_id>-rg/providers/Microsoft.Compute/galleries/gallery_<cluster_id>/images/<cluster_id>-gen2/versions/412.86.20220930 <3>
               sku: ""
               version: ""
             internalLoadBalancer: <cluster_id>-internal <4>

--- a/modules/machineset-yaml-azure.adoc
+++ b/modules/machineset-yaml-azure.adoc
@@ -17,7 +17,7 @@ ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
 
 In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
 ifndef::infra[`<role>`]
-ifdef::infra[`<infra>`]
+ifdef::infra[`infra`]
 is the node label to add.
 
 [source,yaml]
@@ -26,43 +26,43 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id> # <1>
 ifndef::infra[]
-    machine.openshift.io/cluster-api-machine-role: <role> <2>
-    machine.openshift.io/cluster-api-machine-type: <role> <2>
-  name: <infrastructure_id>-<role>-<region> <3>
+    machine.openshift.io/cluster-api-machine-role: <role> # <2>
+    machine.openshift.io/cluster-api-machine-type: <role>
+  name: <infrastructure_id>-<role>-<region> # <3>
 endif::infra[]
 ifdef::infra[]
-    machine.openshift.io/cluster-api-machine-role: <infra> <2>
-    machine.openshift.io/cluster-api-machine-type: <infra> <2>
-  name: <infrastructure_id>-infra-<region> <3>
+    machine.openshift.io/cluster-api-machine-role: infra # <2>
+    machine.openshift.io/cluster-api-machine-type: infra
+  name: <infrastructure_id>-infra-<region> # <3>
 endif::infra[]
   namespace: openshift-machine-api
 spec:
   replicas: 1
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region> <3>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region>
 endif::infra[]
 ifdef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<region> <3>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<region>
 endif::infra[]
   template:
     metadata:
       creationTimestamp: null
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <role> <2>
-        machine.openshift.io/cluster-api-machine-type: <role> <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region> <3>
+        machine.openshift.io/cluster-api-machine-role: <role>
+        machine.openshift.io/cluster-api-machine-type: <role>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region>
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <infra> <2>
-        machine.openshift.io/cluster-api-machine-type: <infra> <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<region> <3>
+        machine.openshift.io/cluster-api-machine-role: infra
+        machine.openshift.io/cluster-api-machine-type: infra
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<region>
 endif::infra[]
     spec:
       metadata:
@@ -70,10 +70,10 @@ endif::infra[]
         labels:
           machine.openshift.io/cluster-api-machineset: <machineset_name>
 ifndef::infra[]
-          node-role.kubernetes.io/<role>: "" <2>
+          node-role.kubernetes.io/<role>: ""
 endif::infra[]
 ifdef::infra[]
-          node-role.kubernetes.io/infra: "" <2>
+          node-role.kubernetes.io/infra: ""
 endif::infra[]
       providerSpec:
         value:
@@ -81,16 +81,16 @@ endif::infra[]
           credentialsSecret:
             name: azure-cloud-credentials
             namespace: openshift-machine-api
-          image: <4>
+          image: # <4>
             offer: ""
             publisher: ""
-            resourceID: /resourceGroups/<infrastructure_id>-rg/providers/Microsoft.Compute/images/<infrastructure_id> <5>
+            resourceID: /resourceGroups/<infrastructure_id>-rg/providers/Microsoft.Compute/galleries/gallery_<infrastructure_id>/images/<infrastructure_id>-gen2/versions/latest # <5>
             sku: ""
             version: ""
           internalLoadBalancer: ""
           kind: AzureMachineProviderSpec
-          location: <region> <6>
-          managedIdentity: <infrastructure_id>-identity <1>
+          location: <region> # <6>
+          managedIdentity: <infrastructure_id>-identity
           metadata:
             creationTimestamp: null
           natRule: null
@@ -102,20 +102,20 @@ endif::infra[]
             osType: Linux
           publicIP: false
           publicLoadBalancer: ""
-          resourceGroup: <infrastructure_id>-rg <1>
+          resourceGroup: <infrastructure_id>-rg
           sshPrivateKey: ""
           sshPublicKey: ""
           tags:
-            - name: <custom_tag_name> <8>
-              value: <custom_tag_value> <8>
-          subnet: <infrastructure_id>-<role>-subnet <1> <2>
+            - name: <custom_tag_name> # <7>
+              value: <custom_tag_value>
+          subnet: <infrastructure_id>-<role>-subnet
           userDataSecret:
-            name: worker-user-data <2>
+            name: worker-user-data
           vmSize: Standard_D4s_v3
-          vnet: <infrastructure_id>-vnet <1>
-          zone: "1" <7>
+          vnet: <infrastructure_id>-vnet
+          zone: "1" # <8>
 ifdef::infra[]
-      taints: <9>
+      taints: # <9>
       - key: node-role.kubernetes.io/infra
         effect: NoSchedule
 endif::infra[]
@@ -148,14 +148,14 @@ ifndef::infra[]
 <3> Specify the infrastructure ID, node label, and region.
 endif::infra[]
 ifdef::infra[]
-<2> Specify the `<infra>` node label.
-<3> Specify the infrastructure ID, `<infra>` node label, and region.
+<2> Specify the `infra` node label.
+<3> Specify the infrastructure ID, `infra` node label, and region.
 endif::infra[]
 <4> Specify the image details for your compute machine set. If you want to use an Azure Marketplace image, see "Selecting an Azure Marketplace image".
 <5> Specify an image that is compatible with your instance type. The Hyper-V generation V2 images created by the installation program have a `-gen2` suffix, while V1 images have the same name without the suffix.
 <6> Specify the region to place machines on.
-<7> Specify the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
-<8> Optional: Specify custom tags in your machine set. Provide the tag name in `<custom_tag_name>` field and the corresponding tag value in `<custom_tag_value>` field.
+<7> Optional: Specify custom tags in your machine set. Provide the tag name in `<custom_tag_name>` field and the corresponding tag value in `<custom_tag_value>` field.
+<8> Specify the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
 ifdef::infra[]
 <9> Specify a taint to prevent user workloads from being scheduled on infra nodes.
 +


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-25398](https://issues.redhat.com//browse/OCPBUGS-25398)

Link to docs preview:
* [Sample YAML for a compute machine set custom resource on Azure](https://72191--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure#machineset-yaml-azure_creating-machineset-azure) (standard compute)
* [Sample YAML for a compute machine set custom resource on Azure](https://72191--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets#machineset-yaml-azure_creating-infrastructure-machinesets) (infra)
* [Sample Azure provider specification](https://72191--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration#cpmso-yaml-provider-spec-azure_cpmso-configuration) (control plane)

QE review:
- [ ] QE has approved this change.

Additional information:
* Fixed a couple other YAML issues
* Might not cherrypick clean