### PR TITLE
RHDEVDOCS 5949 fix redirects for Standalone for a few versions

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -294,7 +294,7 @@ AddType text/vtt                            vtt
 
     # Pipelines landing page
 
-    RewriteRule ^container-platform/(4\.9|4\.10|4\.11|4\.12|4\.13|4\.14|4\.15|4.16\4.17\4.18)/cicd/pipelines/about-pipelines.html /pipelines/latest/about/about-pipelines.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.9|4\.10|4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/pipelines/about-pipelines.html /pipelines/latest/about/about-pipelines.html [NE,R=302]
 
     # redirect links to existing OCP embedded Pipelines content to standalone equivalent for each assembly
     # except the one recently renamed for now

--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -239,7 +239,7 @@ AddType text/vtt                            vtt
     RewriteRule ^(rosa|dedicated)/serverless/serverless-release-notes.html$ /serverless/1.31/about/serverless-release-notes.html [L,R=302]
 
     # redirect any links to existing OCP embedded content to standalone equivalent
-    RewriteRule ^container-platform/(4\.10|4\.11|4\.12|4\.13|4\.14)/serverless/?(.*)$ /serverless/1.31/$2  [L,R=302]
+    RewriteRule ^container-platform/(4\.10|4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/serverless/?(.*)$ /serverless/1.31/$2  [L,R=302]
 
     # redirect any links to existing ROSA/Dedicated embedded content to standalone equivalent
     RewriteRule ^(rosa|dedicated)/serverless/?(.*)$ /serverless/1.31/$2  [L,R=302]
@@ -252,7 +252,7 @@ AddType text/vtt                            vtt
     RewriteRule ^builds/(1\.0)/?$ /builds/$1/about/overview-openshift-builds.html  [L,R=302]
 
     # Builds using Shipwright landing page
-    RewriteRule ^container-platform/(4\.14|4\.15)/cicd/builds_using_shipwright/overview-openshift-builds.html /builds/latest/about/overview-openshift-builds.html  [L,R=302]
+    RewriteRule ^container-platform/(4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/builds_using_shipwright/overview-openshift-builds.html /builds/latest/about/overview-openshift-builds.html  [L,R=302]
 
     # redirect gitops latest to 1.11
     RewriteRule ^gitops/?$ /gitops/latest [R=302]
@@ -262,7 +262,7 @@ AddType text/vtt                            vtt
     RewriteRule ^gitops/(1\.8|1\.9|1\.10|1\.11)/?$ /gitops/$1/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]
 
     # GitOps landing page
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/about-redhat-openshift-gitops.html /gitops/latest/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/about-redhat-openshift-gitops.html /gitops/latest/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]
 
     # redirect any links to existing OCP embedded content to standalone equivalent for each assembly
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/gitops-release-notes.html/ /gitops/latest/release_notes/gitops-release-notes.html  [L,R=302]
@@ -294,7 +294,7 @@ AddType text/vtt                            vtt
 
     # Pipelines landing page
 
-    RewriteRule ^container-platform/(4\.9|4\.10|4\.11|4\.12|4\.13|4\.14)/cicd/pipelines/about-pipelines.html /pipelines/latest/about/about-pipelines.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.9|4\.10|4\.11|4\.12|4\.13|4\.14|4\.15|4.16\4.17\4.18)/cicd/pipelines/about-pipelines.html /pipelines/latest/about/about-pipelines.html [NE,R=302]
 
     # redirect links to existing OCP embedded Pipelines content to standalone equivalent for each assembly
     # except the one recently renamed for now


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
main only

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
RHDEVDOCS 5949

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

This PR extends existing redirects for landing pages of Pipelines, GitOps, Builds, and Serverless not only go OCP 4.15 but also to future OCP versions up to 4.18

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
