### PR TITLE
OBSDOCS-894: COO 0.1.2 release notes

### DIFF
--- a/monitoring/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
+++ b/monitoring/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
@@ -12,12 +12,43 @@ include::snippets/technology-preview.adoc[leveloffset=+2]
 
 The {coo-first} is an optional {product-title} Operator that enables administrators to create standalone monitoring stacks that are independently configurable for use by different services and users.
 
-The {coo-short} complements the built-in monitoring capabilities of {product-title}. You can deploy it in parallel with the default platform and user workload monitoring stacks managed by the Cluster Monitoring Operator (CMO). 
+The {coo-short} complements the built-in monitoring capabilities of {product-title}. You can deploy it in parallel with the default platform and user workload monitoring stacks managed by the Cluster Monitoring Operator (CMO).
 
 These release notes track the development of the {coo-full} in {product-title}.
 
+[id="cluster-observability-operator-release-notes-0-1-2"]
+== {coo-full} 0.1.2
+The following advisory is available for {coo-full} 0.1.2:
+
+* link:https://access.redhat.com/errata/RHEA-2024:127118[2024:127118 Cluster Observability Operator 0.1.2]
+
+[id="cluster-observability-operator-0-1-2-CVEs"]
+=== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2023-45142[CVE-2023-45142]
+
+[id="cluster-observability-operator-0-1-2-bug-fixes"]
+=== Bug fixes
+
+* Previously, certain cluster service version (CSV) annotations were not included in the metadata for {coo-short}.
+Because of these missing annotations, certain {coo-short} features and capabilities did not appear in the package manifest or in the OperatorHub user interface.
+This release adds the missing annotations, thereby resolving this issue. (link:https://issues.redhat.com/browse/COO-11[*COO-11*])
+
+* Previously, automatic updates of the {coo-short} did not work, and a newer version of the Operator did not automatically replace the older version, even though the newer version was available in OperatorHub.
+This release resolves the issue. (link:https://issues.redhat.com/browse/COO-12[*COO-12*])
+
+* Previously, Thanos Querier only listened for network traffic on port 9090 of 127.0.0.1 (`localhost`), which resulted in a `502 Bad Gateway` error if you tried to reach the Thanos Querier service.
+With this release, the Thanos Querier configuration has been updated so that the component now listens on the default port (10902), thereby resolving the issue.
+As a result of this change, you can also now modify the port via server side apply (SSA) and add a proxy chain, if required. (link:https://issues.redhat.com/browse/COO-14[*COO-14*])
+
 [id="cluster-observability-operator-release-notes-0-1-1"]
 == {coo-full} 0.1.1
+The following advisory is available for {coo-full} 0.1.1:
+
+* link:https://access.redhat.com/errata/RHEA-2024:0550[2024:0550 Cluster Observability Operator 0.1.1]
+
+[id="cluster-observability-operator-0-1-1-new-features-enhancements"]
+=== New features and enhancements
 This release updates the {coo-full} to support installing the Operator in restricted networks or disconnected environments.
 
 [id="cluster-observability-operator-release-notes-0-1"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-894
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://73328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/cluster_observability_operator/cluster-observability-operator-release-notes#cluster-observability-operator-release-notes-0-1-2
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- Adds release notes for the Cluster Observability Operator 0.1.2 release.
- Updates the formatting of the 0.1.1 release notes section to be consistent with the 0.1.2 section.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
