### PR TITLE
OBSDOCS-794: Add known Splunk log forwarding issue to 5.8 release notes

### DIFF
--- a/modules/logging-release-notes-5-8-0.adoc
+++ b/modules/logging-release-notes-5-8-0.adoc
@@ -56,6 +56,10 @@ In order to support multi-cluster log forwarding in additional namespaces other 
 [id="logging-release-notes-5-8-0-known-issues"]
 == Known Issues
 
+* Currently, Splunk log forwarding might not work after upgrading to version 5.8 of the {clo}. This issue is caused by transitioning from OpenSSL version 1.1.1 to version 3.0.7. In the newer OpenSSL version, there is a default behavior change, where connections to TLS 1.2 endpoints are rejected if they do not expose the link:https://datatracker.ietf.org/doc/html/rfc5746[RFC 5746] extension.
++
+As a workaround, enable TLS 1.3 support on the TLS terminating load balancer in front of the Splunk HEC (HTTP Event Collector) endpoint. Splunk is a third-party system and this should be configured from the Splunk end.
+
 * Currently, there is a flaw in handling multiplexed streams in the HTTP/2 protocol, where you can repeatedly make a request for a new multiplex stream and immediately send an `RST_STREAM` frame to cancel it. This created extra work for the server set up and tore down the streams, resulting in a denial of service due to server resource consumption. There is currently no workaround for this issue. (link:https://issues.redhat.com/browse/LOG-4609[LOG-4609])
 
 * Currently, when using  FluentD as the collector, the collector pod cannot start on the {product-title} IPv6-enabled cluster. The pod logs produce the `fluentd pod [error]: unexpected error error_class=SocketError error="getaddrinfo: Name or service not known` error. There is currently no workaround for this issue. (link:https://issues.redhat.com/browse/LOG-4706[LOG-4706])


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OBSDOCS-794

Link to docs preview:
https://73122--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/logging_release_notes/logging-5-8-release-notes#logging-release-notes-5-8-0-known-issues

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

**Additional information:**
Requires change management since this includes changes to release notes.

Sign offs:
- [x] Jamie Parker (PM)
- [x] QE @anpingli 
- [x] Eng SME @jcantrill / @alanconway 
- [x] Senthamilarasu - Product Experience
- [x] @kalexand-rh (DPM)
