### PR TITLE
OSDOCS-9962: Documented the 4.15.3 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2678,6 +2678,31 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+[id="ocp-4-15-3"]
+=== RHSA-2024:1255 - {product-title} 4.15.3 bug fix and security update
+
+Issued: 2024-03-19
+
+{product-title} release 4.15.3, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:1255[RHSA-2024:1255] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:1258[RHBA-2024:1258] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.3 --pullspecs
+----
+
+[id="ocp-4-15-3-bug-fixes"]
+==== Bug fixes
+
+* Previously, if the root credentials were removed from a Google Cloud Platform (GCP) cluster that was in mint mode, the Cloud Credential Operator (CCO) would go into a degraded state after approximately 1 hour. This issue means that CCO could not manage the credentials root secret for a component. With this update, mint mode supports custom roles, so that removing root credentials from a GCP cluster does not cause the CCO to go into a degraded state. (link:https://issues.redhat.com/browse/OCPBUGS-30412[*OCPBUGS-30412*])
+
+[id="ocp-4-15-3-updating"]
+==== Updating
+To update an existing {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 [id="ocp-4-15-2"]
 === RHSA-2024:1210 - {product-title} 4.15.2 bug fix and security update
 


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-9962](https://issues.redhat.com/browse/OSDOCS-9962)

Link to docs preview:
[4.15.3 z-stream notes](https://73360--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-3)

QE review:
- [ ] QE not required. See the peer-review checklist.

