### PR TITLE
Fixes small grammar mistake

### DIFF
--- a/modules/images-imagestream-use.adoc
+++ b/modules/images-imagestream-use.adoc
@@ -36,7 +36,7 @@ Using image streams has several significant benefits:
 
 * You can share images using fine-grained access control and quickly distribute images across your teams.
 
-* If the source image changes, the image stream tag still points to a known-good version of the image, ensuring that your application do not break unexpectedly.
+* If the source image changes, the image stream tag still points to a known-good version of the image, ensuring that your application does not break unexpectedly.
 
 * You can configure security around who can view and use the images through permissions on the image stream objects.
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-30984

Link to docs preview:
https://73296--ocpdocs-pr.netlify.app/openshift-enterprise/latest/openshift_images/#images-imagestream-use_overview-of-images

QE not needed. Grammar mistake. 
