### PR TITLE
OBSDOCS-70: Add user roles needed to silence monitoring alerts

### DIFF
--- a/modules/monitoring-granting-users-permission-to-monitor-user-defined-projects.adoc
+++ b/modules/monitoring-granting-users-permission-to-monitor-user-defined-projects.adoc
@@ -11,7 +11,7 @@ Cluster administrators can grant developers and other users permission to monito
 
 * The *monitoring-rules-view* cluster role provides read access to `PrometheusRule` custom resources for a project.
 
-* The *monitoring-rules-edit* cluster role grants a user permission to create, modify, and deleting `PrometheusRule` custom resources for a project.
+* The *monitoring-rules-edit* cluster role grants a user permission to create, modify, and delete `PrometheusRule` custom resources for a project. It also grants a user the ability to silence alerts.
 
 * The *monitoring-edit* cluster role grants the same privileges as the `monitoring-rules-edit` cluster role. Additionally, it enables a user to create new scrape targets for services or pods. With this role, you can also create, modify, and delete `ServiceMonitor` and `PodMonitor` resources.
 


### PR DESCRIPTION
Version(s): `enterprise-4.12` and later

Issue: [OBSDOCS-70](https://issues.redhat.com/browse/OBSDOCS-70)

Link to docs preview: [Granting users permission to monitor user-defined projects](https://72781--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/enabling-monitoring-for-user-defined-projects#granting-users-permission-to-monitor-user-defined-projects_enabling-monitoring-for-user-defined-projects)

QE review:
- [x] QE has approved this change.

Peer review:
- [x] Peer review done

Additional information: