### PR TITLE
OBSDOCS-866: (TRACING-3922) Configure OTEL to scrape in-cluster monitoring stack

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2711,8 +2711,8 @@ Topics:
     File: otel-configuration-of-instrumentation
   - Name: Sending traces and metrics to the Collector
     File: otel-sending-traces-and-metrics-to-otel-collector
-  - Name: Sending metrics to the monitoring stack
-    File: otel-config-send-metrics-monitoring-stack
+  - Name: Configuring metrics for the monitoring stack
+    File: otel-configuring-metrics-for-monitoring-stack
   - Name: Forwarding traces to a TempoStack
     File: otel-forwarding
   - Name: Configuring the Collector metrics

--- a/modules/otel-config-receive-metrics-monitoring-stack.adoc
+++ b/modules/otel-config-receive-metrics-monitoring-stack.adoc
@@ -1,0 +1,83 @@
+// Module included in the following assemblies:
+//
+// * observability/otel/otel-configuring-metrics-for-monitoring-stack.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="configuration-for-receiving-metrics-from-the-monitoring-stack_{context}"]
+= Configuration for receiving metrics from the monitoring stack
+
+A configured OpenTelemetry Collector custom resource (CR) can set up the Prometheus receiver to scrape metrics from the in-cluster monitoring stack.
+
+.Example of the OpenTelemetry Collector CR for scraping metrics from the in-cluster monitoring stack
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otel-collector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view # <1>
+subjects:
+  - kind: ServiceAccount
+    name: otel-collector
+    namespace: observability
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cabundle
+  namespce: observability
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true" # <2>
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel
+  namespace: observability
+spec:
+  volumeMounts:
+    - name: cabundle-volume
+      mountPath: /etc/pki/ca-trust/source/service-ca
+      readOnly: true
+  volumes:
+    - name: cabundle-volume
+      configMap:
+        name: cabundle
+  mode: deployment
+  config: |
+    receivers:
+      prometheus: # <3>
+        config:
+          scrape_configs:
+            - job_name: 'federate'
+              scrape_interval: 15s
+              scheme: https
+              tls_config:
+                ca_file: /etc/pki/ca-trust/source/service-ca/service-ca.crt
+              bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              honor_labels: false
+              params:
+                'match[]':
+                  - '{__name__="<metric_name>"}' # <4>
+              metrics_path: '/federate'
+              static_configs:
+                - targets:
+                  - "prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
+    exporters:
+      debug: # <5>
+        verbosity: detailed
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          processors: []
+          exporters: [debug]
+----
+<1> Assigns the `cluster-monitoring-view` cluster role to the service account of the OpenTelemetry Collector so that it can access the metrics data.
+<2> Injects the OpenShift service CA for configuring the TLS in the Prometheus receiver.
+<3> Configures the Prometheus receiver to scrape the federate endpoint from the in-cluster monitoring stack.
+<4> Uses the Prometheus query language to select the metrics to be scraped. See the in-cluster monitoring documentation for more details and limitations of the federate endpoint.
+<5> Configures the debug exporter to print the metrics to the standard output.

--- a/modules/otel-config-send-metrics-monitoring-stack.adoc
+++ b/modules/otel-config-send-metrics-monitoring-stack.adoc
@@ -1,14 +1,23 @@
-:_mod-docs-content-type: ASSEMBLY
-[id="otel-configuration-for-sending-metrics-to-the-monitoring-stack"]
+// Module included in the following assemblies:
+//
+// * observability/otel/otel-configuring-metrics-for-monitoring-stack.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="configuration-for-sending-metrics-to-the-monitoring-stack_{context}"]
 = Configuration for sending metrics to the monitoring stack
-include::_attributes/common-attributes.adoc[]
-:context: otel-configuration-for-sending-metrics-to-the-monitoring-stack
 
-The OpenTelemetry Collector custom resource (CR) can be configured to create a Prometheus `ServiceMonitor` CR for scraping the Collector's pipeline metrics and the enabled Prometheus exporters.
+One of two following custom resources (CR) configures the sending of metrics to the monitoring stack:
 
-.Example of the OpenTelemetry Collector custom resource with the Prometheus exporter
+* OpenTelemetry Collector CR
+* Prometheus `PodMonitor` CR
+
+A configured OpenTelemetry Collector CR can create a Prometheus `ServiceMonitor` CR for scraping the Collector's pipeline metrics and the enabled Prometheus exporters.
+
+.Example of the OpenTelemetry Collector CR with the Prometheus exporter
 [source,yaml]
 ----
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
 spec:
   mode: deployment
   observability:
@@ -31,9 +40,9 @@ spec:
 ----
 <1> Configures the Operator to create the Prometheus `ServiceMonitor` CR to scrape the Collector's internal metrics endpoint and Prometheus exporter metric endpoints. The metrics will be stored in the OpenShift monitoring stack.
 
-Alternatively, a manually created Prometheus `PodMonitor` can provide fine control, for example removing duplicated labels added during Prometheus scraping.
+Alternatively, a manually created Prometheus `PodMonitor` CR can provide fine control, for example removing duplicated labels added during Prometheus scraping.
 
-.Example of the `PodMonitor` custom resource that configures the monitoring stack to scrape the Collector metrics
+.Example of the `PodMonitor` CR that configures the monitoring stack to scrape the Collector metrics
 [source,yaml]
 ----
 apiVersion: monitoring.coreos.com/v1
@@ -43,7 +52,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: `<cr_name>-collector` # <1>
+      app.kubernetes.io/name: <cr_name>-collector # <1>
   podMetricsEndpoints:
   - port: metrics # <2>
   - port: promexporter # <3>
@@ -60,6 +69,6 @@ spec:
     - action: labeldrop
       regex: job
 ----
-<1> The name of the OpenTelemetry Collector custom resource.
+<1> The name of the OpenTelemetry Collector CR.
 <2> The name of the internal metrics port for the OpenTelemetry Collector. This port name is always `metrics`.
 <3> The name of the Prometheus exporter port for the OpenTelemetry Collector.

--- a/observability/otel/otel-configuring-metrics-for-monitoring-stack.adoc
+++ b/observability/otel/otel-configuring-metrics-for-monitoring-stack.adoc
@@ -1,0 +1,31 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="otel-configuring-metrics-for-monitoring-stack"]
+= Configuring metrics for the monitoring stack
+include::_attributes/common-attributes.adoc[]
+:context: otel-configuring-metrics-for-monitoring-stack
+
+toc::[]
+
+As a cluster administrator, you can configure the OpenTelemetry Collector custom resource (CR) to perform the following tasks:
+
+* Create a Prometheus `ServiceMonitor` CR for scraping the Collector’s pipeline metrics and the enabled Prometheus exporters.
+
+* Configure the Prometheus receiver to scrape metrics from the in-cluster monitoring stack.
+
+include::modules/otel-config-send-metrics-monitoring-stack.adoc[leveloffset=+1]
+include::modules/otel-config-receive-metrics-monitoring-stack.adoc[leveloffset=+1]
+
+[id="additional-resources_otel-configuring-metrics-for-monitoring-stack"]
+== Additional resources
+
+// * xref:../monitoring/accessing-third-party-monitoring-apis.adoc#monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus[Querying metrics by using the federation endpoint for Prometheus]
+
+//* xref:../monitoring/accessing-third-party-monitoring-apis.adoc#monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus_accessing-third-party-monitoring-apis[Querying metrics by using the federation endpoint for Prometheus]
+
+//* xref:../monitoring/accessing-third-party-monitoring-apis.adoc#monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus[Querying metrics by using the federation endpoint for Prometheus]
+
+//* xref:../monitoring/accessing-third-party-monitoring-apis.adoc#monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus_accessing-monitoring-apis-by-using-the-cli[Querying metrics by using the federation endpoint for Prometheus]
+
+//* xref:../monitoring/accessing-third-party-monitoring-apis.adoc#accessing-third-party-monitoring-apis_monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus[Querying metrics by using the federation endpoint for Prometheus]
+
+* xref:../monitoring/accessing-third-party-monitoring-apis.adoc#monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus_accessing-monitoring-apis-by-using-the-cli[Querying metrics by using the federation endpoint for Prometheus]


### PR DESCRIPTION
:warning: This PR is tied to a product release date, which is currently set to **June 5** (Wednesday).

- If the merge review gets delayed, you're welcome to ping `mleonov` on Slack.
- If you have any questions, ping `mleonov` on Slack.

Edit of https://github.com/openshift/openshift-docs/pull/71580

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.16, 4.15, 4.14, 4.13, 4.12

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/TRACING-3922
https://issues.redhat.com/browse/OBSDOCS-866

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://73313--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-configuring-metrics-for-monitoring-stack

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
