### PR TITLE
OBSDOCS-903: Issue in file monitoring/troubleshooting-monitoring-issu…

### DIFF
--- a/modules/monitoring-investigating-why-user-defined-metrics-are-unavailable.adoc
+++ b/modules/monitoring-investigating-why-user-defined-metrics-are-unavailable.adoc
@@ -39,7 +39,7 @@ $ oc -n ns1 get service prometheus-example-app -o yaml
     app: prometheus-example-app
 ----
 +
-.. Check that the `matchLabels` `app` label in the `ServiceMonitor` resource configuration matches the label output in the preceding step:
+.. Check that the `matchLabels` definition in the `ServiceMonitor` resource configuration matches the label output in the preceding step. The following example queries the `prometheus-example-monitor` service monitor in the `ns1` project:
 +
 [source,terminal]
 ----
@@ -47,10 +47,13 @@ $ oc -n ns1 get servicemonitor prometheus-example-monitor -o yaml
 ----
 +
 .Example output
+[source,yaml]
 ----
 apiVersion: v1
-kind: Service
-# ...
+kind: ServiceMonitor
+metadata:
+  name: prometheus-example-monitor
+  namespace: ns1
 spec:
   endpoints:
   - interval: 30s
@@ -59,7 +62,6 @@ spec:
   selector:
     matchLabels:
       app: prometheus-example-app
-# ...
 ----
 +
 [NOTE]


### PR DESCRIPTION
Version(s): `enterprise-4.12` and later

Issue: [OBSDOCS-903](https://issues.redhat.com/browse/OBSDOCS-903)

Link to docs preview: [Investigating why user-defined project metrics are unavailable](https://72973--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/troubleshooting-monitoring-issues#investigating-why-user-defined-metrics-are-unavailable_troubleshooting-monitoring-issues)

QE review:
- [x] QE has approved this change.

Peer review:
- [x] Peer review done

**Additional information:**