### PR TITLE
PR for SRVOCF-598-Serverless: Update links present in the "Creating a function in the web console" section.

### DIFF
--- a/modules/odc-creating-functions.adoc
+++ b/modules/odc-creating-functions.adoc
@@ -18,19 +18,19 @@ You can create a function from a Git repository by using the *Developer* perspec
 .func-s2i task
 [source,terminal]
 ----
-$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.31/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
+$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.32/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
 ----
 +
 .func-deploy task
 [source,terminal]
 ----
-$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.31/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.32/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
 ----
 +
 .Node.js function
 [source,terminal]
 ----
-$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.31/pkg/pipelines/resources/tekton/pipeline/dev-console/0.1/nodejs-pipeline.yaml
+$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.32/pkg/pipelines/resources/tekton/pipeline/dev-console/0.1/nodejs-pipeline.yaml
 ----
 
 * You must log into the {ocp-product-title} web console.


### PR DESCRIPTION
**Affected versions:** `serverless-docs-1.32`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVOCF-598

**Doc preview:** 

- [Creating a function in the web console](https://73133--ocpdocs-pr.netlify.app/openshift-serverless/latest/functions/serverless-functions-creating#odc-creating-functions_serverless-functions-creating)

Updated the links from `1.31` to `1.32` present in the following: 
- func-s2i task
- func-deploy task
- Node.js function