### PR TITLE
CNV-38476: Update runbooks VirtualMachineCRCErrors

### DIFF
--- a/modules/virt-runbook-vmstorageclasswarning.adoc
+++ b/modules/virt-runbook-vmstorageclasswarning.adoc
@@ -5,11 +5,11 @@
 // * virt/monitoring/virt-runbooks.adoc
 
 :_mod-docs-content-type: REFERENCE
-[id="virt-runbook-VirtualMachineCRCErrors"]
-= VirtualMachineCRCErrors
+[id="virt-runbook-VMStorageClassWarning"]
+= VMStorageClassWarning
 
 [discrete]
-[id="meaning-virtualmachinecrcerrors"]
+[id="meaning-vmstorageclasswarning"]
 == Meaning
 
 This alert fires when the storage class is incorrectly configured.
@@ -17,14 +17,14 @@ A system-wide, shared dummy page causes CRC errors when data is
 written and read across different processes or threads.
 
 [discrete]
-[id="impact-virtualmachinecrcerrors"]
+[id="impact-vmstorageclasswarning"]
 == Impact
 
 A large number of CRC errors might cause the cluster to display
 severe performance degradation.
 
 [discrete]
-[id="diagnosis-virtualmachinecrcerrors"]
+[id="diagnosis-vmstorageclasswarning"]
 == Diagnosis
 
 . Navigate to *Observe* -> *Metrics* in the web console.
@@ -54,34 +54,10 @@ $ oc get pv <pv_name> -o=jsonpath='{.spec.storageClassName}'
 ----
 
 [discrete]
-[id="mitigation-virtualmachinecrcerrors"]
+[id="mitigation-vmstorageclasswarning"]
 == Mitigation
 
-Add the `krbd:rxbounce` map option to the storage class configuration to use
-a bounce buffer when receiving data:
-
-[source,yaml]
-----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: vm-sc
-parameters:
-  # ...
-  mounter: rbd
-  mapOptions: "krbd:rxbounce"
-provisioner: openshift-storage.rbd.csi.ceph.com
-# ...
-----
-
-The `krbd:rxbounce` option creates a bounce buffer to receive data. The default
-behavior is for the destination buffer to receive data directly. A bounce buffer
-is required if the stability of the destination buffer cannot be guaranteed.
-
-ifndef::openshift-rosa,openshift-dedicated[]
-See link:https://access.redhat.com/articles/6978371[Optimizing ODF PersistentVolumes for Windows VMs]
-for details.
-endif::openshift-rosa,openshift-dedicated[]
+Create a default OpenShift Virtualization storage class with the `krbd:rxbounce` map option. See  link:https://access.redhat.com/articles/6978371[Optimizing ODF PersistentVolumes for Windows VMs] for details.
 
 If you cannot resolve the issue, log in to the
 link:https://access.redhat.com[Customer Portal] and open a support case,

--- a/virt/monitoring/virt-runbooks.adoc
+++ b/virt/monitoring/virt-runbooks.adoc
@@ -119,6 +119,6 @@ include::modules/virt-runbook-virtoperatorresterrorsburst.adoc[leveloffset=+1]
 
 include::modules/virt-runbook-virtoperatorresterrorshigh.adoc[leveloffset=+1]
 
-include::modules/virt-runbook-virtualmachinecrcerrors.adoc[leveloffset=+1]
-
 include::modules/virt-runbook-vmcannotbeevicted.adoc[leveloffset=+1]
+
+include::modules/virt-runbook-vmstorageclasswarning.adoc[leveloffset=+1]


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/CNV-38476

OCP 4.14+

Preview: https://73108--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-runbooks#virt-runbook-VMStorageClassWarning