### PR TITLE
[SRVKS-1025] Add docs on specifying cipher suites

### DIFF
--- a/knative-serving/config-custom-domains/domain-mapping-odc-admin.adoc
+++ b/knative-serving/config-custom-domains/domain-mapping-odc-admin.adoc
@@ -8,3 +8,4 @@ If you do not want to switch to the *Developer* perspective in the {ocp-product-
 
 // domain mapping as an admin
 include::modules/serverless-domain-mapping-odc-admin.adoc[leveloffset=+1]
+include::modules/serverless-restricting-cipher-suits-odc-admin.adoc[leveloffset=+1]

--- a/modules/serverless-restricting-cipher-suits-odc-admin.adoc
+++ b/modules/serverless-restricting-cipher-suits-odc-admin.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * serverless/knative_serving/serverless-custom-domains.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-restricting-cipher-suits-odc-admin_{context}"]
+= Restricting cipher suits by using the Administrator perspective
+
+When you specify `net-kourier` for Ingress and use `DomainMapping`, the TLS for OpenShift Routing is set to passthrough, and TLS is handled by the Kourier Gateway. In such cases, you might need to restrict which TLS cipher suites for Kourier are allowed for users.
+
+.Prerequisites
+
+* You have logged in to the web console.
+* You are in the *Administrator* perspective.
+* You have installed the {ServerlessOperatorName}.
+* You have installed Knative Serving.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads.
++
+[NOTE]
+====
+Your custom domain must point to the IP address of the cluster.
+====
+
+.Procedure
+
+* In the `KnativeServing` CR, use the `cipher-suites` value to specify the cipher suites you want to enable:
++
+[source,yaml]
+----
+KnativeServing CR example
+spec:
+  config:
+    kourier:
+      cipher-suites: ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-ECDSA-CHACHA20-POLY1305
+----
++
+Other cipher suites will be disabled. You can specify multiple suites by separating them with commas.
++
+[NOTE]
+====
+The Kourier Gateway's container image utilizes the ServiceMesh proxy image, and the default enabled cipher suites depend on the version of the ServiceMesh proxy.
+====


### PR DESCRIPTION
Version(s):
`serverless-docs-1.32`+

Issue:
https://issues.redhat.com/browse/SRVKS-1025

Link to docs preview:
https://72597--docspreview.netlify.app/openshift-serverless/latest/knative-serving/config-custom-domains/domain-mapping-odc-admin#serverless-restricting-cipher-suits-odc-admin_domain-mapping-odc-admin

QE review:
- [ ] QE has approved this change.