### PR TITLE
ocpbugs5541: correcting samesite value descriptions

### DIFF
--- a/modules/nw-route-specific-annotations.adoc
+++ b/modules/nw-route-specific-annotations.adoc
@@ -47,11 +47,11 @@ The maximum number of IP addresses and CIDR ranges directly visible in the `hapr
 |`haproxy.router.openshift.io/rewrite-target` | Sets the rewrite path of the request on the backend. |
 |`router.openshift.io/cookie-same-site` | Sets a value to restrict cookies. The values are:
 
-`Lax`: cookies are transferred between the visited site and third-party sites.
+`Lax`: the browser does not send cookies on cross-site requests, but does send cookies when users navigate to the origin site from an external site. This is the default browser behavior when the `SameSite` value is not specified.
 
-`Strict`: cookies are restricted to the visited site.
+`Strict`: the browser sends cookies only for same-site requests.
 
-`None`: cookies are restricted to the visited site.
+`None`: the browser sends cookies for both cross-site and same-site requests. 
 
 This value is applicable to re-encrypt and edge routes only. For more information, see the link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite[SameSite cookies documentation].|
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUGS-5541](https://issues.redhat.com/browse/OCPBUGS-5541)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://73234--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration.html#nw-route-specific-annotations_route-configuration (look for router.openshift.io/cookie-same-site in the table)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This issue also affects OCP 4.11. However, we no longer support that version of the document.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
