### PR TITLE
OCPBUGS-29907: split modules to move xref

### DIFF
--- a/machine_management/capi-machine-management.adoc
+++ b/machine_management/capi-machine-management.adoc
@@ -47,12 +47,20 @@ Using the Cluster API to manage machines is a Technology Preview feature and has
 
 * Full feature parity with the Machine API is not available.
 
-//Cluster API architecture
-include::modules/cluster-api-architecture.adoc[leveloffset=+1]
+[id="cluster-api-architecture_{context}"]
+== Cluster API architecture
+
+The {product-title} integration of the upstream Cluster API is implemented and managed by the Cluster CAPI Operator. The Cluster CAPI Operator and its operands are provisioned in the `openshift-cluster-api` namespace, in contrast to the Machine API, which uses the `openshift-machine-api` namespace.
+
+//The Cluster CAPI Operator
+include::modules/capi-arch-operator.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../operators/operator-reference.adoc#cluster-capi-operator_cluster-operators-ref[Cluster CAPI Operator]
+
+//Cluster API primary resources
+include::modules/capi-arch-resources.adoc[leveloffset=+2]
 
 [id="capi-sample-yaml-files"]
 == Sample YAML files

--- a/modules/capi-arch-operator.adoc
+++ b/modules/capi-arch-operator.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * machine_management/capi-machine-management.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="capi-arch-operator_{context}"]
+= The Cluster CAPI Operator
+
+The Cluster CAPI Operator is an {product-title} Operator that maintains the lifecycle of Cluster API resources. This Operator is responsible for all administrative tasks related to deploying the Cluster API project within an {product-title} cluster.
+
+If a cluster is configured correctly to allow the use of the Cluster API, the Cluster CAPI Operator installs the Cluster API components on the cluster.
+
+For more information, see the "Cluster CAPI Operator" entry in the _Cluster Operators reference_ content.

--- a/modules/capi-arch-resources.adoc
+++ b/modules/capi-arch-resources.adoc
@@ -2,23 +2,9 @@
 //
 // * machine_management/capi-machine-management.adoc
 
-:_mod-docs-content-type: CONCEPT
-[id="cluster-api-architecture_{context}"]
-= Cluster API architecture
-
-The {product-title} integration of the upstream Cluster API is implemented and managed by the Cluster CAPI Operator. The Cluster CAPI Operator and its operands are provisioned in the `openshift-cluster-api` namespace, in contrast to the Machine API, which uses the `openshift-machine-api` namespace.
-
-[id="capi-arch-operator"]
-== The Cluster CAPI Operator
-
-The Cluster CAPI Operator is an {product-title} Operator that maintains the lifecycle of Cluster API resources. This Operator is responsible for all administrative tasks related to deploying the Cluster API project within an {product-title} cluster.
-
-If a cluster is configured correctly to allow the use of the Cluster API, the Cluster CAPI Operator installs the Cluster API components on the cluster.
-
-For more information, see the entry for the Cluster CAPI Operator in the _Cluster Operators reference_ content.
-
-[id="capi-arch-resources"]
-== Primary resources
+:_mod-docs-content-type: REFERENCE
+[id="capi-arch-resources_{context}"]
+= Cluster API primary resources
 
 The Cluster API consists of the following primary resources. For the Technology Preview of this feature, you must create these resources manually in the `openshift-cluster-api` namespace.
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-29907](https://issues.redhat.com/browse/OCPBUGS-29907)

Link to docs preview:
https://72312--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/capi-machine-management#cluster-api-architecture_capi-machine-management

QE review:
N/A docs only

Additional information: