### PR TITLE
[enterprise-4.13] PSA and SCC Coexistence for PSA RHIBMCS-145

### DIFF
--- a/authentication/understanding-and-managing-pod-security-admission.adoc
+++ b/authentication/understanding-and-managing-pod-security-admission.adoc
@@ -8,6 +8,9 @@ toc::[]
 
 Pod security admission is an implementation of the link:https://kubernetes.io/docs/concepts/security/pod-security-standards/[Kubernetes pod security standards]. Use pod security admission to restrict the behavior of pods.
 
+// Understanding pod security admission coexistence
+include::modules/security-context-constraints-psa-coexistence.adoc[leveloffset=+1]
+
 // Security context constraint synchronization with pod security standards
 include::modules/security-context-constraints-psa-synchronization.adoc[leveloffset=+1]
 

--- a/modules/security-context-constraints-psa-coexistence.adoc
+++ b/modules/security-context-constraints-psa-coexistence.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * authentication/understanding-and-managing-pod-security-admission.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="security-context-constraints-psa-coexistence_{context}"]
+= Pod security admission and security context constraints
+
+Pod security admission standards and security context constraints are reconciled and enforced by two independent controllers. The two controllers work independently using the following processes to enforce security policies:
+
+. The security context constraint controller may mutate some security context fields per the pod's assigned SCC. For example, if the seccomp profile is empty or not set and if the pod's assigned SCC enforces `seccompProfiles` field to be `runtime/default`, the controller sets the default type to `RuntimeDefault`.
+
+. The security context constraint controller validates the pod's security context against the matching SCC.
+
+. The pod security admission controller validates the pod's security context against the pod security standard assigned to the namespace.


### PR DESCRIPTION
Manual CP of #70124 to 4.13. Placement isn't as great as 4.14+, but that's the earliest we have the new reorg/addition of more background info on PSA.