### PR TITLE
Updates disabling IR cluster note

### DIFF
--- a/modules/cluster-image-registry-operator.adoc
+++ b/modules/cluster-image-registry-operator.adoc
@@ -41,7 +41,7 @@ In order to integrate the image registry into the cluster's user authentication 
 If you disable the `ImageRegistry` capability or if you disable the integrated {product-registry} in the Cluster Image Registry Operator's configuration, the service account token secret and image pull secret are not generated for each service account.
 ====
 
-If you disable the `ImageRegistry` capability, you can reduce the overall resource footprint of {product-title} in Telco environments. Depending on your deployment, you can disable this component if you do not need it.
+If you disable the `ImageRegistry` capability, you can reduce the overall resource footprint of {product-title} in resource-constrained environments. Depending on your deployment, you can disable this component if you do not need it.
 endif::[]
 
 [discrete]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OCPBUGS-30321

Link to docs preview:
https://72965--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/cluster-capabilities#cluster-image-registry-operator_cluster-capabilities

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
