### PR TITLE
Update security-context-constraints-about.adoc

### DIFF
--- a/modules/security-context-constraints-about.adoc
+++ b/modules/security-context-constraints-about.adoc
@@ -147,7 +147,7 @@ The `restricted` SCC:
 * Ensures that pods cannot mount host directory volumes
 * Requires that a pod is run as a user in a pre-allocated range of UIDs
 * Requires that a pod is run with a pre-allocated MCS label
-* Allows Pods to use FSGroup as per SCC strategies
+* Allows pods to use the FSGroup as per SCC strategies
 * Allows pods to use any supplemental group
 
 In clusters that were upgraded from {product-title} 4.10 or earlier, this SCC is available for use by any authenticated user. The `restricted` SCC is no longer available to users of new {product-title} 4.11 or later installations, unless the access is explicitly granted.

--- a/modules/security-context-constraints-about.adoc
+++ b/modules/security-context-constraints-about.adoc
@@ -147,7 +147,7 @@ The `restricted` SCC:
 * Ensures that pods cannot mount host directory volumes
 * Requires that a pod is run as a user in a pre-allocated range of UIDs
 * Requires that a pod is run with a pre-allocated MCS label
-* Allows pods to use the FSGroup as per SCC strategies
+* Requires that a pod is run with a preallocated FSGroup
 * Allows pods to use any supplemental group
 
 In clusters that were upgraded from {product-title} 4.10 or earlier, this SCC is available for use by any authenticated user. The `restricted` SCC is no longer available to users of new {product-title} 4.11 or later installations, unless the access is explicitly granted.

--- a/modules/security-context-constraints-about.adoc
+++ b/modules/security-context-constraints-about.adoc
@@ -147,7 +147,7 @@ The `restricted` SCC:
 * Ensures that pods cannot mount host directory volumes
 * Requires that a pod is run as a user in a pre-allocated range of UIDs
 * Requires that a pod is run with a pre-allocated MCS label
-* Allows pods to use any FSGroup
+* Allows Pods to use FSGroup as per SCC strategies
 * Allows pods to use any supplemental group
 
 In clusters that were upgraded from {product-title} 4.10 or earlier, this SCC is available for use by any authenticated user. The `restricted` SCC is no longer available to users of new {product-title} 4.11 or later installations, unless the access is explicitly granted.


### PR DESCRIPTION
restricted SCC : Do not allow pods to use "any FSGroup"
restricted SCC : Allows Pods to use FSGroup as per SCC strategies

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
All RHOCP versions : 4.15, 4.14, 4.13, 4.12 , 4.11

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
DocumentationBug : https://issues.redhat.com/browse/OSDOCS-10006
restricted SCC allows Pods to use FSGroup as per SCC strategies. 
restricted SCC do not allow pods to use "any FSGroup"

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://docs.openshift.com/container-platform/4.13/authentication/managing-security-context-constraints.html#default-sccs_configuring-internal-oauth

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
In the document , it is mentioned that restricted SCC : Allows pods to use any FSGroup , which does not work.
restricted SCC allows Pods to use FSGroup as per SCC strategies. 
restricted SCC do not allow pods to use "any FSGroup"

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
