### PR TITLE
OSDOCS-8714: adds 4.15.2 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -38,12 +38,8 @@ This release adds improvements related to the following components and concepts.
 ** If you run cAdvisor as a standalone DaemonSet for monitoring pods and containers, update it to v0.43.0 or later.
 ** If you deploy Java applications with JDK, ensure you are using JDK 11.0.16 and later or JDK 15 and later, which fully support cgroup v2.
 
-[id="microshift-4-15-security"]
-=== Security and compliance
-
-[id="microshift-4-15-rhel-fips"]
-==== FIPS mode
-* When {op-system-base-full} is installed and started with FIPS enabled, {microshift-short} containers are automatically enabled to run in FIPS mode. See xref:../microshift_install/microshift-fips.adoc#microshift-fips[Running {microshift-short} containers in FIPS mode].
+//[id="microshift-4-15-security"]
+//=== Security and compliance
 
 [id="microshift-4-15-updating"]
 === Updating
@@ -173,12 +169,12 @@ In the following tables, features are marked with the following statuses:
 
 [discrete]
 [id="microshift-4-15-networking-bug-fixes"]
-==== Networking
+=== Networking
 * Whenever `advertiseAddress` is configured with an IP address, any network interfaces must also be configured. Previously, manually setting the `advertiseAddress` in the {microshift-short} `config.yaml` to the IP address value that is expected to be set by default, but not manually setting the same IP address for the `br-ex` network bridge on the host, caused the `ovnkube-master` container in the `ovnkube-master` pod to crash. With this release, the {microshift-short} service verifies whether `advertiseAddress` is set in the `config.yaml` and whether any interface has the same IP address set. If the two settings are not the same, {microshift-short} prints an error, for example, `Advertise address: %s not present in any interface, advertiseAddress` and fails. This helps ensure the proper configuration before the system starts. (link:https://issues.redhat.com/browse/OCPBUGS-27398[*OCPBUGS-27398*]
 
 [discrete]
 [id="microshift-4-15-support-bug-fixes"]
-==== Support
+=== Support
 * Previously, `sos` reports created journal logs in separate files, making it difficult to correlate {microshift-short} and the Greenboot health check. Now the {microshift-short} `sos` tool includes a full system journal with an aggregated view in the same log. With this update, you can see one log with a detailed report that shows all of the enabled plugins and data from the different components and applications.
 (link:https://issues.redhat.com/browse/OCPBUGS-19567[*OCPBUGS-19567*])
 
@@ -203,4 +199,27 @@ Issued: 2024-02-27
 
 {product-title} release 4.15.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:7200[RHSA-2023:7200] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7198[RHSA-2023:7198] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+[id="microshift-4-15-2-dp"]
+=== RHBA-2024:1212 - {microshift-short} 4.15.2 bug fix and enhancement update advisory
+
+Issued: 2024-03-13
+
+{product-title} release 4.15.2 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1212[RHBA-2024:1212] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1210[RHSA-2024:1210] advisory.
+
+[discrete]
+[id="microshift-4-15-2-bug-fixes"]
+==== Bug fixes
+
+FIPS mode::
+* Previously, {microshift-short} used a version of the logical volume manager storage (LVMS) Container Storage Interface (CSI) provider that was not designed for FIPS compliance. This caused {microshift-short} to fail a FIPS validation test. With this release, the LVMS version 4.15.0 is used as the default CSI storage provider and validation passes.
+
+* When a {op-system-base-full} version that uses FIPS libraries is installed and started with FIPS enabled, {microshift-short} containers are automatically enabled to run in FIPS mode. See xref:../microshift_install/microshift-fips.adoc#microshift-fips[Running {microshift-short} containers in FIPS mode].
+
+* Update to the 4.15.2 release to apply this fix for FIPS mode.
+
+[discrete]
+[id="microshift-4-15-2-enhancements"]
+==== Enhancements
+
+Adds OLM image references in dedicated file::
+* Previously, image references for embedding MicroShift OLM in a RHEL for Edge image were part of the `microshift-olm` RPM package. The application package had to be downloaded and run to retrieve the information. With this release, image references are now in the dedicated `microshift-olm-release-info` RPM package for easier use. (link:https://issues.redhat.com/browse/OCPBUGS-29246[OCPBUGS-29246])


### PR DESCRIPTION
Version(s):
4.15 only

Issue:
[4.15.2 release note](https://issues.redhat.com/browse/OSDOCS-8714)

Link to docs preview:
[4.15.2 async release note](https://72921--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes#microshift-4-15-2-dp)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
