### PR TITLE
OBSDOCS-99 - Logging components by version

### DIFF
--- a/logging/cluster-logging.adoc
+++ b/logging/cluster-logging.adoc
@@ -22,6 +22,8 @@ Because the internal {product-title} Elasticsearch log store does not provide se
 
 include::modules/logging-architecture-overview.adoc[leveloffset=+1]
 
+include::modules/logging-components-by-version.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 .Additional resources
 * xref:../logging/log_visualization/log-visualization-ocp-console.adoc#log-visualization-ocp-console[Log visualization with the web console]

--- a/modules/logging-components-by-version.adoc
+++ b/modules/logging-components-by-version.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//logging/logging-getting-started.adoc
+:_mod-docs-content-type: REFERENCE
+[id="logging-components-by-version_{context}"]
+= Logging components by version
+
+For components with a version value of `master` or `main`, the current version is the latest commit to the respective branch.
+
+[options="header"]
+.Component versions
+|===
+| Release | `eventrouter` | `logfilemetricexplorer` | `loki` | `lokistack-gateway` | `opa-openshift` | `vector`
+| 5.9     | master   | main                  | v2.9.4 | main           | main       | v0.34.1
+| 5.8     | master   | v5.8                  | v2.9.4 | main           | main       | v0.28.1
+| 5.7     | master   | main                  | v2.9.4 | main           | main       | v0.28.1
+| 5.6     | master   | main                  | v2.9.4 | main           | main       | v0.21.0
+|===
+
+
+[options="header"]
+.Deprecated component versions
+|===
+| Release | `elasticsearch` | `fluentd`         | `kibana`
+| 5.9     | N/A           | v1.16.2/ ruby v3.1  | N/A
+| 5.8     | v6.8.1        | v1.16.2 / ruby v3.1 | v6.8.1
+| 5.7     | v6.8.1        | v1.14.6 / ruby v2.7 | v6.8.1
+| 5.6     | v6.8.1        | v1.14.6 / ruby v2.7 | v6.8.1
+|===


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OBSDOCS-99](https://issues.redhat.com//browse/OBSDOCS-99) 
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://73212--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/cluster-logging#logging-components-by-version_cluster-logging
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: @anpingli  / @QiaolingTang 
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
SME: @alanconway  / @jcantrill 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
