### PR TITLE
Update rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc

### DIFF
--- a/modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc
+++ b/modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc
@@ -26,11 +26,14 @@ Before using the {product-title} (ROSA) CLI (`rosa`) to create {hcp-title-first}
 ----
 $ rosa create account-roles --hosted-cp
 ----
+** Optional: You can set your prefix as an environmental variable by running the following command:
 +
 [source,terminal]
 ----
-$ ACCOUNT_ROLES_PREFIX="${ACCOUNT_ROLES_PREFIX}"
+$ export ACCOUNT_ROLES_PREFIX="${ACCOUNT_ROLES_PREFIX}"
 ----
++
+Then, you run the following command to create your account roles with the environmental variable providing your prefix:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
`enterprise-4.15+`

Issue:
n\a

Link to docs preview:
- [Creating the account-wide STS roles and policies](https://file.rdu.redhat.com/eponvell/EricPonvelle-patch-2/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html#rosa-sts-creating-account-wide-sts-roles-and-policies_rosa-hcp-sts-creating-a-cluster-quickly)
- [Creating Operator roles and policies](https://file.rdu.redhat.com/eponvell/EricPonvelle-patch-2/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html#rosa-operator-config_rosa-hcp-sts-creating-a-cluster-quickly)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR clarifies the use of environmental variables as well as fixes a command typo.
