### PR TITLE
ROX#22794: Update RNs for 4.3.5

### DIFF
--- a/modules/analyzing-the-collector-pod-status.adoc
+++ b/modules/analyzing-the-collector-pod-status.adoc
@@ -5,19 +5,19 @@
 [id="analyzing-the-collector-pod-status_{context}"]
 = Analyzing the Collector pod status
 
-Examining the pod's most recent status is another easy way to determine the cause of a Collector crash. Failure messages are recorded to the most recent status and are accessible using the `kubectl describe pod` or `oc describe pod` command. 
+Examining the pod's most recent status is another easy way to determine the cause of a Collector crash. Failure messages are recorded to the most recent status and are accessible using the `kubectl describe pod` or `oc describe pod` command.
 
 .Procedure
 
-* Describe the Collector pod:
+. Describe the Collector pod:
 +
 [source,terminal,subs="+quotes"]
 ----
 $ oc describe pod -n stackrox _<collector_pod_name>_ <1>
 ----
-+
-<1>  If you use Kubernetes, enter `kubectl` instead of `oc`. For 
+<1>  If you use Kubernetes, enter `kubectl` instead of `oc`. For
 `_<collector_pod_name>_`, specify the name of your Collector pod, for example, `collector-vclg5`.
+. Review the output:
 +
 .Example output
 +
@@ -32,5 +32,4 @@ $ oc describe pod -n stackrox _<collector_pod_name>_ <1>
       Finished:     Fri, 21 Oct 2022 11:51:25 +0100
 [...]
 ----
-+
 <1> In this example, you can see that Collector has failed to download a kernel driver.

--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -55,7 +55,7 @@ endif::[]
 :osp: Red Hat OpenShift
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 4.3.4
+:rhacs-version: 4.3.5
 :ocp-supported-version: 4.11
 :product-rosa: Red Hat OpenShift Service on AWS
 :product-rosa-short: ROSA

--- a/modules/configuring-network-baselining-timeframe.adoc
+++ b/modules/configuring-network-baselining-timeframe.adoc
@@ -9,19 +9,20 @@ You can use the `ROX_NETWORK_BASELINE_OBSERVATION_PERIOD` and the `ROX_BASELINE_
 
 .Procedure
 
-* Set the `ROX_NETWORK_BASELINE_OBSERVATION_PERIOD` and the `ROX_BASELINE_GENERATION_DURATION` environment variables:
+. Set the `ROX_NETWORK_BASELINE_OBSERVATION_PERIOD` environment variable:
 +
 [source,terminal]
 ----
-$ oc -n stackrox set env deploy/central \ <1>
+$ oc -n stackrox set env deploy/central \//<1>
   ROX_NETWORK_BASELINE_OBSERVATION_PERIOD=<value> <2>
 ----
 <1> If you use Kubernetes, enter `kubectl` instead of `oc`.
 <2> Value must be time units, for example: `300ms`, `-1.5h`, or `2h45m`. Valid time units are `ns`, `us` or `µs`, `ms`, `s`, `m`, `h`.
+. Set the `ROX_BASELINE_GENERATION_DURATION` environment variable:
 +
 [source,terminal]
 ----
-$ oc -n stackrox set env deploy/central \ <1>
+$ oc -n stackrox set env deploy/central \//<1>
   ROX_BASELINE_GENERATION_DURATION=<value> <2>
 ----
 <1> If you use Kubernetes, enter `kubectl` instead of `oc`.

--- a/modules/verify-secured-cluster-upgrade.adoc
+++ b/modules/verify-secured-cluster-upgrade.adoc
@@ -10,13 +10,14 @@ After you have upgraded secured clusters, verify that the updated pods are worki
 
 .Procedure
 
-* Check that the new pods have deployed:
+. Check that the new pods have deployed. Enter the following command:
 +
 [source,terminal]
 ----
 $ oc get deploy,ds -n stackrox -o wide <1>
 ----
 <1> If you use Kubernetes, enter `kubectl` instead of `oc`.
+. Enter the following command:
 +
 [source,terminal]
 ----

--- a/release_notes/43-release-notes.adoc
+++ b/release_notes/43-release-notes.adoc
@@ -20,6 +20,7 @@ toc::[]
 |`4.3.2` | 8 January 2024
 |`4.3.3` | 16 January 2024
 |`4.3.4` | 22 January 2024
+|`4.3.5` | 13 March 2024
 
 |====
 
@@ -292,6 +293,20 @@ A TLS certificate rotation fix is included. In the past, the Operator attempted 
 * The rotation of certificates in the secrets does not trigger the components to automatically reload them. However, reloads typically occur when the pod is replaced as part of an {product-title-short} upgrade or as a result of node reboots. If neither of those events happens at least every 6 months, you must restart the pods before the old (in-memory) service certificates expire. For example, you can delete the pods with an `app` label that contains one of the values of `central`, `central-db`, `scanner`, or `scanner-db`.
 * CA certificates are not updated. They are valid for 5 years.
 * The service certificates in the init bundles used by secured cluster components are not updated. You must rotate the init bundles at regular intervals.
+
+[id="resolved-in-version-435_{context}"]
+=== Resolved in version 4.3.5
+
+*Release date*: 13 March 2024
+
+This release provides the following bug fix:
+
+* Fixed an issue where an upgrade to version 4.3 from an earlier version caused the Central component to enter a crash loop.
+
+It provides the following security fixes:
+
+* pgx: SQL Injection via Protocol Message Size Overflow (link:https://access.redhat.com/security/cve/cve-2024-27304[CVE-2024-27304])
+* pgx: SQL Injection via Line Comment Creation (link:https://access.redhat.com/security/cve/cve-2024-27289[CVE-2024-27289])
 
 [id="known-issues-430_{context}"]
 == Known issues


### PR DESCRIPTION
Version(s):
rhacs-docs-4.3

[Issue](https://issues.redhat.com/browse/ROX-22794)

Link to docs previews:

- [Release note](https://73283--docspreview.netlify.app/openshift-acs/latest/release_notes/43-release-notes#resolved-in-version-435_release-notes-43)

unrelated to RN changes I had to make so the build would pass:

- https://73283--docspreview.netlify.app/openshift-acs/latest/troubleshooting/retrieving-and-analyzing-the-collector-logs-and-pod-status#analyzing-the-collector-pod-status_logs-and-pod-status
- https://73283--docspreview.netlify.app/openshift-acs/latest/operating/manage-network-policies#configuring-network-baselining-timeframe_manage-network-policies
- https://73283--docspreview.netlify.app/openshift-acs/latest/upgrading/upgrade-roxctl#verify-secured-cluster-upgrade_upgrade-roxctl

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
