### PR TITLE
OSDOCS-9820 z-stream RNs for OCP 4.13.36

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -3929,3 +3929,29 @@ $ oc adm release info 4.13.35 --pullspecs
 [id="ocp-4-13-35-updating"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-13-36"]
+=== RHSA-2024:1037 - {product-title} 4.13.36 bug fix and security update
+
+Issued: 2024-03-06
+
+{product-title} release 4.13.36, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:1037[RHSA-2024:1037] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:1039[RHBA-2024:1039] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.36 --pullspecs
+----
+
+[id="ocp-4-13-36-bug-fixes"]
+==== Bug fixes
+
+* Previously, a race condition between `udev` events and the creation queues associated with physical device led to some of the queues being configured with the wrong Receive Packet Steering (RPS) mask while they should be reset to zero. This resulted in the RPS mask being configured on the queues of the physical devices, meaning they were using RPS instead of Receive Side Scaling (RSS) which could impact the performance. With this fix, the event was changed to be triggered per queue creation instead of on device creation. This guarantees that no queue will be missing. The queues of all physical devices are now set up with the correct RPS mask which is empty.
+(link:https://issues.redhat.com/browse/OCPBUGS-24353[*OCPBUGS-24353*])
+
+[id="ocp-4-13-36-updating"]
+==== Updating
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-9820](https://issues.redhat.com/browse/OSDOCS-9820)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Preview](https://72573--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes#ocp-4-13-36)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
Not needed
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Errata links will not work until merge date, March 6. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
