### PR TITLE
OCPBUGS#26212: Remove `channel` from spec in SR-IOV CLI installation docs

### DIFF
--- a/modules/nw-sriov-installing-operator.adoc
+++ b/modules/nw-sriov-installing-operator.adoc
@@ -63,7 +63,6 @@ metadata:
   name: sriov-network-operator-subscription
   namespace: openshift-sriov-network-operator
 spec:
-  channel: stable
   name: sriov-network-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OCPBUGS-26212](https://issues.redhat.com/browse/OCPBUGS-26212)

Link to docs preview:
[CLI: Installing the SR-IOV Network Operator](https://72662--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/installing-sriov-operator#install-operator-cli_installing-sriov-operator)

QE review:
- [ ] QE has approved this change.
