### PR TITLE
OCPBUGS-30166#correcting typos

### DIFF
--- a/modules/nodes-pods-vertical-autoscaler-about.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-about.adoc
@@ -13,10 +13,10 @@ The VPA Operator consists of three components, each of which has its own pod in 
 Recommender::
 The VPA recommender monitors the current and past resource consumption and, based on this data, determines the optimal CPU and memory resources for the pods in the associated workload object.
 
-Updater:: 
+Updater::
 The VPA updater checks if the pods in the associated workload object have the correct resources. If the resources are correct, the updater takes no action. If the resources are not correct, the updater kills the pod so that they can be recreated by their controllers with the updated requests.
 
-Admission controller:: 
+Admission controller::
 The VPA admission controller sets the correct resource requests on each new pod in the associated workload object, whether the pod is new or was recreated by its controller due to the VPA updater actions.
 
 You can use the default recommender or use your own alternative recommender to autoscale based on your own algorithms.
@@ -27,7 +27,7 @@ The VPA then automatically deletes any pods that are out of alignment with these
 
 [NOTE]
 ====
-By default, workload objects must specify a minimum of two replicas in order for the VPA to automatically delete their pods. Workload objects that specify fewer replicas than this minimum are not deleted. If you manually delete these pods, when the workload object redeploys the pods, the VPA does update the new pods with its recommendations. You can change this minimum by modifying the `VerticalPodAutoscalerController` object as shown shown in _Changing the VPA minimum value_.
+By default, workload objects must specify a minimum of two replicas in order for the VPA to automatically delete their pods. Workload objects that specify fewer replicas than this minimum are not deleted. If you manually delete these pods, when the workload object redeploys the pods, the VPA does update the new pods with its recommendations. You can change this minimum by modifying the `VerticalPodAutoscalerController` object as shown in _Changing the VPA minimum value_.
 ====
 
 For example, if you have a pod that uses 50% of the CPU but only requests 10%, the VPA determines that the pod is consuming more CPU than requested and deletes the pod. The workload object, such as replica set, restarts the pods and the VPA updates the new pod with its recommended resources.

--- a/modules/nodes-pods-vertical-autoscaler-custom.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-custom.adoc
@@ -70,7 +70,7 @@ subjects:
   name: alt-vpa-recommender-sa
   namespace: <namespace_name>
 ----
-<1> Creates a service accocunt for the recommender in the namespace where the recommender is deployed.
+<1> Creates a service account for the recommender in the namespace where the recommender is deployed.
 <2> Binds the recommender service account to the `metrics-reader` role. Specify the namespace where the recommender is to be deployed.
 <3> Binds the recommender service account to the `vpa-actor` role. Specify the namespace where the recommender is to be deployed.
 <4> Binds the recommender service account to the `vpa-target-reader` role. Specify the namespace where the recommender is to be deployed.

--- a/modules/nodes-pods-vertical-autoscaler-install.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-install.adoc
@@ -43,7 +43,7 @@ is automatically created if it does not exist.
 $ oc get all -n openshift-vertical-pod-autoscaler
 ----
 +
-The output shows four pods and four deplyoments:
+The output shows four pods and four deployments:
 +
 .Example output
 [source,terminal]

--- a/modules/nodes-pods-vertical-autoscaler-using-about.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-using-about.adoc
@@ -134,7 +134,7 @@ When the pods are created for the workload object, the VPA constantly monitors t
 
 [NOTE]
 ====
-By default, workload objects must specify a minimum of two replicas in order for the VPA to automatically delete their pods. Workload objects that specify fewer replicas than this minimum are not deleted. If you manually delete these pods, when the workload object redeploys the pods, the VPA does update the new pods with its recommendations. You can change this minimum by modifying the `VerticalPodAutoscalerController` object as shown shown in _Changing the VPA minimum value_.
+By default, workload objects must specify a minimum of two replicas in order for the VPA to automatically delete their pods. Workload objects that specify fewer replicas than this minimum are not deleted. If you manually delete these pods, when the workload object redeploys the pods, the VPA does update the new pods with its recommendations. You can change this minimum by modifying the `VerticalPodAutoscalerController` object as shown in _Changing the VPA minimum value_.
 ====
 
 .Example VPA CR for the `Auto` mode


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Versions: 
4.13+

Issue:
https://issues.redhat.com/browse/OCPBUGS-30166

Link to docs preview:
https://72886--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler


QE review not required as fixing non-technical typo. 


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

