### PR TITLE
OSDOCS-9793: Doc edits in storage vol group and getting started

### DIFF
--- a/microshift_getting_started/microshift-architecture.adoc
+++ b/microshift_getting_started/microshift-architecture.adoc
@@ -43,7 +43,7 @@ The following operational differences from {oke} can help you understand where {
 .{product-title} differences from {oke}.
 image::311_RHDevice_Edge_Overview_0223_2.png[<{microshift-short} is tasked with only the Kubernetes cluster capabilities of networking, ingress, storage, helm, with the additional Kubernetes functions of orchestration and security, as the following diagram illustrates.>]
 
-Figure 2 shows that {oke} has the same cluster capabilities as {product-title}, and adds the following:
+The figure "{product-title} differences from {oke}" shows that {oke} has the same cluster capabilities as {product-title}, and adds the following information:
 
 * Install
 * Over-the-air updates

--- a/modules/microshift-lvms-system-requirements.adoc
+++ b/modules/microshift-lvms-system-requirements.adoc
@@ -11,9 +11,10 @@ Using LVMS in {microshift-short} requires the following system specifications.
 [id="lvms-volume-group-name_{context}"]
 == Volume group name
 
-If you did not configure LVMS in an `lvmd.yaml` YAML file placed in the `/etc/microshift/` directory, {microshift-short} attempts to assign a default volume group (VG) dynamically by running the `vgs` command. 
-* {microshift-short} assigns a default VG when only one VG is found. 
-* If more than one VG is present, the VG named `microshift` is assigned as the default. 
+If you did not configure LVMS in an `lvmd.yaml` file placed in the `/etc/microshift/` directory, {microshift-short} attempts to assign a default volume group (VG) dynamically by running the `vgs` command.
+
+* {microshift-short} assigns a default VG when only one VG is found.
+* If more than one VG is present, the VG named `microshift` is assigned as the default.
 * If a VG named `microshift` does not exist, LVMS is not deployed.
 
 If there are no volume groups on the {microshift-short} host, LVMS is disabled.


### PR DESCRIPTION
Version(s):
4.14, 4.15 and 4.16

Issue:
[OSDOCS-9793](https://issues.redhat.com/browse/OSDOCS-9793)

Link to docs preview:
[Architecture](https://72443--ocpdocs-pr.netlify.app/microshift/latest/microshift_getting_started/microshift-architecture)
[volume group name](https://72443--ocpdocs-pr.netlify.app/microshift/latest/microshift_storage/microshift-storage-plugin-overview#lvms-volume-group-name_microshift-storage-plugin-overview)

QE review:
- [ ] QE has approved this change.
