### PR TITLE
Outposts: clarify unmanaged tag requirement

### DIFF
--- a/modules/aws-outposts-machine-set.adoc
+++ b/modules/aws-outposts-machine-set.adoc
@@ -165,7 +165,7 @@ spec:
 <5> Specifies the AWS instance type. You must use an instance type that is configured in your Outpost.
 <6> Specifies the AWS region in which the Outpost availability zone exists.
 <7> Specifies the dedicated subnet for your Outpost.
-<8> Specifies a taint to prevent user workloads from being scheduled on nodes that have the `node-role.kubernetes.io/outposts` label.
+<8> Specifies a taint to prevent workloads from being scheduled on nodes that have the `node-role.kubernetes.io/outposts` label. To schedule user workloads in the Outpost, you must specify a corresponding toleration in the `Deployment` resource for your application.
 --
 
 . Save your changes.

--- a/modules/aws-outposts-requirements-limitations.adoc
+++ b/modules/aws-outposts-requirements-limitations.adoc
@@ -6,20 +6,26 @@
 [id="aws-outposts-requirements-limitations_{context}"]
 = AWS Outposts on {product-title} requirements and limitations
 
-You can manage the resources on your Outpost similarly to those on a cloud-based AWS cluster if you configure your {product-title} cluster to accommodate the following requirements and limitations:
+You can manage the resources on your AWS Outpost similarly to those on a cloud-based AWS cluster if you configure your {product-title} cluster to accommodate the following requirements and limitations:
 
-* To extend an {product-title} cluster on AWS into an Outpost, you must have installed the cluster into an existing VPC.
+* To extend an {product-title} cluster on AWS into an Outpost, you must have installed the cluster into an existing Amazon Virtual Private Cloud (VPC).
+
+* The infrastructure of an Outpost is tied to an availability zone in an AWS region and uses a dedicated subnet.
+Edge compute machines deployed into an Outpost must use the Outpost subnet and the availability zone that the Outpost is tied to.
+
+* When the AWS Kubernetes cloud controller manager discovers an Outpost subnet, it attempts to create service load balancers in the Outpost subnet.
+AWS Outposts do not support running service load balancers.
+To prevent the cloud controller manager from creating unsupported services in the Outpost subnet, you must include the `kubernetes.io/cluster/unmanaged` tag in the Outpost subnet configuration.
+This requirement is a workaround in {product-title} version {product-version}.
+For more information, see link:https://issues.redhat.com/browse/OCPBUGS-30041[OCPBUGS-30041].
 
 * {product-title} clusters on AWS include the `gp3-csi` and `gp2-csi` storage classes.
 These classes correspond to Amazon Elastic Block Store (EBS) gp3 and gp2 volumes.
 {product-title} clusters use the `gp3-csi` storage class by default, but AWS Outposts does not support EBS gp3 volumes.
 
-* An Outpost is an extension of an availability zone associated with an AWS region and has a dedicated subnet.
-Edge compute machines deployed into an Outpost must use the Outpost availability zone and subnet.
-
-* AWS Outposts does not support AWS Network Load Balancers or Classic Load Balancers.
-To manages Ingress objects for your edge compute resources, you must install the AWS Load Balancer Operator so that you can use AWS Application Load Balancers in the AWS Outposts environment.
-If your cluster contains both edge and cloud-based compute instances that share workloads, additional configuration is required.
+* This implementation uses the `node-role.kubernetes.io/outposts` taint to prevent spreading regular cluster workloads to the Outpost nodes.
+To schedule user workloads in the Outpost, you must specify a corresponding toleration in the `Deployment` resource for your application.
+Reserving the AWS Outpost infrastructure for user workloads avoids additional configuration requirements, such as updating the default CSI to `gp2-csi` so that it is compatible.
 
 * To create a volume in the Outpost, the CSI driver requires the Outpost Amazon Resource Name (ARN).
 The driver uses the topology keys stored on the `CSINode` objects to determine the Outpost ARN.
@@ -31,3 +37,11 @@ The cloud-based AWS Elastic Block volume cannot attach to Outpost edge compute n
 +
 As a result, you cannot use CSI snapshots to migrate applications that use persistent storage from cloud-based compute nodes to edge compute nodes or directly use the original persistent volume.
 To migrate persistent storage data for applications, you must perform a manual backup and restore operation.
+
+* AWS Outposts does not support AWS Network Load Balancers or AWS Classic Load Balancers.
+You must use AWS Application Load Balancers to enable load balancing for edge compute resources in the AWS Outposts environment.
++
+To provision an Application Load Balancer, you must use an Ingress resource and install the AWS Load Balancer Operator.
+If your cluster contains both edge and cloud-based compute instances that share workloads, additional configuration is required.
++
+For more information, see "Using the AWS Load Balancer Operator in an AWS VPC cluster extended into an Outpost".

--- a/modules/installation-cloudformation-subnet-localzone.adoc
+++ b/modules/installation-cloudformation-subnet-localzone.adoc
@@ -97,7 +97,7 @@ ifndef::outposts[]
 endif::outposts[]
 ifdef::outposts[]
         Value: !Join ['-', [ !Ref ClusterName, !Ref PublicSubnetLabel, !Ref ZoneName]]
-      - Key: kubernetes.io/cluster/unmanaged
+      - Key: kubernetes.io/cluster/unmanaged # <1>
         Value: true
 endif::outposts[]
 
@@ -123,7 +123,7 @@ ifndef::outposts[]
 endif::outposts[]
 ifdef::outposts[]
         Value: !Join ['-', [!Ref ClusterName, !Ref PrivateSubnetLabel, !Ref ZoneName]]
-      - Key: kubernetes.io/cluster/unmanaged
+      - Key: kubernetes.io/cluster/unmanaged # <2>
         Value: true
 endif::outposts[]
 
@@ -144,6 +144,10 @@ Outputs:
     Value:
       !Join ["", [!Ref PrivateSubnet]]
 ----
+ifdef::outposts[]
+<1> You must include the `kubernetes.io/cluster/unmanaged` tag in the public subnet configuration for AWS Outposts.
+<2> You must include the `kubernetes.io/cluster/unmanaged` tag in the private subnet configuration for AWS Outposts.
+endif::outposts[]
 ====
 
 ifeval::["{context}" == "configuring-aws-outposts"]

--- a/post_installation_configuration/configuring-aws-outposts.adoc
+++ b/post_installation_configuration/configuring-aws-outposts.adoc
@@ -13,6 +13,9 @@ For more information, see the link:https://docs.aws.amazon.com/outposts/[AWS Out
 
 //AWS Outposts on {product-title} requirements and limitations
 include::modules/aws-outposts-requirements-limitations.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+* xref:../post_installation_configuration/configuring-aws-outposts.adoc#nw-aws-load-balancer-with-outposts_configuring-aws-outposts[Using the AWS Load Balancer Operator in an AWS VPC cluster extended into an Outpost]
 
 [id="aws-outposts-environment-info_{context}"]
 == Obtaining information about your environment


### PR DESCRIPTION
Version(s):
4.15+

Issue:
N/A, via [Slack chat](https://redhat-internal.slack.com/archives/C06K5PQSJ2H/p1709128411762009?thread_ts=1708983737.498759&cid=C06K5PQSJ2H)

Link to docs preview:
* [AWS Outposts on OpenShift Container Platform requirements and limitations](https://72291--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-aws-outposts.html#aws-outposts-requirements-limitations_configuring-aws-outposts)
* [CloudFormation template for the VPC subnet](https://72291--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-aws-outposts.html#installation-cloudformation-subnet-localzone_configuring-aws-outposts)

QE review:
- [x] QE has approved this change.

Additional information:
Post-GA refinement