### PR TITLE
WMCO 9.0.1 release notes

### DIFF
--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -8,9 +8,9 @@
 The following information details the supported platform versions, Windows Server versions, and networking configurations for the Windows Machine Config Operator (WMCO). See the vSphere documentation for any information that is relevant to only that platform.
 
 [id="wmco-prerequisites-supported-9.0.0_{context}"]
-== WMCO 9.0.0 supported platforms and Windows Server versions
+== WMCO 9.y supported platforms and Windows Server versions
 
-The following table lists the link:https://docs.microsoft.com/en-us/windows/release-health/windows-server-release-info[Windows Server versions] that are supported by WMCO 9.0.0, based on the applicable platform. Windows Server versions not listed are not supported and attempting to use them will cause errors. To prevent these errors, use only an appropriate version for your platform.
+The following table lists the link:https://docs.microsoft.com/en-us/windows/release-health/windows-server-release-info[Windows Server versions] that are supported by WMCO 9.y, based on the applicable platform. Windows Server versions not listed are not supported and attempting to use them will cause errors. To prevent these errors, use only an appropriate version for your platform.
 
 [cols="3,7",options="header"]
 |===
@@ -18,7 +18,8 @@ The following table lists the link:https://docs.microsoft.com/en-us/windows/rele
 |Supported Windows Server version
 
 |Amazon Web Services (AWS)
-|Windows Server 2019, version 1809
+a|* Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
+* Windows Server 2019, version 1809
 
 |Microsoft Azure
 a|* Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later

--- a/windows_containers/index.adoc
+++ b/windows_containers/index.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+{productwinc} is a feature providing the ability to run Windows compute nodes in an {product-title} cluster. This is possible by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes. With a Red Hat subscription, you can get support for running Windows workloads in {product-title}. Windows instances deployed by the WMCO are configured with the containerd container runtime. For more information, see the xref:../windows_containers/windows-containers-release-notes-9-x.adoc#windows-containers-release-notes-9-x[release notes].
+
 You can add Windows nodes either by creating a xref:../windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc#creating-windows-machineset-aws[compute machine set] or by specifying existing Bring-Your-Own-Host (BYOH) Window instances through a xref:../windows_containers/byoh-windows-instance.adoc#byoh-windows-instance[configuration map].
 
 [NOTE]

--- a/windows_containers/windows-containers-release-notes-9-x.adoc
+++ b/windows_containers/windows-containers-release-notes-9-x.adoc
@@ -26,6 +26,28 @@ You must have this separate subscription to receive support for Windows Containe
 For more information, see the Red Hat OpenShift Container Platform Life Cycle Policy document for link:https://access.redhat.com/support/policy/updates/openshift#windows[{productwinc}].
 endif::openshift-origin[]
 
+[id="wmco-9-0-1"]
+== Release notes for Red Hat Windows Machine Config Operator 9.0.1
+
+This release of the WMCO provides new features and bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 9.0.1 were released in link:https://access.redhat.com/errata/RHSA-2024:1203[RHSA-2024:1203].
+
+
+[id="wmco-9-0-1-bug-fixes"]
+=== Bug fixes
+
+// Reviewed in WMCO 10.15.0 RN PR 
+* Previously, because of a lack of synchronization between Windows machine set nodes and Bring-Your-Own-Host (BYOH) instances, during an update the machine set nodes and the BYOH instances could update simultaneously. This could impact running workloads. This fix introduces a locking mechanism so that machine set nodes and BYOH instances update individually. (link:https://issues.redhat.com/browse/OCPBUGS-22984[*OCPBUGS-22984*])
+
+// Reviewed in WMCO 10.15.0 RN PR
+* Previously, because of a missing secret, the WMCO could not configure proper credentials for the WICD on Nutanix clusters. As a consequence, the WMCO could not create Windows nodes. With this fix, the WMCO creates long-lived credentials for the WICD service account. As a result, the WMCO is able to configure a Windows node on Nutanix clusters. (link:https://issues.redhat.com/browse/OCPBUGS-24748[*OCPBUGS-24748*])
+
+// Reviewed in WMCO 10.15.0 RN PR
+* Previously, because of bad logic in the networking configuration script, the WICD was incorrectly reading carriage returns in the CNI configuration file as changes, and identified the file as modified. This caused the CNI configuration to be unnecessarily reloaded, potentially resulting in container restarts and brief network outages. With this fix, the WICD now reloads the CNI configuration only when the CNI configuration is actually modified. (link:https://issues.redhat.com/browse/OCPBUGS-27046[*OCPBUGS-27046*])
+
+* Previously, because the WMCO performed an erroneous sanitization step that replaced commas with semicolons in the cluster-wide proxy configuration, Windows would ignore the endpoints specified in the `noProxy` parameter. As a consequence, traffic was being incorrectly sent through those proxies. With this fix, the sanitization step was removed. As a result, a web request from a Windows node to a cluster-internal endpoint or an endpoint that exists in the `noProxy` parameter does not go through the proxy. (link:https://issues.redhat.com/browse/OCPBUGS-27240[*OCPBUGS-27240*])
+
+* Previously, because of routing issues present in Windows Server 2019, under certain conditions and after more than one hour of running time, workloads on Windows Server 2019 could have experienced packet loss when communicating with other containers in the cluster. This fix enables Direct Server Return (DSR) routing within kube-proxy. As a result, DSR now causes request and response traffic to use a different network path, circumventing the bug within Windows Server 2019. (link:https://issues.redhat.com/browse/OCPBUGS-28226[*OCPBUGS-28226*])
+
 [id="wmco-9-0-0"]
 == Release notes for Red Hat Windows Machine Config Operator 9.0.0
 


### PR DESCRIPTION
Errata: https://errata.devel.redhat.com/docs/show/124870

PEER REVIEW: Only the two final bug texts need review. The first three have been reviewed in multiple other PRs ([10.15.0](https://github.com/openshift/openshift-docs/pull/71436/files), for example). I will update the link to the errata when it is available.

Preview: [Release notes for Red Hat Windows Machine Config Operator 9.0.1](https://72414--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-9-x#wmco-9-0-1)