### PR TITLE
OCPBUGS-30865: Improve OpenStack CCM config reference for dual-stack

### DIFF
--- a/modules/cluster-cloud-controller-config-osp.adoc
+++ b/modules/cluster-cloud-controller-config-osp.adoc
@@ -154,7 +154,7 @@ For the Amphora provider, if using the `LEAST_CONNECTIONS` or `SOURCE_IP` method
 | Optional. The load balancer API version. Only `"v2"` is supported.
 
 | `subnet-id`
-| The ID of the Networking service subnet on which load balancer VIPs are created.
+| The ID of the Networking service subnet on which load balancer VIPs are created. For dual stack deployments, leave this option unset. The OpenStack cloud provider automatically selects which subnet to use for a load balancer.
 
 // This ID is also used to create pool members if `member-subnet-id` is not set.
 
@@ -162,7 +162,7 @@ For the Amphora provider, if using the `LEAST_CONNECTIONS` or `SOURCE_IP` method
 // | ID of the Neutron network on which to create the members of the load balancer. The load balancer gets another network port on this subnet. Defaults to `subnet-id` if not set.
 
 | `network-id`
-| The ID of the Networking service network on which load balancer VIPs are created. Unnecessary if `subnet-id` is set.
+| The ID of the Networking service network on which load balancer VIPs are created. Unnecessary if `subnet-id` is set. If this property is not set, the network is automatically selected based on the network that cluster nodes use.
 
 // | `manage-security-groups`
 // | If the Neutron security groups should be managed separately. Default: false


### PR DESCRIPTION
This clarifies how to configure `subnet-id` and `network-id` when running on dual-stack clusters.

Version(s):
4.16, 4.15, 4.14

Issue:
https://issues.redhat.com/browse/OCPBUGS-30865

Link to docs preview:
https://73031--ocpdocs-pr.netlify.app/

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
