### PR TITLE
#CNV-15421 - assigning compute resources

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -4036,6 +4036,8 @@ Topics:
       File: virt-high-availability-for-vms
     - Name: Control plane tuning
       File: virt-vm-control-plane-tuning
+    - Name: Assigning compute resources
+      File: virt-assigning-compute-resources
   - Name: VM disks
     Dir: virtual_disks
     Topics:

--- a/modules/virt-setting-cpu-allocation-ratio.adoc
+++ b/modules/virt-setting-cpu-allocation-ratio.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/advanced_vm_management/virt-assigning-compute-resources.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-setting-cpu-allocation-ratio_{context}"]
+= Setting the CPU allocation ratio
+
+The CPU Allocation Ratio specifies the degree of overcommitment by mapping vCPUs to time slices of physical CPUs.
+
+For example, a mapping or ratio of 10:1 maps 10 virtual CPUs to 1 physical CPU by using time slices.
+
+To change the default number of vCPUs mapped to each physical CPU, set the `vmiCPUAllocationRatio` value in the `HyperConverged` CR. The pod CPU request is calculated by multiplying the number of vCPUs by the reciprocal of the CPU allocation ratio. For example, if `vmiCPUAllocationRatio` is set to 10, {VirtProductName} will request 10 times fewer CPUs on the pod for that VM.
+
+.Procedure
+
+Set the `vmiCPUAllocationRatio` value in the `HyperConverged` CR to define a node CPU allocation ratio.
+
+. Open the `HyperConverged` CR in your default editor by running the following command:
++
+[source,terminal]
+----
+$ oc edit hyperconverged kubevirt-hyperconverged -n openshift-cnv
+----
+
+. Set the `vmiCPUAllocationRatio`:
+
++
+[source,yaml]
+----
+...
+spec:
+  resourceRequirements:
+    vmiCPUAllocationRatio: 1 <1>
+# ...
+----
+<1> When `vmiCPUAllocationRatio` is set to `1`, the maximum amount of vCPUs are requested for the pod.

--- a/virt/virtual_machines/advanced_vm_management/virt-assigning-compute-resources.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-assigning-compute-resources.adoc
@@ -1,0 +1,30 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="virt-assigning-compute-resources"]
+= Assigning compute resources
+include::_attributes/common-attributes.adoc[]
+:context: virt-assigning-compute-resources
+
+toc::[]
+
+In {VirtProductName}, compute resources assigned to virtual machines (VMs) are backed by either guaranteed CPUs or time-sliced CPU shares.
+
+Guaranteed CPUs, also known as CPU reservation, dedicate CPU cores or threads to a specific workload, which makes them unavailable to any other workload. Assigning guaranteed CPUs to a VM ensures that the VM will have sole access to a reserved physical CPU. xref:../../../virt/virtual_machines/advanced_vm_management/virt-dedicated-resources-vm.adoc#virt-dedicated-resources-vm[Enable dedicated resources for VMs] to use a guaranteed CPU.
+
+Time-sliced CPUs dedicate a slice of time on a shared physical CPU to each workload. You can specify the size of the slice during VM creation, or when the VM is offline. By default, each vCPU receives 100 milliseconds, or 1/10 of a second, of physical CPU time.
+
+The type of CPU reservation depends on the instance type or VM configuration.
+
+[role="_overcommitting"]
+[id="overcommitting_{context}"]
+== Overcommitting CPU resources
+
+Time-slicing allows multiple virtual CPUs (vCPUs) to share a single physical CPU. This is known as _CPU overcommitment_. Guaranteed VMs can not be overcommitted.
+
+Configure CPU overcommitment to prioritize VM density over performance when assigning CPUs to VMs. With a higher CPU over-commitment of vCPUs, more VMs fit onto a given node.
+
+include::modules/virt-setting-cpu-allocation-ratio.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* link:https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/[Pod Quality of Service Classes]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-15421](https://issues.redhat.com//browse/CNV-15421)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://72544--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-assigning-compute-resources
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
