### PR TITLE
OCPBUGS-29770 update product-version to read stable

### DIFF
--- a/modules/sriov-operator-hosted-control-planes.adoc
+++ b/modules/sriov-operator-hosted-control-planes.adoc
@@ -40,7 +40,7 @@ spec:
 
 . Create a subscription to the SR-IOV Operator:
 +
-[source,yaml,subs="attributes+"]
+[source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -48,7 +48,7 @@ metadata:
   name: sriov-network-operator-subsription
   namespace: openshift-sriov-network-operator
 spec:
-  channel: "{product-version}"
+  channel: stable
   name: sriov-network-operator
   config:
     nodeSelector:


### PR DESCRIPTION
[OCPBUGS-29770]: stable became the channel from 4.14 onwards

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14, 4.15, 4.16 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-29770
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://72266--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-operator#sriov-operator-hosted-control-planes_configuring-sriov-operator
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This is another section where the change made in https://github.com/openshift/openshift-docs/pull/71670 also need to be made
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
