### PR TITLE
CNV-32614: Document deprecate templates functionality

### DIFF
--- a/modules/virt-customizing-vm-template-web.adoc
+++ b/modules/virt-customizing-vm-template-web.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/creating_vms_rh/virt-creating-vms-from-templates.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-customizing-vm-template-web_{context}"]
+= Customizing a VM template by using the web console
+
+You can customize an existing virtual machine (VM) template by modifying the VM or template parameters, such as data sources, cloud-init, or SSH keys, before you start the VM. If you customize a template by copying it and including all of its labels and annotations, the customized template is marked as deprecated when a new version of the Scheduling, Scale, and Performance (SSP) Operator is deployed.
+
+You can remove the deprecated designation from the customized template.
+
+.Procedure
+
+. Navigate to *Virtualization* -> *Templates* in the web console.
+
+. From the list of VM templates, click the template marked as deprecated.
+
+. Click *Edit* next to the pencil icon beside *Labels*.
+
+. Remove the following two labels:
+
+* `template.kubevirt.io/type: "base"`
+* `template.kubevirt.io/version: "version"`
+
+. Click *Save*.
+
+. Click the pencil icon beside the number of existing *Annotations*.
+
+. Remove the following annotation:
+
+* `template.kubevirt.io/deprecated`
+
+. Click *Save*.

--- a/virt/virtual_machines/creating_vms_rh/virt-creating-vms-from-templates.adoc
+++ b/virt/virtual_machines/creating_vms_rh/virt-creating-vms-from-templates.adoc
@@ -23,6 +23,11 @@ You can customize the disk source and VM parameters before you start the VM:
 
 * See the xref:../../../virt/getting_started/virt-web-console-overview.adoc#virtualmachine-details-overview_virt-web-console-overview[*Overview*], xref:../../../virt/getting_started/virt-web-console-overview.adoc#virtualmachine-details-yaml_virt-web-console-overview[*YAML*], and xref:../../../virt/getting_started/virt-web-console-overview.adoc#virtualmachine-details-configuration_virt-web-console-overview[*Configuration*] tab documentation for details about VM settings.
 
+[NOTE]
+====
+If you copy a VM template with all its labels and annotations, your version of the template is marked as deprecated when a new version of the Scheduling, Scale, and Performance (SSP) Operator is deployed. You can remove this designation. See xref:../../../virt/virtual_machines/creating_vms_rh/virt-creating-vms-from-templates.adoc#virt-customizing-vm-template-web_virt-creating-vms-from-templates[Customizing a VM template by using the web console].
+====
+
 {sno-caps}::
 Due to differences in storage behavior, some templates are incompatible with {sno}. To ensure compatibility, do not set the `evictionStrategy` field for templates or VMs that use data volumes or storage profiles.
 
@@ -31,3 +36,5 @@ include::modules/virt-creating-vm-from-template.adoc[leveloffset=+1]
 include::modules/virt-vm-storage-volume-types.adoc[leveloffset=+2]
 
 include::modules/virt-storage-wizard-fields-web.adoc[leveloffset=+2]
+
+include::modules/virt-customizing-vm-template-web.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s): 4.14+

Issue: [CNV-32614](https://issues.redhat.com/browse/CNV-32614)

Links to docs previews:
- [About VM templates (Customization)](https://72894--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/creating_vms_rh/virt-creating-vms-from-templates#virt-about-templates)
- [Customizing a VM template](https://72894--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/creating_vms_rh/virt-creating-vms-from-templates#virt-customizing-vm-template-web_virt-creating-vms-from-templates)

QE review:
- [x] QE has approved this change.



