### PR TITLE
OCPBUGS-20430 - Updates incorrect ConfigMap namespace: multicluster-engine

### DIFF
--- a/modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc
+++ b/modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc
@@ -28,8 +28,8 @@ If you enable TLS for the HTTP server, you must confirm the root certificate is 
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: assisted-installer-config-map
-  namespace: "<infrastructure_operator_namespace>" <1>
+  name: assisted-installer-mirror-config
+  namespace: multicluster-engine <1>
   labels:
     app: assisted-service
 data:
@@ -49,7 +49,7 @@ data:
        [[registry.mirror]]
        location = "mirror1.registry.corp.com:5000/example-repository" <5>
 ----
-<1> The `ConfigMap` namespace must be the same as the namespace of the Infrastructure Operator.
+<1> The `ConfigMap` namespace must be set to `multicluster-engine`.
 <2> The mirror registry’s certificate that is used when creating the mirror registry.
 <3> The configuration file for the mirror registry. The mirror registry configuration adds mirror information to the `/etc/containers/registries.conf` file in the discovery image. The mirror information is stored in the `imageContentSources` section of the `install-config.yaml` file when the information is passed to the installation program. The Assisted Service pod that runs on the hub cluster fetches the container images from the configured mirror registry.
 <4> The URL of the mirror registry. You must use the URL from the `imageContentSources` section by running the `oc adm release mirror` command when you configure the mirror registry. For more information, see the _Mirroring the OpenShift Container Platform image repository_ section.
@@ -65,6 +65,7 @@ apiVersion: agent-install.openshift.io/v1beta1
 kind: AgentServiceConfig
 metadata:
   name: agent
+  namespace: multicluster-engine <1>
 spec:
   databaseStorage:
     volumeName: <db_pv_name>
@@ -81,12 +82,14 @@ spec:
       requests:
         storage: <fs_storage_size>
   mirrorRegistryRef:
-    name: 'assisted-installer-mirror-config'
+    name: 'assisted-installer-mirror-config' <2>
   osImages:
     - openshiftVersion: <ocp_version>
-      url: <iso_url> <1>
+      url: <iso_url> <3>
 ----
-<1> Must match the URL of the HTTPD server.
+<1> Set the `AgentServiceConfig` namespace to `multicluster-engine` to match the `ConfigMap` namespace
+<2> Set `mirrorRegistryRef.name` to match the definition specified in the related `ConfigMap` CR
+<3> Set the URL for the ISO hosted on `httpd` server
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Updates incorrect `ConfigMap` namespace in the GitOps ZTP docs. Namespace corrected to `multicluster-engine`.

Version(s):
enterprise-4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-20430

Link to docs preview:
https://72318--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster#ztp-configuring-the-cluster-for-a-disconnected-environment_ztp-preparing-the-hub-cluster

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->