### PR TITLE
Updating machine set content to reference 'infrastructure name'

### DIFF
--- a/modules/cpmso-creating-cr.adoc
+++ b/modules/cpmso-creating-cr.adoc
@@ -13,6 +13,15 @@ To use the control plane machine set, you must ensure that a `ControlPlaneMachin
 For more information about the structure and parameters of the CR, see "Control plane machine set configuration".
 ====
 
+In the following example, you can obtain some of the values for your cluster by using the OpenShift CLI.
+
+Infrastructure name:: The `<infrastructure_name>` string is the infrastructure name that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure name by running the following command:
++
+[source,terminal]
+----
+$ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
+----
+
 .Procedure
 
 . Create a YAML file using the following template:
@@ -30,34 +39,29 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <cluster_id> <1>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_name> # <1>
       machine.openshift.io/cluster-api-machine-role: master
       machine.openshift.io/cluster-api-machine-type: master
-  state: Active <2>
+  state: Active # <2>
   strategy:
-    type: RollingUpdate <3>
+    type: RollingUpdate # <3>
   template:
     machineType: machines_v1beta1_machine_openshift_io
     machines_v1beta1_machine_openshift_io:
       failureDomains:
-        platform: <platform> <4>
-        <platform_failure_domains> <5>
+        platform: <platform> # <4>
+        <platform_failure_domains> # <5>
       metadata:
         labels:
-          machine.openshift.io/cluster-api-cluster: <cluster_id> <6>
+          machine.openshift.io/cluster-api-cluster: <infrastructure_name> # <6>
           machine.openshift.io/cluster-api-machine-role: master
           machine.openshift.io/cluster-api-machine-type: master
       spec:
         providerSpec:
           value:
-            <platform_provider_spec> <7>
+            <platform_provider_spec> # <7>
 ----
-<1> Specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. You must specify this value when you create a `ControlPlaneMachineSet` CR. If you have the OpenShift CLI (`oc`) installed, you can obtain the infrastructure ID by running the following command:
-+
-[source,terminal]
-----
-$ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
-----
+<1> Specify the infrastructure name that is based on the cluster ID that you set when you provisioned the cluster. You must specify this value when you create a `ControlPlaneMachineSet` CR.
 <2> Specify the state of the Operator. When the state is `Inactive`, the Operator is not operational. You can activate the Operator by setting the value to `Active`.
 +
 [IMPORTANT]
@@ -67,7 +71,7 @@ Before you activate the CR, you must ensure that its configuration is correct fo
 <3> Specify the update strategy for the cluster. Valid values are `OnDelete` and `RollingUpdate`. The default value is `RollingUpdate`. For more information about update strategies, see "Updating the control plane configuration".
 <4> Specify your cloud provider platform name. Valid values are `AWS`, `Azure`, `GCP`, `Nutanix`, `VSphere`, and `OpenStack`.
 <5> Add the `<platform_failure_domains>` configuration for the cluster. The format and values of this section are provider-specific. For more information, see the sample failure domain configuration for your cloud provider.
-<6> Specify the infrastructure ID.
+<6> Specify the infrastructure name.
 <7> Add the `<platform_provider_spec>` configuration for the cluster. The format and values of this section are provider-specific. For more information, see the sample provider specification for your cloud provider.
 --
 

--- a/modules/cpmso-limitations.adoc
+++ b/modules/cpmso-limitations.adoc
@@ -24,10 +24,10 @@ $ oc get machine \
 .Example output showing preexisting control plane machines
 [source,text]
 ----
-NAME                    PHASE     TYPE         REGION      ZONE         AGE
-<cluster_id>-master-0   Running   m6i.xlarge   us-west-1   us-west-1a   5h19m
-<cluster_id>-master-1   Running   m6i.xlarge   us-west-1   us-west-1b   5h19m
-<cluster_id>-master-2   Running   m6i.xlarge   us-west-1   us-west-1a   5h19m
+NAME                             PHASE     TYPE         REGION      ZONE         AGE
+<infrastructure_name>-master-0   Running   m6i.xlarge   us-west-1   us-west-1a   5h19m
+<infrastructure_name>-master-1   Running   m6i.xlarge   us-west-1   us-west-1b   5h19m
+<infrastructure_name>-master-2   Running   m6i.xlarge   us-west-1   us-west-1a   5h19m
 ----
 +
 .Example output missing preexisting control plane machines

--- a/modules/cpmso-openstack-ts-root-volume-azs.adoc
+++ b/modules/cpmso-openstack-ts-root-volume-azs.adoc
@@ -24,12 +24,19 @@ To understand why this procedure is necessary, see link:https://access.redhat.co
 +
 [source,terminal]
 ----
-$ oc edit machine/<cluster_id>-master-0 -n openshift-machine-api
+$ oc edit machine/<infrastructure_name>-master-0 -n openshift-machine-api
 ----
 +
 where:
 +
-`<cluster_id>`:: Specifies the ID of the upgraded cluster.
+`<infrastructure_name>`:: Specifies the infrastructure name of the upgraded cluster.
++
+If you have the OpenShift CLI (`oc`) installed, you can obtain the infrastructure name by running the following command:
++
+[source,terminal]
+----
+$ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
+----
 
 . In the provider spec, set the value of the property `rootVolume.availabilityZone` to the volume of the availability zone you want to use.
 +
@@ -53,22 +60,22 @@ providerSpec:
     - filter: {}
       subnets:
       - filter:
-          name: refarch-lv7q9-nodes
-          tags: openshiftClusterID=refarch-lv7q9
+          name: <infrastructure_name>-nodes
+          tags: openshiftClusterID=<infrastructure_name>
     rootVolume:
-        availabilityZone: nova <1>
+        availabilityZone: nova # <1>
         diskSize: 30
         sourceUUID: rhcos-4.12
         volumeType: fast-0
     securityGroups:
     - filter: {}
-      name: refarch-lv7q9-master
-    serverGroupName: refarch-lv7q9-master
+      name: <infrastructure_name>-master
+    serverGroupName: <infrastructure_name>-master
     serverMetadata:
-      Name: refarch-lv7q9-master
-      openshiftClusterID: refarch-lv7q9
+      Name: <infrastructure_name>-master
+      openshiftClusterID: <infrastructure_name>
     tags:
-    - openshiftClusterID=refarch-lv7q9
+    - openshiftClusterID=<infrastructure_name>
     trunk: true
     userDataSecret:
       name: master-user-data

--- a/modules/cpmso-openstack-with-az-config.adoc
+++ b/modules/cpmso-openstack-with-az-config.adoc
@@ -22,12 +22,19 @@ To understand why this procedure is necessary, see link:https://access.redhat.co
 +
 [source,terminal]
 ----
-$ oc edit machine/<cluster_id>-master-1 -n openshift-machine-api
+$ oc edit machine/<infrastructure_name>-master-1 -n openshift-machine-api
 ----
 +
 where:
 +
-`<cluster_id>`:: Specifies the ID of the upgraded cluster.
+`<infrastructure_name>`:: Specifies the infrastructure name of the upgraded cluster.
++
+If you have the OpenShift CLI (`oc`) installed, you can obtain the infrastructure name by running the following command:
++
+[source,terminal]
+----
+$ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
+----
 
 . For the `master-1` and `master-2` control plane machines, edit the value of the `serverGroupName` property in their provider specs to match that of the machine `master-0`.
 +
@@ -51,17 +58,17 @@ providerSpec:
     - filter: {}
       subnets:
       - filter:
-          name: refarch-lv7q9-nodes
-          tags: openshiftClusterID=refarch-lv7q9
+          name: <infrastructure_name>-nodes
+          tags: openshiftClusterID=<infrastructure_name>
     securityGroups:
     - filter: {}
-      name: refarch-lv7q9-master
-    serverGroupName: refarch-lv7q9-master-az0 <1>
+      name: <infrastructure_name>-master
+    serverGroupName: <infrastructure_name>-master-az0 # <1>
     serverMetadata:
-      Name: refarch-lv7q9-master
-      openshiftClusterID: refarch-lv7q9
+      Name: <infrastructure_name>-master
+      openshiftClusterID: <infrastructure_name>
     tags:
-    - openshiftClusterID=refarch-lv7q9
+    - openshiftClusterID=<infrastructure_name>
     trunk: true
     userDataSecret:
       name: master-user-data

--- a/modules/cpmso-yaml-failure-domain-aws.adoc
+++ b/modules/cpmso-yaml-failure-domain-aws.adoc
@@ -26,28 +26,28 @@ spec:
       failureDomains:
         aws:
         - placement:
-            availabilityZone: <aws_zone_a> <1>
-          subnet: <2>
+            availabilityZone: <aws_zone_a> # <1>
+          subnet: # <2>
             filters:
             - name: tag:Name
               values:
-              - <cluster_id>-private-<aws_zone_a> <3>
-            type: Filters <4>
+              - <infrastructure_name>-private-<aws_zone_a> # <3>
+            type: Filters # <4>
         - placement:
-            availabilityZone: <aws_zone_b> <5>
+            availabilityZone: <aws_zone_b> # <5>
           subnet:
             filters:
             - name: tag:Name
               values:
-              - <cluster_id>-private-<aws_zone_b> <6>
+              - <infrastructure_name>-private-<aws_zone_b> # <6>
             type: Filters
-        platform: AWS <7>
+        platform: AWS # <7>
 # ...
 ----
 <1> Specifies an AWS availability zone for the first failure domain.
 <2> Specifies a subnet configuration. In this example, the subnet type is `Filters`, so there is a `filters` stanza.
-<3> Specifies the subnet name for the first failure domain, using the infrastructure ID and the AWS availability zone.
+<3> Specifies the subnet name for the first failure domain, using the infrastructure name and the AWS availability zone.
 <4> Specifies the subnet type. The allowed values are: `ARN`, `Filters` and `ID`. The default value is `Filters`.
-<5> Specifies the subnet name for an additional failure domain, using the infrastructure ID and the AWS availability zone.
-<6> Specifies the cluster's infrastructure ID and the AWS availability zone for the additional failure domain.
+<5> Specifies the subnet name for an additional failure domain, using the infrastructure name and the AWS availability zone.
+<6> Specifies the cluster's infrastructure name and the AWS availability zone for the additional failure domain.
 <7> Specifies the cloud provider platform name. Do not change this value.

--- a/modules/cpmso-yaml-provider-spec-aws.adoc
+++ b/modules/cpmso-yaml-provider-spec-aws.adoc
@@ -8,7 +8,7 @@
 
 When you create a control plane machine set for an existing cluster, the provider specification must match the `providerSpec` configuration in the control plane machine custom resource (CR) that is created by the installation program. You can omit any field that is set in the failure domain section of the CR.
 
-In the following example, `<cluster_id>` is the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
+In the following example, `<infrastructure_name>` is the infrastructure name that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure name by running the following command:
 
 [source,terminal]
 ----
@@ -31,10 +31,10 @@ spec:
         providerSpec:
           value:
             ami:
-              id: ami-<ami_id_string> <1>
+              id: ami-<ami_id_string> # <1>
             apiVersion: machine.openshift.io/v1beta1
             blockDevices:
-            - ebs: <2>
+            - ebs: # <2>
                 encrypted: true
                 iops: 0
                 kmsKey:
@@ -42,32 +42,32 @@ spec:
                 volumeSize: 120
                 volumeType: gp3
             credentialsSecret:
-              name: aws-cloud-credentials <3>
+              name: aws-cloud-credentials # <3>
             deviceIndex: 0
             iamInstanceProfile:
-              id: <cluster_id>-master-profile <4>
-            instanceType: m6i.xlarge <5>
-            kind: AWSMachineProviderConfig <6>
-            loadBalancers: <7>
-            - name: <cluster_id>-int
+              id: <infrastructure_name>-master-profile # <4>
+            instanceType: m6i.xlarge # <5>
+            kind: AWSMachineProviderConfig # <6>
+            loadBalancers: # <7>
+            - name: <infrastructure_name>-int
               type: network
-            - name: <cluster_id>-ext
+            - name: <infrastructure_name>-ext
               type: network
             metadata:
               creationTimestamp: null
             metadataServiceOptions: {}
-            placement: <8>
-              region: <region> <9>
-              availabilityZone: "" <10>
-              tenancy: <11>
+            placement: # <8>
+              region: <region> # <9>
+              availabilityZone: "" # <10>
+              tenancy: # <11>
             securityGroups:
             - filters:
               - name: tag:Name
                 values:
-                - <cluster_id>-master-sg <12>
-            subnet: {} <13>
+                - <infrastructure_name>-master-sg # <12>
+            subnet: {} # <13>
             userDataSecret:
-              name: master-user-data <14>
+              name: master-user-data # <14>
 ----
 <1> Specifies the {op-system-first} Amazon Machine Images (AMI) ID for the cluster. The AMI must belong to the same region as the cluster. If you want to use an AWS Marketplace image, you must complete the {product-title} subscription from the link:https://aws.amazon.com/marketplace/fulfillment?productId=59ead7de-2540-4653-a8b0-fa7926d5c845[AWS Marketplace] to obtain an AMI ID for your region.
 <2> Specifies the configuration of an encrypted EBS volume.

--- a/modules/cpmso-yaml-provider-spec-azure.adoc
+++ b/modules/cpmso-yaml-provider-spec-azure.adoc
@@ -8,7 +8,7 @@
 
 When you create a control plane machine set for an existing cluster, the provider specification must match the `providerSpec` configuration in the control plane `Machine` CR that is created by the installation program. You can omit any field that is set in the failure domain section of the CR.
 
-In the following example, `<cluster_id>` is the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
+In the following example, `<infrastructure_name>` is the infrastructure name that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure name by running the following command:
 
 [source,terminal]
 ----
@@ -33,38 +33,38 @@ spec:
             acceleratedNetworking: true
             apiVersion: machine.openshift.io/v1beta1
             credentialsSecret:
-              name: azure-cloud-credentials <1>
+              name: azure-cloud-credentials # <1>
               namespace: openshift-machine-api
             diagnostics: {}
-            image: <2>
+            image: # <2>
               offer: ""
               publisher: ""
-              resourceID: /resourceGroups/<cluster_id>-rg/providers/Microsoft.Compute/galleries/gallery_<cluster_id>/images/<cluster_id>-gen2/versions/412.86.20220930 <3>
+              resourceID: /resourceGroups/<infrastructure_name>-rg/providers/Microsoft.Compute/galleries/gallery_<infrastructure_name>/images/<infrastructure_name>-gen2/versions/412.86.20220930 # <3>
               sku: ""
               version: ""
-            internalLoadBalancer: <cluster_id>-internal <4>
-            kind: AzureMachineProviderSpec <5>
-            location: <region> <6>
-            managedIdentity: <cluster_id>-identity
+            internalLoadBalancer: <infrastructure_name>-internal # <4>
+            kind: AzureMachineProviderSpec # <5>
+            location: <region> # <6>
+            managedIdentity: <infrastructure_name>-identity
             metadata:
               creationTimestamp: null
-              name: <cluster_id>
-            networkResourceGroup: <cluster_id>-rg
-            osDisk: <7>
+              name: <infrastructure_name>
+            networkResourceGroup: <infrastructure_name>-rg
+            osDisk: # <7>
               diskSettings: {}
               diskSizeGB: 1024
               managedDisk:
                 storageAccountType: Premium_LRS
               osType: Linux
             publicIP: false
-            publicLoadBalancer: <cluster_id> <8>
-            resourceGroup: <cluster_id>-rg
-            subnet: <cluster_id>-master-subnet <9>
+            publicLoadBalancer: <infrastructure_name> # <8>
+            resourceGroup: <infrastructure_name>-rg
+            subnet: <infrastructure_name>-master-subnet # <9>
             userDataSecret:
-              name: master-user-data <10>
+              name: master-user-data # <10>
             vmSize: Standard_D8s_v3
-            vnet: <cluster_id>-vnet
-            zone: "1" <11>
+            vnet: <infrastructure_name>-vnet
+            zone: "1" # <11>
 ----
 <1> Specifies the secret name for the cluster. Do not change this value.
 <2> Specifies the image details for your control plane machine set.

--- a/modules/cpmso-yaml-provider-spec-gcp.adoc
+++ b/modules/cpmso-yaml-provider-spec-gcp.adoc
@@ -14,7 +14,7 @@ When you create a control plane machine set for an existing cluster, the provide
 
 In the following example, you can obtain some of the values for your cluster by using the OpenShift CLI.
 
-Infrastructure ID:: The `<cluster_id>` string is the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
+Infrastructure name:: The `<infrastructure_name>` string is the infrastructure name that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure name by running the following command:
 +
 [source,terminal]
 ----
@@ -48,37 +48,37 @@ spec:
             apiVersion: machine.openshift.io/v1beta1
             canIPForward: false
             credentialsSecret:
-              name: gcp-cloud-credentials <1>
+              name: gcp-cloud-credentials # <1>
             deletionProtection: false
             disks:
             - autoDelete: true
               boot: true
-              image: <path_to_image> <2>
+              image: <path_to_image> # <2>
               labels: null
               sizeGb: 200
               type: pd-ssd
-            kind: GCPMachineProviderSpec <3>
+            kind: GCPMachineProviderSpec # <3>
             machineType: e2-standard-4
             metadata:
               creationTimestamp: null
             metadataServiceOptions: {}
             networkInterfaces:
-            - network: <cluster_id>-network
-              subnetwork: <cluster_id>-master-subnet
-            projectID: <project_name> <4>
-            region: <region> <5>
+            - network: <infrastructure_name>-network
+              subnetwork: <infrastructure_name>-master-subnet
+            projectID: <project_name> # <4>
+            region: <region> # <5>
             serviceAccounts:
-            - email: <cluster_id>-m@<project_name>.iam.gserviceaccount.com
+            - email: <infrastructure_name>-m@<project_name>.iam.gserviceaccount.com
               scopes:
               - https://www.googleapis.com/auth/cloud-platform
             shieldedInstanceConfig: {}
             tags:
-            - <cluster_id>-master
+            - <infrastructure_name>-master
             targetPools:
-            - <cluster_id>-api
+            - <infrastructure_name>-api
             userDataSecret:
-              name: master-user-data <6>
-            zone: "" <7>
+              name: master-user-data # <6>
+            zone: "" # <7>
 ----
 <1> Specifies the secret name for the cluster. Do not change this value.
 <2> Specifies the path to the image that was used to create the disk.

--- a/modules/cpmso-yaml-provider-spec-nutanix.adoc
+++ b/modules/cpmso-yaml-provider-spec-nutanix.adoc
@@ -14,7 +14,7 @@ When you create a control plane machine set for an existing cluster, the provide
 
 In the following example, you can obtain some of the values for your cluster by using the OpenShift CLI.
 
-Infrastructure ID:: The `<cluster_id>` string is the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
+Infrastructure name:: The `<infrastructure_name>` string is the infrastructure name that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure name by running the following command:
 +
 [source,terminal]
 ----
@@ -37,33 +37,33 @@ spec:
         providerSpec:
           value:
             apiVersion: machine.openshift.io/v1
-            bootType: "" <1>
-            categories: <2>
+            bootType: "" # <1>
+            categories: # <2>
             - key: <category_name>
               value: <category_value>
-            cluster: <3>
+            cluster: # <3>
               type: uuid
               uuid: <cluster_uuid>
             credentialsSecret:
-              name: nutanix-credentials <4>
-            image: <5>
-              name: <cluster_id>-rhcos
+              name: nutanix-credentials # <4>
+            image: # <5>
+              name: <infrastructure_name>-rhcos
               type: name
-            kind: NutanixMachineProviderConfig <6>
-            memorySize: 16Gi <7>
+            kind: NutanixMachineProviderConfig # <6>
+            memorySize: 16Gi # <7>
             metadata:
               creationTimestamp: null
-            project: <8>
+            project: # <8>
               type: name
               name: <project_name>
-            subnets: <9>
+            subnets: # <9>
             - type: uuid
               uuid: <subnet_uuid>
-            systemDiskSize: 120Gi <10>
+            systemDiskSize: 120Gi # <10>
             userDataSecret:
-              name: master-user-data <11>
-            vcpuSockets: 8 <12>
-            vcpusPerSocket: 1 <13>
+              name: master-user-data # <11>
+            vcpuSockets: 8 # <12>
+            vcpusPerSocket: 1 # <13>
 ----
 <1> Specifies the boot type that the control plane machines use. For more information about boot types, see link:https://portal.nutanix.com/page/documents/kbs/details?targetId=kA07V000000H3K9SAK[Understanding UEFI, Secure Boot, and TPM in the Virtualized Environment]. Valid values are `Legacy`, `SecureBoot`, or `UEFI`. The default is `Legacy`.
 +

--- a/modules/cpmso-yaml-provider-spec-openstack.adoc
+++ b/modules/cpmso-yaml-provider-spec-openstack.adoc
@@ -8,6 +8,13 @@
 
 When you create a control plane machine set for an existing cluster, the provider specification must match the `providerSpec` configuration in the control plane machine custom resource (CR) that is created by the installation program.
 
+In the following example, `<infrastructure_name>` is the infrastructure name that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure name by running the following command:
+
+[source,terminal]
+----
+$ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
+----
+
 .Sample OpenStack `providerSpec` values
 [source,yaml]
 ----
@@ -26,28 +33,28 @@ spec:
             apiVersion: machine.openshift.io/v1alpha1
             cloudName: openstack
             cloudsSecret:
-              name: openstack-cloud-credentials <1>
+              name: openstack-cloud-credentials # <1>
               namespace: openshift-machine-api
-            flavor: m1.xlarge <2>
-            image: ocp1-2g2xs-rhcos
-            kind: OpenstackProviderSpec <3>
+            flavor: m1.xlarge # <2>
+            image: <infrastructure_name>-rhcos
+            kind: OpenstackProviderSpec # <3>
             metadata:
               creationTimestamp: null
             networks:
             - filter: {}
               subnets:
               - filter:
-                  name: ocp1-2g2xs-nodes
-                  tags: openshiftClusterID=ocp1-2g2xs
+                  name: <infrastructure_name>-nodes
+                  tags: openshiftClusterID=<infrastructure_name>
             securityGroups:
             - filter: {}
-              name: ocp1-2g2xs-master <4>
-            serverGroupName: ocp1-2g2xs-master
+              name: <infrastructure_name>-master # <4>
+            serverGroupName: <infrastructure_name>-master
             serverMetadata:
-              Name: ocp1-2g2xs-master
-              openshiftClusterID: ocp1-2g2xs
+              Name: <infrastructure_name>-master
+              openshiftClusterID: <infrastructure_name>
             tags:
-            - openshiftClusterID=ocp1-2g2xs
+            - openshiftClusterID=<infrastructure_name>
             trunk: true
             userDataSecret:
               name: master-user-data

--- a/modules/cpmso-yaml-sample-cr.adoc
+++ b/modules/cpmso-yaml-sample-cr.adoc
@@ -8,48 +8,52 @@
 
 The base of the `ControlPlaneMachineSet` CR is structured the same way for all platforms.
 
+In the following example, you can obtain some of the values for your cluster by using the OpenShift CLI.
+
+Infrastructure name:: The `<infrastructure_name>` string is the infrastructure name that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure name by running the following command:
++
+[source,terminal]
+----
+$ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
+----
+
 .Sample `ControlPlaneMachineSet` CR YAML file
 [source,yaml]
 ----
 apiVersion: machine.openshift.io/v1
 kind: ControlPlaneMachineSet
 metadata:
-  name: cluster <1>
+  name: cluster # <1>
   namespace: openshift-machine-api
 spec:
-  replicas: 3 <2>
+  replicas: 3 # <2>
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <cluster_id> <3>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_name> # <3>
       machine.openshift.io/cluster-api-machine-role: master
       machine.openshift.io/cluster-api-machine-type: master
-  state: Active <4>
+  state: Active # <4>
   strategy:
-    type: RollingUpdate <5>
+    type: RollingUpdate # <5>
   template:
     machineType: machines_v1beta1_machine_openshift_io
     machines_v1beta1_machine_openshift_io:
       failureDomains:
-        platform: <platform> <6>
-        <platform_failure_domains> <7>
+        platform: <platform> # <6>
+        <platform_failure_domains> # <7>
       metadata:
         labels:
-          machine.openshift.io/cluster-api-cluster: <cluster_id>
+          machine.openshift.io/cluster-api-cluster: <infrastructure_name>
           machine.openshift.io/cluster-api-machine-role: master
           machine.openshift.io/cluster-api-machine-type: master
       spec:
         providerSpec:
           value:
-            <platform_provider_spec> <8>
+            <platform_provider_spec> # <8>
 ----
 <1> Specifies the name of the `ControlPlaneMachineSet` CR, which is `cluster`. Do not change this value.
 <2> Specifies the number of control plane machines. Only clusters with three control plane machines are supported, so the `replicas` value is `3`. Horizontal scaling is not supported. Do not change this value.
-<3> Specifies the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. You must specify this value when you create a `ControlPlaneMachineSet` CR. If you have the OpenShift CLI (`oc`) installed, you can obtain the infrastructure ID by running the following command:
-+
-[source,terminal]
-----
-$ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
-----
+<3> Specifies the infrastructure name that is based on the cluster ID that you set when you provisioned the cluster. You must specify this value when you create a `ControlPlaneMachineSet` CR.
 <4> Specifies the state of the Operator. When the state is `Inactive`, the Operator is not operational. You can activate the Operator by setting the value to `Active`.
 +
 [IMPORTANT]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-4004](https://issues.redhat.com//browse/OSDOCS-4004)

Link to docs preview:
**Control plane machine sets**
- [Control Plane Machine Set Operator limitations](https://72739--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-about#cpmso-limitations_cpmso-about)
- [Creating a control plane machine set custom resource](https://72739--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-getting-started#cpmso-creating-cr_cpmso-getting-started)
- [Sample YAML for a control plane machine set custom resource](https://72739--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration#cpmso-yaml-sample-cr_cpmso-configuration)
- [Sample AWS provider specification](https://72739--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration#cpmso-yaml-provider-spec-aws_cpmso-configuration)
- [Sample AWS failure domain configuration](https://72739--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration#cpmso-yaml-failure-domain-aws_cpmso-configuration)
- [Sample GCP provider specification](https://72739--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration#cpmso-yaml-provider-spec-gcp_cpmso-configuration)
- [Sample Azure provider specification](https://72739--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration#cpmso-yaml-provider-spec-azure_cpmso-configuration)
- [Sample Nutanix provider specification](https://72739--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration#cpmso-yaml-provider-spec-nutanix_cpmso-configuration)
- [Sample VMware vSphere failure domain configuration](https://72739--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration#cpmso-yaml-failure-domain-vsphere_cpmso-configuration)
- [Sample RHOSP provider specification](https://72739--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration#cpmso-yaml-provider-spec-openstack_cpmso-configuration)
- [Configuring RHOSP clusters that have machines with root volume availability zones after an upgrade](https://72739--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-troubleshooting#cpmso-openstack-ts-root-volume-azs_cpmso-troubleshooting)
- [Configuring RHOSP clusters that have control plane machines with availability zones after an upgrade](https://72739--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-troubleshooting#cpmso-openstack-with-az-config_cpmso-troubleshooting)

**Compute machine sets**
- (later)

QE review:
- [ ] QE has approved this change.

Additional information:
Currently only CPMS. Compute should wait on #72633 to avoid merge conflicts