### PR TITLE
OCPBUGS30632: ROSA/OSD hide customizing the web console

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -205,10 +205,10 @@ Topics:
 # cannot patch resource "consoles", insufficient permissions to read any Cluster configuration
 #- Name: Configuring the web console
 #  File: configuring-web-console
-#  Distros: openshift-rosa
-- Name: Customizing the web console
-  File: customizing-the-web-console
-  Distros: openshift-dedicated
+#  Distros: openshift-dedicated
+#- Name: Customizing the web console
+#  File: customizing-the-web-console
+#  Distros: openshift-dedicated
 - Name: Dynamic plugins
   Dir: dynamic-plugin
   Distros: openshift-dedicated

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -388,9 +388,9 @@ Topics:
 #- Name: Configuring the web console
 #  File: configuring-web-console
 #  Distros: openshift-rosa
-- Name: Customizing the web console
-  File: customizing-the-web-console
-  Distros: openshift-rosa
+#- Name: Customizing the web console
+#  File: customizing-the-web-console
+#  Distros: openshift-rosa
 - Name: Dynamic plugins
   Dir: dynamic-plugin
   Distros: openshift-rosa

--- a/web_console/customizing-the-web-console.adoc
+++ b/web_console/customizing-the-web-console.adoc
@@ -11,7 +11,10 @@ product name, links, notifications, and command line downloads. This is
 especially helpful if you need to tailor the web console to meet specific
 corporate or government requirements.
 
+// Hiding in ROSA/OSD, as Hive overwrites changes to console config
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/adding-a-custom-logo.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-dedicated[]
 
 // Hiding in ROSA/OSD, as dedicated-admins cannot create resource "consolelinks"
 ifndef::openshift-rosa,openshift-dedicated[]
@@ -49,9 +52,15 @@ include::modules/odc-customizing-a-perspective-using-YAML-view.adoc[leveloffset=
 include::modules/odc-customizing-a-perspective-using-form-view.adoc[leveloffset=+2]
 endif::openshift-rosa,openshift-dedicated[]
 
+// Hiding in ROSA/OSD, as Hive overwrites changes to console config
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/odc_con_customizing-a-developer-catalog-or-its-sub-catalogs.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-dedicated[]
 
+// Hiding in ROSA/OSD, as Hive overwrites changes to console config
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/odc_customizing-a-developer-catalog-or-its-sub-catalogs-using-the-yaml-view.adoc[leveloffset=+2]
+endif::openshift-rosa,openshift-dedicated[]
 
 // Hiding in ROSA/OSD, as dedicated-admins do not have sufficient permissions to read any cluster configuration
 ifndef::openshift-rosa,openshift-dedicated[]


### PR DESCRIPTION
The  docs should be hidden in ROSA/OSD, as the changes can get overwritten. I missed this when porting content in https://github.com/openshift/openshift-docs/pull/66934

https://issues.redhat.com/browse/OCPBUGS-30632
Slack: https://redhat-internal.slack.com/archives/C021EMWAQ76/p1709907383063309

Previews:
[OCP](https://72918--ocpdocs-pr.netlify.app/openshift-enterprise/latest/web_console/customizing-the-web-console). Note that _Customizing the web console_ is present.
[ROSA](https://72918--ocpdocs-pr.netlify.app/openshift-rosa/latest/web_console/web-console-overview). Note that _Customizing the web console_ is not present.
[OSD](https://72918--ocpdocs-pr.netlify.app/openshift-rosa/latest/web_console/web-console-overview).  Note that _Customizing the web console_ is not present.
