### PR TITLE
OCPBUGS-30610: Added CloudCredential capability to cluster capabiliti…

### DIFF
--- a/snippets/capabilities-table.adoc
+++ b/snippets/capabilities-table.adoc
@@ -23,7 +23,7 @@ The following table describes the `baselineCapabilitySet` values.
 |Specify this option when you want to enable the default capabilities for {product-title} 4.14. By specifying `v4.14`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.14 are `baremetal`, `MachineAPI`, `marketplace`, `openshift-samples`, `Console`, `Insights`, `Storage`, `CSISnapshot`, `NodeTuning`, `ImageRegistry`, `Build`, and `DeploymentConfig`.
 
 |`v4.15`
-|Specify this option when you want to enable the default capabilities for {product-title} 4.15. By specifying `v4.15`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.15 are `baremetal`, `MachineAPI`, `marketplace`, `OperatorLifecycleManager`, `openshift-samples`, `Console`, `Insights`, `Storage`, `CSISnapshot`, `NodeTuning`, `ImageRegistry`, `Build`, and `DeploymentConfig`.
+|Specify this option when you want to enable the default capabilities for {product-title} 4.15. By specifying `v4.15`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.15 are `baremetal`, `MachineAPI`, `marketplace`, `OperatorLifecycleManager`, `openshift-samples`, `Console`, `Insights`, `Storage`, `CSISnapshot`, `NodeTuning`, `ImageRegistry`, `Build`, `CloudCredential`, and `DeploymentConfig`.
 
 |`None`
 |Specify when the other sets are too large, and you do not need any capabilities or want to fine-tune via `additionalEnabledCapabilities`.


### PR DESCRIPTION
Version(s):
4.16 and 4.15

Issue:
[OCPBUGS-30610](https://issues.redhat.com/browse/OCPBUGS-30610)

Link to docs preview:
[Selecting cluster capabilities](https://73091--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/cluster-capabilities#selecting-cluster-capabilities_cluster-capabilities)

[] SME review: SME has approved this change.
[] QE review: QE has approved this change.
