### PR TITLE
Update Welcome page for OSD/ROSA

### DIFF
--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -21,8 +21,6 @@ endif::openshift-rosa[]
 
 ifdef::openshift-rosa[]
 To navigate the ROSA documentation, use the left navigation bar.
-
-For documentation that is not ROSA-specific, see the link:https://docs.openshift.com/container-platform/latest/welcome/index.html[OpenShift Container Platform documentation].
 endif::[]
 
 ifndef::openshift-rosa[]
@@ -54,8 +52,6 @@ endif::[]
 
 ifdef::openshift-dedicated[]
 To navigate the {product-title} documentation, use the left navigation bar.
-
-For documentation that is not specific to {product-title}, see the link:https://docs.openshift.com/container-platform/latest/welcome/index.html[OpenShift Container Platform documentation].
 endif::[]
 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]


### PR DESCRIPTION
This PR removes an outdated sentence from the ROSA and OSD Welcome pages.

Version(s):
* enterprise-4.15+

Link to docs preview:
* OSD: https://73027--ocpdocs-pr.netlify.app/openshift-dedicated/latest/welcome/
* ROSA: https://73027--ocpdocs-pr.netlify.app/openshift-rosa/latest/welcome/
