### PR TITLE
OCPBUGS-30311: Remove unused IPsec config from Butane

### DIFF
--- a/modules/nw-ovn-ipsec-north-south-enable.adoc
+++ b/modules/nw-ovn-ipsec-north-south-enable.adoc
@@ -67,7 +67,7 @@ spec:
 <2> Specifies the name of the interface to create on the host.
 <3> Specifies the host name of the cluster node that terminates the IPsec tunnel on the cluster side. The name should match SAN `[Subject Alternate Name]` from your supplied PKCS#12 certificates.
 <4> Specifies the external host name, such as `host.example.com`. The name should match the SAN `[Subject Alternate Name]` from your supplied PKCS#12 certificates.
-<5> Specifies the IP address of the external host, such as `10.1.2.3.4/32`.
+<5> Specifies the IP address of the external host, such as `10.1.2.3/32`.
 
 .Example NMState IPsec tunnel configuration
 [source,yaml]
@@ -100,7 +100,7 @@ spec:
 <2> Specifies the name of the interface to create on the host.
 <3> Specifies the host name of the cluster node that terminates the IPsec tunnel on the cluster side. The name should match SAN `[Subject Alternate Name]` from your supplied PKCS#12 certificates.
 <4> Specifies the external host name, such as `host.example.com`. The name should match the SAN `[Subject Alternate Name]` from your supplied PKCS#12 certificates.
-<5> Specifies the IP address of the external host, such as `10.1.2.3.4/32`.
+<5> Specifies the IP address of the external host, such as `10.1.2.3/32`.
 --
 
 .. To configure the IPsec interface, enter the following command:
@@ -117,9 +117,9 @@ $ oc create -f ipsec-config.yaml
 * `ca.pem`: The certificate authority that you signed your certificates with
 --
 
-. Create a machine config to apply the IPsec configuration to your cluster by using the following two steps:
+. Create a machine config to add your certificates to the cluster:
 
-.. To add the IPsec configuration, create Butane config files for the control plane and worker nodes with the following contents:
+.. To create Butane config files for the control plane and worker nodes, enter the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
@@ -128,7 +128,7 @@ $ for role in master worker; do
   variant: openshift
   version: {product-version}.0
   metadata:
-    name: 99-$\{role}-import-certs-enable-svc-os-ext
+    name: 99-$\{role}-import-certs
     labels:
       machineconfiguration.openshift.io/role: $role
   systemd:
@@ -150,11 +150,6 @@ $ for role in master worker; do
         WantedBy=multi-user.target
   storage:
     files:
-    - path: /etc/ipsec.d/ipsec-endpoint-config.conf
-      mode: 0400
-      overwrite: true
-      contents:
-        local: ipsec-endpoint-config.conf
     - path: /etc/pki/certs/ca.pem
       mode: 0400
       overwrite: true


### PR DESCRIPTION
- https://issues.redhat.com/browse/OCPBUGS-30311

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Configuring IPsec encryption for external traffic](https://72734--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn#nw-ovn-ipsec-north-south-enable_configuring-ipsec-ovn)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
