### PR TITLE
Add GitOps argocd CLI topic to the CLI tools section

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -904,6 +904,9 @@ Topics:
     File: op-configuring-tkn
   - Name: Basic tkn commands
     File: op-tkn-reference
+- Name: GitOps CLI (argocd) for use with OpenShift GitOps
+  File: gitops-argocd-cli-tools
+  Distros: openshift-enterprise
 - Name: opm CLI
   Dir: opm
   Distros: openshift-enterprise,openshift-origin

--- a/cli_reference/gitops-argocd-cli-tools.adoc
+++ b/cli_reference/gitops-argocd-cli-tools.adoc
@@ -1,0 +1,23 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="gitops-argocd-cli-tools"]
+= {gitops-shortname} CLI for use with {gitops-title}
+:context: gitops-argocd-cli-tools
+
+toc::[]
+
+The {gitops-shortname} `argocd` CLI is a tool for configuring and managing {gitops-title} and Argo CD resources from a terminal.
+
+With the {gitops-shortname} CLI, you can make {gitops-shortname} computing tasks simple and concise. You can install this CLI tool on different platforms.
+
+
+[id="installing-argocd-gitops-cli"]
+== Installing the {gitops-shortname} CLI
+
+See link:https://docs.openshift.com/gitops/latest/installing_gitops/installing-argocd-gitops-cli[Installing the {gitops-shortname} CLI].
+
+[id="additional-resources_gitops-argocd-cli-tools"]
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://docs.openshift.com/gitops/latest/understanding_openshift_gitops/what-is-gitops.html#what-is-gitops[What is GitOps?]


### PR DESCRIPTION
**PR for GitOps layered product release. Do not merge until this date: Release date target March 14.**

Jira issue : [RHDEVDOCS-5950](https://issues.redhat.com/browse/RHDEVDOCS-5950)

Aligned team: DevTools 
Cherry-pick to versions: 4.12+

Docs preview: [GitOps CLI for use with Red Hat OpenShift GitOps](https://72735--ocpdocs-pr.netlify.app/openshift-enterprise/latest/cli_reference/gitops-argocd-cli-tools)

**Note to reviewers:** The link to the **Installing the GitOps CLI** section is correct, but will work only when the redirect PR is merged for 1.12 as part of the issue https://issues.redhat.com/browse/RHDEVDOCS-5804 at the time of GA.

SME review: @anandf

QE review: @varshab1210 

Peer review: Michael Burke

Additional information: This PR is related to #72634. Please review and approve them together. TY!
