### PR TITLE
OSDOCS-9918: Documented the 4.14.37 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -3955,3 +3955,30 @@ $ oc adm release info 4.13.36 --pullspecs
 [id="ocp-4-13-36-updating"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-13-37"]
+=== RHBA-2024:1200 - {product-title} 4.13.37 bug fix
+
+Issued: 2024-03-13
+
+{product-title} release 4.13.37 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1200[RHBA-2024:1200] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.37 --pullspecs
+----
+
+[id="ocp-4-13-37-bug-fixes"]
+==== Bug fixes
+
+* Previously, the `ovn-ipsec-containerized` and the `ovn-ipsec-host` daemons contained a typographical error for a `openssl` parameter: `-checkedn` instead of `checkend`. This error caused certificate rotation to occur after every `ovn-ipsec` pod restart. With this release, the parameter name is fixed, and the certificate that is used by the Internet Protocol Security (IPsec) now automatically rotates as expected. (link:https://issues.redhat.com/browse/OCPBUGS-30150[*OCPBUGS-30150*])
+
+* Previously, the `nodeStatusUpdateFrequency` mechanism for the Machine Config Operator (MCO) had its default value changed from `0` seconds to `10` seconds. This caused the mechanism to increase node status reporting, determined by the `nodeStatusReportFrequency` parameter, and this impacted control plane CPU resources. With this release, the `nodeStatusReportFrequency` default value is set to `5` minutes, and the CPU resource issue no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-30285[*OCPBUGS-30285*])
+
+[id="ocp-4-13-37-updating"]
+==== Updating
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OSDCOS-9918](https://issues.redhat.com/browse/OSDOCS-9918)

Link to docs preview:
[4.13.37 z-stream release notes](https://72915--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes#ocp-4-13-37)

QE review:
- [X] QE not required as per peer-review checklist


