### PR TITLE
OCPBUGS-23231: Added eu-es to IBM Cloud supported regions

### DIFF
--- a/modules/installation-ibm-cloud-regions.adoc
+++ b/modules/installation-ibm-cloud-regions.adoc
@@ -30,10 +30,16 @@ ifdef::ibm-vpc[]
 * `ca-tor` (Toronto, Canada)
 * `eu-de` (Frankfurt, Germany)
 * `eu-gb` (London, United Kingdom)
+* `eu-es` (Madrid, Spain)
 * `jp-osa` (Osaka, Japan)
 * `jp-tok` (Tokyo, Japan)
 * `us-east` (Washington DC, United States)
 * `us-south` (Dallas, United States)
+
+[NOTE]
+====
+Deploying your cluster in the `eu-es` (Madrid, Spain) region is not supported for {product-title} 4.14.6 and earlier versions.
+====
 endif::ibm-vpc[]
 ifdef::ibm-power-vs[]
 


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OCPBUGS-23231](https://issues.redhat.com/browse/OCPBUGS-23231)

Link to docs preview:
[Supported IBM Cloud regions](https://72692--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-account.html#installation-ibm-cloud-regions_installing-ibm-cloud-account)

- [x] QE has approved this change.
- [x] SME has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
