### PR TITLE
OSDOCS-9957: Created a disclaimer in the Terraform docs about modifying resources

### DIFF
--- a/modules/rosa-sts-account-roles-terraform.adoc
+++ b/modules/rosa-sts-account-roles-terraform.adoc
@@ -16,10 +16,7 @@ endif::tf-full[]
 
 The following example shows how Terraform can be used to create your Amazon Web Services (AWS) Identity and Access Management (IAM) account roles for ROSA.
 
-[NOTE]
-====
-If you want to edit the Terraform files, you can use any text editor. You must re-run the `terraform init` and `terraform apply` commands if you change any values in the files.
-====
+include::snippets/terraform-modification-disclaimer.adoc[]
 
 .Procedure
 

--- a/modules/rosa-sts-cluster-terraform-execute.adoc
+++ b/modules/rosa-sts-cluster-terraform-execute.adoc
@@ -12,6 +12,8 @@ endif::[]
 
 After you create the Terraform files, you must initiate Terraform to provide all of the required dependencies. Then apply the Terraform plan.
 
+include::snippets/terraform-modification-disclaimer.adoc[]
+
 .Procedure
 
 . Set up Terraform to create your resources based on your Terraform files, run the following command:

--- a/modules/rosa-sts-terraform-considerations.adoc
+++ b/modules/rosa-sts-terraform-considerations.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * rosa_planning/rosa-understanding-terraform.adoc
+:_mod-docs-content-type: CONCEPT
+[id="rosa-sts-terraform-considerations_{context}"]
+= Considerations when using Terraform
+
+In general, using Terraform to manage cloud resources should be done with the expectation that any changes should be done using the Terraform methodology. Use caution when using tools outside of Terraform, such as the AWS console or Red Hat console, to modify cloud resources created by Terraform. Using tools outside Terraform to manage cloud resources that are already managed by Terraform introduces configuration drift from your declared Terraform configuration.
+
+For example, if you upgrade your Terraform-created cluster by using the {hybrid-console-url}, you need to reconcile your Terraform state before applying any forthcoming configuration changes. For more information, see link:https://developer.hashicorp.com/terraform/tutorials/state/state-cli[Manage resources in Terraform state] in the HashiCorp Developer documentation.

--- a/rosa_planning/rosa-understanding-terraform.adoc
+++ b/rosa_planning/rosa-understanding-terraform.adoc
@@ -1,6 +1,5 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/attributes-openshift-dedicated.adoc[]
-
 [id="rosa-understanding-terraform"]
 = Preparing Terraform to install ROSA clusters
 :context: rosa-understanding-terraform
@@ -10,6 +9,7 @@ toc::[]
 Terraform is an infrastructure-as-code tool that provides a way to configure your resources once and replicate those resources as desired. Terraform accomplishes the creation tasks by using declarative language. You declare what you want the final state of the infrastructure resource to be, and Terraform creates these resources to your specifications.
 
 include::modules/rosa-sts-terraform-prerequisites.adoc[leveloffset=+1]
+include::modules/rosa-sts-terraform-considerations.adoc[leveloffset=+1]
 
 [discrete]
 [role="_additional-resources"]

--- a/snippets/terraform-modification-disclaimer.adoc
+++ b/snippets/terraform-modification-disclaimer.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * rosa_install_access_delete_clusters/terraform/rosa-sts-creating-a-cluster-quickly-terraform.adoc
+// * rosa_planning/rosa-understanding-terraform.adoc
+
+:_mod-docs-content-type: SNIPPET
+[IMPORTANT]
+====
+Do not modify Terraform state files. For more information, see link:https://docs.openshift.com/rosa/rosa_planning/rosa-understanding-terraform.html#rosa-sts-terraform-considerations_rosa-understanding-terraform[Considerations when using Terraform]
+====


### PR DESCRIPTION
Version(s):
`enterprise-4.15+`

Issue:
**[OSDOCS-9957](https://issues.redhat.com/browse/OSDOCS-9957)**

Link to docs preview:
- [Preparing Terraform to install ROSA clusters](https://file.rdu.redhat.com/eponvell/OSDOCS-9957_Terraform-Disclaimer/rosa_planning/rosa-understanding-terraform.html#sd-terraform-account-roles_rosa-understanding-terraform)
- [Creating a default ROSA Classic cluster using Terraform](https://file.rdu.redhat.com/eponvell/OSDOCS-9957_Terraform-Disclaimer/rosa_install_access_delete_clusters/terraform/rosa-sts-creating-a-cluster-quickly-terraform.html#rosa-sts-cluster-terraform-execute_rosa-sts-creating-a-cluster-quickly-terraform)
    ![image](https://github.com/openshift/openshift-docs/assets/16167833/48452ab4-12cb-47dd-b4d5-5a629fa2eb5c)
   **NOTE**: For the purposes of review, this link currently will go to the main page for preparing your environment for Terraform. The actual link will have to be guessed and point to the considerations section on the first publication.
- [Considerations when using Terraform](https://file.rdu.redhat.com/eponvell/OSDOCS-9957_Terraform-Disclaimer/rosa_planning/rosa-understanding-terraform.html#rosa-sts-terraform-considerations_rosa-understanding-terraform)
    ![image](https://github.com/openshift/openshift-docs/assets/16167833/11e886a2-33d0-4e67-bb03-af2a25af139f)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR creates a disclaimer for Terraform content that warns users that they must modify their resources if they break the Terraform process.