### PR TITLE
OSDOCS#9721: MicroShift 4.14.16 z-stream release note

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -473,3 +473,12 @@ Issued: 2024-03-05
 {product-title} release 4.14.15 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1048[RHBA-2024:1048] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:1046[RHBA-2024:1046] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-14-16-dp"]
+=== RHBA-2024:1207 - {microshift-short} 4.14.16 bug fix update advisory
+
+Issued: 2024-03-13
+
+{product-title} release 4.14.16 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1207[RHBA-2024:1207] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:1205[RHBA-2024:1205] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
**Version(s):** 4.14
**Issue:**
[OSDOCS-9721](https://issues.redhat.com//browse/OSDOCS-9721)

**Link to docs preview:**
https://72936--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes#microshift-4-14-16-dp

**QE review:**
- No QE required

