### PR TITLE
OBSDOCS-685: 'Prometheus database storage requirements' doc doesn't f…

### DIFF
--- a/modules/prometheus-database-storage-requirements.adoc
+++ b/modules/prometheus-database-storage-requirements.adoc
@@ -3,20 +3,23 @@
 // * scalability_and_performance/recommended-performance-scale-practices/recommended-infrastructure-practices.adoc
 // * installing-byoh/installing-existing-hosts.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="prometheus-database-storage-requirements_{context}"]
 = Prometheus database storage requirements
 
-Red Hat performed various tests for different scale sizes.
+Red{nbsp}Hat performed various tests for different scale sizes.
 
 [NOTE]
 ====
-The Prometheus storage requirements below are not prescriptive and should be used as a reference. Higher resource consumption might be observed in your cluster depending on workload activity and resource density, including the number of pods, containers, routes, or other resources exposing metrics collected by Prometheus.
+* The following Prometheus storage requirements are not prescriptive and should be used as a reference. Higher resource consumption might be observed in your cluster depending on workload activity and resource density, including the number of pods, containers, routes, or other resources exposing metrics collected by Prometheus.
+
+* You can configure the size-based data retention policy to suit your storage requirements.
 ====
 
 .Prometheus Database storage requirements based on number of nodes/pods in the cluster
 [options="header"]
 |===
-|Number of Nodes |Number of pods (2 containers per pod) |Prometheus storage growth per day |Prometheus storage growth per 15 days |Network (per tsdb chunk)
+|Number of nodes |Number of pods (2 containers per pod) |Prometheus storage growth per day |Prometheus storage growth per 15 days |Network (per tsdb chunk)
 
 |50
 |1800


### PR DESCRIPTION
Version(s): `enterprise-4.12` and later

Issue: [OBSDOCS-685](https://issues.redhat.com/browse/OBSDOCS-685)

Link to docs preview: [Prometheus database storage requirements](https://72964--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-performance-scale-practices/recommended-infrastructure-practices#prometheus-database-storage-requirements_recommended-infrastructure-practices)

QE review:
- [x] QE has approved this change.

Peer review:
- [x] Peer review done

**Additional information:**