### PR TITLE
ocpbug#29600: Wrong cherry picks have destroyed the etcd restore proc…

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -38,16 +38,16 @@ For non-recovery control plane nodes, it is not required to establish SSH connec
 
 . Establish SSH connectivity to each of the control plane nodes, including the recovery host.
 +
-The Kubernetes API server becomes inaccessible after the restore process starts, so you cannot access the control plane nodes. For this reason, it is recommended to establish SSH connectivity to each control plane host in a separate terminal.
+`kube-apiserver` becomes inaccessible after the restore process starts, so you cannot access the control plane nodes. For this reason, it is recommended to establish SSH connectivity to each control plane host in a separate terminal.
 +
 [IMPORTANT]
 ====
 If you do not complete this step, you will not be able to access the control plane hosts to complete the restore procedure, and you will be unable to recover your cluster from this state.
 ====
 
-. Copy the etcd backup directory to the recovery control plane host.
+. Copy the `etcd` backup directory to the recovery control plane host.
 +
-This procedure assumes that you copied the `backup` directory containing the etcd snapshot and the resources for the static pods to the `/home/core/` directory of your recovery control plane host.
+This procedure assumes that you copied the `backup` directory containing the `etcd` snapshot and the resources for the static pods to the `/home/core/` directory of your recovery control plane host.
 
 . Stop the static pods on any other control plane nodes.
 +
@@ -58,14 +58,14 @@ You do not need to stop the static pods on the recovery host.
 
 .. Access a control plane host that is not the recovery host.
 
-.. Move the existing etcd pod file out of the kubelet manifest directory:
+.. Move the existing `etcd` pod file out of the kubelet manifest directory by running:
 +
 [source,terminal]
 ----
 $ sudo mv -v /etc/kubernetes/manifests/etcd-pod.yaml /tmp
 ----
 
-.. Verify that the etcd pods are stopped.
+.. Verify that the `etcd` pods are stopped by using:
 +
 [source,terminal]
 ----
@@ -81,14 +81,14 @@ The output of this command should be empty. If it is not empty, wait a few minut
 $ sudo mv -v /etc/kubernetes/manifests/kube-apiserver-pod.yaml /tmp
 ----
 
-.. Verify that the Kubernetes API server pods are stopped.
+.. Verify that the `kube-apiserver` containers are stopped by using:
 +
 [source,terminal]
 ----
 $ sudo crictl ps | grep kube-apiserver | egrep -v "operator|guard"
 ----
 +
-The output of this command should be empty. If it is not empty, wait a few minutes and check again.
+If the output of this command is not empty, wait a few minutes and check again.
 
 .. Move the etcd data directory to a different location:
 +
@@ -97,25 +97,82 @@ The output of this command should be empty. If it is not empty, wait a few minut
 $ sudo mv -v /var/lib/etcd/ /tmp
 ----
 
-.. If the `/etc/kubernetes/manifests/keepalived.yaml` file exists and the node is deleted, follow these steps:
+.. If the `kube-apiserver` file exists and the node is deleted, follow these steps:
 
-... Move the `/etc/kubernetes/manifests/keepalived.yaml` file out of the kubelet manifest directory:
+... Move the existing `kube-apiserver` file out of the kubelet manifest directory by running:
++
+[source,terminal]
+----
+$ sudo mv /etc/kubernetes/manifests/kube-apiserver-pod.yaml /tmp
+----
+
+... Verify that the `kube-apiserver` containers are stopped by running:
++
+[source,terminal]
+----
+$ sudo crictl ps | grep kube-apiserver | egrep -v "operator|guard"
+----
++
+If the output of this command is not empty, wait a few minutes and check again.
+
+.. Move the `kube-controller-manager` out of the kubelet manifest directory and verify that it has stopped.
+
+... Move the existing kube-controller-manager file out of the kubelet manifest directory by using:
++
+[source,terminal]
+----
+$ sudo mv /etc/kubernetes/manifests/kube-controller-manager-pod.yaml /tmp
+----
+
+... Verify that the `kube-controller-manager` containers are stopped by running:
++
+[source,terminal]
+----
+$ sudo crictl ps | grep kube-controller-manager | egrep -v "operator|guard"
+----
++
+If the output of this command is not empty, wait a few minutes and check again.
+
+.. Move the existing `kube-scheduler` file out of the kubelet manifest directory by using:
++
+[source,terminal]
+----
+$ sudo mv /etc/kubernetes/manifests/kube-scheduler-pod.yaml /tmp
+----
+
+.. Verify that the `kube-scheduler` containers are stopped by using:
++ 
+[source,terminal]
+----
+$ sudo crictl ps | grep kube-scheduler | egrep -v "operator|guard"
+----
++
+.. Move the `etcd` data directory to a different location with the following example:
++
+[source,terminal]
+----
+$ sudo mv /var/lib/etcd/ /tmp
+----
++
+.. If the `/etc/kubernetes/manifests/keepalived.yaml` file exists, follow these steps:
+
+... Move the `/etc/kubernetes/manifests/keepalived.yaml` file out of the kubelet manifest directory by running:
 +
 [source,terminal]
 ----
 $ sudo mv -v /etc/kubernetes/manifests/keepalived.yaml /tmp
 ----
 
-... Verify that any containers managed by the `keepalived` daemon are stopped:
+... Verify that any containers managed by the `keepalived` daemon are stopped by using:
 +
 [source,terminal]
 ----
 $ sudo crictl ps --name keepalived
 ----
 +
-The output of this command should be empty. If it is not empty, wait a few minutes and check again.
+If the output of this command is not empty, wait a few minutes and check again.
 
-... Check if the control plane has any Virtual IPs (VIPs) assigned to it:
+... Check if the control plane has any Virtual IPs (VIPs) assigned to it by using:
 +
 [source,terminal]
 ----
@@ -129,11 +186,22 @@ $ ip -o address | egrep '<api_vip>|<ingress_vip>'
 $ sudo ip address del <reported_vip> dev <reported_vip_device>
 ----
 
-.. Repeat this step on each of the other control plane hosts that is not the recovery host.
+... Repeat this step on each of the other control plane hosts that is not the recovery host.
+
+.. Access the recovery control plane host.
+
+... For each reported VIP, run the following command to remove it:
++
+[source,terminal]
+----
+$ sudo ip address del <reported_vip> dev <reported_vip_device>
+----
+
+... Repeat this step on each of the other control plane hosts that is not the recovery host.
 
 . Access the recovery control plane host.
 
-. If the `keepalived` daemon is in use, verify that the recovery control plane node owns the VIP:
+. If the `keepalived` daemon is in use, verify that the recovery control plane node owns the VIP by using the followin:
 +
 [source,terminal]
 ----
@@ -149,7 +217,7 @@ The address of the VIP is highlighted in the output if it exists. This command r
 You can check whether the proxy is enabled by reviewing the output of `oc get proxy cluster -o yaml`. The proxy is enabled if the `httpProxy`, `httpsProxy`, and `noProxy` fields have values set.
 ====
 
-. Run the restore script on the recovery control plane host and pass in the path to the etcd backup directory:
+. Run the restore script on the recovery control plane host and pass in the path to the `etcd` backup directory:
 +
 [source,terminal]
 ----
@@ -184,6 +252,8 @@ static-pod-resources/kube-controller-manager-pod-7/kube-controller-manager-pod.y
 starting kube-scheduler-pod.yaml
 static-pod-resources/kube-scheduler-pod-8/kube-scheduler-pod.yaml
 ----
++
+The cluster-restore.sh script must show that `etcd`, `kube-apiserver`, `kube-controller-manager`, and `kube-scheduler` pods are stopped and then started at the end of the restore process.
 +
 [NOTE]
 ====
@@ -269,7 +339,7 @@ csr-zhhhp   3m8s   kubernetes.io/kube-apiserver-client-kubelet   system:servicea
 <1> A pending kubelet service CSR (for user-provisioned installations).
 <2> A pending `node-bootstrapper` CSR.
 
-.. Review the details of a CSR to verify that it is valid:
+.. Review the details of a CSR to verify that it is valid by running:
 +
 [source,terminal]
 ----
@@ -284,7 +354,7 @@ $ oc describe csr <csr_name> <1>
 $ oc adm certificate approve <csr_name>
 ----
 
-.. For user-provisioned installations, approve each valid kubelet service CSR:
+.. For user-provisioned installations, approve each valid kubelet service CSR by running:
 +
 [source,terminal]
 ----
@@ -293,7 +363,7 @@ $ oc adm certificate approve <csr_name>
 
 . Verify that the single member control plane has started successfully.
 
-.. From the recovery host, verify that the etcd container is running.
+.. From the recovery host, verify that the `etcd` container is running by using:
 +
 [source,terminal]
 ----
@@ -306,7 +376,7 @@ $ sudo crictl ps | grep etcd | egrep -v "operator|etcd-guard"
 3ad41b7908e32       36f86e2eeaaffe662df0d21041eb22b8198e0e58abeeae8c743c3e6e977e8009                                                         About a minute ago   Running             etcd                                          0                   7c05f8af362f0
 ----
 
-.. From the recovery host, verify that the etcd pod is running.
+.. From the recovery host, verify that the etcd pod is running by using:
 +
 [source,terminal]
 ----
@@ -320,16 +390,21 @@ NAME                                             READY   STATUS      RESTARTS   
 etcd-ip-10-0-143-125.ec2.internal                1/1     Running     1          2m47s
 ----
 +
-If the status is `Pending`, or the output lists more than one running etcd pod, wait a few minutes and check again.
+If the status is `Pending`, or the output lists more than one running `etcd` pod, wait a few minutes and check again.
 
-. If you are using the `OVNKubernetes` network plugin, delete the node objects that are associated with control plane hosts that are not the recovery control plane host.
+... If you are using the `OVNKubernetes` network plugin, delete the node objects that are associated with control plane hosts that are not the recovery control plane host by using the following command:
 +
 [source,terminal]
 ----
 $ oc delete node <non-recovery-controlplane-host-1> <non-recovery-controlplane-host-2>
 ----
 
-. Verify that the Cluster Network Operator (CNO) redeploys the OVN-Kubernetes control plane and that it no longer references the non-recovery controller IP addresses. To verify this result, regularly check the output of the following command. Wait until it returns an empty result before you proceed to restart the Open Virtual Network (OVN) Kubernetes pods on all of the hosts in the next step.
+.. Verify that the Cluster Network Operator (CNO) redeploys the OVN-Kubernetes control plane and that it no longer references the non-recovery controller IP addresses. To verify this result, regularly check the output of the following command. Wait until it returns an empty result before you proceed to restart the Open Virtual Network (OVN) Kubernetes pods on all of the hosts in the next step:
++
+[NOTE]
+====
+It can take at least 5-10 minutes for the `OVN-Kubernetes` control plane to be redeployed and the previous command to return empty output.
+====
 +
 [source,terminal]
 ----
@@ -340,8 +415,8 @@ $ oc -n openshift-ovn-kubernetes get ds/ovnkube-master -o yaml | grep -E '<non-r
 ====
 It can take at least 5-10 minutes for the OVN-Kubernetes control plane to be redeployed and the previous command to return empty output.
 ====
-
-. Restart the Open Virtual Network (OVN) Kubernetes pods on all the hosts.
++
+.. Restart the Open Virtual Network (OVN) Kubernetes pods on all the hosts.
 +
 [NOTE]
 ====
@@ -356,14 +431,14 @@ Alternatively, you can temporarily set the `failurePolicy` to `Ignore` while res
 ----
 $ sudo rm -f /var/lib/ovn/etc/*.db
 ----
-
++
 .. Delete all OVN-Kubernetes control plane pods by running the following command:
 +
 [source,terminal]
 ----
 $ oc delete pods -l app=ovnkube-master -n openshift-ovn-kubernetes
 ----
-
++
 .. Ensure that any OVN-Kubernetes control plane pods are deployed again and are in a `Running` state by running the following command:
 +
 [source,terminal]
@@ -418,7 +493,7 @@ In a terminal that has access to the cluster as a cluster-admin user, run the fo
 $ oc get machines -n openshift-machine-api -o wide
 ----
 +
-Example output:
+.Example output:
 +
 [source,terminal]
 ----
@@ -432,7 +507,7 @@ clustername-8qw5l-worker-us-east-1c-pkg26   Running   m4.large    us-east-1   us
 ----
 <1> This is the control plane machine for the lost control plane host, `ip-10-0-131-183.ec2.internal`.
 
-.. Save the machine configuration to a file on your file system:
+.. Save the machine configuration to a file on your file system by running:
 +
 [source,terminal]
 ----
@@ -491,14 +566,14 @@ metadata:
   ...
 ----
 
-... Remove the `spec.providerID` field:
+... Remove the `spec.providerID` field by running:
 +
 [source,terminal]
 ----
 providerID: aws:///us-east-1a/i-0fdb85790d76d0c3f
 ----
 
-... Remove the `metadata.annotations` and `metadata.generation` fields:
+... Remove the `metadata.annotations` and `metadata.generation` fields by running:
 +
 [source,terminal]
 ----
@@ -516,7 +591,7 @@ resourceVersion: "13291"
 uid: a282eb70-40a2-4e89-8009-d05dd420d31a
 ----
 
-.. Delete the machine of the lost control plane host:
+.. Delete the machine of the lost control plane host by running:
 +
 [source,terminal]
 ----
@@ -543,14 +618,14 @@ clustername-8qw5l-worker-us-east-1b-lrdxb   Running   m4.large    us-east-1   us
 clustername-8qw5l-worker-us-east-1c-pkg26   Running   m4.large    us-east-1   us-east-1c   3h28m   ip-10-0-170-181.ec2.internal   aws:///us-east-1c/i-06861c00007751b0a   running
 ----
 
-.. Create a machine by using the `new-master-machine.yaml` file:
+.. Create a machine by using the `new-master-machine.yaml` file by running:
 +
 [source,terminal]
 ----
 $ oc apply -f new-master-machine.yaml
 ----
 
-.. Verify that the new machine has been created:
+.. Verify that the new machine has been created by running:
 +
 [source,terminal]
 ----
@@ -571,7 +646,7 @@ clustername-8qw5l-worker-us-east-1c-pkg26   Running        m4.large    us-east-1
 ----
 <1> The new machine, `clustername-8qw5l-master-3` is being created and is ready after the phase changes from `Provisioning` to `Running`.
 +
-It might take a few minutes for the new machine to be created. The etcd cluster Operator will automatically sync when the machine or node returns to a healthy state.
+It might take a few minutes for the new machine to be created. The `etcd` cluster Operator automatically syncs when the machine or node returns to a healthy state.
 
 .. Repeat these steps for each lost control plane host that is not the recovery host.
 
@@ -591,7 +666,7 @@ This command ensures that you can successfully re-create secrets and roll out th
 $ export KUBECONFIG=/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/localhost-recovery.kubeconfig
 ----
 
-. Force etcd redeployment.
+. Force `etcd` redeployment.
 +
 In the same terminal window where you exported the recovery `kubeconfig` file, run the following command:
 +
@@ -626,7 +701,7 @@ In a terminal that has access to the cluster as a `cluster-admin` user, run the 
 $ oc get etcd -o=jsonpath='{range .items[0].status.conditions[?(@.type=="NodeInstallerProgressing")]}{.reason}{"\n"}{.message}{"\n"}'
 ----
 +
-Review the `NodeInstallerProgressing` status condition for etcd to verify that all nodes are at the latest revision. The output shows `AllNodesAtLatestRevision` upon successful update:
+Review the `NodeInstallerProgressing` status condition for `etcd` to verify that all nodes are at the latest revision. The output shows `AllNodesAtLatestRevision` upon successful update:
 +
 [source,terminal]
 ----
@@ -637,11 +712,11 @@ AllNodesAtLatestRevision
 +
 If the output includes multiple revision numbers, such as `2 nodes are at revision 6; 1 nodes are at revision 7`, this means that the update is still in progress. Wait a few minutes and try again.
 
-. After etcd is redeployed, force new rollouts for the control plane. The Kubernetes API server will reinstall itself on the other nodes because the kubelet is connected to API servers using an internal load balancer.
+. After etcd is redeployed, force new rollouts for the control plane. `kube-apiserver` reinstalls itself on the other nodes because the kubelet is connected to API servers using an internal load balancer.
 +
 In a terminal that has access to the cluster as a `cluster-admin` user, run the following commands.
 
-.. Force a new rollout for the Kubernetes API server:
+.. Force a new rollout for the kube-apiserver:
 +
 [source,terminal]
 ----
@@ -666,14 +741,14 @@ AllNodesAtLatestRevision
 +
 If the output includes multiple revision numbers, such as `2 nodes are at revision 6; 1 nodes are at revision 7`, this means that the update is still in progress. Wait a few minutes and try again.
 
-.. Force a new rollout for the Kubernetes controller manager:
+.. Force a new rollout for the `kubecontrollermanager` by running:
 +
 [source,terminal]
 ----
 $ oc patch kubecontrollermanager cluster -p='{"spec": {"forceRedeploymentReason": "recovery-'"$( date --rfc-3339=ns )"'"}}' --type=merge
 ----
 +
-Verify all nodes are updated to the latest revision.
+Verify all nodes are updated to the latest revision by running:
 +
 [source,terminal]
 ----
@@ -691,7 +766,7 @@ AllNodesAtLatestRevision
 +
 If the output includes multiple revision numbers, such as `2 nodes are at revision 6; 1 nodes are at revision 7`, this means that the update is still in progress. Wait a few minutes and try again.
 
-.. Force a new rollout for the Kubernetes scheduler:
+.. Force a new rollout for the `kube-scheduler` by running:
 +
 [source,terminal]
 ----
@@ -733,7 +808,7 @@ etcd-ip-10-0-154-194.ec2.internal                2/2     Running     0          
 etcd-ip-10-0-173-171.ec2.internal                2/2     Running     0          9h
 ----
 
-To ensure that all workloads return to normal operation following a recovery procedure, restart each pod that stores Kubernetes API information. This includes {product-title} components such as routers, Operators, and third-party components.
+To ensure that all workloads return to normal operation following a recovery procedure, restart each pod that stores `kube-apiserver` information. This includes {product-title} components such as routers, Operators, and third-party components.
 
 [NOTE]
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
ocpbugs#29600:restores-the-etcd-content

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
enterprise-4.12

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
[ocpbugs-29600](https://issues.redhat.com/browse/OCPBUGS-29600)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://72302--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
