### PR TITLE
OCPBUGS-30254: Updated the vSphere version for 4.14 onwards

### DIFF
--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -6,12 +6,12 @@
 [id="installation-vsphere-infrastructure_{context}"]
 = VMware vSphere infrastructure requirements
 
-You must install the {product-title} cluster on a VMware vSphere version 7.0 Update 2 or later instance that meets the requirements for the components that you use.
+You must install an {product-title} cluster on one of the following versions of a VMware vSphere instance that meets the requirements for the components that you use:
 
-[NOTE]
-====
-{product-title} version {product-version} supports VMware vSphere version 8.0.
-====
+* Version 7.0 Update 3 or later
+* Version 8.0 Update 2 or later
+
+Both of these releases support Container Storage Interface (CSI) migration, which is enabled by default on {product-title} {product-version}.
 
 You can host the VMware vSphere infrastructure on-premise or on a link:https://cloud.vmware.com/providers[VMware Cloud Verified provider] that meets the requirements outlined in the following tables:
 
@@ -20,8 +20,8 @@ You can host the VMware vSphere infrastructure on-premise or on a link:https://c
 |===
 |Virtual environment product |Required version
 |VMware virtual hardware | 15 or later
-|vSphere ESXi hosts | 7.0 Update 2 or later
-|vCenter host   | 7.0 Update 2 or later
+|vSphere ESXi hosts | 7.0 Update 3 or later; 8.0 Update 2 or later
+|vCenter host | 7.0 Update 3 or later; 8.0 Update 2 or later
 |===
 
 [IMPORTANT]
@@ -34,12 +34,12 @@ You must ensure that the time on your ESXi hosts is synchronized before you inst
 |Component | Minimum supported versions |Description
 
 |Hypervisor
-|vSphere 7.0 Update 2 and later with virtual hardware version 15
-|This version is the minimum version that {op-system-first} supports. For more information about supported hardware on the latest version of {op-system-base-full} that is compatible with {op-system}, see link:https://catalog.redhat.com/hardware/search[Hardware] on the Red Hat Customer Portal.
+|vSphere 7.0 Update 3 (or later) or vSphere 8.0 Update 2 (or later) with virtual hardware version 15
+|This hypervisor version is the minimum version that {op-system-first} supports. For more information about supported hardware on the latest version of {op-system-base-full} that is compatible with {op-system}, see link:https://catalog.redhat.com/hardware/search[Hardware] on the Red Hat Customer Portal.
 
 |Optional: Networking (NSX-T)
-|vSphere 7.0 Update 2 and later
-|vSphere 7.0 Update 2 is required for {product-title}. For more information about the compatibility of NSX and {product-title}, see the Release Notes section of VMware's link:https://docs.vmware.com/en/VMware-NSX-Container-Plugin/index.html[NSX container plugin documentation].
+|vSphere 7.0 Update 3 or later; vSphere 8.0 Update 2 or later
+|At a minimum, vSphere 7.0 Update 3 or vSphere 8.0 Update 2 is required for {product-title}. For more information about the compatibility of NSX and {product-title}, see the Release Notes section of VMware's link:https://docs.vmware.com/en/VMware-NSX-Container-Plugin/index.html[NSX container plugin documentation].
 |===
 
 [IMPORTANT]


### PR DESCRIPTION
Version(s):
4.14 +

Issue:
[OCPBUGS-30254](https://issues.redhat.com/browse/OCPBUGS-30254)

Link to docs preview:
[VMware vSphere infrastructure requirements](https://72608--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs#installation-vsphere-infrastructure_ipi-vsphere-installation-reqs)

- [x] SME has approved this change.
- [x] QE has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
