### PR TITLE
OBSDOCS-339 Configuring Loki to tolerate membership creation failure

### DIFF
--- a/logging/log_storage/cluster-logging-loki.adoc
+++ b/logging/log_storage/cluster-logging-loki.adoc
@@ -50,6 +50,7 @@ endif::[]
 
 include::modules/logging-loki-retention.adoc[leveloffset=+1]
 include::modules/loki-rate-limit-errors.adoc[leveloffset=+1]
+include::modules/logging-loki-memberlist-ip.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources_cluster-logging-loki"]

--- a/modules/logging-loki-memberlist-ip.adoc
+++ b/modules/logging-loki-memberlist-ip.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * logging/cluster-logging-loki.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="logging-loki-memberlist-ip_{context}"]
+= Configuring Loki to tolerate memberlist creation failure
+
+In an OpenShift cluster, administrators generally use a non-private IP network range. As a result, the LokiStack memberlist configuration fails because, by default, it only uses private IP networks.
+
+As an administrator, you can select the pod network for the memberlist configuration. You can modify the LokiStack CR to use the `podIP` in the `hashRing` spec. To configure the LokiStack CR, use the following command:
+
+[source,terminal]
+----
+$ oc patch LokiStack logging-loki -n openshift-logging  --type=merge -p '{"spec": {"hashRing":{"memberlist":{"instanceAddrType":"podIP","type": "memberlist"}}}}'
+----
+
+.Example LokiStack to include `podIP`
+[source,yaml]
+----
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: logging-loki
+  namespace: openshift-logging
+spec:
+# ...
+  hashRing:
+    type: memberlist
+    memberlist:
+      instanceAddrType: podIP
+# ...
+----
+


### PR DESCRIPTION
Change type: Doc update; Configuring Loki to tolerate membership creation failure
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-339

Fix Version: 4.11+

Doc Preview: https://73363--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_storage/cluster-logging-loki#logging-loki-memberlist-ip_cluster-logging-loki

SME Review: @r2d2rnd 
QE Review: @kabirbhartiRH 
Peer Review: @kcarmichael08 