### PR TITLE
OCPBUGS-7964: Clean up infra YAML discrepancies

### DIFF
--- a/machine_management/creating-infrastructure-machinesets.adoc
+++ b/machine_management/creating-infrastructure-machinesets.adoc
@@ -50,23 +50,27 @@ Machine sets running on Azure support non-guaranteed xref:../machine_management/
 
 include::modules/machineset-yaml-azure-stack-hub.adoc[leveloffset=+3]
 
-[NOTE]
+[IMPORTANT]
 ====
 Machine sets running on Azure Stack Hub do not support non-guaranteed Spot VMs.
 ====
-
-include::modules/machineset-yaml-ibm-cloud.adoc[leveloffset=+3]
 
 include::modules/machineset-yaml-gcp.adoc[leveloffset=+3]
 
 Machine sets running on GCP support non-guaranteed xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-non-guaranteed-instance_creating-machineset-gcp[preemptible VM instances]. You can save on costs by using preemptible VM instances at a lower price
 compared to normal instances on GCP. You can xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-creating-non-guaranteed-instance_creating-machineset-gcp[configure preemptible VM instances] by adding `preemptible` to the `MachineSet` YAML file.
 
+include::modules/machineset-yaml-ibm-cloud.adoc[leveloffset=+3]
+
+include::modules/machineset-yaml-ibm-power-vs.adoc[leveloffset=+3]
+
 include::modules/machineset-yaml-nutanix.adoc[leveloffset=+3]
 
 include::modules/machineset-yaml-osp.adoc[leveloffset=+3]
 
 include::modules/machineset-yaml-vsphere.adoc[leveloffset=+3]
+
+include::modules/machineset-yaml-baremetal.adoc[leveloffset=+3]
 
 include::modules/machineset-creating.adoc[leveloffset=+2]
 
@@ -75,7 +79,7 @@ include::modules/creating-an-infra-node.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:moving-resources-to-infrastructure-machinesets[Moving resources to infrastructure machine sets]
+* xref:../machine_management/creating-infrastructure-machinesets.adoc#moving-resources-to-infrastructure-machinesets_creating-infrastructure-machinesets[Moving resources to infrastructure machine sets]
 
 include::modules/creating-infra-machines.adoc[leveloffset=+2]
 
@@ -96,32 +100,11 @@ include::modules/binding-infra-node-workloads-using-taints-tolerations.adoc[leve
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../nodes/scheduling/nodes-scheduler-about.adoc#nodes-scheduler-about[Controlling pod placement using the scheduler] for general information on scheduling a pod to a node.
-* See xref:moving-resources-to-infrastructure-machinesets[Moving resources to infrastructure machine sets] for instructions on scheduling pods to infra nodes.
+* xref:../nodes/scheduling/nodes-scheduler-about.adoc#nodes-scheduler-about[Controlling pod placement using the scheduler]
+* xref:../machine_management/creating-infrastructure-machinesets.adoc#moving-resources-to-infrastructure-machinesets_creating-infrastructure-machinesets[Moving resources to infrastructure machine sets]
 
-[id="moving-resources-to-infrastructure-machinesets"]
-== Moving resources to infrastructure machine sets
-
-Some of the infrastructure resources are deployed in your cluster by default. You can move them to the infrastructure machine sets that you created by adding the infrastructure node selector, as shown:
-
-[source,yaml]
-----
-spec:
-  nodePlacement: <1>
-    nodeSelector:
-      matchLabels:
-        node-role.kubernetes.io/infra: ""
-    tolerations:
-    - effect: NoSchedule
-      key: node-role.kubernetes.io/infra
-      value: reserved
-    - effect: NoExecute
-      key: node-role.kubernetes.io/infra
-      value: reserved
-----
-<1> Add a `nodeSelector` parameter with the appropriate value to the component you want to move. You can use a `nodeSelector` in the format shown or use `<key>: <value>` pairs, based on the value specified for the node.  If you added a taint to the infrasructure node, also add a matching toleration.
-
-Applying a specific node selector to all infrastructure components causes {product-title} to xref:../machine_management/creating-infrastructure-machinesets.adoc#moving-resources-to-infrastructure-machinesets[schedule those workloads on nodes with that label].
+//Moving resources to infrastructure machine sets
+include::modules/moving-resources-to-infrastructure-machinesets.adoc[leveloffset=+1]
 
 include::modules/infrastructure-moving-router.adoc[leveloffset=+2]
 

--- a/modules/infrastructure-moving-logging.adoc
+++ b/modules/infrastructure-moving-logging.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * machine_management/creating-infrastructure-machinesets.adoc
+// * post_installation_configuration/cluster-tasks.adoc
 // * logging/cluster-logging-moving.adoc
 
 :_mod-docs-content-type: PROCEDURE
@@ -34,15 +35,13 @@ spec:
   logStore:
     elasticsearch:
       nodeCount: 3
-      nodeSelector: <1>
+      nodeSelector: # <1>
         node-role.kubernetes.io/infra: ''
-      tolerations:
+      tolerations: # <2>
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
-        value: reserved
       - effect: NoExecute
         key: node-role.kubernetes.io/infra
-        value: reserved
       redundancyPolicy: SingleRedundancy
       resources:
         limits:
@@ -55,16 +54,14 @@ spec:
     type: elasticsearch
   managementState: Managed
   visualization:
-    kibana:
-      nodeSelector: <1>
+    kibana: # <3>
+      nodeSelector:
         node-role.kubernetes.io/infra: ''
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
-        value: reserved
       - effect: NoExecute
         key: node-role.kubernetes.io/infra
-        value: reserved
       proxy:
         resources: null
       replicas: 1
@@ -72,7 +69,9 @@ spec:
     type: kibana
 # ...
 ----
-<1> Add a `nodeSelector` parameter with the appropriate value to the component you want to move. You can use a `nodeSelector` in the format shown or use `<key>: <value>` pairs, based on the value specified for the node.  If you added a taint to the infrasructure node, also add a matching toleration.
+<1> Add a `nodeSelector` parameter with the appropriate value to the component you want to move. You can use a `nodeSelector` in the format shown or use `<key>: <value>` pairs, based on the value specified for the node.
+<2> If you added a taint to the infrastructure node, you must add a matching toleration.
+<3> Add the appropriate values to the `nodeSelector` and `tolerations` sections of `kibana` stanza as well.
 
 .Verification
 

--- a/modules/infrastructure-moving-monitoring.adoc
+++ b/modules/infrastructure-moving-monitoring.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * machine_management/creating-infrastructure-machinesets.adoc
+// * post_installation_configuration/cluster-tasks.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="infrastructure-moving-monitoring_{context}"]
@@ -28,97 +29,80 @@ metadata:
 data:
   config.yaml: |+
     alertmanagerMain:
-      nodeSelector: <1>
+      nodeSelector: # <1>
         node-role.kubernetes.io/infra: ""
-      tolerations:
+      tolerations: # <2>
       - key: node-role.kubernetes.io/infra
-        value: reserved
         effect: NoSchedule
       - key: node-role.kubernetes.io/infra
-        value: reserved
         effect: NoExecute
     prometheusK8s:
       nodeSelector:
         node-role.kubernetes.io/infra: ""
       tolerations:
       - key: node-role.kubernetes.io/infra
-        value: reserved
         effect: NoSchedule
       - key: node-role.kubernetes.io/infra
-        value: reserved
         effect: NoExecute
     prometheusOperator:
       nodeSelector:
         node-role.kubernetes.io/infra: ""
       tolerations:
       - key: node-role.kubernetes.io/infra
-        value: reserved
         effect: NoSchedule
       - key: node-role.kubernetes.io/infra
-        value: reserved
         effect: NoExecute
     k8sPrometheusAdapter:
       nodeSelector:
         node-role.kubernetes.io/infra: ""
       tolerations:
       - key: node-role.kubernetes.io/infra
-        value: reserved
         effect: NoSchedule
       - key: node-role.kubernetes.io/infra
-        value: reserved
         effect: NoExecute
     kubeStateMetrics:
       nodeSelector:
         node-role.kubernetes.io/infra: ""
       tolerations:
       - key: node-role.kubernetes.io/infra
-        value: reserved
         effect: NoSchedule
       - key: node-role.kubernetes.io/infra
-        value: reserved
         effect: NoExecute
     telemeterClient:
       nodeSelector:
         node-role.kubernetes.io/infra: ""
       tolerations:
       - key: node-role.kubernetes.io/infra
-        value: reserved
         effect: NoSchedule
       - key: node-role.kubernetes.io/infra
-        value: reserved
         effect: NoExecute
     openshiftStateMetrics:
       nodeSelector:
         node-role.kubernetes.io/infra: ""
       tolerations:
       - key: node-role.kubernetes.io/infra
-        value: reserved
         effect: NoSchedule
       - key: node-role.kubernetes.io/infra
-        value: reserved
         effect: NoExecute
     thanosQuerier:
       nodeSelector:
         node-role.kubernetes.io/infra: ""
       tolerations:
       - key: node-role.kubernetes.io/infra
-        value: reserved
         effect: NoSchedule
       - key: node-role.kubernetes.io/infra
-        value: reserved
         effect: NoExecute
     monitoringPlugin:
       nodeSelector:
         node-role.kubernetes.io/infra: ""
       tolerations:
       - key: node-role.kubernetes.io/infra
-        value: reserved
         effect: NoSchedule
       - key: node-role.kubernetes.io/infra
-        value: reserved
         effect: NoExecute
 ----
-<1> Add a `nodeSelector` parameter with the appropriate value to the component you want to move. You can use a `nodeSelector` in the format shown or use `<key>: <value>` pairs, based on the value specified for the node. If you added a taint to the infrastructure node, also add a matching toleration.
+<1> Add a `nodeSelector` parameter with the appropriate value to the components that you want to move. You can use a `nodeSelector` in the format shown or use `<key>: <value>` pairs, based on the value specified for the node.
+<2> If you added a taint to the infrastructure node, you must add a matching toleration.
 
 . Watch the monitoring pods move to the new machines:
 +

--- a/modules/infrastructure-moving-registry.adoc
+++ b/modules/infrastructure-moving-registry.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * machine_management/creating-infrastructure-machinesets.adoc
+// * post_installation_configuration/cluster-tasks.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="infrastructure-moving-registry_{context}"]
@@ -72,27 +73,26 @@ spec:
         weight: 100
   logLevel: Normal
   managementState: Managed
-  nodeSelector: <1>
+  nodeSelector: # <1>
     node-role.kubernetes.io/infra: ""
-  tolerations:
+  tolerations: # <2>
   - effect: NoSchedule
     key: node-role.kubernetes.io/infra
-    value: reserved
   - effect: NoExecute
     key: node-role.kubernetes.io/infra
-    value: reserved
 ----
-<1> Add a `nodeSelector` parameter with the appropriate value to the component you want to move. You can use a `nodeSelector` in the format shown or use `<key>: <value>` pairs, based on the value specified for the node.  If you added a taint to the infrasructure node, also add a matching toleration.
+<1> Add a `nodeSelector` parameter with the appropriate value to the component you want to move. You can use a `nodeSelector` in the format shown or use `<key>: <value>` pairs, based on the value specified for the node.
+<2> If you added a taint to the infrastructure node, you must add a matching toleration.
 
-. Verify the registry pod has been moved to the infrastructure node.
-+
+. Confirm that the registry pod is running on the infrastructure node:
+
 .. Run the following command to identify the node where the registry pod is located:
 +
 [source,terminal]
 ----
 $ oc get pods -o wide -n openshift-image-registry
 ----
-+
+
 .. Confirm the node has the label you specified:
 +
 [source,terminal]

--- a/modules/infrastructure-moving-router.adoc
+++ b/modules/infrastructure-moving-router.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * machine_management/creating-infrastructure-machinesets.adoc
+// * post_installation_configuration/cluster-tasks.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="infrastructure-moving-router_{context}"]
@@ -61,20 +62,20 @@ $ oc edit ingresscontroller default -n openshift-ingress-operator
 ----
   spec:
     nodePlacement:
-      nodeSelector: <1>
+      nodeSelector: # <1>
         matchLabels:
           node-role.kubernetes.io/infra: ""
-      tolerations:
+      tolerations: # <2>
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
-        value: reserved
       - effect: NoExecute
         key: node-role.kubernetes.io/infra
-        value: reserved
 ----
-<1> Add a `nodeSelector` parameter with the appropriate value to the component you want to move. You can use a `nodeSelector` in the format shown or use `<key>: <value>` pairs, based on the value specified for the node. If you added a taint to the infrastructure node, also add a matching toleration.
+<1> Add a `nodeSelector` parameter with the appropriate value to the component you want to move. You can use a `nodeSelector` in the format shown or use `<key>: <value>` pairs, based on the value specified for the node.
+<2> If you added a taint to the infrastructure node, you must add a matching toleration.
 
-. Confirm that the router pod is running on the `infra` node.
+. Confirm that the router pod is running on the infrastructure node.
+
 .. View the list of router pods and note the node name of the running pod:
 +
 [source,terminal]

--- a/modules/machineset-yaml-alibaba.adoc
+++ b/modules/machineset-yaml-alibaba.adoc
@@ -17,7 +17,7 @@ ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
 
 In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
 ifndef::infra[`<role>`]
-ifdef::infra[`<infra>`]
+ifdef::infra[`infra`]
 is the node label to add.
 
 [source,yaml]
@@ -26,42 +26,42 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id> # <1>
 ifndef::infra[]
-    machine.openshift.io/cluster-api-machine-role: <role> <2>
-    machine.openshift.io/cluster-api-machine-type: <role> <2>
-  name: <infrastructure_id>-<role>-<zone> <3>
+    machine.openshift.io/cluster-api-machine-role: <role> # <2>
+    machine.openshift.io/cluster-api-machine-type: <role>
+  name: <infrastructure_id>-<role>-<zone> # <3>
 endif::infra[]
 ifdef::infra[]
-    machine.openshift.io/cluster-api-machine-role: <infra> <2>
-    machine.openshift.io/cluster-api-machine-type: <infra> <2>
-  name: <infrastructure_id>-<infra>-<zone> <3>
+    machine.openshift.io/cluster-api-machine-role: infra # <2>
+    machine.openshift.io/cluster-api-machine-type: infra
+  name: <infrastructure_id>-infra-<zone> # <3>
 endif::infra[]
   namespace: openshift-machine-api
 spec:
   replicas: 1
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> <3>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone>
 endif::infra[]
 ifdef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<infra>-<zone> <3>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone>
 endif::infra[]
   template:
     metadata:
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <role> <2>
-        machine.openshift.io/cluster-api-machine-type: <role> <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> <3>
+        machine.openshift.io/cluster-api-machine-role: <role>
+        machine.openshift.io/cluster-api-machine-type: <role>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone>
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <infra> <2>
-        machine.openshift.io/cluster-api-machine-type: <infra> <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<infra>-<zone> <3>
+        machine.openshift.io/cluster-api-machine-role: infra
+        machine.openshift.io/cluster-api-machine-type: infra
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone>
 endif::infra[]
     spec:
       metadata:
@@ -77,36 +77,36 @@ endif::infra[]
           apiVersion: machine.openshift.io/v1
           credentialsSecret:
             name: alibabacloud-credentials
-          imageId: <image_id> <4>
-          instanceType: <instance_type> <5>
+          imageId: <image_id> # <4>
+          instanceType: <instance_type> # <5>
           kind: AlibabaCloudMachineProviderConfig
-          ramRoleName: <infrastructure_id>-role-worker <6>
-          regionId: <region> <7>
-          resourceGroup: <8>
+          ramRoleName: <infrastructure_id>-role-worker # <6>
+          regionId: <region> # <7>
+          resourceGroup: # <8>
             id: <resource_group_id>
             type: ID
           securityGroups:
-          - tags: <9>
+          - tags: # <9>
             - Key: Name
               Value: <infrastructure_id>-sg-<role>
             type: Tags
-          systemDisk: <10>
+          systemDisk: # <10>
             category: cloud_essd
             size: <disk_size>
-          tag: <9>
+          tag:
           - Key: kubernetes.io/cluster/<infrastructure_id>
             Value: owned
           userDataSecret:
-            name: <user_data_secret> <11>
+            name: <user_data_secret> # <11>
           vSwitch:
-            tags: <9>
+            tags:
             - Key: Name
               Value: <infrastructure_id>-vswitch-<zone>
             type: Tags
           vpcId: ""
-          zoneId: <zone> <12>
+          zoneId: <zone> # <12>
 ifdef::infra[]
-      taints: <13>
+      taints: # <13>
       - key: node-role.kubernetes.io/infra
         effect: NoSchedule
 endif::infra[]
@@ -122,24 +122,27 @@ ifndef::infra[]
 <3> Specify the infrastructure ID, node label, and zone.
 endif::infra[]
 ifdef::infra[]
-<2> Specify the `<infra>` node label.
-<3> Specify the infrastructure ID, `<infra>` node label, and zone.
+<2> Specify the `infra` node label.
+<3> Specify the infrastructure ID, `infra` node label, and zone.
 endif::infra[]
 <4> Specify the image to use. Use an image from an existing default compute machine set for the cluster.
 <5> Specify the instance type you want to use for the compute machine set.
-<6> Specify the name of the RAM role to use for the compute machine set. Use the value that the installer populates in the default compute machine set.
+<6> Specify the name of the RAM role to use for the compute machine set. Use the value that the installation program populates in the default compute machine set.
 <7> Specify the region to place machines on.
-<8> Specify the resource group and type for the cluster. You can use the value that the installer populates in the default compute machine set, or specify a different one.
-<9> Specify the tags to use for the compute machine set. Minimally, you must include the tags shown in this example, with appropriate values for your cluster. You can include additional tags, including the tags that the installer populates in the default compute machine set it creates, as needed.
-<10> Specify the type and size of the root disk. Use the `category` value that the installer populates in the default compute machine set it creates. If required, specify a different value in gigabytes for `size`.
-<11> Specify the name of the secret in the user data YAML file that is in the `openshift-machine-api` namespace. Use the value that the installer populates in the default compute machine set.
+<8> Specify the resource group and type for the cluster. You can use the value that the installation program populates in the default compute machine set, or specify a different one.
+<9> Specify the tags to use for the compute machine set. Minimally, you must include the tags shown in this example, with appropriate values for your cluster. You can include additional tags, including the tags that the installation program populates in the default compute machine set it creates, as needed.
+<10> Specify the type and size of the root disk. Use the `category` value that the installation program populates in the default compute machine set it creates. If required, specify a different value in gigabytes for `size`.
+<11> Specify the name of the secret in the user data YAML file that is in the `openshift-machine-api` namespace. Use the value that the installation program populates in the default compute machine set.
 <12> Specify the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
 ifdef::infra[]
 <13> Specify a taint to prevent user workloads from being scheduled on infra nodes.
 +
 [NOTE]
 ====
-After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
+After adding the `NoSchedule` taint to an infrastructure node, existing DNS pods running on that node are marked as "misscheduled". You must take one of the following actions:
+
+* Delete the existing DNS pods running on the infrastructure node.
+* link:https://access.redhat.com/solutions/6592171[Add a toleration] to the DNS Operator.
 ====
 endif::infra[]
 

--- a/modules/machineset-yaml-aws.adoc
+++ b/modules/machineset-yaml-aws.adoc
@@ -29,12 +29,12 @@ This sample YAML defines a compute machine set that runs in the `us-east-1-nyc-1
 [NOTE]
 ====
 If you want to reference the sample YAML file in the context of Wavelength Zones, ensure that you replace the AWS Region and zone information with supported Wavelength Zone values.
-==== 
+====
 endif::[]
 
 In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
 ifndef::infra,edge[`<role>`]
-ifdef::infra[`<infra>`]
+ifdef::infra[`infra`]
 ifdef::edge[`<edge>`]
 is the node label to add.
 
@@ -44,69 +44,69 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id> # <1>
 ifndef::infra,edge[]
-  name: <infrastructure_id>-<role>-<zone> <2>
+  name: <infrastructure_id>-<role>-<zone> # <2>
 endif::infra,edge[]
 ifdef::infra[]
-  name: <infrastructure_id>-infra-<zone> <2>
+  name: <infrastructure_id>-infra-<zone> # <2>
 endif::infra[]
 ifdef::edge[]
-  name: <infrastructure_id>-edge-<zone> <2>
+  name: <infrastructure_id>-edge-<zone> # <2>
 endif::edge[]
   namespace: openshift-machine-api
 spec:
   replicas: 1
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifdef::edge[]
       machine.openshift.io/cluster-api-machineset: <infrastructure_id>-edge-<zone>
 endif::edge[]
 ifndef::infra,edge[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> <2>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone>
 endif::infra,edge[]
 ifdef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone> <2>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone>
 endif::infra[]
   template:
     metadata:
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra,edge[]
-        machine.openshift.io/cluster-api-machine-role: <role> <3>
-        machine.openshift.io/cluster-api-machine-type: <role> <3>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> <2>
+        machine.openshift.io/cluster-api-machine-role: <role> # <3>
+        machine.openshift.io/cluster-api-machine-type: <role>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone>
 endif::infra,edge[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: infra <3>
-        machine.openshift.io/cluster-api-machine-type: infra <3>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone> <2>
+        machine.openshift.io/cluster-api-machine-role: infra # <3>
+        machine.openshift.io/cluster-api-machine-type: infra
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone>
 endif::infra[]
 ifdef::edge[]
-        machine.openshift.io/cluster-api-machine-role: edge <3>
-        machine.openshift.io/cluster-api-machine-type: edge <3>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-edge-<zone> <2>
+        machine.openshift.io/cluster-api-machine-role: edge # <3>
+        machine.openshift.io/cluster-api-machine-type: edge
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-edge-<zone>
 endif::edge[]
     spec:
       metadata:
         labels:
 ifndef::infra,edge[]
-          node-role.kubernetes.io/<role>: "" <3>
+          node-role.kubernetes.io/<role>: ""
 endif::infra,edge[]
 ifdef::infra[]
-          node-role.kubernetes.io/infra: "" <3>
+          node-role.kubernetes.io/infra: ""
 endif::infra[]
 ifdef::edge[]
           machine.openshift.io/parent-zone-name: <value_of_ParentZoneName>
           machine.openshift.io/zone-group: <value_of_GroupName>
           machine.openshift.io/zone-type: <value_of_ZoneType>
-          node-role.kubernetes.io/edge: "" <3>
+          node-role.kubernetes.io/edge: ""
 endif::edge[]
       providerSpec:
         value:
           ami:
-            id: ami-046fe691f52a953f9 <4>
+            id: ami-046fe691f52a953f9 # <4>
           apiVersion: machine.openshift.io/v1beta1
           blockDevices:
             - ebs:
@@ -117,37 +117,37 @@ endif::edge[]
             name: aws-cloud-credentials
           deviceIndex: 0
           iamInstanceProfile:
-            id: <infrastructure_id>-worker-profile <1>
+            id: <infrastructure_id>-worker-profile
           instanceType: m6i.large
           kind: AWSMachineProviderConfig
           placement:
-            availabilityZone: <zone> <6>
-            region: <region> <7>
+            availabilityZone: <zone> # <5>
+            region: <region> # <6>
           securityGroups:
             - filters:
                 - name: tag:Name
                   values:
-                    - <infrastructure_id>-worker-sg <1>
+                    - <infrastructure_id>-worker-sg
           subnet:
 ifndef::edge[]
             filters:
               - name: tag:Name
                 values:
-                  - <infrastructure_id>-private-<zone> <8>
+                  - <infrastructure_id>-private-<zone> # <7>
 endif::edge[]
 ifdef::edge[]
-              id: <value_of_PublicSubnetIds> <8>
+              id: <value_of_PublicSubnetIds> # <7>
           publicIp: true
 endif::edge[]
           tags:
-            - name: kubernetes.io/cluster/<infrastructure_id> <1>
+            - name: kubernetes.io/cluster/<infrastructure_id>
               value: owned
-            - name: <custom_tag_name> <5>
-              value: <custom_tag_value> <5>
+            - name: <custom_tag_name> # <8>
+              value: <custom_tag_value>
           userDataSecret:
             name: worker-user-data
 ifdef::infra,edge[]
-      taints: <9>
+      taints: # <9>
 ifdef::infra[]
         - key: node-role.kubernetes.io/infra
 endif::infra[]
@@ -175,8 +175,7 @@ ifdef::edge[]
 <2> Specify the infrastructure ID, `edge` role node label, and zone name.
 <3> Specify the `edge` role node label.
 endif::edge[]
-<4> Specify a valid {op-system-first} Amazon
-Machine Image (AMI) for your AWS zone for your {product-title} nodes. If you want to use an AWS Marketplace image, you must complete the {product-title} subscription from the link:https://aws.amazon.com/marketplace/fulfillment?productId=59ead7de-2540-4653-a8b0-fa7926d5c845[AWS Marketplace] to obtain an AMI ID for your region.
+<4> Specify a valid {op-system-first} Amazon Machine Image (AMI) for your AWS zone for your {product-title} nodes. If you want to use an AWS Marketplace image, you must complete the {product-title} subscription from the link:https://aws.amazon.com/marketplace/fulfillment?productId=59ead7de-2540-4653-a8b0-fa7926d5c845[AWS Marketplace] to obtain an AMI ID for your region.
 +
 [source,terminal]
 ----
@@ -184,26 +183,25 @@ $ oc -n openshift-machine-api \
     -o jsonpath='{.spec.template.spec.providerSpec.value.ami.id}{"\n"}' \
     get machineset/<infrastructure_id>-<role>-<zone>
 ----
-<5> Optional: Specify custom tag data for your cluster. For example, you might add an admin contact email address by specifying a `name:value` pair of `Email:\admin-email@example.com`.
+ifndef::edge[]
+<5> Specify the zone, for example, `us-east-1a`.
+endif::edge[]
+ifdef::edge[]
+<5> Specify the zone name, for example, `us-east-1-nyc-1a`.
+endif::edge[]
+<6> Specify the region, for example, `us-east-1`.
+ifndef::edge[]
+<7> Specify the infrastructure ID and zone.
+endif::edge[]
+ifdef::edge[]
+<7> The ID of the public subnet that you created in AWS {zone-type}. You created this public subnet ID when you finished the procedure for "Creating a subnet in an AWS zone".
+endif::edge[]
+<8> Optional: Specify custom tag data for your cluster. For example, you might add an admin contact email address by specifying a `name:value` pair of `Email:\admin-email@example.com`.
 +
 [NOTE]
 ====
 Custom tags can also be specified during installation in the `install-config.yml` file. If the `install-config.yml` file and the machine set include a tag with the same `name` data, the value for the tag from the machine set takes priority over the value for the tag in the `install-config.yml` file.
 ====
-
-ifndef::edge[]
-<6> Specify the zone, for example, `us-east-1a`.
-endif::edge[]
-ifdef::edge[]
-<6> Specify the zone name, for example, `us-east-1-nyc-1a`.
-endif::edge[]
-<7> Specify the region, for example, `us-east-1`.
-ifndef::edge[]
-<8> Specify the infrastructure ID and zone.
-endif::edge[]
-ifdef::edge[]
-<8> The ID of the public subnet that you created in AWS {zone-type}. You created this public subnet ID when you finished the procedure for "Creating a subnet in an AWS zone".
-endif::edge[]
 ifdef::infra,edge[]
 <9> Specify a taint to prevent user workloads from being scheduled on
 ifdef::infra[`infra`]
@@ -212,9 +210,11 @@ nodes.
 +
 [NOTE]
 ====
-After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
-====
+After adding the `NoSchedule` taint to an infrastructure node, existing DNS pods running on that node are marked as "misscheduled". You must take one of the following actions:
 
+* Delete the existing DNS pods running on the infrastructure node.
+* link:https://access.redhat.com/solutions/6592171[Add a toleration] to the DNS Operator.
+====
 endif::infra,edge[]
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]

--- a/modules/machineset-yaml-azure-stack-hub.adoc
+++ b/modules/machineset-yaml-azure-stack-hub.adoc
@@ -17,7 +17,7 @@ ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
 
 In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
 ifndef::infra[`<role>`]
-ifdef::infra[`<infra>`]
+ifdef::infra[`infra`]
 is the node label to add.
 
 [source,yaml]
@@ -26,79 +26,71 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id> # <1>
 ifndef::infra[]
-    machine.openshift.io/cluster-api-machine-role: <role> <2>
-    machine.openshift.io/cluster-api-machine-type: <role> <2>
-  name: <infrastructure_id>-<role>-<region> <3>
+    machine.openshift.io/cluster-api-machine-role: <role> # <2>
+    machine.openshift.io/cluster-api-machine-type: <role>
+  name: <infrastructure_id>-<role>-<region> # <3>
 endif::infra[]
 ifdef::infra[]
-    machine.openshift.io/cluster-api-machine-role: <infra> <2>
-    machine.openshift.io/cluster-api-machine-type: <infra> <2>
-  name: <infrastructure_id>-infra-<region> <3>
+    machine.openshift.io/cluster-api-machine-role: infra # <2>
+    machine.openshift.io/cluster-api-machine-type: infra
+  name: <infrastructure_id>-infra-<region> # <3>
 endif::infra[]
   namespace: openshift-machine-api
 spec:
   replicas: 1
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region> <3>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region>
 endif::infra[]
 ifdef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<region> <3>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<region>
 endif::infra[]
   template:
     metadata:
       creationTimestamp: null
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <role> <2>
-        machine.openshift.io/cluster-api-machine-type: <role> <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region> <3>
+        machine.openshift.io/cluster-api-machine-role: <role>
+        machine.openshift.io/cluster-api-machine-type: <role>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region>
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <infra> <2>
-        machine.openshift.io/cluster-api-machine-type: <infra> <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<region> <3>
+        machine.openshift.io/cluster-api-machine-role: infra
+        machine.openshift.io/cluster-api-machine-type: infra
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<region>
 endif::infra[]
     spec:
       metadata:
         creationTimestamp: null
         labels:
 ifndef::infra[]
-          node-role.kubernetes.io/<role>: "" <2>
+          node-role.kubernetes.io/<role>: ""
 endif::infra[]
 ifdef::infra[]
-          node-role.kubernetes.io/infra: "" <2>
-      taints: <4>
-      - key: node-role.kubernetes.io/infra
-        effect: NoSchedule
+          node-role.kubernetes.io/infra: ""
 endif::infra[]
       providerSpec:
         value:
           apiVersion: machine.openshift.io/v1beta1
-          availabilitySet: <availability_set> <6>
+          availabilitySet: <availability_set> # <4>
           credentialsSecret:
             name: azure-cloud-credentials
             namespace: openshift-machine-api
           image:
             offer: ""
             publisher: ""
-            resourceID: /resourceGroups/<infrastructure_id>-rg/providers/Microsoft.Compute/images/<infrastructure_id> <1>
+            resourceID: /resourceGroups/<infrastructure_id>-rg/providers/Microsoft.Compute/images/<infrastructure_id>
             sku: ""
             version: ""
           internalLoadBalancer: ""
           kind: AzureMachineProviderSpec
-ifndef::infra[]
-          location: <region> <4>
-endif::infra[]
-ifdef::infra[]
-          location: <region> <5>
-endif::infra[]
-          managedIdentity: <infrastructure_id>-identity <1>
+          location: <region> # <5>
+          managedIdentity: <infrastructure_id>-identity
           metadata:
             creationTimestamp: null
           natRule: null
@@ -110,19 +102,24 @@ endif::infra[]
             osType: Linux
           publicIP: false
           publicLoadBalancer: ""
-          resourceGroup: <infrastructure_id>-rg <1>
+          resourceGroup: <infrastructure_id>-rg
           sshPrivateKey: ""
           sshPublicKey: ""
-          subnet: <infrastructure_id>-<role>-subnet <1> <2>
-          userDataSecret:
-            name: worker-user-data <2>
-          vmSize: Standard_DS4_v2
-          vnet: <infrastructure_id>-vnet <1>
 ifndef::infra[]
-          zone: "1" <5>
+          subnet: <infrastructure_id>-<role>-subnet # <6>
 endif::infra[]
 ifdef::infra[]
-          zone: "1" <7>
+          subnet: <infrastructure_id>-infra-subnet # <6>
+endif::infra[]
+          userDataSecret:
+            name: worker-user-data
+          vmSize: Standard_DS4_v2
+          vnet: <infrastructure_id>-vnet # <7>
+          zone: "1" # <8>
+ifdef::infra[]
+      taints: # <9>
+      - key: node-role.kubernetes.io/infra
+        effect: NoSchedule
 endif::infra[]
 ----
 <1> Specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
@@ -131,6 +128,17 @@ endif::infra[]
 ----
 $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 ----
+ifndef::infra[]
+<2> Specify the role node label to add.
+<3> Specify the infrastructure ID, role node label, and zone.
+endif::infra[]
+ifdef::infra[]
+<2> Specify the `infra` role node label.
+<3> Specify the infrastructure ID, `infra` role node label, and zone.
+endif::infra[]
+<4> Specify the availability set for the cluster.
+<5> Specify the region to place machines on.
+<6> Specify the subnet.
 +
 You can obtain the subnet by running the following command:
 +
@@ -140,6 +148,8 @@ $  oc -n openshift-machine-api \
     -o jsonpath='{.spec.template.spec.providerSpec.value.subnet}{"\n"}' \
     get machineset/<infrastructure_id>-worker-centralus1
 ----
+<7> Specify the vnet.
++
 You can obtain the vnet by running the following command:
 +
 [source,terminal]
@@ -148,29 +158,18 @@ $  oc -n openshift-machine-api \
     -o jsonpath='{.spec.template.spec.providerSpec.value.vnet}{"\n"}' \
     get machineset/<infrastructure_id>-worker-centralus1
 ----
-ifndef::infra[]
-<2> Specify the node label to add.
-<3> Specify the infrastructure ID, node label, and region.
-<4> Specify the region to place machines on.
-<5> Specify the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
-<6> Specify the availability set for the cluster.
-endif::infra[]
+<8> Specify the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
 ifdef::infra[]
-<2> Specify the `<infra>` node label.
-<3> Specify the infrastructure ID, `<infra>` node label, and region.
-<4> Specify a taint to prevent user workloads from being scheduled on infra nodes.
+<9> Specify a taint to prevent user workloads from being scheduled on infra nodes.
 +
 [NOTE]
 ====
-After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
+After adding the `NoSchedule` taint to an infrastructure node, existing DNS pods running on that node are marked as "misscheduled". You must take one of the following actions:
+
+* Delete the existing DNS pods running on the infrastructure node.
+* link:https://access.redhat.com/solutions/6592171[Add a toleration] to the DNS Operator.
 ====
-
-<5> Specify the region to place machines on.
-<6> Specify the availability set for the cluster.
-<7> Specify the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
-
 endif::infra[]
-
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]
 :!infra:

--- a/modules/machineset-yaml-azure.adoc
+++ b/modules/machineset-yaml-azure.adoc
@@ -108,14 +108,14 @@ endif::infra[]
           tags:
             - name: <custom_tag_name> # <7>
               value: <custom_tag_value>
-          subnet: <infrastructure_id>-<role>-subnet
+          subnet: <infrastructure_id>-<role>-subnet # <8>
           userDataSecret:
             name: worker-user-data
           vmSize: Standard_D4s_v3
-          vnet: <infrastructure_id>-vnet
-          zone: "1" # <8>
+          vnet: <infrastructure_id>-vnet # <9>
+          zone: "1" # <10>
 ifdef::infra[]
-      taints: # <9>
+      taints: # <11>
       - key: node-role.kubernetes.io/infra
         effect: NoSchedule
 endif::infra[]
@@ -125,23 +125,6 @@ endif::infra[]
 [source,terminal]
 ----
 $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
-----
-+
-You can obtain the subnet by running the following command:
-+
-[source,terminal]
-----
-$  oc -n openshift-machine-api \
-    -o jsonpath='{.spec.template.spec.providerSpec.value.subnet}{"\n"}' \
-    get machineset/<infrastructure_id>-worker-centralus1
-----
-You can obtain the vnet by running the following command:
-+
-[source,terminal]
-----
-$  oc -n openshift-machine-api \
-    -o jsonpath='{.spec.template.spec.providerSpec.value.vnet}{"\n"}' \
-    get machineset/<infrastructure_id>-worker-centralus1
 ----
 ifndef::infra[]
 <2> Specify the node label to add.
@@ -155,13 +138,36 @@ endif::infra[]
 <5> Specify an image that is compatible with your instance type. The Hyper-V generation V2 images created by the installation program have a `-gen2` suffix, while V1 images have the same name without the suffix.
 <6> Specify the region to place machines on.
 <7> Optional: Specify custom tags in your machine set. Provide the tag name in `<custom_tag_name>` field and the corresponding tag value in `<custom_tag_value>` field.
-<8> Specify the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
+<8> Specify the subnet.
++
+You can obtain the subnet by running the following command:
++
+[source,terminal]
+----
+$  oc -n openshift-machine-api \
+    -o jsonpath='{.spec.template.spec.providerSpec.value.subnet}{"\n"}' \
+    get machineset/<infrastructure_id>-worker-centralus1
+----
+<9> Specify the vnet.
++
+You can obtain the vnet by running the following command:
++
+[source,terminal]
+----
+$  oc -n openshift-machine-api \
+    -o jsonpath='{.spec.template.spec.providerSpec.value.vnet}{"\n"}' \
+    get machineset/<infrastructure_id>-worker-centralus1
+----
+<10> Specify the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
 ifdef::infra[]
-<9> Specify a taint to prevent user workloads from being scheduled on infra nodes.
+<11> Specify a taint to prevent user workloads from being scheduled on infra nodes.
 +
 [NOTE]
 ====
-After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
+After adding the `NoSchedule` taint to an infrastructure node, existing DNS pods running on that node are marked as "misscheduled". You must take one of the following actions:
+
+* Delete the existing DNS pods running on the infrastructure node.
+* link:https://access.redhat.com/solutions/6592171[Add a toleration] to the DNS Operator.
 ====
 endif::infra[]
 

--- a/modules/machineset-yaml-baremetal.adoc
+++ b/modules/machineset-yaml-baremetal.adoc
@@ -8,7 +8,7 @@ ifeval::["{context}" == "creating-infrastructure-machinesets"]
 endif::[]
 
 :_mod-docs-content-type: REFERENCE
-[id="machineset-yaml-vsphere_{context}"]
+[id="machineset-yaml-baremetal_{context}"]
 = Sample YAML for a compute machine set custom resource on bare metal
 
 This sample YAML defines a compute machine set that runs on bare metal and creates nodes that are labeled with
@@ -17,7 +17,7 @@ ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
 
 In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
 ifndef::infra[`<role>`]
-ifdef::infra[`<infra>`]
+ifdef::infra[`infra`]
 is the node label to add.
 
 [source,yaml]
@@ -27,65 +27,67 @@ kind: MachineSet
 metadata:
   creationTimestamp: null
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id> # <1>
 ifndef::infra[]
-  name: <infrastructure_id>-<role> <2>
+  name: <infrastructure_id>-<role> # <2>
 endif::infra[]
 ifdef::infra[]
-  name: <infrastructure_id>-infra <2>
+  name: <infrastructure_id>-infra # <2>
 endif::infra[]
   namespace: openshift-machine-api
 spec:
   replicas: 1
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role> <2>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
 endif::infra[]
 ifdef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra <2>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra
 endif::infra[]
   template:
     metadata:
       creationTimestamp: null
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <role> <3>
-        machine.openshift.io/cluster-api-machine-type: <role> <3>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role> <2>
+        machine.openshift.io/cluster-api-machine-role: <role> # <3>
+        machine.openshift.io/cluster-api-machine-type: <role>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <infra> <3>
-        machine.openshift.io/cluster-api-machine-type: <infra> <3>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra <2>
+        machine.openshift.io/cluster-api-machine-role: infra # <3>
+        machine.openshift.io/cluster-api-machine-type: infra
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra
 endif::infra[]
     spec:
       metadata:
         creationTimestamp: null
         labels:
 ifndef::infra[]
-          node-role.kubernetes.io/<role>: "" <3>
+          node-role.kubernetes.io/<role>: ""
 endif::infra[]
 ifdef::infra[]
-          node-role.kubernetes.io/infra: "" <3>
-      taints: <4>
-      - key: node-role.kubernetes.io/infra
-        effect: NoSchedule
+          node-role.kubernetes.io/infra: ""
 endif::infra[]
       providerSpec:
         value:
           apiVersion: baremetal.cluster.k8s.io/v1alpha1
           hostSelector: {}
           image:
-            checksum: http:/172.22.0.3:6181/images/rhcos-<version>.<architecture>.qcow2.<md5sum> <4>
-            url: http://172.22.0.3:6181/images/rhcos-<version>.<architecture>.qcow2 <5>
+            checksum: http:/172.22.0.3:6181/images/rhcos-<version>.<architecture>.qcow2.<md5sum> # <4>
+            url: http://172.22.0.3:6181/images/rhcos-<version>.<architecture>.qcow2 # <5>
           kind: BareMetalMachineProviderSpec
           metadata:
             creationTimestamp: null
           userData:
             name: worker-user-data
+ifdef::infra[]
+      taints: # <6>
+      - key: node-role.kubernetes.io/infra
+        effect: NoSchedule
+endif::infra[]
 ----
 <1> Specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI (`oc`) installed, you can obtain the infrastructure ID by running the following command:
 +
@@ -94,10 +96,25 @@ endif::infra[]
 $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 ----
 ifndef::infra[]
-<2> Specify the infrastructure ID and node label.
+<2> Specify the infrastructure ID, node label, and region.
 <3> Specify the node label to add.
+endif::infra[]
+ifdef::infra[]
+<2> Specify the infrastructure ID and `infra` node label.
+<3> Specify the `infra` node label.
+endif::infra[]
 <4> Edit the `checksum` URL to use the API VIP address.
 <5> Edit the `url` URL to use the API VIP address.
+ifdef::infra[]
+<6> Specify a taint to prevent user workloads from being scheduled on infra nodes.
++
+[NOTE]
+====
+After adding the `NoSchedule` taint to an infrastructure node, existing DNS pods running on that node are marked as "misscheduled". You must take one of the following actions:
+
+* Delete the existing DNS pods running on the infrastructure node.
+* link:https://access.redhat.com/solutions/6592171[Add a toleration] to the DNS Operator.
+====
 endif::infra[]
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]

--- a/modules/machineset-yaml-gcp.adoc
+++ b/modules/machineset-yaml-gcp.adoc
@@ -48,7 +48,7 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id> # <1>
   name: <infrastructure_id>-w-a
   namespace: openshift-machine-api
 spec:
@@ -63,12 +63,12 @@ spec:
       labels:
         machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <role> <2>
+        machine.openshift.io/cluster-api-machine-role: <role> # <2>
         machine.openshift.io/cluster-api-machine-type: <role>
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <infra> <2>
-        machine.openshift.io/cluster-api-machine-type: <infra>
+        machine.openshift.io/cluster-api-machine-role: infra # <2>
+        machine.openshift.io/cluster-api-machine-type: infra
 endif::infra[]
         machine.openshift.io/cluster-api-machineset: <infrastructure_id>-w-a
     spec:
@@ -90,11 +90,11 @@ endif::infra[]
           disks:
           - autoDelete: true
             boot: true
-            image: <path_to_image> <3>
+            image: <path_to_image> # <3>
             labels: null
             sizeGb: 128
             type: pd-ssd
-          gcpMetadata: <4>
+          gcpMetadata: # <4>
           - key: <custom_metadata_key>
             value: <custom_metadata_value>
           kind: GCPMachineProviderSpec
@@ -104,7 +104,7 @@ endif::infra[]
           networkInterfaces:
           - network: <infrastructure_id>-network
             subnetwork: <infrastructure_id>-worker-subnet
-          projectID: <project_name> <5>
+          projectID: <project_name> # <5>
           region: us-central1
           serviceAccounts:
           - email: <infrastructure_id>-w@<project_name>.iam.gserviceaccount.com
@@ -116,7 +116,7 @@ endif::infra[]
             name: worker-user-data
           zone: us-central1-a
 ifdef::infra[]
-      taints: <6>
+      taints: # <6>
       - key: node-role.kubernetes.io/infra
         effect: NoSchedule
 endif::infra[]
@@ -126,7 +126,7 @@ ifndef::infra[]
 <2> For `<node>`, specify the node label to add.
 endif::infra[]
 ifdef::infra[]
-<2> For `<infra>`, specify the `<infra>` node label.
+<2> Specify the `infra` node label.
 endif::infra[]
 <3> Specify the path to the image that is used in current compute machine sets.
 +
@@ -144,7 +144,10 @@ ifdef::infra[]
 +
 [NOTE]
 ====
-After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
+After adding the `NoSchedule` taint to an infrastructure node, existing DNS pods running on that node are marked as "misscheduled". You must take one of the following actions:
+
+* Delete the existing DNS pods running on the infrastructure node.
+* link:https://access.redhat.com/solutions/6592171[Add a toleration] to the DNS Operator.
 ====
 endif::infra[]
 

--- a/modules/machineset-yaml-ibm-cloud.adoc
+++ b/modules/machineset-yaml-ibm-cloud.adoc
@@ -17,7 +17,7 @@ ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
 
 In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
 ifndef::infra[`<role>`]
-ifdef::infra[`<infra>`]
+ifdef::infra[`infra`]
 is the node label to add.
 
 [source,yaml]
@@ -26,42 +26,42 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id> # <1>
 ifndef::infra[]
-    machine.openshift.io/cluster-api-machine-role: <role> <2>
-    machine.openshift.io/cluster-api-machine-type: <role> <2>
-  name: <infrastructure_id>-<role>-<region> <3>
+    machine.openshift.io/cluster-api-machine-role: <role> # <2>
+    machine.openshift.io/cluster-api-machine-type: <role>
+  name: <infrastructure_id>-<role>-<region> # <3>
 endif::infra[]
 ifdef::infra[]
-    machine.openshift.io/cluster-api-machine-role: <infra> <2>
-    machine.openshift.io/cluster-api-machine-type: <infra> <2>
-  name: <infrastructure_id>-<infra>-<region> <3>
+    machine.openshift.io/cluster-api-machine-role: infra # <2>
+    machine.openshift.io/cluster-api-machine-type: infra
+  name: <infrastructure_id>-infra-<region> # <3>
 endif::infra[]
   namespace: openshift-machine-api
 spec:
   replicas: 1
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region> <3>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region>
 endif::infra[]
 ifdef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<infra>-<region> <3>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<region>
 endif::infra[]
   template:
     metadata:
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <role> <2>
-        machine.openshift.io/cluster-api-machine-type: <role> <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region> <3>
+        machine.openshift.io/cluster-api-machine-role: <role>
+        machine.openshift.io/cluster-api-machine-type: <role>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region>
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <infra> <2>
-        machine.openshift.io/cluster-api-machine-type: <infra> <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<infra>-<region> <3>
+        machine.openshift.io/cluster-api-machine-role: infra
+        machine.openshift.io/cluster-api-machine-type: infra
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<region>
 endif::infra[]
     spec:
       metadata:
@@ -77,22 +77,22 @@ endif::infra[]
           apiVersion: ibmcloudproviderconfig.openshift.io/v1beta1
           credentialsSecret:
             name: ibmcloud-credentials
-          image: <infrastructure_id>-rhcos <4>
+          image: <infrastructure_id>-rhcos # <4>
           kind: IBMCloudMachineProviderSpec
           primaryNetworkInterface:
               securityGroups:
               - <infrastructure_id>-sg-cluster-wide
               - <infrastructure_id>-sg-openshift-net
-              subnet: <infrastructure_id>-subnet-compute-<zone> <5>
-          profile: <instance_profile> <6>
-          region: <region> <7>
-          resourceGroup: <resource_group> <8>
+              subnet: <infrastructure_id>-subnet-compute-<zone> # <5>
+          profile: <instance_profile> # <6>
+          region: <region> # <7>
+          resourceGroup: <resource_group> # <8>
           userDataSecret:
-              name: <role>-user-data <2>
-          vpc: <vpc_name> <9>
-          zone: <zone> <10>
+              name: worker-user-data
+          vpc: <vpc_name> # <9>
+          zone: <zone> # <10>
 ifdef::infra[]
-        taints: <11>
+        taints: # <11>
         - key: node-role.kubernetes.io/infra
           effect: NoSchedule
 endif::infra[]
@@ -108,8 +108,8 @@ ifndef::infra[]
 <3> The infrastructure ID, node label, and region.
 endif::infra[]
 ifdef::infra[]
-<2> The `<infra>` node label.
-<3> The infrastructure ID, `<infra>` node label, and region.
+<2> The `infra` node label.
+<3> The infrastructure ID, `infra` node label, and region.
 endif::infra[]
 <4> The custom {op-system-first} image that was used for cluster installation.
 <5> The infrastructure ID and zone within your region to place machines on. Be sure that your region supports the zone that you specify.
@@ -123,7 +123,10 @@ ifdef::infra[]
 +
 [NOTE]
 ====
-After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
+After adding the `NoSchedule` taint to an infrastructure node, existing DNS pods running on that node are marked as "misscheduled". You must take one of the following actions:
+
+* Delete the existing DNS pods running on the infrastructure node.
+* link:https://access.redhat.com/solutions/6592171[Add a toleration] to the DNS Operator.
 ====
 endif::infra[]
 

--- a/modules/machineset-yaml-ibm-power-vs.adoc
+++ b/modules/machineset-yaml-ibm-power-vs.adoc
@@ -1,14 +1,24 @@
 // Module included in the following assemblies:
 //
+// * machine_management/creating-infrastructure-machinesets.adoc
 // * machine_management/creating_machinesets/creating-machineset-ibm-power-vs.adoc
+
+ifeval::["{context}" == "creating-infrastructure-machinesets"]
+:infra:
+endif::[]
 
 :_mod-docs-content-type: REFERENCE
 [id="machineset-yaml-ibm-power-vs_{context}"]
 = Sample YAML for a compute machine set custom resource on {ibm-power-server-title}
 
-This sample YAML file defines a compute machine set that runs in a specified {ibm-power-server-name} zone in a region and creates nodes that are labeled with `node-role.kubernetes.io/<role>: ""`.
+This sample YAML file defines a compute machine set that runs in a specified {ibm-power-server-name} zone in a region and creates nodes that are labeled with
+ifndef::infra[`node-role.kubernetes.io/<role>: ""`.]
+ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
 
-In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and `<role>` is the node label to add.
+In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
+ifndef::infra[`<role>`]
+ifdef::infra[`infra`]
+is the node label to add.
 
 [source,yaml]
 ----
@@ -16,35 +26,59 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
-    machine.openshift.io/cluster-api-machine-role: <role> <2>
-    machine.openshift.io/cluster-api-machine-type: <role> <2>
-  name: <infrastructure_id>-<role>-<region> <3>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id> # <1>
+ifndef::infra[]
+    machine.openshift.io/cluster-api-machine-role: <role> # <2>
+    machine.openshift.io/cluster-api-machine-type: <role>
+  name: <infrastructure_id>-<role>-<region> # <3>
+endif::infra[]
+ifdef::infra[]
+    machine.openshift.io/cluster-api-machine-role: infra # <2>
+    machine.openshift.io/cluster-api-machine-type: infra
+  name: <infrastructure_id>-infra-<region> # <3>
+endif::infra[]
   namespace: openshift-machine-api
 spec:
   replicas: 1
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region> <3>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+ifndef::infra[]
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region>
+endif::infra[]
+ifdef::infra[]
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<region>
+endif::infra[]
   template:
     metadata:
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
-        machine.openshift.io/cluster-api-machine-role: <role> <2>
-        machine.openshift.io/cluster-api-machine-type: <role> <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region> <3>
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+ifndef::infra[]
+        machine.openshift.io/cluster-api-machine-role: <role>
+        machine.openshift.io/cluster-api-machine-type: <role>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region>
+endif::infra[]
+ifdef::infra[]
+        machine.openshift.io/cluster-api-machine-role: infra
+        machine.openshift.io/cluster-api-machine-type: infra
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<region>
+endif::infra[]
     spec:
       metadata:
         labels:
+ifndef::infra[]
           node-role.kubernetes.io/<role>: ""
+endif::infra[]
+ifdef::infra[]
+          node-role.kubernetes.io/infra: ""
+endif::infra[]
       providerSpec:
         value:
           apiVersion: machine.openshift.io/v1
           credentialsSecret:
             name: powervs-credentials
           image:
-            name: rhcos-<infrastructure_id> <4>
+            name: rhcos-<infrastructure_id> # <4>
             type: Name
           keyPairName: <infrastructure_id>-key
           kind: PowerVSMachineProviderConfig
@@ -56,10 +90,15 @@ spec:
           processors: "0.5"
           serviceInstance:
             id: <ibm_power_vs_service_instance_id>
-            type: ID <5>
+            type: ID # <5>
           systemType: s922
           userDataSecret:
-            name: <role>-user-data
+            name: worker-user-data
+ifdef::infra[]
+        taints: # <6>
+        - key: node-role.kubernetes.io/infra
+          effect: NoSchedule
+endif::infra[]
 ----
 <1> The infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
 +
@@ -67,7 +106,28 @@ spec:
 ----
 $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 ----
+ifndef::infra[]
 <2> The node label to add.
 <3> The infrastructure ID, node label, and region.
+endif::infra[]
+ifdef::infra[]
+<2> The `infra` node label.
+<3> The infrastructure ID, `infra` node label, and region.
+endif::infra[]
 <4> The custom {op-system-first} image that was used for cluster installation.
 <5> The infrastructure ID within your region to place machines on.
+ifdef::infra[]
+<6> The taint to prevent user workloads from being scheduled on infra nodes.
++
+[NOTE]
+====
+After adding the `NoSchedule` taint to an infrastructure node, existing DNS pods running on that node are marked as "misscheduled". You must take one of the following actions:
+
+* Delete the existing DNS pods running on the infrastructure node.
+* link:https://access.redhat.com/solutions/6592171[Add a toleration] to the DNS Operator.
+====
+endif::infra[]
+
+ifeval::["{context}" == "creating-infrastructure-machinesets"]
+:!infra:
+endif::[]

--- a/modules/machineset-yaml-nutanix.adoc
+++ b/modules/machineset-yaml-nutanix.adoc
@@ -17,7 +17,7 @@ ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
 
 In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
 ifndef::infra[`<role>`]
-ifdef::infra[`<infra>`]
+ifdef::infra[`infra`]
 is the node label to add.
 
 [discrete]
@@ -39,19 +39,19 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id> # <1>
 ifndef::infra[]
-    machine.openshift.io/cluster-api-machine-role: <role> <2>
+    machine.openshift.io/cluster-api-machine-role: <role> # <2>
     machine.openshift.io/cluster-api-machine-type: <role>
-  name: <infrastructure_id>-<role>-<zone> <3>
+  name: <infrastructure_id>-<role>-<zone> # <3>
 endif::infra[]
 ifdef::infra[]
-    machine.openshift.io/cluster-api-machine-role: <infra> <2>
-    machine.openshift.io/cluster-api-machine-type: <infra>
-  name: <infrastructure_id>-<infra>-<zone> <3>
+    machine.openshift.io/cluster-api-machine-role: infra # <2>
+    machine.openshift.io/cluster-api-machine-type: infra
+  name: <infrastructure_id>-infra-<zone> # <3>
 endif::infra[]
   namespace: openshift-machine-api
-  annotations: <4>
+  annotations: # <4>
     machine.openshift.io/memoryMb: "16384"
     machine.openshift.io/vCPU: "4"
 spec:
@@ -63,7 +63,7 @@ ifndef::infra[]
       machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone>
 endif::infra[]
 ifdef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<infra>-<zone>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone>
 endif::infra[]
   template:
     metadata:
@@ -75,9 +75,9 @@ ifndef::infra[]
         machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone>
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <infra>
-        machine.openshift.io/cluster-api-machine-type: <infra>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<infra>-<zone>
+        machine.openshift.io/cluster-api-machine-role: infra
+        machine.openshift.io/cluster-api-machine-type: infra
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone>
 endif::infra[]
     spec:
       metadata:
@@ -91,33 +91,33 @@ endif::infra[]
       providerSpec:
         value:
           apiVersion: machine.openshift.io/v1
-          bootType: "" <5>
-          categories: <6>
+          bootType: "" # <5>
+          categories: # <6>
           - key: <category_name>
             value: <category_value>
-          cluster: <7>
+          cluster: # <7>
             type: uuid
             uuid: <cluster_uuid>
           credentialsSecret:
             name: nutanix-credentials
           image:
-            name: <infrastructure_id>-rhcos <8>
+            name: <infrastructure_id>-rhcos # <8>
             type: name
           kind: NutanixMachineProviderConfig
-          memorySize: 16Gi <9>
-          project: <10>
+          memorySize: 16Gi # <9>
+          project: # <10>
             type: name
             name: <project_name>
           subnets:
           - type: uuid
             uuid: <subnet_uuid>
-          systemDiskSize: 120Gi <11>
+          systemDiskSize: 120Gi # <11>
           userDataSecret:
-            name: <user_data_secret> <12>
-          vcpuSockets: 4 <13>
-          vcpusPerSocket: 1 <14>
+            name: <user_data_secret> # <12>
+          vcpuSockets: 4 # <13>
+          vcpusPerSocket: 1 # <14>
 ifdef::infra[]
-      taints: <15>
+      taints: # <15>
       - key: node-role.kubernetes.io/infra
         effect: NoSchedule
 endif::infra[]
@@ -128,8 +128,8 @@ ifndef::infra[]
 <3> Specify the infrastructure ID, node label, and zone.
 endif::infra[]
 ifdef::infra[]
-<2> Specify the `<infra>` node label.
-<3> Specify the infrastructure ID, `<infra>` node label, and zone.
+<2> Specify the `infra` node label.
+<3> Specify the infrastructure ID, `infra` node label, and zone.
 endif::infra[]
 <4> Annotations for the cluster autoscaler.
 <5> Specifies the boot type that the compute machines use. For more information about boot types, see link:https://portal.nutanix.com/page/documents/kbs/details?targetId=kA07V000000H3K9SAK[Understanding UEFI, Secure Boot, and TPM in the Virtualized Environment]. Valid values are `Legacy`, `SecureBoot`, or `UEFI`. The default is `Legacy`.
@@ -152,7 +152,10 @@ ifdef::infra[]
 +
 [NOTE]
 ====
-After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
+After adding the `NoSchedule` taint to an infrastructure node, existing DNS pods running on that node are marked as "misscheduled". You must take one of the following actions:
+
+* Delete the existing DNS pods running on the infrastructure node.
+* link:https://access.redhat.com/solutions/6592171[Add a toleration] to the DNS Operator.
 ====
 endif::infra[]
 

--- a/modules/machineset-yaml-osp.adoc
+++ b/modules/machineset-yaml-osp.adoc
@@ -17,7 +17,7 @@ ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
 
 In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
 ifndef::infra[`<role>`]
-ifdef::infra[`<infra>`]
+ifdef::infra[`infra`]
 is the node label to add.
 
 [source,yaml]
@@ -26,51 +26,49 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id> # <1>
 ifndef::infra[]
-    machine.openshift.io/cluster-api-machine-role: <role> <2>
-    machine.openshift.io/cluster-api-machine-type: <role> <2>
-  name: <infrastructure_id>-<role> <3>
+    machine.openshift.io/cluster-api-machine-role: <role> # <2>
+    machine.openshift.io/cluster-api-machine-type: <role>
+  name: <infrastructure_id>-<role> # <3>
 endif::infra[]
 ifdef::infra[]
-    machine.openshift.io/cluster-api-machine-role: <infra> <2>
-    machine.openshift.io/cluster-api-machine-type: <infra> <2>
-  name: <infrastructure_id>-infra <3>
+    machine.openshift.io/cluster-api-machine-role: infra # <2>
+    machine.openshift.io/cluster-api-machine-type: infra
+  name: <infrastructure_id>-infra # <3>
 endif::infra[]
   namespace: openshift-machine-api
 spec:
   replicas: <number_of_replicas>
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role> <3>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
 endif::infra[]
 ifdef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra <3>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra
 endif::infra[]
   template:
     metadata:
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <role> <2>
-        machine.openshift.io/cluster-api-machine-type: <role> <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role> <3>
-    spec:
+        machine.openshift.io/cluster-api-machine-role: <role>
+        machine.openshift.io/cluster-api-machine-type: <role>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <infra> <2>
-        machine.openshift.io/cluster-api-machine-type: <infra> <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra <3>
+        machine.openshift.io/cluster-api-machine-role: infra
+        machine.openshift.io/cluster-api-machine-type: infra
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra
+endif::infra[]
     spec:
+ifdef::infra[]
       metadata:
         creationTimestamp: null
         labels:
           node-role.kubernetes.io/infra: ""
-      taints: <4>
-      - key: node-role.kubernetes.io/infra
-        effect: NoSchedule
 endif::infra[]
       providerSpec:
         value:
@@ -81,42 +79,32 @@ endif::infra[]
             namespace: openshift-machine-api
           flavor: <nova_flavor>
           image: <glance_image_name_or_location>
-ifndef::infra[]
-          serverGroupID: <optional_UUID_of_server_group> <4>
-endif::infra[]
-ifdef::infra[]
-          serverGroupID: <optional_UUID_of_server_group> <5>
-endif::infra[]
+          serverGroupID: <optional_UUID_of_server_group> # <4>
           kind: OpenstackProviderSpec
-ifndef::infra[]
-          networks: <5>
-endif::infra[]
-ifdef::infra[]
-          networks: <6>
-endif::infra[]
+          networks: # <5>
           - filter: {}
             subnets:
             - filter:
                 name: <subnet_name>
-                tags: openshiftClusterID=<infrastructure_id> <1>
-ifndef::infra[]
-          primarySubnet: <rhosp_subnet_UUID> <6>
-endif::infra[]
-ifdef::infra[]
-          primarySubnet: <rhosp_subnet_UUID> <7>
-endif::infra[]
+                tags: openshiftClusterID=<infrastructure_id>
+          primarySubnet: <rhosp_subnet_UUID> # <6>
           securityGroups:
           - filter: {}
-            name: <infrastructure_id>-worker <1>
+            name: <infrastructure_id>-worker
           serverMetadata:
-            Name: <infrastructure_id>-worker <1>
-            openshiftClusterID: <infrastructure_id> <1>
+            Name: <infrastructure_id>-worker
+            openshiftClusterID: <infrastructure_id>
           tags:
-          - openshiftClusterID=<infrastructure_id> <1>
+          - openshiftClusterID=<infrastructure_id>
           trunk: true
           userDataSecret:
-            name: worker-user-data <2>
+            name: worker-user-data
           availabilityZone: <optional_openstack_availability_zone>
+ifdef::infra[]
+      taints: # <7>
+      - key: node-role.kubernetes.io/infra
+        effect: NoSchedule
+endif::infra[]
 ----
 <1> Specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
 +
@@ -127,25 +115,25 @@ $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 ifndef::infra[]
 <2> Specify the node label to add.
 <3> Specify the infrastructure ID and node label.
+endif::infra[]
+ifdef::infra[]
+<2> Specify the `infra` node label.
+<3> Specify the infrastructure ID and `infra` node label.
+endif::infra[]
 <4> To set a server group policy for the MachineSet, enter the value that is returned from
 link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.0/html/command_line_interface_reference/server#server_group_create[creating a server group]. For most deployments, `anti-affinity` or `soft-anti-affinity` policies are recommended.
 <5> Required for deployments to multiple networks. To specify multiple networks, add another entry in the networks array. Also, you must include the network that is used as the `primarySubnet` value.
 <6> Specify the {rh-openstack} subnet that you want the endpoints of nodes to be published on. Usually, this is the same subnet that is used as the value of `machinesSubnet` in the `install-config.yaml` file.
-endif::infra[]
 ifdef::infra[]
-<2> Specify the `<infra>` node label.
-<3> Specify the infrastructure ID and `<infra>` node label.
-<4> Specify a taint to prevent user workloads from being scheduled on infra nodes.
+<7> Specify a taint to prevent user workloads from being scheduled on infra nodes.
 +
 [NOTE]
 ====
-After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
-====
+After adding the `NoSchedule` taint to an infrastructure node, existing DNS pods running on that node are marked as "misscheduled". You must take one of the following actions:
 
-<5> To set a server group policy for the MachineSet, enter the value that is returned from
-link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.0/html/command_line_interface_reference/server#server_group_create[creating a server group]. For most deployments, `anti-affinity` or `soft-anti-affinity` policies are recommended.
-<6> Required for deployments to multiple networks. If deploying to multiple networks, this list must include the network that is used as the `primarySubnet` value.
-<7> Specify the {rh-openstack} subnet that you want the endpoints of nodes to be published on. Usually, this is the same subnet that is used as the value of `machinesSubnet` in the `install-config.yaml` file.
+* Delete the existing DNS pods running on the infrastructure node.
+* link:https://access.redhat.com/solutions/6592171[Add a toleration] to the DNS Operator.
+====
 endif::infra[]
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]

--- a/modules/machineset-yaml-vsphere.adoc
+++ b/modules/machineset-yaml-vsphere.adoc
@@ -17,7 +17,7 @@ ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
 
 In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
 ifndef::infra[`<role>`]
-ifdef::infra[`<infra>`]
+ifdef::infra[`infra`]
 is the node label to add.
 
 [source,yaml]
@@ -27,52 +27,49 @@ kind: MachineSet
 metadata:
   creationTimestamp: null
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id> # <1>
 ifndef::infra[]
-  name: <infrastructure_id>-<role> <2>
+  name: <infrastructure_id>-<role> # <2>
 endif::infra[]
 ifdef::infra[]
-  name: <infrastructure_id>-infra <2>
+  name: <infrastructure_id>-infra # <2>
 endif::infra[]
   namespace: openshift-machine-api
 spec:
   replicas: 1
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role> <2>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
 endif::infra[]
 ifdef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra <2>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra
 endif::infra[]
   template:
     metadata:
       creationTimestamp: null
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <role> <3>
-        machine.openshift.io/cluster-api-machine-type: <role> <3>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role> <2>
+        machine.openshift.io/cluster-api-machine-role: <role> # <3>
+        machine.openshift.io/cluster-api-machine-type: <role>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <infra> <3>
-        machine.openshift.io/cluster-api-machine-type: <infra> <3>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra <2>
+        machine.openshift.io/cluster-api-machine-role: infra # <3>
+        machine.openshift.io/cluster-api-machine-type: infra
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra
 endif::infra[]
     spec:
       metadata:
         creationTimestamp: null
         labels:
 ifndef::infra[]
-          node-role.kubernetes.io/<role>: "" <3>
+          node-role.kubernetes.io/<role>: ""
 endif::infra[]
 ifdef::infra[]
-          node-role.kubernetes.io/infra: "" <3>
-      taints: <4>
-      - key: node-role.kubernetes.io/infra
-        effect: NoSchedule
+          node-role.kubernetes.io/infra: ""
 endif::infra[]
       providerSpec:
         value:
@@ -86,36 +83,23 @@ endif::infra[]
             creationTimestamp: null
           network:
             devices:
-ifndef::infra[]
-            - networkName: "<vm_network_name>" <4>
-endif::infra[]
-ifdef::infra[]
-            - networkName: "<vm_network_name>" <5>
-endif::infra[]
+            - networkName: "<vm_network_name>" # <4>
           numCPUs: 4
           numCoresPerSocket: 1
           snapshot: ""
-ifndef::infra[]
-          template: <vm_template_name> <5>
+          template: <vm_template_name> # <5>
           userDataSecret:
             name: worker-user-data
           workspace:
-            datacenter: <vcenter_datacenter_name> <6>
-            datastore: <vcenter_datastore_name> <7>
-            folder: <vcenter_vm_folder_path> <8>
-            resourcepool: <vsphere_resource_pool> <9>
-            server: <vcenter_server_ip> <10>
-endif::infra[]
+            datacenter: <vcenter_datacenter_name> # <6>
+            datastore: <vcenter_datastore_name> # <7>
+            folder: <vcenter_vm_folder_path> # <8>
+            resourcepool: <vsphere_resource_pool> # <9>
+            server: <vcenter_server_ip> # <10>
 ifdef::infra[]
-          template: <vm_template_name> <6>
-          userDataSecret:
-            name: worker-user-data
-          workspace:
-            datacenter: <vcenter_datacenter_name> <7>
-            datastore: <vcenter_datastore_name> <8>
-            folder: <vcenter_vm_folder_path> <9>
-            resourcepool: <vsphere_resource_pool> <10>
-            server: <vcenter_server_ip> <11>
+      taints: # <11>
+      - key: node-role.kubernetes.io/infra
+        effect: NoSchedule
 endif::infra[]
 ----
 <1> Specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI (`oc`) installed, you can obtain the infrastructure ID by running the following command:
@@ -125,8 +109,13 @@ endif::infra[]
 $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 ----
 ifndef::infra[]
-<2> Specify the infrastructure ID and node label.
-<3> Specify the node label to add.
+<2> Specify the infrastructure ID and role node label.
+<3> Specify the role node label to add.
+endif::infra[]
+ifdef::infra[]
+<2> Specify the infrastructure ID and `infra` role node label.
+<3> Specify the `infra` role node label to add.
+endif::infra[]
 <4> Specify the vSphere VM network to deploy the compute machine set to. This VM network must be where other compute machines reside in the cluster.
 <5> Specify the vSphere VM template to use, such as `user-5ddjd-rhcos`.
 <6> Specify the vCenter Datacenter to deploy the compute machine set on.
@@ -134,24 +123,16 @@ ifndef::infra[]
 <8> Specify the path to the vSphere VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
 <9> Specify the vSphere resource pool for your VMs.
 <10> Specify the vCenter server IP or fully qualified domain name.
-endif::infra[]
 ifdef::infra[]
-<2> Specify the infrastructure ID and `<infra>` node label.
-<3> Specify the `<infra>` node label.
-<4> Specify a taint to prevent user workloads from being scheduled on infra nodes.
+<11> Specify a taint to prevent user workloads from being scheduled on infra nodes.
 +
 [NOTE]
 ====
-After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
-====
+After adding the `NoSchedule` taint to an infrastructure node, existing DNS pods running on that node are marked as "misscheduled". You must take one of the following actions:
 
-<5> Specify the vSphere VM network to deploy the compute machine set to. This VM network must be where other compute machines reside in the cluster.
-<6> Specify the vSphere VM template to use, such as `user-5ddjd-rhcos`.
-<7> Specify the vCenter Datacenter to deploy the compute machine set on.
-<8> Specify the vCenter Datastore to deploy the compute machine set on.
-<9> Specify the path to the vSphere VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
-<10> Specify the vSphere resource pool for your VMs.
-<11> Specify the vCenter server IP or fully qualified domain name.
+* Delete the existing DNS pods running on the infrastructure node.
+* link:https://access.redhat.com/solutions/6592171[Add a toleration] to the DNS Operator.
+====
 endif::infra[]
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]

--- a/modules/moving-resources-to-infrastructure-machinesets.adoc
+++ b/modules/moving-resources-to-infrastructure-machinesets.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating-infrastructure-machinesets.adoc
+// * post_installation_configuration/cluster-tasks.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="moving-resources-to-infrastructure-machinesets_{context}"]
+= Moving resources to infrastructure machine sets
+
+Some of the infrastructure resources are deployed in your cluster by default. You can move them to the infrastructure machine sets that you created by adding the infrastructure node selector in the following format:
+
+[source,yaml]
+----
+# ...
+spec:
+  nodePlacement:
+    nodeSelector: # <1>
+      matchLabels:
+        node-role.kubernetes.io/infra: ""
+    tolerations: # <2>
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/infra
+    - effect: NoExecute
+      key: node-role.kubernetes.io/infra
+# ...
+----
+<1> Add a `nodeSelector` parameter with the appropriate value to the component you want to move. You can use a `nodeSelector` in the format shown or use `<key>: <value>` pairs, based on the value specified for the node.
+<2> If you added a taint to the infrastructure node, you must add a matching toleration.
+
+Applying a specific node selector to all infrastructure components causes {product-title} to schedule those workloads on nodes with that label.

--- a/nodes/nodes/nodes-nodes-creating-infrastructure-nodes.adoc
+++ b/nodes/nodes/nodes-nodes-creating-infrastructure-nodes.adoc
@@ -15,7 +15,10 @@ In a production deployment, it is recommended that you deploy at least three mac
 
 [NOTE]
 ====
-After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
+After adding the `NoSchedule` taint to an infrastructure node, existing DNS pods running on that node are marked as "misscheduled". You must take one of the following actions:
+
+* Delete the existing DNS pods running on the infrastructure node.
+* link:https://access.redhat.com/solutions/6592171[Add a toleration] to the DNS Operator.
 ====
 
 include::modules/infrastructure-components.adoc[leveloffset=+1]
@@ -29,5 +32,4 @@ include::modules/creating-an-infra-node.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../machine_management/creating-infrastructure-machinesets.adoc#moving-resources-to-infrastructure-machinesets[Moving resources to infrastructure machine sets]
-
+* xref:../../machine_management/creating-infrastructure-machinesets.adoc#moving-resources-to-infrastructure-machinesets_creating-infrastructure-machinesets[Moving resources to infrastructure machine sets]

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -571,7 +571,7 @@ To create an infrastructure node, you can xref:../post_installation_configuratio
 
 For sample machine sets that you can use with these procedures, see xref:../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets-clouds[Creating machine sets for different clouds].
 
-Applying a specific node selector to all infrastructure components causes {product-title} to xref:../post_installation_configuration/cluster-tasks.adoc#moving-resources-to-infrastructure-machinesets[schedule those workloads on nodes with that label].
+Applying a specific node selector to all infrastructure components causes {product-title} to xref:../post_installation_configuration/cluster-tasks.adoc#moving-resources-to-infrastructure-machinesets_post-install-cluster-tasks[schedule those workloads on nodes with that label].
 
 include::modules/machineset-creating.adoc[leveloffset=+2]
 
@@ -603,10 +603,12 @@ include::modules/binding-infra-node-workloads-using-taints-tolerations.adoc[leve
 
 * See xref:../nodes/scheduling/nodes-scheduler-about.adoc#nodes-scheduler-about[Controlling pod placement using the scheduler] for general information on scheduling a pod to a node.
 
-[id="moving-resources-to-infrastructure-machinesets"]
-== Moving resources to infrastructure machine sets
+//Moving resources to infrastructure machine sets
+include::modules/moving-resources-to-infrastructure-machinesets.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
 
-Some of the infrastructure resources are deployed in your cluster by default. You can move them to the infrastructure machine sets that you created.
+* xref:../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets[Creating infrastructure machine sets]
 
 include::modules/infrastructure-moving-router.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-7964](https://issues.redhat.com/browse/OCPBUGS-7964)

Link to docs preview:
* Postinstallation configuration > Cluster tasks > [Moving resources to infrastructure machine sets](https://72633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks#moving-resources-to-infrastructure-machinesets_post-install-cluster-tasks)
* Machine management > Managing compute machines with the Machine API > Sample YAML for a compute machine set custom resource on [...] (these should not appear changed, they should not have any infra related content though they share the same source file)
  * [Alibaba Cloud](https://72633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-alibaba#machineset-yaml-alibaba_creating-machineset-alibaba)
  * [AWS](https://72633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws#machineset-yaml-aws_creating-machineset-aws)
  * [Azure](https://72633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure#machineset-yaml-azure_creating-machineset-azure)
  * [Azure Stack Hub](https://72633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure-stack-hub#machineset-yaml-azure-stack-hub_creating-machineset-azure-stack-hub)
  * [GCP](https://72633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp#machineset-yaml-gcp_creating-machineset-gcp)
  * [IBM Cloud](https://72633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-ibm-cloud#machineset-yaml-ibm-cloud_creating-machineset-ibm-cloud)
  * [IBM Power Virtual Server](https://72633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-ibm-power-vs#machineset-yaml-ibm-power-vs_creating-machineset-ibm-power-vs)
  * [Nutanix](https://72633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-nutanix#machineset-yaml-nutanix_creating-machineset-nutanix)
  * [RHOSP](https://72633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-osp#machineset-yaml-osp_creating-machineset-osp)
  * [vSphere](https://72633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-vsphere#machineset-yaml-vsphere_creating-machineset-vsphere)
  * [bare metal](https://72633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-bare-metal#machineset-yaml-vsphere_creating-machineset-bare-metal)
* Machine management > Creating infrastructure machine sets > [Creating infrastructure machine sets for different clouds](https://72633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets#creating-infrastructure-machinesets-clouds) (these should all have the updated infra content in each YAML sample, and this now includes IBM Power VS and bare metal)
* Machine management > Creating infrastructure machine sets > [Moving resources to infrastructure machine sets](https://72633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets#moving-resources-to-infrastructure-machinesets_creating-infrastructure-machinesets)
* Nodes > Working with nodes > [Creating infrastructure nodes](https://72633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-creating-infrastructure-nodes)

QE review:
- [ ] QE has approved this change.

Additional information:
- Fixes infra tolerations to match taints in examples
- Some format updates for docs compliance
- Clarified note about DNS pods
- Converted heading in two assemblies to a module, updated xrefs accordingly
- Removed `<>` from several instances of a verbatim (not a variable)
- Added IBM Power VS and bare metal to infra machine set listing, updated YAML to accommodate
- Moved some remaining taint stanzas to the end for less ifdefs