### PR TITLE
[enterprise-4.14] OCPBUGS-25695: CP to 4.14

### DIFF
--- a/modules/cnf-measuring-latency.adoc
+++ b/modules/cnf-measuring-latency.adoc
@@ -23,7 +23,7 @@ oslat:: Behaves similarly to a CPU-intensive DPDK application and measures all t
 The tests introduce the following environment variables:
 
 .Latency test environment variables
-[cols="1,3", options="header"]
+[cols="1,3a", options="header"]
 |====
 |Environment variables
 |Description
@@ -36,6 +36,11 @@ The tests introduce the following environment variables:
 
 |`LATENCY_TEST_RUNTIME`
 |Specifies the amount of time in seconds that the latency test must run. The default value is 300 seconds.
+
+[NOTE]
+====
+To prevent the Ginkgo 2.0 test suite from timing out before the latency tests complete, set the `-ginkgo.timeout` flag to a value greater than `LATENCY_TEST_RUNTIME` + 2 minutes. If you also set a `LATENCY_TEST_DELAY` value then you must set `-ginkgo.timeout` to a value greater than `LATENCY_TEST_RUNTIME` + `LATENCY_TEST_DELAY` + 2 minutes. The default timeout value for the Ginkgo 2.0 test suite is 1 hour.
+====
 
 |`HWLATDETECT_MAXIMUM_LATENCY`
 |Specifies the maximum acceptable hardware latency in microseconds for the workload and operating system. If you do not set the value of `HWLATDETECT_MAXIMUM_LATENCY` or `MAXIMUM_LATENCY`, the tool compares the default expected threshold (20μs) and the actual maximum latency in the tool itself. Then, the test fails or succeeds accordingly.

--- a/modules/cnf-performing-end-to-end-tests-disconnected-mode.adoc
+++ b/modules/cnf-performing-end-to-end-tests-disconnected-mode.adoc
@@ -40,7 +40,7 @@ where:
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 -e DISCOVERY_MODE=true -e FEATURES=performance -e IMAGE_REGISTRY="<disconnected_registry>" \
 -e CNF_TESTS_IMAGE="cnf-tests-rhel8:v{product-version}" \
-/usr/bin/test-run.sh -ginkgo.focus="\[performance\]\ Latency\ Test"
+/usr/bin/test-run.sh -ginkgo.focus="\[performance\]\ Latency\ Test" --ginkgo.timeout="24h"
 ----
 
 [discrete]
@@ -57,7 +57,7 @@ $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 -e IMAGE_REGISTRY="<custom_image_registry>" \
 -e CNF_TESTS_IMAGE="<custom_cnf-tests_image>" \
 -e FEATURES=performance \
-registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh
+registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh --ginkgo.timeout="24h"
 ----
 +
 where:
@@ -143,7 +143,7 @@ registry.redhat.io/openshift4/cnf-tests-rhel8:{product-version} \
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 -e DISCOVERY_MODE=true -e FEATURES=performance -e IMAGE_REGISTRY=image-registry.openshift-image-registry.svc:5000/cnftests \
-cnf-tests-local:latest /usr/bin/test-run.sh -ginkgo.focus="\[performance\]\ Latency\ Test"
+cnf-tests-local:latest /usr/bin/test-run.sh -ginkgo.focus="\[performance\]\ Latency\ Test" --ginkgo.timeout="24h"
 ----
 
 [discrete]

--- a/modules/cnf-performing-end-to-end-tests-running-cyclictest.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-cyclictest.adoc
@@ -36,7 +36,7 @@ $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 -e LATENCY_TEST_RUN=true -e DISCOVERY_MODE=true -e FEATURES=performance -e ROLE_WORKER_CNF=worker-cnf \
 -e LATENCY_TEST_CPUS=10 -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20 \
 registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
-/usr/bin/test-run.sh -ginkgo.v -ginkgo.focus="cyclictest"
+/usr/bin/test-run.sh -ginkgo.v -ginkgo.focus="cyclictest" --ginkgo.timeout="24h"
 ----
 +
 The command runs the `cyclictest` tool for 10 minutes (600 seconds). The test runs successfully when the maximum observed latency is lower than `MAXIMUM_LATENCY` (in this example, 20 μs). Latency spikes of 20 μs and above are generally not acceptable for {rds} workloads.

--- a/modules/cnf-performing-end-to-end-tests-running-hwlatdetect.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-hwlatdetect.adoc
@@ -34,7 +34,7 @@ $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 -e LATENCY_TEST_RUN=true -e DISCOVERY_MODE=true -e FEATURES=performance -e ROLE_WORKER_CNF=worker-cnf \
 -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20 \
 registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
-/usr/bin/test-run.sh -ginkgo.v -ginkgo.focus="hwlatdetect"
+/usr/bin/test-run.sh -ginkgo.v -ginkgo.focus="hwlatdetect" --ginkgo.timeout="24h"
 ----
 +
 The `hwlatdetect` test runs for 10 minutes (600 seconds). The test runs successfully when the maximum observed latency is lower than `MAXIMUM_LATENCY` (20 μs).

--- a/modules/cnf-performing-end-to-end-tests-running-in-single-node-cluster.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-in-single-node-cluster.adoc
@@ -33,7 +33,7 @@ When executing `podman` commands as a non-root or non-privileged user, mounting 
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 -e DISCOVERY_MODE=true -e FEATURES=performance -e ROLE_WORKER_CNF=master \
 registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
-/usr/bin/test-run.sh -ginkgo.focus="\[performance\]\ Latency\ Test"
+/usr/bin/test-run.sh -ginkgo.focus="\[performance\]\ Latency\ Test" --ginkgo.timeout="24h"
 ----
 +
 [NOTE]

--- a/modules/cnf-performing-end-to-end-tests-running-oslat.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-oslat.adoc
@@ -33,7 +33,7 @@ $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 -e LATENCY_TEST_RUN=true -e DISCOVERY_MODE=true -e FEATURES=performance -e ROLE_WORKER_CNF=worker-cnf \
 -e LATENCY_TEST_CPUS=10 -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20 \
 registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
-/usr/bin/test-run.sh -ginkgo.v -ginkgo.focus="oslat"
+/usr/bin/test-run.sh -ginkgo.v -ginkgo.focus="oslat" --ginkgo.timeout="24h"
 ----
 +
 `LATENCY_TEST_CPUS` specifies the list of CPUs to test with the `oslat` command.

--- a/modules/cnf-performing-end-to-end-tests-running-the-tests.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-the-tests.adoc
@@ -30,7 +30,7 @@ You provide the test image with a `kubeconfig` file in current directory and its
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 -e LATENCY_TEST_RUN=true -e DISCOVERY_MODE=true -e FEATURES=performance registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
-/usr/bin/test-run.sh -ginkgo.focus="\[performance\]\ Latency\ Test"
+/usr/bin/test-run.sh -ginkgo.focus="\[performance\]\ Latency\ Test" --ginkgo.timeout="24h"
 ----
 
 . Optional: Append `-ginkgo.dryRun` to run the latency tests in dry-run mode. This is useful for checking what the tests run.
@@ -52,6 +52,7 @@ where:
 --
 <performance_profile> :: Is the name of the performance profile you want to run the latency tests against.
 --
+. Optional: Append `--ginkgo.timeout="24h"` flag to ensure the Ginkgo 2.0 test suite does not timeout before the latency tests complete.
 +
 [IMPORTANT]
 ====


### PR DESCRIPTION
Cherry-pick of #72146 

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OCPBUGS-25695

Link to docs preview:
https://72431--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-performing-platform-verification-latency-tests
