### PR TITLE
OSSM-3169 Missing Documentation for setting CPU/Memory requests/limits to OSSM components

### DIFF
--- a/modules/ossm-recommended-resources.adoc
+++ b/modules/ossm-recommended-resources.adoc
@@ -23,7 +23,7 @@ The settings in the following example are based on 1,000 services and 1,000 requ
 +
 .. Click the *YAML* tab.
 +
-.. Set the values for `spec.proxy.runtime.container.resources.requests.cpu` and `spec.proxy.runtime.container.resources.requests.memory` in your `ServiceMeshControlPlane` resource.
+.. Set the values for `spec.proxy.runtime.container.resources.requests.cpu`, `spec.proxy.runtime.container.resources.requests.memory`, `components.kiali.container`, and `components.global.oauthproxy` in your `ServiceMeshControlPlane` resource.
 +
 .Example version {MaistraVersion} ServiceMeshControlPlane
 [source,yaml, subs="attributes,verbatim"]
@@ -43,7 +43,6 @@ spec:
             cpu: 600m
             memory: 50Mi
           limits: {}
-
   runtime:
     components:
       pilot:
@@ -53,7 +52,27 @@ spec:
               cpu: 1000m
               memory: 1.6Gi
             limits: {}
+      kiali:
+        container:
+          resources:
+            limits:
+              cpu: "90m"
+              memory: "245Mi"
+            requests:
+              cpu: "30m"
+              memory: "108Mi"
+      global.oauthproxy:
+        container:
+          resources:
+            requests:
+              cpu: "101m"
+              memory: "256Mi"
+            limits:
+              cpu: "201m"
+              memory: "512Mi"
 ----
++
+.. To set values for {JaegerName}, see "Configuring and deploying the distributed tracing platform Jaeger".
 +
 .. Click *Save*.
 

--- a/service_mesh/v2x/ossm-performance-scalability.adoc
+++ b/service_mesh/v2x/ossm-performance-scalability.adoc
@@ -12,5 +12,13 @@ The default `ServiceMeshControlPlane` settings are not intended for production u
 
 include::modules/ossm-recommended-resources.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+ifndef::openshift-rosa,openshift-dedicated[]
+* xref:../../observability/distr_tracing/distr_tracing_jaeger/distr-tracing-jaeger-configuring.adoc#distr-tracing-deploy-default_deploying-distributed-tracing-platform[Configuring and deploying the distributed tracing platform Jaeger].
+endif::[]
+
 include::modules/ossm-load-test-results.adoc[leveloffset=+1]
+
+
 


### PR DESCRIPTION
[OSSM-3169](https://issues.redhat.com//browse/OSSM-3169) Missing Documentation for setting CPU/Memory requests/limits to OSSM components(Jaeger, Kiali,Grafana)

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSSM-3169

Link to docs preview:
https://73419--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-performance-scalability

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
