### PR TITLE
OADP-3399: Reworking OpenShift KubeVirt OADP docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3078,6 +3078,8 @@ Topics:
       File: installing-oadp-mcg
     - Name: Configuring OADP with ODF
       File: installing-oadp-ocs
+    - Name: Configuring OADP with OpenShift Virtualization
+      File: installing-oadp-kubevirt
   - Name: Uninstalling OADP
     Dir: installing
     Topics:

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
@@ -38,4 +38,8 @@ include::modules/oadp-installing-dpa-1-2-and-earlier.adoc[leveloffset=+1]
 include::modules/oadp-installing-dpa-1-3.adoc[leveloffset=+1]
 include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc#oadp-installing-dpa-1-3_installing-oadp-kubevirt[Installing the Data Protection Application with the `kubevirt` and `openshift` plugins] 
+
 :!installing-oadp-aws:

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc
@@ -35,4 +35,9 @@ include::modules/oadp-installing-dpa-1-2-and-earlier.adoc[leveloffset=+1]
 include::modules/oadp-installing-dpa-1-3.adoc[leveloffset=+1]
 include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc#oadp-installing-dpa-1-3_installing-oadp-kubevirt[Installing the Data Protection Application with the `kubevirt` and `openshift` plugins] 
+
 :installing-oadp-azure!:

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc
@@ -36,4 +36,8 @@ include::modules/oadp-gcp-wif-cloud-authentication.adoc[leveloffset=+1]
 include::modules/oadp-installing-dpa-1-3.adoc[leveloffset=+1]
 include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc#oadp-installing-dpa-1-3_installing-oadp-kubevirt[Installing the Data Protection Application with the `kubevirt` and `openshift` plugins] 
+
 :installing-oadp-gcp!:

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc
@@ -1,0 +1,58 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="installing-oadp-kubevirt"]
+// If docs team approves the name, "Configuring OADP with Kubevirt" great but I suspect it will need to be "Configuring OADP with OpenShift Virtualization" or "Configuring OADP with Virtualization" or perhaps... bear with me.. "OADP and OpenShift-Virtualization"
+= Configuring the {oadp-full} with {VirtProductName}
+include::_attributes/common-attributes.adoc[]
+:context: installing-oadp-kubevirt
+:installing-oadp-kubevirt:
+:credentials: cloud-credentials
+:provider: kubevirt
+
+toc::[]
+
+You can install the {oadp-first} with {VirtProductName} by installing the OADP Operator and configuring a backup location. Then, you can install the Data Protection Application.
+
+// include::snippets/oadp-mtc-operator.adoc[]
+
+Back up and restore virtual machines by using the xref:../../../backup_and_restore/index.adoc#application-backup-restore-operations-overview[{oadp-full}].
+
+[NOTE]
+====
+{oadp-full} with {VirtProductName} supports the following backup and restore storage options:
+
+* Container Storage Interface (CSI) backups
+
+* Container Storage Interface (CSI) backups with DataMover
+
+The following storage options are excluded:
+
+* File system backup and restore
+
+* Volume snapshot backups and restores
+
+For more information, see xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#oadp-backing-up-applications-restic-doc[Backing up applications with File System Backup: Kopia or Restic].
+====
+To install the OADP Operator in a restricted network environment, you must first disable the default OperatorHub sources and mirror the Operator catalog. See xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks] for details.
+
+include::modules/install-and-configure-oadp-kubevirt.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc#oadp-plugins_oadp-features-plugins[{oadp-short} plugins]
+* xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc#backing-up-applications[`Backup` custom resource (CR)]
+* xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc#restoring-applications[`Restore` CR]
+* xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks]
+
+include::modules/oadp-installing-dpa-1-3.adoc[leveloffset=+1]
+
+[IMPORTANT]
+.{oadp-short} 1.2
+====
+Red Hat only supports the combination of {oadp-short} versions 1.3.0 and later, and {VirtProductName} versions 4.14 and later.
+
+{oadp-short} versions before 1.3.0 are not supported for back up and restore of {VirtProductName}.
+====
+
+
+:!installing-oadp-kubevirt:

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
@@ -42,8 +42,14 @@ include::modules/oadp-installing-dpa-1-2-and-earlier.adoc[leveloffset=+1]
 include::modules/oadp-installing-dpa-1-3.adoc[leveloffset=+1]
 include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
 
+
 [discrete]
 [role="_additional-resources"]
 .Additional resources
 
 * link:https://access.redhat.com/solutions/6719951[Performance tuning guide for Multicloud Object Gateway].
+
+* xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc#oadp-installing-dpa-1-3_installing-oadp-kubevirt[Installing the Data Protection Application with the `kubevirt` and `openshift` plugins]
+
+:installing-oadp-mcg!:
+

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
@@ -46,5 +46,11 @@ include::modules/oadp-installing-dpa-1-3.adoc[leveloffset=+1]
 include::modules/oadp-creating-object-bucket-claim.adoc[leveloffset=+2]
 include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc#oadp-installing-dpa-1-3_installing-oadp-kubevirt[Installing the Data Protection Application] with the `kubevirt` and `openshift` xref:../../../backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc#oadp-plugins_oadp-features-plugins[plugins].
+
 
 :installing-oadp-ocs!:
+

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
@@ -49,7 +49,8 @@ include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc#oadp-installing-dpa-1-3_installing-oadp-kubevirt[Installing the Data Protection Application] with the `kubevirt` and `openshift` xref:../../../backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc#oadp-plugins_oadp-features-plugins[plugins].
+* xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc#oadp-installing-dpa-1-3_installing-oadp-kubevirt[Installing the Data Protection Application]
+*  xref:../../../backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc#oadp-plugins_oadp-features-plugins[plugins].
 
 
 :installing-oadp-ocs!:

--- a/modules/install-and-configure-oadp-kubevirt.adoc
+++ b/modules/install-and-configure-oadp-kubevirt.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="install-and-configure-oadp-kubevirt_{context}"]
+= Installing and configuring {oadp-short} with {VirtProductName}
+
+As a cluster administrator, you install {oadp-short} by installing the {oadp-short} Operator.
+
+The Operator installs link:https://velero.io/docs/v{velero-version}[Velero {velero-version}].
+
+.Prerequisites
+
+* Access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Install the {oadp-short} Operator according to the instructions for your storage provider.
+
+. Install the Data Protection Application (DPA)] with the `kubevirt` and `openshift` {oadp-short} plugins.
+
+. Back up virtual machines by creating a `Backup` custom resource (CR).
+
++
+[WARNING]
+====
+Red Hat support is limited to only the following options:
+
+* CSI backups
+
+* CSI backups with DataMover.
+====
+
+You restore the `Backup` CR by creating a `Restore` CR.
+

--- a/modules/oadp-installing-dpa-1-3.adoc
+++ b/modules/oadp-installing-dpa-1-3.adoc
@@ -5,7 +5,7 @@
 // * backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc
 // * backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
 // * backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
-
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="oadp-installing-dpa-1-3_{context}"]
@@ -321,7 +321,7 @@ spec:
 <14> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
 endif::[]
 
-ifdef::virt-installing-configuring-oadp[]
+ifdef::installing-oadp-kubevirt,virt-installing-configuring-oadp[]
 +
 [source,yaml,subs="attributes+"]
 ----
@@ -370,6 +370,7 @@ spec:
 <13> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
 <14> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
 endif::[]
+
 
 . Click *Create*.
 

--- a/modules/oadp-setting-resource-limits-and-requests.adoc
+++ b/modules/oadp-setting-resource-limits-and-requests.adoc
@@ -3,6 +3,11 @@
 // * backup_and_restore/application_backup_and_restore/configuring-oadp.adoc
 // * virt/backup_restore/virt-installing-configuring-oadp.adoc
 // * backup_and_restore/application_backup_and_restore/oadp-aws-sts/oadp-aws-sts.adoc
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="oadp-setting-resource-limits-and-requests_{context}"]


### PR DESCRIPTION
### JIRA 

* [OADP-3399](https://issues.redhat.com/browse/OADP-3399)

    * Adding KubeVirt to DPA and including Virt docs into OADP docs.

    * Fixed the broken ifdef statement on 1.3 DPA for ODF 

* To do :

    * Check the other parts of the Virt docs for what we should bring over to OADP

GA - 16th April

### Versions

* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
*  OCP 4.16 → branch/enterprise-4.16


### Link to docs preview:

* [Configuring the OpenShift API for Data Protection with OpenShift Virtualization](https://72372--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt)

### QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
