### PR TITLE
Need to mention -n openshift-marketplace instead --all-namespaces  while verifying CatalogSource resources were successfully installed. 

### DIFF
--- a/modules/oc-mirror-updating-cluster-manifests.adoc
+++ b/modules/oc-mirror-updating-cluster-manifests.adoc
@@ -54,5 +54,5 @@ $ oc get imagecontentsourcepolicy
 +
 [source,terminal]
 ----
-$ oc get catalogsource --all-namespaces
+$ oc get catalogsource -n openshift-marketplace
 ----


### PR DESCRIPTION
Need to mention -n openshift-marketplace instead --all-namespaces while verifying CatalogSource resources were successfully installed .  Because in results-1639608409 the generated CatalogSource  always point to namespace openshift-marketplace
~~~
$ cat oc-mirror-workspace/results-1639608409/*operator-index.yaml | grep namespace
  namespace: openshift-marketplace
~~~

Version(s):
4.13, 4.12, 4.11, 4.14, 4.15


Issue:
https://issues.redhat.com/browse/OCPBUGS-30868

Link to docs preview:
https://73051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-disconnected#oc-mirror-updating-cluster-manifests_installing-mirroring-disconnected