### PR TITLE
Allow for Azure Red Hat OpenShift by Vale linter

### DIFF
--- a/.vale/styles/config/vocabularies/OpenShiftDocs/accept.txt
+++ b/.vale/styles/config/vocabularies/OpenShiftDocs/accept.txt
@@ -11,6 +11,7 @@
 [Pp]reinstall
 [Rr]ealtime
 [Tt]elco
+Azure Red Hat OpenShift
 Assisted Installer
 Control Plane Machine Set Operator
 custom resources?

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -76,7 +76,7 @@ Explore the following {product-title} installation tasks:
 
 - **xref:../installing/installing_aws/preparing-to-install-on-aws.adoc#preparing-to-install-on-aws[Install a cluster on AWS]**: On AWS, you can install {product-title} on installer-provisioned infrastructure or user-provisioned infrastructure.
 
-- **xref:../installing/installing_azure/preparing-to-install-on-azure.adoc#preparing-to-install-on-azure[Install a cluster on Azure]**: On Microsoft Azure, you can install {product-title} on installer-provisioned infrastructure or user-provisioned infrastructure.
+- **xref:../installing/installing_azure/preparing-to-install-on-azure.adoc#preparing-to-install-on-azure[Install a cluster on Azure]**: On Azure, you can install {product-title} on installer-provisioned infrastructure or user-provisioned infrastructure. Check out Azure Red Hat OpenShift (ARO) version.
 
 - **xref:../installing/installing_azure_stack_hub/preparing-to-install-on-azure-stack-hub.adoc#preparing-to-install-on-azure-stack-hub[Install a cluster on Azure Stack Hub]**: On Microsoft Azure Stack Hub, you can install {product-title} on installer-provisioned infrastructure or user-provisioned infrastructure.
 


### PR DESCRIPTION
This is currently causing a Vale error because it doesn't say Microsoft Azure. Azure Red Hat OpenShift is used extensively.... I am presuming it is ok.
