### PR TITLE
CNV-36348: We falsely state that MetalLB in BGP mode is not supported

### DIFF
--- a/modules/virt-about-services.adoc
+++ b/modules/virt-about-services.adoc
@@ -17,5 +17,5 @@ LoadBalancer:: Creates an external load balancer in the current cloud (if suppor
 
 [NOTE]
 ====
-For on-premise clusters, you can configure a load balancing service by using the MetalLB Operator in layer 2 mode. The BGP mode is not supported. The MetalLB Operator is installed in the `metallb-system` namespace.
+For on-premise clusters, you can configure a load-balancing service by deploying the MetalLB Operator.
 ====


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/CNV-36348

OCP 4.12+

Preview: https://72297--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-accessing-vm-ssh#virt-about-services_virt-accessing-vm-ssh