### PR TITLE
OCPBUGS-28912 Updating creating a Whereabouts reconciler daemon

### DIFF
--- a/modules/nw-multus-creating-whereabouts-reconciler-daemon-set.adoc
+++ b/modules/nw-multus-creating-whereabouts-reconciler-daemon-set.adoc
@@ -7,7 +7,7 @@
 [id="nw-multus-creating-whereabouts-reconciler-daemon-set_{context}"]
 = Creating a whereabouts-reconciler daemon set
 
-The Whereabouts reconciler is responsible for managing dynamic IP address assignments for the pods within a cluster using the Whereabouts IP Address Management (IPAM) solution. It ensures that each pod gets a unique IP address from the specified IP address range. It also handles IP address releases when pods are deleted or scaled down.
+The Whereabouts reconciler is responsible for managing dynamic IP address assignments for the pods within a cluster by using the Whereabouts IP Address Management (IPAM) solution. It ensures that each pod gets a unique IP address from the specified IP address range. It also handles IP address releases when pods are deleted or scaled down.
 
 [NOTE]
 ====
@@ -29,7 +29,7 @@ Use the following procedure to deploy the `whereabouts-reconciler` daemon set.
 $ oc edit network.operator.openshift.io cluster
 ----
 
-. Modify the `additionalNetworks` parameter in the CR to add the `whereabouts-shim` network attachment definition. For example:
+. Include the `additionalNetworks` section shown in this example YAML extract within the `spec` definition of the custom resource (CR):
 +
 [source,yaml]
 ----
@@ -37,6 +37,7 @@ apiVersion: operator.openshift.io/v1
 kind: Network
 metadata:
   name: cluster
+# ...
 spec:
   additionalNetworks:
   - name: whereabouts-shim
@@ -51,6 +52,7 @@ spec:
        }
       }
     type: Raw
+# ...
 ----
 
 . Save the file and exit the text editor.


### PR DESCRIPTION
[OCPBUGS-28912]: Updating the guidance for adding the additionalNetworks section.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12, 4.13, 4.14, 4.15 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-28912
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://72504--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html#nw-multus-creating-whereabouts-reconciler-daemon-set_configuring-additional-network
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
