### PR TITLE
[TRACING-3899] Document permissions to generate automatically the permissions for the processors

### DIFF
--- a/modules/otel-collector-components.adoc
+++ b/modules/otel-collector-components.adoc
@@ -1135,6 +1135,7 @@ rules:
   - list
   - patch
   - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1147,5 +1148,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: opentelemetry-operator-controller-manager
-  namespace: opentelemetry-operator-system
+  namespace: openshift-opentelemetry-operator
 ----

--- a/modules/otel-collector-components.adoc
+++ b/modules/otel-collector-components.adoc
@@ -1139,13 +1139,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: processors-permissions-rolebinding
+  name: generate-processors-rbac
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: generate-processors-rbac
 subjects:
 - kind: ServiceAccount
-  name: opentelemetry-operator-manager-role
-  namespace: system
+  name: opentelemetry-operator-controller-manager
+  namespace: opentelemetry-operator-system
 ----

--- a/modules/otel-collector-components.adoc
+++ b/modules/otel-collector-components.adoc
@@ -1110,3 +1110,42 @@ zPages are useful for in-process diagnostics without having to depend on a back 
 ----
 
 <1> Specifies the HTTP endpoint that serves zPages. Use `localhost:` to make it available only locally, or `":"` to make it available on all network interfaces. The default is `localhost:55679`.
+
+== Create the needed RBAC resources automatically.
+
+Some of the mentioned components require configuring some extra RBAC resources. The operator is able to create them automatically for your when adding these extra permissions to the `opentelemetry-operator-controller-manage` service account:
+
+.Permissions needed togene
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: generate-processors-rbac
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: processors-permissions-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: generate-processors-rbac
+subjects:
+- kind: ServiceAccount
+  name: opentelemetry-operator-manager-role
+  namespace: system
+----


### PR DESCRIPTION
Version(s):
4.12 +

Issue: [TRACING-3899](https://issues.redhat.com//browse/TRACING-3899)

Link to docs preview: https://72917--ocpdocs-pr.netlify.app/

QE review:
- [x] QE has approved this change.

