### PR TITLE
OBSDOCS-875: Update CLI command for granting permission to configure …

### DIFF
--- a/modules/monitoring-granting-users-permission-to-configure-monitoring-for-user-defined-projects.adoc
+++ b/modules/monitoring-granting-users-permission-to-configure-monitoring-for-user-defined-projects.adoc
@@ -6,7 +6,7 @@
 [id="granting-users-permission-to-configure-monitoring-for-user-defined-projects_{context}"]
 = Granting users permission to configure monitoring for user-defined projects
 
-You can grant users permission to configure monitoring for user-defined projects.
+As a cluster administrator, you can assign the `user-workload-monitoring-config-edit` role to a user. This grants permission to configure and manage monitoring for user-defined projects without giving them permission to configure and manage core {product-title} monitoring components.
 
 .Prerequisites
 
@@ -16,7 +16,7 @@ You can grant users permission to configure monitoring for user-defined projects
 
 .Procedure
 
-* Assign the `user-workload-monitoring-config-edit` role to a user in the `openshift-user-workload-monitoring` project:
+. Assign the `user-workload-monitoring-config-edit` role to a user in the `openshift-user-workload-monitoring` project:
 +
 [source,terminal]
 ----
@@ -24,3 +24,32 @@ $ oc -n openshift-user-workload-monitoring adm policy add-role-to-user \
   user-workload-monitoring-config-edit <user> \
   --role-namespace openshift-user-workload-monitoring
 ----
+
+. Verify that the user is correctly assigned to the `user-workload-monitoring-config-edit` role by displaying the related role binding:
++
+[source,terminal]
+----
+$ oc describe rolebinding <role_binding_name> -n openshift-user-workload-monitoring
+----
++
+.Example command
+[source,terminal]
+----
+$ oc describe rolebinding user-workload-monitoring-config-edit -n openshift-user-workload-monitoring
+----
++
+.Example output
+[source,terminal]
+----
+Name:         user-workload-monitoring-config-edit
+Labels:       <none>
+Annotations:  <none>
+Role:
+  Kind:  Role
+  Name:  user-workload-monitoring-config-edit
+Subjects:
+  Kind  Name  Namespace
+  ----  ----  ---------
+  User  user1           <1>
+----
+<1> In this example, `user1` is assigned to the `user-workload-monitoring-config-edit` role.


### PR DESCRIPTION
Version(s): `enterprise-4.12` and later

Issue: [OBSDOC-S875](https://issues.redhat.com/browse/OBSDOCS-875)

Link to docs preview:  [Granting users permission to configure monitoring for user-defined projects](https://73398--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/enabling-monitoring-for-user-defined-projects#granting-users-permission-to-configure-monitoring-for-user-defined-projects_enabling-monitoring-for-user-defined-projects)

QE review:
- [x] QE has approved this change.

**Additional information:** I also added a verification step to enhance our docs.