### PR TITLE
OCPBUGS#22660: Update link to operator-lib in OSDK tutorial

### DIFF
--- a/modules/osdk-run-proxy.adoc
+++ b/modules/osdk-run-proxy.adoc
@@ -42,7 +42,7 @@ This tutorial uses `HTTP_PROXY` as an example environment variable.
 .Procedure
 ifdef::golang[]
 . Edit the `controllers/memcached_controller.go` file to include the following:
-.. Import the `proxy` package from the link:https://github.com/operator-framework/operator-lib/releases/tag/v0.7.0[`operator-lib`] library:
+.. Import the `proxy` package from the link:https://github.com/operator-framework/operator-lib[`operator-lib`] library:
 +
 [source,golang]
 ----


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-22660

4.12+

Updates link to operator-lib to the project landing page instead of a specific tag.

Preview: https://72355--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-tutorial.html#osdk-run-proxy_osdk-golang-tutorial