### PR TITLE
ICSP and IDMS interoperability release note 4.14

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3650,6 +3650,13 @@ $ oc adm release info 4.14.3 --pullspecs
 [id="ocp-4-14-3-bug-fixes"]
 ==== Bug fixes
 
+* Previously, `ImageDigestMirrorSet` (IDMS) and `ImageTagMirrorSet` (ITMS) objects could not be used if there were any `ImageContentSourcePolicy` (ICSP) objects in the cluster. As a result, to use IDMS or ITMS objects, you needed to delete any ICSP objects in the cluster, which required a cluster reboot. With this release, ICSP, IDMS, and ITMS objects now function in the same cluster at the same time. As a result, you can use any or all of the three types of objects to configure repository mirroring after the cluster is installed. For more information, see xref:../post_installation_configuration/preparing-for-users.html#images-configuration-registry-mirror_post-install-preparing-for-users[Understanding image registry repository mirroring]. (link:https://issues.redhat.com/browse/RHIBMCS-185[RHIBMCS-185])
++
+[IMPORTANT]
+====
+Using an ICSP object to configure repository mirroring is a deprecated feature. Deprecated functionality is still included in {product-title} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.
+====
+
 * Previously, `LoadBalancer` services were not created for a deployment if a node contained an additional port with the `enable_port_security` parameter set to `false`. With this release, `LoadBalancer` services are created for a deployment that contains additional ports with this setting. (link:https://issues.redhat.com/browse/OCPBUGS-22974[*OCPBUGS-22974*])
 
 * Previously, a `ClusterAutoscaler` resource would go into a `CrashBackoff` loop for nodes configured with the Container Storage Interface (CSI) implementation. This release updated dependencies so that a `ClusterAutoscaler` resource no longer goes into a `CrashBackoff` for nodes configured in this way. (link:https://issues.redhat.com/browse/OCPBUGS-23270[*OCPBUGS-23270*])


### PR DESCRIPTION
Release note for https://github.com/openshift/openshift-docs/pull/70881

Issues: 
https://issues.redhat.com//browse/OCPBUGS-22275
https://issues.redhat.com/browse/OSDOCS-9304

Preview: https://72317--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-3-bug-fixes

[Change management discussion](https://redhat-internal.slack.com/archives/C06LX2S9NDU/p1709142556910039) in Slack.

Text is the same as https://github.com/openshift/openshift-docs/pull/72316