### PR TITLE
OSDOCS-9764: adds GitOps assembly MicroShift

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -461,6 +461,8 @@ Topics:
   File: microshift-operators
 - Name: Using Operator Lifecycle Manager
   File: microshift-operators-olm
+- Name: Automating application management with GitOps
+  File: microshift-gitops
 ---
 Name: Backup and restore
 Dir: microshift_backup_and_restore

--- a/microshift_running_apps/microshift-gitops.adoc
+++ b/microshift_running_apps/microshift-gitops.adoc
@@ -1,0 +1,36 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="microshift-gitops"]
+= Automating application management with the GitOps controller
+include::_attributes/attributes-microshift.adoc[]
+:context: microshift-gitops
+
+toc::[]
+
+GitOps with Argo CD for {microshift-short} is a lightweight, optional add-on controller derived from the Red Hat OpenShift GitOps Operator. GitOps for {microshift-short} uses the command-line interface (CLI) of Argo CD to interact with the GitOps controller that acts as the declarative GitOps engine. You can consistently configure and deploy Kubernetes-based infrastructure and applications across clusters and development lifecycles.
+
+[id="microshift-gitops-can-do_{context}"]
+== What you can do with the GitOps agent
+By using the GitOps with Argo CD agent with {microshift-short}, you can utilize the following principles:
+
+* Implement application lifecycle management.
+** Create and manage your clusters and application configuration files using the core principles of developing and maintaining software in a Git repository.
+** You can update the single repository and GitOps automates the deployment of new applications or updates to existing ones.
+** For example, if you have 1,000 edge devices, each using {microshift-short} and a local GitOps agent, you can easily add or update an application on all 1,000 devices with just one change in your central Git repository.
+* The Git repository contains a declarative description of the infrastructure you need in your specified environment and contains an automated process to make your environment match the described state.
+* You can also use the Git repository as an audit trail of changes so that you can create processes based on Git flows such as review and approval for merging pull requests that implement configuration changes.
+
+[id="microshift-gitops-cannot-do_{context}"]
+== Limitations of using the GitOps agent with {microshift-short}
+GitOps with Argo CD for {microshift-short} has the following differences from the Red Hat OpenShift GitOps Operator:
+
+* The `gitops-operator` component is not used with {microshift-short}.
+* To maintain the small resource use of {microshift-short}, the Argo CD web console is not available. You can use the Argo CD CLI or use a pull-based approach.
+* Because {microshift-short} is single-node, there is no multi-cluster support. Each instance of {microshift-short} is paired with a local GitOps agent.
+* Use sos reports for debugging because `oc adm must-gather` is not available in {microshift-short}.
+
+[id="additional-resources_microshift-gitops_{context}"]
+[role="_additional-resources"]
+== Additional resources
+* link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12[Red Hat OpenShift GitOps]
+
+* xref:../microshift_support/microshift-sos-report.adoc#microshift-sos-report[Using sos reports]


### PR DESCRIPTION
Version(s):
4.15+

Issue:
[MicroShift GitOps Intro](https://issues.redhat.com/browse/OSDOCS-9764)

Link to docs preview:
[MicroShift GitOps](https://73201--ocpdocs-pr.netlify.app/microshift/latest/microshift_running_apps/microshift-gitops)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[Install doc](https://github.com/openshift/openshift-docs/pull/72974)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
