### PR TITLE
OCPBUGS-25374 AWS Load Balancer Operator release note should mention …

### DIFF
--- a/networking/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.adoc
+++ b/networking/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.adoc
@@ -13,6 +13,11 @@ These release notes track the development of the AWS Load Balancer Operator in {
 
 For an overview of the AWS Load Balancer Operator, see xref:../../networking/aws_load_balancer_operator/understanding-aws-load-balancer-operator.adoc#aws-load-balancer-operator[AWS Load Balancer Operator in {product-title}].
 
+[NOTE]
+====
+AWS Load Balancer Operator currently does not support AWS GovCloud.
+====
+
 [id="aws-load-balancer-operator-release-notes-1.1.1"]
 == AWS Load Balancer Operator 1.1.1
 


### PR DESCRIPTION
…it doesn't support AWS GovCloud

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-25374
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://72546--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/aws_load_balancer_operator/aws-load-balancer-operator-release-notes 
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
