### PR TITLE
[SRVKE-1479] Add docs on Kafka broker's templates config

### DIFF
--- a/modules/serverless-kafka-broker-configmap.adoc
+++ b/modules/serverless-kafka-broker-configmap.adoc
@@ -30,12 +30,18 @@ data:
   default.topic.partitions: <integer> <3>
   default.topic.replication.factor: <integer> <4>
   bootstrap.servers: <list_of_servers> <5>
+  triggers.consumergroup.template: <template> <6>
+  brokers.topic.template: <template> <7>
+  channels.topic.template: <template> <8>
 ----
 <1> The config map name.
 <2> The namespace where the config map exists.
 <3> The number of topic partitions for the Kafka broker. This controls how quickly events can be sent to the broker. A higher number of partitions requires greater compute resources.
 <4> The replication factor of topic messages. This prevents against data loss. A higher replication factor requires greater compute resources and more storage.
 <5> A comma separated list of bootstrap servers. This can be inside or outside of the {ocp-product-title} cluster, and is a list of Kafka clusters that the broker receives events from and sends events to.
+<6> The template for generating the consumer group ID used by your triggers. Use a valid Go `text/template` value. Defaults to `{% raw %}"knative-trigger-{{ .Namespace }}-{{ .Name }}"{% endraw %}`.
+<7> The template for generating Kafka topic names used by your brokers. Use a valid Go `text/template` value. Defaults to `{% raw %}"knative-broker-{{ .Namespace }}-{{ .Name }}"{% endraw %}`.
+<8> The template for generating Kafka topic names used by your channels. Use a valid Go `text/template` value. Defaults to `{% raw %}"messaging-kafka.{{ .Namespace }}.{{ .Name }}"{% endraw %}`.
 +
 [IMPORTANT]
 ====
@@ -54,6 +60,9 @@ data:
   default.topic.partitions: "10"
   default.topic.replication.factor: "3"
   bootstrap.servers: "my-cluster-kafka-bootstrap.kafka:9092"
+  triggers.consumergroup.template: "{% raw %}"knative-trigger-{{ .Namespace }}-{{ .Name }}-{{ .MyCustomValue}}"{% endraw %}"
+  brokers.topic.template: "{% raw %}"knative-broker-{{ .Namespace }}-{{ .Name }}-{{ .MyCustomValue}}"{% endraw %}"
+  channels.topic.template: "{% raw %}"messaging-kafka.{{ .Namespace }}.{{ .Name }}-{{ .MyCustomValue}}"{% endraw %}"
 ----
 
 . Apply the config map:


### PR DESCRIPTION
Version(s):
`serverless-docs-1.32`+

Issue:
https://issues.redhat.com/browse/SRVKE-1479

Link to docs preview:
https://72598--docspreview.netlify.app/openshift-serverless/latest/eventing/brokers/kafka-broker#serverless-kafka-broker-configmap_kafka-broker

QE review:
- [ ] QE has approved this change.