### PR TITLE
OSDOCS-9818: Removed PrivateLink references to Private ROSA with HCP docs

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -211,7 +211,7 @@ Topics:
 - Name: Creating ROSA with HCP clusters using a custom AWS KMS encryption key
   File: rosa-hcp-creating-cluster-with-aws-kms-key
 - Name: Creating a private cluster on ROSA with HCP
-  File: rosa-hcp-aws-privatelink-creating-cluster
+  File: rosa-hcp-aws-private-creating-cluster
 - Name: Using the Node Tuning Operator on ROSA with HCP
   File: rosa-tuning-config
 ---

--- a/modules/osd-aws-privatelink-about.adoc
+++ b/modules/osd-aws-privatelink-about.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
 // * rosa_install_access_delete_clusters/rosa-aws-privatelink-creating-cluster.adoc
-// * rosa_hcp/rosa-hcp-aws-privatelink-creating-cluster.adoc
-ifeval::["{context}" == "rosa-hcp-aws-privatelink-creating-cluster"]
+// * rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc
+ifeval::["{context}" == "rosa-hcp-aws-private-creating-cluster"]
 :rosa-hcp:
 endif::[]
 ifeval::["{context}" == "rosa-aws-privatelink-creating-cluster"]
@@ -26,7 +26,7 @@ For more information, see link:https://aws.amazon.com/privatelink/[AWS PrivateLi
 You can only make a PrivateLink cluster at installation time. You cannot change a cluster to PrivateLink after installation.
 ====
 
-ifeval::["{context}" == "rosa-hcp-aws-privatelink-creating-cluster"]
+ifeval::["{context}" == "rosa-hcp-aws-private-creating-cluster"]
 :!rosa-hcp:
 endif::[]
 ifeval::["{context}" == "rosa-aws-privatelink-creating-cluster"]

--- a/modules/osd-aws-privatelink-required-resources.adoc
+++ b/modules/osd-aws-privatelink-required-resources.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
 // * rosa_install_access_delete_clusters/rosa-aws-privatelink-creating-cluster.adoc
-// * rosa_hcp/rosa-hcp-aws-privatelink-creating-cluster.adoc
-ifeval::["{context}" == "rosa-hcp-aws-privatelink-creating-cluster"]
+// * rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc
+ifeval::["{context}" == "rosa-hcp-aws-private-creating-cluster"]
 :rosa-hcp:
 endif::[]
 ifeval::["{context}" == "rosa-aws-privatelink-creating-cluster"]
@@ -59,7 +59,7 @@ Your VPC must have private subnets in 1 availability zone for Single-AZ deployme
 endif::rosa-hcp[]
 You must provide appropriate routes and route tables.
 |===
-ifeval::["{context}" == "rosa-hcp-aws-privatelink-creating-cluster"]
+ifeval::["{context}" == "rosa-hcp-aws-private-creating-cluster"]
 :!rosa-hcp:
 endif::[]
 ifeval::["{context}" == "rosa-aws-privatelink-creating-cluster"]

--- a/modules/rosa-hcp-aws-private-create-cluster.adoc
+++ b/modules/rosa-hcp-aws-private-create-cluster.adoc
@@ -1,16 +1,11 @@
 // Module included in the following assemblies:
 //
-// * rosa_hcp/rosa-hcp-aws-privatelink-creating-cluster.adoc
+// * rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc
 :_mod-docs-content-type: PROCEDURE
-[id="rosa-hcp-aws-privatelink-create-cluster_{context}"]
-= Creating an AWS PrivateLink cluster
+[id="rosa-hcp-aws-private-create-cluster_{context}"]
+= Creating an AWS private cluster
 
 You can create a private cluster with multiple availability zones (Multi-AZ) on {hcp-title} using the ROSA command line interface (CLI), `rosa`.
-
-[NOTE]
-====
-AWS PrivateLink is supported on preexisting VPCs only.
-====
 
 .Prerequisites
 
@@ -69,7 +64,7 @@ $ rosa create operator-roles --hosted-cp --prefix <operator_roles_prefix> --oidc
 +
 [source,terminal]
 ----
-$ rosa create cluster --private-link --cluster-name=<cluster-name> --sts --mode=auto --hosted-cp --operator-roles-prefix <operator_role_prefix> --oidc-config-id <oidc_config_id> [--machine-cidr=<VPC CIDR>/16] --subnet-ids=<private-subnet-id1>[,<private-subnet-id2>,<private-subnet-id3>]
+$ rosa create cluster --private --cluster-name=<cluster-name> --sts --mode=auto --hosted-cp --operator-roles-prefix <operator_role_prefix> --oidc-config-id <oidc_config_id> [--machine-cidr=<VPC CIDR>/16] --subnet-ids=<private-subnet-id1>[,<private-subnet-id2>,<private-subnet-id3>]
 ----
 
 . Enter the following command to check the status of your cluster. During cluster creation, the `State` field from the output will transition from `pending` to `installing`, and finally, to `ready`.

--- a/modules/rosa-hcp-aws-private-security-groups.adoc
+++ b/modules/rosa-hcp-aws-private-security-groups.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
-// * rosa_hcp/rosa-hcp-aws-privatelink-creating-cluster.adoc
-[id="rosa-hcp-aws-privatelink-security-groups_{context}"]
+// * rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc
+[id="rosa-hcp-aws-private-security-groups_{context}"]
 :_mod-docs-content-type: PROCEDURE
 = Configuring AWS security groups to access the API
 

--- a/rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc
+++ b/rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc
@@ -1,19 +1,19 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="rosa-hcp-aws-privatelink-creating-cluster"]
+[id="rosa-hcp-aws-private-creating-cluster"]
 = Creating a private cluster on {hcp-title}
 include::_attributes/attributes-openshift-dedicated.adoc[]
-:context: rosa-hcp-aws-privatelink-creating-cluster
+:context: rosa-hcp-aws-private-creating-cluster
 
 toc::[]
 
 This document describes how to create a {hcp-title-first} private cluster.
 
-include::modules/osd-aws-privatelink-about.adoc[leveloffset=+1]
-include::modules/osd-aws-privatelink-required-resources.adoc[leveloffset=+1]
-include::modules/rosa-hcp-aws-privatelink-create-cluster.adoc[leveloffset=+1]
-include::modules/rosa-hcp-aws-privatelink-security-groups.adoc[leveloffset=+1]
+//include::modules/osd-aws-privatelink-about.adoc[leveloffset=+1]
+//include::modules/osd-aws-privatelink-required-resources.adoc[leveloffset=+1]
+include::modules/rosa-hcp-aws-private-create-cluster.adoc[leveloffset=+1]
+include::modules/rosa-hcp-aws-private-security-groups.adoc[leveloffset=+1]
 
-[id="next-steps_rosa-hcp-aws-privatelink-creating-cluster"]
+[id="next-steps_rosa-hcp-aws-private-creating-cluster"]
 == Next steps
 xref:../rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.adoc#rosa-sts-config-identity-providers[Configuring identity providers]
 


### PR DESCRIPTION
Version(s):
`enterprise-4.15+`

Issue:
**[OSDOCS-9818](https://issues.redhat.com/browse/OSDOCS-9818)**

Link to docs preview:
- [Creating a private cluster on ROSA with HCP](https://file.rdu.redhat.com/eponvell/OSDOCS-9818_Private-Typo/rosa_hcp/rosa-hcp-aws-private-creating-cluster.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Replaced the `--private-link` tag with `--private`
