### PR TITLE
OSSM-6124 2.5 doc cleanup and style fixes

### DIFF
--- a/modules/ossm-configuring-distr-tracing-tempo.adoc
+++ b/modules/ossm-configuring-distr-tracing-tempo.adoc
@@ -49,7 +49,7 @@ spec:
   members:
     - tracing-system
 ----
-<1> The `spec.tracing.type` setting defines a deprecated Distributed Tracing Jaeger instance. Set `spec.tracing.type` to `None` when connecting to a TempoStack using an `extensionProvider` setting.
+<1> The `spec.tracing.type` setting defines a deprecated distributed tracing Jaeger instance. Set `spec.tracing.type` to `None` when connecting to a TempoStack using an `extensionProvider` setting.
 +
 [NOTE]
 ====


### PR DESCRIPTION
[OSSM-6124](https://issues.redhat.com//browse/OSSM-6124) 2.5 doc cleanup and style fixes

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSSM-6124

Link to docs preview:
https://73482--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-observability#ossm-configuring-distr-tracing-tempo_observability

QE review:
QE is not necessary. Fixing capitalization of "Distributed Tracing" so it reads "distributed tracing."

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
