### PR TITLE
[internal fix] Added doc_guidelines.adoc entry for table style operators

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -2128,6 +2128,18 @@ Do _not_ delete the file.
 a|
 > Do _not_ delete the file.
 
+|Table style operators
+
+|A style operator styles the content of a table cell or a table column, depending on where you set the operator. Using the literal (`l`) operator in a column might impact the documentation platform's copy and paste functionality. For example, when you paste copied code block content to a location, the first styled literal value in an assembly is pasted instead of the intended code block. To avoid this issue, use the monospace (`m`) style operator. When using any style operator in a table, check all copy and paste functions that follow the defined style operator work correctly for all code blocks in an assembly.
+
+See link:https://docs.asciidoctor.org/asciidoc/latest/tables/format-cell-content/[Cell styles and their operators] (Asciidoctor Documentation)
+
+a|
+----
+.Required parameters
+[cols=".^2m,.^3,.^5a",options="header"]
+----
+
 |Footnotes
 
 |A footnote is created with the footnote macro. If you plan to reference a footnote more than once, use the ID footnoteref macro. The Customer Portal does not support spaces in the footnoteref. For example, "dynamic PV" should be "dynamicPV".

--- a/contributing_to_docs/doc_guidelines.html
+++ b/contributing_to_docs/doc_guidelines.html
@@ -1,0 +1,4093 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.20">
+<meta name="author" content="include::_attributes/common-attributes.adoc">
+<title>Documentation guidelines</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment the following line when using as a custom stylesheet */
+/* @import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700"; */
+html{font-family:sans-serif;-webkit-text-size-adjust:100%}
+a{background:none}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+b,strong{font-weight:bold}
+abbr{font-size:.9em}
+abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
+dfn{font-style:italic}
+hr{height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type=checkbox],input[type=radio]{padding:0}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,::before,::after{box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:0}
+p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ul.square{list-style-type:square}
+ul.circle ul:not([class]),ul.disc ul:not([class]),ul.square ul:not([class]){list-style:inherit}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
+table thead,table tfoot{background:#f7f8f7}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt{background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+:not(pre).nobreak{word-wrap:normal}
+:not(pre).nowrap{white-space:nowrap}
+:not(pre).pre-wrap{white-space:pre-wrap}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
+pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
+pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre>code{display:block}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#content{margin-top:1.25em}
+#content::before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
+#content{margin-bottom:.625em}
+.sect1{padding-bottom:.625em}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details{margin-left:1.25rem}
+details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
+details>summary::-webkit-details-marker{display:none}
+details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
+details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
+details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
+.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:first-child,.sidebarblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child,.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
+pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint li code[data-lang]::before{opacity:1}
+pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
+table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.linenotable td.code{padding-left:.75em}
+table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
+pre.pygments span.linenos{display:inline-block;margin-right:.75em}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
+td.tableblock>.content>:last-child{margin-bottom:-1.25em}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>*>tr>*{border-width:1px}
+table.grid-cols>*>tr>*{border-width:0 1px}
+table.grid-rows>*>tr>*{border-width:1px 0}
+table.frame-all{border-width:1px}
+table.frame-ends{border-width:1px 0}
+table.frame-sides{border-width:0 1px}
+table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
+table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
+table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
+table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
+table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+li>p:empty:only-child::before{content:"";display:inline-block}
+ul.checklist>li>p:first-child{margin-left:-1em}
+ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
+ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+td.hdlist2{word-wrap:anywhere}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background:#00fafa}
+.black{color:#000}
+.black-background{background:#000}
+.blue{color:#0000bf}
+.blue-background{background:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background:#fa00fa}
+.gray{color:#606060}
+.gray-background{background:#7d7d7d}
+.green{color:#006000}
+.green-background{background:#007d00}
+.lime{color:#00bf00}
+.lime-background{background:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background:#7d0000}
+.navy{color:#000060}
+.navy-background{background:#00007d}
+.olive{color:#606000}
+.olive-background{background:#7d7d00}
+.purple{color:#600060}
+.purple-background{background:#7d007d}
+.red{color:#bf0000}
+.red-background{background:#fa0000}
+.silver{color:#909090}
+.silver-background{background:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]::after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,td.hdlist1,span.alt,summary{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]{border-bottom:1px dotted}
+abbr[title]::after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#header,#content,#footnotes,#footer{max-width:none}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span::before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+</style>
+</head>
+<body id="contributing-to-docs-doc-guidelines" class="article">
+<div id="header">
+<h1>Documentation guidelines</h1>
+<div class="details">
+<span id="author" class="author">include::_attributes/common-attributes.adoc</span><br>
+</div>
+</div>
+<div id="content">
+<div id="preamble">
+<div class="sectionbody">
+<div class="paragraph">
+<p>The documentation guidelines for OpenShift 4 build on top of the
+<a href="https://redhat-documentation.github.io/modular-docs/"><em>Red Hat modular docs reference guide</em></a>.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>These <em>Documentation guidelines</em> are primarily concerned with the modular structure and AsciiDoc / AsciiBinder requirements for building OpenShift documention. For general style guidelines in OpenShift docs, see the following:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Primary source: <a href="https://www.ibm.com/docs/en/ibm-style"><em>IBM Style</em></a></p>
+</li>
+<li>
+<p>Supplementary source: <a href="https://redhat-documentation.github.io/supplementary-style-guide/"><em>Red Hat supplementary style guide for product documentation</em></a></p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>When looking for style guidance, reference the <em>Red Hat supplementary style guide for product documentation</em> first, because it overrides certain guidance from the <em>IBM Style</em> guide.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<!-- toc disabled -->
+</div>
+</div>
+<div class="sect1">
+<h2 id="_general_file_guidelines">General file guidelines</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p>Set your editor to strip trailing whitespace.</p>
+</li>
+<li>
+<p>Do <strong>not</strong> hard wrap lines at 80 characters (or at any other length).</p>
+<div class="paragraph">
+<p>It is not necessary to update existing content to unwrap lines, but you can remove existing hard wrapping from any lines that you are currently working in.</p>
+</div>
+<div class="admonitionblock tip">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Tip</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>In the Atom editor, you can use <code>Ctrl</code>+<code>J</code> to undo hard wrapping on a paragraph.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="assembly-file-metadata">Assembly file metadata</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Every assembly file should contain the following metadata at the top, with no line spacing in between, except where noted:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>:_mod-docs-content-type: ASSEMBLY                                        <b class="conum">(1)</b>
+[id="&lt;unique-heading-for-assembly&gt;"]                            <b class="conum">(2)</b>
+= Assembly title                                                <b class="conum">(3)</b>
+include::_attributes/common-attributes.adoc[]                   <b class="conum">(4)</b>
+:context: &lt;unique-context-for-assembly&gt;                         <b class="conum">(5)</b>
+                                                                <b class="conum">(6)</b>
+toc::[]                                                         <b class="conum">(7)</b></pre>
+</div>
+</div>
+<div class="colist arabic">
+<ol>
+<li>
+<p>The content type for the file. For assemblies, always use <code>:_mod-docs-content-type: ASSEMBLY</code>. Place this attribute before the anchor ID or, if present, the conditional that contains the anchor ID.</p>
+</li>
+<li>
+<p>A unique (within OpenShift docs) anchor ID for this assembly. Use lowercase. Example: cli-developer-commands</p>
+</li>
+<li>
+<p>Human readable title (notice the <code>=</code> top-level header)</p>
+</li>
+<li>
+<p>Includes attributes common to OpenShift docs.</p>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="ulist">
+<ul>
+<li>
+<p>The <code>{product-title}</code> and <code>{product-version}</code> common attributes are not defined in the <code>_attributes/common-attributes.adoc</code> file. Those attributes are pulled by AsciiBinder from the distro mapping definitions in the <a href="https://github.com/openshift/openshift-docs/blob/main/_distro_map.yml">_distro_map.yml</a> file. See <a href="#product-name-and-version">Product title and version</a> and <a href="#attribute-files">attribute files</a> for more information on this topic.</p>
+</li>
+<li>
+<p>If you use a variable in the title of the first assembly in a section, move the include attributes directive above the title in this assembly. Otherwise, the variable will not render correctly on access.redhat.com.</p>
+</li>
+</ul>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</li>
+<li>
+<p>Context used for identifying headers in modules that is the same as the anchor ID. Example: cli-developer-commands.</p>
+</li>
+<li>
+<p>A blank line. You <strong>must</strong> have a blank line here before the toc.</p>
+</li>
+<li>
+<p>The table of contents for the current assembly.</p>
+</li>
+</ol>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>Do not use backticks or other markup in assembly or module headings. You can use backticks or other markup in the title for a block, such as a code block <code>.Example</code> or a table <code>.Description</code> title.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>After the heading block and a single whitespace line, you can include any content for this assembly.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>The assembly title, which is the first line of the document, is the only level 1 ( = ) title.
+Section headers within the assembly must be level 2 ( == ) or lower. When you include modules, you must add
+leveloffsets in the include statements. You can manually add more level 2 or lower section headers in the assembly.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="module-file-metadata">Module file metadata</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Every module should be placed in the modules folder and should contain the following metadata at the top:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>// Module included in the following assemblies:
+//
+// * list of assemblies where this module is included              <b class="conum">(1)</b>
+
+:_mod-docs-content-type: &lt;TYPE&gt;                                    <b class="conum">(2)</b>
+[id="&lt;module-anchor&gt;_{context}"]                                   <b class="conum">(3)</b>
+= Module title                                                     <b class="conum">(4)</b></pre>
+</div>
+</div>
+<div class="colist arabic">
+<ol>
+<li>
+<p>List of assemblies in which this module is included.</p>
+</li>
+<li>
+<p>The content type for the file. Replace <code>&lt;TYPE&gt;</code> with the actual type of the module, <code>CONCEPT</code>, <code>REFERENCE</code>, or <code>PROCEDURE</code>. Place this attribute before the anchor ID or, if present, the conditional that contains the anchor ID.</p>
+</li>
+<li>
+<p>A module anchor with {context} that must be lowercase and must match the module&#8217;s file name.</p>
+</li>
+<li>
+<p>Human readable title. To ensure consistency in the results of the
+leveloffset values in include statements, you must use a level one heading
+( = ) for the module title.</p>
+</li>
+</ol>
+</div>
+<div class="paragraph">
+<p>Example:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>// Module included in the following assemblies:
+//
+// * cli_reference/openshift_cli/developer-cli-commands.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="cli-basic-commands_{context}"]
+= Basic CLI commands</pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>Do not use backticks or other markup in assembly or module headings. You can use backticks or other markup in the title for a block, such as a code block <code>.Example</code> or a table <code>.Description</code> title.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="snippet-file-metadata">Text snippet file metadata</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Every text snippet should be placed in the <code>snippets/</code> folder and should contain the following metadata at the top:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>// Text snippet included in the following assemblies: <b class="conum">(1)</b>
+//
+// * list of assemblies where this text snippet is included
+//
+// Text snippet included in the following modules:    <b class="conum">(2)</b>
+//
+// * list of modules where this text snippet is included
+
+:_mod-docs-content-type: SNIPPET                               <b class="conum">(3)</b></pre>
+</div>
+</div>
+<div class="colist arabic">
+<ol>
+<li>
+<p>List of assemblies in which this text snippet is included.</p>
+</li>
+<li>
+<p>List of modules in which this text snippet is included.</p>
+</li>
+<li>
+<p>The content type for the file. For snippets, always use <code>:_mod-docs-content-type: SNIPPET</code>. Place this attribute before the anchor ID, the conditional that contains the anchor ID, or the first line of body text.</p>
+</li>
+</ol>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>An anchor ID and human readable title are not required metadata. This type of component is text only and not intended to be published or cross referenced on its own. See <a href="#writing-text-snippets">Writing text snippets</a>.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>Example:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>// Text snippet included in the following assemblies:
+//
+// * installing/installing_aws/installing-aws-default.adoc
+// * installing/installing_azure/installing-azure-default.adoc
+// * installing/installing_gcp/installing-gcp-default.adoc
+
+:_mod-docs-content-type: SNIPPET
+In {product-title} version {product-version}, you can install a cluster on {cloud-provider-first} ({cloud-provider}) that uses the default configuration options.</pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_content_type_attributes">Content type attributes</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Each <code>.adoc</code> file must contain a <code>:_mod-docs-content-type:</code> attribute in its metadata that indicates its file type. This information is used by some publication processes to sort and label files.</p>
+</div>
+<div class="paragraph">
+<p>Add the attribute from the following list that corresponds to your file type:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>:_mod-docs-content-type: ASSEMBLY</code></p>
+</li>
+<li>
+<p><code>:_mod-docs-content-type: CONCEPT</code></p>
+</li>
+<li>
+<p><code>:_mod-docs-content-type: PROCEDURE</code></p>
+</li>
+<li>
+<p><code>:_mod-docs-content-type: REFERENCE</code></p>
+</li>
+<li>
+<p><code>:_mod-docs-content-type: SNIPPET</code></p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Place the attribute in the file metadata. The following list describes the best attribute placement options:</p>
+</div>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>Directly before the first anchor ID in a file</p>
+</li>
+<li>
+<p>If the first anchor ID is enclosed in a conditional, before the conditional</p>
+</li>
+<li>
+<p>Between the list of assemblies in which this module is included and the first line of body text</p>
+</li>
+</ol>
+</div>
+<div class="paragraph">
+<p>The metadata examples contain sample placement for each file type, <a href="#assembly-file-metadata">assembly</a>, <a href="#module-file-metadata">module</a>, and <a href="#snippet-file-metadata">snippet</a>.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="attribute-files">Attribute files</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>All attribute files must be placed in the <code>_attributes</code> directory. In most cases involving OpenShift Container Platform or OKD, add attributes to the <code>common-attributes.adoc</code> file instead of creating or using a separate attributes file. Before you add an attribute, review the contents of the <code>common-attributes.adoc</code> file to ensure that it is not already defined.</p>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Important</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>If you think that you need a separate attributes file, check with the docs team before you create it.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>It is acceptable to group related attributes in the <code>common-attributes.adoc</code> file under a comment, as shown in the following example:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>//gitops
+:gitops-title: Red Hat OpenShift GitOps
+:gitops-shortname: GitOps</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>It is also acceptable to enclose attributes in a <a href="#product-name-and-version">distro-based</a> conditional, but you must place attribute definitions for the <code>openshift-enterprise</code> distro first. The following example shows how to set a different value for the <code>:op-system-base:</code> attribute for OKD:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>:op-system-base: RHEL</pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>When backporting content that contains IBM-related attributes to <code>enterprise-4.13</code> and earlier branches, you might need to create manual cherry picks because IBM-related attributes names are not consistent with later release branches.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_assemblymodule_file_names">Assembly/module file names</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Try to shorten the file name as much as possible <em>without</em> abbreviating important terms that may cause confusion. For example, the <code>managing-authorization-policies.adoc</code> file name would be appropriate for an assembly titled "Managing Authorization Policies".</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_directory_names">Directory names</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>If you create a directory with a multiple-word name, separate each word with an underscore, for example <code>backup_and_restore</code>.</p>
+</div>
+<div class="paragraph">
+<p>Do not create or rename a top-level directory in the repository and topic map without checking with the docs program manager first.</p>
+</div>
+<div class="paragraph">
+<p>Avoid creating two levels of subdirectories because the <a href="https://github.com/openshift/openshift-docs/issues/52149">breadcrumb bar on docs.openshift.com breaks</a>. If you have a valid use case for two levels of subdirectories, talk with your DPM/CS (and, for aligned teams, the OpenShift DPM) for approval before creating it.</p>
+</div>
+<div class="paragraph">
+<p>When creating a new directory or subdirectory, you must create four symbolic links in it:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>An <code>images</code> symbolic link to the top-level <code>images/</code> directory</p>
+</li>
+<li>
+<p>A <code>modules</code> symbolic link to the top-level <code>modules/</code> directory</p>
+</li>
+<li>
+<p>A <code>snippets</code> symbolic link to the top-level <code>snippets/</code> directory</p>
+</li>
+<li>
+<p>An <code>_attributes</code> symbolic link to the top-level <code>_attributes/</code> directory</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>If the directory that contains an assembly does not have the <code>images</code> symbolic link, any images in that assembly or its modules will not be included properly when building the docs.</p>
+</div>
+<div class="admonitionblock tip">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Tip</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>To create the symbolic links:</p>
+</div>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>Navigate to the directory that you need to add the links in.</p>
+</li>
+<li>
+<p>Use the following command to create a symbolic link:</p>
+<div class="listingblock">
+<div class="content">
+<pre>$ ln -s &lt;target_directory&gt; &lt;link_name&gt;</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>For example, if you are creating the links in a directory that is two levels deep, such as <code>cli_reference/openshift_cli</code>, use the following commands:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>$ ln -s ../../images/ images
+$ ln -s ../../modules/ modules
+$ ln -s ../../snippets/ snippets
+$ ln -s ../../_attributes/ _attributes</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Be sure to adjust the number of levels to back up (<code>../</code>) depending on how deep your directory is.</p>
+</div>
+</li>
+</ol>
+</div>
+<div class="paragraph">
+<p>If you accidentally create an incorrect link, you can remove that link by using <code>unlink &lt;link_name&gt;</code>.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_assemblymodule_titles_and_section_headings">Assembly/Module titles and section headings</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Use sentence case in all titles and section headings. See <a href="http://www.titlecase.com/" class="bare">http://www.titlecase.com/</a> or <a href="https://convertcase.net/" class="bare">https://convertcase.net/</a> for a conversion tool.</p>
+</div>
+<div class="paragraph">
+<p>Try to be as descriptive as possible with the title or section headings
+without making them unnecessarily long. For assemblies and task modules,
+use a gerund form in headings, such as:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Creating</p>
+</li>
+<li>
+<p>Managing</p>
+</li>
+<li>
+<p>Using</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Do not use "Overview" as a heading.</p>
+</div>
+<div class="paragraph">
+<p>Do not use backticks or other markup in assembly or module headings.</p>
+</div>
+<div class="paragraph">
+<p>Do not use special characters or symbols in titles. Symbols and special characters in titles can cause rendering errors in the HTML output.</p>
+</div>
+<div class="paragraph">
+<p>Use only one level 1 heading (<code>=</code>) in any file.</p>
+</div>
+<div class="sect2">
+<h3 id="_discrete_headings">Discrete headings</h3>
+<div class="paragraph">
+<p>If you have a section heading that you do not want to appear in the TOC (like if you think that some section is not worth showing up or if there are already too many nested levels), you can use a discrete (or floating) heading:</p>
+</div>
+<div class="paragraph">
+<p><a href="https://docs.asciidoctor.org/asciidoc/latest/blocks/discrete-headings/" class="bare">https://docs.asciidoctor.org/asciidoc/latest/blocks/discrete-headings/</a></p>
+</div>
+<div class="paragraph">
+<p>A discrete heading also will not get a section number in the Customer Portal build of the doc. Previously, we would use plain bold mark-up around a heading like this, but discrete headings also allow you to ignore section nesting rules (like jumping from a <code>==</code> section level to a <code>====</code> level if you wanted for some style reason).</p>
+</div>
+<div class="paragraph">
+<p>To use a discrete heading, just add <code>[discrete]</code> to the line before your unique ID. For example:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>[discrete]
+[id="managing-authorization-policies_{context}"]
+== Managing authorization policies</pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_anchoring_titles_and_section_headings">Anchoring titles and section headings</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>All titles and section headings must have an anchor ID. The anchor ID must be similar to the title or section heading.</p>
+</div>
+<div class="sect2">
+<h3 id="_anchoring_in_assembly_files">Anchoring in assembly files</h3>
+<div class="paragraph">
+<p>The following is an example anchor ID in an assembly file:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>[id="configuring-alert-notifications"]
+= Configuring alert notifications</pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>Do not include line spaces between the anchor ID and the section title.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_anchoring_in_module_files">Anchoring in module files</h3>
+<div class="paragraph">
+<p>You must add the <code>{context}</code> variable to the end of each anchor ID in module files. When called, the <code>{context}</code> variable is resolved into the value declared in the <code>:context:</code> attribute in the corresponding assembly file. This enables cross-referencing to module IDs in context to a specific assembly and is useful when a module is included in multiple assemblies.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>The <code>{context}</code> variable must be preceded by an underscore (<code>_</code>) when declared in an anchor ID.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>The following is an example of an anchor ID for a module file title:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>[id="sending-notifications-to-external-systems_{context}"]
+= Sending notifications to external systems</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The following is an example of an anchor ID for a second level (<code>==</code>) heading:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>[id="deployment-scaling-benefits_{context}"]
+== Deployment and scaling benefits</pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_anchoring_prerequisites_additional_resources_and_next_steps_titles_in_assemblies">Anchoring "Prerequisites", "Additional resources", and "Next steps" titles in assemblies</h3>
+<div class="paragraph">
+<p>Use unique IDs for "Prerequisites", "Additional resources", and "Next steps" titles in assemblies. You can add the prefixes <code>prerequisites_</code>, <code>additional-resources_</code>, or <code>next-steps_</code> to a unique string that describes the assembly topic. The unique string can match the value assigned to the <code>:context:</code> attribute in the assembly.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>The <code>prerequisites_</code>, <code>additional-resources_</code>, and <code>next-steps_</code> prefixes must end with an underscore (<code>_</code>) when declared in an anchor ID in an assembly.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>The following examples include IDs that are unique to the "Configuring alert notifications" assembly:</p>
+</div>
+<div class="paragraph">
+<p><strong>Example unique ID for a "Prerequisites" title</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>[id="prerequisites_configuring-alert-notifications"]
+== Prerequisites</pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>Example unique ID for an "Additional resources" title</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>[role="_additional-resources"]
+[id="additional-resources_configuring-alert-notifications"]
+== Additional resources</pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>Example unique ID for a "Next steps" title</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>[id="next-steps_configuring-alert-notifications"]
+== Next steps</pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_writing_assemblies">Writing assemblies</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>An <em>assembly</em> is a collection of modules that describes how to accomplish a user story.</p>
+</div>
+<div class="paragraph">
+<p>Avoid <a href="https://redhat-documentation.github.io/modular-docs/#nesting-assemblies">nesting assemblies</a> in other assembly files. You can create more complicated document structures by modifying the <a href="https://github.com/openshift/openshift-docs/tree/main/_topic_maps">topic maps</a>.</p>
+</div>
+<div class="paragraph">
+<p>For more information about forming assemblies, see the
+<a href="https://redhat-documentation.github.io/modular-docs/#forming-assemblies"><em>Red Hat modular docs reference guide</em></a> and the <a href="https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/modular-docs-manual/files/TEMPLATE_ASSEMBLY_a-collection-of-modules.adoc">assembly template</a>.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>When using the "Prerequisites", "Next steps", or "Additional resources" headings in an assembly, use <code>==</code> formatting, such as <code>== Prerequisites</code> or <code>== Additional resources</code>. Use of this heading syntax at the assembly level indicates that the sections relate to the whole assembly.</p>
+</div>
+<div class="paragraph">
+<p>Only use <code>.</code> formatting (<code>.Additional resources</code>) to follow a module in an assembly. Because you cannot use the xrefs in modules, this functions as a <em>trailing include</em> at the assembly level, where the <code>.</code> formatting of the <code>include</code> statement indicates that the resource applies specifically to the module and not to the assembly.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_writing_concepts">Writing concepts</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>A <em>concept</em> contains information to support the tasks that users want to do and
+must not include task information like commands or numbered steps. In most
+cases, create your concepts as individual modules and include them in
+appropriate assemblies.</p>
+</div>
+<div class="paragraph">
+<p>Avoid using gerunds in concept titles. "About &lt;concept&gt;"
+is a common concept module title.</p>
+</div>
+<div class="paragraph">
+<p>For more information about creating concept modules, see the
+<a href="https://redhat-documentation.github.io/modular-docs/#creating-concept-modules"><em>Red Hat modular docs reference guide</em></a> and the <a href="https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/modular-docs-manual/files/TEMPLATE_CONCEPT_concept-explanation.adoc">concept template</a>.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_writing_procedures">Writing procedures</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>A <em>procedure</em> contains the steps that users follow to complete a single process or task. Procedures contain ordered steps and explicit commands. In most cases, create your procedures as individual modules and include them in appropriate assemblies.</p>
+</div>
+<div class="paragraph">
+<p>Use a gerund in the procedure title, such as "Creating".</p>
+</div>
+<div class="paragraph">
+<p>For more information about writing procedures, see the
+<a href="https://redhat-documentation.github.io/modular-docs/#con-creating-procedure-modules_writing-mod-docs"><em>Red Hat modular docs reference guide</em></a> and the <a href="https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/modular-docs-manual/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc">procedure template</a>.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>When needed, use <code>.Prerequisites</code>, <code>.Next steps</code>, or <code>.Additional resources</code> syntax to suppress TOC formatting within a module. Do not use <code>==</code> syntax for these headings in modules. Because you cannot use the xrefs in modules, if you need to include a link under one of these headings, place the entire subsection in the assembly instead.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="writing-text-snippets">Writing text snippets</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>A <em>text snippet</em> is an optional component that lets you reuse content in multiple modules and assemblies. Text snippets are not a substitute for modules but instead are a more granular form of content reuse. While a module is content that a reader can understand on its own (like an article) or as part of a larger body of work (like an assembly), a text snippet is not self-contained and is not intended to be published or cross referenced on its own.</p>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Important</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>Only include entire snippets in an assembly or module. Including <a href="https://docs.asciidoctor.org/asciidoc/latest/directives/include-lines/">lines by content ranges</a> can lead to content errors when the included file is subsequently updated and is not permitted.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>In the context of modules and assemblies, text snippets do not include headings or anchor IDs. Text snippets also cannot contain xrefs. This type of component is text only. Examples include the following:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Admonitions that appear in multiple modules.</p>
+</li>
+<li>
+<p>An introductory paragraph that appears in multiple assemblies.</p>
+</li>
+<li>
+<p>The same series of steps that appear in multiple procedure modules.</p>
+</li>
+<li>
+<p>A deprecation statement that appears in multiple sets of release notes.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Example:</p>
+</div>
+<div class="paragraph">
+<p>You could write the following paragraph once and include it in each assembly that explains how to install a cluster using the installer-provisioned default values:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-text" data-lang="text">In {product-title} version {product-version}, you can install a cluster on {cloud-provider-first} ({cloud-provider}) that uses the default configuration options.</code></pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>In the example, <code>cloud-provider-first</code> and <code>cloud-provider</code> are not defined by the <code>common-attributes</code> module. If you use an attribute that is not common to OpenShift docs, make sure to define it locally in either the assembly or module, depending on where the text snippet is included. Because of this, consider adding all attributes that you add to snippets to the <code>common-attributes.adoc</code> file.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>For more information about creating text snippets, see the
+<a href="https://redhat-documentation.github.io/modular-docs/#using-text-snippets"><em>Red Hat modular docs reference guide</em></a>.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="Auto-generated-content">Auto-generated content</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>The following content is auto-generated in each release and must not be manually edited:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>The OpenShift CLI (<code>oc</code>) command references <code>modules/oc-by-example-content.adoc</code> and <code>modules/oc-adm-by-example-content.adoc</code>.</p>
+</li>
+<li>
+<p>The following API references content in the <code>rest_api</code> folder: the contents of all <code>&lt;topic&gt;_apis</code> subfolders and the <code>rest_api/objects/index.adoc</code> and <code>rest_api/index.adoc</code> assemblies.</p>
+</li>
+<li>
+<p>OpenShift Virtualization runbook modules: <code>modules/virt-runbook-&lt;runbook&gt;.adoc</code>.</p>
+</li>
+</ul>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>If the content in these files needs to be updated, the update must be made in the applicable code repository where these files are generated from. The updates are reflected when the files are generated the next time, for example a future release. For help with where to make the updates, you can contact <a href="https://github.com/bergerhoffer">Andrea Hoffer</a> for the CLI docs, <a href="https://github.com/jboxman-rh">Jason Boxman</a> for the API docs, or <a href="https://github.com/apinnick">Avital Pinnick</a> for the OpenShift Virtualization runbooks.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="using-conscious-language">Using conscious language</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>To assist with the removal of the problematic word "master" from the documentation, use the following terminology when referring to OpenShift control plane nodes:</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Branch</th>
+<th class="tableblock halign-left valign-top">Control plane node reference</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>main</code>, <code>enterprise-4.9</code>, and later enterprise versions</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Control plane node</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>enterprise-4.8</code> and earlier enterprise versions</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Control plane (also known as master) node</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>enterprise-3.11</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Master node</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>You can replace "node" in the preceding examples with "machine", "host", or another suitable description.</p>
+</div>
+<div class="paragraph">
+<p>In general text, use the term "control plane machine" in place of "master machine"; use the term "compute machine" in place of "worker machine". Be mindful of certain valid code entities, such as <code>master</code> role, <code>worker</code> role, and <code>infra</code> role.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>If you are cherry picking from <code>main</code> to <code>enterprise-4.8</code> or earlier, you must manually cherry pick to include the “(also known as master)” phrasing. This is required only if the phrase “control plane” is introduced for the first time in an assembly or module.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="sect2">
+<h3 id="adding-a-subsection-on-making-open-source-more-inclusive">Adding a subsection on making open source more inclusive</h3>
+<div class="paragraph">
+<p>If you create a release notes assembly for a sub-product within the <code>openshift/openshift-docs</code> repo, you might include a "Making open source more inclusive" statement. Instead of pasting the statement from the OpenShift Release Notes, use the following module, which is available in the <code>enterprise-4.8</code> branch and later:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-text" data-lang="text">include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="product-name-and-version">Product title and version</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>When possible, generalize references to the product name and/or version by using
+the <code>{product-title}</code> and/or <code>{product-version}</code> attributes. These attributes
+are pulled by AsciiBinder from the OpenShift distribution, or <em>distro</em>, mapping definitions in the
+<a href="https://github.com/openshift/openshift-docs/blob/main/_distro_map.yml">_distro_map.yml</a>
+file.</p>
+</div>
+<div class="paragraph">
+<p>The <code>{product-title}</code> comes from the first <code>name:</code> field in a distro mapping,
+while the associated <code>{product-version}</code> comes from the <code>name:</code> fields on any
+<code>branches:</code> defined.</p>
+</div>
+<div class="paragraph">
+<p>How these attributes render is dependent on which distro and branch build you
+are viewing. The following table shows the current distros and the
+possible values for <code>{product-title}</code> and <code>{product-version}</code>, depending on the branch:</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Distro</th>
+<th class="tableblock halign-left valign-top"><code>{product-title}</code></th>
+<th class="tableblock halign-left valign-top"><code>{product-version}</code></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>openshift-origin</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OKD</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
+<ul>
+<li>
+<p>3.6, 3.7, 3.9, 3.10, 3.11</p>
+</li>
+<li>
+<p>4.8, 4.9, 4.10, 4.11, 4.12, 4.13, 4.14, 4.15</p>
+</li>
+<li>
+<p>4 for the <code>latest/</code> build from the <code>main</code> branch</p>
+</li>
+</ul>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>openshift-enterprise</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpenShift Container Platform</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
+<ul>
+<li>
+<p>3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.9, 3.10, 3.11</p>
+</li>
+<li>
+<p>4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 4.10, 4.11, 4.12, 4.13, 4.14, 4.15, 4.16</p>
+</li>
+</ul>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>openshift-dedicated</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpenShift Dedicated</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="ulist">
+<ul>
+<li>
+<p>No value set for the latest <code>dedicated/</code> build from the <code>enterprise-4.15</code> branch</p>
+</li>
+<li>
+<p>3 for the <code>dedicated/3</code> build from the <code>enterprise-3.11</code> branch</p>
+</li>
+</ul>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>openshift-rosa</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Red Hat OpenShift Service on AWS</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">No value set for the <code>rosa/</code> build from the <code>enterprise-4.15</code> branch</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>openshift-online</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpenShift Online</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Pro</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>For example:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>You can deploy applications on {product-title}.</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This is a safe statement that could appear in probably any of the builds, so an
+<a href="https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/contributing.adoc#conditional-text-between-products">ifdef/endif
+statement</a> is not necessary. For example, if you were viewing a build for the
+<code>openshift-enterprise</code> distro (for any of the distro-defined branches), this
+would render as:</p>
+</div>
+<div class="quoteblock">
+<blockquote>
+<div class="paragraph">
+<p>You can deploy applications on OpenShift Container Platform.</p>
+</div>
+</blockquote>
+</div>
+<div class="paragraph">
+<p>And for the <code>openshift-origin</code> distro:</p>
+</div>
+<div class="quoteblock">
+<blockquote>
+<div class="paragraph">
+<p>You can deploy applications on OKD.</p>
+</div>
+</blockquote>
+</div>
+<div class="paragraph">
+<p>Considering that we use distinct branches to keep content for product versions separated, global use of <code>{product-version}</code> across all branches is probably less useful, but it is available if you come across a requirement for it. Just consider how it will render across any branches that the content appears in.</p>
+</div>
+<div class="paragraph">
+<p>If it makes more sense in context to refer to the major version of the product instead of a specific minor version (for example, if comparing how something in OpenShift Container Platform 4 differs from OpenShift Container Platform 3), just use the major version number. Do not prepend with a <code>v</code>, as in <code>v3</code> or <code>v4</code>.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>Other common attribute values are defined in the <code>_attributes/common-attributes.adoc</code> file. Where possible, generalize references to those values by using the common attributes. For example, use <code>{cluster-manager-first}</code> to refer to Red Hat OpenShift Cluster Manager. If you need to add an attribute to the <code>_attributes/common-attributes.adoc</code> file, open a pull request to add it to the attribute list. Do not create a separate attributes file without first consulting the docs team.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="third-party-vendor-product-names">Third-party vendor product names</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Red Hat integrates with many third-party vendor products. For certain integrated products, third-party vendor staff might have access to certain Red Hat resources and be contactable within Red Hat. On other occasions, common open-source products might be widely used across IT infrastructure providers, so Red Hat might not have direct contacts to organizations that own these products.</p>
+</div>
+<div class="paragraph">
+<p>Depending on the third-party vendor&#8217;s requirements, you might need to add a registered trademark symbol to all of the vendor&#8217;s product names or only on the first occurence of referencing the product name in an assembly, a module, or a document.</p>
+</div>
+<div class="paragraph">
+<p>Choose any of the following sources for clarification on using the symbol for a specific third-party vendor product name:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Visit the third-party vendor&#8217;s website and contact them directly.</p>
+</li>
+<li>
+<p>Contact internal Red Hat product teams or integrated third-party vendor teams.</p>
+</li>
+<li>
+<p>Contact the Red Hat Legal team. Only consider this option when the other two options did not provide clear context for your query.</p>
+</li>
+</ul>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Important</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>Do not use Asciidoctor character replacement substitutions, which rely on a Unicode code point such as <em>&#174;</em>, to set the registered symbol in an Asciidoc file. Instead use <em>&#174;</em> beside the product name. For example, <code>IBM&#174; LinuxONE</code>.</p>
+</div>
+<div class="paragraph">
+<p>Do not apply any superscript, such as <code>&#174;</code>, or subscript formatting to module or assembly headings.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>For more information about contacting the Red Hat&#8217;s Legal team, see <a href="https://source.redhat.com/departments/legal/redhatintellectualproperty/trademarks/trademarks_and_domain_names_wiki/copyright_notices_and_trademark_legends">Copyright Notices and Trademark Legends</a> on the The Source.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="conditional-content">Conditional content</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>You can use ifdef and ifeval statements to control the way content displays in different distributions and assemblies.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+You can nest conditional statements that involve distribution and assembly context, but you must ensure that you close the if statements correctly.
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>Because we maintain separate branches for each OpenShift Container Platform version, do not use if statements that are based on product version to vary content.</p>
+</div>
+<div class="sect2">
+<h3 id="conditionals-for-distributions">Conditionals for distributions</h3>
+<div class="paragraph">
+<p>Use ifdef and ifndef statements to control content based on distribution, as described in the previous section. For example, the following example renders differently in (<code>openshift-origin</code>) and OpenShift Container Platform (<code>openshift-enterprise</code>):</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>ifdef::openshift-origin[]
+You can link:https://www.keycloak.org/docs/latest/server_admin/index.html#openshift[configure a Keycloak] server as an OpenID
+Connect identity provider for {product-title}.
+endif::[]
+
+ifdef::openshift-enterprise[]
+You can
+link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/[configure Red Hat Single Sign-On]
+as an OpenID Connect identity provider for {product-title}.
+endif::[]</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>In OKD, this section renders as the following text:</p>
+</div>
+<div class="quoteblock">
+<blockquote>
+<div class="paragraph">
+<p>You can <a href="https://www.keycloak.org/docs/latest/server_admin/index.html#openshift">configure a Keycloak</a> server as an OpenID
+Connect identity provider for OKD.</p>
+</div>
+</blockquote>
+</div>
+<div class="paragraph">
+<p>In OpenShift Container Platform, this section renders as the following text:</p>
+</div>
+<div class="quoteblock">
+<blockquote>
+<div class="paragraph">
+<p>You can
+<a href="https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/">configure Red Hat Single Sign-On</a>
+as an OpenID Connect identity provider for OpenShift Container Platform.</p>
+</div>
+</blockquote>
+</div>
+</div>
+<div class="sect2">
+<h3 id="conditionals-for-assemblies">Conditionals for different assemblies</h3>
+<div class="paragraph">
+<p>Use a combination of ifdef and ifeval statements to control content that needs to vary between assemblies. These conditional statements rely on a combination of the context attribute for each assembly and specific temporary attributes within each module to control content.</p>
+</div>
+<div class="paragraph">
+<p>The following sample shows a simple example. In the assembly that contains the <code>context</code> attribute <code>updating-restricted-network-cluster</code>, an extra paragraph is displayed.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>ifeval::["{context}" == "updating-restricted-network-cluster"]
+:restricted:
+endif::[]
+
+...
+
+ifdef::restricted[]
+If you are upgrading a cluster in a restricted network, install the `oc` version that you plan to upgrade to.
+endif::restricted[]
+
+...
+
+ifeval::["{context}" == "updating-restricted-network-cluster"]
+:!restricted:
+endif::[]</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Note that you must set and unset each temporary attribute that you introduce to an assembly. Use the temporary attributes in the applicable ifdef and ifndef statements to vary text between the assemblies. The preceeding example uses <code>restricted</code> as the temporary attribute to display an additional paragraph for the assembly with the <code>updating-restricted-network-cluster</code> context attribute.</p>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_node_names">Node names</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Do not use internal company server names in commands or example output. Provide generic OpenShift Container Platform node name examples that are not provider-specific, unless required. Where possible, use the example.com domain name when providing fully qualified domain names (FQDNs).</p>
+</div>
+<div class="paragraph">
+<p>The following table includes example OpenShift Container Platform 4 node names and their corresponding role types:</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Node name</th>
+<th class="tableblock halign-left valign-top">Role type</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>node-1.example.com</strong></p></td>
+<td class="tableblock halign-left valign-middle" rowspan="3"><p class="tableblock">You can use this format for nodes that do not need role-specific node names.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>node-2.example.com</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>node-3.example.com</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>control-plane-1.example.com</strong></p></td>
+<td class="tableblock halign-left valign-middle" rowspan="3"><p class="tableblock">You can use this format if you need to describe the control plane role type within a node name.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>control-plane-2.example.com</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>control-plane-3.example.com</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>compute-1.example.com</strong></p></td>
+<td class="tableblock halign-left valign-middle" rowspan="2"><p class="tableblock">You can use this format if you need to describe the compute node role type within a node name.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>compute-2.example.com</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>bootstrap.example.com</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">You can use this format if you need to describe the bootstrap node role type within a node name.</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>This example lists the status of cluster nodes that use the node name formatting guidelines:</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>[source,terminal]
+----
+$ oc get nodes
+----
++
+.Example output
+[source,terminal]
+----
+NAME                          STATUS   ROLES    AGE   VERSION
+compute-1.example.com         Ready    worker   33m   v1.19.0+9f84db3
+control-plane-1.example.com   Ready    master   41m   v1.19.0+9f84db3
+control-plane-2.example.com   Ready    master   45m   v1.19.0+9f84db3
+compute-2.example.com         Ready    worker   38m   v1.19.0+9f84db3
+compute-3.example.com         Ready    worker   33m   v1.19.0+9f84db3
+control-plane-3.example.com   Ready    master   41m   v1.19.0+9f84db3
+----</pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>Some provider-formatted hostnames include IPv4 addresses. An OpenShift Container Platform node name typically reflects the hostname of a node. If node names in your output need to be provider-specific and require this format, use private IPv4 addresses. For example, you could use <code>ip-10-0-48-9.example.com</code> as a node name that includes a private IPv4 address.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_ip_addresses">IP addresses</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>You may include IPv4 addresses from test clusters in examples in the documentation, as long as they are private. Private IPv4 addresses fall into one of the following ranges:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>10.0.0.0 to 10.255.255.255 (class A address block 10.0.0.0/8)</p>
+</li>
+<li>
+<p>172.16.0.0 to 172.31.255.255 (class B address block 172.16.0.0/12)</p>
+</li>
+<li>
+<p>192.168.0.0 to 192.168.255.255 (class C address block 192.168.0.0/16)</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Replace all public IP addresses with an address from the following blocks. These address blocks are reserved for documentation:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>192.0.2.0 to 192.0.2.255 (TEST-NET-1 address block 192.0.2.0/24)</p>
+</li>
+<li>
+<p>198.51.100.0 to 198.51.100.255 (TEST-NET-2 address block 198.51.100.0/24)</p>
+</li>
+<li>
+<p>203.0.113.0 to 203.0.113.255 (TEST-NET-3 address block 203.0.113.0/24)</p>
+</li>
+</ul>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>There might be advanced networking examples that require specific IP addresses, or cloud provider-specific examples that require a public IP address. Contact a subject matter expert if you need assistance with replacing IP addresses.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_links_hyperlinks_and_cross_references">Links, hyperlinks, and cross references</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Links can be used to cross-reference internal assemblies or send readers to external information resources for further reading.</p>
+</div>
+<div class="paragraph">
+<p>In OpenShift docs:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>All links to internal content is created using <code>xref</code> and <strong>must have an anchor ID</strong>.</p>
+</li>
+<li>
+<p>Only use <code>xref</code> in assemblies, not in modules.</p>
+</li>
+<li>
+<p>All links to external websites are created using <code>link</code>.</p>
+</li>
+<li>
+<p>Links between different distros, such as from ROSA to OpenShift Container Platform, are external links and not cross-references. These external links use <code>link</code> instead of <code>xref</code> and need to be in distro-specific files or conditionalized to apply to the relevant distros.</p>
+</li>
+</ul>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Important</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>Do not split link paths across lines when wrapping text. This will cause issues with the doc builds.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_example_urls">Example URLs</h3>
+<div class="paragraph">
+<p>To provide an example URL path that you do not want to render as a hyperlink, use this format:</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>`\https://www.example.com`</pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_internal_cross_references">Internal cross-references</h3>
+<div class="paragraph">
+<p>Use the relative file path (from the file you are editing to the file you are linking to), even if you are linking to the same directory that you are writing in. This makes search and replace operations to fix broken links much easier.</p>
+</div>
+<div class="paragraph">
+<p>For example, if you are writing in <code>architecture/core_concepts/deployments.adoc</code> and you want to link to <code>architecture/core_concepts/routes.adoc</code>, then you must include the path back to the first level of the assembly directory:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>xref:../../architecture/networking/routes.adoc#architecture-core-concepts-routes</pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>In OpenShift docs, you can only use <code>xref</code> in assemblies, not in modules.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="listingblock">
+<div class="title">Markup example of cross-referencing</div>
+<div class="content">
+<pre>For more information, see xref:../dev_guide/application_lifecycle/new_app.adoc#dev-guide-new-app[Creating an application].
+
+Rollbacks can be performed using the REST API or the xref:../cli_reference/openshift_cli/get_started_cli.adoc#installing-openshift-cli[OpenShift CLI].</pre>
+</div>
+</div>
+<div class="quoteblock">
+<div class="title">Rendered output of cross-referencing</div>
+<blockquote>
+<div class="paragraph">
+<p>For more information, see <a href="../dev_guide/application_lifecycle/new_app.html#dev-guide-new-app">Creating an application</a>.</p>
+</div>
+<div class="paragraph">
+<p>Rollbacks can be performed using the REST API or the <a href="../cli_reference/openshift_cli/get_started_cli.html#installing-openshift-cli">OpenShift CLI</a>.</p>
+</div>
+</blockquote>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_links_to_external_websites">Links to external websites</h3>
+<div class="paragraph">
+<p>If you want to link to a different website, use:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>link:http://othersite.com/otherpath[friendly reference text]</pre>
+</div>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Important</div>
+</td>
+<td class="content">
+You must use <code>link:</code> before the start of the URL.
+</td>
+</tr>
+</table>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Important</div>
+</td>
+<td class="content">
+You cannot link to a repository that is hosted on www.github.com.
+</td>
+</tr>
+</table>
+</div>
+<div class="admonitionblock tip">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Tip</div>
+</td>
+<td class="content">
+If you want to build a link from a URL <em>without</em> changing the text from the actual URL, just print the URL without adding a <code>[friendly text]</code> block at the end; it will automatically be rendered as a link.
+</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_links_to_internal_content">Links to internal content</h3>
+<div class="paragraph">
+<p>There are two scenarios for linking to other assemblies:</p>
+</div>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>Link to another file that exists in the same directory.</p>
+</li>
+<li>
+<p>Link to another file that exists in a separate directory.</p>
+</li>
+</ol>
+</div>
+<div class="paragraph">
+<p>The following examples use the example directory structure shown here:</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>/
+/foo
+/foo/bar.adoc
+/baz
+/baz/zig.adoc
+/baz/zag.adoc</pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>Link to assembly in same directory</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>xref:&lt;filename&gt;#anchor-id[friendly title]</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>You must use the <code>.adoc</code> file extension. The document processor will correctly link this to the resulting HTML file.</p>
+</div>
+<div class="paragraph">
+<p>For example, using the above syntax, if you are working on <code>zig.adoc</code> and want to link to <code>zag.adoc</code>, do it this way:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>xref:../zag.adoc#baz-zag[comment]</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>where <code>baz-zag</code> is the anchor ID at the top of the file <code>zag.adoc</code>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Link to assembly in different directory</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>xref:../dir/&lt;filename&gt;.adoc#anchor-id[friendly title]</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>For example, if you are working on <code>bar.adoc</code> and you want to link to <code>zig.adoc</code>, do it this way:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>For more information, see the xref:../baz/zig.adoc#baz-zig[ZIG manual].</pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>You must use the <code>.adoc</code> extension in order for the link to work correctly and you must specify an anchor ID.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_embedding_an_external_file">Embedding an external file</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>You can embed content hosted outside the <a href="https://github.com/openshift/openshift-docs">openshift-docs</a>
+GitHub repository by using the <code>include</code> directive to target the URI of a raw
+file. This is helpful for cases where content frequently changes; you embed the raw
+file and the content auto-updates based on the changes made to the content on its
+host site.</p>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Important</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>You are restricted to only embed files from GitHub repositories managed by the
+<code>openshift</code> GitHub user. You must also prefix your external file URI with <code>https</code>.
+URIs beginning with <code>http</code> are forbidden for security reasons and will fail the
+documentation build.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>For example, if you want to embed the <a href="https://github.com/openshift/installer/blob/release-4.8/upi/azure/01_vnet.json">01_vnet.json</a> template, include the URI of its raw file version like this:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code>.`01_vnet.json` ARM template
+[source,json]
+----
+include::https://raw.githubusercontent.com/openshift/installer/release-4.8/upi/azure/01_vnet.json[]
+----</code></pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>Embedding external files is restricted for files that change frequently, like templates. You must ensure that embedded files are QE verified before they are updated on their host site.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>You must get approval from the Engineering, QE, and Docs teams before embedding an external file.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_embedding_a_local_yaml_file">Embedding a local YAML file</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>You can embed local YAML files in AsciiDoc modules.
+Consider embedding a local YAML file when you have a complete and valid YAML file that you want to use.
+This is useful when you want to include a complete YAML CR in the docs.
+The YAML file that you include must be a local file maintained in the <a href="https://github.com/openshift/openshift-docs">openshift-docs</a> GitHub repository.
+Use the <code>include</code> directive to target the local file.</p>
+</div>
+<div class="paragraph">
+<p>To use a local YAML file, add it to the <code>snippets/</code> folder, and include it in your module. For example:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-yaml" data-lang="yaml">include::snippets/install-config.yaml[]</code></pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>Do not include <a href="https://docs.asciidoctor.org/asciidoc/latest/directives/include-lines/">lines by content ranges</a>. This approach can lead to content errors when the included file is subsequently updated.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Important</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>If the YAML file you want to include is from a GitHub repository that is managed by the <code>openshift</code> GitHub user, link to the file directly rather than copying the file to the <code>/openshift-docs</code> folder.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<h3 id="_using_asciidoc_callouts_in_the_yaml" class="discrete">Using AsciiDoc callouts in the YAML</h3>
+<div class="paragraph">
+<p>You can use AsciiDoc callouts in the YAML file.
+Comment out the callout in the YAML file to ensure that file can still be parsed as valid YAML.
+Asciidoctor recognises the commented callout and renders it correctly in the output.
+For example:</p>
+</div>
+<div class="paragraph">
+<p><code>apiVersion: v1 # &lt;1&gt;</code></p>
+</div>
+<h3 id="_version_and_upgrade_implications" class="discrete">Version and upgrade implications</h3>
+<div class="paragraph">
+<p>Carefully consider the version and upgrade implications of including the local YAML file in your content. Including a local YAML file can increase the maintenance overhead for the content.
+If you have a doubt, talk to your content strategist or docs team lead.</p>
+</div>
+<h3 id="_validating_the_local_yaml_file" class="discrete">Validating the local YAML file</h3>
+<div class="paragraph">
+<p>Before you include the YAML file, use a YAML linter or the <code>oc</code> CLI to verify that the YAML is valid.
+For example, to validate the <code>snippets/SiteConfig.yaml</code> file using <code>oc</code>, log in to a cluster and run the following command from a terminal opened in the <code>openshift-docs/</code> folder:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-terminal" data-lang="terminal">$ oc apply -f snippets/SiteConfig.yaml --dry-run=client</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">Example output</div>
+<div class="content">
+<pre class="highlight"><code class="language-terminal" data-lang="terminal">siteconfig.ran.openshift.io/example-sno created (dry run)</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Running <code>oc</code> with the <code>--dry-run=client</code> switch does not succeed with an invalid YAML file.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_indicating_technology_preview_features">Indicating Technology Preview features</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>To indicate that a feature is in Technology Preview, include the <code>snippets/technology-preview.adoc</code> file in the feature&#8217;s assembly or module to keep the supportability wording consistent across Technology Preview features. Provide a value for the <code>:FeatureName:</code> variable before you include this module.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-text" data-lang="text">:FeatureName: The XYZ plug-in
+include::snippets/technology-preview.adoc[]</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_indicating_deprecated_features">Indicating deprecated features</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>To indicate that a feature is deprecated, include the <code>modules/deprecated-feature.adoc</code> file in the feature&#8217;s assembly, or to each relevant assembly such as for a deprecated Operator, to keep the supportability wording consistent across deprecated features. Provide a value for the <code>:FeatureName:</code> variable before you include this module.</p>
+</div>
+<div class="paragraph">
+<p>For more information on how this is applied, see <a href="https://github.com/openshift/openshift-docs/pull/31776/files">this example PR</a>.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_verification_of_your_content">Verification of your content</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>All documentation changes that update or add technical content must be verified by a QE team associate before merging. This QE verification process includes executing all procedures, confirming expected results, and confirming the accuracy of conceptual and reference content. The only exceptions are for typo-level changes, formatting-only changes, and other negotiated documentation sets and distributions.</p>
+</div>
+<div class="paragraph">
+<p>If a documentation change is due to a Bugzilla bug or Jira issue, the bug/issue should be put on ON_QA when you have a PR ready. After QE approval is given (either in the bug/issue or in the PR), the QE associate should move the bug/issue status to VERIFIED, at which point the associated PR can be merged. It is also ok for the assigned writer to change the status of the bug/issue to VERIFIED if approval for the changes has been provided in another forum (slack, PR, or email). The writer should indicate that the QE team approved the change as a comment in the bug/issue.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_images">Images</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_image_format">Image format</h3>
+<div class="paragraph">
+<p>Use <code>*.png</code> format images.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_block_images">Block images</h3>
+<div class="paragraph">
+<p>To include a block image (an image on its own line):</p>
+</div>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>Put the image file in the <code>images</code> folder.</p>
+<div class="paragraph">
+<p>Ensure that the folder containing your assembly contains an <code>images</code> symbolic link to the top-level <code>images/</code> directory, otherwise the image will not be found when building the docs.</p>
+</div>
+</li>
+<li>
+<p>In the <code>.adoc</code> content, use this format to link to the image:</p>
+<div class="listingblock">
+<div class="content">
+<pre>image::&lt;image_filename&gt;[&lt;alt_text&gt;]</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Note the double <code>::</code> instead of a single <code>:</code>, as seen in inline image usage.
+You only have to specify <code>&lt;image_filename&gt;</code> itself and not the full file path;
+the build mechanism automatically expands this appropriately.</p>
+</div>
+</li>
+</ol>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_inline_images_icons">Inline images (icons)</h3>
+<div class="paragraph">
+<p>Inline images can be used to indicate graphic items in the web console, such as
+buttons or menu icons.</p>
+</div>
+<div class="sect3">
+<h4 id="_inserting_reusable_images_inline">Inserting reusable images inline</h4>
+<div class="paragraph">
+<p>To simplify reuse, the following common SVGs (the OpenShift web console uses the
+Font Awesome icon set) have already been added to the <code>images</code> folder with a
+user-defined entity added to the <code>common-attributes.adoc</code> module:</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Icon</th>
+<th class="tableblock halign-left valign-top">Entity</th>
+<th class="tableblock halign-left valign-top">Alt text</th>
+<th class="tableblock halign-left valign-top">File name</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kebab</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>:kebab:</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Options menu</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>ellipsis-v.svg</code></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>When using inline, include the image after the UI element name. For example:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>Click the *Options* menu {kebab}.</pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_inserting_images_inline_without_reuse">Inserting images inline without reuse</h4>
+<div class="paragraph">
+<p>If you are inserting an image that is not part of the <code>common-attributes.adoc</code>
+module, then include the image using this formatting:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>image:&lt;image_filename&gt;[title="&lt;alt_text&gt;"]</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Note the single <code>:</code> instead of a double <code>::</code>, as seen in block image usage.</p>
+</div>
+<div class="paragraph">
+<p>For example:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>image:manage-columns.png[title="Manage Columns icon"]</pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_formatting">Formatting</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>For all of the system blocks including table delimiters, use four characters. For example:</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>|=== for tables
+---- for code blocks</pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>You can use backticks or other markup in the title for a block, such as a code block <code>.Example</code> or a table <code>.Description</code> title.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_code_blocks_command_syntax_and_example_output">Code blocks, command syntax, and example output</h3>
+<div class="paragraph">
+<p>Code blocks are generally used to show examples of command syntax, example screen output, and configuration files.</p>
+</div>
+<div class="paragraph">
+<p>The main distinction between showing command syntax and a command example is that a command syntax shows readers how to use the command without real values. An example command, however, shows the command with actual values with an example output of that command, where applicable.</p>
+</div>
+<div class="sect3">
+<h4 id="use-source-terminal">Source tags for terminal commands and output</h4>
+<div class="ulist">
+<ul>
+<li>
+<p>Use <code>[source,terminal]</code> for <code>oc</code> commands or any terminal commands to enable syntax highlighting. If you are also showing a code block for the output of the command, use <code>[source,terminal]</code> for that code block as well. Separate a command and its related example output into individual code blocks. See <a href="#single-command-per-code-block">Single command per code block</a>.</p>
+<div class="paragraph">
+<p>For example:</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>In the following example, the `oc get` operation returns a complete list of services that are currently defined:
+
+[source,terminal]
+----
+$ oc get se
+----
+
+.Example output
+[source,terminal]
+----
+NAME                LABELS                                    SELECTOR            IP                  PORT
+kubernetes          component=apiserver,provider=kubernetes   &lt;none&gt;              172.30.17.96        443
+kubernetes-ro       component=apiserver,provider=kubernetes   &lt;none&gt;              172.30.17.77        80
+docker-registry     &lt;none&gt;                                    name=registrypod    172.30.17.158       5001
+----</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This renders as:</p>
+</div>
+</li>
+</ul>
+</div>
+<div class="quoteblock">
+<blockquote>
+<div class="paragraph">
+<p>In the following example, the <code>oc get</code> operation returns a complete list of services that are currently defined:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>$ oc get se</pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">Example output</div>
+<div class="content">
+<pre>NAME                LABELS                                    SELECTOR            IP                  PORT
+kubernetes          component=apiserver,provider=kubernetes   &lt;none&gt;              172.30.17.96        443
+kubernetes-ro       component=apiserver,provider=kubernetes   &lt;none&gt;              172.30.17.77        80
+docker-registry     &lt;none&gt;                                    name=registrypod    172.30.17.158       5001</pre>
+</div>
+</div>
+</blockquote>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Any <code>[source]</code> metadata must go on the line directly before the code block. Also, do not insert a space in between the <code>[source]</code> tag and the metadata.</p>
+<div class="paragraph">
+<p>For example:</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>[source,terminal]
+----
+$ oc get se
+----
+
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: Scheduler
+metadata:
+  name: cluster
+# ...
+spec:
+  defaultNodeSelector: node-role.kubernetes.io/app=
+# ...
+----</pre>
+</div>
+</div>
+</li>
+<li>
+<p>For Bash "here" documents use <code>[source,terminal]</code>, such as the following example:</p>
+<div class="literalblock">
+<div class="content">
+<pre>[source,terminal]
+----
+$ cat &lt;&lt;EOF| oc create -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mlistener
+  labels:
+    app: multicast-verify
+EOF
+----</pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>For bash scripts, use <code>[source,bash]</code>. For example:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-bash" data-lang="bash">#!/bin/bash
+
+# optional argument handling
+if [[ "$1" == "config" ]]
+then
+    echo $KUBECONFIG
+    exit 0
+fi
+
+echo "I am a plugin named kubectl-test"</code></pre>
+</div>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>The following guidelines go into more detail about specific requirements and recommendations when using code blocks:</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="step-with-command">Procedure step that introduces a command</h4>
+<div class="paragraph">
+<p>If a step in a procedure is to run a command, make sure that the step text includes an explicit instruction to "run" or "enter" the command. In most cases, use one of the following patterns to introduce the code block:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>&lt;Step description&gt; by running the following command:</p>
+</li>
+<li>
+<p>&lt;Step description&gt; by entering the following command:</p>
+</li>
+<li>
+<p>&lt;Step description&gt;, run the following command:</p>
+</li>
+<li>
+<p>&lt;Step description&gt;, enter the following command:</p>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect3">
+<h4 id="no-markup-codeblock">No markup in code blocks</h4>
+<div class="paragraph">
+<p>Do NOT use any markup in code blocks; code blocks generally do not accept any markup.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="empty-line-before-codeblock">Empty line before code blocks</h4>
+<div class="paragraph">
+<p>For all code blocks, you must include an empty line above a code block (unless that line is introducing block metadata, such as <code>[source,terminal]</code> for syntax highlighting).</p>
+</div>
+<div class="paragraph">
+<p>Acceptable:</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>Lorem ipsum
+
+----
+$ lorem.sh
+----</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Not acceptable:</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>Lorem ipsum
+----
+$ lorem.sh
+----</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Without the line spaces, the content is likely to be not parsed correctly.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="source-tags-for-programming-language">Source tags for programming languages</h4>
+<div class="paragraph">
+<p>Use source tags for the programming language used in the code block to enable syntax highlighting. For example:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>[source,yaml]</code></p>
+</li>
+<li>
+<p><code>[source,go]</code></p>
+</li>
+<li>
+<p><code>[source,javascript]</code></p>
+</li>
+<li>
+<p><code>[source,jsx]</code></p>
+</li>
+<li>
+<p><code>[source,bash]</code></p>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect3">
+<h4 id="single-command-per-code-block">Single command per code block</h4>
+<div class="paragraph">
+<p>Do not use more than one command per code block.</p>
+</div>
+<div class="paragraph">
+<p>When commands are bunched together, the copy to clipboard functionality might not break the lines up correctly. Using single command per code block makes it copy-and-paste friendly.</p>
+</div>
+<div class="paragraph">
+<p>For example, the following must be split up into three separate code blocks:</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>To create templates you can modify, run the following commands:
+
+[source,terminal]
+----
+$ oc adm create-login-template &gt; login.html
+----
+
+[source,terminal]
+----
+$ oc adm create-provider-selection-template &gt; providers.html
+----
+
+[source,terminal]
+----
+$ oc adm create-error-template &gt; errors.html
+----</pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="command-syntax-replaceable-values">Command syntax for replaceable values</h4>
+<div class="paragraph">
+<p>To mark up command syntax, use the code block and wrap any replaceable values in angle brackets (<code>&lt;&gt;</code>) with the required command parameter, using underscores (<code>_</code>) between words as necessary for legibility.</p>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Important</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>Do not italicize user-replaced values. This guideline is an exception to the <a href="https://redhat-documentation.github.io/supplementary-style-guide/#user-replaced-values"><em>Red Hat supplementary style guide for product documentation</em></a>.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>For example:</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>To view a list of objects for the specified object type, enter the following command:
+
+[source,terminal]
+----
+$ oc get &lt;object_type&gt; &lt;object_id&gt;
+----</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This renders as:</p>
+</div>
+<div class="openblock">
+<div class="content">
+<div class="quoteblock">
+<blockquote>
+<div class="paragraph">
+<p>To view a list of objects for the specified object type, enter the following command:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>$ oc get &lt;object_type&gt; &lt;object_id&gt;</pre>
+</div>
+</div>
+</blockquote>
+</div>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+Avoid using full command syntax inline with sentences.
+</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="resource-names-oc-commands">Resource names in oc commands</h4>
+<div class="ulist">
+<ul>
+<li>
+<p>When you specify <a href="https://kubernetes.io/docs/reference/kubectl/#resource-types">resource names</a> in <code>oc</code> commands, use the full name of the resource type by default. You can use the abbreviation of the resource type name if it improves readability, such as with very long commands, or to be consistent with existing content in the same assembly.</p>
+<div class="paragraph">
+<p>For example, use <code>namespaces</code> instead of <code>ns</code> and <code>poddisruptionbudgets</code> instead of <code>pdb</code>.</p>
+</div>
+</li>
+<li>
+<p>When referring to a path to a location that the user has selected or created, treat the part of the path that the user chose as a replaceable value. For example:</p>
+<div class="literalblock">
+<div class="content">
+<pre>Create a secret that contains the certificate and key in the `openshift-config` namespace:
+
+[source,terminal]
+----
+$ oc create secret tls &lt;certificate&gt; --cert=&lt;path_to_certificate&gt;/cert.crt --key=&lt;path_to_key&gt;/cert.key -n openshift-config
+----</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This renders as:</p>
+</div>
+<div class="openblock">
+<div class="content">
+<div class="quoteblock">
+<blockquote>
+<div class="paragraph">
+<p>Create a secret that contains the certificate and key in the <code>openshift-config</code> namespace:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>$ oc create secret tls &lt;certificate&gt; --cert=&lt;path_to_certificate&gt;/cert.crt --key=&lt;path_to_key&gt;/cert.key -n openshift-config</pre>
+</div>
+</div>
+</blockquote>
+</div>
+</div>
+</div>
+<div class="paragraph">
+<p>The following example shows a more complex use of user-chosen elements and prescriptive placement:</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>&lt;resource_group_name&gt;/providers/Microsoft.Compute/diskEncryptionSets/&lt;disk_encryption_set_name&gt;</pre>
+</div>
+</div>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect3">
+<h4 id="backslash-for-long-code-line">Backslash for long lines of code</h4>
+<div class="paragraph">
+<p>For long lines of code that you want to break up among multiple lines, use a backslash to show the line break. For example:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>$ oc get endpoints --all-namespaces --template \
+    '{{ range .items }}{{ .metadata.namespace }}:{{ .metadata.name }} \
+    {{ range .subsets }}{{ range .addresses }}{{ .ip }} \
+    {{ end }}{{ end }}{{ "\n" }}{{ end }}' | awk '/ 172\.30\./ { print $1 }'</pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="callouts-in-codeblocks">Callouts in code blocks</h4>
+<div class="ulist">
+<ul>
+<li>
+<p>If you must provide additional information on what a line of a code block represents, use callouts (<code>&lt;1&gt;</code>, <code>&lt;2&gt;</code>, etc.) to provide that information.</p>
+<div class="paragraph">
+<p>Use this format when embedding callouts into the code block:</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>----
+code example 1 &lt;1&gt;
+code example 2 &lt;2&gt;
+----
+&lt;1&gt; A note about the first example value.
+&lt;2&gt; A note about the second example value.</pre>
+</div>
+</div>
+</li>
+<li>
+<p>If your command contains multiple lines and uses callout annotations, you must comment out the callout(s) in the codeblock, as shown in the following example:</p>
+<div class="paragraph">
+<p>To scale based on the percent of CPU utilization, create a <code>HorizontalPodAutoscaler</code> object for an existing object:</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>[source,terminal]
+----
+$ oc autoscale &lt;object_type&gt;/&lt;name&gt; \// &lt;1&gt;
+  --min &lt;number&gt; \// &lt;2&gt;
+  --max &lt;number&gt; \// &lt;3&gt;
+  --cpu-percent=&lt;percent&gt; &lt;4&gt;
+----
+&lt;1&gt; Specify the type and name of the object to autoscale.
+&lt;2&gt; Optional: Specify the minimum number of replicas when scaling down.
+&lt;3&gt; Specify the maximum number of replicas when scaling up.
+&lt;4&gt; Specify the target average CPU utilization over all the pods, represented as a percent of requested CPU.</pre>
+</div>
+</div>
+</li>
+<li>
+<p>If you must provide additional information on what a line of a code block represents and the use of callouts is impractical, you can use a description list to provide information about the variables in the code block. Using callouts might be impractical if a code block contains too many conditional statements to easily use numbered callouts or if the same note applies to multiple lines of the codeblock.</p>
+<div class="paragraph">
+<p>Be sure to introduce the description list with "where:" and start each variable description with "Specifies."</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>----
+code &lt;variable_1&gt;
+code &lt;variable_2&gt;
+----
++
+where:
+
+&lt;variable_1&gt;:: Specifies the explanation of the first variable.
+&lt;variable_2&gt;:: Specifies the explanation of the first variable.</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>For example:</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>[source,terminal]
+----
+$ oc annotate route &lt;route_name&gt; router.openshift.io/cookie_name="&lt;cookie_name&gt;"
+----
++
+where:
+
+`&lt;route_name&gt;`:: Specifies the name of the route.
+`&lt;cookie_name&gt;`:: Specifies the name for the cookie.</pre>
+</div>
+</div>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect3">
+<h4 id="signs-symbols-in-codeblocks">Signs and symbols in code blocks</h4>
+<div class="ulist">
+<ul>
+<li>
+<p>If the user must run a command as root, use a number sign (<code>#</code>) at the start of the command instead of a dollar sign (<code>$</code>). For example:</p>
+<div class="listingblock">
+<div class="content">
+<pre># subscription-manager list</pre>
+</div>
+</div>
+</li>
+<li>
+<p>For snippets or sections of a file, use an ellipsis (<code>&#8230;&#8203;</code>) to show that the file continues before or after the quoted block. For YAML, use ('#&#8230;&#8203;') instead.</p>
+<div class="listingblock">
+<div class="content">
+<pre>apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    test: liveness
+# ...</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>or</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>Name:               ci-ln-iyhx092-f76d1-nvdfm-worker-b-wln2l
+Roles:              worker
+...
+Taints:             node-role.kubernetes.io/infra:NoSchedule
+...</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Do not use <code>[&#8230;&#8203;]</code>, <code>&lt;snip&gt;</code>, or any other variant.</p>
+</div>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect3">
+<h4 id="jq-commands">Commands with jq</h4>
+<div class="paragraph">
+<p>Do not use <code>jq</code> in commands (unless it is truly required), because this requires users to install the <code>jq</code> tool. Oftentimes, the same or similar result can be accomplished using <code>jsonpath</code> for <code>oc</code> commands.</p>
+</div>
+<div class="paragraph">
+<p>For example, this command that uses <code>jq</code>:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>$ oc get clusterversion -o json|jq ".items[0].spec"</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>can be updated to use <code>jsonpath</code> instead:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>$ oc get clusterversion -o jsonpath='{.items[0].spec}{"\n"}'</pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_yaml_formatting_for_kubernetes_and_openshift_api_objects">YAML formatting for Kubernetes and OpenShift API objects</h3>
+<div class="paragraph">
+<p>The following formatting guidelines apply to YAML manifests, but do not apply to the installation configuration YAML specified by <code>install-config.yaml</code>.</p>
+</div>
+<div class="paragraph">
+<p>When possible, ensure that YAML is valid in a running cluster. You can validate YAML with <code>oc apply</code> with the following invocation:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>$ oc apply -f test.yaml --dry-run=client</pre>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_required_fields">Required fields</h4>
+<div class="ulist">
+<ul>
+<li>
+<p>Include the <code>apiVersion</code> and <code>kind</code> so that a user always knows the context of the YAML.</p>
+</li>
+<li>
+<p>Include the full hierarchy to a deeply nested key.</p>
+</li>
+<li>
+<p>For objects that are in the global scope, such as for <code>config.openshift.io</code> API group, always include the <code>metadata.name</code> for the object, which is usually <code>cluster</code>.</p>
+</li>
+</ul>
+</div>
+<div class="listingblock">
+<div class="title">Example API object in the global scope</div>
+<div class="content">
+<pre>apiVersion: config.openshift.io/v1
+kind: Scheduler
+metadata:
+  name: cluster
+# ...
+spec:
+  defaultNodeSelector: node-role.kubernetes.io/app=
+# ...</pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">Example deeply nested key with full context for <code>.ports</code> array</div>
+<div class="content">
+<pre>apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+  namespace: default
+spec:
+  containers:
+  - name: web
+    image: nginx
+    ports:
+    - name: web
+      containerPort: 80
+      protocol: TCP</pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_yaml_formatting">YAML formatting</h4>
+<div class="paragraph">
+<p>The following conventions govern the layout of YAML for API objects:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Begin YAML at the beginning of the left margin.</p>
+</li>
+<li>
+<p>Use two-space indentation.</p>
+</li>
+<li>
+<p>Indent arrays at the same depth as the parent field.</p>
+</li>
+<li>
+<p>Include a space immediately after the colon for keys.</p>
+</li>
+<li>
+<p>Use block style for complex strings, such as embedded JSON or text blocks. You can enable block style by specifying <code>|</code> or <code>|-</code> after a field and indenting the field content by two spaces, such as in the following example:</p>
+<div class="listingblock">
+<div class="content">
+<pre>fieldName: |-
+  This is a string.
+  And it can be on multiple lines.</pre>
+</div>
+</div>
+</li>
+<li>
+<p>When truncating YAML, comment out the ellipsis (<code># &#8230;&#8203;</code>) because three dots (<code>&#8230;&#8203;</code>) in YAML is actually a <a href="https://yaml.org/spec/1.2.2/#22-structures">document end marker</a>.</p>
+</li>
+<li>
+<p>Use three hyphens (<code>---</code>) to separate YAML definitions in a single YAML file.</p>
+</li>
+</ul>
+</div>
+<div class="listingblock">
+<div class="title">Example with array indentation flush with parent field</div>
+<div class="content">
+<pre>apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+  labels:
+  - key1: val1
+  - key2: val2
+spec:
+# ...</pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">Example with block string for annotation</div>
+<div class="content">
+<pre>apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+  annotations:
+    k8s.v1.cni.cncf.io/networks: |-
+      [
+        {
+          "name": "net"
+        }
+      ]
+spec:
+# ...</pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_inline_code_or_commands">Inline code or commands</h3>
+<div class="paragraph">
+<p>Do NOT show full commands or command syntax inline within a sentence. The next section covers how to show commands and command syntax.</p>
+</div>
+<div class="paragraph">
+<p>Only use case for inline commands would be general commands and operations, without replaceables and command options. In this case an inline command is marked up using the back ticks:</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>Use the `GET` operation to do x.</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This renders as:</p>
+</div>
+<div class="quoteblock">
+<blockquote>
+<div class="paragraph">
+<p>Use the <code>GET</code> operation to do x.</p>
+</div>
+</blockquote>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_system_messages">System messages</h3>
+<div class="paragraph">
+<p>System messages include error, warning, confirmation, and information messages that are presented to the user in places such as the GUI, CLI, or system logs.</p>
+</div>
+<div class="paragraph">
+<p>If a message is short enough to include inline, enclose it in back ticks:</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>Previously, image builds and pushes would fail with the `error reading blob from source` error message because the builder logic would compute the contents of new layers twice.</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This renders as:</p>
+</div>
+<div class="quoteblock">
+<blockquote>
+<div class="paragraph">
+<p>Previously, image builds and pushes would fail with the <code>error reading blob from source</code> error message because the builder logic would compute the contents of new layers twice.</p>
+</div>
+</blockquote>
+</div>
+<div class="paragraph">
+<p>If a message is too long to include inline, put it inside a code block with <code>[source,text]</code> metadata:</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>Previously, the AWS Terraform provider that the installation program used occasionally caused a race condition with the S3 bucket, and the cluster installation failed with the following error message:
+
+[source,text]
+----
+When applying changes to module.bootstrap.aws_s3_bucket.ignition, provider level=error msg="\"aws\" produced an unexpected new value for was present, but now absent.
+----
+
+Now, the installation program uses different AWS Terraform provider code, which now robustly handles S3 eventual consistency, and the installer-provisioned AWS cluster installation does not fail with that error message.</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This renders as:</p>
+</div>
+<div class="quoteblock">
+<blockquote>
+<div class="paragraph">
+<p>Previously, the AWS Terraform provider that the installation program used occasionally caused a race condition with the S3 bucket, and the cluster installation failed with the following error message:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>When applying changes to module.bootstrap.aws_s3_bucket.ignition, provider level=error msg="\"aws\" produced an unexpected new value for was present, but now absent.</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Now, the installation program uses different AWS Terraform provider code, which now robustly handles S3 eventual consistency, and the installer-provisioned AWS cluster installation does not fail with that error message.</p>
+</div>
+</blockquote>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+Always refer to a message with the type of message it is, followed by the word "message". For example, refer to an error message as an "error message", and not simply as an "error".
+</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_lists">Lists</h3>
+<div class="paragraph">
+<p>Lists are created as shown in this example:</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>. Item 1 (2 spaces between the period and the first character)
+
+. Item 2
+
+. Item 3</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This renders as:</p>
+</div>
+<div class="quoteblock">
+<blockquote>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>Item 1</p>
+</li>
+<li>
+<p>Item 2</p>
+</li>
+<li>
+<p>Item 3</p>
+</li>
+</ol>
+</div>
+</blockquote>
+</div>
+<div class="paragraph">
+<p>If you must add any text, admonitions, or code blocks you have to add the continuous +, as shown in the example:</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>. Item 1
++
+----
+some code block
+----
+
+. Item 2
+
+. Item 3</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This renders as:</p>
+</div>
+<div class="quoteblock">
+<blockquote>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>Item 1</p>
+<div class="listingblock">
+<div class="content">
+<pre>some code block</pre>
+</div>
+</div>
+</li>
+<li>
+<p>Item 2</p>
+</li>
+<li>
+<p>Item 3</p>
+</li>
+</ol>
+</div>
+</blockquote>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_footnotes">Footnotes</h3>
+<div class="paragraph">
+<p>Avoid footnotes when possible.</p>
+</div>
+<div class="paragraph">
+<p>If you reference a footnote from only a single location, use the following syntax:</p>
+</div>
+<div class="literalblock">
+<div class="title">Footnote</div>
+<div class="content">
+<pre>footnote:[This is the footnote text.]</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>If you reference a footnote from multiple locations, set an attribute with the footnote text. As a consequence, this will duplicate the footnote text at bottom of the page.</p>
+</div>
+<div class="literalblock">
+<div class="title">Footnote with text set by an attribute</div>
+<div class="content">
+<pre>:note-text: This is a footnote.
+
+This text has a footnote qualifier attached footnote:[{note-text}].
+
+But this other text uses the same qualifier elsewhere footnote:[{note-text}].</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Avoid using <code>footnoteref</code>.</p>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Important</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>The <code>footnoteref</code> directive is deprecated in asciidoctor and causes a build warning when <code>ascii_binder</code> is run.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="literalblock">
+<div class="title">Footnote with reference</div>
+<div class="content">
+<pre>footnoteref:[ref-string, This is the footnote text.]</pre>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_alternative_footnote_styling_in_tables">Alternative footnote styling in tables</h4>
+<div class="paragraph">
+<p>For footnotes in tables, use the following syntax to mimic Asciidoctor&#8217;s
+styling:</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>[cols="3",options="header"]
+|===
+|Header 1
+|Header 2
+|Header 3
+
+|Item A ^[1]^
+|Item B
+|Item C ^[2]^
+
+|Item D
+|Item E ^[3]^
+|Item F ^[3]^
+|===
+[.small]
+--
+1. A description.
+2. Another description.
+3. Two items relate to this description.
+--</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The notes are kept immediately after the table, instead of moved to the bottom of the rendered assembly. This manual method also allows you to reuse the same footnote number for multiple references as needed.</p>
+</div>
+<div class="paragraph">
+<p>Note the following:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Add a space before the superscripted numbers with square brackets.</p>
+</li>
+<li>
+<p>To match the table cell&#8217;s font size, start the ordered list with a <code>[.small]</code>
+style and wrap it in a <code>--</code> block.</p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="collapsible-content">Collapsible content</h3>
+<div class="paragraph">
+<p>You can collapse sections of content by using the <code>collapsible</code> option, which converts the Asciidoctor markup to HTML <code>details</code> and <code>summary</code> sections. The <code>collapsible</code> option is used at the writer&#8217;s discretion and is appropriate for considerably long code blocks, lists, or other such content that significantly increases the length of a module or assembly.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>You must set a title for the <code>summary</code> section. If a title is not set, the default title is "Details."</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>Collapsible content is formatted as shown:</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>.Title of the `summary` dropdown
+[%collapsible]
+====
+This is content within the `details` section.
+====</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This renders as a dropdown with collapsed content:</p>
+</div>
+<details>
+<summary class="title">Title of the <code>summary</code> dropdown</summary>
+<div class="content">
+<div class="paragraph">
+<p>This is content within the <code>details</code> section.</p>
+</div>
+</div>
+</details>
+<div class="paragraph">
+<p>If your collapsible content includes an admonition such as a note or warning, the admonition must be nested:</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>.Collapsible content that includes an admonition
+[%collapsible]
+====
+This content includes an admonition.
+
+[source,terminal]
+----
+$ oc whoami
+----
+
+[NOTE]
+=====
+Nest admonitions when using the `collapsible` option.
+=====
+====</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This renders as:</p>
+</div>
+<details>
+<summary class="title">Collapsible content that includes an admonition</summary>
+<div class="content">
+<div class="paragraph">
+<p>This content includes an admonition.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-terminal" data-lang="terminal">$ oc whoami</code></pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>Nest admonitions when using the <code>collapsible</code> option.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</div>
+</details>
+</div>
+<div class="sect2">
+<h3 id="_quick_reference">Quick reference</h3>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. User accounts and info</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Markup in command syntax</th>
+<th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Substitute value in Example block</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>&lt;username&gt;</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name of user account</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="mailto:user@example.com">user@example.com</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>&lt;password&gt;</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">User password</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">password</p></td>
+</tr>
+</tbody>
+</table>
+<div class="admonitionblock important">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Important</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>Do not use a password format that matches the format of a real password. Documenting such a password format can cause the following issues:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Indicates that Red Hat publicly exposes sensitive data in their documentation.</p>
+</li>
+<li>
+<p>Leads to additional security incidents that the Information Security, InfoSec, team must investigate. Such security incidents, although minor, can impact the InfoSec team&#8217;s resources and potentially delay them from focusing on actual security incidents.</p>
+</li>
+</ul>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 2. Projects and applications</caption>
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Markup in command syntax</th>
+<th class="tableblock halign-left valign-top">Description</th>
+<th class="tableblock halign-left valign-top">Substitute value in Example block</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>&lt;project&gt;</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name of project</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">myproject</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>&lt;app&gt;</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name of an application</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">myapp</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_additional_resources_sections">Additional resources sections</h3>
+<div class="paragraph">
+<p>The following guidelines apply to all "Additional resources" sections:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>You must include the <code>[role="_additional-resources"]</code> attribute declaration before the section heading.</p>
+</li>
+<li>
+<p>You must not include paragraphs in the section. Use an unordered list.</p>
+</li>
+<li>
+<p>The links and xrefs in the unordered list must contain minimal-length, human-readable text between the square brackets. This text is often the title of the linked page.</p>
+</li>
+<li>
+<p>You must not include text outside of the square brackets.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Additionally, in an assembly, use <code>==</code> formatting for the section heading (<code>== Additional resources</code>). Use of this heading syntax at the assembly level indicates that the sections relate to the whole assembly. For example:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>[role="_additional-resources"]
+[id="additional-resources_configuring-alert-notifications"]
+== Additional resources
+* link:example.com[IANA example domain for documentation]
+* xref:../installation/installing-the-product.adoc#installing-the-product[Installing the product]
+* xref:../configuration/product-settings.adoc#installation-parameters_product-settings[Product installation configuration parameters]</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Only use <code>.</code> formatting (<code>.Additional resources</code>) in a module or to follow a module in an assembly. Because you cannot use the xrefs in modules, this functions as a <em>trailing include</em> at the assembly level, where the <code>.</code> formatting of the <code>include</code> statement indicates that the resource applies specifically to the module and not to the assembly. For example:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>[role="_additional-resources"]
+.Additional resources
+* link:example.com[IANA example domain for documentation]
+* xref:../installation/installing-the-product.adoc#installing-the-product[Installing the product]
+* xref:../configuration/product-settings.adoc#installation-parameters_product-settings[Product installation configuration parameters]</pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_admonitions">Admonitions</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Admonitions such as notes and warnings are formatted as shown:</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>[ADMONITION]
+====
+Text for admonition
+====</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>See the <a href="https://redhat-documentation.github.io/supplementary-style-guide/#admonitions">Red Hat Supplementary style guide</a> for the valid admonition types and their definitions.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="api-object-formatting">API object formatting</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>For terms that are API objects, the way they are written depends on whether the term is a general reference or an actual reference to the object.</p>
+</div>
+<div class="sect2">
+<h3 id="api-object-general-references">General references</h3>
+<div class="paragraph">
+<p>A general reference is any time you are speaking conceptually, or generally, about these components in a cluster.</p>
+</div>
+<div class="paragraph">
+<p>When referring to API object terms in general usage, use lowercase and separate multi-word API objects. <strong>Default to following this guidance unless you are specifically interacting with/referring to the API object (see <a href="#api-object-object-references">Object references</a>).</strong></p>
+</div>
+<div class="paragraph">
+<p>For example:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>pod</p>
+</li>
+<li>
+<p>node</p>
+</li>
+<li>
+<p>daemon set</p>
+</li>
+<li>
+<p>config map</p>
+</li>
+<li>
+<p>deployment</p>
+</li>
+<li>
+<p>image stream</p>
+</li>
+<li>
+<p>persistent volume claim</p>
+</li>
+</ul>
+</div>
+<div class="literalblock">
+<div class="title">Examples of general references</div>
+<div class="content">
+<pre>Kubernetes runs your workload by placing containers into pods to run on nodes.
+
+You must have at least one secret, config map, or service account.
+
+The total number of persistent volume claims in a project.</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Note that if an object uses an acronym or other special capitalization, then its general reference should honor that. For example, general references to <code>APIService</code> should be written as "API service", not "api service". Any other exceptions or special guidance are noted in the <a href="../contributing_to_docs/term_glossary.html">glossary</a>.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="api-object-object-references">Object references</h3>
+<div class="paragraph">
+<p>An object reference is when you are referring to the actual instance of an API object, where the object name is important.</p>
+</div>
+<div class="paragraph">
+<p>When referring to actual instances of API objects, use <a href="https://en.wikipedia.org/wiki/Camel_case#Variations_and_synonyms">PascalCase</a> and mark it up as monospace in backticks (<code>``</code>).</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>Do not use backticks or other markup in assembly or module headings. You can use backticks or other markup in the title for a block, such as a code block <code>.Example</code> or a table <code>.Description</code> title.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>Be sure to match the proper object type (or <code>kind</code> in Kubernetes terms); for example, do not add an "s" to make it plural. <strong>Only follow this guidance if you are explicitly referring to the API object (for example, when editing an object in the CLI or viewing an object in the web console).</strong></p>
+</div>
+<div class="paragraph">
+<p>For example:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>Pod</code></p>
+</li>
+<li>
+<p><code>Node</code></p>
+</li>
+<li>
+<p><code>DaemonSet</code></p>
+</li>
+<li>
+<p><code>ConfigMap</code></p>
+</li>
+<li>
+<p><code>Deployment</code></p>
+</li>
+<li>
+<p><code>ImageStream</code></p>
+</li>
+<li>
+<p><code>PersistentVolumeClaim</code></p>
+</li>
+</ul>
+</div>
+<div class="literalblock">
+<div class="title">Examples of API object references</div>
+<div class="content">
+<pre>After you create a `Node` object, or the kubelet on a node self-registers, the control plane checks whether the new `Node` object is valid.
+
+The default amount of CPU that a container can use if not specified in the `Pod` spec.
+
+Create a file, `pvc.yaml`, with the `PersistentVolumeClaim` object definition.</pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>Use "object", "resource", "custom resource", "spec", etc. as appropriate after the object reference. This helps with clarity and readability.</p>
+</div>
+<div class="paragraph">
+<p>Another situation where this is necessary is when referring to the plural version of objects. Do not add an "s" to the end of an object name reference to make it plural. Use only the official <code>kind</code> of object (for example, seen when you run <code>oc api-resources</code>).</p>
+</div>
+<div class="paragraph">
+<p>For example, the object <code>kind</code> for a node is <code>Node</code>, not <code>Nodes</code>. So do not write "You can create <code>Nodes</code> using <code>kubectl</code>." Instead, rewrite to something like "You can create <code>Node</code> objects using <code>kubectl</code>."</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="operator-name-capitalization">Operator capitalization</h3>
+<div class="paragraph">
+<p>The term "Operator" is always capitalized. For example:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>= Support policy for unmanaged Operators
+
+Individual Operators have a `managementState` parameter in their configuration.</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>An Operator&#8217;s full name must be a proper noun, with each word initially
+capitalized. If it includes a product name, defer the product&#8217;s capitalization
+style guidelines. For example:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Red Hat OpenShift Logging Operator</p>
+</li>
+<li>
+<p>Prometheus Operator</p>
+</li>
+<li>
+<p>etcd Operator</p>
+</li>
+<li>
+<p>Node Tuning Operator</p>
+</li>
+<li>
+<p>Cluster Version Operator</p>
+</li>
+</ul>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>Red Hat Brand and Legal guidance for Operator names will likely differ. For marketing materials, they prefer lowercase names for anything that is not a Red Hat product.</p>
+</div>
+<div class="paragraph">
+<p>However, the Brand team recognizes that there are different standards for marketing materials versus technical content. For this reason, the title case capitalization for Operator names in technical product documentation and OperatorHub is acceptable.</p>
+</div>
+<div class="paragraph">
+<p>The "Naming" page by Red Hat Brand on the Source provides an overview of naming slide deck that also confirms this difference.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_declarative_config_examples">Declarative config examples</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Many of our procedures provide imperative <code>oc</code> commands (which cannot be stored in a Git repo). Due to efforts around improving the experience for GitOps users, we sometimes also want to provide a declarative YAML example that achieves the same configuration. This allows users to store these YAML configurations in a Git repo and follow GitOps practices to configure OpenShift.</p>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Important</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>When adding declarative examples to procedures, do not completely replace the imperative command with the declarative YAML example. Some users might still prefer the imperative option.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>To add a declarative YAML example to a procedure step with an existing imperative command, add it in a "TIP" admonition by following the template in the example below. This example uses an imperative command (<code>oc create configmap</code>) to create a config map, and then provides the declarative YAML example of the <code>ConfigMap</code> object afterward.</p>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>* Define a `ConfigMap` object containing the certificate authority by using the following command:
++
+[source,terminal]
+----
+$ oc create configmap ca-config-map --from-file=ca.crt=/path/to/ca -n openshift-config
+----
++
+[TIP]
+====
+You can alternatively apply the following YAML to create the config map:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ca-config-map
+  namespace: openshift-config
+type: Opaque
+data:
+  ca.crt: &lt;base64_encoded_CA_certificate_PEM&gt;
+----
+====</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This renders as:</p>
+</div>
+<div class="quoteblock">
+<blockquote>
+<div class="ulist">
+<ul>
+<li>
+<p>Define a <code>ConfigMap</code> object containing the certificate authority by using the following command:</p>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-terminal" data-lang="terminal">$ oc create configmap ca-config-map --from-file=ca.crt=/path/to/ca -n openshift-config</code></pre>
+</div>
+</div>
+<div class="admonitionblock tip">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Tip</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>You can alternatively apply the following YAML to create the config map:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-yaml" data-lang="yaml">apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ca-config-map
+  namespace: openshift-config
+type: Opaque
+data:
+  ca.crt: &lt;base64_encoded_CA_certificate_PEM&gt;</code></pre>
+</div>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</li>
+</ul>
+</div>
+</blockquote>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>If you are adding a particularly long YAML block, you can optionally use the <a href="#collapsible-content"><code>%collapsible</code></a> feature to allow users to collapse the code block.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_quick_markup_reference">Quick markup reference</h2>
+<div class="sectionbody">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Convention</th>
+<th class="tableblock halign-left valign-top">Markup</th>
+<th class="tableblock halign-left valign-top">Example rendered output</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Code blocks</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="literalblock">
+<div class="content">
+<pre>Use the following syntax for the `oc` command:
+
+----
+$ oc &lt;action&gt; &lt;object_type&gt; &lt;object_name_or_id&gt;
+----</pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="quoteblock">
+<blockquote>
+<div class="paragraph">
+<p>Use the following syntax for the <code>oc</code> command:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>$ oc &lt;action&gt; &lt;object_type&gt; &lt;object_name_or_id&gt;</pre>
+</div>
+</div>
+</blockquote>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>Use backticks for all non-GUI "system items", including:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Inline commands, operations, literal values, variables, parameters, settings,
+flags, environment variables, user input</p>
+</li>
+<li>
+<p>System term/item, user names, unique or example names for individual API
+objects/resources (e.g., a pod named <code>mypod</code>), daemon, service, or software
+package</p>
+</li>
+<li>
+<p>RPM packages</p>
+</li>
+<li>
+<p>File names or directory paths</p>
+</li>
+</ul>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="literalblock">
+<div class="content">
+<pre>`oc get`
+
+Set the `upgrade` variable to `true`.
+
+Use the `--amend` flag.
+
+Answer by typing `Yes` or `No` when prompted.
+
+`user_name`
+
+`service_name`
+
+`package_name`
+
+`filename`</pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="quoteblock">
+<blockquote>
+<div class="paragraph">
+<p>Use the <code>oc get services</code> command to get a list of services that are currently defined.</p>
+</div>
+<div class="paragraph">
+<p>&nbsp;</p>
+</div>
+<div class="paragraph">
+<p>Use the <code>--amend</code> flag.</p>
+</div>
+<div class="paragraph">
+<p>&nbsp;</p>
+</div>
+<div class="paragraph">
+<p>Set the <code>upgrade</code> variable to <code>true</code>.</p>
+</div>
+<div class="paragraph">
+<p>&nbsp;</p>
+</div>
+<div class="paragraph">
+<p>Answer by typing <code>Yes</code> or <code>No</code> when prompted.</p>
+</div>
+<div class="paragraph">
+<p>&nbsp;</p>
+</div>
+<div class="paragraph">
+<p><code>cluster-admin</code> user</p>
+</div>
+<div class="paragraph">
+<p>&nbsp;</p>
+</div>
+<div class="paragraph">
+<p><code>firewalld</code> service</p>
+</div>
+<div class="paragraph">
+<p>&nbsp;</p>
+</div>
+<div class="paragraph">
+<p><code>rubygems</code> RPM package</p>
+</div>
+<div class="paragraph">
+<p>&nbsp;</p>
+</div>
+<div class="paragraph">
+<p>The <code>express.conf</code> configuration file is located in the <code>/usr/share</code> directory.</p>
+</div>
+</blockquote>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">System or software variable to be replaced by the user</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="literalblock">
+<div class="content">
+<pre>`&lt;project&gt;`
+
+`&lt;deployment&gt;`
+
+`&lt;install_mode_value&gt;`</pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="quoteblock">
+<blockquote>
+<div class="paragraph">
+<p>Use the following command to roll back a Deployment, specifying the Deployment name:</p>
+</div>
+<div class="paragraph">
+<p><code>oc rollback &lt;deployment&gt;</code></p>
+</div>
+<div class="paragraph">
+<p>&nbsp;</p>
+</div>
+<div class="paragraph">
+<p>Apply the new configuration file:</p>
+</div>
+<div class="paragraph">
+<p><code>oc apply -f &lt;path_to_configuration_file&gt;/&lt;filename&gt;.yaml</code></p>
+</div>
+</blockquote>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Use single asterisks for web console / GUI items (menus, buttons, page titles, etc.).
+Use two characters to form the arrow in a series of menu items (<code>-&gt;</code>).</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="literalblock">
+<div class="content">
+<pre>Choose *Cluster Console* from the list.
+
+Navigate to the *Operators* -&gt; *Catalog Sources* page.
+
+Click *Create Subscription*.</pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="quoteblock">
+<blockquote>
+<div class="paragraph">
+<p>Choose <strong>Cluster Console</strong> from the list.</p>
+</div>
+<div class="paragraph">
+<p>&nbsp;</p>
+</div>
+<div class="paragraph">
+<p>Navigate to the <strong>Operators</strong> &#8594; <strong>Catalog Sources</strong> page.</p>
+</div>
+<div class="paragraph">
+<p>&nbsp;</p>
+</div>
+<div class="paragraph">
+<p>Click <strong>Create Subscription</strong>.</p>
+</div>
+</blockquote>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Use underscores to emphasize the first appearance of a new term.</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="literalblock">
+<div class="content">
+<pre>An _Operator_ is a method of packaging, deploying,
+and managing a Kubernetes application.</pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="quoteblock">
+<blockquote>
+<div class="paragraph">
+<p>An <em>Operator</em> is a method of packaging, deploying, and managing a Kubernetes application.</p>
+</div>
+</blockquote>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Use of underscores for general emphasis is allowed but should only be used
+very sparingly. Let the writing, instead of font usage, create the emphasis
+wherever possible.</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="literalblock">
+<div class="content">
+<pre>Do _not_ delete the file.</pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="quoteblock">
+<blockquote>
+<div class="paragraph">
+<p>Do <em>not</em> delete the file.</p>
+</div>
+</blockquote>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Table style operators</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">A style operator styles the content of a table cell or a table column, depending on where you set the operator. Using the literal (<code>l</code>) operator in a column might impact the documentation platform&#8217;s copy and paste functionality. For example, when you paste copied code block content to a location, the first styled literal value in an assembly is pasted instead of the intended code block. To avoid this issue, use the monospace (<code>m</code>) style operator. When using any style operator in a table, check that all the copy and paste function works correctly for all code blocks in an assembly.</p>
+<p class="tableblock">See <a href="https://docs.asciidoctor.org/asciidoc/latest/tables/format-cell-content/">Cell styles and their operators</a> (Asciidoctor Documentation)</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre>.Required parameters
+[cols=".^2m,.^3,.^5a",options="header"]</pre>
+</div>
+</div></div></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Footnotes</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">A footnote is created with the footnote macro. If you plan to reference a footnote more than once, use the ID footnoteref macro. The Customer Portal does not support spaces in the footnoteref. For example, "dynamic PV" should be "dynamicPV".</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">For footnote and footnoteref syntax, see <a href="http://asciidoctor.org/docs/user-manual/#user-footnotes">AsciiDoctor documentation</a>.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated 2024-03-01 16:59:40 UTC
+</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Version(s):
main

Issue:
[OCPBUGS-20158](https://issues.redhat.com/browse/OCPBUGS-20158) - Reference Jira that prompted this guidance update.

Link to docs preview:
[Quick markup reference:Table style operators](https://file.emea.redhat.com/dfitzmau/contrib-doc-col-operators/doc_guidelines.html#:~:text=Table%20style%20operators)

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
