### PR TITLE
OADP-3084: GCP-WIF VSL backup PartiallyFailed phase

### DIFF
--- a/modules/oadp-gcp-wif-cloud-authentication.adoc
+++ b/modules/oadp-gcp-wif-cloud-authentication.adoc
@@ -17,10 +17,9 @@ Workload identity federation handles encrypting and decrypting certificates, ext
 Google workload identity federation is available for OADP 1.3.x and later.
 ====
 
-[NOTE]
-====
-For backing up volumes, OADP on GCP with Google workload identity federation authentication supports only CSI snapshots.
-====
+When backing up volumes, OADP on GCP with Google workload identity federation authentication only supports CSI snapshots.
+
+OADP on GCP with Google workload identity federation authentication does not support Volume Snapshot Locations (VSL) backups. For more details, see xref:oadp-gcp-wif-known-issues[Google workload identity federation known issues].
 
 If you do not use Google workload identity federation cloud authentication, continue to _Installing the Data Protection Application_.
 
@@ -96,3 +95,8 @@ $ oc create namespace <OPERATOR_INSTALL_NS>
 ----
 $ oc apply -f manifests/openshift-adp-cloud-credentials-gcp-credentials.yaml
 ----
+
+[id="oadp-gcp-wif-known-issues"]
+== Google workload identity federation known issues
+
+* Volume Snapshot Location (VSL) backups finish with a `PartiallyFailed` phase when GCP workload identity federation is configured. Google workload identity federation authentication does not support VSL backups.


### PR DESCRIPTION
### JIRA

* [OADP-3084](https://issues.redhat.com/browse/OADP-3084)


### VERSIONS

* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16


### Link to docs preview:

* [Google workload identity federation cloud authentication](https://72963--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp#oadp-gcp-wif-cloud-authentication_installing-oadp-gcp)

### QE review:
- [X ] QE has approved this change. See comments in JIRA ticket
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
