### PR TITLE
OSDOCS-9794: add build file 4.16 MicroShift release notes

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -33,8 +33,8 @@ Name: Release notes
 Dir: microshift_release_notes
 Distros: microshift
 Topics:
-- Name: Red Hat build of MicroShift 4.15 release notes
-  File: microshift-4-15-release-notes
+- Name: Red Hat build of MicroShift 4.16 release notes
+  File: microshift-4-16-release-notes
 ---
 Name: Getting started
 Dir: microshift_getting_started

--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="microshift-4-16-release-notes"]
+= {product-title} {product-version} release notes
+include::_attributes/attributes-microshift.adoc[]
+:context: release-notes
+
+Do not add or edit release notes here. Edit release notes directly in the branch
+that they are relevant for.
+
+Release note changes should be added/edited in their own PR.
+
+This file is here to allow builds to work.

--- a/microshift_welcome/index.adoc
+++ b/microshift_welcome/index.adoc
@@ -16,7 +16,7 @@ To get started with {microshift-short}, use the following links:
 
 * xref:../microshift_getting_started/microshift-understanding.adoc#microshift-understanding[Understanding {product-title}]
 * xref:../microshift_install/microshift-install-rpm.adoc#microshift-install-rpm[Installing {product-title}]
-* xref:../microshift_release_notes/microshift-4-15-release-notes.adoc#microshift-4-15-release-notes[{product-title} release notes]
+* xref:../microshift_release_notes/microshift-4-16-release-notes.adoc#microshift-4-16-release-notes[{product-title} release notes]
 
 For related information, use the following links:
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Version(s):
main

Issue:
[OSDOCS-9794](https://issues.redhat.com/browse/OSDOCS-9794)

Link to docs preview:
[Build file](https://72325--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes#microshift-4-16-release-notes)

QE review:
- N/A docs plumbing

Template https://github.com/openshift/openshift-docs/pull/72323

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
