### PR TITLE
ROX#19537: update requirements for secured cluster collector

### DIFF
--- a/modules/default-requirements-secured-cluster-services.adoc
+++ b/modules/default-requirements-secured-cluster-services.adoc
@@ -152,7 +152,7 @@ By default, the collector service runs 3 replicas. The following tables list the
 
 | *Limit*
 | 2.75 cores
-| 5000 MiB
+| 3500 MiB
 |===
 
 == Scanner V4 (optional)


### PR DESCRIPTION
Version(s):

- merge to `rhacs-docs`
- cherry pick to `rhacs-docs-4.4`
- cherry pick to `rhacs-docs-4.3`

[Issue](https://issues.redhat.com/browse/ROX-19537)

[Link to docs preview
](https://73487--docspreview.netlify.app/openshift-acs/latest/installing/acs-default-requirements#default-requirements-secured-cluster-services-collector_acs-default-requirements)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

First issue in ticket was aready addressed in the doc. This fixes the math error.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
