### PR TITLE
OSDOCS-9853 Adding signBlob permission to GCP install doc

### DIFF
--- a/modules/minimum-required-permissions-ipi-gcp.adoc
+++ b/modules/minimum-required-permissions-ipi-gcp.adoc
@@ -126,6 +126,7 @@ If your organization’s security policies require a more restrictive set of per
 * `storage.objects.delete`
 * `storage.objects.get`
 * `storage.objects.list`
+* `iam.serviceAccounts.signBlob`
 ====
 
 .Required permissions for creating health check resources


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-9853

Link to docs preview:
https://72549--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account#minimum-required-permissions-ipi-gcp_installing-gcp-account
(under "creating storage resources")

QE review:
- [ ] QE has approved this change.
