### PR TITLE
OBSDOCS-72: Document that when metrics data retention time is set to …

### DIFF
--- a/modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc
+++ b/modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc
@@ -6,7 +6,7 @@
 [id="modifying-retention-time-and-size-for-prometheus-metrics-data_{context}"]
 = Modifying the retention time and size for Prometheus metrics data
 
-By default, Prometheus automatically retains metrics data for 11 days. You can modify the retention time for
+By default, Prometheus automatically retains metrics data for 15 days. You can modify the retention time for
 ifndef::openshift-dedicated,openshift-rosa[]
 Prometheus
 endif::openshift-dedicated,openshift-rosa[]
@@ -21,11 +21,12 @@ Note the following behaviors of these data retention settings:
 * Data in the `/wal` and `/head_chunks` directories counts toward the retention size limit, but Prometheus never purges data from these directories based on size- or time-based retention policies.
 Thus, if you set a retention size limit lower than the maximum size set for the `/wal` and `/head_chunks` directories, you have configured the system not to retain any data blocks in the `/prometheus` data directories.
 * The size-based retention policy is applied only when Prometheus cuts a new data block, which occurs every two hours after the WAL contains at least three hours of data.
-* If you do not explicitly define values for either `retention` or `retentionSize`, retention time defaults to 11 days, and retention size is not set.
+* If you do not explicitly define values for either `retention` or `retentionSize`, retention time defaults to 15 days and retention size is not set.
 * If you define values for both `retention` and `retentionSize`, both values apply.
 If any data blocks exceed the defined retention time or the defined size limit, Prometheus purges these data blocks.
 * If you define a value for `retentionSize` and do not define `retention`, only the `retentionSize` value applies.
 * If you do not define a value for `retentionSize` and only define a value for `retention`, only the `retention` value applies.
+* If you set the `retentionSize` or `retention` value to number 0, the default settings apply. The default settings set retention time to 15 days and do not set a value for retention size.
 
 .Prerequisites
 


### PR DESCRIPTION
Version(s): `enterprise-4.12` and later

Issue: [OBSDOCS-72](https://issues.redhat.com/browse/OBSDOCS-72)

Link to docs preview: [Modifying the retention time and size for Prometheus metrics data](https://72782--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack#modifying-retention-time-and-size-for-prometheus-metrics-data_configuring-the-monitoring-stack)

QE review:
- [x] QE has approved this change.

Peer review:
- [x] Peer review done

**Additional information:** 