### PR TITLE
OSDOCS-9784: Bump HAProxy version to 2.8

### DIFF
--- a/modules/nw-http2-haproxy.adoc
+++ b/modules/nw-http2-haproxy.adoc
@@ -14,11 +14,6 @@ To enable the use of HTTP/2 for the connection from the client to HAProxy, a rou
 
 The connection from HAProxy to the application pod can use HTTP/2 only for re-encrypt routes and not for edge-terminated or insecure routes. This restriction is because HAProxy uses Application-Level Protocol Negotiation (ALPN), which is a TLS extension, to negotiate the use of HTTP/2 with the back-end. The implication is that end-to-end HTTP/2 is possible with passthrough and re-encrypt and not with insecure or edge-terminated routes.
 
-[WARNING]
-====
-Using WebSockets with a re-encrypt route and with HTTP/2 enabled on an Ingress Controller requires WebSocket support over HTTP/2. WebSockets over HTTP/2 is a feature of HAProxy 2.4, which is unsupported in {product-title} at this time.
-====
-
 [IMPORTANT]
 ====
 For non-passthrough routes, the Ingress Controller negotiates its connection to the application independently of the connection from the client. This means a client may connect to the Ingress Controller and negotiate HTTP/1.1, and the Ingress Controller may then connect to the application, negotiate HTTP/2, and forward the request from the client HTTP/1.1 connection using the HTTP/2 connection to the application. This poses a problem if the client subsequently tries to upgrade its connection from HTTP/1.1 to the WebSocket protocol, because the Ingress Controller cannot forward WebSocket to HTTP/2 and cannot upgrade its HTTP/2 connection to WebSocket. Consequently, if you have an application that is intended to accept WebSocket connections, it must not allow negotiating the HTTP/2 protocol or else clients will fail to upgrade to the WebSocket protocol.

--- a/modules/nw-ingress-converting-http-header-case.adoc
+++ b/modules/nw-ingress-converting-http-header-case.adoc
@@ -10,7 +10,7 @@ HAProxy 2.2 lowercases HTTP header names by default, for example, changing `Host
 
 [IMPORTANT]
 ====
-Because {product-title} includes HAProxy 2.2, make sure to add the necessary configuration by using `spec.httpHeaders.headerNameCaseAdjustments` before upgrading.
+Because {product-title} includes HAProxy 2.8, be sure to add the necessary configuration by using `spec.httpHeaders.headerNameCaseAdjustments` before upgrading.
 ====
 
 .Prerequisites


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/73008