### PR TITLE
[enterprise-4.14] OSDOCS#Correct GCE in-tree migraiton info

### DIFF
--- a/storage/container_storage_interface/persistent-storage-csi-gcp-pd.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-gcp-pd.adoc
@@ -20,10 +20,12 @@ To create CSI-provisioned persistent volumes (PVs) that mount to GCP PD storage 
 
 * *GCP PD driver*: The driver enables you to create and mount GCP PD PVs.
 
-[IMPORTANT]
+ifndef::openshift-dedicated[]
+[NOTE]
 ====
-{product-title} defaults to using the CSI plugin to provision GCP PD storage.
+{product-title} provides automatic migration for the GCE Persistent Disk in-tree volume plugin to its equivalent CSI driver. For more information, see xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration].
 ====
+endif::openshift-dedicated[]
 
 include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
 

--- a/storage/persistent_storage/persistent-storage-gce.adoc
+++ b/storage/persistent_storage/persistent-storage-gce.adoc
@@ -23,17 +23,16 @@ they can be shared across the {product-title} cluster.
 Persistent volume claims are specific to a project or namespace and can be
 requested by users.
 
+ifndef::openshift-dedicated[]
 [IMPORTANT]
 ====
-{product-title} defaults to using an in-tree (non-CSI) plugin to provision gcePD storage.
+{product-title} 4.12 and later provides automatic migration for the GCE Persist Disk in-tree volume plugin to its equivalent CSI driver.
 
-In future {product-title} versions, volumes provisioned using existing in-tree plug-ins are planned for migration to their equivalent CSI driver. CSI automatic migration should be seamless. Migration does not change how you use all existing API objects, such as persistent volumes, persistent volume claims, and storage classes.
-ifndef::openshift-dedicated[]
+CSI automatic migration should be seamless. Migration does not change how you use all existing API objects, such as persistent volumes, persistent volume claims, and storage classes.
+
 For more information about migration, see xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration].
-endif::openshift-dedicated[]
-
-After full migration, in-tree plugins will eventually be removed in future versions of {product-title}.
 ====
+endif::openshift-dedicated[]
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Cherry Picked from 95e62def9c25b97a90fd23ade11acc76743a6627 xref: https://github.com/openshift/openshift-docs/pull/70251

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
