### PR TITLE
WMCO 8.1.1 release notes

### DIFF
--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -7,10 +7,39 @@
 
 The following information details the supported platform versions, Windows Server versions, and networking configurations for the Windows Machine Config Operator. See the vSphere documentation for any information that is relevant to only that platform.
 
+[id="wmco-prerequisites-supported-8.1.1_{context}"]
+== WMCO 8.1.1 supported platforms and Windows Server versions
+
+The following table lists the link:https://docs.microsoft.com/en-us/windows/release-health/windows-server-release-info[Windows Server versions] that are supported by WMCO 8.1.1, based on the applicable platform. Windows Server versions not listed are not supported, and attempting to use them will cause errors. To prevent these errors, use only an appropriate version for your platform.
+
+[cols="3,7",options="header"]
+|===
+|Platform
+|Supported Windows Server version
+
+|Amazon Web Services (AWS)
+a|* Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
+* Windows Server 2019, version 1809
+
+|Microsoft Azure
+a|* Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
+* Windows Server 2019, version 1809
+
+|VMware vSphere
+|Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
+
+|Google Cloud Platform (GCP)
+|Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
+
+|Bare metal or provider agnostic
+a|* Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
+* Windows Server 2019, version 1809
+|===
+
 [id="wmco-prerequisites-supported-8.0.1_{context}"]
 == WMCO 8.0.1 supported platforms and Windows Server versions
 
-The following table lists the link:https://docs.microsoft.com/en-us/windows/release-health/windows-server-release-info[Windows Server versions] that are supported by WMCO 8.0.1, based on the applicable platform. Windows Server versions not listed are not supported and attempting to use them will cause errors. To prevent these errors, use only an appropriate version for your platform.
+The following table lists the link:https://docs.microsoft.com/en-us/windows/release-health/windows-server-release-info[Windows Server versions] that are supported by WMCO 8.0.1, based on the applicable platform. Windows Server versions not listed are not supported, and attempting to use them will cause errors. To prevent these errors, use only an appropriate version for your platform.
 
 [cols="3,7",options="header"]
 |===
@@ -39,7 +68,7 @@ a|* Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic
 [id="wmco-prerequisites-supported-8.0.0_{context}"]
 == WMCO 8.0.0 supported platforms and Windows Server versions
 
-The following table lists the link:https://docs.microsoft.com/en-us/windows/release-health/windows-server-release-info[Windows Server versions] that are supported by WMCO 8.0.0, based on the applicable platform. Windows Server versions not listed are not supported and attempting to use them will cause errors. To prevent these errors, use only an appropriate version for your platform.
+The following table lists the link:https://docs.microsoft.com/en-us/windows/release-health/windows-server-release-info[Windows Server versions] that are supported by WMCO 8.0.0, based on the applicable platform. Windows Server versions not listed are not supported, and attempting to use them will cause errors. To prevent these errors, use only an appropriate version for your platform.
 
 [cols="3,7",options="header"]
 |===

--- a/windows_containers/windows-containers-release-notes-8-x.adoc
+++ b/windows_containers/windows-containers-release-notes-8-x.adoc
@@ -28,6 +28,18 @@ For more information, see the Red Hat OpenShift Container Platform Life Cycle Po
 If you do not have this additional Red Hat subscription, you can use the Community Windows Machine Config Operator, a distribution that lacks official support.
 endif::openshift-origin[]
 
+[id="wmco-8-1-1"]
+== Release notes for Red Hat Windows Machine Config Operator 8.1.1
+
+This release of the WMCO provides new features and bug fixes for running Windows compute nodes in an {product-title} cluster. The components of WMCO 8.1.1 were released in link:https://access.redhat.com/errata/RHSA-2023:7709[RHBA-2023:7709].
+
+[id="wmco-8-1-1-bug-fixes"]
+=== Bug fixes
+
+* Previously, the WMCO did not properly wait for Windows virtual machines (VMs) to finish rebooting. This led to occasional timing issues where the WMCO would attempt to interact with a node that was in the middle of a reboot, causing WMCO to log an error and restart node configuration. Now, the WMCO waits for the instance to completely reboot. (link:https://issues.redhat.com/browse/OCPBUGS-20259[*OCPBUGS-20259*])
+
+* Previously, the WMCO configuration was missing the DeleteEmptyDirData: true field, which is required for draining nodes that have emptyDir volumes attached. As a consequence, customers that had nodes with emptyDir volumes would see the following error in the logs: cannot delete Pods with local storage. With this fix, the DeleteEmptyDirData: true field was added to the node drain helper struct in the WMCO. As a result, customers are able to drain nodes with emptyDir volumes attached. (link:https://issues.redhat.com/browse/OCPBUGS-22748[*OCPBUGS-22748*])
+
 [id="wmco-8-0-1"]
 == Release notes for Red Hat Windows Machine Config Operator 8.0.1
 


### PR DESCRIPTION
Errata: https://access.redhat.com/errata/RHSA-2023:7709

Previews:  
[Release notes for Red Hat Windows Machine Config Operator 8.1.1](https://72482--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-8-x#wmco-8-1-1)
[WMCO 8.1.1 supported platforms and Windows Server versions](https://72482--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-8-x#wmco-prerequisites-supported-8.1.1_windows-containers-release-notes)
