### PR TITLE
OCPBUGS#30172: Fixing doc bug in multi-arch docs

### DIFF
--- a/post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-configuration.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-configuration.adoc
@@ -33,62 +33,62 @@ To create a cluster with multi-architecture compute machines with different inst
 |Microsoft Azure
 |
 |&#10003;
-|`x84_64`
+|`x86_64`
 |`aarch64`
 
 |xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-aws.adoc#creating-multi-arch-compute-nodes-aws[Creating a cluster with multi-architecture compute machines on AWS]
 |Amazon Web Services (AWS)
 |
 |&#10003;
-|`x84_64`
+|`x86_64`
 |`aarch64`
 
 |xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-gcp.adoc#creating-multi-arch-compute-nodes-gcp[Creating a cluster with multi-architecture compute machines on GCP]
 |Google Cloud Platform (GCP)
 |
 |&#10003;
-|`x84_64`
+|`x86_64`
 |`aarch64`
 
 .3+|xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-bare-metal.adoc#creating-multi-arch-compute-nodes-bare-metal[Creating a cluster with multi-architecture compute machines on bare metal, {ibm-power-title}, or {ibm-z-title}]
 |Bare metal
 |&#10003;
 |
-|`x84_64`
+|`x86_64`
 |`aarch64`
 
 |{ibm-power-title}
 |&#10003;
 |
-|`x84_64` or `ppc64le`
-|`x84_64`, `ppc64le`
+|`x86_64` or `ppc64le`
+|`x86_64`, `ppc64le`
 
 |{ibm-z-title}
 |&#10003;
 |
-|`x84_64` or `s390x`
-|`x84_64`, `s390x`
+|`x86_64` or `s390x`
+|`x86_64`, `s390x`
 
 |xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z.adoc#creating-multi-arch-compute-nodes-ibm-z[Creating a cluster with multi-architecture compute machines on {ibm-z-name} and {ibm-linuxone-name} with z/VM]
 |{ibm-z-name} and {ibm-linuxone-name}
 |&#10003;
 |
-|`x84_64`
-|`x84_64`, `s390x`
+|`x86_64`
+|`x86_64`, `s390x`
 
 |xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z-kvm.adoc#creating-multi-arch-compute-nodes-ibm-z-kvm[Creating a cluster with multi-architecture compute machines on {ibm-z-name} and {ibm-linuxone-name} with {op-system-base} KVM]
 |{ibm-z-name} and {ibm-linuxone-name}
 |&#10003;
 |
-|`x84_64`
-|`x84_64`, `s390x`
+|`x86_64`
+|`x86_64`, `s390x`
 
 |xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-power.adoc#creating-multi-arch-compute-nodes-ibm-power[Creating a cluster with multi-architecture compute machines on {ibm-power-name}]
 |{ibm-power-name}
 |&#10003;
 |
-|`x84_64`
-|`x84_64`, `ppc64le`
+|`x86_64`
+|`x86_64`, `ppc64le`
 
 |===
 


### PR DESCRIPTION
**Version(s):** 4.15+ 
**Issue:** [OCPBUGS-30172](https://issues.redhat.com/browse/OCPBUGS-30172)

**Link to docs preview:**
- [About cluster with multi-architecture compute machines -> Configuring your cluster with multi-architecture compute machines](https://73105--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-configuration#configuring-your-cluster-with-multi-architecture-compute-machines)

**QE review:**
- I don't think this needs QE since its a typo, but please lmk 
