### PR TITLE
OCPBUGS25674: Adding api-int pre-req to Creating Win Machineset on Nutanix

### DIFF
--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-nutanix.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-nutanix.adoc
@@ -13,6 +13,7 @@ You can create a Windows `MachineSet` object to serve a specific purpose in your
 
 * You installed the Windows Machine Config Operator (WMCO) using Operator Lifecycle Manager (OLM).
 * You are using a supported Windows Server as the operating system image.
+* You added a new DNS entry for the internal API server URL, `api-int.<cluster_name>.<base_domain>`, that points to the external API server URL, `api.<cluster_name>.<base_domain>`. This can be a CNAME or an additional A record.
 
 include::modules/machine-api-overview.adoc[leveloffset=+1]
 include::modules/windows-machineset-nutanix.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUGS-25674](https://issues.redhat.com/browse/OCPBUGS-25674)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://73214--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-nutanix (under Prerequisites)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: The Jira bug suggests that instructions for the prerequisite of how to create a Windows OS image on Nutanix be added to the OCP doc. However, instructions such as these are outside the scope of our documentation. I've documented the api-int prerequisite and am moving forward with this PR.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
