### PR TITLE
[internal-fix] OCPBUGS-29252-revert-12

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1679,89 +1679,70 @@ ifdef::vsphere,vmc[]
 [id="installation-configuration-parameters-additional-vsphere_{context}"]
 == Additional VMware vSphere configuration parameters
 
-Additional VMware vSphere configuration parameters are described in the following table:
+Additional VMware vSphere configuration parameters are described in the following table.
+
+[NOTE]
+====
+The `platform.vsphere` parameter prefixes each parameter listed in the table.
+====
 
 .Additional VMware vSphere cluster parameters
 [cols=".^2,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
 |====
 |Parameter|Description|Values
 
-l|platform
-     vsphere
-       vCenter
+|`vCenter`
 |The fully-qualified hostname or IP address of the vCenter server.
 |String
 
-l|platform
-     vsphere
-       username
+|`username`
 |The user name to use to connect to the vCenter instance with. This user must have at least
 the roles and privileges that are required for
 link:https://github.com/vmware-archive/vsphere-storage-for-kubernetes/blob/master/documentation/vcp-roles.md[static or dynamic persistent volume provisioning]
 in vSphere.
 |String
 
-l|platform
-     vsphere
-       password
+|`password`
 |The password for the vCenter user name.
 |String
 
-l|platform
-     vsphere
-       datacenter
+|`datacenter`
 |The name of the data center to use in the vCenter instance.
 |String
 
-l|platform
-    vsphere
-      defaultDatastore
+|`defaultDatastore`
 |The name of the default datastore to use for provisioning volumes.
 |String
 
-l|platform
-    vsphere
-      folder
+|`folder`
 |Optional. The absolute path of an existing folder where the installation program creates the virtual machines. If you do not provide this value, the installation program creates a folder that is named with the infrastructure ID in the data center virtual machine folder.
 |String, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
 
-l|platform
-    vsphere
-      resourcePool
+|`resourcePool`
 |Optional. The absolute path of an existing resource pool where the installation program creates the virtual machines. If you do not specify a value, the installation program installs the resources in the root of the cluster under `/<datacenter_name>/host/<cluster_name>/Resources`.
 |String, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
 
-l|platform
-    vsphere
-      network
+|`network`
 |The network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured.
 |String
 
-l|platform
-    vsphere
-      cluster
+|`cluster`
 |The vCenter cluster to install the {product-title} cluster in.
 |String
 
-l|platform
-    vsphere
-      apiVIPs
+|`apiVIPs`
 |The virtual IP (VIP) address that you configured for control plane API access.
 
 *Note:* In {product-title} 4.12 and later, the `apiVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `apiVIPs` configuration setting.
 |An IP address, for example `128.0.0.1`.
 
-l|platform
-    vsphere
-      ingressVIPs
+|`ingressVIPs`
 |The virtual IP (VIP) address that you configured for cluster ingress.
 
 *Note:* In {product-title} 4.12 and later, the `ingressVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `ingressVIPs` configuration setting.
 a|An IP address, for example `128.0.0.1`.
 
-l|platform
-    vsphere
-      diskType
+|`diskType`
 |Optional. The disk provisioning method. This value defaults to the vSphere default storage policy if not set.
 |Valid values are `thin`, `thick`, or `eagerZeroedThick`.
 |====
@@ -1769,41 +1750,35 @@ l|platform
 [id="installation-configuration-parameters-optional-vsphere_{context}"]
 == Optional VMware vSphere machine pool configuration parameters
 
-Optional VMware vSphere machine pool configuration parameters are described in the following table:
+Optional VMware vSphere machine pool configuration parameters are described in the following table.
+
+[NOTE]
+====
+The `platform.vsphere` parameter prefixes each parameter listed in the table.
+====
 
 .Optional VMware vSphere machine pool parameters
 [cols=".^2,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
 |====
 |Parameter|Description|Values
 
-l|platform
-    vsphere
-      clusterOSImage
+|`clusterOSImage`
 |The location from which the installation program downloads the {op-system} image. You must set this parameter to perform an installation in a restricted network.
 |An HTTP or HTTPS URL, optionally with a SHA-256 checksum. For example, `\https://mirror.openshift.com/images/rhcos-<version>-vmware.<architecture>.ova`.
 
-l|platform
-    vsphere
-      osDisk
-        diskSizeGB
+|`osDisk.diskSizeGB`
 |The size of the disk in gigabytes.
 |Integer
 
-l|platform
-    vsphere
-      cpus
+|`cpus`
 |The total number of virtual processor cores to assign a virtual machine. The value of `platform.vsphere.cpus` must be a multiple of `platform.vsphere.coresPerSocket` value.
 |Integer
 
-l|platform
-    vsphere
-      coresPerSocket
+|`coresPerSocket`
 |The number of cores per socket in a virtual machine. The number of virtual sockets on the virtual machine is `platform.vsphere.cpus`/`platform.vsphere.coresPerSocket`. The default value for control plane nodes and worker nodes is `4` and `2`, respectively.
 |Integer
 
-l|platform
-    vsphere
-      memoryMB
+|`memoryMB`
 |The size of a virtual machine's memory in megabytes.
 |Integer
 |====
@@ -1818,83 +1793,53 @@ To use the region and zone enablement feature, you must specify region and zone 
 Before you modify the `install-config.yaml` file to configure a region and zone enablement environment, read the "VMware vSphere region and zone enablement" and the "Configuring regions and zones for a VMware vCenter" sections.
 ====
 
+[NOTE]
+====
+The `platform.vsphere` parameter prefixes each parameter listed in the table.
+====
+
 .Region and zone enablement parameters
 [cols=".^2,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
 |====
 |Parameter|Description|Values
 
-l|platform
-    vsphere
-      failureDomains
+|`failureDomains`
 |Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
 |String
 
-l|platform
-    vsphere
-      failureDomains
-        name
+|`failureDomains.name`
 |The name of the failure domain. The machine pools use this name to reference the failure domain.
 |String
 
-l|platform
-    vsphere
-      failureDomains
-        region
+|`failureDomains.region`
 |You define a region by using a tag from the `openshift-region` tag category. The tag must be attached to the vCenter datacenter.
 |String
 
-l|platform
-    vsphere
-      failureDomains
-        zone
+|`failureDomains.zone`
 |You define a zone by using a tag from the `openshift-zone` tag category. The tag must be attached to the vCenter datacenter.
 |String
 
-l|platform
-    vsphere
-      failureDomains
-        topology
-          computeCluster
+|`failureDomains.topology.computeCluster`
 |This parameter defines the compute cluster associated with the failure domain. If you do not define this parameter in your configuration, the compute cluster takes the value of `platform.vsphere.cluster` and `platform.vsphere.datacenter`.
 |String
 
-l|platform
-    vsphere
-      failureDomains
-        topology
-          folder
+|`failureDomains.topology.folder`
 |The absolute path of an existing folder where the installation program creates the virtual machines. If you do not define this parameter in your configuration, the folder takes the value of `platform.vsphere.folder`.
 |String
 
-l|platform
-    vsphere
-      failureDomains
-        topology
-          datacenter
+|`failureDomains.topology.datacenter`
 |Defines the datacenter where {product-title} virtual machines (VMs) operate. If you do not define this parameter in your configuration, the datacenter defaults to `platform.vsphere.datacenter`.
 |String
 
-l|platform
-    vsphere
-      failureDomains
-        topology
-          datastore
+|`failureDomains.topology.datastore`
 | The name of the datastore to use for provisioning volumes. If you do not define this parameter in your configuration, the datastore takes the value of `platform.vsphere.defaultDatastore`.
 |String
 
-l|platform
-    vsphere
-      failureDomains
-        topology
-          networks
+|`failureDomains.topology.networks`
 | Lists any network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured. If you do not define this parameter in your configuration, the network takes the value of `platform.vsphere.network`.
 |String
 
-l|platform
-    vsphere
-      failureDomains
-        topology
-          resourcePool
+|`failureDomains.topology.resourcePool`
 |The absolute path of an existing resource pool where the installation program creates the virtual machines. If you do not define this parameter in your configuration, the resource pool takes the value of `platform.vsphere.failureDomains.topology.computeCluster`.
 |====
 endif::vsphere,vmc[]


### PR DESCRIPTION
This PR is a follow on from https://github.com/openshift/openshift-docs/pull/72388 that reverts the `m` style operator to an `l` style operator. However, the 4.12 and 4.13 docs should remove all style operators as these operators are problematic. Style operators will be a focus point for 4.14+ only. 

Note: Only the vSphere parameter tables were updated for 4.13 and 4.12 to use the literal style operator. 

The monspace style operator is also not a working solution. See [example](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/installing/installing-on-vsphere#installation-configuration-parameters-additional-vsphere_installation-config-parameters-vsphere). For now, revert to the `l` style operator, and then a better working solution could be devised (such as removing code blocks from these tables, so that the `l` operator does not cause copy&paste issues). Here is the [Slack](https://redhat-internal.slack.com/archives/C02KBD8A4UF/p1709312758104259) thread for why to revert the style operator from `m` to `l`. 


Version(s):
4.12

Issue:
[OCPBUGS-29262](https://issues.redhat.com/browse/OCPBUGS-29262)

Preview link: 

* [Required configuration parameters-vsphere](https://72961--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations#installation-configuration-parameters-additional-vsphere_installing-vsphere-installer-provisioned-customizations)