### PR TITLE
OSDOCS-9722: Adds 4.15.3 release notes MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -223,3 +223,10 @@ FIPS mode::
 
 Adds OLM image references in dedicated file::
 * Previously, image references for embedding MicroShift OLM in a RHEL for Edge image were part of the `microshift-olm` RPM package. The application package had to be downloaded and run to retrieve the information. With this release, image references are now in the dedicated `microshift-olm-release-info` RPM package for easier use. (link:https://issues.redhat.com/browse/OCPBUGS-29246[OCPBUGS-29246])
+
+[id="microshift-4-15-3-dp"]
+=== RHBA-2024:1257 - {microshift-short} 4.15.3 bug fix and enhancement update advisory
+
+Issued: 2024-03-20
+
+{product-title} release 4.15.3 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1257[RHBA-2024:1257] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1255[RHSA-2024:1255] advisory.


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-9722](https://issues.redhat.com/browse/OSDOCS-9722)

Link to docs preview:
[MicroShift 4.15.3 async release note](https://73445--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes#microshift-4-15-3-dp)

QE review:
- N/A


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
