### PR TITLE
OCPBUGS#22656: Update MultiNamespacedCacheBuilder link for OSDK tutorial

### DIFF
--- a/modules/osdk-golang-manager.adoc
+++ b/modules/osdk-golang-manager.adoc
@@ -22,7 +22,7 @@ By default, the Manager watches the namespace where the Operator runs. To watch 
 mgr, err := ctrl.NewManager(cfg, manager.Options{Namespace: ""})
 ----
 
-You can also use the link:https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/cache#MultiNamespacedCacheBuilder[`MultiNamespacedCacheBuilder`] function to watch a specific set of namespaces:
+You can also use the link:https://pkg.go.dev/github.com/kubernetes-sigs/controller-runtime@v0.2.0-alpha.0/pkg/cache#MultiNamespacedCacheBuilder[`MultiNamespacedCacheBuilder`] function to watch a specific set of namespaces:
 
 [source,go]
 ----


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-22656

4.12+

Updates to a valid reference link, as the original URL did not actually show `MultiNamespacedCacheBuilder` in the Go docs.

Preview: https://72338--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-tutorial.html#osdk-golang-manager_osdk-golang-tutorial