### PR TITLE
OCPBUGS-29262: Updated the vSphere add parameters to include more

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -300,8 +300,7 @@ endif::agent,bare[]
 |networking:
   clusterNetwork:
     cidr:
-|
-Required if you use `networking.clusterNetwork`. An IP address block.
+|Required if you use `networking.clusterNetwork`. An IP address block.
 
 ifndef::agent,bare[]
 An IPv4 network.
@@ -2642,44 +2641,40 @@ ifdef::agent,vsphere[]
 Additional VMware vSphere configuration parameters are described in the following table:
 
 .Additional VMware vSphere cluster parameters
-[cols=".^2l,.^3a,.^3",options="header,word-wrap",subs="+quotes,+attributes"]
+[cols=".^2l,.^2,.^1",options="header,word-wrap",subs="quotes,attributes"]
 |====
 |Parameter|Description|Values
-ifdef::agent[]
 
 |platform:
   vsphere:
-| Describes your account on the cloud platform that hosts your cluster. You can use the parameter to customize the platform. If you provide additional configuration settings for compute and control plane machines in the machine pool, the parameter is not required. You can only specify one vCenter server for your {product-title} cluster.
+|Describes your account on the cloud platform that hosts your cluster.
+You can use the parameter to customize the platform. If you provide additional configuration
+settings for compute and control plane machines in the machine pool,
+the parameter is not required. You can only specify one vCenter server for your {product-title} cluster.
 |A dictionary of vSphere configuration objects
-endif::agent[]
-ifdef::vsphere[]
 
+ifdef::vsphere[]
 |platform:
   vsphere:
     apiVIPs:
 |Virtual IP (VIP) addresses that you configured for control plane API access.
-
 *Note:* This parameter applies only to installer-provisioned infrastructure.
 |Multiple IP addresses
 
 |platform:
   vsphere:
     diskType:
-|Optional. The disk provisioning method. This value defaults to the vSphere default storage policy if not set.
+|Optional. The disk provisioning method. This value defaults to the vSphere
+default storage policy if not set.
 |Valid values are `thin`, `thick`, or `eagerZeroedThick`.
-
-|platform:
-  vsphere:
-    failureDomains:
-|Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
-|String
 endif::vsphere[]
-ifdef::agent[]
 
 |platform:
   vsphere:
     failureDomains:
-|Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
+|Establishes the relationships between a region and zone. You define a
+failure domain by using vCenter objects, such as a `datastore` object.
+A failure domain defines the vCenter location for {product-title} cluster nodes.
 |An array of failure domain configuration objects.
 
 |platform:
@@ -2692,27 +2687,30 @@ ifdef::agent[]
 |platform:
   vsphere:
     failureDomains:
+      region:
+|If you define multiple failure domains for your cluster, you must attach
+the tag to each vCenter datacenter. To define a region, use a tag from the
+ `openshift-region` tag category. For a single vSphere datacenter environment,
+ you do not need to attach a tag, but you must enter an alphanumeric value, such as `datacenter`, for the parameter.
+|String
+
+|platform:
+  vsphere:
+    failureDomains:
       server:
 |The fully qualified domain name (FQDN) of the vCenter server.
 |An FQDN such as example.com
-endif::agent[]
 
 |platform:
   vsphere:
     failureDomains:
-      topology:
-        datastore:
-|Specifies the path to a vSphere datastore that stores virtual machines files for a failure domain. You must apply the `datastore` role to the vSphere vCenter datastore location.
+      template:
+|Specify the absolute path to a pre-existing {op-system-first} image template or virtual machine.
+The installation program can use the image template or virtual machine
+to quickly install {op-system} on vSphere hosts. Consider using this
+parameter as an alternative to uploading an {op-system} image on vSphere hosts.
+The parameter is available for use only on installer-provisioned infrastructure.
 |String
-
-|platform:
-  vsphere:
-    failureDomains:
-      topology:
-        networks:
-|Lists any network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured.
-|String
-ifdef::agent[]
 
 |platform:
   vsphere:
@@ -2737,70 +2735,87 @@ The list of datacenters must match the list of datacenters specified in the `vce
       topology:
         datastore:
 |The path to the vSphere datastore that holds virtual machine files, templates, and ISO images.
-[IMPORTANT]
-====
+
 You can specify the path of any datastore that exists in a datastore cluster.
 By default, Storage vMotion is automatically enabled for a datastore cluster.
-Red{nbsp}Hat does not support Storage vMotion, so you must disable Storage vMotion to avoid data loss issues for your {product-title} cluster.
-
-If you must specify VMs across multiple datastores, use a `datastore` object to specify a failure domain in your cluster's `install-config.yaml` configuration file.
+If you must specify VMs across multiple datastores, use a `datastore` object to
+specify a failure domain in your cluster's `install-config.yaml` configuration file.
 For more information, see "VMware vSphere region and zone enablement".
-====
+
+**Important:** Red{nbsp}Hat does not support Storage vMotion, so you must disable Storage vMotion to avoid data loss issues for your {product-title} cluster.
 |String
 
-|platform:
-  vsphere:
-    failureDomains:
-      topology:
-        resourcePool:
-// When this content is added to vSphere docs, the line below should likely say "where the installation program creates the virtual machines".
-|Optional: The absolute path of an existing resource pool where the user creates the virtual machines, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
-// Commenting out the line below because it doesn't apply to Agent, but it may be needed when this content is brought into the regular vSphere docs.
-// If you do not specify a value, resources are installed in the root of the cluster, for example `/example_datacenter/host/example_cluster/Resources`.
-|String
-
+ifdef::agent[]
 |platform:
   vsphere:
     failureDomains:
       topology:
         folder:
-// When this content is added to vSphere docs, the line below should likely say "where the installation program creates the virtual machines", and should be Optional.
-|The absolute path of an existing folder where the user creates the virtual machines, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
-// Commenting out the two lines below because they don't apply to Agent, but they may be needed when this content is brought into the regular vSphere docs.
-// If you do not provide this value, the installation program creates a top-level folder in the datacenter virtual machine folder that is named with the infrastructure ID.
-// If you are providing the infrastructure for the cluster and you do not want to use the default `StorageClass` object, named `thin`, you can omit the `folder` parameter from the `install-config.yaml` file.
+|The absolute path of an existing folder where the user creates the virtual machines,
+for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
 |String
 endif::agent[]
+ifdef::vsphere[]
+|platform:
+  vsphere:
+    failureDomains:
+      topology:
+        folder:
+|Optional parameter. The absolute path of an existing folder
+where the installation program creates the virtual machines,
+for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
+
+If you do not provide this value, the installation program creates a top-level folder
+in the datacenter virtual machine folder that is named with the infrastructure ID.
+If you are providing the infrastructure for the cluster and you do not want to
+use the default `StorageClass` object, named `thin`, you can omit the `folder`
+parameter from the `install-config.yaml` file.
+|String
+endif::vsphere[]
 
 |platform:
   vsphere:
     failureDomains:
-      server:
-|Specifies the fully-qualified hostname or IP address of the VMware vCenter server, so that a client can access failure domain resources. You must apply the `server` role to the vSphere vCenter server location.
+      topology:
+        networks:
+|Lists any network in the vCenter instance that contains the virtual IP
+addresses and DNS records that you configured.
 |String
 
+ifdef::agent[]
 |platform:
   vsphere:
     failureDomains:
-      region:
-|If you define multiple failure domains for your cluster, you must attach the tag to each vCenter datacenter. To define a region, use a tag from the `openshift-region` tag category. For a single vSphere datacenter environment, you do not need to attach a tag, but you must enter an alphanumeric value, such as `datacenter`, for the parameter.
+      topology:
+        resourcePool:
+|Optional parameter. The absolute path of an existing resource pool where the
+user creates the virtual machines, for example,
+`/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
 |String
+endif::agent[]
+ifdef::vsphere[]
+|platform:
+  vsphere:
+    failureDomains:
+      topology:
+        resourcePool:
+|Optional parameter. The absolute path of an existing resource pool where the installation program
+ creates the virtual machines, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.If you do not specify a value,
+ resources are installed in the root of the cluster, for example `/example_datacenter/host/example_cluster/Resources`.
+|String
+endif::vsphere[]
 
 |platform:
   vsphere:
     failureDomains:
       zone:
-|If you define multiple failure domains for your cluster, you must attach the tag to each vCenter cluster. To define a zone, use a tag from the `openshift-zone` tag category. For a single vSphere datacenter environment, you do not need to attach a tag, but you must enter an alphanumeric value, such as `cluster`, for the parameter.
+|If you define multiple failure domains for your cluster, you must attach the tag to
+each vCenter cluster. To define a zone, use a tag from the `openshift-zone` tag category.
+For a single vSphere datacenter environment, you do not need to attach a tag,
+but you must enter an alphanumeric value, such as `cluster`, for the parameter.
 |String
 
-|platform:
-  vsphere:
-    failureDomains:
-      template:
-|Specify the absolute path to a pre-existing {op-system-first} image template or virtual machine. The installation program can use the image template or virtual machine to quickly install {op-system} on vSphere hosts. Consider using this parameter as an alternative to uploading an {op-system} image on vSphere hosts. The parameter is available for use only on installer-provisioned infrastructure.
-|String
 ifdef::vsphere[]
-
 |platform:
   vsphere:
     ingressVIPs:
@@ -2808,19 +2823,7 @@ ifdef::vsphere[]
 
 *Note:* This parameter applies only to installer-provisioned infrastructure.
 |Multiple IP addresses
-
-|platform:
-  vsphere:
-| Describes your account on the cloud platform that hosts your cluster. You can use the parameter to customize the platform. When providing additional configuration settings for compute and control plane machines in the machine pool, the parameter is optional. You can only specify one vCenter server for your {product-title} cluster.
-|String
-
-|platform:
-  vsphere:
-    vcenters:
-|Lists any fully-qualified hostname or IP address of a vCenter server.
-|String
 endif::vsphere[]
-ifdef::agent[]
 
 |platform:
   vsphere:
@@ -2828,15 +2831,14 @@ ifdef::agent[]
 |Configures the connection details so that services can communicate with vCenter.
 Currently, only a single vCenter is supported.
 |An array of vCenter configuration objects.
-endif::agent[]
 
 |platform:
   vsphere:
     vcenters:
       datacenters:
-|Lists and defines the datacenters where {product-title} virtual machines (VMs) operate. The list of datacenters must match the list of datacenters specified in the `failureDomains` field.
+|Lists and defines the datacenters where {product-title} virtual machines (VMs) operate.
+The list of datacenters must match the list of datacenters specified in the `failureDomains` field.
 |String
-ifdef::agent[]
 
 |platform:
   vsphere:
@@ -2865,7 +2867,6 @@ ifdef::agent[]
       user:
 |The username associated with the vSphere user.
 |String
-endif::agent[]
 |====
 
 [id="deprecated-parameters-vsphere_{context}"]
@@ -2876,7 +2877,7 @@ In {product-title} 4.13, the following vSphere configuration parameters are depr
 The following table lists each deprecated vSphere configuration parameter:
 
 .Deprecated VMware vSphere cluster parameters
-[cols=".^2l,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
+[cols=".^2m,.^3,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
 |====
 |Parameter|Description|Values
 ifdef::vsphere[]
@@ -2905,7 +2906,7 @@ endif::vsphere[]
 |platform:
   vsphere:
     defaultDatastore:
-|The name of the default datastore to use for provisioning volumes.
+    |The name of the default datastore to use for provisioning volumes.
 |String
 
 |platform:
@@ -2915,7 +2916,6 @@ endif::vsphere[]
 |String, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
 
 ifdef::vsphere[]
-
 |platform:
   vsphere:
     ingressVIP:
@@ -2966,7 +2966,7 @@ ifdef::vsphere[]
 Optional VMware vSphere machine pool configuration parameters are described in the following table:
 
 .Optional VMware vSphere machine pool parameters
-[cols=".^2l,.^3a,.^3a",options="header"]
+[cols=".^2m,.^3a,.^1a",options="header,word-wrap"]
 |====
 |Parameter|Description|Values
 
@@ -3297,7 +3297,7 @@ If defined, the parameters `compute.platform.alibabacloud` and `controlPlane.pla
 endif::alibaba-cloud[]
 
 ifdef::nutanix[]
-[id="installation-configuration-parameters-additional-vsphere_{context}"]
+[id="installation-configuration-parameters-additional-nutanix_{context}"]
 == Additional Nutanix configuration parameters
 
 Additional Nutanix configuration parameters are described in the following table:


### PR DESCRIPTION
Version(s):
4.12 to 4.16

Issue:
[OCPBUGS-29262](https://issues.redhat.com/browse/OCPBUGS-29262)

Link to docs preview:
[Additional VMware vSphere configuration parameters](https://72733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere#installation-configuration-parameters-additional-vsphere_installation-config-parameters-vsphere)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* https://github.com/openshift/openshift-docs/pull/70551#issuecomment-1930706031
