### PR TITLE
OSDOCS-4924: Verify max MTU value acceptance

### DIFF
--- a/modules/nw-cluster-mtu-change-about.adoc
+++ b/modules/nw-cluster-mtu-change-about.adoc
@@ -35,6 +35,11 @@ When planning your MTU migration there are two related but distinct MTU values t
 
 If your cluster requires different MTU values for different nodes, you must subtract the overhead value for your network plugin from the lowest MTU value that is used by any node in your cluster. For example, if some nodes in your cluster have an MTU of `9001`, and some have an MTU of `1500`, you must set this value to `1400`.
 
+[IMPORTANT]
+====
+To avoid selecting an MTU value that is not acceptable by a node, verify the maximum MTU value (`maxmtu`) that is accepted by the network interface by using the `ip -d link` command.
+====
+
 [id="how-the-migration-process-works_{context}"]
 == How the migration process works
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-4924

Link to docs preview:
https://72472--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/changing-cluster-network-mtu#mtu-value-selection_changing-cluster-network-mtu

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
