### PR TITLE
OBSDOCS-67: Add info that monitoring API routes are not available in web browsers

### DIFF
--- a/modules/monitoring-about-accessing-monitoring-web-service-apis.adoc
+++ b/modules/monitoring-about-accessing-monitoring-web-service-apis.adoc
@@ -18,4 +18,9 @@ You can directly access web service API endpoints from the command line for the 
 To access Thanos Ruler and Thanos Querier service APIs, the requesting account must have `get` permission on the namespaces resource, which can be granted by binding the `cluster-monitoring-view` cluster role to the account.
 ====
 
-Accessing web service APIs only supports using a Bearer Token for authentication.
+When you access web service API endpoints for monitoring components, be aware of the following limitations:
+
+* You can only use Bearer Token authentication to access API endpoints.
+* You can only access endpoints in the `/api` path for a route.
+If you try to access an API endpoint in a web browser, an `Application is not available` error occurs.
+To access monitoring features in a web browser, use the {product-title} web console to review monitoring dashboards.

--- a/monitoring/accessing-third-party-monitoring-apis.adoc
+++ b/monitoring/accessing-third-party-monitoring-apis.adoc
@@ -21,6 +21,10 @@ To avoid these issues, follow these recommendations:
 
 // Accessing service APIs for third-party monitoring components
 include::modules/monitoring-about-accessing-monitoring-web-service-apis.adoc[leveloffset=+1]
+
+.Additional resources
+* xref:../monitoring/reviewing-monitoring-dashboards.adoc#reviewing-monitoring-dashboards[Reviewing monitoring dashboards]
+
 include::modules/monitoring-accessing-third-party-monitoring-web-service-apis.adoc[leveloffset=+1]
 
 // Querying metrics by using the federation endpoint for Prometheus


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-67
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://73397--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/accessing-third-party-monitoring-apis#about-accessing-monitoring-web-service-apis_accessing-third-party-monitoring-apis
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR adds information about monitoring API routes not being available in a web browser.

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
