### PR TITLE
OCPBUGS#20304: Remove `alpha` flag from `opm` script

### DIFF
--- a/modules/olm-fb-catalogs-example.adoc
+++ b/modules/olm-fb-catalogs-example.adoc
@@ -37,7 +37,7 @@ for l in $(yq e '.name as $catalog | .references[] | .image + "|" + $catalog + "
   file=$(echo $l | cut -d'|' -f2)
   opm render "$image" > "$file"
 done
-opm alpha generate dockerfile "$name"
+opm generate dockerfile "$name"
 indexImage=$(yq eval '.repo + ":" + .tag' catalog.yaml)
 docker build -t "$indexImage" -f "$name.Dockerfile" .
 docker push "$indexImage"


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUGS- 20304](https://issues.redhat.com/browse/OCPBUGS-20304)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Understanding Operators > Packaging format > Example catalog (Step 2)](https://72547--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/understanding/olm-packaging-format#olm-fb-catalogs-example_olm-packaging-format)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
