### PR TITLE
OSDOCS#9729: Installing GitOps on MicroShift

### DIFF
--- a/microshift_install/microshift-install-rpm.adoc
+++ b/microshift_install/microshift-install-rpm.adoc
@@ -46,6 +46,8 @@ include::modules/microshift-install-rpms-olm.adoc[leveloffset=+1]
 * xref:../microshift_install/microshift-install-rpm.adoc#microshift-install-rpm-preparing_microshift-install-rpm[Preparing to install MicroShift from an RPM package]
 * xref:../microshift_running_apps/microshift-operators-olm.adoc#microshift-operators-olm[Using Operator Lifecycle Manager with {microshift-short}]
 
+include::modules/microshift-install-rpms-gitops.adoc[leveloffset=+1]
+
 include::modules/microshift-service-starting.adoc[leveloffset=+1]
 
 include::modules/microshift-service-stopping.adoc[leveloffset=+1]

--- a/modules/microshift-install-rpms-gitops.adoc
+++ b/modules/microshift-install-rpms-gitops.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// microshift/microshift-install-rpm.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-installing-rpms-for-gitops_{context}"]
+== Installing the GitOps Argo CD manifests from an RPM package
+
+You can use a lightweight version of the OpenShift GitOps with {microshift-short} to help manage your applications. Install the necessary Argo CD manifests using an RPM package. This RPM package included the necessary manifests that runs core Argo CD. 
+
+[IMPORTANT]
+====
+This process installs the basic GitOps functionalities, the Argo CD CLI is not currently available on {microshift-short}.
+====
+
+.Prerequisites
+
+* You installed {microshift-short} version 4.14 or higher
+* Additional RAM storage of 250MB recommended 
+
+.Procedure
+
+. Enable the GitOps repository with the subscription manager by running the following command:
++
+[source,terminal]
+----
+$ sudo subscription-manager repos --enable=gitops-1.12-for-rhel-9-$(uname -m)-rpms
+----
+
+. Install the GitOps package by running the following command: 
++
+[source,terminal]
+----
+$ sudo dnf install -y microshift-gitops 
+----
+
+. To deploy Argo CD pods, restart the {microshift-short} service by running the following command: 
++
+[source,terminal]
+----
+$ sudo systemctl restart microshift
+----
+
+.Verification 
+
+* You can verify that your pods are running properly by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-gitops
+----
++
+.Example output 
+[source,terminal]
+----
+NAME                                  READY   STATUS    RESTARTS   AGE
+argocd-application-controller-0       1/1     Running   0          4m11s
+argocd-redis-56844446bc-dzmhf         1/1     Running   0          4m12s
+argocd-repo-server-57b4f896cf-7qk8l   1/1     Running   0          4m12s
+----


### PR DESCRIPTION
**Version(s):** 4.15+ 
**Issue:** [OSDOCS-9729](https://issues.redhat.com//browse/OSDOCS-9729)

**Link to docs preview:**

- [Installing the GitOps ArgoCD manifests from an RPM package](https://72974--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-install-rpm#microshift-installing-rpms-for-gitops_microshift-install-rpm)

**QE review:**
- [x] QE has approved this change.

