### PR TITLE
OCPBUGS-29262-revert-literal

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -90,7 +90,7 @@ endif::agent[]
 Required installation configuration parameters are described in the following table:
 
 .Required parameters
-[cols=".^2m,.^3,.^5a",options="header"]
+[cols=".^2l,.^3,.^5a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -239,7 +239,7 @@ Globalnet is not supported with {rh-storage-first} disaster recovery solutions. 
 ====
 
 .Network parameters
-[cols=".^2m,.^3a,.^3a",options="header"]
+[cols=".^2l,.^3a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -416,7 +416,7 @@ Set the `networking.machineNetwork` to match the CIDR that the preferred NIC res
 Optional installation configuration parameters are described in the following table:
 
 .Optional parameters
-[cols=".^2m,.^3a,.^3a",options="header"]
+[cols=".^2l,.^3a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -793,7 +793,7 @@ ifdef::aws[]
 Optional AWS configuration parameters are described in the following table:
 
 .Optional AWS parameters
-[cols=".^2m,.^3,.^5a",options="header"]
+[cols=".^2l,.^3,.^5a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -1022,7 +1022,7 @@ ifdef::osp[]
 Additional {rh-openstack} configuration parameters are described in the following table:
 
 .Additional {rh-openstack} parameters
-[cols=".^2m,.^3a,^5a",options="header"]
+[cols=".^2l,.^3a,^5a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -1126,7 +1126,7 @@ This property is deprecated. To use a flavor as the default for all machine pool
 Optional {rh-openstack} configuration parameters are described in the following table:
 
 .Optional {rh-openstack} parameters
-[%header, cols=".^2m,.^3,.^5a"]
+[%header, cols=".^2l,.^3,.^5a"]
 |====
 |Parameter|Description|Values
 
@@ -1285,7 +1285,7 @@ within link:https://azure.microsoft.com/en-us/global-infrastructure/regions[a re
 ====
 
 .Additional Azure parameters
-[cols=".^2m,.^3a,.^3a",options="header"]
+[cols=".^2l,.^3a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -1939,7 +1939,7 @@ Configuring these fields at install time eliminates the need to set them as a Da
 ====
 
 .Additional bare metal parameters
-[cols=".^2m,.^3a,.^3a",options="header"]
+[cols=".^2l,.^3a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -2066,7 +2066,7 @@ ifdef::gcp[]
 Additional GCP configuration parameters are described in the following table:
 
 .Additional GCP parameters
-[cols=".^1m,.^6a,.^3a",options="header"]
+[cols=".^1l,.^6a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -2500,7 +2500,7 @@ ifdef::ibm-cloud[]
 Additional {ibm-cloud-name} configuration parameters are described in the following table:
 
 .Additional {ibm-cloud-name} parameters
-[cols=".^1m,.^6a,.^3a",options="header"]
+[cols=".^1l,.^6a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -2641,7 +2641,7 @@ ifdef::agent,vsphere[]
 Additional VMware vSphere configuration parameters are described in the following table:
 
 .Additional VMware vSphere cluster parameters
-[cols=".^2m,.^3a,.^3",options="header,word-wrap",subs="+quotes,+attributes"]
+[cols=".^2l,.^3a,.^3",options="header,word-wrap",subs="+quotes,+attributes"]
 |====
 |Parameter|Description|Values
 ifdef::agent[]
@@ -2860,7 +2860,7 @@ In {product-title} 4.13, the following vSphere configuration parameters are depr
 The following table lists each deprecated vSphere configuration parameter:
 
 .Deprecated VMware vSphere cluster parameters
-[cols=".^2m,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
+[cols=".^2l,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
 |====
 |Parameter|Description|Values
 ifdef::vsphere[]
@@ -2950,7 +2950,7 @@ ifdef::vsphere[]
 Optional VMware vSphere machine pool configuration parameters are described in the following table:
 
 .Optional VMware vSphere machine pool parameters
-[cols=".^2m,.^3a,.^3a",options="header"]
+[cols=".^2l,.^3a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -2995,7 +2995,7 @@ ifdef::ash[]
 Additional Azure configuration parameters are described in the following table:
 
 .Additional Azure Stack Hub parameters
-[cols=".^2m,.^3a,.^3a",options="header"]
+[cols=".^2l,.^3a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -3131,7 +3131,7 @@ If defined, the parameters `compute.platform.alibabacloud` and `controlPlane.pla
 ====
 
 .Optional {alibaba} parameters
-[cols=".^2m,.^3,.^5a",options="header"]
+[cols=".^2l,.^3,.^5a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -3287,7 +3287,7 @@ ifdef::nutanix[]
 Additional Nutanix configuration parameters are described in the following table:
 
 .Additional Nutanix cluster parameters
-[cols=".^2m,.^3a,.^3a",options="header"]
+[cols=".^2l,.^3a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 


### PR DESCRIPTION
This PR reverts https://github.com/openshift/openshift-docs/pull/72388. The monspace style operator is also not a working solution. See [example](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/installing/installing-on-vsphere#installation-configuration-parameters-additional-vsphere_installation-config-parameters-vsphere). For now, revert to the `l` style operator, and then a better working solution could be devised (such as removing code blocks from these tables, so that the `l` operator does not cause copy&paste issues). Here is the [Slack](https://redhat-internal.slack.com/archives/C02KBD8A4UF/p1709312758104259) thread for why to revert the style operator from `m` to `l`. 


Version(s):
4.14 to 4.16

Issue:
[OCPBUGS-29262](https://issues.redhat.com/browse/OCPBUGS-29262)

Preview link: 

* [Required configuration parameters-vsphere](https://72929--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere)
* [Required configuration parameters-GCP](https://72929--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installation-config-parameters-gcp#installation-configuration-parameters-required_installation-config-parameters-gcp)
* [Required configuration parameters-IBM Z and IBM LinuxOne](https://72929--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installation-config-parameters-ibm-z#installation-configuration-parameters-required_installation-config-parameters-ibm-z)
* [Required configuration parameters-IBM Cloud](https://72929--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installation-config-parameters-ibm-cloud-vpc#installation-configuration-parameters-required_installation-config-parameters-ibm-cloud-vpc)
* [Required configuration parameters-Azure](https://72929--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/installation-config-parameters-azure#installation-configuration-parameters-required_installation-config-parameters-azure)
* [Required configuration parameters-Bare metal](https://72929--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installation-config-parameters-bare-metal#installation-configuration-parameters-required_installation-config-parameters-bare-metal)
* [Required configuration parameters-Alibaba](https://72929--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_alibaba/installation-config-parameters-alibaba#installation-configuration-parameters-required_installation-config-parameters-alibaba)
* [Required configuration parameters-Nutanix](https://72929--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installation-config-parameters-nutanix#installation-configuration-parameters-required_installation-config-parameters-nutanix)
* [Required configuration parameters-AWS](https://72929--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installation-config-parameters-aws#installation-configuration-parameters-required_installation-config-parameters-aws)