### PR TITLE
OBSDOCS-890: Fix bugs in syslog docs

### DIFF
--- a/logging/log_collection_forwarding/cluster-logging-collector.adoc
+++ b/logging/log_collection_forwarding/cluster-logging-collector.adoc
@@ -25,9 +25,9 @@ The service name is generated based on the following:
 * For multi log forwarder `ClusterLogForwarder` CR deployments, the service name is in the format `<ClusterLogForwarder_CR_name>-<input_name>`. For example, `example-http-receiver`.
 * For legacy `ClusterLogForwarder` CR deployments, meaning those named `instance` and located in the `openshift-logging` namespace, the service name is in the format `collector-<input_name>`. For example, `collector-http-receiver`.
 
+include::modules/log-collector-http-server.adoc[leveloffset=+2]
 //include::modules/log-collector-rsyslog-server.adoc[leveloffset=+2]
 // uncomment for 5.9 release
-include::modules/log-collector-http-server.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/log-collector-rsyslog-server.adoc
+++ b/modules/log-collector-rsyslog-server.adoc
@@ -19,12 +19,15 @@ In {logging} version 5.9 and newer versions, you can configure your log collecto
 
 . Modify the `ClusterLogForwarder` CR to add configuration for the `syslog` receiver input:
 +
+--
+.Example `ClusterLogForwarder` CR if you are using a multi log forwarder deployment
 [source,yaml]
 ----
-apiVersion: logging.openshift.io/v1beta1
+apiVersion: logging.openshift.io/v1
 kind: ClusterLogForwarder
 metadata:
-# ...
+  name: example
+  namespace: <namespace>
 spec:
   serviceAccountName: <service_account_name>
   inputs:
@@ -43,6 +46,35 @@ spec:
 <2> Specify the input receiver type as `syslog`.
 <3> Optional: Specify the port that the input receiver listens on. This must be a value between `1024` and `65535`. The default value is `10514` if this is not specified.
 <4> Configure a pipeline for your input receiver.
+--
++
+--
+.Example `ClusterLogForwarder` CR if you are using a legacy deployment
+[source,yaml]
+----
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: instance
+  namespace: openshift-logging
+spec:
+  inputs:
+    - name: syslog-receiver # <1>
+      receiver:
+        type: syslog # <2>
+        syslog:
+          port: 10514 # <3>
+  pipelines: # <4>
+  - inputRefs:
+    - syslog-receiver
+    name: syslog-pipeline
+# ...
+----
+<1> Specify a name for your input receiver.
+<2> Specify the input receiver type as `syslog`.
+<3> Optional: Specify the port that the input receiver listens on. This must be a value between `1024` and `65535`. The default value is `10514` if this is not specified.
+<4> Configure a pipeline for your input receiver.
+--
 
 . Apply the changes to the `ClusterLogForwarder` CR by running the following command:
 +


### PR DESCRIPTION
Version(s):
4.13+ (logging 5.9+)

Issue:
https://issues.redhat.com/browse/OBSDOCS-890

Link to docs preview:
https://73478--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_collection_forwarding/cluster-logging-collector#cluster-logging-collector-input-receivers

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
