### PR TITLE
Revert "SRVCOM-2931 - adds 1.32 to list of versions"

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -216,7 +216,6 @@
               <%= distro %>
             </a>
             <select id="version-selector" onchange="versionSelector(this);">
-              <option value="1.32">1.32</option>
               <option value="1.31">1.31</option>
               <option value="1.30">1.30</option>
               <option value="1.29">1.29</option>


### PR DESCRIPTION
Reverts openshift/openshift-docs#73052 which was merged a day early.