### PR TITLE
OCPBUGS23451: Invalid YAML examples in custom metrics autoscaler docs

### DIFF
--- a/modules/nodes-cma-autoscaling-custom-trigger-prom.adoc
+++ b/modules/nodes-cma-autoscaling-custom-trigger-prom.adoc
@@ -33,8 +33,8 @@ spec:
       query: sum(rate(http_requests_total{job="test-app"}[1m])) <6>
       authModes: basic <7>
       cortexOrgID: my-org <8>
-      ignoreNullValues: false <9>
-      unsafeSsl: false <10>
+      ignoreNullValues: "false" <9>
+      unsafeSsl: "false" <10>
 ----
 <1> Specifies Prometheus as the trigger type.
 <2> Specifies the address of the Prometheus server. This example uses  {product-title} monitoring.


### PR DESCRIPTION
Update the doc section so the example has `ignoreNullValues` and `unsafeSSL` fields values are properly quoted. 

https://issues.redhat.com/browse/OCPBUGS-23451

Preview:
[Understanding the Prometheus trigger](https://72920--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-trigger#nodes-cma-autoscaling-custom-trigger-prom_nodes-cma-autoscaling-custom-trigger) -- Put values for parameters 9 and 10 in quotes.