### PR TITLE
[ROX#23218] Update RNs for 4.2.5

### DIFF
--- a/modules/analyzing-the-collector-pod-status.adoc
+++ b/modules/analyzing-the-collector-pod-status.adoc
@@ -5,19 +5,20 @@
 [id="analyzing-the-collector-pod-status_{context}"]
 = Analyzing the Collector pod status
 
-Examining the pod's most recent status is another easy way to determine the cause of a Collector crash. Failure messages are recorded to the most recent status and are accessible using the `kubectl describe pod` or `oc describe pod` command. 
+Examining the pod's most recent status is another easy way to determine the cause of a Collector crash. Failure messages are recorded to the most recent status and are accessible using the `kubectl describe pod` or `oc describe pod` command.
 
 .Procedure
 
-* Describe the Collector pod:
+. Describe the Collector pod:
 +
 [source,terminal,subs="+quotes"]
 ----
 $ oc describe pod -n stackrox _<collector_pod_name>_ <1>
 ----
 +
-<1>  If you use Kubernetes, enter `kubectl` instead of `oc`. For 
+<1>  If you use Kubernetes, enter `kubectl` instead of `oc`. For
 `_<collector_pod_name>_`, specify the name of your Collector pod, for example, `collector-vclg5`.
+. Review the output:
 +
 .Example output
 +

--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -53,7 +53,7 @@ endif::[]
 :osp: Red Hat OpenShift
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 4.2.4
+:rhacs-version: 4.2.5
 :ocp-supported-version: 4.10
 :product-title: Red Hat Advanced Cluster Security for Kubernetes
 :product-version: 4.2

--- a/modules/configuring-network-baselining-timeframe.adoc
+++ b/modules/configuring-network-baselining-timeframe.adoc
@@ -9,19 +9,20 @@ You can use the `ROX_NETWORK_BASELINE_OBSERVATION_PERIOD` and the `ROX_BASELINE_
 
 .Procedure
 
-* Set the `ROX_NETWORK_BASELINE_OBSERVATION_PERIOD` and the `ROX_BASELINE_GENERATION_DURATION` environment variables:
+. Set the `ROX_NETWORK_BASELINE_OBSERVATION_PERIOD` environment variable:
 +
 [source,terminal]
 ----
-$ oc -n stackrox set env deploy/central \ <1>
+$ oc -n stackrox set env deploy/central \//<1>
   ROX_NETWORK_BASELINE_OBSERVATION_PERIOD=<value> <2>
 ----
 <1> If you use Kubernetes, enter `kubectl` instead of `oc`.
 <2> Value must be time units, for example: `300ms`, `-1.5h`, or `2h45m`. Valid time units are `ns`, `us` or `µs`, `ms`, `s`, `m`, `h`.
+. Set the `ROX_BASELINE_GENERATION_DURATION` environment variable:
 +
 [source,terminal]
 ----
-$ oc -n stackrox set env deploy/central \ <1>
+$ oc -n stackrox set env deploy/central \//<1>
   ROX_BASELINE_GENERATION_DURATION=<value> <2>
 ----
 <1> If you use Kubernetes, enter `kubectl` instead of `oc`.

--- a/modules/verify-secured-cluster-upgrade.adoc
+++ b/modules/verify-secured-cluster-upgrade.adoc
@@ -10,13 +10,14 @@ After you have upgraded secured clusters, verify that the updated pods are worki
 
 .Procedure
 
-* Check that the new pods have deployed:
+. Check that the new pods have deployed:
 +
 [source,terminal]
 ----
 $ oc get deploy,ds -n stackrox -o wide <1>
 ----
 <1> If you use Kubernetes, enter `kubectl` instead of `oc`.
+. Enter the following command:
 +
 [source,terminal]
 ----

--- a/release_notes/42-release-notes.adoc
+++ b/release_notes/42-release-notes.adoc
@@ -20,6 +20,7 @@ toc::[]
 |`4.2.2` | 23 October 2023
 |`4.2.3` | 27 November 2023
 |`4.2.4` | 22 January 2024
+|`4.2.5` | 14 March 2024
 
 |====
 
@@ -460,6 +461,16 @@ This release of {product-title-short} includes updates to {op-system-base-full} 
 *Release date:* 22 January 2024
 
 * Fixed PostgreSQL vulnerabilities in `scanner-db` containers.
+
+[id="resolved-in-version-425_{context}"]
+=== Resolved in version 4.2.5
+
+*Release date*: 14 March 2024
+
+This release provides the following bug fix:
+
+* Fixed an issue where an upgrade to version 4.2 from an earlier version caused the Central component to enter a crash loop.
+
 
 [id="image-versions_{context}"]
 == Image versions


### PR DESCRIPTION
Version(s):
- rhacs-docs-4.2

[Issue](https://issues.redhat.com/browse/ROX-23218)

Link to docs preview:

- [Release notes](https://file.rdu.redhat.com/kcarmich/ROX-23218-rn-4.2.5/release_notes/42-release-notes.html)

unrelated to RN changes I had to make so the build would pass:

- https://file.rdu.redhat.com/kcarmich/ROX-23218-rn-4.2.5/troubleshooting/retrieving-and-analyzing-the-collector-logs-and-pod-status.html
- https://file.rdu.redhat.com/kcarmich/ROX-23218-rn-4.2.5/operating/manage-network-policies.html#configuring-network-baselining-timeframe_manage-network-policies
- https://file.rdu.redhat.com/kcarmich/ROX-23218-rn-4.2.5/upgrading/upgrade-roxctl.html#verify-secured-cluster-upgrade_upgrade-roxctl


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
