### PR TITLE
OCPBUGS-29899: Remove migration to OpenShift SDN

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1474,10 +1474,6 @@ Topics:
   Topics:
   - Name: About the OpenShift SDN network plugin
     File: about-openshift-sdn
-  - Name: Migrating to the OpenShift SDN network plugin
-    File: migrate-to-openshift-sdn
-  - Name: Rolling back to the OVN-Kubernetes network plugin
-    File: rollback-to-ovn-kubernetes
   - Name: Configuring egress IPs for a project
     File: assigning-egress-ips
     Distros: openshift-origin,openshift-enterprise


### PR DESCRIPTION
- https://issues.redhat.com/browse/OCPBUGS-29899

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://72738--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/about-openshift-sdn

This removes the entry from the _topic map:

> Migrating to the OpenShift SDN network plugin
> Rolling back to the OVN-Kubernetes network plugin

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
