### PR TITLE
OSDOCS-9756: Added a release note that log linking is enabled by default

### DIFF
--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -16,6 +16,8 @@ toc::[]
 [id="rosa-q1-2024_{context}"]
 === Q1 2024
 
+* **Log linking is enabled by default** - Beginning with {product-title} 4.15, log linking is enabled by default. Log linking gives you access to the container logs for your pods.
+
 * **Availability zone update.** You can now optionally select a single availability zone (AZ) for machine pools when you have a multi-AZ cluster. For more information, see xref:../rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc#creating_machine_pools_cli_rosa-managing-worker-nodes[Creating a machine pool using the ROSA CLI].
 
 * **ROSA CLI update.** The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/tag/v1.2.35[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-about_rosa-getting-started-cli[About the ROSA CLI].


### PR DESCRIPTION
Version(s):
`enterprise-4.15+`

Issue:
[OSDOCS-9756](https://issues.redhat.com/browse/OSDOCS-9756)

Link to docs preview:
- [What's New](https://file.rdu.redhat.com/eponvell/OSDOCS-9756_Host-Container-Logs-Note/rosa_release_notes/rosa-release-notes.html#rosa-q1-2024_rosa-whats-new) with ROSA

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR adds a release note to ROSA that notes that log linking is enabled by default.