### PR TITLE
OBSDOCS-74: Update remote write topic that only remote write sender c…

### DIFF
--- a/modules/monitoring-configuring-remote-write-storage.adoc
+++ b/modules/monitoring-configuring-remote-write-storage.adoc
@@ -25,6 +25,11 @@ ifdef::openshift-dedicated,openshift-rosa[]
 endif::openshift-dedicated,openshift-rosa[]
 * You have installed the OpenShift CLI (`oc`).
 * You have set up a remote write compatible endpoint (such as Thanos) and know the endpoint URL. See the link:https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage[Prometheus remote endpoints and storage documentation] for information about endpoints that are compatible with the remote write feature.
++
+[IMPORTANT]
+====
+Red{nbsp}Hat only provides information for configuring remote write senders and does not offer guidance on configuring receiver endpoints. Customers are responsible for setting up their own endpoints that are remote-write compatible. Issues with endpoint receiver configurations are not included in Red{nbsp}Hat production support.
+====
 * You have set up authentication credentials in a `Secret` object for the remote write endpoint. You must create the secret in the
 ifndef::openshift-dedicated,openshift-rosa[]
 same namespace as the Prometheus object for which you configure remote write: the `openshift-monitoring` namespace for default platform monitoring or the `openshift-user-workload-monitoring` namespace for user workload monitoring.
@@ -34,7 +39,7 @@ ifdef::openshift-dedicated,openshift-rosa[]
 endif::openshift-dedicated,openshift-rosa[]
 
 +
-[CAUTION]
+[WARNING]
 ====
 To reduce security risks, use HTTPS and authentication to send metrics to an endpoint.
 ====


### PR DESCRIPTION
Version(s): `enterprise-4.12` and later

Issue: [OBSDOCS-74](https://issues.redhat.com/browse/OBSDOCS-74)

Link to docs preview: [Configuring remote write storage](https://72783--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack#configuring_remote_write_storage_configuring-the-monitoring-stack)

QE review:
- [x] QE has approved this change.

Peer review:
- [x] Peer review done

Additional information: