### PR TITLE
Changing redirects and version selector for GitOps 1.12

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -256,12 +256,12 @@ AddType text/vtt                            vtt
     # Builds using Shipwright landing page
     RewriteRule ^container-platform/(4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/builds_using_shipwright/overview-openshift-builds.html /builds/latest/about/overview-openshift-builds.html  [L,R=302]
 
-    # redirect gitops latest to 1.11
+    # redirect gitops latest to 1.12
     RewriteRule ^gitops/?$ /gitops/latest [R=302]
-    RewriteRule ^gitops/latest/?(.*)$ /gitops/1\.11/$1 [NE,R=302]
+    RewriteRule ^gitops/latest/?(.*)$ /gitops/1\.12/$1 [NE,R=302]
 
     # redirect top-level without filespec to the about file
-    RewriteRule ^gitops/(1\.8|1\.9|1\.10|1\.11)/?$ /gitops/$1/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]
+    RewriteRule ^gitops/(1\.8|1\.9|1\.10|1\.11|1\.12)/?$ /gitops/$1/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]
 
     # GitOps landing page
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/about-redhat-openshift-gitops.html /gitops/latest/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -245,6 +245,7 @@
               <%= distro %>
             </a>
             <select id="version-selector" onchange="versionSelector(this);">
+              <option value="1.12">1.12</option>
               <option value="1.11">1.11</option>
               <option value="1.10">1.10</option>
               <option value="1.9">1.9</option>


### PR DESCRIPTION
**Version(s):** `main` only

**Issue:**
-  [RHDEVDOCS 5802](https://issues.redhat.com/browse/RHDEVDOCS-5802)
-  [RHDEVDOCS 5804](https://issues.redhat.com/browse/RHDEVDOCS-5804)

**Link to docs preview:** Not applicable


**SME and QE review:** Not applicable

**Additional information:** This PR enables publishing a new version of a standalone documentation set on docs.openshift.com. This PR does not alter any documentation content, so no documentation preview is available. 