### PR TITLE
[RHACS] ROX-21994: Migrating SCCs during the manual upgrade documentation

### DIFF
--- a/modules/migrating-sccs-during-the-manual-upgrade.adoc
+++ b/modules/migrating-sccs-during-the-manual-upgrade.adoc
@@ -1,0 +1,360 @@
+// Module included in the following assemblies:
+//
+// * upgrading/upgrade-roxctl.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="migrating-sccs-during-the-manual-upgrade_{context}"]
+= Migrating SCCs during the manual upgrade
+
+By migrating the security context constraints (SCCs) during the manual upgrade by using `roxctl` CLI, you can seamlessly transition the {rh-rhacs-first} services to use the {osp} SCCs, ensuring compatibility and optimal security configurations across Central and all secured clusters.
+
+.Procedure
+
+. List all of the {product-title-short} services that are deployed on Central and all secured clusters:
++
+[source,terminal]
+----
+$ oc -n stackrox describe pods | grep 'openshift.io/scc\|^Name:'
+----
++
+.Example output
++
+[source,text,subs="+quotes"]
+----
+Name:      admission-control-6f4dcc6b4c-2phwd
+           *openshift.io/scc: stackrox-admission-control*
+#...
+Name:      central-575487bfcb-sjdx8
+           *openshift.io/scc: stackrox-central*
+Name:      central-db-7c7885bb-6bgbd
+           *openshift.io/scc: stackrox-central-db*
+Name:      collector-56nkr
+           *openshift.io/scc: stackrox-collector*
+#...
+Name:      scanner-68fc55b599-f2wm6
+           *openshift.io/scc: stackrox-scanner*
+Name:      scanner-68fc55b599-fztlh
+#...
+Name:      sensor-84545f86b7-xgdwf
+           *openshift.io/scc: stackrox-sensor*
+#...
+----
++
+In this example, you can see that each pod has its own custom SCC, which is specified through the `openshift.io/scc` field.
+
+. Add the required roles and role bindings to use the {osp} SCCs instead of the {product-title-short} custom SCCs. 
++
+To add the required roles and role bindings to use the {osp} SCCs for the Central cluster, perform the following steps:
+
+.. Create a file named `update-central.yaml` that defines the role and role binding resources by using the following content:
++
+.Example YAML file
+[%collapsible]
+====
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role # <1>
+metadata:
+  annotations:
+     email: support@stackrox.com
+     owner: stackrox
+  labels:
+     app.kubernetes.io/component: central
+     app.kubernetes.io/instance: stackrox-central-services
+     app.kubernetes.io/name: stackrox
+     app.kubernetes.io/part-of: stackrox-central-services
+     app.kubernetes.io/version: 4.4.0
+  name: use-central-db-scc # <2>
+  namespace: stackrox # <3>
+Rules: # <4>
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - nonroot-v2
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- - -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+     email: support@stackrox.com
+     owner: stackrox
+  labels:
+     app.kubernetes.io/component: central
+     app.kubernetes.io/instance: stackrox-central-services
+     app.kubernetes.io/managed-by: Helm
+     app.kubernetes.io/name: stackrox
+     app.kubernetes.io/part-of: stackrox-central-services
+     app.kubernetes.io/version: 4.4.0
+  name: use-central-scc
+  namespace: stackrox
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - nonroot-v2
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- - -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+     email: support@stackrox.com
+     owner: stackrox
+  labels:
+     app.kubernetes.io/component: scanner
+     app.kubernetes.io/instance: stackrox-central-services
+     app.kubernetes.io/name: stackrox
+     app.kubernetes.io/part-of: stackrox-central-services
+     app.kubernetes.io/version: 4.4.0
+  name: use-scanner-scc
+  namespace: stackrox
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - nonroot-v2
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- - -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding # <5>
+metadata:
+  annotations:
+     email: support@stackrox.com
+     owner: stackrox
+  labels:
+     app.kubernetes.io/component: central
+     app.kubernetes.io/instance: stackrox-central-services
+     app.kubernetes.io/name: stackrox
+     app.k ubernetes.io/part-of: stackrox-central-services
+     app.kubernetes.io/version: 4.4.0
+  name: central-db-use-scc # <6>
+  namespace: stackrox 
+roleRef: # <7>
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: use-central-db-scc
+subjects: # <8>
+- kind: ServiceAccount
+  name: central-db
+  namespace: stackrox
+- - -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+     email: support@stackrox.com
+     owner: stackrox
+  labels:
+     app.kubernetes.io/component: central
+     app.kubernetes.io/instance: stackrox-central-services
+     app.kubernetes.io/name: stackrox
+     app.kubernetes.io/part-of: stackrox-central-services
+     app.kubernetes.io/version: 4.4.0
+  name: central-use-scc
+  namespace: stackrox
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: use-central-scc
+subjects:
+- kind: ServiceAccount
+  name: central
+  namespace: stackrox
+- - -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+     email: support@stackrox.com
+     owner: stackrox
+  labels:
+     app.kubernetes.io/component: scanner
+     app.kubernetes.io/instance: stackrox-central-services
+     app.kubernetes.io/name: stackrox
+     app.kubernetes.io/part-of: stackrox-central-services
+     app.kubernetes.io/version: 4.4.0
+  name: scanner-use-scc
+  namespace: stackrox
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: use-scanner-scc
+subjects:
+- kind: ServiceAccount
+  name: scanner
+  namespace: stackrox
+- - -
+----
+<1> The type of Kubernetes resource, in this example, `Role`.
+<2> The name of the role resource.
+<3> The namespace in which the role is created. 
+<4> Describes the permissions granted by the role resource.
+<5> The type of Kubernetes resource, in this example, `RoleBinding`.
+<6> The name of the role binding resource.
+<7> Specifies the role to bind in the same namespace.
+<8> Specifies the subjects that are bound to the role.
+====
+
+.. Create the role and role binding resources specified in the `update-central.yaml` file by running the following command:
++
+[source,terminal]
+----
+$ oc -n stackrox create -f ./update-central.yaml
+----
+
+. To add the required roles and role bindings to use the {osp} SCCs for all secured clusters, perform the following steps:
+
+.. Create a file named `upgrade-scs.yaml` that defines the role and role binding resources by using the following content:
++
+.Example YAML file
+[%collapsible]
+====
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role  # <1>
+metadata:
+  annotations:
+     email: support@stackrox.com
+     owner: stackrox
+  labels:
+     app.kubernetes.io/component: collector
+     app.kubernetes.io/instance: stackrox-secured-cluster-services
+     app.kubernetes.io/name: stackrox
+     app.kubernetes.io/part-of: stackrox-secured-cluster-services
+     app.kubernetes.io/version: 4.4.0
+     auto-upgrade.stackrox.io/component: sensor
+  name: use-privileged-scc  # <2>
+  namespace: stackrox # <3> 
+rules:  # <4>
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- - -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding # <5>
+metadata:
+  annotations:
+     email: support@stackrox.com
+     owner: stackrox
+  labels:
+     app.kubernetes.io/component: collector
+     app.kubernetes.io/instance: stackrox-secured-cluster-services
+     app.kubernetes.io/name: stackrox
+     app.kubernetes.io/part-of: stackrox-secured-cluster-services
+     app.kubernetes.io/version: 4.4.0
+     auto-upgrade.stackrox.io/component: sensor
+  name: collector-use-scc # <6>
+  namespace: stackrox
+roleRef: # <7>
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: use-privileged-scc
+subjects: # <8>
+- kind: ServiceAccount
+  name: collector
+  namespace: stackrox
+- - -
+----
+<1> The type of Kubernetes resource, in this example, `Role`.
+<2> The name of the role resource.
+<3> The namespace in which the role is created. 
+<4> Describes the permissions granted by the role resource.
+<5> The type of Kubernetes resource, in this example, `RoleBinding`.
+<6> The name of the role binding resource.
+<7> Specifies the role to bind in the same namespace.
+<8> Specifies the subjects that are bound to the role.
+====
+
+.. Create the role and role binding resources specified in the `upgrade-scs.yaml` file by running the following command:
++
+[source,terminal]
+----
+$ oc -n stackrox create -f ./update-scs.yaml
+----
++
+[IMPORTANT]
+====
+You must run this command on each secured cluster to create the role and role bindings specified in the `upgrade-scs.yaml` file.
+====
+
+. Delete the SCCs that are specific to {product-title-short}:
+
+.. To delete the SCCs that are specific to the Central cluster, run the following command:
++
+[source,terminal]
+----
+$ oc delete scc/stackrox-central scc/stackrox-central-db scc/stackrox-scanner
+----
+
+.. To delete the SCCs that are specific to all secured clusters, run the following command:
++
+[source,terminal]
+----
+$ oc delete scc/stackrox-admission-control scc/stackrox-collector scc/stackrox-sensor
+----
++
+[IMPORTANT]
+====
+You must run this command on each secured cluster to delete the SCCs that are specific to each secured cluster.
+====
+
+.Verification
+
+* Ensure that all the pods are using the correct SCCs by running the following command:
++
+[source,terminal]
+----
+$ oc -n stackrox describe pods | grep 'openshift.io/scc\|^Name:'
+----
++
+Compare the output with the following table:
++
+[cols="2,2,2",options="header"]
+|===
+|Component |Previous custom SCC |New {osp} 4 SCC
+
+|Central
+|`stackrox-central`
+|`nonroot-v2`
+
+|Central-db
+|`stackrox-central-db`
+|`nonroot-v2`
+
+|Scanner
+|`stackrox-scanner`
+|`nonroot-v2`
+
+|Scanner-db
+|`stackrox-scanner`
+|`nonroot-v2`
+
+|Admission Controller
+|`stackrox-admission-control`
+|`restricted-v2`
+
+|Collector
+|`stackrox-collector`
+|`privileged`
+
+|Sensor
+|`stackrox-sensor`
+|`restricted-v2`
+|===

--- a/modules/update-other-images.adoc
+++ b/modules/update-other-images.adoc
@@ -51,3 +51,10 @@ $ oc -n stackrox set image ds/collector collector=registry.redhat.io/advanced-cl
 ----
 $ oc -n stackrox set image deploy/admission-control admission-control=registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:{rhacs-version}
 ----
+
+[IMPORTANT]
+====
+If you have installed {product-title-short} on {osp} by using the `roxctl` CLI, you need to migrate the security context constraints (SCCs).
+
+For more information, see "Migrating SCCs during the manual upgrade" in the "Additional resources" section.
+====

--- a/upgrading/upgrade-roxctl.adoc
+++ b/upgrading/upgrade-roxctl.adoc
@@ -15,14 +15,14 @@ You can upgrade to the latest version of {rh-rhacs-first} from a supported older
 * For upgrading to {product-title-short} 4.0, you must be using the latest patch release of {product-title-short} 3.74. If you are using an older version, you must first upgrade to {product-title-short} 3.74 before upgrading to {product-title-short} 4.0.
 ====
 
-To upgrade {product-title} to the latest version, you must perform the following:
+To upgrade {product-title-short} to the latest version, perform the following steps:
 
-* Backup the Central database
-* Upgrade the `roxctl` CLI
-* Generate Central database provisioning bundle
-* Upgrade Central
-* Upgrade Scanner
-* Verify all the upgraded secured clusters
+. xref:../upgrading/upgrade-roxctl.adoc#back-up-central-database_upgrade-roxctl[Backup the Central database]
+. xref:../upgrading/upgrade-roxctl.adoc#upgrade-roxctl-cli[Upgrade the `roxctl` CLI]
+. xref:../upgrading/upgrade-roxctl.adoc#generate-central-database-provisioning-bundle_upgrade-roxctl[Generate Central database provisioning bundle]
+. xref:../upgrading/upgrade-roxctl.adoc#create-resource-central-db-bundle_upgrade-roxctl[Create resources by using the Central DB provisioning bundle]
+. xref:../upgrading/upgrade-roxctl.adoc#upgrade-central-cluster[Upgrade the Central cluster]
+. xref:../upgrading/upgrade-roxctl.adoc#upgrade-secured-clusters[Upgrade all secured clusters]
 
 // include::modules/set-rox-scanner-init-db-env-variable.adoc[leveloffset=+1]
 
@@ -74,13 +74,23 @@ To complete manual upgrades of each secured cluster running Sensor, Collector, a
 
 include::modules/update-other-images.adoc[leveloffset=+2]
 
+.Next steps
+* xref:../upgrading/upgrade-roxctl.adoc#verify-secured-cluster-upgrade_upgrade-roxctl[Verifying secured cluster upgrade]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../upgrading/upgrade-roxctl.adoc#migrating-sccs-during-the-manual-upgrade_upgrade-roxctl[Migrating SCCs during the manual upgrade]
+
+include::modules/migrating-sccs-during-the-manual-upgrade.adoc[leveloffset=+2]
+
 include::modules/verify-secured-cluster-upgrade.adoc[leveloffset=+2]
 
-include::modules/rhcos-enable-node-scan.adoc[leveloffset=+2]
+include::modules/rhcos-enable-node-scan.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../operating/manage-vulnerabilities/scan-rhcos-node-host.html#scan-rhcos-node-host[Scanning {op-system} node hosts]
+
 
 include::modules/remove-central-attached-pv-overview.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.4
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/ROX-21994
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://72486--docspreview.netlify.app/openshift-acs/latest/upgrading/upgrade-roxctl#migrating-sccs-during-the-manual-upgrade_upgrade-roxctl
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- Merge into `rhacs-docs` and cherry-pick to:
    - `rhacs-docs-4.4` 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
