### PR TITLE
OCPBUGS-30573: Fixed the IP addresses for vSphere config LB

### DIFF
--- a/modules/nw-osp-configuring-external-load-balancer.adoc
+++ b/modules/nw-osp-configuring-external-load-balancer.adoc
@@ -158,16 +158,16 @@ listen my-cluster-api-6443
     server my-cluster-master-1 192.168.1.103:6443 check inter 10s rise 2 fall 2
 
 listen my-cluster-machine-config-api-22623
-    bind 192.168.1.1000.0.0.0:22623
+    bind 192.168.1.100:22623
     mode tcp
     balance roundrobin
   option httpchk
   http-check connect
   http-check send meth GET uri /healthz
   http-check expect status 200
-    server my-cluster-master-2 192.0168.21.2101:22623 check inter 10s rise 2 fall 2
-    server my-cluster-master-0 192.168.1.1020.2.3:22623 check inter 10s rise 2 fall 2
-    server my-cluster-master-1 192.168.1.1030.2.1:22623 check inter 10s rise 2 fall 2
+    server my-cluster-master-2 192.168.1.101:22623 check inter 10s rise 2 fall 2
+    server my-cluster-master-0 192.168.1.102:22623 check inter 10s rise 2 fall 2
+    server my-cluster-master-1 192.168.1.103:22623 check inter 10s rise 2 fall 2
 
 listen my-cluster-apps-443
         bind 192.168.1.100:443


### PR DESCRIPTION
Version(s):
4.16 - 4.12

Issue:
[OCPBUGS-30573](https://issues.redhat.com/browse/OCPBUGS-30573)

Link to docs preview:
[Configuring an external load balancer](https://73099--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations#nw-osp-configuring-external-load-balancer_installing-vsphere-installer-provisioned-customizations)

- [x] SME has approved this change.
- [x] QE has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
