### PR TITLE
Add redirect for broken 4.3 RHACS link

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -147,6 +147,8 @@ AddType text/vtt                            vtt
     RewriteRule ^acs/(3\.65|3\.66|3\.67|3\.68|3\.69|3\.70|3\.71|3\.72|3\.73|3\.74|4\.0|4\.1|4\.2|4\.3)/?$ /acs/$1/welcome/index.html [L,R=301]
     #redirect for 4.0 Manage vulneribility page
     RewriteRule ^(acs/(?:4\.0/)?)?operating/manage-vulnerabilities\.html$ /acs/4.0/operating/manage-vulnerabilities/vulnerability-management.html [NE,R=301]
+    #redirect for missing 4.3 page
+    RewriteRule ^(acs/(?:4\.3/)?)?installing/acs-installation-platforms\.html$ /acs/4.3/installing/acs-high-level-overview.html [NE,R=301]
 
       # remove aro docs to just the welcome page
     RewriteRule aro/4/(?!welcome)(.*)?$ /container-platform/latest/$1 [L,R=301]


### PR DESCRIPTION
Version(s):
Just merged to openshift-main, I think

[Issue](https://issues.redhat.com/browse/ROX-23005)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: **N/A**
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Link from GUI to 4.3 page is broken because page was removed.
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
