### PR TITLE
ROX#18584: add ebpf upgrade info to 4.3

### DIFF
--- a/modules/change-collection-method-ebpf.adoc
+++ b/modules/change-collection-method-ebpf.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * upgrading/upgrade-operator.adoc
+:_mod-docs-content-type: CONCEPT
+[id="change-collection-method-ebpf_{context}"]
+= Changing the collection method to EBPF
+
+[role="_abstract"]
+If the cluster that you are upgrading contains the `SecuredCluster` CR, you must ensure that the per node collection setting is set to EBPF before you upgrade.
+
+.Procedure
+
+. In the {ocp} web console, go to the {product-title-short} Operator page.
+. In the top navigation menu, select *Secured Cluster*.
+. Click the instance name, for example, *stackrox-secured-cluster-services*.
+. Click YAML to open the YAML editor.
+. Locate the `spec.perNode.collector.collection` attribute.
+. If the value is `KernelModule`, then change it to `EBPF`.
+. Click *Save*.

--- a/modules/prepare-operator-upgrades.adoc
+++ b/modules/prepare-operator-upgrades.adoc
@@ -10,3 +10,4 @@ Before you upgrade {rh-rhacs-first} version, you must:
 
 * Verify that you are running the latest patch release version of the {product-title-short} Operator 3.74.
 * Backup your existing Central database.
+* If the cluster you are upgrading contains the `SecuredCluster` custom resource (CR), change the collection method to EBPF.

--- a/upgrading/upgrade-operator.adoc
+++ b/upgrading/upgrade-operator.adoc
@@ -20,6 +20,7 @@ Upgrades through the {rh-rhacs-first} Operator are performed automatically or ma
 ====
 
 include::modules/prepare-operator-upgrades.adoc[leveloffset=+1]
+include::modules/change-collection-method-ebpf.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
Version(s):
4.3

[Issue](https://issues.redhat.com/browse/ROX-18584)

[Link to docs preview
](https://72968--docspreview.netlify.app/openshift-acs/latest/upgrading/upgrade-operator#prepare-operator-upgrades_upgrade-operator)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

See #72950 for 4.4
