### PR TITLE
Adding Known Issue to 1.5 RN for kernel taint warning

### DIFF
--- a/network_observability/network-observability-operator-release-notes.adoc
+++ b/network_observability/network-observability-operator-release-notes.adoc
@@ -96,6 +96,8 @@ With this fix, the status only becomes `Ready` when all the underlying component
 === Known issues
 * When trying to access the web console, cache issues on OCP 4.14.10 prevent access to the *Observe* view. The web console shows the error message: `Failed to get a valid plugin manifest from /api/plugins/monitoring-plugin/`. The recommended workaround is to update the cluster to the latest minor version. If this does not work, you need to apply the workarounds described in this link:https://access.redhat.com/solutions/7052408[Red Hat Knowledgebase article].(link:https://issues.redhat.com/browse/NETOBSERV-1493[*NETOBSERV-1493*])
 
+* Since the 1.3.0 release of the Network Observability Operator, installing the Operator causes a warning kernel taint to appear. The reason for this error is that the Network Observability eBPF agent has memory constraints that prevent preallocating the entire hashmap table. The Operator eBPF agent sets the `BPF_F_NO_PREALLOC` flag so that pre-allocation is disabled when the hashmap is too memory expansive. 
+
 [id="network-observability-operator-release-notes-1-4-2"]
 == Network Observability Operator 1.4.2
 The following advisory is available for the Network Observability Operator 1.4.2:
@@ -218,6 +220,8 @@ Network Observability Operator can now run on `s390x` architecture. Previously i
 
 * Currently, when the `processor.metrics.server.tls.type` is configured to use a `PROVIDED` certificate, the operator enters an unsteady state that might affect its performance and resource consumption. It is recommended to not use a `PROVIDED` certificate until this issue is resolved, and instead using an auto-generated certificate, setting `processor.metrics.server.tls.type` to `AUTO`. (link:https://issues.redhat.com/browse/NETOBSERV-1293)[*NETOBSERV-1293*]
 
+* Since the 1.3.0 release of the Network Observability Operator, installing the Operator causes a warning kernel taint to appear. The reason for this error is that the Network Observability eBPF agent has memory constraints that prevent preallocating the entire hashmap table. The Operator eBPF agent sets the `BPF_F_NO_PREALLOC` flag so that pre-allocation is disabled when the hashmap is too memory expansive.
+
 [id="network-observability-operator-release-notes-1-3"]
 == Network Observability Operator 1.3.0
 The following advisory is available for the Network Observability Operator 1.3.0:
@@ -277,6 +281,8 @@ The release of Network Observability Operator 1.3 deprecates the `spec.Loki.auth
 * When `processor.metrics.tls` is set to `PROVIDED` in the `FlowCollector`, the `flowlogs-pipeline` `servicemonitor` is not adapted to the TLS scheme. (link:https://issues.redhat.com/browse/NETOBSERV-1087[*NETOBSERV-1087*])
 
 * Since the 1.2.0 release of the Network Observability Operator, using {loki-op} 5.6, a Loki certificate change periodically affects the `flowlogs-pipeline` pods and results in dropped flows rather than flows written to Loki. The problem self-corrects after some time, but it still causes temporary flow data loss during the Loki certificate change. This issue has only been observed in large-scale environments of 120 nodes or greater.(link:https://issues.redhat.com/browse/NETOBSERV-980[*NETOBSERV-980*])
+
+* When you install the Operator, a warning kernel taint can appear. The reason for this error is that the Network Observability eBPF agent has memory constraints that prevent preallocating the entire hashmap table. The Operator eBPF agent sets the `BPF_F_NO_PREALLOC` flag so that pre-allocation is disabled when the hashmap is too memory expansive.
 
 [id="network-observability-operator-release-notes-1-2"]
 == Network Observability Operator 1.2.0


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-29826
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
- [1.5 Known Issues](https://72349--ocpdocs-pr.netlify.app/openshift-enterprise/latest/network_observability/network-observability-operator-release-notes#network-observability-operator-1.5.0-known-issue)
- [1.4 Known Issues](https://72349--ocpdocs-pr.netlify.app/openshift-enterprise/latest/network_observability/network-observability-operator-release-notes#network-observability-operator-1.4.0-known-issues)
- [1.3 Known Issues](https://72349--ocpdocs-pr.netlify.app/openshift-enterprise/latest/network_observability/network-observability-operator-release-notes#network-observability-operator-1.3.0-known-issues)
QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
