### PR TITLE
Cleaning up Agent docs 3/14/24

### DIFF
--- a/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.adoc
+++ b/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.adoc
@@ -34,7 +34,11 @@ include::modules/pxe-assets-ocp-agent.adoc[leveloffset=+1]
 
 // Manually adding IBM Z agents
 include::modules/installing-ocp-agent-ibm-z.adoc[leveloffset=+1]
+
+// Adding {ibm-z-title} agents with z/VM
 include::modules/installing-ocp-agent-ibm-z-zvm.adoc[leveloffset=+2]
+
+// Adding {ibm-z-name} agents with {op-system-base} KVM
 include::modules/installing-ocp-agent-ibm-z-kvm.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/modules/installing-ocp-agent-ibm-z-kvm.adoc
+++ b/modules/installing-ocp-agent-ibm-z-kvm.adoc
@@ -22,7 +22,7 @@ $ virt-install \
    --ram=16384 \
    --cpu host \
    --vcpus=8 \
-   --location <path_to_kernel_initrd_image>,kernel=kernel.img,initrd=initrd.img \ <1>
+   --location <path_to_kernel_initrd_image>,kernel=kernel.img,initrd=initrd.img \// <1>
    --disk <qcow_image_path> \
    --network network:macvtap ,mac=<mac_address> \
    --graphics none \

--- a/modules/installing-ocp-agent-ibm-z-zvm.adoc
+++ b/modules/installing-ocp-agent-ibm-z-zvm.adoc
@@ -6,7 +6,7 @@
 [id="installing-ocp-agent-ibm-z-zvm_{context}"]
 = Adding {ibm-z-title} agents with z/VM
 
-Use the following procedure to manually add {ibm-z-name} agents with z/VM
+Use the following procedure to manually add {ibm-z-name} agents with z/VM.
 
 .Procedure
 
@@ -14,7 +14,7 @@ Use the following procedure to manually add {ibm-z-name} agents with z/VM
 +
 .Example parameter file
 +
-[source,terminal]
+[source,text]
 ----
 rd.neednet=1 \
 console=ttysclp0 \
@@ -29,10 +29,10 @@ ignition.firstboot ignition.platform.id=metal \
 console=tty1 console=ttyS1,115200n8 \
 coreos.inst.persistent-kargs="console=tty1 console=ttyS1,115200n8"
 ----
-<1> For the `coreos.live.rootfs_url=` artifact, specify the matching `rootfs` artifact for the `kernel` and `initramfs` that you are booting. Only HTTP and HTTPS protocols are supported.
-<2> For the `ip=` parameter, assign the IP address automatically using DHCP, or manually assign the IP address, as described in "Installing a cluster with z/VM on {ibm-z-name} and {ibm-linuxone-name}".
-<3> The default is '1'. Omit this entry when using an OSA network adapter.
-<4> For installations on DASD-type disks, use `rd.dasd=` to specify the DASD where {op-system} is to be installed. Omit this entry for FCP-type disks.
+<1> For the `coreos.live.rootfs_url` artifact, specify the matching `rootfs` artifact for the `kernel` and `initramfs` that you are booting. Only HTTP and HTTPS protocols are supported.
+<2> For the `ip` parameter, assign the IP address automatically using DHCP, or manually assign the IP address, as described in "Installing a cluster with z/VM on {ibm-z-name} and {ibm-linuxone-name}".
+<3> The default is `1`. Omit this entry when using an OSA network adapter.
+<4> For installations on DASD-type disks, use `rd.dasd` to specify the DASD where {op-system-first} is to be installed. Omit this entry for FCP-type disks.
 <5> For installations on FCP-type disks, use `rd.zfcp=<adapter>,<wwpn>,<lun>` to specify the FCP disk where {op-system} is to be installed. Omit this entry for DASD-type disks.
 +
 Leave all other parameters unchanged.
@@ -43,13 +43,14 @@ For more information, see link:https://www.ibm.com/docs/en/zvm/latest?topic=comm
 +
 [TIP]
 ====
-You can use the CP PUNCH command or, if you use Linux, the **vmur** command, to transfer files between two z/VM guest virtual machines.
+You can use the `CP PUNCH` command or, if you use Linux, the `vmur` command, to transfer files between two z/VM guest virtual machines.
 ====
 +
-. Log in to CMS on the bootstrap machine.
+. Log in to the conversational monitor system (CMS) on the bootstrap machine.
 
 . IPL the bootstrap machine from the reader by running the following command:
 +
+[source,terminal]
 ----
 $ ipl c
 ----

--- a/modules/installing-ocp-agent-inputs.adoc
+++ b/modules/installing-ocp-agent-inputs.adoc
@@ -51,7 +51,7 @@ $ cat << EOF > ./my-cluster/install-config.yaml
 apiVersion: v1
 baseDomain: test.example.com
 compute:
-- architecture: amd64 <1>
+- architecture: amd64 // <1>
   hyperthreading: Enabled
   name: worker
   replicas: 0
@@ -61,20 +61,20 @@ controlPlane:
   name: master
   replicas: 1
 metadata:
-  name: sno-cluster <2>
+  name: sno-cluster // <2>
 networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
   machineNetwork:
   - cidr: 192.168.0.0/16
-  networkType: OVNKubernetes <3>
+  networkType: OVNKubernetes // <3>
   serviceNetwork:
   - 172.30.0.0/16
 platform: <4>
   none: {}
-pullSecret: '<pull_secret>' <5>
-sshKey: '<ssh_pub_key>' <6>
+pullSecret: '<pull_secret>' // <5>
+sshKey: '<ssh_pub_key>' // <6>
 EOF
 ----
 <1> Specify the system architecture, valid values are `amd64`, `arm64`, `ppc64le`, and `s390x`.
@@ -136,15 +136,15 @@ apiVersion: v1beta1
 kind: AgentConfig
 metadata:
   name: sno-cluster
-rendezvousIP: 192.168.111.80 <1>
-hosts: <2>
-  - hostname: master-0 <3>
+rendezvousIP: 192.168.111.80 // <1>
+hosts: // <2>
+  - hostname: master-0 // <3>
     interfaces:
       - name: eno1
         macAddress: 00:ef:44:21:e6:a5
-    rootDeviceHints: <4>
+    rootDeviceHints: // <4>
       deviceName: /dev/sdb
-    networkConfig: <5>
+    networkConfig: // <5>
       interfaces:
         - name: eno1
           type: ethernet

--- a/modules/installing-ocp-agent-verify.adoc
+++ b/modules/installing-ocp-agent-verify.adoc
@@ -19,7 +19,7 @@ Use the following procedure to track installation progress and to verify a succe
 +
 [source,terminal]
 ----
-$ ./openshift-install --dir <install_directory> agent wait-for bootstrap-complete \ <1>
+$ ./openshift-install --dir <install_directory> agent wait-for bootstrap-complete \// <1>
     --log-level=info <2>
 ----
 <1> For `<install_directory>`, specify the path to the directory where the agent ISO was generated.


### PR DESCRIPTION
Versions: 4.14+ (4.14 CP may fail)

This PR makes some small edits to align Agent Installer content better with style guide and doc guidelines.

QE review:
No QE required, just formatting changes

Preview: 

- [Preparing PXE assets for OCP](https://73204--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent)
- [Installing a cluster with Agent-based Installer](https://73204--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer)