### PR TITLE
ROX-22864: core_bpf does not need support-package

### DIFF
--- a/modules/update-kernel-support-packages.adoc
+++ b/modules/update-kernel-support-packages.adoc
@@ -6,9 +6,13 @@
 = Updating kernel support packages in offline mode
 
 Collector monitors the runtime activity for each node in your secured clusters.
-To monitor the activities, Collector requires probes.
-These probes are eBPF programs specific to the Linux kernel version installed on the host.
-The Collector image contains a set of built-in probes.
+To monitor the activities, Collector requires probes in the form of eBPF programs.
+
+With the `CORE_BPF` collection method, the probe is not specific to any kernel version, and can still be used after the underlying kernel
+has been updated. This collection method does not require you to provide or update a support package.
+
+Instead, when you use the collection method `EBPF`, the probes are specific to the Linux kernel version installed on the host.
+The Collector image contains a set of built-in probes for the kernels supported at release time. However, later kernels will require newer probes.
 
 When {product-title} runs in normal mode (connected to the internet), Collector automatically downloads a new probe if the required probe is not built in.
 


### PR DESCRIPTION
Version(s):
`>=4.4`

Issue:
Explain that the customer is not required to update a support-package in offline-mode when using core_bpf. This is only required for ebpf.

Link to docs preview:
https://72821--docspreview.netlify.app/openshift-acs/latest/configuration/enable-offline-mode#update-kernel-support-packages_enable-offline-mode

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
