### PR TITLE
OSDOCS-9589: Update Architecture Models Sub-Section to Show the Differences between Classic and HCP

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -28,6 +28,8 @@ Distros: openshift-rosa
 Topics:
 - Name: Welcome
   File: index
+- Name: Learn more about ROSA with HCP
+  File: about-hcp
 - Name: Legal notice
   File: legal-notice
   Distros: openshift-rosa

--- a/modules/rosa-architecture.adoc
+++ b/modules/rosa-architecture.adoc
@@ -1,21 +1,34 @@
 // Module included in the following assemblies:
 //
 // * rosa_architecture/rosa_architecture_sub/rosa-architecture-models.adoc
-[id="rosa-architecture_{context}"]
-= ROSA architecture on public and private networks
 
-You can install ROSA using either a public or private network. Configure a private cluster and private network connection during or after the cluster creation process.
-Red Hat manages the cluster with limited access through a public network. For more information, see xref:../../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-service-definition[ROSA service definition].
+[id="rosa-classic-architecture_{context}"]
+= ROSA Classic architecture
+
+In {product-rosa} (ROSA) Classic, both the control plane and the worker nodes are deployed in your VPC subnets.
+
+[id="rosa-classic-architecture-networks_{context}"]
+== ROSA Classic architecture on public and private networks
+
+With ROSA Classic, you can create clusters that are accessible over public or private networks.
+
+You can customize access patterns for your API server endpoint and Red Hat SRE management in the following ways:
+
+* Public - API server endpoint and application routes are internet-facing.
+
+* Private - API server endpoint and application routes are private. Private ROSA Classic clusters use some public subnets, but no control plane or worker nodes are deployed in public subnets.
+
+* Private with AWS PrivateLink - API server endpoint and application routes are private. Public subnets or NAT gateways are not required in your VPC for egress. ROSA SRE management uses AWS PrivateLink.
+
+The following image depicts the architecture of a ROSA Classic cluster deployed on both public and private networks.
 
 .ROSA Classic deployed on public and private networks
 image::156_OpenShift_ROSA_Arch_0621_private_public_classic.png[ROSA deployed on public and private networks]
 
-If you are using {hcp-title-first}, you can create your clusters on public and private networks as well. The following images depict the architecture of both public and private networks.
+ROSA Classic clusters include infrastructure nodes where OpenShift components such as the ingress controller, image registry, and monitoring are deployed. The infrastructure nodes and the OpenShift components deployed on them are managed by ROSA Service SREs.
 
-.ROSA with HCP deployed on a public network
-image::ROSA-HCP-and-ROSA-Classic-public.png[ROSA with HCP deployed on a public network]
+The following types of clusters are available with ROSA Classic:
 
-.ROSA with HCP deployed on a private network
-image::ROSA-HCP-and-ROSA-Classic-private.png[ROSA with HCP deployed on a private network]
+* Single zone cluster - The control plane and worker nodes are hosted on a single availability zone.
 
-Alternatively, you can install a ROSA Classic cluster using AWS PrivateLink, which is hosted on private subnets only.
+* Multi-zone cluster - The control plane is hosted on three availability zones with an option to run worker nodes on one or three availability zones.

--- a/modules/rosa-hcp-architecture.adoc
+++ b/modules/rosa-hcp-architecture.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * rosa_architecture/rosa_architecture_sub/rosa-architecture-models.adoc
+
+[id="rosa-hcp-architecture_{context}"]
+= ROSA with HCP architecture
+
+In {hcp-title-first}, the ROSA service hosts a highly-available, single-tenant OpenShift control plane. The hosted control plane is deployed across 3 availability zones with 2 API server instances and 3 etcd instances. 
+
+You can create a ROSA with HCP cluster with or without an internet-facing API server. Private API servers are only accessible from your VPC subnets. You access the hosted control plane through an AWS PrivateLink endpoint. 
+
+The worker nodes are deployed in your AWS account and run on your VPC private subnets. You can add additional private subnets from one or more availability zones to ensure high availability. Worker nodes are shared by OpenShift components and applications. OpenShift components such as the ingress controller, image registry, and monitoring are deployed on the worker nodes hosted on your VPC.
+
+[id="rosa-hcp-network-architecture_{context}"]
+== ROSA with HCP architecture on public and private networks
+With ROSA with HCP, you can create your clusters on public or private networks. The following images depict the architecture of both public and private networks.
+
+.ROSA with HCP deployed on a public network
+image::ROSA-HCP-and-ROSA-Classic-public.png[ROSA with HCP deployed on a public network]
+
+.ROSA with HCP deployed on a private network
+image::ROSA-HCP-and-ROSA-Classic-private.png[ROSA with HCP deployed on a private network]

--- a/modules/rosa-hcp-classic-comparison.adoc
+++ b/modules/rosa-hcp-classic-comparison.adoc
@@ -1,97 +1,48 @@
 // Module included in the following assemblies:
 //
-// * rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+// * rosa-architecture-models.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="rosa-hcp-classic-comparison_{context}"]
-= Comparing ROSA with hosted control planes and ROSA Classic
-
-{hcp-title-first} offers a different way to create a managed {product-title} (ROSA) cluster. {hcp-title} offers a reduced-cost solution with focuses on reliability and efficiency. With a focus on efficiency, you can quickly create a new cluster and deploy applications in minutes.
-
-{hcp-title} requires only a minimum of two nodes making it ideal for smaller projects while still being able to scale to support larger projects and enterprises.
+= Comparing ROSA with HCP and ROSA Classic
 
 .ROSA architectures comparison table
 
 [cols="3a,8a,8a",options="header"]
 |===
 | {nbsp} +
-| Hosted Control Plane
-| Classic
+| *Hosted Control Plane (HCP)*
+| *Classic*
 
-| *Cluster infrastructure hosting*
-| {hcp-title} deploys control plane components, such as etcd, API server, and oauth, that are hosted separately on AWS in a Red Hat-owned and managed account.
-| ROSA Classic deploys the control plane components side by side with infrastructure and worker nodes that are hosted together in the customer’s same AWS account.
+| *Control plane hosting*
+| Control plane components, such as the API server etcd database, are hosted in a Red Hat-owned AWS account.
+| Control plane components, such as the API server etcd database, are hosted in a customer-owned AWS account.
 
-| *Provisioning Time*
-| Approximately 10 minutes
-| Approximately 40 minutes
+| *Virtual Private Cloud (VPC)*
+| Worker nodes communicate with the control plane over link:https://docs.aws.amazon.com/vpc/latest/privatelink/what-is-privatelink.html[AWS PrivateLink].
+| Worker nodes and control plane nodes are deployed in the customer's VPC.
 
-| *Architecture*
-|
-    * Underlying control plane infrastructure is fully managed
-    * Customer can access control plane infrastructure through dedicated and explicitly exposed endpoints
-    * Worker nodes are hosted in the customer's AWS account
-|
-    * Customer is responsible for hosting control plane and AWS infrastructure, while still being _managed_ by Red Hat
-    * Worker nodes are hosted in the customer's AWS account
+| *Multi-zone deployment*
+| The control plane is always deployed across multiple availability zones (AZs).
+| The control plane can be deployed within a single AZ or across multiple AZs.
 
-| *Minimum Amazon EC2 footprint*
-| One cluster requires a minimum of two nodes
-| One cluster requires a minimum of seven nodes
+| *Machine pools*
+| Each machine pool is deployed in a single AZ (private subnet).
+| Machine pools can be deployed in single AZ or across multiple AZs.
 
-| *Deployment*
-|
-    * Deploy using the ROSA CLI (`rosa`)
-    * Customers provision "Hosted Clusters" that deploy the control plane components into Red Hat's AWS account
-    * Customers provision "Machine Pools" that deploy worker nodes into the customer's AWS account
-|
-    * Deploy using the ROSA CLI or the web UI
-    * Full cluster provisioning occurs in customer's AWS account
+| *Infrastructure Nodes*
+| Does not use any dedicated nodes to host platform components, such as ingress and image registry.
+| Uses 2 (single-AZ) or 3 (multi-AZ) dedicated nodes to host platform components.
 
-| *Upgrades*
-| Selectively upgrade control plane and machine pools separately
-| Entire cluster is upgraded at one time
+| *OpenShift Capabilities*
+| Platform monitoring, image registry, and the ingress controller are deployed in the worker nodes.
+| Platform monitoring, image registry, and the ingress controller are deployed in the dedicated infrastructure nodes.
 
-| *Regional Availability*
-|
-* US East - N. Virginia (us-east-1)
-* US East - Ohio (us-east-2)
-* US West - Oregon (us-west-2)
-* Africa - Cape Town (af-south-1)
-* Asia Pacific - Hyderabad (ap-south-2)
-* Asia Pacific - Jakarta (ap-southeast-3)
-* Asia Pacific - Melbourne (ap-southeast-4)
-* Asia Pacific - Mumbai (ap-south-1)
-* Asia Pacific - Seoul (ap-northeast-2)
-* Asia Pacific - Singapore (ap-southeast-1)
-* Asia Pacific - Sydney (ap-southeast-2)
-* Asia Pacific - Tokyo (ap-northeast-1)
-* Canada - Central (ca-central-1)
-* Europe - Frankfurt (eu-central-1)
-* Europe - Ireland (eu-west-1)
-* Europe - London (eu-west-2)
-* Europe - Milan (eu-south-1)
-* Europe - Stockholm (eu-north-1)
-* Middle East - Bahrain (me-south-1)
-| For AWS Region availability, see link:https://docs.aws.amazon.com/general/latest/gr/rosa.html[Red Hat OpenShift Service on AWS endpoints and quotas] in the AWS documentation.
+| *Cluster upgrades*
+| The control plane and each machine pool can be upgraded separately.
+| The entire cluster must be upgraded at the same time.
 
-| *Compliance*
-|
-    * Compliance certifications and FIPS are not yet available.
-|
-    * Compliance specifics are located in the {product-title} documentation.
+| *Minimum EC2 footprint*
+| 2 EC2 instances are needed to create a cluster.
+| 7 (single-AZ) or 9 (multi-AZ) EC2 instances are needed to create a cluster.
 |===
-
-[id="rosa-hcp-classic-comparison-networks_{context}"]
-== ROSA architecture network comparisons
-
-ROSA Classic and ROSA with HCP offer options to install your cluster on public and private networks. The following images show the differences between these options.
-
-.ROSA Classic deployed on public and private networks
-image::156_OpenShift_ROSA_Arch_0621_private_public_classic.png[ROSA deployed on public and private networks]
-
-.ROSA with HCP deployed on a public network
-image::ROSA-HCP-and-ROSA-Classic-public.png[ROSA with HCP deployed on a public network]
-
-.ROSA with HCP deployed on a private network
-image::ROSA-HCP-and-ROSA-Classic-private.png[ROSA with HCP deployed on a private network]

--- a/rosa_architecture/rosa_architecture_sub/rosa-architecture-models.adoc
+++ b/rosa_architecture/rosa_architecture_sub/rosa-architecture-models.adoc
@@ -2,16 +2,26 @@
 [id="rosa-architecture-models"]
 = Architecture models
 include::_attributes/attributes-openshift-dedicated.adoc[]
+include::_attributes/common-attributes.adoc[]
 :context: rosa-architecture-models
 
 toc::[]
 
-ROSA has two installation offerings. The architecture supports the following network configuration types:
+{product-rosa} (ROSA) has the following cluster topologies:
 
-* Public network
-* Private network
-* AWS PrivateLink (ROSA Classic only)
+* Hosted control plane (HCP) - The control plane is hosted in a Red Hat account and the worker nodes are deployed in the customer's AWS account.
+* Classic - The control plane and the worker nodes are deployed in the customer's AWS account.
 
+include::modules/rosa-hcp-classic-comparison.adoc[leveloffset=+1]
+
+.Additional resources
+
+* For AWS region availability, see the xref:../../rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc#rosa-sdpolicy-regions-az_rosa-hcp-service-definition[{hcp-title} regions and availability zones].
+
+* For compliance status, see the xref:../../rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.adoc#rosa-policy-compliance_rosa-policy-process-security[security and regulation compliance] documentation.
+
+
+include::modules/rosa-hcp-architecture.adoc[leveloffset=+1]
 include::modules/rosa-architecture.adoc[leveloffset=+1]
-include::modules/osd-aws-privatelink-architecture.adoc[leveloffset=+1]
-include::modules/rosa-architecture-local-zones.adoc[leveloffset=+1]
+include::modules/osd-aws-privatelink-architecture.adoc[leveloffset=+2]
+include::modules/rosa-architecture-local-zones.adoc[leveloffset=+2]

--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
@@ -26,9 +26,8 @@ Since it is not possible to upgrade or convert existing ROSA clusters to a {hcp}
 ====
 
 .Further reading
+* For a comparison between {hcp-title} and ROSA Classic, see the xref:../rosa_architecture/rosa_architecture_sub/rosa-architecture-models.adoc#rosa-hcp-classic-comparison_rosa-architecture-models[Comparing architecture models] documentation.
 * See the AWS documentation for information about link:https://docs.aws.amazon.com/rosa/latest/userguide/getting-started-hcp.html[Getting started with ROSA with HCP using the ROSA CLI in auto mode].
-
-include::modules/rosa-hcp-classic-comparison.adoc[leveloffset=+1]
 
 .Additional resources
 

--- a/welcome/about-hcp.adoc
+++ b/welcome/about-hcp.adoc
@@ -1,0 +1,100 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="about-hcp"]
+= Learn more about ROSA with HCP
+include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: about-hcp
+
+toc::[]
+
+{hcp-title-first} offers a reduced-cost solution to create a managed ROSA cluster with a focus on efficiency. You can quickly create a new cluster and deploy applications in minutes.
+
+== Key features of {hcp-title}
+
+* {hcp-title} requires a minimum of only two nodes, making it ideal for smaller projects while still being able to scale to support larger projects and enterprises.
+
+* The underlying control plane infrastructure is fully managed. Control plane components, such as the API server and etcd database, are hosted in a Red Hat-owned AWS account.
+
+* Provisioning time is approximately 10 minutes.
+
+* Customers can upgrade the control plane and machine pools separately, which means they do not have to shut down the entire cluster during upgrades.
+
+== Getting started with {hcp-title}
+
+Use the following sections to find content to help you learn about and use {hcp-title}.
+
+[id="architect"]
+=== Architect
+
+[options="header",cols="3*"]
+|===
+| Learn about {hcp-title} |Plan {hcp-title} deployment |Additional resources
+
+| xref:../rosa_architecture/rosa_architecture_sub/rosa-basic-architecture-concepts.adoc#rosa-basic-architecture-concepts[ROSA architecture concepts]
+| xref:../rosa_backing_up_and_restoring_applications/backing-up-applications.adoc#rosa-backing-up-applications[Back up and restore]
+| xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.adoc#rosa-hcp-life-cycle[{hcp-title} life cycle]
+
+| xref:../rosa_architecture/rosa_architecture_sub/rosa-architecture-models.adoc#rosa-architecture-models[{hcp-title} architecture]
+|
+| xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc#rosa-hcp-service-definition[{hcp-title} service definition]
+
+|
+|
+| xref:../support/index.adoc#support-overview[Getting support]
+|===
+
+
+[id="cluster-administrator"]
+=== Cluster Administrator
+
+[options="header",cols="4*"]
+|===
+|Learn about {hcp-title} |Deploy {hcp-title} |Manage {hcp-title} |Additional resources
+
+| xref:../rosa_architecture/rosa_architecture_sub/rosa-architecture-models.adoc#rosa-architecture-models[{hcp-title} architecture]
+| xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly[Installing {hcp-title}]
+| xref:../logging/cluster-logging.adoc#cluster-logging[Logging]
+| xref:../support/index.adoc#support-overview[Getting Support]
+
+| link:https://learn.openshift.com/?extIdCarryOver=true&sc_cid=701f2000001Css5AAC[OpenShift Interactive Learning Portal]
+| xref:../storage/index.adoc#storage-overview[Storage]
+| xref:../monitoring/monitoring-overview.adoc#monitoring-overview_virt-monitoring-overview[Monitoring overview]
+| xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.adoc#rosa-hcp-life-cycle[{hcp-title} life cycle]
+
+| 
+| xref:../rosa_backing_up_and_restoring_applications/backing-up-applications.adoc#rosa-backing-up-applications[Back up and restore]
+|
+|
+
+|
+| xref:../upgrading/rosa-hcp-upgrading.adoc#rosa-hcp-upgrading[Upgrading]
+|
+|
+
+|===
+
+
+[id="Developer"]
+=== Developer
+
+[options="header",cols="3*"]
+|===
+|Learn about application development in {hcp-title} |Deploy applications |Additional resources
+
+| link:https://developers.redhat.com/[Red Hat Developers site]
+| xref:../applications/index.adoc#building-applications-overview[Building applications overview]
+| xref:../support/index.adoc#support-overview[Getting support]
+
+| link:https://developers.redhat.com/products/openshift-dev-spaces/overview[{openshift-dev-spaces-productname} (formerly Red Hat CodeReady Workspaces)]
+| xref:../operators/index.adoc#operators-overview[Operators overview]
+|
+
+|
+| xref:../openshift_images/index.adoc#overview-of-images[Images]
+|
+
+|
+| xref:../cli_reference/odo-important-update.adoc#odo-important_update[Developer-focused CLI]
+|
+
+|===


### PR DESCRIPTION
[OSDOCS-9589](https://issues.redhat.com//browse/OSDOCS-9589): Update Architecture Models Sub-Section to Show the Differences between Classic and HCP

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-9589

Link to docs preview:

- Architecture models: https://72358--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_architecture_sub/rosa-architecture-models

- Creating ROSA with HCP clusters using the default options: https://72358--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly

- Learn More About ROSA with HCP: https://72358--ocpdocs-pr.netlify.app/openshift-rosa/latest/welcome/about-hcp

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
