### PR TITLE
DOCS OBSDOCS-847 Logging 5.8.4 Release Notes

### DIFF
--- a/logging/logging_release_notes/logging-5-8-release-notes.adoc
+++ b/logging/logging_release_notes/logging-5-8-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-8-4.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-8-3.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-8-2.adoc[leveloffset=+1]

--- a/modules/logging-release-notes-5-8-2.adoc
+++ b/modules/logging-release-notes-5-8-2.adoc
@@ -2,7 +2,7 @@
 :content-type: REFERENCE
 [id="logging-release-notes-5-8-2"]
 = Logging 5.8.2
-This release includes link:https://access.redhat.com/errata/RHSA-2024:0271[OpenShift Logging Bug Fix Release 5.8.2].
+This release includes link:https://access.redhat.com/errata/RHBA-2024:0271[OpenShift Logging Bug Fix Release 5.8.2].
 
 [id="logging-release-notes-5-8-2-bug-fixes"]
 == Bug fixes

--- a/modules/logging-release-notes-5-8-4.adoc
+++ b/modules/logging-release-notes-5-8-4.adoc
@@ -1,0 +1,45 @@
+// module included in /logging/logging-5-8-release-notes
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-5-8-4_{context}"]
+= Logging 5.8.4
+This release includes link:https://access.redhat.com/errata/RHBA-2024:1065[OpenShift Logging Bug Fix Release 5.8.4].
+
+[id="logging-release-notes-5-8-4-bug-fixes"]
+== Bug fixes
+None.
+
+[id="logging-release-notes-5-8-4-CVEs"]
+== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2021-35937[CVE-2021-35937]
+* link:https://access.redhat.com/security/cve/CVE-2021-35938[CVE-2021-35938]
+* link:https://access.redhat.com/security/cve/CVE-2021-35939[CVE-2021-35939]
+* link:https://access.redhat.com/security/cve/CVE-2022-3545[CVE-2022-3545]
+* link:https://access.redhat.com/security/cve/CVE-2022-24963[CVE-2022-24963]
+* link:https://access.redhat.com/security/cve/CVE-2022-36402[CVE-2022-36402]
+* link:https://access.redhat.com/security/cve/CVE-2022-41858[CVE-2022-41858]
+* link:https://access.redhat.com/security/cve/CVE-2023-2166[CVE-2023-2166]
+* link:https://access.redhat.com/security/cve/CVE-2023-2176[CVE-2023-2176]
+* link:https://access.redhat.com/security/cve/CVE-2023-3777[CVE-2023-3777]
+* link:https://access.redhat.com/security/cve/CVE-2023-3812[CVE-2023-3812]
+* link:https://access.redhat.com/security/cve/CVE-2023-4015[CVE-2023-4015]
+* link:https://access.redhat.com/security/cve/CVE-2023-4622[CVE-2023-4622]
+* link:https://access.redhat.com/security/cve/CVE-2023-4623[CVE-2023-4623]
+* link:https://access.redhat.com/security/cve/CVE-2023-5178[CVE-2023-5178]
+* link:https://access.redhat.com/security/cve/CVE-2023-5363[CVE-2023-5363]
+* link:https://access.redhat.com/security/cve/CVE-2023-5388[CVE-2023-5388]
+* link:https://access.redhat.com/security/cve/CVE-2023-5633[CVE-2023-5633]
+* link:https://access.redhat.com/security/cve/CVE-2023-6679[CVE-2023-6679]
+* link:https://access.redhat.com/security/cve/CVE-2023-7104[CVE-2023-7104]
+* link:https://access.redhat.com/security/cve/CVE-2023-27043[CVE-2023-27043]
+* link:https://access.redhat.com/security/cve/CVE-2023-38409[CVE-2023-38409]
+* link:https://access.redhat.com/security/cve/CVE-2023-40283[CVE-2023-40283]
+* link:https://access.redhat.com/security/cve/CVE-2023-42753[CVE-2023-42753]
+* link:https://access.redhat.com/security/cve/CVE-2023-43804[CVE-2023-43804]
+* link:https://access.redhat.com/security/cve/CVE-2023-45803[CVE-2023-45803]
+* link:https://access.redhat.com/security/cve/CVE-2023-46813[CVE-2023-46813]
+* link:https://access.redhat.com/security/cve/CVE-2024-20918[CVE-2024-20918]
+* link:https://access.redhat.com/security/cve/CVE-2024-20919[CVE-2024-20919]
+* link:https://access.redhat.com/security/cve/CVE-2024-20921[CVE-2024-20921]
+* link:https://access.redhat.com/security/cve/CVE-2024-20926[CVE-2024-20926]
+* link:https://access.redhat.com/security/cve/CVE-2024-20945[CVE-2024-20945]
+* link:https://access.redhat.com/security/cve/CVE-2024-20952[CVE-2024-20952]


### PR DESCRIPTION
Change type: Doc update; Logging Z-Stream Release Notes - 5.8.4
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-847

Fix Version: 4.12+

Doc Preview: https://72491--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/logging_release_notes/logging-5-8-release-notes#logging-release-notes-5-8-4_logging-5-8-release-notes

SME Review: 
QE Review: 
Peer Review: 