### PR TITLE
RHDEVDOCS-5857-new: Contains content fixes for 2 follow-up comments for RHDEVDOCS-5857

### DIFF
--- a/modules/gitops-using-argo-cd-instance-to-manage-cluster-scoped-resources.adoc
+++ b/modules/gitops-using-argo-cd-instance-to-manage-cluster-scoped-resources.adoc
@@ -3,12 +3,11 @@
 // * declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="using-argo-cd-instance-to-manage-cluster-scoped-resources{context}"]
+[id="using-argo-cd-instance-to-manage-cluster-scoped-resources_{context}"]
 = Using an Argo CD instance to manage cluster-scoped resources
 
 To manage cluster-scoped resources, update the existing `Subscription` object for the `gitops-title` Operator and add the namespace of the Argo CD instance to the `ARGOCD_CLUSTER_CONFIG_NAMESPACES` environment variable in the `spec` section.
 
-[discrete]
 .Procedure
 . In the *Administrator* perspective of the web console, navigate to *Operators* → *Installed Operators* → *{gitops-title}* → *Subscription*. 
 . Click the *Actions* drop-down menu then click *Edit Subscription*.


### PR DESCRIPTION
This is a follow-up to post-merge review comments added in https://github.com/openshift/openshift-docs/pull/71331

This also does not need any additional QE review as the old PR already includes acks from all the required stakeholders.

Versions:  GitOps 1.8++