### PR TITLE
OSSM-6011 [DOC] Issue in file service_mesh/v2x/ossm-create-smcp.adoc

### DIFF
--- a/modules/ossm-validate-smcp-cli.adoc
+++ b/modules/ossm-validate-smcp-cli.adoc
@@ -25,8 +25,8 @@ $ oc get smcp -n istio-system
 +
 The installation has finished successfully when the `STATUS` column is `ComponentsReady`.
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 NAME    READY   STATUS            PROFILES      VERSION   AGE
-basic   10/10   ComponentsReady   ["default"]   2.1.1     66m
+basic   10/10   ComponentsReady   ["default"]   {SMProductVersion}     66m
 ----


### PR DESCRIPTION
[OSSM-6011](https://issues.redhat.com//browse/OSSM-6011) [DOC] Issue in file service_mesh/v2x/ossm-create-smcp.adoc

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSSM-6011

Link to docs preview: https://72768--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-create-smcp#ossm-validate-control-plane-cli_ossm-create-smcp
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
Change does not impact meaning of docs. QE review is not needed.

Additional information:
Terminal content had not been updated since 2.1.1. To remedy this, without requiring writers to update this small piece with every update, and so users will see the correct information, the attribute {SMProductVersion} as replaced 2.1.1

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
