### PR TITLE
OCPBUGS#29286: Updating AWS install permissions

### DIFF
--- a/modules/installation-aws-permissions.adoc
+++ b/modules/installation-aws-permissions.adoc
@@ -274,7 +274,7 @@ If you use an existing VPC, your account does not require these permissions to d
 * `s3:PutBucketPublicAccessBlock`
 * `s3:GetBucketPublicAccessBlock`
 * `s3:PutLifecycleConfiguration`
-* `s3:HeadBucket`
+* `s3:ListBucket`
 * `s3:ListBucketMultipartUploads`
 * `s3:AbortMultipartUpload`
 
@@ -294,5 +294,5 @@ If you are managing your cloud provider credentials with mint mode, the IAM user
 .Optional permissions for the cluster owner account when installing a cluster on a shared VPC
 [%collapsible]
 ====
-* `sts:AssumeRole` 
+* `sts:AssumeRole`
 ====


### PR DESCRIPTION
Version(s):
4.12+

Issue:
This PR addresses [ocpbugs-29286](https://issues.redhat.com/browse/OCPBUGS-29286).

Link to docs preview:

[Default permissions for IAM instance profiles](https://72925--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account#installation-aws-permissions-iam-roles_installing-aws-account)

QE review:
- [x] QE has approved this change.