### PR TITLE
TELCODOCS-1188 creating new PR 415 416 about adding new parameter

### DIFF
--- a/modules/nw-sriov-networknodepolicy-object.adoc
+++ b/modules/nw-sriov-networknodepolicy-object.adoc
@@ -25,17 +25,18 @@ spec:
   mtu: <mtu> <6>
   needVhostNet: false <7>
   numVfs: <num> <8>
-  nicSelector: <9>
-    vendor: "<vendor_code>" <10>
-    deviceID: "<device_id>" <11>
-    pfNames: ["<pf_name>", ...] <12>
-    rootDevices: ["<pci_bus_id>", ...] <13>
-    netFilter: "<filter_string>" <14>
-  deviceType: <device_type> <15>
-  isRdma: false <16>
-  linkType: <link_type> <17>
-  eSwitchMode: <mode> <18>
-  excludeTopology: false <19>
+  externallyManaged: false <9>
+  nicSelector: <10>
+    vendor: "<vendor_code>" <11>
+    deviceID: "<device_id>" <12>
+    pfNames: ["<pf_name>", ...] <13>
+    rootDevices: ["<pci_bus_id>", ...] <14>
+    netFilter: "<filter_string>" <15>
+  deviceType: <device_type> <16>
+  isRdma: false <17>
+  linkType: <link_type> <18>
+  eSwitchMode: "switchdev" <19>
+  excludeTopology: false <20>
 ----
 <1> The name for the custom resource object.
 
@@ -67,43 +68,47 @@ If you want to create virtual function on the default network interface, ensure 
 
 <8> The number of the virtual functions (VF) to create for the SR-IOV physical network device. For an Intel network interface controller (NIC), the number of VFs cannot be larger than the total VFs supported by the device. For a Mellanox NIC, the number of VFs cannot be larger than `128`.
 
-<9> The NIC selector identifies the device for the Operator to configure. You do not have to specify values for all the parameters. It is recommended to identify the network device with enough precision to avoid selecting a device unintentionally.
+<9> Set `externallyManaged` to `true` to allow the SR-IOV Network Operator to use all or a subset of externally managed virtual functions (VFs) and attach them to pods. With the value set to `false` the SR-IOV Network Operator manages and configures all allocated VFs.
++
+[NOTE]
+====
+When `externallyManaged` is set to `true`, you must create the Virtual Functions (VFs) before applying the policy. If not, the webhook will block the request.
+If `externallyManaged` is set to `false`, the SR-IOV Network Operator handles the creation and management of VFs, including resetting them if necessary. Therefore to use VFs on the host system they must be created manually and `externallyManaged` must be set to `true` so the SR-IOV Network Operator will not take any actions on the PF and the VFs that are not defined in the policy `nicSelector`.
+====
+
+<10> The NIC selector identifies the device for the Operator to configure. You do not have to specify values for all the parameters. It is recommended to identify the network device with enough precision to avoid selecting a device unintentionally.
 +
 If you specify `rootDevices`, you must also specify a value for `vendor`, `deviceID`, or `pfNames`. If you specify both `pfNames` and `rootDevices` at the same time, ensure that they refer to the same device. If you specify a value for `netFilter`, then you do not need to specify any other parameter because a network ID is unique.
 
-<10> Optional: The vendor hexadecimal code of the SR-IOV network device. The only allowed values are `8086` and `15b3`.
+<11> Optional: The vendor hexadecimal code of the SR-IOV network device. The only allowed values are `8086` and `15b3`.
 
-<11> Optional: The device hexadecimal code of the SR-IOV network device. For example, `101b` is the device ID for a Mellanox ConnectX-6 device.
+<12> Optional: The device hexadecimal code of the SR-IOV network device. For example, `101b` is the device ID for a Mellanox ConnectX-6 device.
 
-<12> Optional: An array of one or more physical function (PF) names for the device.
+<13> Optional: An array of one or more physical function (PF) names for the device.
 
-<13> Optional: An array of one or more PCI bus addresses for the PF of the device. Provide the address in the following format: `0000:02:00.1`.
+<14> Optional: An array of one or more PCI bus addresses for the PF of the device. Provide the address in the following format: `0000:02:00.1`.
 
-<14> Optional: The platform-specific network filter. The only supported platform is {rh-openstack-first}. Acceptable values use the following format: `openstack/NetworkID:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`. Replace `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` with the value from the `/var/config/openstack/latest/network_data.json` metadata file.
+<15> Optional: The platform-specific network filter. The only supported platform is {rh-openstack-first}. Acceptable values use the following format: `openstack/NetworkID:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`. Replace `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` with the value from the `/var/config/openstack/latest/network_data.json` metadata file.
 
-<15> Optional: The driver type for the virtual functions. The only allowed values are `netdevice` and `vfio-pci`. The default value is `netdevice`.
+<16> Optional: The driver type for the virtual functions. The only allowed values are `netdevice` and `vfio-pci`. The default value is `netdevice`.
 +
 For a Mellanox NIC to work in DPDK mode on bare metal nodes, use the `netdevice` driver type and set `isRdma` to `true`.
 
-<16> Optional: Configures whether to enable remote direct memory access (RDMA) mode. The default value is `false`.
+<17> Optional: Configures whether to enable remote direct memory access (RDMA) mode. The default value is `false`.
 +
 If the `isRdma` parameter is set to `true`, you can continue to use the RDMA-enabled VF as a normal network device. A device can be used in either mode.
 +
 Set `isRdma` to `true` and additionally set `needVhostNet` to `true` to configure a Mellanox NIC for use with Fast Datapath DPDK applications.
 
-<17> Optional: The link type for the VFs. The default value is `eth` for Ethernet. Change this value to 'ib' for InfiniBand.
+<18> Optional: The link type for the VFs. The default value is `eth` for Ethernet. Change this value to 'ib' for InfiniBand.
 +
 When `linkType` is set to `ib`, `isRdma` is automatically set to `true` by the SR-IOV Network Operator webhook. When `linkType` is set to `ib`, `deviceType` should not be set to `vfio-pci`.
 +
-Do not set linkType to 'eth' for SriovNetworkNodePolicy, because this can lead to an incorrect number of available devices reported by the device plugin.
+Do not set linkType to `eth` for SriovNetworkNodePolicy, because this can lead to an incorrect number of available devices reported by the device plugin.
 
-<18> Optional: The NIC device mode. The only allowed values are `legacy` or `switchdev`.
-+
-When `eSwitchMode` is set to `legacy`, the default SR-IOV behavior is enabled.
-+
-When `eSwitchMode` is set to `switchdev`, hardware offloading is enabled. 
+<19> Optional: To enable hardware offloading, the `eSwitchMode` field must be set to `"switchdev"`.
 
-<19> Optional: To exclude advertising an SR-IOV network resource's NUMA node to the Topology Manager, set the value to `true`. The default value is `false`.
+<20> Optional: To exclude advertising an SR-IOV network resource's NUMA node to the Topology Manager, set the value to `true`. The default value is `false`.
 
 [id="sr-iov-network-node-configuration-examples_{context}"]
 == SR-IOV network node configuration examples


### PR DESCRIPTION
[TELCODOCS-1002]:  [CNF-6356](https://issues.redhat.com//browse/CNF-6356) SR-IOV Network Operator alongside with host-reserved SR-IOV VFs

Version(s):
4.15, 4.16 and main

Issue:
https://issues.redhat.com/browse/TELCODOCS-1188

Link to docs preview: 
https://72304--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-device.html#nw-sriov-networknodepolicy-object_configuring-sriov-device

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
All approvals tracked in https://github.com/openshift/openshift-docs/pull/62354. I created this with same content as other PR is out of sync and it was proving difficult to resolve. 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->