### PR TITLE
Update ACS redirects and version selector for RHACS 4.4 release

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -138,13 +138,13 @@ AddType text/vtt                            vtt
     # ACS Redirects to go to the latest version - change here when a new version drops
     # it should probably be best to combine the next few lines in one reg exp but for clarity keeping them separate
     # the first one redirects
-    RewriteRule ^acs/?$ /acs/4.3/welcome/index.html [R=301]
+    RewriteRule ^acs/?$ /acs/4.4/welcome/index.html [R=301]
     # redirect to the latest release notes
-    RewriteRule ^acs/release_notes/?$ /acs/4.3/release_notes/43-release-notes.html [R=301,NE]
+    RewriteRule ^acs/release_notes/?$ /acs/4.4/release_notes/44-release-notes.html [R=301,NE]
     # redirect from ACS CLoud Service page
-    RewriteRule ^acs/installing/install-ocp-operator.html /acs/4.3/installing/installing_ocp/init-bundle-ocp.html [NE,R=301]
-    RewriteRule ^acs/(\D.*)$ /acs/4.3/$1 [NE,R=301]
-    RewriteRule ^acs/(3\.65|3\.66|3\.67|3\.68|3\.69|3\.70|3\.71|3\.72|3\.73|3\.74|4\.0|4\.1|4\.2|4\.3)/?$ /acs/$1/welcome/index.html [L,R=301]
+    RewriteRule ^acs/installing/install-ocp-operator.html /acs/4.4/installing/installing_ocp/init-bundle-ocp.html [NE,R=301]
+    RewriteRule ^acs/(\D.*)$ /acs/4.4/$1 [NE,R=301]
+    RewriteRule ^acs/(3\.65|3\.66|3\.67|3\.68|3\.69|3\.70|3\.71|3\.72|3\.73|3\.74|4\.0|4\.1|4\.2|4\.3|4\.4)/?$ /acs/$1/welcome/index.html [L,R=301]
     #redirect for 4.0 Manage vulneribility page
     RewriteRule ^(acs/(?:4\.0/)?)?operating/manage-vulnerabilities\.html$ /acs/4.0/operating/manage-vulnerabilities/vulnerability-management.html [NE,R=301]
     #redirect for missing 4.3 page

--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -295,6 +295,9 @@ openshift-acs:
     rhacs-docs-4.3:
       name: '4.3'
       dir: acs/4.3
+    rhacs-docs-4.4:
+      name: '4.4'
+      dir: acs/4.4
 microshift:
   name: Red Hat build of MicroShift
   author: OpenShift Documentation Project <openshift-docs@redhat.com>

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -196,6 +196,7 @@
               <%= distro %>
             </a>
             <select id="version-selector" onchange="versionSelector(this);">
+              <option value="4.4">4.4</option>
               <option value="4.3">4.3</option>
               <option value="4.2">4.2</option>
               <option value="4.1">4.1</option>

--- a/index-commercial.html
+++ b/index-commercial.html
@@ -243,6 +243,7 @@
               <div class="btn-group">
                 <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">Select version<span class="caret"></span></button>
                 <ul class="dropdown-menu" role="menu">
+                  <li><a href="acs/4.4/welcome/index.html"><i class="fa fa-arrow-circle-o-right"></i> RHACS 4.4</a></li>
                   <li><a href="acs/4.3/welcome/index.html"><i class="fa fa-arrow-circle-o-right"></i> RHACS 4.3</a></li>
                   <li><a href="acs/4.2/welcome/index.html"><i class="fa fa-arrow-circle-o-right"></i> RHACS 4.2</a></li>
                   <li><a href="acs/4.1/welcome/index.html"><i class="fa fa-arrow-circle-o-right"></i> RHACS 4.1</a></li>


### PR DESCRIPTION
Version(s):
4.4

For https://issues.redhat.com/browse/ROX-21145

Based on: https://github.com/openshift/openshift-docs/pull/67792