### PR TITLE
OSDOCS#6634: specifying agent subdirectory for additional config

### DIFF
--- a/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
@@ -37,6 +37,13 @@ include::modules/installing-ocp-agent-inputs.adoc[leveloffset=+2]
 
 You can create additional manifests to further configure your cluster beyond the configurations available in the `install-config.yaml` and `agent-config.yaml` files.
 
+// Creating a directory to contain additional manifests
+include::modules/installing-ocp-agent-manifest-folder.adoc[leveloffset=+3]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../post_installation_configuration/machine-configuration-tasks.adoc#using-machineconfigs-to-change-machines[Using MachineConfig objects to configure nodes]
+
 // Partitioning the disk
 include::modules/installation-user-infra-machines-advanced.adoc[leveloffset=+3]
 

--- a/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.adoc
+++ b/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.adoc
@@ -28,6 +28,7 @@ include::modules/installing-ocp-agent-inputs.adoc[leveloffset=+1]
 * See xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-three-node-cluster_installing-restricted-networks-bare-metal[Configuring a three-node cluster] to deploy three-node clusters in bare metal environments.
 * xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#root-device-hints_preparing-to-install-with-agent-based-installer[About root device hints].
 * link:https://nmstate.io/examples.html[NMState state examples].
+* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-ocp-agent-opt-manifests_installing-with-agent-based-installer[Optional: Creating additional manifest files]
 
 // Creating the PXE assets
 include::modules/pxe-assets-ocp-agent.adoc[leveloffset=+1]

--- a/modules/installation-user-infra-machines-advanced.adoc
+++ b/modules/installation-user-infra-machines-advanced.adoc
@@ -125,6 +125,11 @@ The use of a separate partition for the `/var` directory or a subdirectory of `/
 
 The following procedure sets up a separate `/var` partition by adding a machine config manifest that is wrapped into the Ignition config file for a node type during the preparation phase of an installation.
 
+ifdef::agent[]
+.Prerequisites
+* You have created an `openshift` subdirectory within your installation directory.
+endif::agent[]
+
 .Procedure
 
 ifndef::agent[]
@@ -133,15 +138,6 @@ ifndef::agent[]
 [source,terminal]
 ----
 $ openshift-install create manifests --dir <installation_directory>
-----
-endif::agent[]
-
-ifdef::agent[]
-. On your installation host, create the `openshift` subdirectory within the installation directory:
-+
-[source,terminal]
-----
-$ mkdir <installation_directory>/openshift
 ----
 endif::agent[]
 

--- a/modules/installing-ocp-agent-manifest-folder.adoc
+++ b/modules/installing-ocp-agent-manifest-folder.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * installing/installing-with-agent-based-installer/installing-with-agent-based-installer.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="installing-ocp-agent-manifest-folder_{context}"]
+= Creating a directory to contain additional manifests
+
+If you create additional manifests to configure your Agent-based installation beyond the `install-config.yaml` and `agent-config.yaml` files, you must create an `openshift` subdirectory within your installation directory.
+All of your additional machine configurations must be located within this subdirectory.
+
+[NOTE]
+====
+The most common type of additional manifest you can add is a `MachineConfig` object.
+For examples of `MachineConfig` objects you can add during the Agent-based installation, see "Using MachineConfig objects to configure nodes" in the "Additional resources" section.
+====
+
+.Procedure
+
+* On your installation host, create an `openshift` subdirectory within the installation directory by running the following command:
++
+[source,terminal]
+----
+$ mkdir <installation_directory>/openshift
+----


### PR DESCRIPTION
[OSDOCS-6634](https://issues.redhat.com/browse/OSDOCS-6634)

Version(s): 4.14+ 

This PR adds a subsection to the Agent install docs that instruct users to create a directory necessary for containing additional configuration files.

QE review:
- [x] QE has approved this change.

Preview: [Creating a directory to contain additional manifests](https://73169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer#installing-ocp-agent-manifest-folder_installing-with-agent-based-installer)  