### PR TITLE
OBSDOCS-772: Fix containerLimit docs bug

### DIFF
--- a/modules/logging-set-input-rate-limit.adoc
+++ b/modules/logging-set-input-rate-limit.adoc
@@ -33,7 +33,7 @@ spec:
       application:
         selector:
           matchLabels: { example: label } <2>
-      limitPerContainer:
+      containerLimit:
           maxRecordsPerSecond: 0 <3>
 # ...
 ----
@@ -54,12 +54,12 @@ spec:
     - name: <input_name> <1>
       application:
         namespaces: [ example-ns-1, example-ns-2 ] <2>
-      limitPerContainer:
+      containerLimit:
         maxRecordsPerSecond: 10 <3>
     - name: <input_name>
       application:
         namespaces: [ test ]
-      limitPerContainer:
+      containerLimit:
           maxRecordsPerSecond: 1000
 # ...
 ----


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OBSDOCS-772

Link to docs preview:
https://73314--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/performance_reliability/logging-flow-control-mechanisms#logging-set-input-rate-limit_logging-flow-control-mechanisms

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
