### PR TITLE
OBSDOCS-765: Add clarification about exceeded maximum retention size …

### DIFF
--- a/modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc
+++ b/modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc
@@ -28,6 +28,11 @@ If any data blocks exceed the defined retention time or the defined size limit, 
 * If you do not define a value for `retentionSize` and only define a value for `retention`, only the `retention` value applies.
 * If you set the `retentionSize` or `retention` value to number 0, the default settings apply. The default settings set retention time to 15 days and do not set a value for retention size.
 
+[NOTE]
+====
+Data compaction occurs every two hours. Therefore, a persistent volume (PV) might fill up before compaction, potentially exceeding the `retentionSize` limit. In such cases, the `KubePersistentVolumeFillingUp` alert fires until the space on a PV is lower than the `retentionSize` limit.
+====
+
 .Prerequisites
 
 ifndef::openshift-dedicated,openshift-rosa[]


### PR DESCRIPTION
Version(s): `enterprise-4.12` and later

Issue: [OBSDOCS-765](https://issues.redhat.com/browse/OBSDOCS-765)

Link to docs preview: [modifying the retention time and size for Prometheus metrics data](https://72916--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack#modifying-retention-time-and-size-for-prometheus-metrics-data_configuring-the-monitoring-stack)

QE review:
- [x] QE has approved this change.

Peer review:
- [x] Peer review done

**Additional information:**