### PR TITLE
[INTERNAL FIX] contrib-doc-col-operator: Added doc_guidelines.adoc entry for table s…

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -2128,6 +2128,18 @@ Do _not_ delete the file.
 a|
 > Do _not_ delete the file.
 
+|Table style operators
+
+|A style operator styles the content of a table cell or a table column, depending on where you set the operator. Using the literal (`l`) operator in a column might impact the documentation platform's copy and paste functionality. For example, when you paste copied code block content to a location, the first styled literal value in an assembly is pasted instead of the intended code block. To avoid this issue, use the monospace (`m`) style operator. When using any style operator in a table, check all copy and paste functions that follow the defined style operator work correctly for all code blocks in an assembly.
+
+See link:https://docs.asciidoctor.org/asciidoc/latest/tables/format-cell-content/[Cell styles and their operators] (Asciidoctor Documentation)
+
+a|
+----
+.Required parameters
+[cols=".^2m,.^3,.^5a",options="header"]
+----
+
 |Footnotes
 
 |A footnote is created with the footnote macro. If you plan to reference a footnote more than once, use the ID footnoteref macro. The Customer Portal does not support spaces in the footnoteref. For example, "dynamic PV" should be "dynamicPV".


### PR DESCRIPTION
Fix stemmed from https://github.com/openshift/openshift-docs/pull/72388 and was mentioned in the latest OCP team call.

Version(s):
main

Issue:
[OCPBUGS-20158](https://issues.redhat.com/browse/OCPBUGS-20158) - Reference Jira that prompted this guidance update.

Link to docs preview:
[Quick markup reference:Table style operators](https://file.emea.redhat.com/dfitzmau/contrib-doc-col-operators/doc_guidelines.html#:~:text=Table%20style%20operators)
