### PR TITLE
TRACING-3799: Documentation for the Tempo monolithic CRD

### DIFF
--- a/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-configuring.adoc
+++ b/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-configuring.adoc
@@ -45,7 +45,7 @@ include::modules/distr-tracing-tempo-configuring-tempooperator-metrics-and-alert
 The `TempoMonolithic` Custom Resource (CR) creates a Tempo deployment in monolithic mode.
 All components of the Tempo deployment (compactor, distributor, ingester, querier and query-frontend) are contained in a single container.
 
-This type of deployment is ideal for demo and test setups, for in-memory and Persistent Volume storage of traces (object storage is not required) and the recommended migration path of the {JaegerName} all-in-one deployment.
+This type of deployment is ideal for small deployments, demo and test setups, supports storing traces in memory, in a Persistent Volume and in object storage, and is the recommended migration path of the {JaegerName} all-in-one deployment.
 
 The `TempoMonolithic` deployment is currently a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] feature.
 

--- a/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-configuring.adoc
+++ b/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-configuring.adoc
@@ -38,3 +38,13 @@ The {TempoOperator} supports monitoring and alerting of each TempoStack componen
 include::modules/distr-tracing-tempo-configuring-tempostack-metrics-and-alerts.adoc[leveloffset=+2]
 
 include::modules/distr-tracing-tempo-configuring-tempooperator-metrics-and-alerts.adoc[leveloffset=+2]
+
+[id="setting-up-tempo-monolithic-deployment"]
+== Setting up a Tempo Monolithic Deployment
+
+The `TempoMonolithic` Custom Resource (CR) creates a Tempo deployment in monolithic mode.
+All components of the Tempo deployment (compactor, distributor, ingester, querier and query-frontend) are contained in a single container.
+
+include::modules/distr-tracing-tempo-configuring-tempomonolithic-quickstart.adoc[leveloffset=+2]
+include::modules/distr-tracing-tempo-configuring-tempomonolithic-storage.adoc[leveloffset=+2]
+include::modules/distr-tracing-tempo-configuring-tempomonolithic-jaegerui.adoc[leveloffset=+2]

--- a/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-configuring.adoc
+++ b/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-configuring.adoc
@@ -45,6 +45,16 @@ include::modules/distr-tracing-tempo-configuring-tempooperator-metrics-and-alert
 The `TempoMonolithic` Custom Resource (CR) creates a Tempo deployment in monolithic mode.
 All components of the Tempo deployment (compactor, distributor, ingester, querier and query-frontend) are contained in a single container.
 
+This type of deployment is ideal for demo and test setups, for in-memory and Persistent Volume storage of traces (object storage is not required) and the recommended migration path of the {JaegerName} all-in-one deployment.
+
+The `TempoMonolithic` deployment is currently a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] feature.
+
+[NOTE]
+====
+The monolithic deployment of Tempo does not scale horizontally.
+If you require horizontal scaling, please use the `TempoStack` CR for a Tempo deployment in microservices mode.
+====
+
 include::modules/distr-tracing-tempo-configuring-tempomonolithic-quickstart.adoc[leveloffset=+2]
 include::modules/distr-tracing-tempo-configuring-tempomonolithic-storage.adoc[leveloffset=+2]
 include::modules/distr-tracing-tempo-configuring-tempomonolithic-jaegerui.adoc[leveloffset=+2]

--- a/modules/distr-tracing-tempo-config-default.adoc
+++ b/modules/distr-tracing-tempo-config-default.adoc
@@ -6,7 +6,7 @@
 [id="distr-tracing-tempo-config-default_{context}"]
 = Distributed tracing default configuration options
 
-The Tempo custom resource (CR) defines the architecture and settings to be used when creating the {TempoShortName} resources. You can modify these parameters to customize your {TempoShortName} implementation to your business needs.
+The `TempoStack` custom resource (CR) defines the architecture and settings to be used when creating the {TempoShortName} resources. You can modify these parameters to customize your {TempoShortName} implementation to your business needs.
 
 .Example of a generic Tempo YAML file
 [source,yaml]

--- a/modules/distr-tracing-tempo-configuring-tempomonolithic-jaegerui.adoc
+++ b/modules/distr-tracing-tempo-configuring-tempomonolithic-jaegerui.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * distr-tracing-tempo-configuring.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="configuring-tempomonolithic-jaegerui_{context}"]
+= Configuring Jaeger UI
+
+The following manifests enables the Jaeger UI.
+
+[source,yaml]
+----
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoMonolithic
+metadata:
+  name: sample
+spec:
+  jaegerui:
+    enabled: true # <1>
+    route:
+      enabled: true # <2>
+----
+<1> Enables Jaeger UI.
+<2> Enables creation of a Route for the Jaeger UI.

--- a/modules/distr-tracing-tempo-configuring-tempomonolithic-quickstart.adoc
+++ b/modules/distr-tracing-tempo-configuring-tempomonolithic-quickstart.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * distr-tracing-tempo-configuring.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="configuring-tempomonolithic-quickstart_{context}"]
+= Quickstart
+
+The following manifest creates a Tempo monolithic deployment with trace ingestion over OTLP/gRPC and OTLP/HTTP, storing traces in a 2 GiB tmpfs volume (in-memory storage) and exposing Jaeger UI via a Route.
+
+[source,yaml]
+----
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoMonolithic
+metadata:
+  name: sample
+spec:
+  storage:
+    traces:
+      backend: memory
+  jaegerui:
+    enabled: true
+    route:
+      enabled: true
+----
+
+Once the pod is ready, you can send traces to `tempo-sample:4317` (OTLP/gRPC) and `tempo-sample:4318` (OTLP/HTTP) inside the cluster.
+The Tempo API is available at `tempo-sample:3200` inside the cluster.
+
+Jaeger UI is available at the location of the `tempo-sample-jaegerui` Route (Navigate to the *Console* -> *Networking* -> *Routes*).

--- a/modules/distr-tracing-tempo-configuring-tempomonolithic-storage.adoc
+++ b/modules/distr-tracing-tempo-configuring-tempomonolithic-storage.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * distr-tracing-tempo-configuring.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="configuring-tempomonolithic-storage_{context}"]
+= Configuring Storage
+
+.In-Memory Storage
+
+The following Tempo deployment stores traces in a `tmpfs` (in-memory storage).
+
+[source,yaml]
+----
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoMonolithic
+metadata:
+  name: sample
+spec:
+  storage:
+    traces:
+      backend: memory
+      size: 2Gi # <1>
+----
+<1> Size of the tmpfs volume. Default: `2Gi`.
+
+.Persistent Volume
+
+The following Tempo deployment stores traces in a Persistent Volume.
+
+[source,yaml]
+----
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoMonolithic
+metadata:
+  name: sample
+spec:
+  storage:
+    traces:
+      backend: pv
+      size: 10Gi # <1>
+----
+<1> Size of the Persistent Volume Claim. Default: `10Gi`.
+
+
+.Object Storage
+
+The following Tempo deployment stores traces in a an object storage.
+
+[source,yaml]
+----
+apiVersion: tempo.grafana.com/v1alpha1
+kind: TempoMonolithic
+metadata:
+  name: sample
+spec:
+  storage:
+    traces:
+      backend: s3 # <1>
+      size: 10Gi # <2>
+      s3: # <1>
+        secret: <secret-name> # <3>
+----
+<1> Object storage type. Supported object stores: `s3`, `gcs`, `azure`.
+<2> Size of the Persistent Volume Claim for the Tempo WAL. Default: `10Gi`.
+<3> Name of the storage secret.
+
+The storage secret must be in the same namespace as the `TempoMonolithic` instance and contain the fields as specified in the <<required_secret_parameters_{context}>> table.

--- a/snippets/distr-tracing-tempo-required-secret-parameters.adoc
+++ b/snippets/distr-tracing-tempo-required-secret-parameters.adoc
@@ -5,6 +5,7 @@
 
 :_mod-docs-content-type: SNIPPET
 
+[id="required_secret_parameters_{context}"]
 .Required secret parameters
 [cols="25h,~"]
 |===


### PR DESCRIPTION
Version(s):
RHOSDT-3.2

Issue:
https://issues.redhat.com/browse/TRACING-3799

Link to docs preview:
https://72786--ocpdocs-pr.netlify.app/openshift-enterprise/latest/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-configuring#setting-up-tempo-monolithic-deployment

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
@max-cx 