### PR TITLE
OBSDOCS-400: update-CLI-command-for-getting-federation-host-for-monitoring

### DIFF
--- a/modules/monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus.adoc
+++ b/modules/monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus.adoc
@@ -6,7 +6,7 @@
 [id="monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus_{context}"]
 = Querying metrics by using the federation endpoint for Prometheus
 
-You can use the federation endpoint to scrape platform and user-defined metrics from a network location outside the cluster.
+You can use the federation endpoint for Prometheus to scrape platform and user-defined metrics from a network location outside the cluster.
 To do so, access the Prometheus `/federate` endpoint for the cluster via an {product-title} route.
 
 [IMPORTANT]
@@ -17,11 +17,11 @@ This delay can affect the accuracy and timeliness of the scraped metrics.
 Using the federation endpoint can also degrade the performance and scalability of your cluster, especially if you use the federation endpoint to retrieve large amounts of metrics data.
 To avoid these issues, follow these recommendations:
 
-* Do not try to retrieve all metrics data via the federation endpoint.
+* Do not try to retrieve all metrics data via the federation endpoint for Prometheus.
 Query it only when you want to retrieve a limited, aggregated data set.
 For example, retrieving fewer than 1,000 samples for each request helps minimize the risk of performance degradation.
 
-* Avoid querying the federation endpoint frequently.
+* Avoid frequent querying of the federation endpoint for Prometheus.
 Limit queries to a maximum of one every 30 seconds.
 
 If you need to forward large amounts of data outside the cluster, use remote write instead. For more information, see the _Configuring remote write storage_ section.
@@ -30,34 +30,43 @@ If you need to forward large amounts of data outside the cluster, use remote wri
 .Prerequisites
 
 * You have installed the OpenShift CLI (`oc`).
-* You have obtained the host URL for the {product-title} route.
 * You have access to the cluster as a user with the `cluster-monitoring-view` cluster role or have obtained a bearer token with `get` permission on the `namespaces` resource.
 +
 [NOTE]
 ====
-You can only use bearer token authentication to access the federation endpoint.
+You can only use bearer token authentication to access the Prometheus federation endpoint.
+====
+
+* You are logged in to an account that has permission to get the Prometheus federation route.
++
+[NOTE]
+====
+If your account does not have permission to get the Prometheus federation route, a cluster administrator can provide the URL for the route.
 ====
 
 .Procedure
 
-. Retrieve the bearer token:
+. Retrieve the bearer token by running the following the command:
 +
 [source,terminal]
 ----
-$ TOKEN=`oc whoami -t`
+$ TOKEN=$(oc whoami -t)
+----
+
+. Get the Prometheus federation route URL by running the following command:
++
+[source,terminal]
+----
+$ HOST=$(oc -n openshift-monitoring get route prometheus-k8s-federate -ojsonpath={.spec.host})
 ----
 
 . Query metrics from the `/federate` route.
-The following example queries `up` metrics:
+The following example command queries `up` metrics:
 +
 [source,terminal]
 ----
-$ curl -G -s -k -H "Authorization: Bearer $TOKEN" \
-    'https://<federation_host>/federate' \ <1>
-    --data-urlencode 'match[]=up'
+$ curl -G -k -H "Authorization: Bearer $TOKEN" https://$HOST/federate --data-urlencode 'match[]=up'
 ----
-+
-<1> For <federation_host>, substitute the host URL for the federation route.
 +
 .Example output
 +

--- a/monitoring/accessing-third-party-monitoring-apis.adoc
+++ b/monitoring/accessing-third-party-monitoring-apis.adoc
@@ -26,20 +26,16 @@ include::modules/monitoring-accessing-third-party-monitoring-web-service-apis.ad
 // Querying metrics by using the federation endpoint for Prometheus
 include::modules/monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus.adoc[leveloffset=+1]
 
-// Accessing metrics from outside the cluster for custom applications 
+// Accessing metrics from outside the cluster for custom applications
 include::modules/accessing-metrics-outside-cluster.adoc[leveloffset=+1]
-
-ifndef::openshift-dedicated,openshift-rosa[]
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects_enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
-endif::openshift-dedicated,openshift-rosa[]
 
 [role="_additional-resources"]
 [id="additional-resources_accessing-third-party-monitoring-apis"]
 == Additional resources
 
+ifndef::openshift-dedicated,openshift-rosa[]
+* xref:../monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects_enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
+endif::openshift-dedicated,openshift-rosa[]
 * xref:../monitoring/configuring-the-monitoring-stack.adoc#configuring_remote_write_storage_configuring-the-monitoring-stack[Configuring remote write storage]
 * xref:../monitoring/managing-metrics.adoc#managing-metrics[Managing metrics]
 * xref:../monitoring/managing-alerts.adoc#managing-alerts[Managing alerts]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-400
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://73192--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/accessing-third-party-monitoring-apis#monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus_accessing-third-party-monitoring-apis
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR updates the [querying metrics using the federation endpoint procedure](https://docs.openshift.com/container-platform/4.15/monitoring/accessing-third-party-monitoring-apis.html#monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus_accessing-third-party-monitoring-apis) to include a step to get the federation host and to include the host in the curl command.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
