### PR TITLE
Add updated index file for 4.15 WINC redirects

### DIFF
--- a/windows_containers/index.adoc
+++ b/windows_containers/index.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+Documentation for {productwinc} will be available for {product-title} {product-version} in the near future.
+
+////
 You can add Windows nodes either by creating a xref:../windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc#creating-windows-machineset-aws[compute machine set] or by specifying existing Bring-Your-Own-Host (BYOH) Window instances through a xref:../windows_containers/byoh-windows-instance.adoc#byoh-windows-instance[configuration map].
 
 [NOTE]
@@ -31,3 +34,4 @@ You can xref:../windows_containers/disabling-windows-container-workloads.adoc#di
 
 * Uninstalling the Windows Machine Config Operator
 * Deleting the Windows Machine Config Operator namespace
+////


### PR DESCRIPTION
Redirects added via https://github.com/openshift/openshift-docs/pull/72193. Need to get the updated index.adoc into 4.12 without needing the redirect files in 4.12. This is effectively a manual CP of 1 file in the 50315 PR.