### PR TITLE
OSDOCS-9819: Documented the 4.14.15 z-stream release notes

### DIFF
--- a/modules/virt-about-services.adoc
+++ b/modules/virt-about-services.adoc
@@ -17,5 +17,5 @@ LoadBalancer:: Creates an external load balancer in the current cloud (if suppor
 
 [NOTE]
 ====
-For on-premise clusters, you can configure a load balancing service by using the MetalLB Operator in layer 2 mode. The BGP mode is not supported. The MetalLB Operator is installed in the `metallb-system` namespace.
+For on-premise clusters, you can configure a load-balancing service by deploying the MetalLB Operator.
 ====

--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3279,6 +3279,43 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+[id="ocp-4-14-15"]
+
+=== RHBA-2024:1046 - {product-title} 4.14.15 bug fix and security update
+
+Issued: 2024-03-04
+
+{product-title} release 4.14.15, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1046[RHBA-2024:1046] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:1049[RHBA-2024:1049] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.15 --pullspecs
+----
+
+[id="ocp-4-14-15-bug-fixes"]
+==== Bug fixes
+
+* Previously, the `manila-csi-driver-controller-metrics` service had empty endpoints because of an incorrect name for the app selector. With this release the app selector name is changed to `openstack-manila-csi` and the issue is fixed.. (link:https://issues.redhat.com/browse/OCPBUGS-23443[*OCPBUGS-23443*])
+
+* Previously, an Amazon Web Services (AWS) code that provided image credentials was removed from the kubelet in {product-title} {product-version}. Consequently, pulling images from Amazon Elastic Container Registry (ECR) failed without a specified pull secret, because the kubelet could no longer authenticate itself and pass credentials to the container runtime. With this update, a separate credential provider has been configured, which is now responsible for providing ECR credentials for the kubelet. As a result, the kubelet can now pull private images from ECR. (link:https://issues.redhat.com/browse/OCPBUGS-29630[*OCPBUGS-29630*])
+
+* Previously, the {product-title} {product-version} release introduced a change that gave users the perception that their images were lost when updating from {product-title} version 4.13 to 4.14. A change to the default internal registry caused the registry to use an incorrect path when using the Microsoft Azure object storage. With this release, the correct path is used and a job has been added to the registry operator that moves any blobs pushed to the registry that used the wrong storage path into the correct storage path, which effectively merges the two distinct storage paths into a single path. (link:https://issues.redhat.com/browse/OCPBUGS-29604[*OCPBUGS-29604*])
++
+[NOTE]
+====
+This fix does *not* work on Azure Stack Hub (ASH). ASH users who used OCP versions 4.14.0 through 4.14.13 when upgrading to 4.14.14+ will need to execute manual steps to move their blobs to the correct storage path.
+====
+
+* Previously, machine sets that ran on Microsoft Azure regions with no availability zone support always created `AvailabilitySets` objects for Spot instances. This operation caused Spot instances to fail because the instances did not support availability sets. Now, machine sets do not create `AvailabilitySets` objects for Spot instances that operate in non-zonal configured regions. (link:https://issues.redhat.com/browse/OCPBUGS-29152[*OCPBUGS-29152*])
+
+[id="ocp-4-14-15-updating"]
+==== Updating
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+
 [id="ocp-4-14-14"]
 === RHSA-2024:0941 - {product-title} 4.14.14 bug fix and security update
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-9819](https://issues.redhat.com/browse/OSDOCS-9819)

Link to docs preview:
[OpenShift Container Platform 4.14.15 ](https://72503--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-15)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
