### PR TITLE
OSDOCS9355: Node certificates chapter has no information about the time it takes for the certifications to be renewed

### DIFF
--- a/security/certificate_types_descriptions/node-certificates.adoc
+++ b/security/certificate_types_descriptions/node-certificates.adoc
@@ -14,6 +14,22 @@ Node certificates are signed by the cluster; they come from a certificate author
 
 These certificates are managed by the system and not the user.
 
+== Expiration
+
+These certificates are managed by the system and not the user.
+
+== Services
+
+
+
+== Customization
+
+These certificates are managed by the system and not the user.
+
+== Renewal
+
+The node controller automatically rotates the certificates that it issues. However, it is possible to use `oc delete secret <secret>` to manually rotate service serving certificates.
+
 [discrete]
 [role="_additional-resources"]
 == Additional resources


### PR DESCRIPTION
Node certificates chapter in our OpenShift 4 documentation has no information about the time it takes for the certifications to be renewed.

https://issues.redhat.com/browse/OSDOCS-9355