### PR TITLE
[enterprise-4.12] OBSDOCS-69: Reorganize steps in Query Browser procedure

### DIFF
--- a/modules/monitoring-exploring-the-visualized-metrics.adoc
+++ b/modules/monitoring-exploring-the-visualized-metrics.adoc
@@ -29,11 +29,11 @@ By default, the query table shows an expanded view that lists every metric and i
 
 * Use the menu in the left upper corner to select the time range.
 
-. To reset the time range, select *Reset Zoom*.
+. To reset the time range, select *Reset zoom*.
 
 . To display outputs for all queries at a specific point in time, hold the mouse cursor on the plot at that point. The query outputs will appear in a pop-up box.
 
-. To hide the plot, select *Hide Graph*.
+. To hide the plot, select *Hide graph*.
 
 In the *Developer* perspective:
 
@@ -43,6 +43,6 @@ In the *Developer* perspective:
 
 * Use the menu in the left upper corner to select the time range.
 
-. To reset the time range, select *Reset Zoom*.
+. To reset the time range, select *Reset zoom*.
 
 . To display outputs for all queries at a specific point in time, hold the mouse cursor on the plot at that point. The query outputs will appear in a pop-up box.

--- a/modules/monitoring-querying-metrics-for-all-projects-as-an-administrator.adoc
+++ b/modules/monitoring-querying-metrics-for-all-projects-as-an-administrator.adoc
@@ -16,35 +16,35 @@ As a cluster administrator or as a user with view permissions for all projects, 
 
 .Procedure
 
-. Select the *Administrator* perspective in the {product-title} web console.
+. From the *Administrator* perspective of the {product-title} web console, go to *Observe* -> *Metrics*.
 
-. Select *Observe* -> *Metrics*.
-
-. To create a custom query, add your Prometheus Query Language (PromQL) query to the *Expression* field.
+. To add one or more queries, perform any of the following actions:
 +
-[NOTE]
-====
-As you type a PromQL expression, autocomplete suggestions appear in a drop-down list.
-These suggestions include functions, metrics, labels, and time tokens.
-You can use the keyboard arrows to select one of these suggested items and then press Enter to add the item to your expression.
-You can also move your mouse pointer over a suggested item to view a brief description of that item.
-====
+|===
+|Option |Description
 
-. To add multiple queries, select *Add Query*.
+|Create a custom query.
+|Add your Prometheus Query Language (PromQL) query to the *Expression* field.
 
-. To duplicate an existing query, select {kebab} next to the query, then choose *Duplicate query*.
+As you type a PromQL expression, autocomplete suggestions are displayed in a list. These suggestions include functions, metrics, labels, and time tokens.
+You can use the keyboard arrows to select one of these suggested items and then press Enter to add the item to your expression. You can also move your mouse pointer over a suggested item to view a brief description of that item.
 
-. To delete a query, select {kebab} next to the query, then choose *Delete query*.
+|Add multiple queries. |Click *Add query*.
 
-. To disable a query from being run, select {kebab} next to the query and choose *Disable query*.
+|Duplicate an existing query. |Click the Options menu {kebab} next to the query and select *Duplicate query*.
 
-. To run queries that you created, select *Run Queries*.
+|Delete a query. |Click the Options menu {kebab} next to the query and select *Delete query*.
+
+|Disable a query from being run. |Click the Options menu {kebab} next to the query and select *Disable query*.
+|===
+
+. To run queries that you created, click *Run queries*.
 The metrics from the queries are visualized on the plot.
 If a query is invalid, the UI shows an error message.
 +
 [NOTE]
 ====
-Queries that operate on large amounts of data might time out or overload the browser when drawing time series graphs. To avoid this, select *Hide graph* and calibrate your query using only the metrics table. Then, after finding a feasible query, enable the plot to draw the graphs.
+Queries that operate on large amounts of data might time out or overload the browser when drawing time series graphs. To avoid this, click *Hide graph* and calibrate your query by using the metrics table. After finding a feasible query, enable the plot to draw the graphs.
 ====
 
 . Optional: The page URL now contains the queries you ran. To use this set of queries again in the future, save this URL.


### PR DESCRIPTION
Version(s): `enterprise-4.12`

Issue: [OBSDOCS-69](https://issues.redhat.com/browse/OBSDOCS-69)

Links to docs preview:

- [Querying metrics for all projects as a cluster administrator](https://72500--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/querying-metrics#querying-metrics-for-all-projects-as-an-administrator_querying-metrics)
- [Exploring the visualized metrics](https://72500--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/querying-metrics#exploring-the-visualized-metrics_querying-metrics)

QE review:
- [x] QE has approved this change.

Peer review:
- [x] Peer review done

Additional information: 
**This issue is created against `enterprise-4.12` branch because newer versions already have this change implemented.**