### PR TITLE
OCPBUGS-29262-re: Updated the vSphere add parameters to include more

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -90,7 +90,7 @@ endif::agent[]
 Required installation configuration parameters are described in the following table:
 
 .Required parameters
-[cols=".^2m,.^3,.^5a",options="header"]
+[cols=".^2l,.^3,.^5a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -239,7 +239,7 @@ Globalnet is not supported with {rh-storage-first} disaster recovery solutions. 
 ====
 
 .Network parameters
-[cols=".^2m,.^3a,.^3a",options="header"]
+[cols=".^2l,.^3a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -416,7 +416,7 @@ Set the `networking.machineNetwork` to match the CIDR that the preferred NIC res
 Optional installation configuration parameters are described in the following table:
 
 .Optional parameters
-[cols=".^2m,.^3a,.^3a",options="header"]
+[cols=".^2l,.^3a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -793,7 +793,7 @@ ifdef::aws[]
 Optional AWS configuration parameters are described in the following table:
 
 .Optional AWS parameters
-[cols=".^2m,.^3,.^5a",options="header"]
+[cols=".^2l,.^3,.^5a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -1022,7 +1022,7 @@ ifdef::osp[]
 Additional {rh-openstack} configuration parameters are described in the following table:
 
 .Additional {rh-openstack} parameters
-[cols=".^2m,.^3a,^5a",options="header"]
+[cols=".^2l,.^3a,^5a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -1126,7 +1126,7 @@ This property is deprecated. To use a flavor as the default for all machine pool
 Optional {rh-openstack} configuration parameters are described in the following table:
 
 .Optional {rh-openstack} parameters
-[%header, cols=".^2m,.^3,.^5a"]
+[%header, cols=".^2l,.^3,.^5a"]
 |====
 |Parameter|Description|Values
 
@@ -1285,7 +1285,7 @@ within link:https://azure.microsoft.com/en-us/global-infrastructure/regions[a re
 ====
 
 .Additional Azure parameters
-[cols=".^2m,.^3a,.^3a",options="header"]
+[cols=".^2l,.^3a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -1939,7 +1939,7 @@ Configuring these fields at install time eliminates the need to set them as a Da
 ====
 
 .Additional bare metal parameters
-[cols=".^2m,.^3a,.^3a",options="header"]
+[cols=".^2l,.^3a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -2066,7 +2066,7 @@ ifdef::gcp[]
 Additional GCP configuration parameters are described in the following table:
 
 .Additional GCP parameters
-[cols=".^1m,.^6a,.^3a",options="header"]
+[cols=".^1l,.^6a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -2500,7 +2500,7 @@ ifdef::ibm-cloud[]
 Additional {ibm-cloud-name} configuration parameters are described in the following table:
 
 .Additional {ibm-cloud-name} parameters
-[cols=".^1m,.^6a,.^3a",options="header"]
+[cols=".^1l,.^6a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -2641,16 +2641,14 @@ ifdef::agent,vsphere[]
 Additional VMware vSphere configuration parameters are described in the following table:
 
 .Additional VMware vSphere cluster parameters
-[cols=".^2m,.^3a,.^3",options="header,word-wrap",subs="+quotes,+attributes"]
+[cols=".^2l,.^3a,.^3",options="header,word-wrap",subs="+quotes,+attributes"]
 |====
 |Parameter|Description|Values
-ifdef::agent[]
 
 |platform:
   vsphere:
 | Describes your account on the cloud platform that hosts your cluster. You can use the parameter to customize the platform. If you provide additional configuration settings for compute and control plane machines in the machine pool, the parameter is not required. You can only specify one vCenter server for your {product-title} cluster.
 |A dictionary of vSphere configuration objects
-endif::agent[]
 ifdef::vsphere[]
 
 |platform:
@@ -2666,14 +2664,7 @@ ifdef::vsphere[]
     diskType:
 |Optional. The disk provisioning method. This value defaults to the vSphere default storage policy if not set.
 |Valid values are `thin`, `thick`, or `eagerZeroedThick`.
-
-|platform:
-  vsphere:
-    failureDomains:
-|Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
-|String
 endif::vsphere[]
-ifdef::agent[]
 
 |platform:
   vsphere:
@@ -2694,7 +2685,6 @@ ifdef::agent[]
       server:
 |The fully qualified domain name (FQDN) of the vCenter server.
 |An FQDN such as example.com
-endif::agent[]
 
 |platform:
   vsphere:
@@ -2703,7 +2693,6 @@ endif::agent[]
         networks:
 |Lists any network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured.
 |String
-ifdef::agent[]
 
 |platform:
   vsphere:
@@ -2739,29 +2728,44 @@ For more information, see "VMware vSphere region and zone enablement".
 ====
 |String
 
+ifdef::agent[]
 |platform:
   vsphere:
     failureDomains:
       topology:
-        resourcePool:
-// When this content is added to vSphere docs, the line below should likely say "where the installation program creates the virtual machines".
-|Optional: The absolute path of an existing resource pool where the user creates the virtual machines, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
-// Commenting out the line below because it doesn't apply to Agent, but it may be needed when this content is brought into the regular vSphere docs.
-// If you do not specify a value, resources are installed in the root of the cluster, for example `/example_datacenter/host/example_cluster/Resources`.
+        folder:
+|The absolute path of an existing folder where the user creates the virtual machines, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
 |String
 
 |platform:
   vsphere:
     failureDomains:
       topology:
-        folder:
-// When this content is added to vSphere docs, the line below should likely say "where the installation program creates the virtual machines", and should be Optional.
-|The absolute path of an existing folder where the user creates the virtual machines, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
-// Commenting out the two lines below because they don't apply to Agent, but they may be needed when this content is brought into the regular vSphere docs.
-// If you do not provide this value, the installation program creates a top-level folder in the datacenter virtual machine folder that is named with the infrastructure ID.
-// If you are providing the infrastructure for the cluster and you do not want to use the default `StorageClass` object, named `thin`, you can omit the `folder` parameter from the `install-config.yaml` file.
+        resourcePool:
+|Optional: The absolute path of an existing resource pool where the user creates the virtual machines, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
 |String
 endif::agent[]
+ifdef::vsphere[]
+|platform:
+  vsphere:
+    failureDomains:
+      topology:
+        folder:
+|Optional parameter. The absolute path of an existing folder where the installation program creates the virtual machines, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`. 
+
+If you do not provide this value, the installation program creates a top-level folder in the datacenter virtual machine folder that is named with the infrastructure ID. 
+
+If you are providing the infrastructure for the cluster and you do not want to use the default `StorageClass` object, named `thin`, you can omit the `folder` parameter from the `install-config.yaml` file.
+|String
+
+|platform:
+  vsphere:
+    failureDomains:
+      topology:
+        resourcePool:
+|Optional parameter. The absolute path of an existing resource pool where the installation program  creates the virtual machines, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.If you do not specify a value, resources are installed in the root of the cluster, for example `/example_datacenter/host/example_cluster/Resources`.
+|String
+endif::vsphere[]
 
 |platform:
   vsphere:
@@ -2795,16 +2799,10 @@ ifdef::vsphere[]
 
 |platform:
   vsphere:
-| Describes your account on the cloud platform that hosts your cluster. You can use the parameter to customize the platform. When providing additional configuration settings for compute and control plane machines in the machine pool, the parameter is optional. You can only specify one vCenter server for your {product-title} cluster.
-|String
-
-|platform:
-  vsphere:
     vcenters:
 |Lists any fully-qualified hostname or IP address of a vCenter server.
 |String
 endif::vsphere[]
-ifdef::agent[]
 
 |platform:
   vsphere:
@@ -2812,7 +2810,6 @@ ifdef::agent[]
 |Configures the connection details so that services can communicate with vCenter.
 Currently, only a single vCenter is supported.
 |An array of vCenter configuration objects.
-endif::agent[]
 
 |platform:
   vsphere:
@@ -2820,7 +2817,6 @@ endif::agent[]
       datacenters:
 |Lists and defines the datacenters where {product-title} virtual machines (VMs) operate. The list of datacenters must match the list of datacenters specified in the `failureDomains` field.
 |String
-ifdef::agent[]
 
 |platform:
   vsphere:
@@ -2849,7 +2845,6 @@ ifdef::agent[]
       user:
 |The username associated with the vSphere user.
 |String
-endif::agent[]
 |====
 
 [id="deprecated-parameters-vsphere_{context}"]
@@ -2860,7 +2855,7 @@ In {product-title} 4.13, the following vSphere configuration parameters are depr
 The following table lists each deprecated vSphere configuration parameter:
 
 .Deprecated VMware vSphere cluster parameters
-[cols=".^2m,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
+[cols=".^2l,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
 |====
 |Parameter|Description|Values
 ifdef::vsphere[]
@@ -2950,7 +2945,7 @@ ifdef::vsphere[]
 Optional VMware vSphere machine pool configuration parameters are described in the following table:
 
 .Optional VMware vSphere machine pool parameters
-[cols=".^2m,.^3a,.^3a",options="header"]
+[cols=".^2l,.^3a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -2995,7 +2990,7 @@ ifdef::ash[]
 Additional Azure configuration parameters are described in the following table:
 
 .Additional Azure Stack Hub parameters
-[cols=".^2m,.^3a,.^3a",options="header"]
+[cols=".^2l,.^3a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -3131,7 +3126,7 @@ If defined, the parameters `compute.platform.alibabacloud` and `controlPlane.pla
 ====
 
 .Optional {alibaba} parameters
-[cols=".^2m,.^3,.^5a",options="header"]
+[cols=".^2l,.^3,.^5a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -3281,13 +3276,13 @@ If defined, the parameters `compute.platform.alibabacloud` and `controlPlane.pla
 endif::alibaba-cloud[]
 
 ifdef::nutanix[]
-[id="installation-configuration-parameters-additional-vsphere_{context}"]
+[id="installation-configuration-parameters-additional-nutanix_{context}"]
 == Additional Nutanix configuration parameters
 
 Additional Nutanix configuration parameters are described in the following table:
 
 .Additional Nutanix cluster parameters
-[cols=".^2m,.^3a,.^3a",options="header"]
+[cols=".^2l,.^3a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 


### PR DESCRIPTION
Version(s):
4.12 to 4.16

Issue:
[OCPBUGS-29262](https://issues.redhat.com/browse/OCPBUGS-29262)

Link to docs preview:
[Additional VMware vSphere configuration parameters](https://72733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere#installation-configuration-parameters-additional-vsphere_installation-config-parameters-vsphere)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* https://github.com/openshift/openshift-docs/pull/70551#issuecomment-1930706031
