### PR TITLE
OSDOCS-9949: Removed an egress section from the ROSA docs

### DIFF
--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -169,7 +169,6 @@ On Azure, the following capacity limits exist for IP address assignment:
 - Per virtual network, the maximum number of assigned IP addresses cannot exceed 65,536.
 
 For more information, see link:https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits?toc=/azure/virtual-network/toc.json#networking-limits[Networking limits].
-endif::openshift-rosa[]
 
 [id="nw-egress-ips-multi-nic-considerations_{context}"]
 == Considerations for using an egress IP on additional network interfaces
@@ -196,7 +195,6 @@ You can determine which other network interfaces might support egress IPs by ins
 OVN-Kubernetes provides a mechanism to control and direct outbound network traffic from specific namespaces and pods. This ensures that it exits the cluster through a particular network interface and with a specific egress IP address.
 ====
 
-ifndef::openshift-rosa[]
 [discrete]
 [id="nw-egress-ips-multi-nic-requirements_{context}"]
 === Requirements for assigning an egress IP to a network interface that is not the primary network interface


### PR DESCRIPTION
Version(s):
`enterprise-4.15+`

Issue:
[OSDOCS-9949](https://issues.redhat.com/browse/OSDOCS-9949)

Link to docs preview:
- [Configuring an egress IP address
](https://file.rdu.redhat.com/eponvell/OSDOCS-9949_Remove-Egress-Section/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html#nw-egress-ips-multi-nic-considerations_configuring-egress-ips-ovn)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Conditioned out "Considerations for using an egress IP on additional network interfaces" from ROSA docs