### PR TITLE
OSDOCS-2435: Updating sparse CVO entry

### DIFF
--- a/modules/cluster-version-operator.adoc
+++ b/modules/cluster-version-operator.adoc
@@ -10,7 +10,9 @@
 
 Cluster Operators manage specific areas of cluster functionality. The Cluster Version Operator (CVO) manages the lifecycle of cluster Operators, many of which are installed in {product-title} by default.
 
-The CVO also checks with the OpenShift Update Service to see the valid updates and update paths based on current component versions and information in the graph.
+The CVO also checks with the OpenShift Update Service to see the valid updates and update paths based on current component versions and information in the graph by collecting the status of both the cluster version and its cluster Operators. This status includes the condition type, which informs you of the health and current state of the {product-title} cluster. 
+
+For more information regarding cluster version condition types, see "Understanding cluster version condition types".
 
 [discrete]
 == Project

--- a/operators/operator-reference.adoc
+++ b/operators/operator-reference.adoc
@@ -73,6 +73,10 @@ include::modules/cluster-storage-operator.adoc[leveloffset=+1]
 
 include::modules/cluster-version-operator.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../updating/understanding_updates/intro-to-updates.adoc#understanding-clusterversion-conditiontypes_understanding-openshift-updates[Understanding cluster version condition types]
+
 include::modules/console-operator.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-2435

Link to docs preview:
https://72292--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator-reference#cluster-version-operator_cluster-operators-ref

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
