### PR TITLE
OCPBUGS#30133: Updates to dynamic plugin docs

### DIFF
--- a/web_console/dynamic-plugin/overview-dynamic-plugin.adoc
+++ b/web_console/dynamic-plugin/overview-dynamic-plugin.adoc
@@ -9,7 +9,7 @@ toc::[]
 [id="dynamic-plug-in-overview"]
 == About dynamic plugins
 
-A dynamic plugin allows you to add custom pages and other extensions to your interface at runtime. The `ConsolePlugin` custom resource registers plugins with the console, and a cluster administrator enables plugins in the `console-operator` configuration.
+Dynamic plugins are deployed as workloads on the cluster. They allow you to add custom pages and other extensions to your console user interface at runtime. The `ConsolePlugin` custom resource registers plugins with the console, and a cluster administrator enables plugins in the `console-operator` configuration.
 
 [id="dynamic-plugins-features"]
 == Key features
@@ -39,11 +39,15 @@ conster Header: React.FC = () => {
 ----
 
 * Avoid selectors that could affect markup outside of your plugins components, such as element selectors. These are not APIs and are subject to change. Using them might break your plugin. Avoid selectors like element selectors that could affect markup outside of your plugins components.
+* Provide valid JavaScript Multipurpose Internet Mail Extension (MIME) type using the `Content-Type` response header for all assets served by your plugin web server. Each plugin deployment should include a web server that hosts the generated assets of the given plugin.
 
 [discrete]
 == PatternFly guidelines
 When creating your plugin, follow these guidelines for using PatternFly:
 
 * Use link:https://www.patternfly.org/components/all-components/[PatternFly] components and PatternFly CSS variables. Core PatternFly components are available through the SDK. Using PatternFly components and variables help your plugin look consistent in future console versions.
+** Use Patternfly 4.x if you are using {product-title} versions 4.14 and earlier.
+** Use Patternfly 5.x if you are using {product-title} 4.15 or later.
 * Make your plugin accessible by following link:https://www.patternfly.org/accessibility/accessibility-fundamentals/[PatternFly's accessibility fundamentals].
-* Avoid using other CSS libraries such as Bootstrap or Tailwind. They can conflict with PatternFly and will not match the console look and feel.
+* Avoid using other CSS libraries such as Bootstrap or Tailwind. They can conflict with PatternFly and will not match the console look and feel. Plugins should only include styles that are specific to their user interfaces to be evaluated on top of base PatternFly styles. Avoid importing styles such as `@patternfly/react-styles/**/*.css` or any styles from `@patternfly/patternfly` package in your plugin.
+* The console application is responsible for loading base styles for all supported PatternFly version(s).


### PR DESCRIPTION
 Updates to dynamic plugin docs

Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OCPBUGS-30133

Link to docs preview:
https://72479--ocpdocs-pr.netlify.app/openshift-enterprise/latest/web_console/dynamic-plugin/overview-dynamic-plugin

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Provides doc updates for https://github.com/openshift/console/pull/13637
