### PR TITLE
OSDOCS-9529: Create a guide to installing a ROSA HCP cluster with no CNI plugin

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -262,6 +262,8 @@ Topics:
   File: rosa-hcp-aws-private-creating-cluster
 - Name: Creating ROSA with HCP clusters with external authentication
   File: rosa-hcp-sts-creating-a-cluster-ext-auth
+- Name: Creating ROSA with HCP clusters without a CNI plugin
+  File: rosa-hcp-cluster-no-cni
 - Name: Using the Node Tuning Operator on ROSA with HCP
   File: rosa-tuning-config
 - Name: Deleting a ROSA with HCP cluster

--- a/modules/rosa-create-objects.adoc
+++ b/modules/rosa-create-objects.adoc
@@ -240,6 +240,9 @@ OVN-Kubernetes, the default network provider in ROSA 4.11 and later, uses the `1
 |--multi-az
 |Deploys to multiple data centers.
 
+|--no-cni
+|Creates a cluster without a Container Network Interface (CNI) plugin. Customers can then bring their own CNI plugin and install it after cluster creation.
+
 |--operator-roles-prefix <string>
 |Prefix that are used for all IAM roles used by the operators needed in the OpenShift installer. A prefix is generated automatically if you do not specify one.
 
@@ -283,7 +286,7 @@ a|--sts \| --non-sts
 When using `--private-link`, the `--subnet-ids` argument is required and only one private subnet is allowed per zone.
 
 |--support-role-arn string
-|The ARN of the role used by Red{nbsp}Hat Site Reliabilty Engineers (SREs) to enable access to the cluster account to provide support.
+|The ARN of the role used by Red Hat Site Reliability Engineers (SREs) to enable access to the cluster account to provide support.
 
 |--tags
 a|Tags that are used on resources created by {product-title} in AWS. Tags can help you manage, identify, organize, search for, and filter resources within AWS. Tags are comma separated, for example: "key value, foo bar".

--- a/modules/rosa-hcp-sts-creating-a-cluster-cli-no-cni-plugin.adoc
+++ b/modules/rosa-hcp-sts-creating-a-cluster-cli-no-cni-plugin.adoc
@@ -1,0 +1,84 @@
+// Module included in the following assemblies:
+//
+// * rosa_hcp/rosa-hcp-cluster-no-cni.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-hcp-sts-creating-a-cluster-cli_{context}-no-cni"]
+= Creating the cluster
+
+When using the {product-title} (ROSA) command line interface (CLI), `rosa`, to create a cluster, you can add an optional flag `--no-cni` to create a cluster without a CNI plugin.
+
+.Prerequisites
+
+* You have completed the AWS prerequisites for {hcp-title}.
+* You have available AWS service quotas.
+* You have enabled the ROSA service in the AWS Console.
+* You have installed and configured the latest ROSA CLI (`rosa`) on your installation host. Run `rosa version` to see your currently installed version of the ROSA CLI. If a newer version is available, the CLI provides a link to download this upgrade.
+* You have logged in to your Red Hat account by using the ROSA CLI.
+* You have created an OIDC configuration.
+* You have verified that the AWS Elastic Load Balancing (ELB) service role exists in your AWS account.
+
+.Procedure
+
+. You can create your {hcp-title} cluster with one of the following commands.
++
+[NOTE]
+====
+When creating a {hcp-title} cluster, the default machine Classless Inter-Domain Routing (CIDR) is `10.0.0.0/16`. If this does not correspond to the CIDR range for your VPC subnets, add `--machine-cidr <address_block>` to the following commands. To learn more about the default CIDR ranges for {product-title}, see xref:../networking/cidr-range-definitions.adoc#cidr-range-definitions[CIDR range definitions].
+====
++
+** Create a cluster with a single, initial machine pool, publicly available API, publicly available Ingress, and no CNI plugin by running the following command:
++
+[source,terminal]
+----
+$ rosa create cluster --cluster-name=<cluster_name> \
+    --sts --mode=auto --hosted-cp --operator-roles-prefix <operator-role-prefix> \
+    --oidc-config-id <ID-of-OIDC-configuration> --subnet-ids=<public-subnet-id>,<private-subnet-id> --no-cni
+----
+
+** Create a cluster with a single, initial machine pool, privately available API, privately available Ingress, and no CNI plugin by running the following command:
++
+[source,terminal]
+----
+$ rosa create cluster --private --cluster-name=<cluster_name> \
+    --sts --mode=auto --hosted-cp --subnet-ids=<private-subnet-id> --no-cni
+----
+
+** If you used the `OIDC_ID`, `SUBNET_IDS`, and `OPERATOR_ROLES_PREFIX` variables to prepare your environment, you can continue to use those variables when creating your cluster without a CNI plugin. For example, run the following command:
++
+[source,terminal]
+----
+$ rosa create cluster --hosted-cp --subnet-ids=$SUBNET_IDS --oidc-config-id=$OIDC_ID --cluster-name=<cluster_name> --operator-roles-prefix=$OPERATOR_ROLES_PREFIX --no-cni
+----
+
+. Check the status of your cluster by running the following command:
++
+[source,terminal]
+----
+$ rosa describe cluster --cluster=<cluster_name>
+----
++
+The following `State` field changes are listed in the output as the cluster installation progresses:
++
+* `pending (Preparing account)`
+* `installing (DNS setup in progress)`
+* `installing`
+* `ready`
++
+[NOTE]
+====
+If the installation fails or the `State` field does not change to `ready` after more than 10 minutes, check the installation troubleshooting documentation for details. For more information, see _Troubleshooting installations_. For steps to contact Red Hat Support for assistance, see _Getting support for Red Hat OpenShift Service on AWS_.
+====
++
+[IMPORTANT]
+====
+When you first log in to the cluster after it reaches `ready` status, the nodes will still be in the `not ready` state until you install your own CNI plugin. After CNI installation, the nodes will change to `ready`. 
+====
+
+. Track the progress of the cluster creation by watching the {product-title} installation program logs. To check the logs, run the following command:
++
+[source,terminal]
+----
+$ rosa logs install --cluster=<cluster_name> --watch <1>
+----
+<1> Optional: To watch for new log messages as the installation progresses, use the `--watch` argument.

--- a/modules/rosa-policy-change-management.adoc
+++ b/modules/rosa-policy-change-management.adoc
@@ -117,6 +117,8 @@ You can review the history of all cluster upgrade events in the {cluster-manager
 |- Configure your firewall to grant access to the required OpenShift and AWS domains and ports before the cluster is provisioned. For more information, see "AWS firewall prerequisites".
 - Provide optional non-default IP address ranges for machine CIDR, service CIDR, and pod CIDR if needed through {cluster-manager} when the cluster is provisioned.
 - Request that the API service endpoint be made public or private on cluster creation or after cluster creation through {cluster-manager}.
+- Create additional Ingress Controllers to publish additional application routes.
+- Install, configure, and upgrade optional CNI plugins if clusters are installed without the default OpenShift CNI plugins.
 
 |Virtual networking management
 |**Red{nbsp}Hat**

--- a/modules/rosa-policy-incident.adoc
+++ b/modules/rosa-policy-incident.adoc
@@ -23,6 +23,12 @@ service, and respond to alerts.
 |- Monitor health of application routes, and the endpoints behind them.
 - Report outages to Red{nbsp}Hat and AWS.
 
+|Cluster networking
+|**Red Hat**
+
+- Monitor, alert, and address incidents related to cluster DNS, network plugin connectivity between cluster components, and the default Ingress Controller.
+|- Monitor and address incidents related to optional Ingress Controllers, additional Operators installed through the OperatorHub, and network plugins replacing the default OpenShift CNI plugins.
+
 |Virtual networking management
 |**Red{nbsp}Hat**
 
@@ -84,7 +90,7 @@ permissions to AWS resources in the customer account.
 |**AWS**
 
 - For information regarding AWS incident and operations management, see link:https://docs.aws.amazon.com/whitepapers/latest/aws-operational-resilience/how-aws-maintains-operational-resilience-and-continuity-of-service.html#incident-management[How AWS maintains operational
-resilience and continuity of service] in the AWS whitepaper.
+resilience and continuity of service] in the AWS white paper.
 
 |- Configure, manage, and monitor customer applications and data to ensure application and data security controls are properly enforced.
 

--- a/modules/rosa-policy-responsibilities.adoc
+++ b/modules/rosa-policy-responsibilities.adoc
@@ -6,7 +6,6 @@
 [id="rosa-policy-responsibilities_{context}"]
 = Shared responsibilities for {product-title}
 
-
 While Red{nbsp}Hat and Amazon Web Services (AWS) manage the {product-title} services, the customer shares certain responsibilities. The {product-title} services are accessed remotely, hosted on public cloud resources, created in customer-owned AWS accounts, and have underlying platform and data security that is owned by Red{nbsp}Hat.
 
 [IMPORTANT]
@@ -36,7 +35,12 @@ If the `cluster-admin` role is added to a user, see the responsibilities and exc
 
 |Application networking |Red{nbsp}Hat and Customer |Red{nbsp}Hat and Customer |Red{nbsp}Hat and Customer |Red{nbsp}Hat |Red{nbsp}Hat
 
-|Cluster networking |Red{nbsp}Hat |Red{nbsp}Hat and Customer ^[1]^ |Red{nbsp}Hat and Customer |Red{nbsp}Hat |Red{nbsp}Hat
+|Cluster networking 
+|Red Hat ^[1]^ 
+|Red Hat and Customer ^[2]^ 
+|Red Hat and Customer 
+|Red Hat ^[1]^ 
+|Red Hat ^[1]^
 
 |Virtual networking management |Red{nbsp}Hat and Customer |Red{nbsp}Hat and Customer |Red{nbsp}Hat and Customer |Red{nbsp}Hat and Customer |Red{nbsp}Hat and Customer
 
@@ -54,4 +58,5 @@ If the `cluster-admin` role is added to a user, see the responsibilities and exc
 |Hardware/AWS global infrastructure |AWS |AWS |AWS |AWS |AWS
 
 |===
-. The customer must configure their firewall to grant access to the required OpenShift and AWS domains and ports before the cluster is provisioned. For more information, see "AWS firewall prerequisites".
+1. If the customer chooses to use their own CNI plugin, the responsibility shifts to the customer.
+2. The customer must configure their firewall to grant access to the required OpenShift and AWS domains and ports before the cluster is provisioned. For more information, see "AWS firewall prerequisites".

--- a/rosa_hcp/rosa-hcp-cluster-no-cni.adoc
+++ b/rosa_hcp/rosa-hcp-cluster-no-cni.adoc
@@ -1,0 +1,44 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="rosa-hcp-cluster-no-cli"]
+= {hcp-title} clusters without a CNI plugin
+include::_attributes/attributes-openshift-dedicated.adoc[]
+include::_attributes/common-attributes.adoc[]
+:context: rosa-hcp-cluster-no-cni
+
+toc::[]
+
+You can use your own Container Network Interface (CNI) plugin when creating a {hcp-title-first} cluster.
+You can create a {hcp-title} cluster without a CNI and install your own CNI plugin after cluster creation.
+
+[NOTE]
+====
+For customers who choose to use their own CNI, the responsibility of CNI plugin support belongs to the customer in coordination with their chosen CNI vendor.
+====
+
+[id="rosa-hcp-no-cni-cluster-creation"]
+== Creating a {hcp-title} cluster without a CNI plugin
+
+=== Prerequisites
+* Ensure that you have completed the xref:../rosa_planning/rosa-sts-aws-prereqs.adoc[AWS prerequisites].
+
+* Ensure that you have a configured xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-creating-vpc[virtual private cloud] (VPC).
+
+include::modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc[leveloffset=+2]
+
+include::modules/rosa-sts-byo-oidc.adoc[leveloffset=+2]
+
+include::modules/rosa-operator-config.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="additional-resources_rosa-hcp-operator-prefix-no-cni"]
+.Additional resources
+
+* See xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-operator-role-prefixes_rosa-sts-about-iam-resources[About custom Operator IAM role prefixes] for information on the Operator prefixes.
+
+include::modules/rosa-hcp-sts-creating-a-cluster-cli-no-cni-plugin.adoc[leveloffset=+1]
+
+[id="next-steps-2_{context}"]
+== Next steps
+
+* Install your CNI plugin. The nodes will then change from the `not ready` to `ready` state.  
+* Access your ROSA cluster with the xref:../rosa_install_access_delete_clusters/rosa-sts-accessing-cluster.adoc#rosa-sts-accessing-cluster[Accessing a ROSA cluster] documentation.


### PR DESCRIPTION
[OSDOCS-9529](https://issues.redhat.com//browse/OSDOCS-9529): Create a guide to installing a ROSA HCP cluster with no CNI plugin

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-9529

Link to docs preview:
No CNI plugin page: https://72902--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-cluster-no-cni
CLI page: https://72902--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli#rosa-create-cluster-command_rosa-managing-objects-cli
Responsibility matrix: https://72902--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
