### PR TITLE
OBSDOCS-578: Update the information in document - Restrict to use clu…

### DIFF
--- a/modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc
+++ b/modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc
@@ -6,7 +6,7 @@
 [id="attaching-additional-labels-to-your-time-series-and-alerts_{context}"]
 = Attaching additional labels to your time series and alerts
 
-Using the external labels feature of Prometheus, you can attach custom labels to all time series and alerts leaving Prometheus.
+You can attach custom labels to all time series and alerts leaving Prometheus by using the external labels feature of Prometheus.
 
 .Prerequisites
 
@@ -49,17 +49,19 @@ data:
   config.yaml: |
     prometheusK8s:
       externalLabels:
-        <key>: <value> <1>
+        <key>: <value> # <1>
 ----
 +
 <1> Substitute `<key>: <value>` with a map of key-value pairs where `<key>` is a unique name for the new label and `<value>` is its value.
 +
 [WARNING]
 ====
-Do not use `prometheus` or `prometheus_replica` as key names, because they are reserved and will be overwritten.
+* Do not use `prometheus` or `prometheus_replica` as key names, because they are reserved and will be overwritten.
+
+* Do not use `cluster` or `managed_cluster` as key names. Using them can cause issues where you are unable to see data in the developer dashboards.
 ====
 +
-For example, to add metadata about the region and environment to all time series and alerts, use:
+For example, to add metadata about the region and environment to all time series and alerts, use the following example:
 +
 [source,yaml]
 ----
@@ -98,14 +100,16 @@ data:
   config.yaml: |
     prometheus:
       externalLabels:
-        <key>: <value> <1>
+        <key>: <value> # <1>
 ----
 +
 <1> Substitute `<key>: <value>` with a map of key-value pairs where `<key>` is a unique name for the new label and `<value>` is its value.
 +
 [WARNING]
 ====
-Do not use `prometheus` or `prometheus_replica` as key names, because they are reserved and will be overwritten.
+* Do not use `prometheus` or `prometheus_replica` as key names, because they are reserved and will be overwritten.
+
+* Do not use `cluster` or `managed_cluster` as key names. Using them can cause issues where you are unable to see data in the developer dashboards.
 ====
 +
 [NOTE]
@@ -113,7 +117,7 @@ Do not use `prometheus` or `prometheus_replica` as key names, because they are r
 In the `openshift-user-workload-monitoring` project, Prometheus handles metrics and Thanos Ruler handles alerting and recording rules. Setting `externalLabels` for `prometheus` in the `user-workload-monitoring-config` `ConfigMap` object will only configure external labels for metrics and not for any rules.
 ====
 +
-For example, to add metadata about the region and environment to all time series and alerts related to user-defined projects, use:
+For example, to add metadata about the region and environment to all time series and alerts related to user-defined projects, use the following example:
 +
 [source,yaml]
 ----


### PR DESCRIPTION
Version(s): `enterprise-4.12` and later

Issue: [OBSDOCS-578](https://issues.redhat.com/browse/OBSDOCS-578)

Link to docs preview: [Attaching additional labels to your time series and alerts](https://73136--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack#attaching-additional-labels-to-your-time-series-and-alerts_configuring-the-monitoring-stack)

QE review:
- [x] QE has approved this change.

Peer review:
- [x] Peer review done

**Additional information:**