### PR TITLE
Updating ignored files and folders for vale review

### DIFF
--- a/scripts/prow-vale-review.sh
+++ b/scripts/prow-vale-review.sh
@@ -15,7 +15,7 @@ else
     COMMIT_ID=$2
 fi
 
-FILES=$(git diff --name-only HEAD~1 HEAD --diff-filter=d "*.adoc" ':(exclude)_unused_topics/*')
+FILES=$(git diff --name-only HEAD~1 HEAD --diff-filter=d "*.adoc" ':(exclude)_unused_topics/*' ':(exclude)rest_api/*' ':(exclude)microshift_rest_api/*' ':(exclude)modules/virt-runbook-*' ':(exclude)modules/oc-by-example-content.adoc' ':(exclude)modules/oc-adm-by-example-content.adoc' ':(exclude)monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc' ':(exclude)modules/microshift-oc-adm-by-example-content.adoc' ':(exclude)modules/microshift-oc-by-example-content.adoc')
 
 function post_review_comment {
 


### PR DESCRIPTION
Vale review should ignore:

* _unused_topics/*
* rest_api/*
* microshift_rest_api/*
* modules/virt-runbook-*
* modules/oc-by-example-content.adoc
* modules/oc-adm-by-example-content.adoc
* modules/microshift-oc-adm-by-example-content.adoc
* modules/microshift-oc-by-example-content.adoc

See https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#auto-generated-content

Verified no comments were added in https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_openshift-docs/73236/pull-ci-openshift-openshift-docs-main-validate-asciidoc/1768661018679971840