### PR TITLE
OSDOCS-9720: adds 4.14.15 release note MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -464,3 +464,12 @@ Issued: 2024-02-28
 {product-title} release 4.14.14, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0943[RHBA-2024:0943] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0941[RHSA-2024:0941] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-14-15-dp"]
+=== RHBA-2024:1048 - {microshift-short} 4.14.15 bug fix update advisory
+
+Issued: 2024-03-05
+
+{product-title} release 4.14.15 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1048[RHBA-2024:1048] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:1046[RHBA-2024:1046] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-9720](https://issues.redhat.com/browse/OSDOCS-9720)

Link to docs preview:
[4.14.15 async release note](https://72435--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes#microshift-4-14-15-dp)

QE review:
- N/A no technical content, stock text only

<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
