### PR TITLE
OSDOCS-9112: Added tagging requirements for subnets for ROSA with HCP

### DIFF
--- a/modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc
+++ b/modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc
@@ -24,20 +24,13 @@ Before using the {product-title} (ROSA) CLI (`rosa`) to create {hcp-title-first}
 +
 [source,terminal]
 ----
-$ rosa create account-roles --hosted-cp
+$ rosa create account-roles --hosted-cp --mode auto --yes
 ----
 ** Optional: Set your prefix as an environmental variable by running the following command:
 +
 [source,terminal]
 ----
 $ export ACCOUNT_ROLES_PREFIX="${ACCOUNT_ROLES_PREFIX}"
-----
-+
-Then, run the following command to create your account roles with the environmental variable:
-+
-[source,terminal]
-----
-$ rosa create account-roles --hosted-cp --prefix $ACCOUNT_ROLES_PREFIX
 ----
 
 For more information regarding AWS managed IAM policies for ROSA, see link:https://docs.aws.amazon.com/ROSA/latest/userguide/security-iam-awsmanpol.html[AWS managed IAM policies for ROSA].

--- a/modules/rosa-hcp-vpc-manual.adoc
+++ b/modules/rosa-hcp-vpc-manual.adoc
@@ -23,7 +23,7 @@ If you choose to manually create your Virtual Private Cloud (VPC) instead of usi
 | You need one availability zone for a single zone, and you need three for availability zones for multi-zone.
 
 | Public subnet
-| You must have one public subnet with a NAT gateway.
+| You must have one public subnet with a NAT gateway for public clusters. Private clusters do not need a public subnet.
 
 | DNS hostname and resolution
 | You must ensure that the DNS hostname and resolution are enabled.

--- a/modules/rosa-hcp-vpc-subnet-tagging.adoc
+++ b/modules/rosa-hcp-vpc-subnet-tagging.adoc
@@ -1,0 +1,81 @@
+// Module included in the following assemblies:
+//
+// * rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-hcp-vpc-subnet-tagging_{context}"]
+= Tagging your subnets
+
+Before you can use your VPC to create a {hcp-title} cluster, you must tag your VPC subnets. Automated service preflight checks verify that these resources are tagged correctly before you can use these resources. The following table shows how your resources should be tagged as the following:
+
+[cols="3a,8a,8a", options="header"]
+|===
+| Resource
+| Key
+| Value
+
+| Public subnet
+| `kubernetes.io/role/elb`	
+| `1` or no value
+
+| Private subnet 
+| `kubernetes.io/role/internal-elb`	
+| `1` or no value
+
+|===
+
+[NOTE]
+====
+You must tag at least one private subnet and, if applicable, and one public subnet.
+====
+
+.Prerequisites
+
+* You have created a VPC.
+* You have installed the `aws` CLI.
+
+.Procedure
+
+. Verify the tags currently on your subnet by running the following command:
++
+[source,terminal]
+----
+$ aws ec2 describe-tags --filters "Name=resource-id,Values=<subnet-id>"
+----
++
+.Example output
++
+[source,text]
+----
+TAGS    Name    <subnet-id>    subnet  <prefix>-subnet-public1-us-east-1a
+----
+
+. Tag your resources in your terminal by running the following commands:
+.. For public subnets, run:
++
+[source,terminal]
+----
+$ aws ec2 create-tags --resources <public-subnet-id> --tags Key=kubernetes.io/role/elb,Value=1
+----
+.. For private subnets, run:
++
+[source,terminal]
+----
+$ aws ec2 create-tags --resources <private-subnet-id> --tags Key=kubernetes.io/role/internal-elb,Value=1
+----
+
+.Verification
+
+. Verify that the tag is correctly applied by running the following command:
++
+[source,terminal]
+----
+$ aws ec2 describe-tags --filters "Name=resource-id,Values=<subnet_id>"
+----
++
+.Example output
++
+[source,text]
+----
+TAGS    Name                    <subnet-id>        subnet  <prefix>-subnet-public1-us-east-1a
+TAGS    kubernetes.io/role/elb  <subnet-id>        subnet  1
+----

--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
@@ -92,7 +92,9 @@ include::modules/rosa-hcp-vpc-terraform.adoc[leveloffset=+3]
 * See the link:https://github.com/openshift-cs/terraform-vpc-example[Terraform VPC] repository for a detailed list of all options available when customizing the VPC for your needs.
 
 [discrete]
-include::modules/rosa-hcp-vpc-manual.adoc[leveloffset=+3]
+include::modules/rosa-hcp-vpc-manual.adoc[leveloffset=+2]
+[discrete]
+include::modules/rosa-hcp-vpc-subnet-tagging.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 [id="additional-resources_rosa-hcp-vpc-aws"]
@@ -100,6 +102,7 @@ include::modules/rosa-hcp-vpc-manual.adoc[leveloffset=+3]
 
 * link:https://docs.aws.amazon.com/vpc/latest/userguide/vpc-getting-started.html[Get Started with Amazon VPC]
 * link:https://developer.hashicorp.com/terraform[HashiCorp Terraform documentation]
+* link:https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/deploy/subnet_discovery/[Subnet Auto Discovery]
 
 include::modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
`enterprise-4.15+`

Issue:
[OSDOCS-9112](https://issues.redhat.com/browse/OSDOCS-9112)

Link to docs preview:
- [Creating a virtual private cloud for your ROSA with HCP clusters](https://file.rdu.redhat.com/eponvell/OSDOCS-9112_Subnet-Validation/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html#rosa-hcp-creating-vpc)
- [Tagging your subnets](https://file.rdu.redhat.com/eponvell/OSDOCS-9112_Subnet-Validation/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html#rosa-hcp-vpc-subnet-tagging_rosa-hcp-sts-creating-a-cluster-quickly)
- [Creating a machine pool](https://file.rdu.redhat.com/eponvell/OSDOCS-9112_Subnet-Validation/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html#creating_a_machine_pool_rosa-managing-worker-nodes) - **maybe**

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added information about the AWS tagging requirements for public and private subnets for ROSA with HCP.
