### PR TITLE
OSDOCS-9902 Removing OCPBUGS-26573 from 4.14.14 RNs

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3305,11 +3305,6 @@ The following enhancements are included in this z-stream release:
 
 * Previously, the installation program failed to install a cluster on IBM Cloud VPC for the "eu-es" region, although it is supported. With this update, the installation program successfully installs a cluster on IBM Cloud VPC for the "eu-es" region. (link:https://issues.redhat.com/browse/OCPBUGS-19398[*OCPBUGS-19398*])
 
-[id="ocp-4-14-14-IC-updates-troubleshooting"]
-===== Improved troubleshooting for IC updates
-
-* Previously, during an update from {product-title} 4.13 to {product-title} 4.14, a cluster could become stuck while updating to OVN interconnect configmap (IC) during phase 1 or phase 2. With this release, if the update process gets stuck, a cluster admin can edit the IC and add the fast-forward-to-multizone key, which bypasses the two-phase update and applies the final 4.14 YAML files for ovn-kubernetes. (link:https://issues.redhat.com/browse/OCPBUGS-26573[*OCPBUGS-26573*])
-
 [id="ocp-4-14-14-updating"]
 ==== Updating
 


### PR DESCRIPTION
Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-9902](https://issues.redhat.com/browse/OSDOCS-9902)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://72646--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-14-enhancements
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: 
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
Removing https://issues.redhat.com/browse/OCPBUGS-26573 release note from 4.14.14 RNs based on Riccardo Ravaioli and Chris Fields decision via Slack.
Approved for announce-only Change Management by Kathryn Alexander via Slack.
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
