### PR TITLE
[enterprise-4.12] OBSDOCS-884: OCP, default retention time for in-cluster prometheus

### DIFF
--- a/modules/monitoring-granting-users-permission-to-monitor-user-defined-projects.adoc
+++ b/modules/monitoring-granting-users-permission-to-monitor-user-defined-projects.adoc
@@ -2,6 +2,7 @@
 //
 // * monitoring/enabling-monitoring-for-user-defined-projects.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="granting-users-permission-to-monitor-user-defined-projects_{context}"]
 = Granting users permission to monitor user-defined projects
 

--- a/modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc
+++ b/modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc
@@ -6,7 +6,11 @@
 [id="modifying-retention-time-and-size-for-prometheus-metrics-data_{context}"]
 = Modifying the retention time and size for Prometheus metrics data
 
-By default, Prometheus automatically retains metrics data for 15 days.
+By default, Prometheus retains metrics data for the following durations:
+
+* *Core platform monitoring*: 15 days
+* *Monitoring for user-defined projects*: 24 hours
+
 You can modify the retention time to change how soon data is deleted by specifying a time value in the `retention` field.
 You can also configure the maximum amount of disk space the retained metrics data uses by specifying a size value in the `retentionSize` field.
 If the data reaches this size limit, Prometheus deletes the oldest data first until the disk space used is again below the limit.
@@ -17,12 +21,12 @@ Note the following behaviors of these data retention settings:
 * Data in the `/wal` and `/head_chunks` directories counts toward the retention size limit, but Prometheus never purges data from these directories based on size- or time-based retention policies.
 Thus, if you set a retention size limit lower than the maximum size set for the `/wal` and `/head_chunks` directories, you have configured the system not to retain any data blocks in the `/prometheus` data directories.
 * The size-based retention policy is applied only when Prometheus cuts a new data block, which occurs every two hours after the WAL contains at least three hours of data.
-* If you do not explicitly define values for either `retention` or `retentionSize`, retention time defaults to 15 days and retention size is not set.
+* If you do not explicitly define values for either `retention` or `retentionSize`, retention time defaults to 15 days for core platform monitoring and 24 hours for user-defined project monitoring. Retention size is not set.
 * If you define values for both `retention` and `retentionSize`, both values apply.
 If any data blocks exceed the defined retention time or the defined size limit, Prometheus purges these data blocks.
 * If you define a value for `retentionSize` and do not define `retention`, only the `retentionSize` value applies.
 * If you do not define a value for `retentionSize` and only define a value for `retention`, only the `retention` value applies.
-* If you set the `retentionSize` or `retention` value to number 0, the default settings apply. The default settings set retention time to 15 days and do not set a value for retention size.
+* If you set the `retentionSize` or `retention` value to `0`, the default settings apply. The default settings set retention time to 15 days for core platform monitoring and 24 hours for user-defined project monitoring. By default, retention size is not set.
 
 .Prerequisites
 


### PR DESCRIPTION
Manual CP from #72913 to 4.12