### PR TITLE
Update ipi-install-replacing-a-bare-metal-control-plane-node.adoc

### DIFF
--- a/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
+++ b/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
@@ -36,10 +36,10 @@ $ oc get clusteroperator baremetal
 ----
 +
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 NAME        VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
-baremetal   4.15.0   True        False         False      3d15h
+baremetal   {product-version}   True        False         False      3d15h
 ----
 
 . Remove the old `BareMetalHost` and `Machine` objects:


### PR DESCRIPTION
Requirement :

Version should be called as a variable so that every release would be able to get the correct version info

Version(s):
4.15

Issue:
Ensure that the Bare Metal Operator is available:


Link to docs preview:
https://docs.openshift.com/container-platform/4.15/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html#replacing-a-bare-metal-control-plane-node_ipi-install-expanding

QE review:
- N/A docs work