### PR TITLE
[WIP] OSDOCS#9506: Cloud expert tutorial revision in ROSA Docs

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -105,27 +105,27 @@ Topics:
   File: index
 #- Name: ROSA prerequisites
 #  File: rosa-mobb-prerequisites-tutorial
-- Name: ROSA with HCP activation and account linking
+- Name: Activating ROSA with HCP activation and account linking
   File: cloud-experts-rosa-hcp-activation-and-account-linking-tutorial
-- Name: Verifying Permissions for a ROSA STS Deployment
+- Name: Verifying permissions for a ROSA STS Deployment with a script
   File: rosa-mobb-verify-permissions-sts-deployment
 - Name: Configuring log forwarding for CloudWatch logs and STS
   File: cloud-experts-rosa-cloudwatch-sts
-- Name: Using AWS WAF and Amazon CloudFront to protect ROSA workloads
+- Name: Protecting ROSA workloads with AWS WAF and Amazon CloudFront
   File: cloud-experts-using-cloudfront-and-waf
-- Name: Using AWS WAF and AWS ALBs to protect ROSA workloads
+- Name: Protecting ROSA workloads with AWS WAF and AWS ALBs
   File: cloud-experts-using-alb-and-waf
 - Name: Deploying OpenShift API for Data Protection on a ROSA cluster
   File: cloud-experts-deploy-api-data-protection
-- Name: AWS Load Balancer Operator on ROSA
+- Name: Configuring AWS Load Balancer Operator on ROSA
   File: cloud-experts-aws-load-balancer-operator
-- Name: Configuring ROSA/OSD to use custom TLS ciphers on the ingress controllers
+- Name: Configuring ROSA or OSD to use custom TLS ciphers on the Ingress Controller
   File: cloud-experts-configure-custom-tls-ciphers
 - Name: Configuring Microsoft Entra ID (formerly Azure Active Directory) as an identity provider
   File: cloud-experts-entra-id-idp
-- Name: Using AWS Secrets Manager CSI on ROSA with STS
+- Name: Deploying AWS Secrets Manager CSI on ROSA with STS
   File: cloud-experts-aws-secret-manager
-- Name: Using AWS Controllers for Kubernetes on ROSA
+- Name: Configuring AWS Controllers for Kubernetes on ROSA
   File: cloud-experts-using-aws-ack
 - Name: Deploying the External DNS Operator on ROSA
   File: cloud-experts-external-dns
@@ -174,7 +174,7 @@ Topics:
     File: cloud-experts-getting-started-deleting
   - Name: Obtaining support
     File: cloud-experts-getting-started-support
-- Name: Deploying an application
+- Name: Deploying a sample application
   Dir: cloud-experts-deploying-application
   Distros: openshift-rosa
   Topics:

--- a/cloud_experts_tutorials/cloud-experts-aws-load-balancer-operator.adoc
+++ b/cloud_experts_tutorials/cloud-experts-aws-load-balancer-operator.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-aws-load-balancer-operator"]
-= Tutorial: AWS Load Balancer Operator on ROSA
+= Tutorial: Configuring a load balancer on ROSA with AWS Load Balancer Operator 
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-aws-load-balancer-operator
 

--- a/cloud_experts_tutorials/cloud-experts-aws-secret-manager.adoc
+++ b/cloud_experts_tutorials/cloud-experts-aws-secret-manager.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-aws-secret-manager"]
-= Tutorial: Using AWS Secrets Manager CSI on ROSA with STS
+= Tutorial: Deploying AWS Secrets Manager CSI on ROSA with STS
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-aws-secret-manager
 

--- a/cloud_experts_tutorials/cloud-experts-configure-custom-tls-ciphers.adoc
+++ b/cloud_experts_tutorials/cloud-experts-configure-custom-tls-ciphers.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-configure-custom-tls-ciphers"]
-= Tutorial: Configuring ROSA/OSD to use custom TLS ciphers on the Ingress Controller
+= Tutorial: Configuring ROSA or OSD to use custom TLS ciphers on the Ingress Controller
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-configure-custom-tls-ciphers
 

--- a/cloud_experts_tutorials/cloud-experts-deploying-application/cloud-experts-deploying-application-intro.adoc
+++ b/cloud_experts_tutorials/cloud-experts-deploying-application/cloud-experts-deploying-application-intro.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-deploying-application-intro"]
-= Tutorial: Deploying an application
+= Tutorial: Deploying a sample application
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-deploying-application-intro
 

--- a/cloud_experts_tutorials/cloud-experts-deploying-application/cloud-experts-deploying-application-lab-overview.adoc
+++ b/cloud_experts_tutorials/cloud-experts-deploying-application/cloud-experts-deploying-application-lab-overview.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-deploying-application-lab-overview"]
-= Tutorial: Deploying an application
+= Tutorial: Deploying a sample application
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-deploying-application-intro
 

--- a/cloud_experts_tutorials/cloud-experts-deploying-application/cloud-experts-deploying-application-prerequisites.adoc
+++ b/cloud_experts_tutorials/cloud-experts-deploying-application/cloud-experts-deploying-application-prerequisites.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-deploying-application-prerequisites"]
-= Tutorial: Deploying an application
+= Tutorial: Deploying a sample application
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-deploying-application-prerequisites
 

--- a/cloud_experts_tutorials/cloud-experts-dynamic-certificate-custom-domain.adoc
+++ b/cloud_experts_tutorials/cloud-experts-dynamic-certificate-custom-domain.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-dynamic-certificate-custom-domain"]
-= Tutorial: Dynamically issuing certificates using the cert-manager Operator on ROSA
+= Tutorial: Dynamically issuing certificates with the cert-manager Operator on ROSA
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-dynamic-certificate-custom-domain
 

--- a/cloud_experts_tutorials/cloud-experts-rosa-cloudwatch-sts.adoc
+++ b/cloud_experts_tutorials/cloud-experts-rosa-cloudwatch-sts.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-rosa-cloudwatch-sts"]
-= Configuring log forwarding for CloudWatch logs and STS
+= Tutorial: Configuring log forwarding for CloudWatch logs and STS
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-rosa-cloudwatch-sts
 

--- a/cloud_experts_tutorials/cloud-experts-rosa-hcp-activation-and-account-linking-tutorial.adoc
+++ b/cloud_experts_tutorials/cloud-experts-rosa-hcp-activation-and-account-linking-tutorial.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id=“cloud-experts-rosa-hcp-activation-and-account-linking-tutorial”]
-= Tutorial: ROSA with HCP activation and account linking
+= Tutorial: Activating ROSA with HCP and account linking
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-rosa-hcp-activation-and-account-linking-tutorial
 

--- a/cloud_experts_tutorials/cloud-experts-using-alb-and-waf.adoc
+++ b/cloud_experts_tutorials/cloud-experts-using-alb-and-waf.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-using-alb-and-waf"]
-= Tutorial: Using AWS WAF and AWS ALBs to protect ROSA workloads
+= Tutorial: Protecting ROSA workloads with AWS WAF and AWS ALBs
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-using-alb-and-waf
 

--- a/cloud_experts_tutorials/cloud-experts-using-aws-ack.adoc
+++ b/cloud_experts_tutorials/cloud-experts-using-aws-ack.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id=“cloud-experts-using-aws-ack]
-= Tutorial: Using AWS Controllers for Kubernetes on ROSA
+= Tutorial: Configuring AWS Controllers for Kubernetes on ROSA
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-using-aws-ack
 

--- a/cloud_experts_tutorials/cloud-experts-using-cloudfront-and-waf.adoc
+++ b/cloud_experts_tutorials/cloud-experts-using-cloudfront-and-waf.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-using-cloudfront-and-waf"]
-= Tutorial: Using AWS WAF and Amazon CloudFront to protect ROSA workloads
+= Tutorial: Protecting ROSA workloads with AWS WAF and Amazon CloudFront
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-using-cloudfront-and-waf
 

--- a/cloud_experts_tutorials/rosa-mobb-verify-permissions-sts-deployment.adoc
+++ b/cloud_experts_tutorials/rosa-mobb-verify-permissions-sts-deployment.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="rosa-mobb-verify-permissions-sts-deployment"]
-= Tutorial: Verifying Permissions for a ROSA STS Deployment
+= Tutorial: Verifying permissions for a ROSA STS deployment with a script
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-mobb-verify-permissions-sts-deployment
 


### PR DESCRIPTION
This PR deals with the reorganization of the cloud expert tutorials in the ROSA documentation.

Version(s):
4.15+

Issue:
[OSDOCS-9506](https://issues.redhat.com/browse/OSDOCS-9506)

Link to docs preview:
[ROSA docs](https://73101--ocpdocs-pr.netlify.app/openshift-rosa/latest/welcome/)

Peer reviewer:
- [ ] Peer reviewer has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
