### PR TITLE
OSDOCS#8311: cert-manager minor fixes

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1110,18 +1110,18 @@ Topics:
     File: cert-manager-operator-release-notes
   - Name: Installing the cert-manager Operator for Red Hat OpenShift
     File: cert-manager-operator-install
-  - Name: Configuring an ACME issuer
-    File: cert-manager-operator-issuer-acme
-  - Name: Configuring certificates with an issuer
-    File: cert-manager-creating-certificate
-  - Name: Monitoring the cert-manager Operator for Red Hat OpenShift
-    File: cert-manager-monitoring
   - Name: Configuring the egress proxy
     File: cert-manager-operator-proxy
   - Name: Customizing cert-manager by using the cert-manager Operator API fields
     File: cert-manager-customizing-api-fields
   - Name: Authenticating the cert-manager Operator for Red Hat OpenShift
     File: cert-manager-authenticate
+  - Name: Configuring an ACME issuer
+    File: cert-manager-operator-issuer-acme
+  - Name: Configuring certificates with an issuer
+    File: cert-manager-creating-certificate
+  - Name: Monitoring the cert-manager Operator for Red Hat OpenShift
+    File: cert-manager-monitoring
   - Name: Configuring log levels for cert-manager and the cert-manager Operator for Red Hat OpenShift
     File: cert-manager-log-levels
   - Name: Uninstalling the cert-manager Operator for Red Hat OpenShift

--- a/modules/cert-manager-supported-versions.adoc
+++ b/modules/cert-manager-supported-versions.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="cert-manager-operator-supported-versions_{context}"]
-== Supported {cert-manager-operator} versions
+= Supported {cert-manager-operator} versions
 {product-title} {product-version} supports the following versions of {cert-manager-operator}:
 
 * {cert-manager-operator} 1.13

--- a/security/cert_manager_operator/cert-manager-authenticate.adoc
+++ b/security/cert_manager_operator/cert-manager-authenticate.adoc
@@ -1,5 +1,5 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="cert-manager-authenticate-aws"]
+[id="cert-manager-authenticate"]
 = Authenticating the {cert-manager-operator}
 include::_attributes/common-attributes.adoc[]
 :context: cert-manager-authenticate

--- a/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
@@ -13,7 +13,7 @@ These release notes track the development of {cert-manager-operator}.
 For more information, see xref:../../security/cert_manager_operator/index.adoc#cert-manager-operator-about[About the {cert-manager-operator}].
 
 [id="cert-manager-operator-release-notes-1-13"]
-== Release notes for {cert-manager-operator} 1.13.0
+== {cert-manager-operator} 1.13.0
 
 Issued: 2024-01-16
 


### PR DESCRIPTION
Version(s): 4.15+

Issue: https://issues.redhat.com/browse/OSDOCS-8311

Link to docs preview: https://72489--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/#cert-manager-operator-supported-versions_cert-manager-operator-about

QE review:
- [x] QE has approved this change. @lunarwhite 
- [x] SME has approved this change. @swghosh 