### PR TITLE
TELCODOCS-1578 Improve documentation of workload hints

### DIFF
--- a/modules/cnf-understanding-workload-hints.adoc
+++ b/modules/cnf-understanding-workload-hints.adoc
@@ -78,38 +78,38 @@ a| Specifies that the timestamp counter (TSC) should be used as a reliable time 
 
 
 | `rcupdate.rcu_normal_after_boot=1`
-a| This setting ensures that read-copy update (RCU) `normal` state is deferred until after the system boot process completes, potentially optimizing boot performance and avoiding interference with other boot-time tasks.
+a| This setting ensures that read-copy update (RCU) `normal` state is used until after the system boot process completes, optimizing boot performance and avoiding interference with other boot-time tasks.
 
 | `nohz=on`
-|This setting enables the `NOHZ` feature in the Linux kernel, which reduces timer interrupts on idle CPUs to improve power efficiency and overall system performance.
+| This setting enables the `NOHZ` feature in the Linux kernel, which eliminates timer interrupts on idle CPUs to improve power efficiency and overall system performance.
 
 
-| `rcu_nocbs=3-15`
-| Specifies that CPUs 3 through 15 (inclusive) are excluded from acting as "no-CBs" CPUs. This means that these CPUs will not be responsible for executing RCU callbacks. Instead, other CPUs in the system will handle RCU-related tasks. By specifying the CPUs that handle RCU callbacks, you can better use CPU resources and improve overall system performance.
+| `rcu_nocbs=<list of isolated cpus>`
+| Specifies that the isolated cpus are excluded from acting as "no-CBs" CPUs. This means that these CPUs will not be responsible for executing RCU callbacks. Instead, other CPUs in the system will handle RCU-related tasks. By specifying the CPUs that handle RCU callbacks, you can better use CPU resources and improve overall system performance.
 
 
-| `tuned.non_isolcpus=00000007`
-| Configures the tuned daemon to select CPUs 0, 1, 2 as non-isolated CPUs. This informs tuned that those CPUs are going to be busy and are not suitable for low latency workloads.
+| `tuned.non_isolcpus=<list of reserved cpus>`
+| Configures the tuned daemon with the list of non-isolated CPUs. This informs tuned that those CPUs are available for performing system tasks.
 
 
-| `systemd.cpu_affinity=0,1,2`
-| Sets CPU affinity for `systemd` processes, restricting them to run on CPU cores 0, 1, and 2. You can use this to optimize system performance and resource use in certain scenarios.
+| `systemd.cpu_affinity<list of reserved cpus>`
+| Sets CPU affinity for `systemd` processes, restricting them to run on reserved cpus. Ensures that system processes don't interfere with low-latency workloads.
 
 
 | `intel_iommu=on`
-| Activates Intel's virtualization for technology direct (VT-d) I/O access support in the Linux kernel, enabling enhanced virtualization capabilities and improved security and performance for I/O device management in virtual environments.
+| Activates Intel virtualization echnology direct (VT-d) I/O access support in the Linux kernel, enabling enhanced virtualization capabilities and improved security and performance for I/O device management in virtual environments.
 
 
 | `iommu=pt`
 | Configures the input–output memory management unit (IOMMU) to operate in passthrough mode, enabling direct assignment of physical I/O devices to virtual machines in virtualized environments. This can improve performance and flexibility for certain workloads but requires careful consideration and configuration.
 
 
-| `isolcpus=managed_irq,3-15`
-| Isolates CPU cores 3 through 15 from the Linux kernel scheduler, ensuring that they are dedicated only to running specific tasks or processes without interruption from other system activities. Pay particular attention to the `managed_irq` argument. It provides a hint to the kernel to tell it that its internally managed interrupts should avoid CPUs 3-15. This ensures the affinity cannot be changed by userspace and lands the interrupts on the busy cores 0-2.
+| `isolcpus=managed_irq,<list of isolated cpus>`
+| Isolates CPU from being targeted by interrupts to ensure these don't interfere with low latency workloads.
 
 
-| `nohz_full=3-15`
-|Configures the kernel to operate in a tickless mode on CPUs 3 through 15. Tickless mode reduces unnecessary timer interrupts on idle CPUs, improving power efficiency and reducing latency.
+| `nohz_full=<list of isolated cpus>`
+| Configures the kernel to operate in a tickless mode on the isolated cpus. Tickless mode eliminates timer interrupts on idle CPUs or those which only have a single runnable task, improving power efficiency and reducing latency.
 
 
 | `nosoftlockup`

--- a/modules/cnf-understanding-workload-hints.adoc
+++ b/modules/cnf-understanding-workload-hints.adoc
@@ -2,14 +2,14 @@
 //
 // scalability_and_performance/cnf-low-latency-tuning.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="cnf-understanding-workload-hints_{context}"]
 = Understanding workload hints
 
-The following table describes how combinations of power consumption and real-time settings impact on latency.
+The following table describes how combinations of power consumption and real-time settings impact on latency. The recommended way to work with workload hints is by using the Performance Profile Creator however they can also be created manually. For more information about the performance profile, see the "Creating a performance profile" section. 
+
 [NOTE]
 ====
-The following workload hints can be configured manually. You can also work with workload hints using the Performance Profile Creator. For more information about the performance profile, see the "Creating a performance profile" section.
 If the workload hint is configured manually and the `realTime` workload hint is not explicitly set then it defaults to `true`.
 ====
 
@@ -29,7 +29,7 @@ realTime: false
 
 
 
-    | Low-latency
+    | low-latency
     a|[source,terminal]
 ----
 workloadHints:
@@ -40,7 +40,7 @@ realTime: true
     | Both energy savings and low-latency are desirable: compromise between power management, latency and throughput.
 
 
-    | Ultra-low-latency
+    | ultra-low-latency
     a|[source,terminal]
 ----
 workloadHints:
@@ -50,7 +50,7 @@ realTime: true
     | Far edge clusters, latency critical workloads
     | Optimized for absolute minimal latency and maximum determinism at the cost of increased power consumption.
 
-    | Per-pod power management
+    | per-pod power management
     a|[source,terminal]
 ----
 workloadHints:
@@ -62,3 +62,122 @@ perPodPowerManagement: true
     | Allows for power management per pod.
 
 |===
+
+This table describes the list of kernel arguments configured by applying the workload hints. The kernel arguments apply to all profiles with the exceptions called out in notes in the description field.
+
+[cols="33%,67",options="header"]
+|===
+| Argument | Description 
+
+| `skew_tick=1`
+a|Configures the kernel to adjust the timer skew. This parameter adjusts the timing of timer interrupts to synchronize with the CPU frequency and reduce timing errors.
+
+
+| `tsc=reliable`
+a| Specifies that the timestamp counter (TSC) should be used as a reliable time source. The TSC is a high-resolution per-CPU counter used for performance monitoring and timing purposes.
+
+
+| `rcupdate.rcu_normal_after_boot=1`
+a| This setting ensures that read-copy update (RCU) `normal` state is deferred until after the system boot process completes, potentially optimizing boot performance and avoiding interference with other boot-time tasks.
+
+| `nohz=on`
+|This setting enables the `NOHZ` feature in the Linux kernel, which reduces timer interrupts on idle CPUs to improve power efficiency and overall system performance.
+
+
+| `rcu_nocbs=3-15`
+| Specifies that CPUs 3 through 15 (inclusive) are excluded from acting as "no-CBs" CPUs. This means that these CPUs will not be responsible for executing RCU callbacks. Instead, other CPUs in the system will handle RCU-related tasks. By specifying the CPUs that handle RCU callbacks, you can better use CPU resources and improve overall system performance.
+
+
+| `tuned.non_isolcpus=00000007`
+| Configures the tuned daemon to select CPUs 0, 1, 2 as non-isolated CPUs. This informs tuned that those CPUs are going to be busy and are not suitable for low latency workloads.
+
+
+| `systemd.cpu_affinity=0,1,2`
+| Sets CPU affinity for `systemd` processes, restricting them to run on CPU cores 0, 1, and 2. You can use this to optimize system performance and resource use in certain scenarios.
+
+
+| `intel_iommu=on`
+| Activates Intel's virtualization for technology direct (VT-d) I/O access support in the Linux kernel, enabling enhanced virtualization capabilities and improved security and performance for I/O device management in virtual environments.
+
+
+| `iommu=pt`
+| Configures the input–output memory management unit (IOMMU) to operate in passthrough mode, enabling direct assignment of physical I/O devices to virtual machines in virtualized environments. This can improve performance and flexibility for certain workloads but requires careful consideration and configuration.
+
+
+| `isolcpus=managed_irq,3-15`
+| Isolates CPU cores 3 through 15 from the Linux kernel scheduler, ensuring that they are dedicated only to running specific tasks or processes without interruption from other system activities. Pay particular attention to the `managed_irq` argument. It provides a hint to the kernel to tell it that its internally managed interrupts should avoid CPUs 3-15. This ensures the affinity cannot be changed by userspace and lands the interrupts on the busy cores 0-2.
+
+
+| `nohz_full=3-15`
+|Configures the kernel to operate in a tickless mode on CPUs 3 through 15. Tickless mode reduces unnecessary timer interrupts on idle CPUs, improving power efficiency and reducing latency.
+
+
+| `nosoftlockup`
+| Disables the soft lockup detection mechanism in the kernel. Soft lockup detection monitors for prolonged periods of CPU inactivity, which might indicate a system hang.
+
+
+| `nmi_watchdog=0`
+a| Disables the non-maskable Interrupt (NMI) watchdog timer. The NMI watchdog is a hardware timer used to detect system hangs or lockups.
+
+| `mce=off`
+a|Disables Machine Check Exception (MCE) reporting. MCE is a hardware feature that detects and reports hardware errors.
+
+| `processor.max_cstate=1`
+a|Specifies the maximum processor idle state (C-state) allowed. Limiting the maximum C-state can improve system responsiveness and reduce power consumption.
+
+[NOTE]
+====
+Only applies to ultra low latency profile.
+====
+
+| `intel_idle.max_cstate=0`
+a| Sets the maximum C-state allowed for Intel CPUs to C0, effectively disabling deeper idle states.
+
+[NOTE]
+====
+Only applies to ultra low latency profile.
+====
+
+| `intel_pstate=disable`
+a| Disables Intel P-state driver. Intel P-state is a feature that dynamically adjusts CPU frequency and voltage for power management.
+
+[NOTE]
+====
+Applies when the ultra low and low latency profile is configured. The per pod management profile sets this to `passive`. The `passive` mode aims to balance performance and power management by allowing the operating system to dynamically adjust CPU frequencies while benefiting from performance hints provided by the Intel P-state driver.
+====
+
+
+| `rcutree.kthread_prio=11`
+| By setting the priority of read-copy update (RCU) kernel threads to `11`, the kernel prioritizes RCU related tasks, potentially ensuring timely execution and efficient handling of RCU processing, which can contribute to overall system performance and responsiveness.
+
+| `idle=poll`
+| By specifying `idle=poll`, the kernel instructs the idle process to continuously poll for tasks to run rather than entering traditional idle states. Instead of transitioning to a low-power idle state and waiting for an interrupt to awaken the CPU, the kernel keeps the CPU actively checking for pending tasks. The `idle=poll` parameter can be useful in specific scenarios where latency is critical, and the overhead associated with transitioning between idle states is undesirable. 
+
+|===
+
+In addition, with the `realTime` hint set to `true` the following arguments are added to tuned configuration:
+
+.kernel arguments
+[cols="33%,70",options="header"]
+|===
+| Argument | Description 
+
+| `service.stalld=start,enable`
+a|This setting configures the `stalld` service to start and enable during system boot. The `stalld` service is part of the tuned framework and is responsible for monitoring system stalls. Enabling and starting this service ensures that the system is actively monitored for stalls, which can indicate performance issues or resource contention.
+
+| `sched_rt_runtime_us=-1`
+a| This parameter configures the maximum runtime period for real-time tasks scheduled by the Linux kernel. A value of -1 or infinity means that there is no enforced time limit, allowing real-time tasks to run without restriction. Real-time tasks are those that require deterministic and low-latency execution, such as audio/video processing or industrial control systems.
+
+| `kernel.hung_task_timeout_secs=600`
+a| This setting configures the timeout period in seconds for detecting hung tasks in the Linux kernel. When a task becomes unresponsive or hung, the kernel might mark it as such and trigger a system notification or action. Setting this parameter to 600 seconds means that the kernel will consider a task as hung if it remains unresponsive for more than 10 minutes.
+
+| `kernel.nmi_watchdog=0`
+a| Disables the NMI watchdog timer in the kernel. The NMI watchdog is a hardware mechanism that detects system hangs or lockups by periodically generating NMIs. Setting this parameter to 0 disables the NMI watchdog, which might be necessary in certain environments or configurations where the watchdog is not required or causes unnecessary interrupts.
+
+| `kernel.sched_rt_runtime_us=-1`
+a|  Similar to `sched_rt_runtime_us=-1`, this parameter sets the maximum runtime period for real-time tasks scheduled by the kernel to infinity, allowing real-time tasks to run without time restrictions.
+
+| `vm.stat_interval=10`
+a|  Configures the interval in seconds for collecting statistics about memory usage and performance in the virtual memory subsystem. Setting this parameter to 10 seconds means that memory statistics are collected every 10 seconds, providing insights into memory use and performance over time.
+|===
+ 

--- a/modules/cnf-verifying-performance-setting.adoc
+++ b/modules/cnf-verifying-performance-setting.adoc
@@ -1,0 +1,149 @@
+// Module included in the following assemblies:
+//
+// scalability_and_performance/cnf-low-latency-tuning.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="verifying-performance-configuration_{context}"]
+= Verifying performance configuration
+
+.Procedure
+
+Follow this procedure to verify the performance settings applied to your cluster.
+
+. Start a debugging session on one of your nodes that is targeted by the performance profile by running this command:
++
+[source,terminal]
+----
+$ oc debug node/<node_name>
+----
+
+. Set `/host` as the root directory within the debug shell by running this command:
++
+[source,terminal]
+----
+sh-4.4# chroot /host
+----
+
+. Display the kernel command line parameters without any performance profile applied by running the following command:
++
+[source,terminal]
+----
+$ cat /proc/cmdline
+----
++
+.Example output
++
+[source,terminal]
+----
+systemd.unified_cgroup_hierarchy=1 cgroup_no_v1=all psi=1
+----
++
+.Example 1 
+
+With the following low latency performance profile applied to a single-node OpenShift cluster.
++
+[source,yaml]
+----
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+spec:
+  cpu:
+    isolated: 3-15
+    reserved: 0-2
+  machineConfigPoolSelector:
+    pools.operator.machineconfiguration.openshift.io/master: ""
+  nodeSelector:
+    node-role.kubernetes.io/master: ""
+  numa:
+    topologyPolicy: restricted
+  realTimeKernel:
+    enabled: true
+  workloadHints:
+    highPowerConsumption: false
+    perPodPowerManagement: false
+    realTime: true
+----
++
+The kernel parameters that deliver both energy savings and low-latency are as follows: 
++
+[source,terminal]
+----
+skew_tick=1 tsc=reliable rcupdate.rcu_normal_after_boot=1 nohz=on rcu_nocbs=3-15 tuned.non_isolcpus=00000007 systemd.cpu_affinity=0,1,2 intel_iommu=on iommu=pt isolcpus=managed_irq,3-15 nohz_full=3-15 tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11 intel_pstate=disable systemd.unified_cgroup_hierarchy=0 systemd.legacy_systemd_cgroup_controller=1
+----
++
+.Example 2 
++
+With the following lowest latency performance profile applied to a single-node OpenShift cluster.
++
+[source,yaml]
+----
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+spec:
+  cpu:
+    isolated: 3-15
+    reserved: 0-2
+  machineConfigPoolSelector:
+    pools.operator.machineconfiguration.openshift.io/master: ""
+  nodeSelector:
+    node-role.kubernetes.io/master: ""
+  numa:
+    topologyPolicy: restricted
+  realTimeKernel:
+    enabled: true
+  workloadHints:
+    highPowerConsumption: true
+    perPodPowerManagement: false
+    realTime: true
+----
++
+The kernel parameters optimized for absolute minimal latency and maximum determinism at the cost of increased power consumption are as follows: 
++
+[source,terminal]
+----
+skew_tick=1 tsc=reliable rcupdate.rcu_normal_after_boot=1 nohz=on rcu_nocbs=3-15 tuned.non_isolcpus=00000007 systemd.cpu_affinity=0,1,2 intel_iommu=on iommu=pt isolcpus=managed_irq,3-15 nohz_full=3-15 tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11 processor.max_cstate=1 intel_idle.max_cstate=0 idle=poll intel_pstate=disable systemd.unified_cgroup_hierarchy=0 systemd.legacy_systemd_cgroup_controller=1
+----
++
+.Example 3 
++
+With the following per-pod power management performance profile applied to a single-node OpenShift cluster.
++
+[source,yaml]
+----
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+spec:
+  cpu:
+    isolated: 3-15
+    reserved: 0-2
+  machineConfigPoolSelector:
+    pools.operator.machineconfiguration.openshift.io/master: ""
+  nodeSelector:
+    node-role.kubernetes.io/master: ""
+  numa:
+    topologyPolicy: restricted
+  realTimeKernel:
+    enabled: true
+  workloadHints:
+    highPowerConsumption: false
+    perPodPowerManagement: true
+    realTime: true
+----
++
+The kernel parameters that allow for power management per pod are as follows: 
++
+[NOTE]
+====
+For more information about enabling power savings for a node, see the "Optional: Power saving configurations" section. 
+====
++
+[source,terminal]
+----
+skew_tick=1 tsc=reliable rcupdate.rcu_normal_after_boot=1 nohz=on rcu_nocbs=3-15 tuned.non_isolcpus=00000007 systemd.cpu_affinity=0,1,2 intel_iommu=on iommu=pt isolcpus=managed_irq,3-15 nohz_full=3-15 tsc=reliable nosoftlockup nmi_watchdog=0 mce=off skew_tick=1 rcutree.kthread_prio=11 intel_pstate=passive systemd.unified_cgroup_hierarchy=0 systemd.legacy_systemd_cgroup_controller=1
+----

--- a/scalability_and_performance/cnf-low-latency-tuning.adoc
+++ b/scalability_and_performance/cnf-low-latency-tuning.adoc
@@ -31,7 +31,7 @@ include::modules/cnf-tuning-nodes-for-low-latency-via-performanceprofile.adoc[le
 [role="_additional-resources"]
 .Additional resources
 
-* For information on using the Performance Profile Creator (PPC) to generate a performance profile, see xref:../scalability_and_performance/cnf-create-performance-profiles.adoc#cnf-create-performance-profiles[Creating a performance profile].
+* For information about using the Performance Profile Creator (PPC) to generate a performance profile, see xref:../scalability_and_performance/cnf-create-performance-profiles.adoc#cnf-create-performance-profiles[Creating a performance profile].
 
 include::modules/cnf-configuring-huge-pages.adoc[leveloffset=+2]
 
@@ -50,7 +50,11 @@ include::modules/cnf-understanding-workload-hints.adoc[leveloffset=+2]
 
 * For information about using the Performance Profile Creator (PPC) to generate a performance profile, see xref:../scalability_and_performance/cnf-create-performance-profiles.adoc#cnf-create-performance-profiles[Creating a performance profile].
 
+* For more information about power saving configurations, see xref:../scalability_and_performance/cnf-low-latency-tuning.adoc#node-tuning-operator-pod-power-saving-config_cnf-master[Power saving configurations].
+
 include::modules/cnf-configuring-workload-hints.adoc[leveloffset=+2]
+
+include::modules/cnf-verifying-performance-setting.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
[TELCODOCS-1578]: Improve documentation of workload hints

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16, 4.15, 4.14, 4.13, 4.12, main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-1578
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://72761--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-low-latency-tuning#cnf-understanding-workload-hints_cnf-master
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
