### PR TITLE
PR for SRVCOM 2909: Update the Serverless 1.32 release notes

### DIFF
--- a/about/serverless-release-notes.adoc
+++ b/about/serverless-release-notes.adoc
@@ -28,6 +28,9 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 
 // Release notes included, most to least recent
 // OCP + OSD + ROSA
+include::modules/serverless-rn-1-32-0.adoc[leveloffset=+1]
+
+// OCP + OSD + ROSA
 include::modules/serverless-rn-1-31-0.adoc[leveloffset=+1]
 
 

--- a/modules/serverless-deprecated-removed-features.adoc
+++ b/modules/serverless-deprecated-removed-features.adoc
@@ -11,9 +11,45 @@ Some features that were Generally Available (GA) or a Technology Preview (TP) in
 For the most recent list of major functionality deprecated and removed within {ServerlessProductName}, refer to the following table:
 
 .Deprecated and removed features tracker
-[cols="3,1,1,1,1,1,1",options="header"]
+[cols="3,1,1,1,1,1,1,1",options="header"]
 |====
-|Feature |1.22 to 1.26|1.27|1.28|1.29|1.30|1.31
+|Feature |1.22 to 1.26|1.27|1.28|1.29|1.30|1.31|1.32
+
+|Serving TLS for internal traffic
+|-
+|-
+|-
+|-
+|-
+|-
+|Removed
+
+|EventTypes `v1beta1` API
+|-
+|-
+|-
+|-
+|-
+|-
+|Deprecated
+
+|`domain-mapping` and `domain-mapping-webhook` deployments
+|-
+|-
+|-
+|-
+|-
+|-
+|Removed
+
+|{SMProductName} with {ServerlessProductShortName} when Kourier is enabled
+|-
+|-
+|-
+|-
+|-
+|-
+|Deprecated
 
 |`NamespacedKafka` annotation
 |-
@@ -22,10 +58,12 @@ For the most recent list of major functionality deprecated and removed within {S
 |-
 |Deprecated
 |Deprecated
+|Deprecated
 
 |`enable-secret-informer-filtering` annotation
 |-
 |-
+|Deprecated
 |Deprecated
 |Deprecated
 |Deprecated
@@ -38,6 +76,7 @@ For the most recent list of major functionality deprecated and removed within {S
 |Removed
 |Removed
 |Removed
+|Removed
 
 |`kn func emit` (`kn func invoke` in 1.21+)
 |Removed
@@ -46,8 +85,10 @@ For the most recent list of major functionality deprecated and removed within {S
 |Removed
 |Removed
 |Removed
+|Removed
 
 |`KafkaBinding` API
+|Removed
 |Removed
 |Removed
 |Removed

--- a/modules/serverless-rn-1-32-0.adoc
+++ b/modules/serverless-rn-1-32-0.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies
+//
+// * about/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-32-0_{context}"]
+= Red Hat {ServerlessProductName} 1.32
+
+{ServerlessProductName} 1.32 is now available. New features, updates, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes.
+
+[id="new-features-1-32-0_{context}"]
+== New features
+
+* {ServerlessProductName} now uses Knative Serving 1.11.
+* {ServerlessProductName} now uses Knative Eventing 1.11.
+* {ServerlessProductName} now uses Kourier 1.11.
+* {ServerlessProductName} now uses Knative (`kn`) CLI 1.11.
+* {ServerlessProductName} now uses Knative for Apache Kafka 1.11.
+* The `kn func` CLI plugin now uses `func` 1.13.
+
+* Serverless Logic, which is available as a Technology Preview (TP) feature, has been updated.
++
+See link:https://openshift-knative.github.io/docs/docs/latest/serverless-logic/about.html[the Serverless Logic documentation] for usage instructions.
+
+* You can configure the {FunctionsProductName} readiness and liveness probe settings for the `user` container and `queue-proxy` container.
+
+* {FunctionsProductName} now supports {pipelines-shortname} versions from `1.10` till `1.14` (latest). The older versions of {pipelines-shortname} are no longer compatible with {FunctionsProductName}. 
+
+* {FunctionsProductName} now supports Go function container and is now available as a Technology Preview (TP) feature.
+
+* On-cluster function building, including using {pac} is now supported on IBM zSystems (s390x) and IBM Power (ppc64le) on {rh-storage} storage only.
+
+* You can now subscribe a function to a set of events by using the `func subscribe` command. This links your function to `CloudEvent` objects defined by your filters and enables automated responses.
+
+* The Knative Serving TLS encryption feature for internal traffic is now deprecated. It was a Tech Preview feature. The functionality with the `internal-encryption` configuration flag is no longer available and it will be replaced by new configuration flags in a future release.
+
+* The secret filtering is enabled by default on the {ServerlessOperatorName} side. An environment variable `ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID=true`, is added by default to the `net-istio` and `net-kourier` controller pods.
+
+* The `domain-mapping` and `domain-mapping-webhook` deployments functionality in the `knative-serving` namespace is now removed. They are now integrated with Serving Webhook and Serving Controller.
+
+* If you set `spec.config.domain` field in the `KnativeServing` custom resource (CR), the default external domain will no longer auto-populates the `config-domain` config map in the `knative-serving` namespace. Now, you must configure the `config-domain` config map manually to ensure accurate domain settings.
+
+* You can now use the gRPC health probe for `net-kourier` deployments. The the Kourier Controller now uses a standard Kubernetes gRPC health probe for both readiness and liveness, replacing its previous use of exec and custom commands. The `timeoutSeconds` value has been adjusted from 100 milliseconds to 1 second to ensure more reliable probe responses.
+
+* The new trigger filters feature is now available as a Technology Preview. The new trigger filters are now enabled by default. It allows users to specify a set of filter expressions, where each expression evaluates to either true or false for each event.
+
+* Knative Eventing now offers support for data in transit encryption (Eventing TLS) as a developer preview. You can configure Knative Eventing components to expose HTTPS addresses as well as add user-provided CA trust bundles to clients. 
+
+* {ServerlessProductName} now supports custom OpenShift CA bundle injection for system components. For more information, see link:https://docs.openshift.com/container-platform/latest/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki[Configuring a custom PKI].
+
+* You can now use the Custom Metrics Autoscaler Operator to autoscale Knative Eventing sources for Apache Kafka sources. This functionality is available as a developer preview, offering enhanced scalability and efficiency for Kafka-based event sources within Knative Eventing.
+
+* You can now explore the Knative Eventing monitoring dashboards directly within the *Observe* tab of the Developer view in the OpenShift Developer Console. 
+
+* The support for EventTypes `v1beta1` in Knative shipped is deprecated in {ServerlessProductName} 1.32. In {ServerlessProductName} 1.32, the Knative CLI uses the EventType `v1beta2` API to facilitate the new reference model. In previous releases, the `kn` CLI is not backward compatible with the EventType API `v1beta1` and is limited to the `kn eventtypes` sub-commands group. Therefore, it is recommended to use a matching `kn` version for the best user experience.  
+
+[id="fixed-issues-1-32-0_{context}"]
+== Fixed issues
+
+* The default CPU limit is now increased for `3scale-kourier-gateways` from `500m` to `1s`. When more than 500 Knative Service instances are created, it could lead to readiness and liveness probe failures in the `3scale-kourier-gateways` pod due to CPU resource exhaustion. This adjustment aims to reduce such failures and ensures smoother operation even under heavy loads.
+
+[id="known-issues-1-32-0_{context}"]
+== Known issues
+
+* Due to different mount point permissions, direct upload on a cluster build does not work on IBM zSystems (s390x) and IBM Power (ppc64le).
+
+* Building and deploying a function using Podman version 4.6 fails with the `invalid pull policy "1"` error.
++
+To work around this issue, use Podman version 4.5.

--- a/modules/serverless-tech-preview-features.adoc
+++ b/modules/serverless-tech-preview-features.adoc
@@ -13,25 +13,40 @@ The following table provides information about which {ServerlessProductName} fea
 .Generally Available and Technology Preview features tracker
 [cols="2,1,1,1",options="header"]
 |====
-|Feature |1.29|1.30|1.31
+|Feature |1.30|1.31|1.32
+
+|Pipelines-as-code
+|-
+|-
+|TP
+
+|`new-trigger-filters`
+|-
+|-
+|TP
+
+|Go function using S2I builder
+|-
+|-
+|TP
 
 |Installing and using {ServerlessProductShortName} on {sno}
 |-
-|-
+|GA
 |GA
 
 |Using {SMProductShortName} to isolate network traffic with {ServerlessProductShortName}
 |-
-|-
+|TP
 |TP
 
 |Serverless Logic
-|-
+|TP
 |TP
 |TP
 
 |Overriding `liveness` and `readiness` in functions
-|-
+|GA
 |GA
 |GA
 
@@ -61,8 +76,8 @@ The following table provides information about which {ServerlessProductName} fea
 |TP
 
 |Service Mesh mTLS
-|-
 |TP
+|GA
 |GA
 
 |`emptyDir` volumes
@@ -94,11 +109,6 @@ The following table provides information about which {ServerlessProductName} fea
 |GA
 |GA
 |GA
-
-|TLS for internal traffic
-|TP
-|TP
-|TP
 
 |Namespace-scoped brokers
 |TP


### PR DESCRIPTION
**Affected versions:** `serverless-docs-1.32`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVCOM-2919

**Doc preview:** 

- [Serverless 1.32.0 release notes](https://72487--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes#serverless-rn-1-32-0_serverless-release-notes)

- [Generally Available and Technology Preview features table](https://72487--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes#serverless-tech-preview-features_serverless-release-notes)

- [Deprecated and removed features table](https://72487--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes#serverless-deprecated-removed-features_serverless-release-notes)