### PR TITLE
Demo for Vale review comments in Prow CI

### DIFF
--- a/modules/cnf-performing-end-to-end-tests-disconnected-mode.adoc
+++ b/modules/cnf-performing-end-to-end-tests-disconnected-mode.adoc
@@ -8,6 +8,8 @@
 
 Adding the error term GIT to trigger a Vale alert.
 
+Adding this in a second commit to show only 1 further Vale review comment: lower case podman is an error.
+
 The CNF tests image can run tests in a disconnected cluster that is not able to reach external registries. This requires two steps:
 
 . Mirroring the `cnf-tests` image to the custom disconnected registry.

--- a/modules/cnf-performing-end-to-end-tests-disconnected-mode.adoc
+++ b/modules/cnf-performing-end-to-end-tests-disconnected-mode.adoc
@@ -6,6 +6,8 @@
 [id="cnf-performing-end-to-end-tests-disconnected-mode_{context}"]
 = Running latency tests in a disconnected cluster
 
+Adding the error term GIT to trigger a Vale alert.
+
 The CNF tests image can run tests in a disconnected cluster that is not able to reach external registries. This requires two steps:
 
 . Mirroring the `cnf-tests` image to the custom disconnected registry.

--- a/modules/virt-creating-linux-bridge-nad-web.adoc
+++ b/modules/virt-creating-linux-bridge-nad-web.adoc
@@ -8,6 +8,12 @@
 [id="virt-creating-linux-bridge-nad-web_{context}"]
 = Creating a Linux bridge NAD by using the web console
 
+You can create a network attachment definition (NAD) to provide layer-2 networking to pods and virtual machines by using the {product-title} web console. 
+
+This is passive tense - the cat was eaten by the dog - but it is only a Vale suggestion so won't trigger a Vale review comment.
+
+However, if I use the term white hat hacker, this term is a Vale error and triggers a Vale review comment.
+
 You can create a network attachment definition (NAD) to provide layer-2 networking to pods and virtual machines by using the {product-title} web console.
 
 A Linux bridge network attachment definition is the most efficient method for connecting a virtual machine to a VLAN.

--- a/modules/virt-creating-storage-pool-pvc-template.adoc
+++ b/modules/virt-creating-storage-pool-pvc-template.adoc
@@ -46,7 +46,7 @@ spec:
 ----
 <1> The `storagePools` stanza is an array that can contain both basic and PVC template storage pools.
 <2> Specify the storage pool directories under this node path.
-<3> Optional: The `volumeMode` parameter can be either `Block` or `Filesystem` as long as it matches the provisioned volume format. If no value is specified, the default is `Filesystem`. If the `volumeMode` is `Block`, the mounting pod creates an XFS file system on the block volume before mounting it.
+<3> Optional: The `volumeMode` parameter can be either `Block` or `Filesystem` as long as it matches the provisioned volume format. If no value is specified, the default is `Filesystem`. If the `volumeMode` is `Block`, the mounting pod creates an XFS file system on the block volume before mounting it. Editing this sentence triggers a Vale review comment.
 <4> If the `storageClassName` parameter is omitted, the default storage class is used to create PVCs. If you omit `storageClassName`, ensure that the HPP storage class is not the default storage class.
 <5> You can specify statically or dynamically provisioned storage. In either case, ensure the requested storage size is appropriate for the volume you want to virtually divide or the PVC cannot be bound to the large PV. If the storage class you are using uses dynamically provisioned storage, pick an allocation size that matches the size of a typical request.
 


### PR DESCRIPTION
Proof of concept (POC) for running Vale in the Prow CI. All feedback welcome.

- Vale review runs on any modified or changed content only.
- Runs on the latest commit every time you push.
- Review comments are added for any error level (`level: error`) Vale [rules](https://github.com/search?q=repo%3Aredhat-documentation%2Fvale-at-red-hat+%22level%3A+error%22&type=code). 
- It does not fail the build
- Doesn't duplicate a comment if a comment already exists on the same line for the same issue
- The Vale review check for the first commit in this PR took 16 seconds.

Test it out by PR'ing the `prow-test-2` branch with content that will trigger an error level Vale rule. For example, use the term "[hyperthreading](https://github.com/redhat-documentation/vale-at-red-hat/blob/c56f7414b69a490de0a13d1a8731126d454349cd/.vale/styles/RedHat/CaseSensitiveTerms.yml#L146)" in content. 