### PR TITLE
OCPBUGS-31097: etcd restore procedure list of steps is destroyed

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -298,9 +298,7 @@ csr-4hl85   13m    kubernetes.io/kube-apiserver-client-kubelet   system:servicea
 csr-zhhhp   3m8s   kubernetes.io/kube-apiserver-client-kubelet   system:serviceaccount:openshift-machine-config-operator:node-bootstrapper   Pending <2>
 ...
 ----
-<1> A pending kubelet service 
-
-CSR (for user-provisioned installations).
+<1> A pending kubelet service CSR (for user-provisioned installations).
 <2> A pending `node-bootstrapper` CSR.
 
 .. Review the details of a CSR to verify that it is valid by running:


### PR DESCRIPTION
A tiny tipo seems to have broken the nested list starting step 11

Version(s):
4.15, 4.14

Issue:
https://issues.redhat.com/browse/OCPBUGS-31097

Link to docs preview:

https://73447--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state

QE review:
- ~[ ] QE has approved this change.~ (not needed because this is formatting issue)


Additional information:

Currently, only 4.14 and 4.15 are impacted because 4.13 and lower require manual merge (due to different OVN-Kubernetes related steps). However, if this bug is not fixed, this issue might eventually be backported to 4.13 and lower if we are not very careful.
