### PR TITLE
[enterprise-4.14] OADP-3604 : openshift-velero-plugin panics on imagestream backup due to a missing secret

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
@@ -26,4 +26,6 @@ OADP 1.1.0 was tested successfully against {product-title} 4.11 for both {ibm-po
 include::modules/oadp-ibm-power-test-support.adoc[leveloffset=+2]
 include::modules/oadp-ibm-z-test-support.adoc[leveloffset=+2]
 
+include::modules/oadp-features-plugins-known-issues.adoc[leveloffset=+1]
+
 :!oadp-features-plugins:

--- a/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
@@ -70,6 +70,7 @@ This section describes the additional steps required to restore resources for se
 
 include::modules/migration-debugging-velero-admission-webhooks-knative.adoc[leveloffset=+3]
 include::modules/migration-debugging-velero-admission-webhooks-ibm-appconnect.adoc[leveloffset=+3]
+include::modules/oadp-features-plugins-known-issues.adoc[leveloffset=+2]
 include::modules/oadp-plugins-receiving-eof-message.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/modules/oadp-features-plugins-known-issues.adoc
+++ b/modules/oadp-features-plugins-known-issues.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+// oadp-features-plugins-known-issues
+// * backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
+// * backup_and_restore/application_backup_and_restore/troubleshooting.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="oadp-features-plugins-known-issues_{context}"]
+= OADP plugins known issues
+
+The following section describes known issues in {oadp-first} plugins:
+
+[id="velero-plugin-panic_{context}"]
+== Velero plugin panics during imagestream backups due to a missing secret
+
+When the backup and the Backup Storage Location (BSL) are managed outside the scope of the Data Protection Application (DPA), the OADP controller, meaning the DPA reconciliation does not create the relevant `oadp-<bsl_name>-<bsl_provider>-registry-secret`.
+
+When the backup is run, the OpenShift Velero plugin panics on the imagestream backup, with the following panic error:
+
+[source,terminal]
+----
+024-02-27T10:46:50.028951744Z time="2024-02-27T10:46:50Z" level=error msg="Error backing up item"
+backup=openshift-adp/<backup name> error="error executing custom action (groupResource=imagestreams.image.openshift.io,
+namespace=<BSL Name>, name=postgres): rpc error: code = Aborted desc = plugin panicked:
+runtime error: index out of range with length 1, stack trace: goroutine 94…
+----
+
+[id="velero-plugin-panic-workaround_{context}"]
+=== Workaround to avoid the panic error
+
+To avoid the Velero plugin panic error, perform the following steps:
+
+. Label the custom BSL with the relevant label:
++
+[source,terminal]
+----
+$ oc label BackupStorageLocation <bsl_name> app.kubernetes.io/component=bsl
+----
+
+. After the BSL is labeled, wait until the DPA reconciles.
++
+[NOTE]
+====
+You can force the reconciliation by making any minor change to the DPA itself.
+====
+
+. When the DPA reconciles, confirm that the relevant `oadp-<bsl_name>-<bsl_provider>-registry-secret` has been created and that the correct registry data has been populated into it:
++
+[source,terminal]
+----
+$ oc -n openshift-adp get secret/oadp-<bsl_name>-<bsl_provider>-registry-secret -o json | jq -r '.data'
+----


### PR DESCRIPTION
## Cherrypicked from [PR#72456](https://github.com/openshift/openshift-docs/pull/72456)

### JIRA

* [OADP-3604](https://issues.redhat.com/browse/OADP-3604)


This PR is to fix the OCP 4.14 cherry pick issue in the following [PR#72456](https://github.com/openshift/openshift-docs/pull/72456)

* Creating a new module named `oadp-features-plugins-known-issues.adoc`:
        
    * Including module in `oadp-features-plugins.adoc`
    * Including module in `troubleshooting.adoc`

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

### Version(s):

* OCP 4.14 → branch/enterprise-4.14

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

### Link to docs preview:

* [OADP plugins known issues](https://72907--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-features-plugins#oadp-features-plugins-known-issues_oadp-features-plugins)
* [OADP plugins known issues](https://72907--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting#oadp-features-plugins-known-issues_oadp-troubleshooting)

### QE review:
- [ X] QE has approved this change. - [approved by Tiger -- see previous PR](https://github.com/openshift/openshift-docs/pull/72456)

