### PR TITLE
OCPBUGS#27438: Adding ARM instance types to GCP UPI

### DIFF
--- a/installing/installing_gcp/installing-gcp-user-infra.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra.adoc
@@ -70,6 +70,7 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 * xref:../../scalability_and_performance/optimization/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
 
 include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
+include::modules/installation-gcp-tested-machine-types-arm.adoc[leveloffset=+2]
 include::modules/installation-using-gcp-custom-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-user-infra-generate.adoc[leveloffset=+1]


### PR DESCRIPTION
**Version(s):** 4.14+ 
**Issue:** [OCPBUGS-27438](https://issues.redhat.com/browse/OCPBUGS-27438)

**Link to docs preview:** 

- [Installing a cluster on user-provisioned infrastructure in GCP by using Deployment Manager templates ->  Tested instance types for GCP on 64-bit ARM infrastructures](https://72376--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra#installation-gcp-tested-machine-types-arm_installing-gcp-user-infra)

**QE review:**
- [x] QE has approved this change.

