### PR TITLE
CNV-38655: Update actions text in snapshots tab

### DIFF
--- a/modules/virt-deleting-vm-snapshot-web.adoc
+++ b/modules/virt-deleting-vm-snapshot-web.adoc
@@ -13,5 +13,5 @@ You can delete an existing virtual machine (VM) snapshot by using the web consol
 . Navigate to *Virtualization* -> *VirtualMachines* in the web console.
 . Select a VM to open the *VirtualMachine details* page.
 . Click the *Snapshots* tab to view a list of snapshots associated with the VM.
-. Click the options menu {kebab} beside a snapshot and select *Delete VirtualMachineSnapshot*.
+. Click the options menu {kebab} beside a snapshot and select *Delete snapshot*.
 . Click *Delete*.

--- a/modules/virt-restoring-vm-from-snapshot-web.adoc
+++ b/modules/virt-restoring-vm-from-snapshot-web.adoc
@@ -15,5 +15,5 @@ You can restore a virtual machine (VM) to a previous configuration represented b
 . If the VM is running, click the options menu {kebab} and select *Stop* to power it down.
 . Click the *Snapshots* tab to view a list of snapshots associated with the VM.
 . Select a snapshot to open the *Snapshot Details* screen.
-. Click the options menu {kebab} and select *Restore VirtualMachineSnapshot*.
+. Click the options menu {kebab} and select *Restore VirtualMachine from snapshot*.
 . Click *Restore*.

--- a/virt/getting_started/virt-web-console-overview.adoc
+++ b/virt/getting_started/virt-web-console-overview.adoc
@@ -277,12 +277,12 @@ The *Cluster* tab displays the {VirtProductName} version and update status. You 
 |Select a dedicated secondary network for live migration.
 
 |*General Settings* -> *SSH Configuration* -> *SSH over LoadBalancer service* switch
-|Enable the creation of LoadBalancer services for SSH connections to VMs. 
+|Enable the creation of LoadBalancer services for SSH connections to VMs.
 
 You must configure a load balancer.
 
 |*General Settings* -> *SSH Configuration* -> *SSH over NodePort service* switch
-|Allow the creation of node port services for SSH connections to virtual machines. 
+|Allow the creation of node port services for SSH connections to virtual machines.
 
 |*General Settings* -> *Template project* section
 |Expand this section to select a project for Red Hat templates. The default project is `openshift`.
@@ -1002,7 +1002,7 @@ You can create a snapshot, create a copy of a virtual machine from a snapshot, r
 
 Click the snapshot name to edit the labels or annotations.
 
-Click the actions menu {kebab} beside a snapshot to select *Create VirtualMachine*, *Restore*, or *Delete*.
+Click the options menu {kebab} beside a snapshot to select *Create VirtualMachine*, *Restore VirtualMachine from snapshot*, or *Delete snapshot*.
 |====
 =====
 


### PR DESCRIPTION
Version(s): 4.16+

Issue: [CNV-38655](https://issues.redhat.com/browse/CNV-38655)

Links to docs preview:

- [Snapshot table](https://72313--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/getting_started/virt-web-console-overview)
- [Deleting a snapshot by using the web console](https://72313--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-backup-restore-snapshots#virt-deleting-vm-snapshot-web_virt-backup-restore-snapshots)
- [Restoring a VM from a snapshot by using the web console](https://72313--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-backup-restore-snapshots)

QE review:
- [x] QE has approved this change.

