### PR TITLE
OCPBUGS#29704: update page intro edits

### DIFF
--- a/updating/updating_a_cluster/updating-cluster-cli.adoc
+++ b/updating/updating_a_cluster/updating-cluster-cli.adoc
@@ -17,7 +17,7 @@ WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to 
 To do: Remove this comment once 4.13 docs are EOL.
 ////
 
-You can update, or upgrade, an {product-title} cluster within a minor version by using the OpenShift CLI (`oc`). You can also update a cluster between minor versions by following the same instructions.
+You can perform minor version and patch updates on an {product-title} cluster by using the OpenShift CLI (`oc`).
 
 == Prerequisites
 

--- a/updating/updating_a_cluster/updating-cluster-rhel-compute.adoc
+++ b/updating/updating_a_cluster/updating-cluster-rhel-compute.adoc
@@ -12,7 +12,7 @@ WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to 
 To do: Remove this comment once 4.13 docs are EOL.
 ////
 
-You can update an {product-title} cluster. If your cluster contains {op-system-base-full} machines, you must perform more steps to update those machines.
+You can perform minor version and patch updates on an {product-title} cluster. If your cluster contains {op-system-base-full} machines, you must take additional steps to update those machines.
 
 == Prerequisites
 

--- a/updating/updating_a_cluster/updating-cluster-web-console.adoc
+++ b/updating/updating_a_cluster/updating-cluster-web-console.adoc
@@ -12,7 +12,7 @@ WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to 
 To do: Remove this comment once 4.13 docs are EOL.
 ////
 
-You can update, or upgrade, an {product-title} cluster by using the web console. The following steps update a cluster within a minor version. You can use the same instructions for updating a cluster between minor versions.
+You can perform minor version and patch updates on an {product-title} cluster by using the web console.
 
 [NOTE]
 ====


### PR DESCRIPTION
[OCPBUGS-29704](https://issues.redhat.com/browse/OCPBUGS-29704)

Versions: 4.12+ (note to merge reviewer: auto cherry picks to 4.12 and 4.13 may fail)

This PR rewords/simplifies the introductions to a few of the Updating clusters assemblies.

QE review:
- [x] QE has approved this change.

Preview:

- [Updating a cluster using the CLI](https://72683--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-cluster-cli)
- [Updating a cluster using the web console](https://72683--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-cluster-web-console)
- [Updating a cluster that includes RHEL compute machines](https://72683--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-cluster-rhel-compute)
