### PR TITLE
Fixes small typo in Image Registry documentation

### DIFF
--- a/modules/pruning-images.adoc
+++ b/modules/pruning-images.adoc
@@ -80,5 +80,5 @@ The Image Registry Operator's behavior for managing the pruner is orthogonal to 
 However, the `managementState` of the Image Registry Operator alters the behavior of the deployed image pruner job:
 
 * `Managed`: the `--prune-registry` flag for the image pruner is set to `true`.
-* `Removed`: the `--prune-registry` flag for the image pruner is set to `false`, meaning it only prunes image metatdata in etcd.
+* `Removed`: the `--prune-registry` flag for the image pruner is set to `false`, meaning it only prunes image metadata in etcd.
 ====

--- a/registry/configuring-registry-operator.adoc
+++ b/registry/configuring-registry-operator.adoc
@@ -39,7 +39,7 @@ The Image Registry Operator's behavior for managing the pruner is orthogonal to 
 However, the `managementState` of the Image Registry Operator alters the behavior of the deployed image pruner job:
 
 * `Managed`: the `--prune-registry` flag for the image pruner is set to `true`.
-* `Removed`: the `--prune-registry` flag for the image pruner is set to `false`, meaning it only prunes image metatdata in etcd.
+* `Removed`: the `--prune-registry` flag for the image pruner is set to `false`, meaning it only prunes image metadata in etcd.
 ====
 endif::openshift-dedicated,openshift-rosa[]
 


### PR DESCRIPTION
Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OCPBUGS-30168

Link to docs preview:
https://72580--ocpdocs-pr.netlify.app/openshift-enterprise/latest/registry/configuring-registry-operator

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
