### PR TITLE
OSDOCS-9842: adds 4.14.17 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -482,3 +482,12 @@ Issued: 2024-03-13
 {product-title} release 4.14.16 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1207[RHBA-2024:1207] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:1205[RHBA-2024:1205] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-14-17-dp"]
+=== RHBA-2024:1262 - {microshift-short} 4.14.17 bug fix update advisory
+
+Issued: 2024-03-20
+
+{product-title} release 4.14.17 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1262[RHBA-2024:1262] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:1260[RHBA-2024:1260] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-9842](https://issues.redhat.com/browse/OSDOCS-9842)

Link to docs preview:
[4.14.17 async release note](https://73135--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes#microshift-4-14-17-dp)

QE review:
- N/A release notes stock text