### PR TITLE
[internal-fix] OCPBUGS-29252-revert-13

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1931,78 +1931,59 @@ ifdef::vsphere,vmc[]
 [id="installation-configuration-parameters-additional-vsphere_{context}"]
 == Additional VMware vSphere configuration parameters
 
-Additional VMware vSphere configuration parameters are described in the following table:
+Additional VMware vSphere configuration parameters are described in the following table.
+
+[NOTE]
+====
+The `platform.vsphere` parameter prefixes each parameter listed in the table.
+====
 
 .Additional VMware vSphere cluster parameters
 [cols=".^2,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
 |====
 |Parameter|Description|Values
 
-l|platform:
-    vsphere
-      apiVIPs
+|`apiVIPs`
 |Virtual IP (VIP) addresses that you configured for control plane API access.
 
 *Note:* This parameter applies only to installer-provisioned infrastructure.
 |Multiple IP addresses
 
-l|platform
-    vsphere
-      diskType
+|`diskType`
 |Optional. The disk provisioning method. This value defaults to the vSphere default storage policy if not set.
 |Valid values are `thin`, `thick`, or `eagerZeroedThick`.
 
-l|platform
-    vsphere
-      failureDomains
+|`failureDomains`
 |Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
 |String
 
-l|platform
-    vsphere
-      failureDomains
-        topology
-          networks
+|`failureDomains.topology.networks`
 |Lists any network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured.
 |String
 
-l|platform
-    vsphere
-      failureDomains
-        region
+|`failureDomains.region`
 |If you define multiple failure domains for your cluster, you must attach the tag to each vCenter datacenter. To define a region, use a tag from the `openshift-region` tag category. For a single vSphere datacenter environment, you do not need to attach a tag, but you must enter an alphanumeric value, such as `datacenter`, for the parameter.
 |String
 
-l|platform
-    vsphere
-      failureDomains
-        zone
+|`failureDomains.zone`
 |If you define multiple failure domains for your cluster, you must attach the tag to each vCenter cluster. To define a zone, use a tag from the `openshift-zone` tag category. For a single vSphere datacenter environment, you do not need to attach a tag, but you must enter an alphanumeric value, such as `cluster`, for the parameter.
 |`String`
 
-l|platform
-    vsphere
-      ingressVIPs
+|`ingressVIPs`
 |Virtual IP (VIP) addresses that you configured for cluster Ingress.
 
 *Note:* This parameter applies only to installer-provisioned infrastructure.
 |Multiple IP addresses
 
-l|platform
-    vsphere
+|`vsphere`
 | Describes your account on the cloud platform that hosts your cluster. You can use the parameter to customize the platform. When providing additional configuration settings for compute and control plane machines in the machine pool, the parameter is optional. You can only specify one vCenter server for your {product-title} cluster.
 |String
 
-l|platform
-    vsphere
-      vcenters
+|`vcenters`
 |Lists any fully-qualified hostname or IP address of a vCenter server.
 |String
 
-l|platform
-    vsphere
-      vcenters
-        datacenters
+|`vcenters.datacenters`
 |Lists and defines the datacenters where {product-title} virtual machines (VMs) operate. The list of datacenters must match the list of datacenters specified in the `failureDomains` field.
 |String
 |====
@@ -2012,83 +1993,66 @@ l|platform
 
 In {product-title} 4.13, the following vSphere configuration parameters are deprecated. You can continue to use these parameters, but the installation program does not automatically specify these parameters in the `install-config.yaml` file.
 
-The following table lists each deprecated vSphere configuration parameter:
+The following table lists each deprecated vSphere configuration parameter.
+
+[NOTE]
+====
+The `platform.vsphere` parameter prefixes each parameter listed in the table.
+====
 
 .Deprecated VMware vSphere cluster parameters
 [cols=".^2,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
 |====
 |Parameter|Description|Values
 
-l|platform
-    vsphere
-      apiVIP
+|`apiVIP`
 |The virtual IP (VIP) address that you configured for control plane API access.
 
 *Note:* In {product-title} 4.12 and later, the `apiVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `apiVIPs` configuration setting.
 a|An IP address, for example `128.0.0.1`.
 
-l|platform
-    vsphere
-      cluster
+|`cluster`
 |The vCenter cluster to install the {product-title} cluster in.
 |String
 
-l|platform
-    vsphere
-      datacenter
+|`datacenter`
 |Defines the datacenter where {product-title} virtual machines (VMs) operate.
 |String
 
-l|platform
-    vsphere
-      defaultDatastore
+|`defaultDatastore`
 |The name of the default datastore to use for provisioning volumes.
 |String
 
-l|platform
-    vsphere
-      folder
+|`folder`
 |Optional. The absolute path of an existing folder where the installation program creates the virtual machines. If you do not provide this value, the installation program creates a folder that is named with the infrastructure ID in the data center virtual machine folder.
 |String, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
 
-l|platform
-    vsphere
-      ingressVIP
+|`ingressVIP`
 |Virtual IP (VIP) addresses that you configured for cluster Ingress.
 
 *Note:* In {product-title} 4.12 and later, the `ingressVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `ingressVIPs` configuration setting.
 a|An IP address, for example `128.0.0.1`.
 
-l|platform
-    vsphere
-      network
+|`network`
 |The network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured.
 |String
 
-l|platform
-    vsphere
-      password
+|`password`
 |The password for the vCenter user name.
 |String
 
-l|platform
-    vsphere
-      resourcePool
+|`resourcePool`
 |Optional. The absolute path of an existing resource pool where the installation program creates the virtual machines. If you do not specify a value, the installation program installs the resources in the root of the cluster under `/<datacenter_name>/host/<cluster_name>/Resources`.
 a|String, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
 
-l|platform
-    vsphere
-      username
+|`username`
 |The user name to use to connect to the vCenter instance with. This user must have at least
 the roles and privileges that are required for
 link:https://github.com/vmware-archive/vsphere-storage-for-kubernetes/blob/master/documentation/vcp-roles.md[static or dynamic persistent volume provisioning]
 in vSphere.
 |String
 
-l|platform
-    vsphere
-      vCenter
+|`vCenter`
 |The fully-qualified hostname or IP address of a vCenter server.
 |String
 |====
@@ -2096,41 +2060,35 @@ l|platform
 [id="installation-configuration-parameters-optional-vsphere_{context}"]
 == Optional VMware vSphere machine pool configuration parameters
 
-Optional VMware vSphere machine pool configuration parameters are described in the following table:
+Optional VMware vSphere machine pool configuration parameters are described in the following table.
+
+[NOTE]
+====
+The `platform.vsphere` parameter prefixes each parameter listed in the table.
+====
 
 .Optional VMware vSphere machine pool parameters
 [cols=".^2a,.^3a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
-l|platform
-    vsphere
-      clusterOSImage
+|`clusterOSImage`
 |The location from which the installation program downloads the {op-system} image. You must set this parameter to perform an installation in a restricted network.
 |An HTTP or HTTPS URL, optionally with a SHA-256 checksum. For example, `\https://mirror.openshift.com/images/rhcos-<version>-vmware.<architecture>.ova`.
 
-l|platform
-    vsphere
-      osDisk
-        diskSizeGB
+|`osDisk.diskSizeGB`
 |The size of the disk in gigabytes.
 |Integer
 
-l|platform
-    vsphere
-      cpus
+|`cpus`
 |The total number of virtual processor cores to assign a virtual machine. The value of `platform.vsphere.cpus` must be a multiple of `platform.vsphere.coresPerSocket` value.
 |Integer
 
-l|platform
-    vsphere
-      coresPerSocket
+|`coresPerSocket`
 |The number of cores per socket in a virtual machine. The number of virtual sockets on the virtual machine is `platform.vsphere.cpus`/`platform.vsphere.coresPerSocket`. The default value for control plane nodes and worker nodes is `4` and `2`, respectively.
 |Integer
 
-l|platform
-    vsphere
-      memoryMB
+|`memoryMB`
 |The size of a virtual machine's memory in megabytes.
 |Integer
 |====


### PR DESCRIPTION
This PR is a follow on from https://github.com/openshift/openshift-docs/pull/72388 that reverts the m style operator to an l style operator. However, the 4.12 and 4.13 docs should remove all style operators as these operators are problematic. Style operators will be a focus point for 4.14+ only.

Note: Only the vSphere parameter tables were updated for 4.13 and 4.12 to use the literal style operator. 

This PR reverts https://github.com/openshift/openshift-docs/pull/72388. The monspace style operator is also not a working solution. See [example](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/installing/installing-on-vsphere#installation-configuration-parameters-additional-vsphere_installation-config-parameters-vsphere). For now, revert to the `l` style operator, and then a better working solution could be devised (such as removing code blocks from these tables, so that the `l` operator does not cause copy&paste issues). Here is the [Slack](https://redhat-internal.slack.com/archives/C02KBD8A4UF/p1709312758104259) thread for why to revert the style operator from `m` to `l`. 


Version(s):
4.13

Issue:
[OCPBUGS-29262](https://issues.redhat.com/browse/OCPBUGS-29262)

Preview link: 

* [Required configuration parameters-vsphere](https://72946--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations#installation-configuration-parameters-additional-vsphere_installing-vsphere-installer-provisioned-customizations)
