### PR TITLE
HAProxy version bump Release Note

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -143,6 +143,12 @@ The Network Observability Operator releases updates independently from the {prod
 //=== Cloud controller managers for additional cloud providers
 //
 
+[discrete]
+[id="ocp-4-16-HAProxy-version"]
+===  HAProxy version 2.8
+
+{product-title} {product-version} uses HAProxy 2.8.
+
 [id="ocp-4-16-deprecated-removed-features"]
 == Deprecated and removed features
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-9784

Link to docs preview:
https://73012--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes#ocp-4-16-notable-technical-changes)

QE review:
- [x] QE has approved this change.