### PR TITLE
fix docs for VM live migration network

### DIFF
--- a/modules/virt-configuring-secondary-network-vm-live-migration.adoc
+++ b/modules/virt-configuring-secondary-network-vm-live-migration.adoc
@@ -33,18 +33,19 @@ spec:
     "cniVersion": "0.3.1",
     "name": "migration-bridge",
     "type": "macvlan",
-    "master": "eth1", <2>
+    "master": "eth1", <3>
     "mode": "bridge",
     "ipam": {
-      "type": "whereabouts", <3>
-      "range": "10.200.5.0/24" <4>
+      "type": "whereabouts", <4>
+      "range": "10.200.5.0/24" <5>
     }
   }'
 ----
 <1> Specify the name of the `NetworkAttachmentDefinition` object.
-<2> Specify the name of the NIC to be used for live migration.
-<3> Specify the name of the CNI plugin that provides the network for the NAD.
-<4> Specify an IP address range for the secondary network. This range must not overlap the IP addresses of the main network.
+<2> The `NetworkAttachmentDefinition` object must be created in the {CNVNamespace} namespace.
+<3> Specify the name of the NIC to be used for live migrations.
+<4> Specify the name of the CNI plugin that provides the network for the `NetworkAttachmentDefinition`.
+<5> Specify an IP address range for the secondary network. This range must not overlap the IP addresses of the main network.
 
 . Open the `HyperConverged` CR in your default editor by running the following command:
 +


### PR DESCRIPTION
Avoid using the number-2 callout/identifier multiple times. Instruct users to create the net-attach-def in a particular namespace. Avoid using NAD abbreviation when the short form of NetworkAttachmentDefinition is net-attach-def

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
Applies to all versions of OpenShift documentation

Issue:
No issue exists. Do I need to create a Jira / Bugzilla for a minor change like this?

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
