### PR TITLE
[Internal fix] OCPBUGS#30962: Modularized the Config an external LB section

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
@@ -12,4 +12,8 @@ include::modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc[leve
 
 include::modules/nw-enabling-a-provisioning-network-after-installation.adoc[leveloffset=+1]
 
-include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+1]
+// Configuring an external load balancer
+include::modules/nw-osp-services-external-load-balancer.adoc[leveloffset=+1]
+
+// Services for an external load balancer
+include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+2]

--- a/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc
+++ b/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc
@@ -88,7 +88,11 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 * See xref:../../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
 
-include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+1]
+// Services for an external load balancer
+include::modules/nw-osp-services-external-load-balancer.adoc[leveloffset=+1]
+
+// Configuring an external load balancer
+include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+2]
 
 [id="next-steps_installing-restricted-networks-installer-provisioned-vsphere"]
 == Next steps

--- a/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.adoc
+++ b/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.adoc
@@ -80,7 +80,12 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 * See xref:../../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
 
-include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+1]
+// Services for an external load balancer
+include::modules/nw-osp-services-external-load-balancer.adoc[leveloffset=+1]
+
+// Configuring an external load balancer
+include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+2]
+
 
 == Next steps
 

--- a/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations.adoc
+++ b/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations.adoc
@@ -90,7 +90,12 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 * See xref:../../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
 
-include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+1]
+// Services for an external load balancer
+include::modules/nw-osp-services-external-load-balancer.adoc[leveloffset=+1]
+
+// Configuring an external load balancer
+include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+2]
+
 include::modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc[leveloffset=+1]
 
 == Next steps

--- a/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned.adoc
+++ b/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned.adoc
@@ -55,8 +55,6 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 * See xref:../../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
 
-include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+1]
-
 == Next steps
 
 * xref:../../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].

--- a/modules/nw-osp-configuring-external-load-balancer.adoc
+++ b/modules/nw-osp-configuring-external-load-balancer.adoc
@@ -30,55 +30,17 @@ on {rh-openstack-first}
 endif::[]
 to use an external load balancer in place of the default load balancer.
 
+[IMPORTANT]
+====
+Before you configure an external load balancer, ensure that you read the "Services for an external load balancer" section.
+====
+
+Read the following prerequisites that apply to the service that you want to configure for your external load balancer.
+
 [NOTE]
 ====
 MetalLB, that runs on a cluster, functions as an external load balancer.
 ====
-
-[IMPORTANT]
-====
-Configuring an external load balancer depends on your vendor's load balancer.
-
-The information and examples in this section are for guideline purposes only. Consult the vendor documentation for more specific information about the vendor's load balancer.
-====
-
-Red Hat supports the following services for an external load balancer:
-
-* Ingress Controller
-* OpenShift API
-* OpenShift MachineConfig API
-
-You can choose whether you want to configure one or all of these services for an external load balancer. Configuring only the Ingress Controller service is a common configuration option. To better understand each service, view the following diagrams:
-
-.Example network workflow that shows an Ingress Controller operating in an {product-title} environment
-image::external-load-balancer-default.png[An image that shows an example network workflow of an Ingress Controller operating in an {product-title} environment.]
-
-.Example network workflow that shows an OpenShift API operating in an {product-title} environment
-image::external-load-balancer-openshift-api.png[An image that shows an example network workflow of an OpenShift API operating in an {product-title} environment.]
-
-.Example network workflow that shows an OpenShift MachineConfig API operating in an {product-title} environment
-image::external-load-balancer-machine-config-api.png[An image that shows an example network workflow of an OpenShift MachineConfig API operating in an {product-title} environment.]
-
-The following configuration options are supported for external load balancers:
-
-* Use a node selector to map the Ingress Controller to a specific set of nodes. You must assign a static IP address to each node in this set, or configure each node to receive the same IP address from the Dynamic Host Configuration Protocol (DHCP). Infrastructure nodes commonly receive this type of configuration.
-
-* Target all IP addresses on a subnet. This configuration can reduce maintenance overhead, because you can create and destroy nodes within those networks without reconfiguring the load balancer targets. If you deploy your ingress pods by using a machine set on a smaller network, such as a `/27` or `/28`, you can simplify your load balancer targets.
-+
-[TIP]
-====
-You can list all IP addresses that exist in a network by checking the machine config pool's resources.
-====
-
-.Considerations
-
-* For a front-end IP address, you can use the same IP address for the front-end IP address, the Ingress Controller's load balancer, and API load balancer. Check the vendor's documentation for this capability.
-
-* For a back-end IP address, ensure that an IP address for an {product-title} control plane node does not change during the lifetime of the external load balancer. You can achieve this by completing one of the following actions:
-** Assign a static IP address to each control plane node.
-** Configure each node to receive the same IP address from the DHCP every time the node requests a DHCP lease. Depending on the vendor, the DHCP lease might be in the form of an IP reservation or a static DHCP assignment.
-
-* Manually define each node that runs the Ingress Controller in the external load balancer for the Ingress Controller back-end service. For example, if the Ingress Controller moves to an undefined node, a connection outage can occur.
 
 .OpenShift API prerequisites
 

--- a/modules/nw-osp-services-external-load-balancer.adoc
+++ b/modules/nw-osp-services-external-load-balancer.adoc
@@ -1,0 +1,89 @@
+// Module included in the following assemblies:
+
+// * networking/load-balancing-openstack.adoc ( Load balancing on OpenStack)
+// * installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc (Post-installation configuration)
+// * installing/installing-vsphere-installer-provisioned.adoc(Installing a cluster)
+// * installing/installing-vsphere-installer-provisioned-customizations.adoc (Installing a cluster on vSphere with customizations)
+// * installing/installing-vsphere-installer-provisioned-network-customizations.adoc (Installing a cluster on vSphere with network customizations)
+// * installing/installing-restricted-networks-installer-provisioned-vsphere.adoc (Installing a cluster on vSphere in a restricted network)
+
+ifeval::["{context}" == "installing-vsphere-installer-provisioned"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-customizations"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == installing-restricted-networks-installer-provisioned-vsphere]
+:vsphere:
+endif::[]
+
+:_mod-docs-content-type: CONCEPT
+[id="nw-osp-services-external-load-balancer_{context}"]
+= Services for an external load balancer
+
+You can configure an {product-title} cluster
+ifeval::["{context}" == "load-balancing-openstack"]
+on {rh-openstack-first}
+endif::[]
+to use an external load balancer in place of the default load balancer.
+
+[IMPORTANT]
+====
+Configuring an external load balancer depends on your vendor's load balancer.
+
+The information and examples in this section are for guideline purposes only. Consult the vendor documentation for more specific information about the vendor's load balancer.
+====
+
+Red Hat supports the following services for an external load balancer:
+
+* Ingress Controller
+* OpenShift API
+* OpenShift MachineConfig API
+
+You can choose whether you want to configure one or all of these services for an external load balancer. Configuring only the Ingress Controller service is a common configuration option. To better understand each service, view the following diagrams:
+
+.Example network workflow that shows an Ingress Controller operating in an {product-title} environment
+image::external-load-balancer-default.png[An image that shows an example network workflow of an Ingress Controller operating in an {product-title} environment.]
+
+.Example network workflow that shows an OpenShift API operating in an {product-title} environment
+image::external-load-balancer-openshift-api.png[An image that shows an example network workflow of an OpenShift API operating in an {product-title} environment.]
+
+.Example network workflow that shows an OpenShift MachineConfig API operating in an {product-title} environment
+image::external-load-balancer-machine-config-api.png[An image that shows an example network workflow of an OpenShift MachineConfig API operating in an {product-title} environment.]
+
+The following configuration options are supported for external load balancers:
+
+* Use a node selector to map the Ingress Controller to a specific set of nodes. You must assign a static IP address to each node in this set, or configure each node to receive the same IP address from the Dynamic Host Configuration Protocol (DHCP). Infrastructure nodes commonly receive this type of configuration.
+
+* Target all IP addresses on a subnet. This configuration can reduce maintenance overhead, because you can create and destroy nodes within those networks without reconfiguring the load balancer targets. If you deploy your ingress pods by using a machine set on a smaller network, such as a `/27` or `/28`, you can simplify your load balancer targets.
++
+[TIP]
+====
+You can list all IP addresses that exist in a network by checking the machine config pool's resources.
+====
+
+Before you configure an external load balancer for your {product-title} cluster, consider the following information:
+
+* For a front-end IP address, you can use the same IP address for the front-end IP address, the Ingress Controller's load balancer, and API load balancer. Check the vendor's documentation for this capability.
+
+* For a back-end IP address, ensure that an IP address for an {product-title} control plane node does not change during the lifetime of the external load balancer. You can achieve this by completing one of the following actions:
+** Assign a static IP address to each control plane node.
+** Configure each node to receive the same IP address from the DHCP every time the node requests a DHCP lease. Depending on the vendor, the DHCP lease might be in the form of an IP reservation or a static DHCP assignment.
+
+* Manually define each node that runs the Ingress Controller in the external load balancer for the Ingress Controller back-end service. For example, if the Ingress Controller moves to an undefined node, a connection outage can occur.
+
+ifeval::["{context}" == "installing-vsphere-installer-provisioned"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-customizations"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == installing-restricted-networks-installer-provisioned-vsphere]
+:!vsphere:
+endif::[]

--- a/networking/load-balancing-openstack.adoc
+++ b/networking/load-balancing-openstack.adoc
@@ -10,4 +10,9 @@ include::modules/nw-osp-loadbalancer-limitations.adoc[leveloffset=+1]
 include::modules/nw-osp-loadbalancer-etp-local.adoc[leveloffset=+2]
 include::modules/installation-osp-api-octavia.adoc[leveloffset=+1]
 include::modules/installation-osp-api-scaling.adoc[leveloffset=+2]
-include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+1]
+
+// Services for an external load balancer
+include::modules/nw-osp-services-external-load-balancer.adoc[leveloffset=+1]
+
+// Configuring an external load balancer
+include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.16 through to 4.12

Issue:
[OCPBUGS-30962](https://issues.redhat.com/browse/OCPBUGS-30962)

Link to docs preview:
* [Installer-provisioned postinstallation configuration](https://73443--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration#nw-osp-configuring-external-load-balancer_ipi-install-post-installation-configuration)
* [Installing a cluster on vSphere in a restricted network](https://73443--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere#nw-osp-services-external-load-balancer_installing-restricted-networks-installer-provisioned-vsphere)
* [Installing a cluster on vSphere with network customizations](https://73443--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations#nw-osp-services-external-load-balancer_installing-vsphere-installer-provisioned-network-customizations)
* [Installing a cluster on vSphere with customizations](https://73443--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations#nw-osp-services-external-load-balancer_installing-vsphere-installer-provisioned-customizations)
* [Installing a cluster on vSphere](https://73443--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned#nw-osp-services-external-load-balancer_installing-vsphere-installer-provisioned)
* [Load balancing on RHOSP](https://73443--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/load-balancing-openstack#nw-osp-services-external-load-balancer_load-balancing-openstack)

Additional information:
See Jira for the reason for this PR.
