### PR TITLE
OSDOCS-9583

### DIFF
--- a/modules/rosa-accessing-your-cluster-quick.adoc
+++ b/modules/rosa-accessing-your-cluster-quick.adoc
@@ -30,10 +30,11 @@ $ rosa create admin --cluster=<cluster_name>
 W: It is recommended to add an identity provider to login to this cluster. See 'rosa create idp --help' for more information.
 I: Admin account has been added to cluster 'cluster_name'. It may take up to a minute for the account to become active.
 I: To login, run the following command:
-oc login https://api.cluster-name.t6k4.i1.oragnization.org:6443 \
+oc login https://api.cluster-name.t6k4.i1.oragnization.org:6443 \ <1>
 --username cluster-admin \
 --password FWGYL-2mkJI-3ZTTZ-rINns
 ----
+<1> For a {hcp-title-first} cluster, the port number should be `443`.
 
 . Enter the `oc login` command, username, and password from the output of the previous command:
 
@@ -41,11 +42,12 @@ oc login https://api.cluster-name.t6k4.i1.oragnization.org:6443 \
 .Example output
 [source,terminal]
 ----
-$ oc login https://api.cluster_name.t6k4.i1.oragnization.org:6443 \
+$ oc login https://api.cluster_name.t6k4.i1.oragnization.org:6443 \ <1>
 >  --username cluster-admin \
 >  --password FWGYL-2mkJI-3ZTTZ-rINns
 Login successful.                                                                                                                                                                                                                                                       You have access to 77 projects, the list has been suppressed. You can list all projects with ' projects'
 ----
+<1> For a {hcp-title} cluster, the port number should be `443`.
 
 . Using the default project, enter this `oc` command to verify that the cluster administrator access is created:
 +

--- a/modules/rosa-accessing-your-cluster.adoc
+++ b/modules/rosa-accessing-your-cluster.adoc
@@ -106,13 +106,14 @@ $ rosa describe cluster --cluster=<cluster_name>
 Name:        rh-rosa-test-cluster1
 ID:          1de87g7c30g75qechgh7l5b2bha6r04e
 External ID: 34322be7-b2a7-45c2-af39-2c684ce624e1
-API URL:     https://api.rh-rosa-test-cluster1.j9n4.s1.devshift.org:6443
+API URL:     https://api.rh-rosa-test-cluster1.j9n4.s1.devshift.org:6443 <1>
 Console URL: https://console-openshift-console.apps.rh-rosa-test-cluster1.j9n4.s1.devshift.org
 Nodes:       Master: 3, Infra: 3, Compute: 4
 Region:      us-east-2
 State:       ready
 Created:     May 27, 2020
 ----
+<1> For a {hcp-title-first} cluster, the port number should be `443`.
 +
 .. Navigate to the `Console URL`, and log in using your Github credentials.
 .. In the top right of the OpenShift console, click your name and click **Copy Login Command**.
@@ -121,18 +122,21 @@ Created:     May 27, 2020
 +
 [source,terminal]
 ----
-$ oc login --token=z3sgOGVDk0k4vbqo_wFqBQQTnT-nA-nQLb8XEmWnw4X --server=https://api.rh-rosa-test-cluster1.j9n4.s1.devshift.org:6443
+$ oc login --token=z3sgOGVDk0k4vbqo_wFqBQQTnT-nA-nQLb8XEmWnw4X --server=https://api.rh-rosa-test-cluster1.j9n4.s1.devshift.org:6443 <1>
 ----
+<1> For a {hcp-title} cluster, use the port number `443`.
 +
 .Example output
 [source,terminal]
 ----
-Logged into "https://api.rh-rosa-cluster1.j9n4.s1.devshift.org:6443" as "rh-rosa-test-user" using the token provided.
+Logged into "https://api.rh-rosa-cluster1.j9n4.s1.devshift.org:6443" as "rh-rosa-test-user" using the token provided. <1>
 
 You have access to 67 projects, the list has been suppressed. You can list all projects with 'oc projects'
 
 Using project "default".
 ----
+<1> For a {hcp-title} cluster, the port number should be `443`.
+
 .. Enter a simple `oc` command to verify everything is setup properly and that you are logged in.
 +
 [source,terminal]


### PR DESCRIPTION
[OSDOCS-9583](https://issues.redhat.com/browse/OSDOCS-9583): [rosa-] Issue in file rosa_install_access_delete_clusters/rosa-sts-accessing-cluster.adoc
Aligned team: Service Delivery
OCP version for cherry-picking: enterprise-4.15+
JIRA issues: [OSDOCS-9583](https://issues.redhat.com/browse/OSDOCS-9583)
Preview pages: [Accessing your cluster quickly](https://72868--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-accessing-cluster#rosa-accessing-your-cluster-quick_rosa-sts-accessing-cluster), [Accessing your cluster with an IDP account](https://72868--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-accessing-cluster#rosa-accessing-your-cluster_rosa-sts-accessing-cluster)
SME review **completed**: @sureshgaikwad
QE review **completed**: @yuwang-RH
Peer review **completed**: @gwynnemonahan and @skopacz1 

Note: We have SME approval in [Jira comment](https://issues.redhat.com/browse/OSDOCS-9583?focusedId=24325740&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-24325740).