### PR TITLE
Updates deny by default policy in ocp docs

### DIFF
--- a/modules/nw-networkpolicy-create-cli.adoc
+++ b/modules/nw-networkpolicy-create-cli.adoc
@@ -71,10 +71,12 @@ metadata:
   name: deny-by-default
 ifdef::multi[]
   annotations:
-    k8s.v1.cni.cncf.io/policy-for: <network_name>
+    k8s.v1.cni.cncf.io/policy-for:<namespace_name>/<network_name>
 endif::multi[]
 spec:
-  podSelector:
+  podSelector: {}
+  policyTypes:
+  - Ingress
   ingress: []
 ----
 +

--- a/modules/nw-networkpolicy-deny-all-allowed.adoc
+++ b/modules/nw-networkpolicy-deny-all-allowed.adoc
@@ -48,10 +48,12 @@ metadata:
   name: deny-by-default
   namespace: default <1>
   annotations:
-    k8s.v1.cni.cncf.io/policy-for: <network_name> <2>
+    k8s.v1.cni.cncf.io/policy-for: <namespace_name>/<network_name> <2>
 spec:
   podSelector: {} <3>
-  ingress: [] <4>
+  policyTypes: <4>
+  - Ingress <5>
+  ingress: [] <6>
 endif::multi[]
 ifndef::multi[]
 kind: NetworkPolicy
@@ -68,7 +70,9 @@ ifdef::multi[]
 <1> `namespace: default` deploys this policy to the `default` namespace.
 <2> `network_name`: specifies the name of a network attachment definition.
 <3> `podSelector:` is empty, this means it matches all the pods. Therefore, the policy applies to all pods in the default namespace.
-<4> There are no `ingress` rules specified. This causes incoming traffic to be dropped to all pods.
+<4> `policyTypes:` a list of rule types that the `NetworkPolicy` relates to.
+<5> Specifies as `Ingress` only `policyType`.
+<6> There are no `ingress` rules specified. This causes incoming traffic to be dropped to all pods.
 endif::multi[]
 ifndef::multi[]
 <1> `namespace: default` deploys this policy to the `default` namespace.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-29069 and https://issues.redhat.com/browse/OCPBUGS-28863

Link to docs preview:
https://72976--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-multi-network-policy#nw-networkpolicy-create-cli_configuring-multi-network-policy

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
