### PR TITLE
OSDOCS-9082: Add restoring cluster state link to troubleshooting docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -723,6 +723,8 @@ Topics:
    # File: recovering-update-before-applied
   - Name: Gathering data about your cluster update
     File: gathering-data-cluster-update
+  - Name: Restoring your cluster to a previous state
+    File: restoring-cluster-previous-state
 ---
 Name: Support
 Dir: support

--- a/updating/troubleshooting_updates/restoring-cluster-previous-state.adoc
+++ b/updating/troubleshooting_updates/restoring-cluster-previous-state.adoc
@@ -1,0 +1,9 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="restoring-cluster-previous-state"]
+= Restoring your cluster to a previous state
+include::_attributes/common-attributes.adoc[]
+:context: restoring-cluster-previous-state
+
+toc::[]
+
+For information on restoring your cluster to a previous state, see xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[Restoring to a previous cluster state].


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-9082](https://issues.redhat.com/browse/OSDOCS-9082)

Link to docs preview:
https://72648--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/troubleshooting_updates/restoring-cluster-previous-state

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
