### PR TITLE
OCPBUGS#30887: Added ec2:DescribeSecurityGroupRules to AWS perms

### DIFF
--- a/modules/installation-aws-permissions.adoc
+++ b/modules/installation-aws-permissions.adoc
@@ -49,6 +49,7 @@ cluster, the IAM user requires the following permissions:
 * `ec2:DescribeRegions`
 * `ec2:DescribeRouteTables`
 * `ec2:DescribeSecurityGroups`
+* `ec2:DescribeSecurityGroupRules`
 * `ec2:DescribeSubnets`
 * `ec2:DescribeTags`
 * `ec2:DescribeVolumes`


### PR DESCRIPTION
Version(s):
4.14+

Issue:
This PR address [ocpbugs-30887](https://issues.redhat.com/browse/OCPBUGS-30887).

Link to docs preview:

[Required AWS permissions for the IAM user](https://73100--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account#installation-aws-permissions_installing-aws-account) > Required EC2 permissions for installation

QE review:
- [x] QE has approved this change.