### PR TITLE
OCPBUGS-30827: Adding SDN deprecation statements across the doc set

### DIFF
--- a/modules/nw-networking-glossary-terms.adoc
+++ b/modules/nw-networking-glossary-terms.adoc
@@ -105,6 +105,8 @@ The Single Root I/O Virtualization (SR-IOV) Network Operator manages the SR-IOV 
 software-defined networking (SDN)::
 {product-title} uses a software-defined networking (SDN) approach to provide a unified cluster network that enables communication between pods across the {product-title} cluster.
 
+include::snippets/sdn-deprecation-statement.adoc[]
+
 Stream Control Transmission Protocol (SCTP)::
 SCTP is a reliable message based protocol that runs on top of an IP network.
 

--- a/modules/nw-ovn-kubernetes-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-migration-about.adoc
@@ -24,6 +24,8 @@ Migrating to or from the OVN-Kubernetes network plugin is not supported for mana
 Migrating from OpenShift SDN network plugin to OVN-Kubernetes network plugin is not supported on Nutanix.
 ====
 
+include::snippets/sdn-deprecation-statement.adoc[]
+
 [id="considerations-migrating-ovn-kubernetes-network-provider_{context}"]
 == Considerations for migrating to the OVN-Kubernetes network plugin
 

--- a/modules/optimizing-mtu-networking.adoc
+++ b/modules/optimizing-mtu-networking.adoc
@@ -11,6 +11,8 @@ The NIC MTU is only configured at the time of {product-title} installation. The 
 
 The OpenShift SDN network plugin overlay MTU must be less than the NIC MTU by 50 bytes at a minimum. This accounts for the SDN overlay header. So, on a normal ethernet network, this should be set to `1450`. On a jumbo frame ethernet network, this should be set to `8950`. These values should be set automatically by the Cluster Network Operator based on the NIC's configured MTU. Therefore, cluster administrators do not typically update these values. Amazon Web Services (AWS) and bare-metal environments support jumbo frame ethernet networks. This setting will help throughput, especially with transmission control protocol (TCP).
 
+include::snippets/sdn-deprecation-statement.adoc[]
+
 For OVN and Geneve, the MTU must be less than the NIC MTU by 100 bytes at a minimum.
 
 [NOTE]

--- a/networking/about-networking.adoc
+++ b/networking/about-networking.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 {openshift-networking} is an ecosystem of features, plugins and advanced networking capabilities that extend Kubernetes networking with the advanced networking-related features that your cluster needs to manage its network traffic for one or multiple hybrid clusters. This ecosystem of networking capabilities integrates ingress, egress, load balancing, high-performance throughput, security, inter- and intra-cluster traffic management and provides role-based observability tooling to reduce its natural complexities.
 
+include::snippets/sdn-deprecation-statement.adoc[]
+
 The following list highlights some of the most commonly used {openshift-networking} features available on your cluster:
 
 - Primary cluster network provided by either of the following Container Network Interface (CNI) plugins:

--- a/networking/openshift_sdn/about-openshift-sdn.adoc
+++ b/networking/openshift_sdn/about-openshift-sdn.adoc
@@ -12,6 +12,8 @@ that enables communication between pods across the {product-title} cluster. This
 pod network is established and maintained by OpenShift SDN, which configures
 an overlay network using Open vSwitch (OVS).
 
+include::snippets/sdn-deprecation-statement.adoc[]
+
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 include::modules/nw-openshift-sdn-modes.adoc[leveloffset=+1]
 endif::[]

--- a/networking/openshift_sdn/assigning-egress-ips.adoc
+++ b/networking/openshift_sdn/assigning-egress-ips.adoc
@@ -9,6 +9,8 @@ toc::[]
 [role="_abstract"]
 As a cluster administrator, you can configure the OpenShift SDN Container Network Interface (CNI) network plugin to assign one or more egress IP addresses to a project.
 
+include::snippets/sdn-deprecation-statement.adoc[]
+
 include::modules/nw-egress-ips-about.adoc[leveloffset=+1]
 
 include::modules/nw-egress-ips-automatic.adoc[leveloffset=+1]

--- a/networking/openshift_sdn/configuring-egress-firewall.adoc
+++ b/networking/openshift_sdn/configuring-egress-firewall.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 As a cluster administrator, you can create an egress firewall for a project that restricts egress traffic leaving your {product-title} cluster.
 
+include::snippets/sdn-deprecation-statement.adoc[]
+
 include::modules/nw-egressnetworkpolicy-about.adoc[leveloffset=+1]
 include::modules/nw-egressnetworkpolicy-object.adoc[leveloffset=+1]
 include::modules/nw-egressnetworkpolicy-create.adoc[leveloffset=+1]

--- a/networking/openshift_sdn/editing-egress-firewall.adoc
+++ b/networking/openshift_sdn/editing-egress-firewall.adoc
@@ -8,4 +8,6 @@ toc::[]
 
 As a cluster administrator, you can modify network traffic rules for an existing egress firewall.
 
+include::snippets/sdn-deprecation-statement.adoc[]
+
 include::modules/nw-egressnetworkpolicy-edit.adoc[leveloffset=+1]

--- a/networking/openshift_sdn/enabling-multicast.adoc
+++ b/networking/openshift_sdn/enabling-multicast.adoc
@@ -11,5 +11,6 @@ endif::[]
 
 toc::[]
 
+include::snippets/sdn-deprecation-statement.adoc[]
 include::modules/nw-about-multicast.adoc[leveloffset=+1]
 include::modules/nw-enabling-multicast.adoc[leveloffset=+1]

--- a/networking/openshift_sdn/migrate-to-openshift-sdn.adoc
+++ b/networking/openshift_sdn/migrate-to-openshift-sdn.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 As a cluster administrator, you can migrate to the OpenShift SDN network plugin from the OVN-Kubernetes network plugin.
 
+include::snippets/sdn-deprecation-statement.adoc[]
+
 To learn more about OpenShift SDN, read xref:../../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[About the OpenShift SDN network plugin].
 
 include::modules/nw-network-plugin-migration-process.adoc[leveloffset=+1]

--- a/networking/openshift_sdn/multitenant-isolation.adoc
+++ b/networking/openshift_sdn/multitenant-isolation.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/sdn-deprecation-statement.adoc[]
+
 When your cluster is configured to use the multitenant isolation mode for the
 OpenShift SDN network plugin, each project is isolated by default. Network traffic
 is not allowed between pods or services in different projects in multitenant

--- a/networking/openshift_sdn/removing-egress-firewall.adoc
+++ b/networking/openshift_sdn/removing-egress-firewall.adoc
@@ -8,4 +8,6 @@ toc::[]
 
 As a cluster administrator, you can remove an egress firewall from a project to remove all restrictions on network traffic from the project that leaves the {product-title} cluster.
 
+include::snippets/sdn-deprecation-statement.adoc[]
+
 include::modules/nw-egressnetworkpolicy-delete.adoc[leveloffset=+1]

--- a/networking/openshift_sdn/rollback-to-ovn-kubernetes.adoc
+++ b/networking/openshift_sdn/rollback-to-ovn-kubernetes.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 As a cluster administrator, you can rollback to the OVN-Kubernetes network plugin from the OpenShift SDN network plugin if the migration to OpenShift SDN is unsuccessful.
 
+include::snippets/sdn-deprecation-statement.adoc[]
+
 To learn more about OVN-Kubernetes, read xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[About the OVN-Kubernetes network plugin].
 
 include::modules/nw-ovn-kubernetes-migration.adoc[leveloffset=+1]

--- a/networking/ovn_kubernetes_network_provider/rollback-to-openshift-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/rollback-to-openshift-sdn.adoc
@@ -8,4 +8,6 @@ toc::[]
 
 As a cluster administrator, you can rollback to the OpenShift SDN network plugin from the OVN-Kubernetes network plugin if the migration to OVN-Kubernetes is unsuccessful.
 
+include::snippets/sdn-deprecation-statement.adoc[]
+
 include::modules/nw-ovn-kubernetes-rollback.adoc[leveloffset=+1]

--- a/networking/ovn_kubernetes_network_provider/viewing-egress-firewall-ovn.adoc
+++ b/networking/ovn_kubernetes_network_provider/viewing-egress-firewall-ovn.adoc
@@ -8,4 +8,6 @@ toc::[]
 
 As a cluster administrator, you can list the names of any existing egress firewalls and view the traffic rules for a specific egress firewall.
 
+include::snippets/sdn-deprecation-statement.adoc[]
+
 include::modules/nw-egressnetworkpolicy-view.adoc[leveloffset=+1]

--- a/snippets/sdn-deprecation-statement.adoc
+++ b/snippets/sdn-deprecation-statement.adoc
@@ -1,0 +1,27 @@
+// Text snippet included in the following assemblies:
+//
+// * networking/about-networking.adoc
+// * networking/openshift_sdn/assigning-egress-ips.adoc
+// * networking/openshift_sdn/editing-egress-firewall.adoc
+// * networking/openshift_sdn/enabling-multicast.adoc
+// * networking/openshift_sdn/migrate-to-openshift-sdn.adoc
+// * networking/openshift_sdn/multitenant-isolation.adoc
+// * networking/openshift_sdn/removing-egress-firewall.adoc
+// * networking/ovn_kubernetes_network_provider/rollback-to-openshift-sdn.adoc
+// * networking/ovn_kubernetes_network_provider/viewing-egress-firewall-ovn.adoc
+// * networking/openshift_sdn/about-openshift-sdn.adoc
+// * networking/openshift_sdn/rollback-to-ovn-kubernetes.adoc
+// * networking/openshift_sdn/configuring-egress-firewall.adoc
+//
+// Text snippet included in the following modules:
+//
+// * modules/nw-networking-glossary-terms.adoc
+// * modules/nw-ovn-kubernetes-migration-about.adoc
+// * modules/optimizing-mtu-networking.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+[NOTE]
+====
+OpenShift SDN CNI is deprecated as of {product-title} 4.14. As of {product-title} 4.15, the network plugin is not an option for new installations. In a subsequent future release, the OpenShift SDN network plugin is planned to be removed and no longer supported. Red Hat will provide bug fixes and support for this feature until it is removed, but this feature will no longer receive enhancements. As an alternative to OpenShift SDN CNI, you can use OVN Kubernetes CNI instead.
+====


### PR DESCRIPTION
Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OCPBUGS-30827

Link to docs preview:
https://73316--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/about-networking

This deprecation language is already reviewed and approved by PM, as it was included in the release notes. This PR adds the language to the body of the text in the form of a snippet.