### PR TITLE
TELCODOCS-1187: Release note for host networking setting for SR-IOV VFs

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -691,6 +691,13 @@ This update to CoreDNS resulted in the deprecation and removal of certain metric
 
 For more information, see xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[Supported devices].
 
+[id="ocp-4-15-networking-nncp-host-network-settings"]
+==== Host network configuration policy for SR-IOV network VFs (Technology Preview)
+
+With this release, you can use the `NodeNetworkConfigurationPolicy` resource to manage host network settings for Single Root I/O Virtualization (SR-IOV) network virtual functions (VF) in an existing cluster.
+
+For example, you can configure a host network Quality of Service (QoS) policy to manage network access to host resources by an attached SR-IOV network VF. For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc#virt-example-vf-host-services_k8s_nmstate-updating-node-network-config[Node network configuration policy for virtual functions].
+
 [id="ocp-4-15-registry"]
 === Registry
 
@@ -2016,6 +2023,11 @@ In the following tables, features are marked with the following statuses:
 |Not Available
 |Technology Preview
 |General Availability
+
+|Host network settings for SR-IOV VFs
+|Not Available
+|Not Available
+|Technology Preview
 
 |====
 


### PR DESCRIPTION
[TELCODOCS-1187](https://issues.redhat.com//browse/TELCODOCS-1187): Adding technology preview release note for #63405 

Version(s):
4.15

Issue:
https://issues.redhat.com/browse/TELCODOCS-1187

Link to docs preview:
https://72740--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-networking-nncp-host-network-settings

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This has been through the change management process and received all necessary ACKs.