### PR TITLE
OSDOCS-7573: link to k8s CAPI Provider AWS CRD ref

### DIFF
--- a/machine_management/capi-machine-management.adoc
+++ b/machine_management/capi-machine-management.adoc
@@ -47,6 +47,8 @@ Using the Cluster API to manage machines is a Technology Preview feature and has
 
 * Full feature parity with the Machine API is not available.
 
+* {product-title} does not support all Kubernetes Cluster API features.
+
 [id="cluster-api-architecture_{context}"]
 == Cluster API architecture
 
@@ -81,11 +83,25 @@ The remaining Cluster API resources are provider-specific. Refer to the example 
 
 Some Cluster API resources are provider-specific. The following example YAML files show configurations for an Amazon Web Services (AWS) cluster.
 
-//Sample YAML for a CAPI AWS provider resource
+//Sample YAML for a Cluster API infrastructure resource on Amazon Web Services
 include::modules/capi-yaml-infrastructure-aws.adoc[leveloffset=+3]
+[IMPORTANT]
+====
+{product-title} does not support all Kubernetes Cluster API Provider AWS configuration options.
+====
+[role="_additional-resources"]
+.Additional resources
+* link:https://cluster-api-aws.sigs.k8s.io/crd/#infrastructure.cluster.x-k8s.io/v1beta1.AWSCluster[Kubernetes Cluster API Provider AWS `AWSCluster` CRD reference]
 
 //Sample YAML for CAPI AWS machine template resource
 include::modules/capi-yaml-machine-template-aws.adoc[leveloffset=+3]
+[IMPORTANT]
+====
+{product-title} does not support all Kubernetes Cluster API Provider AWS configuration options.
+====
+[role="_additional-resources"]
+.Additional resources
+* link:https://cluster-api-aws.sigs.k8s.io/crd/#infrastructure.cluster.x-k8s.io/v1beta1.AWSMachineTemplate[Kubernetes Cluster API Provider AWS `AWSMachineTemplate` CRD reference]
 
 //Sample YAML for a CAPI AWS compute machine set resource
 include::modules/capi-yaml-machine-set-aws.adoc[leveloffset=+3]


### PR DESCRIPTION
Version(s):
4.11+

Issue:
[OSDOCS-7573](https://issues.redhat.com//browse/OSDOCS-7573)

Link to docs preview:
https://72766--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/capi-machine-management#capi-sample-yaml-files-aws

QE review:
- [ ] QE has approved this change.

Additional information:
Needs PX approval.