### PR TITLE
OADP 3523 fs-backup/restic default timeout is being changed to 4 hours

### DIFF
--- a/modules/oadp-converting-to-new-dpa-1-2-0.adoc
+++ b/modules/oadp-converting-to-new-dpa-1-2-0.adoc
@@ -49,3 +49,8 @@ spec:
 ----
 
 . Wait for the DPA to reconcile successfully.
+
+[NOTE]
+====
+The default timeout value for the Restic file system backup is one hour. In OADP 1.3.1 and later, the default timeout value for Restic and Kopia is four hours.
+====

--- a/modules/oadp-upgrade-from-oadp-data-mover-1-2-0.adoc
+++ b/modules/oadp-upgrade-from-oadp-data-mover-1-2-0.adoc
@@ -19,5 +19,10 @@ back up the applications with a CSI backup.
 
 [NOTE]
 ====
+The default timeout value for the Restic file system backup is one hour. In OADP 1.3.1 and later, the default timeout value for Restic and Kopia is four hours.
+====
+
+[IMPORTANT]
+====
 To restore OADP 1.2 Data Mover backup, you must uninstall OADP, and install and configure OADP 1.2.
 ====


### PR DESCRIPTION
OADP 1.3.1

OCP 4.13+

Resolves - https://issues.redhat.com/browse/OADP-3523

Deploy preview - 

https://72492--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3#upgrade-notes-1-3-0_oadp-release-notes

https://72492--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-2#Upgrade-notes-1-2-0_oadp-release-notes
