### PR TITLE
OBSDOCS-365: menu is different with UI for 4.11 and above version docs

### DIFF
--- a/modules/monitoring-accessing-the-alerting-ui.adoc
+++ b/modules/monitoring-accessing-the-alerting-ui.adoc
@@ -7,15 +7,15 @@
 [id="monitoring-accessing-the-alerting-ui_{context}"]
 = Accessing the Alerting UI in the Administrator and Developer perspectives
 
-The Alerting UI is accessible through the Administrator perspective and the Developer perspective in the {product-title} web console.
+The Alerting UI is accessible through the *Administrator* perspective and the *Developer* perspective of the {product-title} web console.
 
-* In the *Administrator* perspective, select *Observe* -> *Alerting*. The three main pages in the Alerting UI in this perspective are the *Alerts*, *Silences*, and *Alerting Rules* pages.
+* In the *Administrator* perspective, go to *Observe* -> *Alerting*. The three main pages in the Alerting UI in this perspective are the *Alerts*, *Silences*, and *Alerting rules* pages.
 
 //Next to the title of each of these pages is a link to the Alertmanager interface.
 
-* In the *Developer* perspective, select *Observe* -> *<project_name>* -> *Alerts*. In this perspective, alerts, silences, and alerting rules are all managed from the *Alerts* page. The results shown in the *Alerts* page are specific to the selected project.
+* In the *Developer* perspective, go to *Observe* -> *<project_name>* -> *Alerts*. In this perspective, alerts, silences, and alerting rules are all managed from the *Alerts* page. The results shown in the *Alerts* page are specific to the selected project.
 
 [NOTE]
 ====
-In the *Developer* perspective, you can select from core {product-title} and user-defined projects that you have access to in the *Project:* list. However, alerts, silences, and alerting rules relating to core {product-title} projects are not displayed if you are not logged in as a cluster administrator.
+In the *Developer* perspective, you can select from core {product-title} and user-defined projects that you have access to in the *Project: <project_name>* list. However, alerts, silences, and alerting rules relating to core {product-title} projects are not displayed if you are not logged in as a cluster administrator.
 ====

--- a/modules/monitoring-applying-custom-alertmanager-configuration.adoc
+++ b/modules/monitoring-applying-custom-alertmanager-configuration.adoc
@@ -111,8 +111,8 @@ $ oc -n openshift-monitoring create secret generic alertmanager-main --from-file
 
 To change the Alertmanager configuration from the {product-title} web console:
 
-. Navigate to the *Administration* -> *Cluster Settings* -> *Configuration* -> *Alertmanager* -> *YAML* page of the web console.
+. Go to the *Administration* -> *Cluster Settings* -> *Configuration* -> *Alertmanager* -> *YAML* page of the web console.
 
 . Modify the YAML configuration file.
 
-. Select *Save*.
+. Click *Save*.

--- a/modules/monitoring-configuring-alert-receivers.adoc
+++ b/modules/monitoring-configuring-alert-receivers.adoc
@@ -15,16 +15,16 @@ You can configure alert receivers to ensure that you learn about important issue
 
 .Procedure
 
-. In the *Administrator* perspective, navigate to *Administration* -> *Cluster Settings* -> *Configuration* -> *Alertmanager*.
+. In the *Administrator* perspective, go to *Administration* -> *Cluster Settings* -> *Configuration* -> *Alertmanager*.
 +
 [NOTE]
 ====
-Alternatively, you can navigate to the same page through the notification drawer. Select the bell icon at the top right of the {product-title} web console and choose *Configure* in the *AlertmanagerReceiverNotConfigured* alert.
+Alternatively, you can go to the same page through the notification drawer. Select the bell icon at the top right of the {product-title} web console and choose *Configure* in the *AlertmanagerReceiverNotConfigured* alert.
 ====
 
-. Select *Create Receiver* in the *Receivers* section of the page.
+. Click *Create Receiver* in the *Receivers* section of the page.
 
-. In the *Create Receiver* form, add a *Receiver Name* and choose a *Receiver Type* from the list.
+. In the *Create Receiver* form, add a *Receiver name* and choose a *Receiver type* from the list.
 
 . Edit the receiver configuration:
 +
@@ -34,13 +34,13 @@ Alternatively, you can navigate to the same page through the notification drawer
 +
 .. Add the URL of your PagerDuty installation.
 +
-.. Select *Show advanced configuration* if you want to edit the client and incident details or the severity specification.
+.. Click *Show advanced configuration* if you want to edit the client and incident details or the severity specification.
 +
 * For webhook receivers:
 +
 .. Add the endpoint to send HTTP POST requests to.
 +
-.. Select *Show advanced configuration* if you want to edit the default option to send resolved alerts to the receiver.
+.. Click *Show advanced configuration* if you want to edit the default option to send resolved alerts to the receiver.
 +
 * For email receivers:
 +
@@ -48,9 +48,9 @@ Alternatively, you can navigate to the same page through the notification drawer
 +
 .. Add SMTP configuration details, including the address to send notifications from, the smarthost and port number used for sending emails, the hostname of the SMTP server, and authentication details.
 +
-.. Choose whether TLS is required.
+.. Select whether TLS is required.
 +
-.. Select *Show advanced configuration* if you want to edit the default option not to send resolved alerts to the receiver or edit the body of email notifications configuration.
+.. Click *Show advanced configuration* if you want to edit the default option not to send resolved alerts to the receiver or edit the body of email notifications configuration.
 +
 * For Slack receivers:
 +
@@ -60,11 +60,9 @@ Alternatively, you can navigate to the same page through the notification drawer
 +
 .. Select *Show advanced configuration* if you want to edit the default option not to send resolved alerts to the receiver or edit the icon and username configuration. You can also choose whether to find and link channel names and usernames.
 
-. By default, firing alerts with labels that match all of the selectors will be sent to the receiver. If you want label values for firing alerts to be matched exactly before they are sent to the receiver:
-.. Add routing label names and values in the *Routing Labels* section of the form.
-+
-.. Select *Regular Expression* if want to use a regular expression.
-+
-.. Select *Add Label* to add further routing labels.
+. By default, firing alerts with labels that match all of the selectors are sent to the receiver. If you want label values for firing alerts to be matched exactly before they are sent to the receiver, perform the following steps:
+.. Add routing label names and values in the *Routing labels* section of the form.
 
-. Select *Create* to create the receiver.
+.. Click *Add label* to add further routing labels.
+
+. Click *Create* to create the receiver.

--- a/modules/monitoring-getting-information-about-alerts-silences-and-alerting-rules.adoc
+++ b/modules/monitoring-getting-information-about-alerts-silences-and-alerting-rules.adoc
@@ -10,87 +10,79 @@ The Alerting UI provides detailed information about alerts and their governing a
 
 .Prerequisites
 
-* You have access to the cluster as a developer or as a user with view permissions for the project that you are viewing metrics for.
+* You have access to the cluster as a developer or as a user with view permissions for the project that you are viewing alerts for.
 
 .Procedure
 
 *To obtain information about alerts in the Administrator perspective*:
 
-. Open the {product-title} web console and navigate to the *Observe* -> *Alerting* -> *Alerts* page.
+. Open the {product-title} web console and go to the *Observe* -> *Alerting* -> *Alerts* page.
 
-. Optional: Search for alerts by name using the *Name* field in the search list.
+. Optional: Search for alerts by name by using the *Name* field in the search list.
 
 . Optional: Filter alerts by state, severity, and source by selecting filters in the *Filter* list.
 
 . Optional: Sort the alerts by clicking one or more of the *Name*, *Severity*, *State*, and *Source* column headers.
 
-. Select the name of an alert to navigate to its *Alert Details* page. The page includes a graph that illustrates alert time series data. It also provides information about the alert, including:
-+
---
-** A description of the alert
-** Messages associated with the alerts
-** Labels attached to the alert
-** A link to its governing alerting rule
-** Silences for the alert, if any exist
---
+. Click the name of an alert to view its *Alert details* page. The page includes a graph that illustrates alert time series data. It also provides the following information about the alert:
+
+* A description of the alert
+* Messages associated with the alert
+* Labels attached to the alert
+* A link to its governing alerting rule
+* Silences for the alert, if any exist
 
 *To obtain information about silences in the Administrator perspective*:
 
-. Navigate to the *Observe* -> *Alerting* -> *Silences* page.
+. Go to the *Observe* -> *Alerting* -> *Silences* page.
 
 . Optional: Filter the silences by name using the *Search by name* field.
 
 . Optional: Filter silences by state by selecting filters in the *Filter* list. By default, *Active* and *Pending* filters are applied.
 
-. Optional: Sort the silences by clicking one or more of the *Name*, *Firing Alerts*, and *State* column headers.
+. Optional: Sort the silences by clicking one or more of the *Name*, *Firing alerts*, *State*, and *Creator* column headers.
 
-. Select the name of a silence to navigate to its *Silence Details* page. The page includes the following details:
-+
---
+. Select the name of a silence to view its *Silence details* page. The page includes the following details:
+
 * Alert specification
 * Start time
 * End time
 * Silence state
 * Number and list of firing alerts
---
 
 *To obtain information about alerting rules in the Administrator perspective*:
 
-. Navigate to the *Observe* -> *Alerting* -> *Alerting Rules* page.
+. Go to the *Observe* -> *Alerting* -> *Alerting rules* page.
 
 . Optional: Filter alerting rules by state, severity, and source by selecting filters in the *Filter* list.
 
-. Optional: Sort the alerting rules by clicking one or more of the *Name*, *Severity*, *Alert State*, and *Source* column headers.
+. Optional: Sort the alerting rules by clicking one or more of the *Name*, *Severity*, *Alert state*, and *Source* column headers.
 
-. Select the name of an alerting rule to navigate to its *Alerting Rule Details* page. The page provides the following details about the alerting rule:
-+
---
-** Alerting rule name, severity, and description
-** The expression that defines the condition for firing the alert
-** The time for which the condition should be true for an alert to fire
-** A graph for each alert governed by the alerting rule, showing the value with which the alert is firing
-** A table of all alerts governed by the alerting rule
---
+. Select the name of an alerting rule to view its *Alerting rule details* page. The page provides the following details about the alerting rule:
+
+* Alerting rule name, severity, and description.
+* The expression that defines the condition for firing the alert.
+* The time for which the condition should be true for an alert to fire.
+* A graph for each alert governed by the alerting rule, showing the value with which the alert is firing.
+* A table of all alerts governed by the alerting rule.
 
 *To obtain information about alerts, silences, and alerting rules in the Developer perspective*:
 
-. Navigate to the *Observe* -> *<project_name>* -> *Alerts* page.
+. Go to the *Observe* -> *<project_name>* -> *Alerts* page.
 
 . View details for an alert, silence, or an alerting rule:
 
-* *Alert Details* can be viewed by selecting *>* to the left of an alert name and then selecting the alert in the list.
+* *Alert details* can be viewed by clicking a greater than symbol (*>*) next to an alert name and then selecting the alert from the list.
 
-* *Silence Details* can be viewed by selecting a silence in the *Silenced By* section of the *Alert Details* page. The *Silence Details* page includes the following information:
-+
---
-* Alert specification
-* Start time
-* End time
-* Silence state
-* Number and list of firing alerts
---
+* *Silence details* can be viewed by clicking a silence in the *Silenced by* section of the *Alert details* page. The *Silence details* page includes the following information:
 
-* *Alerting Rule Details* can be viewed by selecting *View Alerting Rule* in the {kebab} menu on the right of an alert in the *Alerts* page.
+** Alert specification
+** Start time
+** End time
+** Silence state
+** Number and list of firing alerts
+
+* *Alerting rule details* can be viewed by clicking the {kebab} menu next to an alert in the *Alerts* page and then clicking *View Alerting Rule*.
 
 [NOTE]
 ====

--- a/modules/monitoring-searching-alerts-silences-and-alerting-rules.adoc
+++ b/modules/monitoring-searching-alerts-silences-and-alerting-rules.adoc
@@ -15,10 +15,10 @@ In the *Administrator* perspective, the *Alerts* page in the Alerting UI provide
 
 You can filter by alert state, severity, and source. By default, only *Platform* alerts that are *Firing* are displayed. The following describes each alert filtering option:
 
-* *Alert State* filters:
-** *Firing*. The alert is firing because the alert condition is true and the optional `for` duration has passed. The alert will continue to fire as long as the condition remains true.
+* *State* filters:
+** *Firing*. The alert is firing because the alert condition is true and the optional `for` duration has passed. The alert continues to fire while the condition remains true.
 ** *Pending*. The alert is active but is waiting for the duration that is specified in the alerting rule before it fires.
-** *Silenced*. The alert is now silenced for a defined time period. Silences temporarily mute alerts based on a set of label selectors that you define. Notifications will not be sent for alerts that match all the listed values or regular expressions.
+** *Silenced*. The alert is now silenced for a defined time period. Silences temporarily mute alerts based on a set of label selectors that you define. Notifications are not sent for alerts that match all the listed values or regular expressions.
 
 * *Severity* filters:
 ** *Critical*. The condition that triggered the alert could have a critical impact. The alert requires immediate attention when fired and is typically paged to an individual or to a critical response team.
@@ -38,7 +38,7 @@ In the *Administrator* perspective, the *Silences* page in the Alerting UI provi
 
 You can filter by silence state. By default, only *Active* and *Pending* silences are displayed. The following describes each silence state filter option:
 
-* *Silence State* filters:
+* *State* filters:
 ** *Active*. The silence is active and the alert will be muted until the silence is expired.
 ** *Pending*. The silence has been scheduled and it is not yet active.
 ** *Expired*. The silence has expired and notifications will be sent if the conditions for an alert are true.
@@ -46,14 +46,14 @@ You can filter by silence state. By default, only *Active* and *Pending* silence
 [discrete]
 == Understanding alerting rule filters
 
-In the *Administrator* perspective, the *Alerting Rules* page in the Alerting UI provides details about alerting rules relating to default {product-title} and user-defined projects. The page includes a summary of the state, severity, and source for each alerting rule.
+In the *Administrator* perspective, the *Alerting rules* page in the Alerting UI provides details about alerting rules relating to default {product-title} and user-defined projects. The page includes a summary of the state, severity, and source for each alerting rule.
 
 You can filter alerting rules by alert state, severity, and source. By default, only *Platform* alerting rules are displayed. The following describes each alerting rule filtering option:
 
-* *Alert State* filters:
-** *Firing*. The alert is firing because the alert condition is true and the optional `for` duration has passed. The alert will continue to fire as long as the condition remains true.
+* *Alert state* filters:
+** *Firing*. The alert is firing because the alert condition is true and the optional `for` duration has passed. The alert continues to fire while the condition remains true.
 ** *Pending*. The alert is active but is waiting for the duration that is specified in the alerting rule before it fires.
-** *Silenced*. The alert is now silenced for a defined time period. Silences temporarily mute alerts based on a set of label selectors that you define. Notifications will not be sent for alerts that match all the listed values or regular expressions.
+** *Silenced*. The alert is now silenced for a defined time period. Silences temporarily mute alerts based on a set of label selectors that you define. Notifications are not sent for alerts that match all the listed values or regular expressions.
 ** *Not Firing*. The alert is not firing.
 
 * *Severity* filters:
@@ -70,6 +70,6 @@ You can filter alerting rules by alert state, severity, and source. By default, 
 [discrete]
 == Searching and filtering alerts, silences, and alerting rules in the Developer perspective
 
-In the *Developer* perspective, the Alerts page in the Alerting UI provides a combined view of alerts and silences relating to the selected project. A link to the governing alerting rule is provided for each displayed alert.
+In the *Developer* perspective, the *Alerts* page in the Alerting UI provides a combined view of alerts and silences relating to the selected project. A link to the governing alerting rule is provided for each displayed alert.
 
 In this view, you can filter by alert state and severity. By default, all alerts in the selected project are displayed if you have permission to access the project. These filters are the same as those described for the *Administrator* perspective.

--- a/modules/monitoring-silencing-alerts.adoc
+++ b/modules/monitoring-silencing-alerts.adoc
@@ -42,7 +42,7 @@ To silence a specific alert in the *Developer* perspective:
 
 . Go to *Observe* -> *<project_name>* -> *Alerts* in the {product-title} web console.
 
-. If necessary, expand the details for the alert by selecting *>* next to the alert name.
+. If necessary, expand the details for the alert by selecting a greater than symbol (*>*) next to the alert name.
 
 . Click the alert message in the expanded view to open the *Alert details* page for the alert.
 


### PR DESCRIPTION
Version(s):  **PLEASE NOTE**: this issue needs to be manually cherry-picked to 4.12 and 4.13. For `enterprise-4.14` and later, the issue can be cherry-picked automatically. For more information, see [this comment](https://github.com/openshift/openshift-docs/pull/72590#discussion_r1512700154)

Issue: [OBSDOCS-365](https://issues.redhat.com/browse/OBSDOCS-365)

Link to docs preview: [Managing alerts](https://72590--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/managing-alerts)

QE review:
- [x] QE has approved this change.

Peer review:
- [x] Peer review done

Additional information: