### PR TITLE
OSSM-6010 [DOC] Update user-workload monitoring so Kiali can fetch metrics from Thanos

### DIFF
--- a/modules/ossm-integrating-with-user-workload-monitoring.adoc
+++ b/modules/ossm-integrating-with-user-workload-monitoring.adoc
@@ -19,28 +19,22 @@ The following steps show how to integrate Service Mesh with user-workload monito
 
 .Procedure
 
-. Create a token to Thanos for Kiali by running the following commands:
+. Grant the `cluster-monitoring-view` role to the Kiali Service Account, replacing `<kiali-namespace>` with the name of the Kiali deployment namespace:
 +
-.. Set the `SECRET` environment variable by running the following command:
-+
-[source,terminal]
+[source,yaml]
 ----
-$ SECRET=`oc get secret -n openshift-user-workload-monitoring |
- grep  prometheus-user-workload-token | head -n 1 | awk '{print $1 }'`
-----
-+
-.. Set the `TOKEN` environment variable by running the following command:
-+
-[source,terminal]
-----
-$ TOKEN=`oc get secret $SECRET -n openshift-user-workload-monitoring -o jsonpath='{.data.token}' | base64 -d`
-----
-+
-.. Create a token to Thanos for Kiali by running the following command:
-+
-[source,terminal]
-----
-$ oc create secret generic thanos-querier-web-token -n istio-system --from-literal=token=$TOKEN
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: 
+  name: kiali-monitoring-rbac
+roleRef: 
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects: 
+- kind: ServiceAccount
+  name: kiali-service-account
+  namespace: <kiali-namespace>
 ----
 
 . Configure Kiali for user-workload monitoring:
@@ -52,15 +46,37 @@ kind: Kiali
 metadata:
   name: kiali-user-workload-monitoring
   namespace: istio-system
-spec: 
-  external_services: 
-    istio: 
+spec:
+  external_services:
+    prometheus:
+      auth:
+        token: secret:thanos-querier-web-token:token
+        type: bearer
+        use_kiali_token: false
+      query_scope:
+        mesh_id: "basic-istio-system"
+      thanos_proxy:
+        enabled: true
+      url: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
+----
+** If you use Istio Operator 2.4, use this configuration to configure Kiali for user-workload monitoring:
++
+[source,yaml]
+----
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+metadata:
+  name: kiali-user-workload-monitoring
+  namespace: istio-system
+spec:
+  external_services:
+    istio:
       config_map_name: istio-<smcp-name>
       istio_sidecar_injector_config_map_name: istio-sidecar-injector-<smcp-name>
       istiod_deployment_name: istiod-<smcp-name>
       url_service_version: 'http://istiod-<smcp-name>.istio-system:15014/version'
-    prometheus: 
-      auth: 
+    prometheus:
+      auth:
         token: secret:thanos-querier-web-token:token
         type: bearer
         use_kiali_token: false
@@ -168,7 +184,7 @@ spec:
 ====
 If there is only one mesh using user-workload monitoring, then both the `mesh_id` relabeling and the `spec.prometheus.query_scope` field in the Kiali resource are optional (but the `query_scope` field given here should be removed if the `mesh_id` label is removed).
 
-If multiple mesh instances on the cluster may use user-workload monitoring, then both the `mesh_id` relabelings and the `spec.prometheus.query_scope` field in the Kiali resource are required. This ensures that Kiali only sees metrics from its associated mesh.
+If multiple mesh instances on the cluster might use user-workload monitoring, then both the `mesh_id` relabelings and the `spec.prometheus.query_scope` field in the Kiali resource are required. This ensures that Kiali only sees metrics from its associated mesh.
 
 If you are not deploying Kiali, you can still apply `mesh_id` relabeling so that metrics from different meshes can be distinguished from one another.
 ====
@@ -227,7 +243,7 @@ spec:
 ====
 If there is only one mesh using user-workload monitoring, then both the `mesh_id` relabeling and the `spec.prometheus.query_scope` field in the Kiali resource are optional (but the `query_scope` field given here should be removed if the `mesh_id` label is removed).
 
-If multiple mesh instances on the cluster may use user-workload monitoring, then both the `mesh_id` relabelings and the `spec.prometheus.query_scope` field in the Kiali resource are required. This ensures that Kiali only sees metrics from its associated mesh.
+If multiple mesh instances on the cluster might use user-workload monitoring, then both the `mesh_id` relabelings and the `spec.prometheus.query_scope` field in the Kiali resource are required. This ensures that Kiali only sees metrics from its associated mesh.
 
 If you are not deploying Kiali, you can still apply `mesh_id` relabeling so that metrics from different meshes can be distinguished from one another.
 ====


### PR DESCRIPTION
[OSSM-6010](https://issues.redhat.com//browse/OSSM-6010) [DOC] Update user-workload monitoring so Kiali can fetch metrics from Thanos

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSSM-6010

Link to docs preview:
https://72324--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-observability#ossm-integrating-with-user-workload-monitoring_observability 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Updating Step 1 due to changes in OpenShift 4.15. 

Also changed "may" to "might" in NOTE to be in line with current IBM/Red Hat Style. 

Per Jacek, change made to Step 2 per his PR https://github.com/maistra/istio-operator/pull/1653 . This is not part of the Jira issue associated with this PR, however, the change is necessary and in the same file so it seems sensible to make the change before this PR has gone through all approval processes.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
