### PR TITLE
CMA update the Supported Version table in release notes

### DIFF
--- a/nodes/cma/nodes-cma-autoscaling-custom-rn.adoc
+++ b/nodes/cma/nodes-cma-autoscaling-custom-rn.adoc
@@ -31,19 +31,19 @@ The following table defines the Custom Metrics Autoscaler Operator versions for 
 |General availability
 
 |2.11.2
+|4.15
+|General availability
+
+|2.11.2
+|4.14
+|General availability
+
+|2.11.2
 |4.13
 |General availability
 
 |2.11.2
 |4.12
-|General availability
-
-|2.11.2
-|4.11
-|General availability
-
-|2.11.2
-|4.10
 |General availability
 |===
 


### PR DESCRIPTION
Need to update the Supported Version table in Custom Metrics Autoscaler release notes to include current OCP versions.

[Per Slack conversation](https://redhat-internal.slack.com/archives/C02F1J9UJJD/p1710940854590759)

https://github.com/openshift/openshift-docs/pull/73467

Preview:
Node -> CMA -> Release Notes -> [Supported Versions](https://73467--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-rn#nodes-pods-autoscaling-custom-rn-versions_nodes-cma-autoscaling-custom-removing)  [Current docs](https://docs.openshift.com/container-platform/4.15/nodes/cma/nodes-cma-autoscaling-custom-rn.html#nodes-pods-autoscaling-custom-rn-versions_nodes-cma-autoscaling-custom-removing)