### PR TITLE
OSDOCS-8651: HAProxy version fix

### DIFF
--- a/modules/nw-ingress-converting-http-header-case.adoc
+++ b/modules/nw-ingress-converting-http-header-case.adoc
@@ -6,7 +6,7 @@
 [id="nw-ingress-converting-http-header-case_{context}"]
 = Converting HTTP header case
 
-HAProxy 2.2 lowercases HTTP header names by default, for example, changing `Host: xyz.com` to `host: xyz.com`. If legacy applications are sensitive to the capitalization of HTTP header names, use the Ingress Controller `spec.httpHeaders.headerNameCaseAdjustments` API field for a solution to accommodate legacy applications until they can be fixed.
+HAProxy lowercases HTTP header names by default, for example, changing `Host: xyz.com` to `host: xyz.com`. If legacy applications are sensitive to the capitalization of HTTP header names, use the Ingress Controller `spec.httpHeaders.headerNameCaseAdjustments` API field for a solution to accommodate legacy applications until they can be fixed.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Follow up to https://github.com/openshift/openshift-docs/pull/72835

Version(s):
4.16

Relates to https://issues.redhat.com/browse/OSDOCS-8651