### PR TITLE
OCPBUGS#29742: Adding clarity for arches in Azure docs

### DIFF
--- a/modules/installation-azure-user-infra-uploading-rhcos.adoc
+++ b/modules/installation-azure-user-infra-uploading-rhcos.adoc
@@ -78,8 +78,12 @@ $ export ACCOUNT_KEY=`az storage account keys list -g ${RESOURCE_GROUP} --accoun
 ifdef::azure[]
 [source,terminal]
 ----
-$ export VHD_URL=`openshift-install coreos print-stream-json | jq -r '.architectures.<architecture>."rhel-coreos-extensions"."azure-disk".url'`
+$ export VHD_URL=`openshift-install coreos print-stream-json | jq -r '.architectures.<architecture>."rhel-coreos-extensions"."azure-disk".url'` 
 ----
++
+where:
+
+`<architecture>`:: Specifies the architecture, valid values include `x86_64` or `aarch64`.
 endif::azure[]
 ifdef::ash[]
 [source,terminal]


### PR DESCRIPTION
**Version(s):** 4.14+
**Issue:** [OCPBUGS-29742](https://issues.redhat.com/browse/OCPBUGS-29742)

**Link to docs preview:**

- [Uploading the RHCOS cluster image and bootstrap Ignition config file](https://72310--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-user-infra#installation-azure-user-infra-uploading-rhcos_installing-azure-user-infra)

**QE review:**
- [x] QE has approved this change.