### PR TITLE
OCPBUGS-30274 PerformanceProfile examples contain wrong type of quotation marks

### DIFF
--- a/modules/cnf-adjusting-nic-queues-with-the-performance-profile.adoc
+++ b/modules/cnf-adjusting-nic-queues-with-the-performance-profile.adoc
@@ -90,10 +90,10 @@ spec:
   net:
     userLevelNetworking: true
     devices:
-    - interfaceName: “eth0”
-    - interfaceName: “eth1”
-    - vendorID: “0x1af4”
-    - deviceID: “0x1000”
+    - interfaceName: "eth0"
+    - interfaceName: "eth1"
+    - vendorID: "0x1af4"
+    - deviceID: "0x1000"
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""
 ----
@@ -113,7 +113,7 @@ spec:
   net:
     userLevelNetworking: true
     devices:
-    - interfaceName: “eth*”
+    - interfaceName: "eth*"
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""
 ----
@@ -133,7 +133,7 @@ spec:
   net:
     userLevelNetworking: true
     devices:
-    - interfaceName: “!eno1”
+    - interfaceName: "!eno1"
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""
 ----
@@ -153,9 +153,9 @@ spec:
   net:
     userLevelNetworking: true
     devices:
-    - interfaceName: “eth0”
-    - vendorID: “0x1af4”
-    - deviceID: “0x1000”
+    - interfaceName: "eth0"
+    - vendorID: "0x1af4"
+    - deviceID: "0x1000"
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""
 ----

--- a/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
+++ b/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
@@ -321,7 +321,7 @@ spec:
   cpu:
     isolated: "2-23,26-47"
     reserved: "0,1,24,25"
-    offlined: “48-59” <1>
+    offlined: "48-59" <1>
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""
   numa:


### PR DESCRIPTION
[OCPBUGS-30274]: PerformanceProfile examples contain wrong type of quotation marks

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12, 4.13, 4.14, 4.15, 4.16, main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-30274
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
* https://72784--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-low-latency-tuning#adjusting-nic-queues-with-the-performance-profile_cnf-master
* https://72784--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-low-latency-tuning#node-tuning-operator-disabling-CPUs-for-power-consumption_cnf-master
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
