### PR TITLE
OCPBUGS#29456: Removed a restriction related to adding/removing a deviceClass in the LVMCluster CR

### DIFF
--- a/modules/lvms-about-lvmcluster-cr.adoc
+++ b/modules/lvms-about-lvmcluster-cr.adoc
@@ -36,8 +36,6 @@ The `LVMCluster` CR fields are described in the following table:
 
 To create multiple device storage classes, create a device class for each storage class. 
 
-After creating an `LVMCluster` CR, if you add or remove a device class, the update reflects in the `LVMCluster` CR only after deleting and recreating the `TopoLVM-Node` pod. 
-
 |`deviceClasses.name`
 |`string`
 |Specify a name for the LVM volume group (VG). 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16

Issue:
[OCPBUGS-29456](https://issues.redhat.com/browse/OCPBUGS-29456)

Link to docs preview:
[Preview](https://72957--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms#about-lvmcluster_logical-volume-manager-storage)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

