### PR TITLE
OSDOCS-9742: add view a NP to MicroShift

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -413,6 +413,8 @@ Topics:
     File: microshift-editing-network-policy
   - Name: Deleting network policies
     File: microshift-deleting-network-policy
+  - Name: Viewing network policies
+    File: microshift-viewing-network-policy
 - Name: Firewall configuration
   File: microshift-firewall
 - Name: Networking settings for fully disconnected hosts

--- a/microshift_networking/microshift-network-policy/microshift-viewing-network-policy.adoc
+++ b/microshift_networking/microshift-network-policy/microshift-viewing-network-policy.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="microshift-viewing-network-policy"]
+= Viewing a network policy
+include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-microshift.adoc[]
+:context: microshift-viewing-network-policy
+
+toc::[]
+
+Use the following procedure to view a network policy for a namespace.
+
+include::modules/nw-networkpolicy-view-cli.adoc[leveloffset=+1]

--- a/modules/nw-networkpolicy-view-cli.adoc
+++ b/modules/nw-networkpolicy-view-cli.adoc
@@ -18,17 +18,19 @@ endif::[]
 
 You can examine the {name} policies in a namespace.
 
-ifndef::multi[]
+ifndef::multi,microshift[]
 [NOTE]
 ====
 If you log in with a user with the `cluster-admin` role, then you can view any network policy in the cluster.
 ====
-endif::multi[]
+endif::multi,microshift[]
 
 .Prerequisites
 
 * You installed the OpenShift CLI (`oc`).
+ifndef::microshift[]
 * You are logged in to the cluster with a user with `{role}` privileges.
+endif::microshift[]
 * You are working in the namespace where the {name} policy exists.
 
 .Procedure
@@ -90,8 +92,9 @@ endif::multi[]
 :!name:
 :!role:
 
-
+ifndef::microshift[]
 [NOTE]
 ====
 If you log in to the web console with `cluster-admin` privileges, you have a choice of viewing a network policy in any namespace in the cluster directly in YAML or from a form in the web console.
 ====
+endif::microshift[]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-9742](https://issues.redhat.com/browse/OSDOCS-9742)

Link to docs preview:
[Viewing a network policy](https://72311--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-network-policy/microshift-viewing-network-policy)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Content port from OCP with conditionals

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
