### PR TITLE
OSDOCS-9821: 4.12.51 RN

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -4567,3 +4567,29 @@ $ oc adm release info 4.12.50 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-12-51"]
+=== RHSA-2024:1052 - {product-title} 4.12.51 bug fix and security update
+
+Issued: 2024-03-06
+
+{product-title} release 4.12.51, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:1052[RHSA-2024:1052] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:1054[RHBA-2024:1054] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.51 --pullspecs
+----
+
+[id="ocp-4-12-51-bug-fixes"]
+==== Bug fixes
+
+* Previously, when the most recent and default channels were selectively mirrored, and a new release introduced a new channel, the current default channel became invalid. This caused the automatic assignment of the new default channel to fail. With this release, you can now define a `defaultChannel` field in the `ImageSetConfig` custom resource (CR) that overrides the `currentDefault` channel. (link:https://issues.redhat.com/browse/OCPBUGS-29232[*OCPBUGS-29232*])
+
+* Previously, the `compat-openssl10` package was included in the Red Hat Enterprise Linux CoreOS (RHCOS). This package did not meet Common Vulnerabilities and Exposures (CVE) remediation requirements for Federal Risk and Authorization Management Program (FedRAMP). With this release, `compat-openssl10` has been removed from the RHCOS. As a result, security scanners will no longer identify potential common vulnerabilities and exposures (CVEs) in this package. Any binary running on the host RHCOS requiring Red Hat Enterprise Linux (RHEL) OpenSSL compatibility must be upgraded to support RHEL8 OpenSSL. (link:https://issues.redhat.com/browse/OCPBUGS-22928[*OCPBUGS-22928*])
+
+[id="ocp-4-12-51-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.12.51

Issue:
https://issues.redhat.com/browse/OSDOCS-9821

Link to docs preview:
https://72641--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes#ocp-4-12-51

QE review:
N/A

Additional information:
Links will return 404 until go-live (2/6/23)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
