### PR TITLE
OSDOCS-9958: Add February released ROSA with HCP AWS regions to "What's New" page

### DIFF
--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -18,6 +18,10 @@ toc::[]
 
 * **{hcp-title} regional availability update.** {hcp-title-first} is now available in the following regions:
 +
+** Hyderabad (`ap-south-2`)
+** Milan (`eu-south-1`)
+** London (`eu-west-2`)
+** Mumbai (`ap-south-1`)
 ** Cape Town (`af-south-1`)
 ** Seoul (`ap-northeast-2`)
 ** Stockholm (`eu-north-1`)


### PR DESCRIPTION
[OSDOCS-9958](https://issues.redhat.com//browse/OSDOCS-9958): Add February released ROSA with HCP AWS regions to "What's New" page

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-9958

Link to docs preview:
ROSA: https://73117--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
