### PR TITLE
OSSM-6086: Formatting issue in federation gateway parameters table

### DIFF
--- a/modules/ossm-federation-config-smcp.adoc
+++ b/modules/ossm-federation-config-smcp.adoc
@@ -200,7 +200,7 @@ To avoid naming conflicts between meshes, you must create separate egress and in
 |spec:
   gateways:
     additionalEgress:
-      <egressName>:
+      <egress_name>:
 |Define an additional egress gateway for _each_ mesh peer in the federation.
 |
 |
@@ -208,7 +208,7 @@ To avoid naming conflicts between meshes, you must create separate egress and in
 |spec:
   gateways:
     additionalEgress:
-      <egressName>:
+      <egress_name>:
         enabled:
 |This parameter enables or disables the federation egress.
 |`true`/`false`
@@ -217,7 +217,7 @@ To avoid naming conflicts between meshes, you must create separate egress and in
 |spec:
   gateways:
     additionalEgress:
-      <egressName>:
+      <egress_name>:
         requestedNetworkView:
 |Networks associated with exported services.
 |Set to the value of `spec.cluster.network` in the SMCP for the mesh, otherwise use <ServiceMeshPeer-name>-network. For example, if the `ServiceMeshPeer` resource for that mesh is named `west`, then the network would be named `west-network`.
@@ -226,7 +226,7 @@ To avoid naming conflicts between meshes, you must create separate egress and in
 |spec:
   gateways:
     additionalEgress:
-      <egressName>:
+      <egress_name>:
         service:
           metadata:
             labels:
@@ -238,7 +238,7 @@ To avoid naming conflicts between meshes, you must create separate egress and in
 |spec:
   gateways:
     additionalEgress:
-      <egressName>:
+      <egress_name>:
         service:
           ports:
 |Used to specify the `port:` and `name:` used for TLS and service discovery. Federation traffic consists of raw encrypted TCP for service traffic.
@@ -255,7 +255,7 @@ To avoid naming conflicts between meshes, you must create separate egress and in
 |spec:
   gateways:
     additionalIgress:
-      <ingressName>:
+      <ingress_name>:
         enabled:
 |This parameter enables or disables the federation ingress.
 |`true`/`false`
@@ -265,7 +265,7 @@ To avoid naming conflicts between meshes, you must create separate egress and in
 |spec:
   gateways:
     additionalIngress:
-      <ingressName>:
+      <ingress_name>:
         service:
           type:
 |The ingress gateway service must be exposed through a load balancer that operates at Layer 4 of the OSI model and is publicly available.
@@ -275,7 +275,7 @@ To avoid naming conflicts between meshes, you must create separate egress and in
 |spec:
   gateways:
     additionalIngress:
-      <ingressName>:
+      <ingress_name>:
         service:
           type:
 |If the cluster does not support `LoadBalancer` services, the ingress gateway service can be exposed through a `NodePort` service.
@@ -285,7 +285,7 @@ To avoid naming conflicts between meshes, you must create separate egress and in
 |spec:
   gateways:
     additionalIngress:
-      <ingressName>:
+      <ingress_name>:
         service:
           metadata:
             labels:
@@ -297,7 +297,7 @@ To avoid naming conflicts between meshes, you must create separate egress and in
 |spec:
   gateways:
     additionalIngress:
-      <ingressName>:
+      <ingress_name>:
         service:
           ports:
 |Used to specify the `port:` and `name:` used for TLS and service discovery. Federation traffic consists of raw encrypted TCP for service traffic. Federation traffic consists of HTTPS for discovery.
@@ -307,7 +307,7 @@ To avoid naming conflicts between meshes, you must create separate egress and in
 |spec:
   gateways:
     additionalIngress:
-      <ingressName>:
+      <ingress_name>:
         service:
           ports:
             nodePort:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): OCP 4.15, 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSSM-6086
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://73013--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-federation.html#understanding-federation-gateways
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
