### PR TITLE
SRVCOM-2931 - adds 1.32 to list of versions

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -216,6 +216,7 @@
               <%= distro %>
             </a>
             <select id="version-selector" onchange="versionSelector(this);">
+              <option value="1.32">1.31</option>
               <option value="1.31">1.31</option>
               <option value="1.30">1.30</option>
               <option value="1.29">1.29</option>

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -216,7 +216,7 @@
               <%= distro %>
             </a>
             <select id="version-selector" onchange="versionSelector(this);">
-              <option value="1.32">1.31</option>
+              <option value="1.32">1.32</option>
               <option value="1.31">1.31</option>
               <option value="1.30">1.30</option>
               <option value="1.29">1.29</option>


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[SRVCOM-2931](https://issues.redhat.com/browse/SRVCOM-2931)

Link to docs preview:
N/A

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
