### PR TITLE
[SRVKE-1479] Add docs on Kafka broker's templates config

### DIFF
--- a/eventing/tuning/overriding-config-eventing.adoc
+++ b/eventing/tuning/overriding-config-eventing.adoc
@@ -24,6 +24,7 @@ All Knative Serving deployments define a readiness and a liveness probe by defau
 ====
 
 include::modules/knative-eventing-CR-system-deployments.adoc[leveloffset=+1]
+include::modules/knative-eventing-modifying-consumer-group-ids-and-topic-names.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/knative-eventing-modifying-consumer-group-ids-and-topic-names.adoc
+++ b/modules/knative-eventing-modifying-consumer-group-ids-and-topic-names.adoc
@@ -1,0 +1,63 @@
+// Module included in the following assemblies:
+//
+// * serverless/eventing/tuning/overriding-config-eventing.adoc
+
+:_content-type: PROCEDURE
+[id="knative-eventing-modifying-consumer-group-ids-and-topic-names_{context}"]
+= Modifying consumer group IDs and topic names
+
+You can change templates for generating consumer group IDs and topic names used by your triggers, brokers, and channels.
+
+.Prerequisites
+
+* You have cluster or dedicated administrator permissions on {ocp-product-title}.
+* The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource (CR) are installed on your {ocp-product-title} cluster.
+* You have created a project or have access to a project that has the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
+* You have installed the OpenShift CLI (`oc`).
+
+.Procedure
+
+. To change templates for generating consumer group IDs and topic names used by your triggers, brokers, and channels, modify the `KnativeKafka` resource:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: KnativeKafka
+metadata:
+  name: knative-kafka
+  namespace: knative-eventing
+# ...
+spec:
+  config:
+    config-kafka-features:
+      triggers.consumergroup.template: <template> <1>
+      brokers.topic.template: <template> <2>
+      channels.topic.template: <template> <3>
+----
+<1> The template for generating the consumer group ID used by your triggers. Use a valid Go `text/template` value. Defaults to `{% raw %}"knative-trigger-{{ .Namespace }}-{{ .Name }}"{% endraw %}`.
+<2> The template for generating Kafka topic names used by your brokers. Use a valid Go `text/template` value. Defaults to `{% raw %}"knative-broker-{{ .Namespace }}-{{ .Name }}"{% endraw %}`.
+<3> The template for generating Kafka topic names used by your channels. Use a valid Go `text/template` value. Defaults to `{% raw %}"messaging-kafka.{{ .Namespace }}.{{ .Name }}"{% endraw %}`.
++
+.Example template configuration
+[source,yaml]
+----
+apiVersion: v1
+kind: KnativeKafka
+metadata:
+  name: knative-kafka
+  namespace: knative-eventing
+# ...
+spec:
+  config:
+    config-kafka-features:
+      triggers.consumergroup.template: "{% raw %}"knative-trigger-{{ .Namespace }}-{{ .Name }}-{{ .annotations.my-annotation }}"{% endraw %}"
+      brokers.topic.template: "{% raw %}"knative-broker-{{ .Namespace }}-{{ .Name }}-{{ .annotations.my-annotation }}"{% endraw %}"
+      channels.topic.template: "{% raw %}"messaging-kafka.{{ .Namespace }}.{{ .Name }}-{{ .annotations.my-annotation }}"{% endraw %}"
+----
+
+. Apply the `KnativeKafka` YAML file:
++
+[source,yaml]
+----
+$ oc apply -f <knative_kafka_filename>
+----


### PR DESCRIPTION
Version(s):
`serverless-docs-1.32`+

Issue:
https://issues.redhat.com/browse/SRVKE-1479

Link to docs preview:
https://72688--ocpdocs-pr.netlify.app/openshift-serverless/latest/eventing/tuning/overriding-config-eventing#knative-eventing-modifying-consumer-group-IDs-and-topic-names_overriding-config-eventing

QE review:
- [ ] QE has approved this change.