### PR TITLE
[OSDOCS-9897]:Remove "IAM" from role names in required GCP roles doc

### DIFF
--- a/modules/installation-gcp-permissions.adoc
+++ b/modules/installation-gcp-permissions.adoc
@@ -21,8 +21,8 @@ When you attach the `Owner` role to the service account that you create, you gra
 
 .Required roles for the installation program
 * Compute Admin
-* IAM Role Administrator
-* IAM Security Admin
+* Role Administrator
+* Security Admin
 * Service Account Admin
 * Service Account Key Admin
 * Service Account User


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.15+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-9897
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://72678--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account#installation-gcp-permissions_installing-gcp-account
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
Reviewers: Please note that QE has approved updating naming conventions here: https://issues.redhat.com/browse/OSDOCS-9635 / https://github.com/openshift/openshift-docs/pull/72303
<!--- Optional: Include additional context or expand the description here.--->
![image](https://github.com/openshift/openshift-docs/assets/122639474/74224a01-315a-4d09-85df-5640ba6d5423)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
