### PR TITLE
OSDOCS#3994:Port performance and scalability content to the ROSA doc set

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1197,7 +1197,7 @@ Topics:
   File: using-rfhe
 - Name: What huge pages do and how they are consumed by apps
   File: what-huge-pages-do-and-how-they-are-consumed-by-apps
-  Distros: openshift-dedicated,openshift-origin
+#  Distros: openshift-dedicated,openshift-origin
 - Name: Low latency tuning
   File: cnf-low-latency-tuning
   Distros: openshift-dedicated,openshift-rosa

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1192,7 +1192,7 @@ Topics:
     File: optimizing-cpu-usage
 # - Name: Managing bare metal hosts
 #   File: managing-bare-metal-hosts
-#   Distros: openshift-dedicated,openshift-rosa
+  Distros: openshift-dedicated,openshift-rosa
 - Name: Monitoring bare-metal events
   File: using-rfhe
 - Name: What huge pages do and how they are consumed by apps
@@ -1213,34 +1213,34 @@ Topics:
   Distros: openshift-dedicated,openshift-rosa
 - Name: Using the Node Observability Operator
   File: node-observability-operator
-  Distros: openshift-dedicated,openshift-enterprise
-- Name: Clusters at the network far edge
-  Dir: ztp_far_edge
-  Distros: openshift-dedicated,openshift-rosa
-  Topics:
-  - Name: Challenges of the network far edge
-    File: ztp-deploying-far-edge-clusters-at-scale
+#  Distros: openshift-dedicated,openshift-enterprise
+# Name: Clusters at the network far edge
+#  Dir: ztp_far_edge
+#  Distros: openshift-dedicated,openshift-rosa
+#  Topics:
+#  - Name: Challenges of the network far edge
+#    File: ztp-deploying-far-edge-clusters-at-scale
 #  - Name: Preparing the hub cluster for ZTP
 #    File: ztp-preparing-the-hub-cluster
-  - Name: Updating GitOps ZTP
-    File: ztp-updating-gitops
+#  - Name: Updating GitOps ZTP
+#    File: ztp-updating-gitops
 #  - Name: Installing managed clusters with RHACM and SiteConfig resources
 #    File: ztp-deploying-far-edge-sites
-  - Name: Configuring managed clusters with policies and PolicyGenTemplate resources
-    File: ztp-configuring-managed-clusters-policies
+#  - Name: Configuring managed clusters with policies and PolicyGenTemplate resources
+#    File: ztp-configuring-managed-clusters-policies
 #  - Name: Manually installing a single-node OpenShift cluster with ZTP
 #    File: ztp-manual-install
-  - Name: Recommended single-node OpenShift cluster configuration for vDU application workloads
-    File: ztp-reference-cluster-configuration-for-vdu
-  - Name: Validating cluster tuning for vDU application workloads
-    File: ztp-vdu-validating-cluster-tuning
-  - Name: Advanced managed cluster configuration with SiteConfig resources
-    File: ztp-advanced-install-ztp
+#  - Name: Recommended single-node OpenShift cluster configuration for vDU application workloads
+#    File: ztp-reference-cluster-configuration-for-vdu
+#  - Name: Validating cluster tuning for vDU application workloads
+#    File: ztp-vdu-validating-cluster-tuning
+#  - Name: Advanced managed cluster configuration with SiteConfig resources
+#    File: ztp-advanced-install-ztp
 #  - Name: Advanced managed cluster configuration with PolicyGenTemplate resources
 #    File: ztp-advanced-policy-config
-  - Name: Updating managed clusters with the Topology Aware Lifecycle Manager
-    File: cnf-talm-for-cluster-upgrades
-    Distros: openshift-dedicated,openshift-rosa
+#  - Name: Updating managed clusters with the Topology Aware Lifecycle Manager
+#    File: cnf-talm-for-cluster-upgrades
+#    Distros: openshift-dedicated,openshift-rosa
 #  - Name: Updating managed clusters in a disconnected environment with the Topology Aware Lifecycle Manager
 #    File: ztp-talm-updating-managed-policies
 #  - Name: Expanding single-node OpenShift clusters with GitOps ZTP

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1149,6 +1149,105 @@ Topics:
 # - Name: Using the internal registry
 #   File: rosa-using-internal-registry
 ---
+Name: Scalability and performance
+Dir: scalability_and_performance
+Distros: openshift-dedication,openshift-rosa
+Topics:
+- Name: Recommended performance and scalability practices
+  Dir: recommended-performance-scale-practices
+  Distros: openshift-dedicated,openshift-rosa
+  Topics:
+  - Name: Recommended control plane practices
+    File: recommended-control-plane-practices
+  - Name: Recommended infrastructure practices
+    File: recommended-infrastructure-practices
+  - Name: Recommended etcd practices
+    File: recommended-etcd-practices
+- Name: Planning your environment according to object maximums
+  File: planning-your-environment-according-to-object-maximums
+  Distros: openshift-dedicated,openshift-rosa
+# - Name: Recommended host practices for IBM Z & IBM LinuxONE environments
+#   File: ibm-z-recommended-host-practices
+#   Distros: openshift-dedicated,openshift-rosa
+- Name: Using the Node Tuning Operator
+  File: using-node-tuning-operator
+  Distros: openshift-dedicated,openshift-rosa
+- Name: Using CPU Manager and Topology Manager
+  File: using-cpu-manager
+  Distros: openshift-dedicated,openshift-rosa
+- Name: Scheduling NUMA-aware workloads
+  File: cnf-numa-aware-scheduling
+  Distros: openshift-dedicated,openshift-rosa
+- Name: Scalability and performance optimization
+  Dir: optimization
+  Distros: openshift-dedicated,openshift-rosa
+  Topics:
+  - Name: Optimizing storage
+    File: optimizing-storage
+  - Name: Optimizing routing
+    File: routing-optimization
+  - Name: Optimizing networking
+    File: optimizing-networking
+  - Name: Optimizing CPU usage
+    File: optimizing-cpu-usage
+# - Name: Managing bare metal hosts
+#   File: managing-bare-metal-hosts
+#   Distros: openshift-dedicated,openshift-rosa
+- Name: Monitoring bare-metal events
+  File: using-rfhe
+- Name: What huge pages do and how they are consumed by apps
+  File: what-huge-pages-do-and-how-they-are-consumed-by-apps
+  Distros: openshift-dedicated,openshift-origin
+- Name: Low latency tuning
+  File: cnf-low-latency-tuning
+  Distros: openshift-dedicated,openshift-rosa
+- Name: Performing latency tests for platform verification
+  File: cnf-performing-platform-verification-latency-tests
+- Name: Improving cluster stability in high latency environments using worker latency profiles
+  File: scaling-worker-latency-profiles
+- Name: Creating a performance profile
+  File: cnf-create-performance-profiles
+  Distros: openshift-dedicated,openshift-rosa
+- Name: Workload partitioning
+  File: enabling-workload-partitioning
+  Distros: openshift-dedicated,openshift-rosa
+- Name: Using the Node Observability Operator
+  File: node-observability-operator
+  Distros: openshift-dedicated,openshift-enterprise
+- Name: Clusters at the network far edge
+  Dir: ztp_far_edge
+  Distros: openshift-dedicated,openshift-rosa
+  Topics:
+  - Name: Challenges of the network far edge
+    File: ztp-deploying-far-edge-clusters-at-scale
+#  - Name: Preparing the hub cluster for ZTP
+#    File: ztp-preparing-the-hub-cluster
+  - Name: Updating GitOps ZTP
+    File: ztp-updating-gitops
+#  - Name: Installing managed clusters with RHACM and SiteConfig resources
+#    File: ztp-deploying-far-edge-sites
+  - Name: Configuring managed clusters with policies and PolicyGenTemplate resources
+    File: ztp-configuring-managed-clusters-policies
+#  - Name: Manually installing a single-node OpenShift cluster with ZTP
+#    File: ztp-manual-install
+  - Name: Recommended single-node OpenShift cluster configuration for vDU application workloads
+    File: ztp-reference-cluster-configuration-for-vdu
+  - Name: Validating cluster tuning for vDU application workloads
+    File: ztp-vdu-validating-cluster-tuning
+  - Name: Advanced managed cluster configuration with SiteConfig resources
+    File: ztp-advanced-install-ztp
+#  - Name: Advanced managed cluster configuration with PolicyGenTemplate resources
+#    File: ztp-advanced-policy-config
+  - Name: Updating managed clusters with the Topology Aware Lifecycle Manager
+    File: cnf-talm-for-cluster-upgrades
+    Distros: openshift-dedicated,openshift-rosa
+#  - Name: Updating managed clusters in a disconnected environment with the Topology Aware Lifecycle Manager
+#    File: ztp-talm-updating-managed-policies
+#  - Name: Expanding single-node OpenShift clusters with GitOps ZTP
+#    File: ztp-sno-additional-worker-node
+#  - Name: Pre-caching images for single-node OpenShift deployments
+#    File: ztp-precaching-tool
+---
 Name: Backing up and restoring applications
 Dir: rosa_backing_up_and_restoring_applications
 Distros: openshift-rosa

--- a/edge_computing/ztp-advanced-policy-config.adoc
+++ b/edge_computing/ztp-advanced-policy-config.adoc
@@ -73,8 +73,15 @@ include::modules/ztp-configuring-ptp-fast-events-amqp.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
+<<<<<<< HEAD:edge_computing/ztp-advanced-policy-config.adoc
 * xref:../networking/ptp/using-ptp-events.adoc#cnf-installing-amq-interconnect-messaging-bus_using-ptp-events[Installing the AMQ messaging bus]
 * For more information about container image registries, see xref:../registry/index.adoc#registry-overview[{product-registry} overview].
+=======
+ifndef::openshift-dedicated,openshift-rosa[]
+* xref:../../networking/ptp/using-ptp-events.adoc#cnf-installing-amq-interconnect-messaging-bus_using-ptp-events[Installing the AMQ messaging bus]
+endif::[]
+* For more information about container image registries, see xref:../../registry/index.adoc#registry-overview[{product-registry} overview].
+>>>>>>> 722e97a881 (add original conditions in new PR):scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc
 
 [id="ztp-advanced-policy-config-bare-metal_{context}"]
 == Configuring bare-metal events with PolicyGenTemplate CRs
@@ -85,12 +92,18 @@ include::snippets/ptp-amq-interconnect-eol.adoc[]
 
 include::modules/ztp-configuring-hwevents-using-pgt.adoc[leveloffset=+2]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../scalability_and_performance/using-rfhe.adoc#nw-rfhe-installing-operator-cli_using-rfhe[Installing the {redfish-operator} using the CLI]
 
+<<<<<<< HEAD:edge_computing/ztp-advanced-policy-config.adoc
 * xref:../scalability_and_performance/using-rfhe.adoc#nw-rfhe-creating-hardware-event_using-rfhe[Creating the bare-metal event and Secret CRs]
+=======
+* xref:../../scalability_and_performance/using-rfhe.adoc#nw-rfhe-creating-hardware-event_using-rfhe[Creating the bare-metal event and Secret CRs]
+endif::[]
+>>>>>>> 722e97a881 (add original conditions in new PR):scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc
 
 include::modules/ztp-creating-hwevents-amqp.adoc[leveloffset=+2]
 

--- a/edge_computing/ztp-advanced-policy-config.adoc
+++ b/edge_computing/ztp-advanced-policy-config.adoc
@@ -92,6 +92,7 @@ ifndef::openshift-dedicated,openshift-rosa[]
 
 * xref:../../scalability_and_performance/using-rfhe.adoc#nw-rfhe-installing-operator-cli_using-rfhe[Installing the {redfish-operator} using the CLI]
 * xref:../../scalability_and_performance/using-rfhe.adoc#nw-rfhe-creating-hardware-event_using-rfhe[Creating the bare-metal event and Secret CRs]
+endif::[]
 
 include::modules/ztp-creating-hwevents-amqp.adoc[leveloffset=+2]
 

--- a/edge_computing/ztp-advanced-policy-config.adoc
+++ b/edge_computing/ztp-advanced-policy-config.adoc
@@ -73,15 +73,9 @@ include::modules/ztp-configuring-ptp-fast-events-amqp.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-<<<<<<< HEAD:edge_computing/ztp-advanced-policy-config.adoc
-* xref:../networking/ptp/using-ptp-events.adoc#cnf-installing-amq-interconnect-messaging-bus_using-ptp-events[Installing the AMQ messaging bus]
-* For more information about container image registries, see xref:../registry/index.adoc#registry-overview[{product-registry} overview].
-=======
-ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../networking/ptp/using-ptp-events.adoc#cnf-installing-amq-interconnect-messaging-bus_using-ptp-events[Installing the AMQ messaging bus]
-endif::[]
+
 * For more information about container image registries, see xref:../../registry/index.adoc#registry-overview[{product-registry} overview].
->>>>>>> 722e97a881 (add original conditions in new PR):scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc
 
 [id="ztp-advanced-policy-config-bare-metal_{context}"]
 == Configuring bare-metal events with PolicyGenTemplate CRs
@@ -96,14 +90,8 @@ ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../scalability_and_performance/using-rfhe.adoc#nw-rfhe-installing-operator-cli_using-rfhe[Installing the {redfish-operator} using the CLI]
-
-<<<<<<< HEAD:edge_computing/ztp-advanced-policy-config.adoc
-* xref:../scalability_and_performance/using-rfhe.adoc#nw-rfhe-creating-hardware-event_using-rfhe[Creating the bare-metal event and Secret CRs]
-=======
+* xref:../../scalability_and_performance/using-rfhe.adoc#nw-rfhe-installing-operator-cli_using-rfhe[Installing the {redfish-operator} using the CLI]
 * xref:../../scalability_and_performance/using-rfhe.adoc#nw-rfhe-creating-hardware-event_using-rfhe[Creating the bare-metal event and Secret CRs]
-endif::[]
->>>>>>> 722e97a881 (add original conditions in new PR):scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc
 
 include::modules/ztp-creating-hwevents-amqp.adoc[leveloffset=+2]
 

--- a/edge_computing/ztp-deploying-far-edge-sites.adoc
+++ b/edge_computing/ztp-deploying-far-edge-sites.adoc
@@ -43,9 +43,17 @@ include::modules/ztp-sno-siteconfig-config-reference.adoc[leveloffset=+2]
 
 * xref:../edge_computing/ztp-manual-install.adoc#ztp-creating-the-site-secrets_ztp-manual-install[Creating the managed bare-metal host secrets]
 
+<<<<<<< HEAD:edge_computing/ztp-deploying-far-edge-sites.adoc
 * xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#bmc-addressing_ipi-install-installation-workflow[BMC addressing]
 
 * xref:../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#root-device-hints_preparing-to-install-with-agent-based-installer[About root device hints]
+=======
+ifndef::openshift-dedicated,openshift-rosa[]
+* xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#bmc-addressing_ipi-install-installation-workflow[BMC addressing]
+
+* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#root-device-hints_preparing-to-install-with-agent-based-installer[About root device hints]
+endif::[]
+>>>>>>> 722e97a881 (add original conditions in new PR):scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc
 
 include::modules/ztp-monitoring-installation-progress.adoc[leveloffset=+1]
 

--- a/edge_computing/ztp-precaching-tool.adoc
+++ b/edge_computing/ztp-precaching-tool.adoc
@@ -30,11 +30,23 @@ include::modules/ztp-precaching-booting-from-live-os.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
+<<<<<<< HEAD:edge_computing/ztp-precaching-tool.adoc
 * For more information about the `butane` utility, see xref:../installing/install_config/installing-customizing.adoc#installation-special-config-butane-about_installing-customizing[About Butane].
 * For more information about creating a custom live {op-system} ISO, see xref:../installing/installing_sno/install-sno-installing-sno.adoc#create-custom-live-rhcos-iso_install-sno-installing-sno-with-the-assisted-installer[Creating a custom live {op-system} ISO for remote server access].
 * For more information about using the Dell RACADM tool, see link:https://www.dell.com/support/manuals/en-ie/poweredge-r440/idrac9_6.xx_racadm_pub/supported-racadm-interfaces?guid=guid-a5747353-fc88-4438-b617-c50ca260448e&lang=en-us[Integrated Dell Remote Access Controller 9 RACADM CLI Guide].
 * For more information about using the HP HPONCFG tool, see link:https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-a00007610en_us[Using HPONCFG].
 * For more information about using the Redfish BMC API, see xref:../installing/installing_sno/install-sno-installing-sno.adoc#install-booting-from-an-iso-over-http-redfish_install-sno-installing-sno-with-the-assisted-installer[Booting from an HTTP-hosted ISO image using the Redfish API].
+=======
+ifndef::openshift-dedicated,openshift-rosa[]
+* For more information about the `butane` utility, see xref:../../installing/install_config/installing-customizing.adoc#installation-special-config-butane-about_installing-customizing[About Butane].
+* For more information about creating a custom live {op-system} ISO, see xref:../../installing/installing_sno/install-sno-installing-sno.adoc#create-custom-live-rhcos-iso_install-sno-installing-sno-with-the-assisted-installer[Creating a custom live {op-system} ISO for remote server access].
+endif::[]
+* For more information about using the Dell RACADM tool, see link:https://www.dell.com/support/manuals/en-ie/poweredge-r440/idrac9_6.xx_racadm_pub/supported-racadm-interfaces?guid=guid-a5747353-fc88-4438-b617-c50ca260448e&lang=en-us[Integrated Dell Remote Access Controller 9 RACADM CLI Guide].
+* For more information about using the HP HPONCFG tool, see link:https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-a00007610en_us[Using HPONCFG].
+ifndef::operating-dedicated,openshift-rosa[]
+* For more information about using the Redfish BMC API, see xref:../../installing/installing_sno/install-sno-installing-sno.adoc#install-booting-from-an-iso-over-http-redfish_install-sno-installing-sno-with-the-assisted-installer[Booting from an HTTP-hosted ISO image using the Redfish API].
+endif::[]
+>>>>>>> 722e97a881 (add original conditions in new PR):scalability_and_performance/ztp_far_edge/ztp-precaching-tool.adoc
 
 include::modules/ztp-precaching-partitioning.adoc[leveloffset=+1]
 

--- a/edge_computing/ztp-preparing-the-hub-cluster.adoc
+++ b/edge_computing/ztp-preparing-the-hub-cluster.adoc
@@ -26,7 +26,13 @@ include::modules/ztp-acm-installing-disconnected-rhacm.adoc[leveloffset=+1]
 
 * xref:../edge_computing/cnf-talm-for-cluster-upgrades.adoc#installing-topology-aware-lifecycle-manager-using-cli_cnf-topology-aware-lifecycle-manager[Installing {cgu-operator}]
 
+<<<<<<< HEAD:edge_computing/ztp-preparing-the-hub-cluster.adoc
 * xref:../operators/admin/olm-restricted-networks.adoc#olm-mirror-catalog_olm-restricted-networks[Mirroring an Operator catalog]
+=======
+ifndef::openshift-dedicated,openshift-rosa[]
+* xref:../../operators/admin/olm-restricted-networks.adoc#olm-mirror-catalog_olm-restricted-networks[Mirroring an Operator catalog]
+endif::[]
+>>>>>>> 722e97a881 (add original conditions in new PR):scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc
 
 include::modules/ztp-acm-adding-images-to-mirror-registry.adoc[leveloffset=+1]
 
@@ -41,10 +47,16 @@ include::modules/ztp-enabling-assisted-installer-service-on-bare-metal.adoc[leve
 
 include::modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc[leveloffset=+1]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 
+<<<<<<< HEAD:edge_computing/ztp-preparing-the-hub-cluster.adoc
 * xref:../installing/disconnected_install/installing-mirroring-installation-images.adoc#installation-mirror-repository_installing-mirroring-installation-images[Mirroring the OpenShift Container Platform image repository]
+=======
+* xref:../../installing/disconnected_install/installing-mirroring-installation-images.adoc#installation-mirror-repository_installing-mirroring-installation-images[Mirroring the OpenShift Container Platform image repository]
+endif::[]
+>>>>>>> 722e97a881 (add original conditions in new PR):scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc
 
 include::modules/ztp-configuring-the-hub-cluster-to-use-unauthenticated-registries.adoc[leveloffset=+1]
 

--- a/edge_computing/ztp-sno-additional-worker-node.adoc
+++ b/edge_computing/ztp-sno-additional-worker-node.adoc
@@ -26,9 +26,15 @@ include::snippets/technology-preview.adoc[]
 
 * For more information about {sno} clusters tuned for vDU application deployments, see xref:../edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc#sno-configure-for-vdu[Reference configuration for deploying vDUs on {sno}].
 
+<<<<<<< HEAD:edge_computing/ztp-sno-additional-worker-node.adoc
 * For more information about worker nodes, see xref:../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno} clusters].
 
 * For information about removing a worker node from an expanded {sno} cluster, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#auto-remove-host-steps-cli[Removing managed cluster nodes by using the command line interface].
+=======
+ifndef::openshift-dedicated,openshift-rosa[]
+* For more information about worker nodes, see xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc[Adding worker nodes to single-node OpenShift clusters].
+endif::[]
+>>>>>>> 722e97a881 (add original conditions in new PR):scalability_and_performance/ztp_far_edge/ztp-sno-additional-worker-node.adoc
 
 include::modules/ztp-worker-node-applying-du-profile.adoc[leveloffset=+1]
 

--- a/edge_computing/ztp-talm-updating-managed-policies.adoc
+++ b/edge_computing/ztp-talm-updating-managed-policies.adoc
@@ -22,13 +22,27 @@ include::modules/cnf-topology-aware-lifecycle-manager-preparing-for-updates.adoc
 
 * For more information about how to update {ztp-first}, see xref:../edge_computing/ztp-updating-gitops.adoc#ztp-updating-gitops[Upgrading {ztp}].
 
+<<<<<<< HEAD:edge_computing/ztp-talm-updating-managed-policies.adoc
 * For more information about how to mirror an {product-title} image repository, see xref:../installing/disconnected_install/installing-mirroring-installation-images.adoc#installation-mirror-repository_installing-mirroring-installation-images[Mirroring the {product-title} image repository].
 
 * For more information about how to mirror Operator catalogs for disconnected clusters, see xref:../installing/disconnected_install/installing-mirroring-installation-images.adoc#olm-mirror-catalog_installing-mirroring-installation-images[Mirroring Operator catalogs for use with disconnected clusters].
+=======
+ifndef::openshift-dedicated,openshift-rosa[]
+* For more information about how to mirror an {product-title} image repository, see xref:../../installing/disconnected_install/installing-mirroring-installation-images.adoc#installation-mirror-repository_installing-mirroring-installation-images[Mirroring the {product-title} image repository].
+
+* For more information about how to mirror Operator catalogs for disconnected clusters, see xref:../../installing/disconnected_install/installing-mirroring-installation-images.adoc#olm-mirror-catalog_installing-mirroring-installation-images[Mirroring Operator catalogs for use with disconnected clusters].
+endif::[]
+>>>>>>> 722e97a881 (add original conditions in new PR):scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc
 
 * For more information about how to prepare the disconnected environment and mirroring the desired image repository, see xref:../edge_computing/ztp-preparing-the-hub-cluster.adoc#ztp-preparing-the-hub-cluster[Preparing the disconnected environment].
 
+<<<<<<< HEAD:edge_computing/ztp-talm-updating-managed-policies.adoc
 * For more information about update channels and releases, see xref:../updating/understanding_updates/understanding-update-channels-release.adoc#understanding-update-channels-releases[Understanding update channels and releases].
+=======
+ifndef::openshift-dedicated,openshift-rosa[]
+* For more information about update channels and releases, see xref:../../updating/understanding_updates/understanding-update-channels-release.adoc#understanding-update-channels-releases[Understanding update channels and releases].
+endif::[]
+>>>>>>> 722e97a881 (add original conditions in new PR):scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc
 
 include::modules/cnf-topology-aware-lifecycle-manager-platform-update.adoc[leveloffset=+2]
 

--- a/modules/cpms-changing-aws-instance-type.adoc
+++ b/modules/cpms-changing-aws-instance-type.adoc
@@ -22,6 +22,12 @@ You can change the Amazon Web Services (AWS) instance type that your control pla
 
 .Procedure
 
+ifdef::openshift-dedicated,openshift-rosa[]
+[NOTE]
+====
+The following command is valid for classic clusters and not for host clusters.
+====
+endif::openshift-dedicated,openshift-rosa[]
 ifdef::scale-host[]
 . Edit your control plane machine set CR by running the following command:
 +

--- a/modules/openshift-cluster-maximums-environment.adoc
+++ b/modules/openshift-cluster-maximums-environment.adoc
@@ -57,6 +57,7 @@
 5. Cluster is scaled in iterations and performance and scalability tests are executed at the specified node counts.
 --
 
+ifndef::openshift-dedicated.openshift-rosa[]
 == {ibm-power-title} platform
 
 [options="header",cols="6*"]
@@ -130,3 +131,4 @@
 4. Physical number of processors used is six Integrated Facilities for Linux (IFLs).
 5. Total physical memory used is 512 GiB.
 --
+endif::[]

--- a/modules/recommended-configurable-storage-technology.adoc
+++ b/modules/recommended-configurable-storage-technology.adoc
@@ -100,7 +100,12 @@ In a scaled/HA {product-registry} cluster deployment:
 * The storage technology must support RWX access mode.
 * The storage technology must ensure read-after-write consistency.
 * The preferred storage technology is object storage.
+ifndef::openshift-dedicated,openshift-rosa[]
 * Red Hat OpenShift Data Foundation (ODF), Amazon Simple Storage Service (Amazon S3), Google Cloud Storage (GCS), Microsoft Azure Blob Storage, and OpenStack Swift are supported.
+endif::[]
+ifdef::openshift-dedicated,openshift[]
+* Amazon Simple Storage Service (Amazon S3) is supported.
+endif::[]
 * Object storage should be S3 or Swift compliant.
 * For non-cloud platforms, such as vSphere and bare metal installations, the only configurable technology is file storage.
 * Block storage is not configurable.

--- a/scalability_and_performance/cnf-create-performance-profiles.adoc
+++ b/scalability_and_performance/cnf-create-performance-profiles.adoc
@@ -1,0 +1,39 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="cnf-create-performance-profiles"]
+= Creating a performance profile
+include::_attributes/common-attributes.adoc[]
+:context: cnf-create-performance-profiles
+
+toc::[]
+
+Learn about the Performance Profile Creator (PPC) and how you can use it to create a performance profile.
+
+[NOTE]
+====
+Currently, disabling CPU load balancing is not supported by cgroup v2. As a result, you might not get the desired behavior from performance profiles if you have cgroup v2 enabled. Enabling cgroup v2 is not recommended if you are using performance profiles.
+====
+
+include::modules/cnf-about-the-profile-creator-tool.adoc[leveloffset=+1]
+
+include::modules/cnf-gathering-data-about-cluster-using-must-gather.adoc[leveloffset=+2]
+
+include::modules/cnf-running-the-performance-creator-profile.adoc[leveloffset=+2]
+
+include::modules/cnf-how-run-podman-to-create-profile.adoc[leveloffset=+3]
+
+include::modules/cnf-running-the-performance-creator-profile-offline.adoc[leveloffset=+2]
+
+include::modules/cnf-performance-profile-creator-arguments.adoc[leveloffset=+2]
+
+[id="cnf-create-performance-profiles-reference"]
+== Reference performance profiles
+
+include::modules/installation-openstack-ovs-dpdk-performance-profile.adoc[leveloffset=+2]
+
+ifndef::openshift-dedicated,openshift-rosa[]
+[id="{context}-additional-resources"]
+[role="_additional-resources"]
+== Additional resources
+* For more information about the `must-gather` tool,
+see xref:../support/gathering-cluster-data.adoc#nodes-nodes-managing[Gathering data about your cluster].
+endif::[]

--- a/scalability_and_performance/cnf-low-latency-tuning.adoc
+++ b/scalability_and_performance/cnf-low-latency-tuning.adoc
@@ -8,9 +8,7 @@ toc::[]
 
 include::modules/cnf-understanding-low-latency.adoc[leveloffset=+1]
 
-ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/cnf-about_hyperthreading_for_low_latency_and_real_time_applications.adoc[leveloffset=+2]
-endif::[]
 
 [role="_additional-resources"]
 .Additional resources

--- a/scalability_and_performance/cnf-low-latency-tuning.adoc
+++ b/scalability_and_performance/cnf-low-latency-tuning.adoc
@@ -8,14 +8,18 @@ toc::[]
 
 include::modules/cnf-understanding-low-latency.adoc[leveloffset=+1]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/cnf-about_hyperthreading_for_low_latency_and_real_time_applications.adoc[leveloffset=+2]
+endif::[]
 
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../scalability_and_performance/cnf-low-latency-tuning.adoc#configuring_hyperthreading_for_a_cluster_{context}[Configuring hyperthreading for a cluster]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc[leveloffset=+1]
+endif::[]
 
 [role="_additional-resources"]
 .Additional resources
@@ -41,9 +45,11 @@ include::modules/cnf-configure_for_irq_dynamic_load_balancing.adoc[leveloffset=+
 
 include::modules/cnf-about-irq-affinity-setting.adoc[leveloffset=+2]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/configuring_hyperthreading_for_a_cluster.adoc[leveloffset=+2]
 
 include::modules/cnf-understanding-workload-hints.adoc[leveloffset=+2]
+endif::[]
 
 [role="_additional-resources"]
 .Additional resources

--- a/scalability_and_performance/cnf-low-latency-tuning.adoc
+++ b/scalability_and_performance/cnf-low-latency-tuning.adoc
@@ -1,0 +1,103 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="cnf-low-latency-tuning"]
+= Low latency tuning
+include::_attributes/common-attributes.adoc[]
+:context: cnf-master
+
+toc::[]
+
+include::modules/cnf-understanding-low-latency.adoc[leveloffset=+1]
+
+include::modules/cnf-about_hyperthreading_for_low_latency_and_real_time_applications.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../scalability_and_performance/cnf-low-latency-tuning.adoc#configuring_hyperthreading_for_a_cluster_{context}[Configuring hyperthreading for a cluster]
+
+include::modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about recommended firmware configuration, see xref:../scalability_and_performance/ztp_far_edge/ztp-vdu-validating-cluster-tuning.adoc#ztp-du-firmware-config-reference_vdu-config-ref[Recommended firmware configuration for vDU cluster hosts].
+
+include::modules/cnf-managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus.adoc[leveloffset=+2]
+
+include::modules/cnf-use-device-interrupt-processing-for-isolated-cpus.adoc[leveloffset=+2]
+
+include::modules/cnf-tuning-nodes-for-low-latency-via-performanceprofile.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For information on using the Performance Profile Creator (PPC) to generate a performance profile, see xref:../scalability_and_performance/cnf-create-performance-profiles.adoc#cnf-create-performance-profiles[Creating a performance profile].
+
+include::modules/cnf-configuring-huge-pages.adoc[leveloffset=+2]
+
+include::modules/cnf-allocating-multiple-huge-page-sizes.adoc[leveloffset=+2]
+
+include::modules/cnf-configure_for_irq_dynamic_load_balancing.adoc[leveloffset=+2]
+
+include::modules/cnf-about-irq-affinity-setting.adoc[leveloffset=+2]
+
+include::modules/configuring_hyperthreading_for_a_cluster.adoc[leveloffset=+2]
+
+include::modules/cnf-understanding-workload-hints.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For information about using the Performance Profile Creator (PPC) to generate a performance profile, see xref:../scalability_and_performance/cnf-create-performance-profiles.adoc#cnf-create-performance-profiles[Creating a performance profile].
+
+include::modules/cnf-configuring-workload-hints.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For information about reducing CPU throttling for individual guaranteed pods, see xref:../scalability_and_performance/cnf-low-latency-tuning.adoc#disabling-cpu-cfs-quota_cnf-master[Disabling CPU CFS quota].
+
+include::modules/cnf-cpu-infra-container.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../scalability_and_performance/cnf-low-latency-tuning.adoc#managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus_{context}[Managing device interrupt processing for guaranteed pod isolated CPUs]
+
+* link:https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-guaranteed[Create a pod that gets assigned a QoS class of Guaranteed]
+
+include::modules/cnf-reducing-netqueues-using-nto.adoc[leveloffset=+1]
+
+include::modules/cnf-adjusting-nic-queues-with-the-performance-profile.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../scalability_and_performance/cnf-create-performance-profiles.adoc#cnf-create-performance-profiles[Creating a performance profile].
+
+include::modules/cnf-verifying-queue-status.adoc[leveloffset=+2]
+
+include::modules/cnf-logging-associated-with-adjusting-nic-queues.adoc[leveloffset=+2]
+
+include::modules/cnf-debugging-low-latency-cnf-tuning-status.adoc[leveloffset=+1]
+
+include::modules/cnf-collecting-low-latency-tuning-debugging-data-for-red-hat-support.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about the `must-gather` tool, see xref:../support/gathering-cluster-data.adoc#gathering-cluster-data[Gathering data about your cluster]
+
+ifndef::openshift-dedicated.openshift-rosa[]
+* For more information about MachineConfig and KubeletConfig,
+see xref:../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-managing[Managing nodes].
+endif::[]
+
+* For more information about the Node Tuning Operator,
+see xref:../scalability_and_performance/using-node-tuning-operator.adoc#using-node-tuning-operator[Using the Node Tuning Operator].
+
+* For more information about the PerformanceProfile,
+see xref:../scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc#configuring-huge-pages_huge-pages[Configuring huge pages].
+
+* For more information about consuming huge pages from your containers,
+see xref:../scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc#how-huge-pages-are-consumed-by-apps_huge-pages[How huge pages are consumed by apps].

--- a/scalability_and_performance/cnf-numa-aware-scheduling.adoc
+++ b/scalability_and_performance/cnf-numa-aware-scheduling.adoc
@@ -14,9 +14,11 @@ The NUMA Resources Operator allows you to schedule high-performance workloads in
 
 include::modules/cnf-about-numa-aware-scheduling.adoc[leveloffset=+1]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 .Additional resources
 
 * For more information about running secondary pod schedulers in your cluster and how to deploy pods with a secondary pod scheduler, see xref:../nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.adoc#secondary-scheduler-configuring[Scheduling pods using a secondary scheduler].
+endif::[]
 
 [id="installing-the-numa-resources-operator_{context}"]
 == Installing the NUMA Resources Operator

--- a/scalability_and_performance/ibm-z-recommended-host-practices.adoc
+++ b/scalability_and_performance/ibm-z-recommended-host-practices.adoc
@@ -52,7 +52,9 @@ include::modules/ibm-z-choose-networking-setup.adoc[leveloffset=+1]
 
 * link:https://www.ibm.com/docs/en/linux-on-systems?topic=openshift-performance#openshift_perf__ocp_net[{product-title} on {ibm-z-name} Networking Performance]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../nodes/scheduling/nodes-scheduler-node-affinity.adoc[Controlling pod placement on nodes using node affinity rules]
+endif::[]
 
 include::modules/ibm-z-ensure-high-disk-performance-hyperpav.adoc[leveloffset=+1]
 

--- a/scalability_and_performance/optimization/optimizing-cpu-usage.adoc
+++ b/scalability_and_performance/optimization/optimizing-cpu-usage.adoc
@@ -27,4 +27,6 @@ include::modules/running-services-with-encapsulation.adoc[leveloffset=+1]
 
 * link:https://www.redhat.com/sysadmin/container-namespaces-nsenter[Manage containers in namespaces by using nsenter]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../rest_api/machine_apis/machineconfig-machineconfiguration-openshift-io-v1.adoc[MachineConfig]
+endif::[]

--- a/scalability_and_performance/optimization/optimizing-networking.adoc
+++ b/scalability_and_performance/optimization/optimizing-networking.adoc
@@ -6,9 +6,17 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+<<<<<<< HEAD
 The xref:../../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[OpenShift SDN] uses OpenvSwitch, virtual extensible LAN (VXLAN) tunnels, OpenFlow rules, and iptables. This network can be tuned by using jumbo frames, multi-queue, and ethtool settings.
 
 xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes] uses Generic Network Virtualization Encapsulation (Geneve) instead of VXLAN as the tunnel protocol. This network can be tuned by using network interface controller (NIC) offloads.
+=======
+ifndef::openshift-dedicated,openshift-rosa[]
+The xref:../../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[OpenShift SDN] uses OpenvSwitch, virtual extensible LAN (VXLAN) tunnels, OpenFlow rules, and iptables. This network can be tuned by using jumbo frames, network interface controllers (NIC) offloads, multi-queue, and ethtool settings.
+
+xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes] uses Geneve (Generic Network Virtualization Encapsulation) instead of VXLAN as the tunnel protocol.
+endif::[]
+>>>>>>> 722e97a881 (add original conditions in new PR)
 
 VXLAN provides benefits over VLANs, such as an increase in networks from 4096 to over 16 million, and layer 2 connectivity across physical networks. This allows for all pods behind a service to communicate with each other, even if they are running on different systems.
 
@@ -35,7 +43,13 @@ include::modules/ipsec-impact-networking.adoc[leveloffset=+1]
 [id="optimizing-networking-additional-resources"]
 == Additional resources
 
+<<<<<<< HEAD
 * xref:../../installing/installing_aws/ipi/installing-aws-network-customizations.adoc#modifying-nwoperator-config-startup_installing-aws-network-customizations[Specifying advanced network configuration]
+=======
+ifndef::openshift-dedicated,openshift-rosa[]
+* xref:../../installing/installing_aws/installing-aws-network-customizations.adoc#modifying-nwoperator-config-startup_installing-aws-network-customizations[Modifying advanced network configuration parameters]
+>>>>>>> 722e97a881 (add original conditions in new PR)
 * xref:../../networking/cluster-network-operator.adoc#nw-operator-configuration-parameters-for-ovn-sdn_cluster-network-operator[Configuration parameters for the OVN-Kubernetes network plugin]
 * xref:../../networking/cluster-network-operator.adoc#nw-operator-configuration-parameters-for-openshift-sdn_cluster-network-operator[Configuration parameters for the OpenShift SDN network plugin]
+endif::[]
 * xref:../../scalability_and_performance/scaling-worker-latency-profiles.adoc#scaling-worker-latency-profiles[Improving cluster stability in high latency environments using worker latency profiles]

--- a/scalability_and_performance/optimization/optimizing-storage.adoc
+++ b/scalability_and_performance/optimization/optimizing-storage.adoc
@@ -30,7 +30,9 @@ include::modules/recommended-configurable-storage-technology.adoc[leveloffset=+1
 
 include::modules/data-storage-management.adoc[leveloffset=+1]
 
+ifndef::opernshift-dedicated,openshift-rosa[]
 include::modules/optimizing-storage-azure.adoc[leveloffset=+1]
+endif::[]
 
 [role="_additional-resources"]
 [id="admission-plug-ins-additional-resources"]

--- a/scalability_and_performance/recommended-performance-scale-practices/recommended-control-plane-practices.adoc
+++ b/scalability_and_performance/recommended-performance-scale-practices/recommended-control-plane-practices.adoc
@@ -21,20 +21,27 @@ If the control plane machines in an Amazon Web Services (AWS) cluster require mo
 ====
 The procedure for clusters that use a control plane machine set is different from the procedure for clusters that do not use a control plane machine set.
 
+ifndef::openshift-dedicated,openshift-rosa[]
 If you are uncertain about the state of the `ControlPlaneMachineSet` CR in your cluster, you can xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-checking-status_cpmso-getting-started[verify the CR status].
+endif::[]
 ====
 
 //Changing the Amazon Web Services instance type by using a control plane machine set
 include::modules/cpms-changing-aws-instance-type.adoc[leveloffset=+3]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-managing-machines[Managing control plane machines with control plane machine sets]
+ifndef::openshift-dedicated,openshift-rosa[]
+* xref:../../machine_management/control_plane_machine_management/cpmso-using.adoc#cpmso-using[Managing control plane machines with control plane machine sets]
+endif::[]
 
 //Changing the Amazon Web Services instance type by using the AWS console
 include::modules/aws-console-changing-aws-instance-type.adoc[leveloffset=+3]
 
 [role="_additional-resources"]
 .Additional resources
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backing-up-etcd[Backing up etcd]
+endif
 * link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-resize.html[AWS documentation about changing the instance type]

--- a/scalability_and_performance/recommended-performance-scale-practices/recommended-infrastructure-practices.adoc
+++ b/scalability_and_performance/recommended-performance-scale-practices/recommended-infrastructure-practices.adoc
@@ -24,4 +24,6 @@ include::modules/configuring-cluster-monitoring.adoc[leveloffset=+1]
 
 * link:https://access.redhat.com/solutions/5034771[Infrastructure Nodes in OpenShift 4]
 * xref:../../scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc#planning-your-environment-according-to-object-maximums[{product-title} cluster maximums]
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets[Creating infrastructure machine sets]
+endif::[]

--- a/scalability_and_performance/using-node-tuning-operator.adoc
+++ b/scalability_and_performance/using-node-tuning-operator.adoc
@@ -23,9 +23,11 @@ include::modules/custom-tuning-example.adoc[leveloffset=+1]
 
 include::modules/node-tuning-operator-supported-tuned-daemon-plug-ins.adoc[leveloffset=+1]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/node-tuning-hosted-cluster.adoc[leveloffset=+1]
 
 include::modules/advanced-node-tuning-hosted-cluster.adoc[leveloffset=+1]
+endif::[]
 
 [role="_additional-resources"]
 .Additional resources

--- a/scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc
+++ b/scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc
@@ -12,10 +12,12 @@ include::modules/how-huge-pages-are-consumed-by-apps.adoc[leveloffset=+1]
 
 include::modules/consuming-huge-pages-resource-using-the-downward-api.adoc[leveloffset=+1]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../nodes/containers/nodes-containers-downward-api.adoc#nodes-containers-downward-api[Allowing containers to consume Downward API objects]
+endif::[]
 
 include::modules/configuring-huge-pages.adoc[leveloffset=+1]
 

--- a/scalability_and_performance/ztp_far_edge/ztp-manual-install.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-manual-install.adoc
@@ -1,0 +1,57 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="ztp-manual-install"]
+= Manually installing a {sno} cluster with ZTP
+include::_attributes/common-attributes.adoc[]
+:context: ztp-manual-install
+
+toc::[]
+
+You can deploy a managed {sno} cluster by using {rh-rhacm-first} and the assisted service.
+
+[NOTE]
+====
+If you are creating multiple managed clusters, use the `SiteConfig` method described in xref:../../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc#ztp-deploying-far-edge-sites[Deploying far edge sites with ZTP].
+====
+
+[IMPORTANT]
+====
+The target bare-metal host must meet the networking, firmware, and hardware requirements listed in xref:../../scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc#sno-configure-for-vdu[Recommended cluster configuration for vDU application workloads].
+====
+
+include::modules/ztp-generating-install-and-config-crs-manually.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-sno-du-enabling-workload-partitioning_sno-configure-for-vdu[Workload partitioning]
+
+ifndef::openshift-dedicated,openshift-rosa[]
+* xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#bmc-addressing_ipi-install-installation-workflow[BMC addressing]
+
+* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#root-device-hints_preparing-to-install-with-agent-based-installer[About root device hints]
+endif::[]
+
+* xref:../../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc#ztp-sno-siteconfig-config-reference_ztp-deploying-far-edge-sites[{sno-caps} SiteConfig CR installation reference]
+
+include::modules/ztp-creating-the-site-secrets.adoc[leveloffset=+1]
+
+include::modules/ztp-configuring-kernel-arguments-for-discovery-iso-in-manual-installations.adoc[leveloffset=+1]
+
+include::modules/ztp-manually-install-a-single-managed-cluster.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-managed-cluster-network-prereqs_sno-configure-for-vdu[Connectivity prerequisites for managed cluster networks]
+
+ifndef::openshift-dedicated,openshift-rosa[]
+* xref:../../storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc#lvms-preface-sno-ran_logical-volume-manager-storage[Deploying LVM Storage on single-node OpenShift clusters]
+endif::[]
+
+* xref:../../scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc#ztp-provisioning-lvm-storage_ztp-advanced-policy-config[Configuring LVM Storage using PolicyGenTemplate CRs]
+
+include::modules/ztp-checking-the-managed-cluster-status.adoc[leveloffset=+1]
+
+include::modules/ztp-troubleshooting-the-managed-cluster.adoc[leveloffset=+1]
+
+include::modules/ztp-installation-crs.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.15+

Issue:
[OSDOCS-3994](https://issues.redhat.com/browse/OSDOCS-3994)

Link to docs preview: https://73423--ocpdocs-pr.netlify.app/openshift-rosa/latest/scalability_and_performance/recommended-performance-scale-practices/recommended-control-plane-practices
(Updated 3/19/2024)

QE review:
- [ ] QE has approved this change.

Additional information:
The original [PR](https://github.com/openshift/openshift-docs/pull/65079) was based on 4.13. The most efficient way to get these updates in a PR based on 'main' was to start a new PR and add the changes.
