### PR TITLE
OSDOCS#8946 pt.2: Adds link to Pipelines dashboard information to the web console products landing page

### DIFF
--- a/web_console/capabilities_products-web-console.adoc
+++ b/web_console/capabilities_products-web-console.adoc
@@ -22,7 +22,8 @@ include::modules/pipelines-web-console.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://access.redhat.com/documentation/en-us/red_hat_openshift_pipelines/1.13/html/creating_cicd_pipelines/working-with-pipelines-web-console[Working with {pipelines-title} in the web console]
+* link:https://docs.openshift.com/pipelines/1.14/create/working-with-pipelines-web-console.html[Working with {pipelines-title} in the web console]
+* link:https://docs.openshift.com/pipelines/1.14/create/working-with-pipelines-web-console.html#op-console-statistics_working-with-pipelines-web-console[Pipeline execution statistics in the web console]
 
 //serverless
 include::modules/serverless-web-console.adoc[leveloffset=+1]


### PR DESCRIPTION
Adds link to Pipelines dashboard information to the web console products landing page

Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-8946

Link to docs preview:
https://72444--ocpdocs-pr.netlify.app/openshift-enterprise/latest/web_console/capabilities_products-web-console#pipelines-web-console_capabilities-web-console

QE review:
- [ ] QE has approved this change.
I dont think QE is needed to add a reference link.

Additional information:
Related to #72132 and #71872
