### PR TITLE
[OCPBUGS-30024] 4.15 RNs - Change SBO and NOO support for IBM Z and IBM Power

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -520,6 +520,10 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 |Supported
 |Supported
 
+|Cost Management Metrics Operator
+|Supported
+|Supported
+
 |File Integrity Operator
 |Supported
 |Supported
@@ -536,6 +540,10 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 |Supported
 |Supported
 
+|Network Observability Operator
+|Supported
+|Supported
+
 |NFD Operator
 |Supported
 |Supported
@@ -545,10 +553,6 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 |Supported
 
 |OpenShift Elasticsearch Operator
-|Supported
-|Supported
-
-|Service Binding Operator
 |Supported
 |Supported
 
@@ -1240,15 +1244,6 @@ In the following tables, features are marked with the following statuses:
 --
 1. While the OpenShift SDN network plugin is no longer supported by the installation program in version 4.15, you can upgrade a cluster that uses the OpenShift SDN plugin from version 4.14 to version 4.15.
 --
-[discrete]
-=== Updating clusters deprecated and removed features
-
-.Updating clusters deprecated and removed tracker
-[cols="4,1,1,1",options="header"]
-|====
-|Feature |4.13 |4.14 |4.15
-
-|====
 
 [discrete]
 === Storage deprecated and removed features
@@ -1306,13 +1301,17 @@ In the following tables, features are marked with the following statuses:
 |====
 
 [discrete]
-=== Web console deprecated and removed features
+=== Building applications deprecated and removed features
 
-.Web console deprecated and removed tracker
+.Service Binding Operator deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
 |Feature |4.13 |4.14 |4.15
 
+|Service Binding Operator
+|Deprecated
+|Deprecated
+|Deprecated
 |====
 
 [discrete]
@@ -1400,6 +1399,11 @@ OpenShift SDN CNI is deprecated as of {product-title} 4.14. As of {product-title
 ==== Bare Metal Event Relay Operator
 
 The Bare Metal Event Relay Operator is deprecated. The ability to monitor bare-metal hosts by using the Bare Metal Event Relay Operator will be removed in a future {product-title} release.
+
+[id="ocp-4-15-deprecation-sbo"]
+==== Service Binding Operator
+
+The Service Binding Operator is deprecated and will be removed with the {product-title} 4.16 release. Red Hat will provide critical bug fixes and support for this component during the current release lifecycle, but this component will no longer receive feature enhancements.
 
 [id="ocp-4-15-dedicated-service-monitors-for-core-platform-monitoring"]
 ==== Dedicated service monitors for core platform monitoring


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: Requires CM
- https://issues.redhat.com/browse/OCPBUGS-30024
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Deprecated and removed features](https://72919--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-deprecated-removed-features)
- [IBM Power/IBM Z section](https://72919--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-ibm-z)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: 
This PR adds support for Network Oberservability Operator, Cost Management Metrics Operator and removes SBO support in the IBM Power and IBM Z support matrix. It also adds deprecation for SBO. 

Related PRs: 
- PR for 4.14 RNs https://github.com/openshift/openshift-docs/pull/72995
- PR for 4.13 RNs https://github.com/openshift/openshift-docs/pull/72996
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
