### PR TITLE
OSDOCS-9941: Correction to the ROSA with HCP cluster creation process

### DIFF
--- a/modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc
+++ b/modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc
@@ -30,7 +30,21 @@ $ rosa create account-roles --hosted-cp --mode auto --yes
 +
 [source,terminal]
 ----
-$ export ACCOUNT_ROLES_PREFIX="${ACCOUNT_ROLES_PREFIX}"
+$ export ACCOUNT_ROLES_PREFIX=<account_role_prefix>
+----
+
+** View the value of the variable by running the following command:
++
+[source,terminal]
+----
+$ echo $ACCOUNT_ROLES_PREFIX
+----
++
+.Example output
++
+[source,terminal]
+----
+ManagedOpenShift
 ----
 
 For more information regarding AWS managed IAM policies for ROSA, see link:https://docs.aws.amazon.com/ROSA/latest/userguide/security-iam-awsmanpol.html[AWS managed IAM policies for ROSA].

--- a/modules/rosa-sts-byo-oidc.adoc
+++ b/modules/rosa-sts-byo-oidc.adoc
@@ -44,7 +44,7 @@ $ rosa create oidc-config --mode=auto  --yes
 +
 This command returns the following information.
 +
-.Sample output
+.Example output
 +
 [source,terminal]
 ----
@@ -60,25 +60,26 @@ I: Created OIDC provider with ARN 'arn:aws:iam::4540112244:oidc-provider/dvbwgdz
 +
 When creating your cluster, you must supply the OIDC config ID. The CLI output provides this value for `--mode auto`, otherwise you must determine these values based on `aws` CLI output for `--mode manual`.
 
-* Optional: you can save the OIDC configuration ID as a variable to use later. Run the following command to save the variable:
+** Optional: you can save the OIDC configuration ID as a variable to use later. Run the following command to save the variable:
 +
 [source,terminal]
 ----
-$ export OIDC_ID=30f5dqmk
+$ export OIDC_ID=<oidc_config_id><1>
 ----
+<1> In the example output above, the OIDC configuration ID is 13cdr6b.
 
-. View the value of the variable by running with the following command:
+** View the value of the variable by running the following command:
 +
 [source,terminal]
 ----
 $ echo $OIDC_ID
 ----
 +
-.Sample output
+.Example output
 +
 [source,terminal]
 ----
-$ 30f5dqmk
+13cdr6b
 ----
 
 .Verification
@@ -90,7 +91,7 @@ $ 30f5dqmk
 $ rosa list oidc-config
 ----
 +
-.Sample output
+.Example output
 +
 [source,terminal]
 ----


### PR DESCRIPTION
[OSDOCS-9941](https://issues.redhat.com//browse/OSDOCS-9941): Correction to the ROSA with HCP cluster creation process

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-9941

Link to docs preview:
ROSA: https://73024--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly#rosa-sts-creating-account-wide-sts-roles-and-policies_rosa-hcp-sts-creating-a-cluster-quickly
1. Account Roles
    ![image](https://github.com/openshift/openshift-docs/assets/16167833/6565f5e5-f558-4c21-afe9-e3e395befc12)


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
