### PR TITLE
OADP-3181: Update attributes for OADP 1.3.1

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -46,6 +46,7 @@ endif::openshift-origin[]
 :oadp-first: OpenShift API for Data Protection (OADP)
 :oadp-full: OpenShift API for Data Protection
 :oadp-short: OADP
+:oadp-version: 1.3.1
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
 :product-registry: OpenShift image registry
 :rh-storage-first: Red Hat OpenShift Data Foundation


### PR DESCRIPTION
### JIRA

* [OADP-3181](https://issues.redhat.com/browse/OADP-3181)

Moving attribute for OADP to 1.3.1

GA - 16th April

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

### Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

OCP 4.13 → branch/enterprise-4.13
OCP 4.14 → branch/enterprise-4.14
OCP 4.15 → branch/enterprise-4.15
OCP 4.16 → branch/enterprise-4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
