### PR TITLE
OSDOCS#29991: Removes mentions of Mode (connectivity or consumption)

### DIFF
--- a/modules/odc-viewing-application-topology.adoc
+++ b/modules/odc-viewing-application-topology.adoc
@@ -16,9 +16,6 @@ You can customize the views as required using the following:
 * Use the *Find by name* field to find the required components. Search results may appear outside of the visible area; click *Fit to Screen* from the lower-left toolbar to resize the *Topology* view to show all components.
 * Use the *Display Options* drop-down list to configure the *Topology* view of the various application groupings. The options are available depending on the types of components deployed in the project:
 
-** *Mode* (*Connectivity* or *Consumption*)
-*** Connectivity: Select to show all the connections between the different nodes in the topology.
-*** Consumption: Select to show the resource consumption for all nodes in the topology.
 ** *Expand* group
 *** Virtual Machines: Toggle to show or hide the virtual machines.
 *** Application Groupings: Clear to condense the application groups into cards with an overview of an application group and alerts associated with it.


### PR DESCRIPTION
Removes mentions of Mode (connectivity or consumption)

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-29991

Link to docs preview:
https://72437--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/odc-viewing-application-composition-using-topology-view#odc-viewing-application-topology_viewing-application-composition-using-topology-view

QE review: @sanketpathak 
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
