### PR TITLE
OADP - 3354 fixed remove-Tech Preview-1-3 

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/about-oadp-1-3-data-mover.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/about-oadp-1-3-data-mover.adoc
@@ -13,8 +13,10 @@ OADP supports CSI snapshots on the following:
 * Red Hat OpenShift Data Foundation
 * Any other cloud storage provider with the Container Storage Interface (CSI) driver that supports the Kubernetes Volume Snapshot API
 
-:FeatureName: The OADP built-in Data Mover
-include::snippets/technology-preview.adoc[]
+[IMPORTANT]
+====
+The OADP built-in Data Mover, which was introduced in OADP 1.3 as a Technology Preview, is now fully supported for both containerized and virtual machine workloads.
+====
 
 [id="enabling-oadp-1-3-data-mover"]
 == Enabling the built-in Data Mover


### PR DESCRIPTION
OADP 1.3.1

OCP 4.13+

GA April 16, 2024

Resolves - https://issues.redhat.com/browse/OADP-3354

Deploy preview - https://73312--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-oadp-1-3-data-mover