### PR TITLE
Add step on how to get DN for allowedSubjectPatterns

### DIFF
--- a/modules/nw-mutual-tls-auth.adoc
+++ b/modules/nw-mutual-tls-auth.adoc
@@ -61,3 +61,9 @@ $ oc edit IngressController default -n openshift-ingress-operator
       allowedSubjectPatterns:
       - "^/CN=example.com/ST=NC/C=US/O=Security/OU=OpenShift$"
 ----
+. Optional, get the Distinguished Name (DN) for `allowedSubjectPatterns` by entering the following command.
+[source,terminal]
+----
+$ openssl  x509 -in custom-cert.pem  -noout -subject
+subject= /CN=example.com/ST=NC/C=US/O=Security/OU=OpenShift
+----


### PR DESCRIPTION
Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
OCP 4.15 and below till OCP 4.9

Issue:
https://issues.redhat.com/browse/OCPBUGS-31006


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
We need to make sure that the Distinguished Name (DN)  name for `allowedSubjectPatterns`  should be same as the below command output:

```
$ openssl  x509 -in custom-cert.pem  -noout -subject
subject= /CN=example.com/ST=NC/C=US/O=Security/OU=OpenShift
```
