### PR TITLE
OSDOCS-9950: Add recently released ROSA with HCP AWS regions to "What's New" page

### DIFF
--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -16,6 +16,14 @@ toc::[]
 [id="rosa-q1-2024_{context}"]
 === Q1 2024
 
+* **{hcp-title} regional availability update.** {hcp-title-first} is now available in the following regions:
++
+** Cape Town (`af-south-1`)
+** Seoul (`ap-northeast-2`)
+** Stockholm (`eu-north-1`)
++
+For more information on region availabilities, see xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc#rosa-sdpolicy-regions-az_rosa-hcp-service-definition[Regions and availability zones].
+
 * **ROSA CLI update.** The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/tag/v1.2.36[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-about_rosa-getting-started-cli[About the ROSA CLI].
 
 * **Log linking is enabled by default.** Beginning with {product-title} 4.15, log linking is enabled by default. Log linking gives you access to the container logs for your pods.


### PR DESCRIPTION
[OSDOCS-9950](https://issues.redhat.com//browse/OSDOCS-9950): Add recently released ROSA with HCP AWS regions to "What's New" page

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-9950

Link to docs preview:
ROSA: https://72999--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
