### PR TITLE
DOCS OBSDOCS-848 - Logging 5.6.17 Release Notes

### DIFF
--- a/logging/logging_release_notes/logging-5-6-release-notes.adoc
+++ b/logging/logging_release_notes/logging-5-6-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-6-17.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-6-16.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-6-15.adoc[leveloffset=+1]

--- a/modules/logging-release-notes-5-6-17.adoc
+++ b/modules/logging-release-notes-5-6-17.adoc
@@ -1,0 +1,26 @@
+// module included in /logging/logging-5-6-release-notes
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-5-6-17_{context}"]
+= Logging 5.6.17
+This release includes link:https://access.redhat.com/errata/RHSA-2024:1507[OpenShift Logging Bug Fix 5.6.17]
+
+[id="logging-release-notes-5-6-17-bug-fixes"]
+== Bug fixes
+
+* Before this update, the Red Hat build pipeline did not use the existing build details in Loki builds and omitted information such as revision, branch, and version. With this update, the Red Hat build pipeline now adds these details to the Loki builds, fixing the issue. (link:https://issues.redhat.com/browse/LOG-5203[LOG-5203])
+
+
+* Before this update, the configuration of the `ServiceMonitor` by Loki Operator could match many Kubernetes services, which led to Loki Operator's metrics being collected multiple times. With this update, the `ServiceMonitor` setup now only matches the dedicated metrics service. (link:https://issues.redhat.com/browse/LOG-5252[LOG-5252])
+
+
+* Before this update, the build pipeline did not include linker flags for the build date, causing Loki builds to show empty strings for `buildDate` and `goVersion`. With this update, adding the missing linker flags in the build pipeline fixes the issue. (link:https://issues.redhat.com/browse/LOG-5276[LOG-5276])
+
+* Before this update, the Loki Operator `ServiceMonitor` in the `openshift-operators-redhat` namespace used static token and CA files for authentication, causing errors in the Prometheus Operator in the User Workload Monitoring spec on the `ServiceMonitor` configuration. With this update, the Loki Operator `ServiceMonitor` in `openshift-operators-redhat` namespace now references a service account token secret by a `LocalReference` object. This approach allows the User Workload Monitoring spec in the Prometheus Operator to handle the Loki Operator `ServiceMonitor` successfully, enabling Prometheus to scrape the Loki Operator metrics. (link:https://issues.redhat.com/browse/LOG-5242[LOG-5242])
+
+[id="logging-release-notes-5-6-17-CVEs"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2021-35937[CVE-2021-35937]
+* link:https://access.redhat.com/security/cve/CVE-2021-35938[CVE-2021-35938]
+* link:https://access.redhat.com/security/cve/CVE-2021-35939[CVE-2021-35939]
+* link:https://access.redhat.com/security/cve/CVE-2024-24786[CVE-2024-24786]


### PR DESCRIPTION
Change type: Doc update; Logging Z-Stream Release Notes - 5.6.17
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-848

Fix Version: 4.11, 4.12, 4.13
Note: Since this branch isn't from main, I have created PRs for each versions. This PR is for 4.13.
4.12: https://github.com/openshift/openshift-docs/pull/73854
4.11: https://github.com/openshift/openshift-docs/pull/73855

Doc Preview: https://73273--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/logging_release_notes/logging-5-6-release-notes#logging-release-notes-5-6-17_logging-5-6-release-notes

SME Review: @periklis 
QE Review: @anpingli 
Peer Review: @bergerhoffer 