### PR TITLE
Added instructions for environmental variables and fixed typos

### DIFF
--- a/modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc
+++ b/modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc
@@ -26,15 +26,18 @@ Before using the {product-title} (ROSA) CLI (`rosa`) to create {hcp-title-first}
 ----
 $ rosa create account-roles --hosted-cp
 ----
+** Optional: Set your prefix as an environmental variable by running the following command:
 +
 [source,terminal]
 ----
-$ ACCOUNT_ROLES_PREFIX="${ACCOUNT_ROLES_PREFIX}"
+$ export ACCOUNT_ROLES_PREFIX="${ACCOUNT_ROLES_PREFIX}"
 ----
++
+Then, run the following command to create your account roles with the environmental variable:
 +
 [source,terminal]
 ----
 $ rosa create account-roles --hosted-cp --prefix $ACCOUNT_ROLES_PREFIX
 ----
-+
+
 For more information regarding AWS managed IAM policies for ROSA, see link:https://docs.aws.amazon.com/ROSA/latest/userguide/security-iam-awsmanpol.html[AWS managed IAM policies for ROSA].

--- a/modules/rosa-operator-config.adoc
+++ b/modules/rosa-operator-config.adoc
@@ -21,14 +21,14 @@ When using a {hcp-title} cluster, you must create the Operator IAM roles that ar
 +
 [source,terminal]
 ----
-$ OPERATOR_ROLES_PREFIX=<prefix_name>
+$ export OPERATOR_ROLES_PREFIX=<prefix_name>
 ----
 . To create your Operator roles, run the following command:
 
 +
 [source,terminal]
 ----
-$ rosa create operator-roles --hosted-cp --prefix $OPERATOR_ROLES_PREFIX --oidc-config-id $OIDC_ID --installer-role-arn arn:aws:iam::${AWS_ACCOUNT_ID}:role/${ACCOUNT_ROLES_PREFIX}-HCP-ROSA-Installer-Role
+$ rosa create operator-roles --hosted-cp --prefix=$OPERATOR_ROLES_PREFIX --oidc-config-id=$OIDC_ID --installer-role-arn arn:aws:iam::${AWS_ACCOUNT_ID}:role/${ACCOUNT_ROLES_PREFIX}-HCP-ROSA-Installer-Role
 ----
 +
 The following breakdown provides options for the Operator role creation.
@@ -36,8 +36,8 @@ The following breakdown provides options for the Operator role creation.
 [source,terminal]
 ----
 $ rosa create operator-roles --hosted-cp
-	--prefix $OPERATOR_ROLES_PREFIX <1>
-	--oidc-config-id $OIDC_ID <2>
+	--prefix=$OPERATOR_ROLES_PREFIX <1>
+	--oidc-config-id=$OIDC_ID <2>
 	--installer-role-arn arn:aws:iam::${AWS_ACCOUNT_ID}:role/${ACCOUNT_ROLES_PREFIX}-HCP-ROSA-Installer-Role <3>
 ----
 +


### PR DESCRIPTION
Version(s):
`enterprise-4.15+`

Issue:
n\a

Link to docs preview:
- [Creating the account-wide STS roles and policies](http://file.rdu.redhat.com/eponvell/ROSA-with-HCP-typos/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html#rosa-sts-creating-account-wide-sts-roles-and-policies_rosa-hcp-sts-creating-a-cluster-quickly)
- [Creating Operator roles and policies](http://file.rdu.redhat.com/eponvell/ROSA-with-HCP-typos/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html#rosa-operator-config_rosa-hcp-sts-creating-a-cluster-quickly)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR clarifies the use of environmental variables as well as fixes a command typo. Fixes #72649