### PR TITLE
moving two assemblies in postinstall to a more logical order

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -627,12 +627,12 @@ Topics:
 - Name: Fedora CoreOS (FCOS) image layering
   File: coreos-layering
   Distros: openshift-origin
-- Name: AWS Local Zone or Wavelength Zone tasks
-  File: aws-compute-edge-zone-tasks
-  Distros: openshift-enterprise
 - Name: Adding failure domains to an existing Nutanix cluster
   File: adding-nutanix-failure-domains
   Distros: openshift-origin,openshift-enterprise
+- Name: AWS Local Zone or Wavelength Zone tasks
+  File: aws-compute-edge-zone-tasks
+  Distros: openshift-enterprise
 - Name: Extending an AWS VPC cluster into an AWS Outpost
   File: configuring-aws-outposts
 ---


### PR DESCRIPTION
Version(s):
4.15+

Issue:
N/A

Link to docs preview:
https://72309--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/adding-nutanix-failure-domains
![image](https://github.com/openshift/openshift-docs/assets/61474374/438498b0-fcfc-4488-b431-031f5036761a)

QE review:
N/A just docs

Additional information:
Just FYI @dfitzmau @mjpytlak 