### PR TITLE
OCPBUGS-29959:fixes two typos in OVN-K docs

### DIFF
--- a/modules/nw-ovn-kubernetes-list-resources.adoc
+++ b/modules/nw-ovn-kubernetes-list-resources.adoc
@@ -79,7 +79,7 @@ $ oc get pods ovnkube-node-bcvts -o jsonpath='{.spec.containers[*].name}' -n ope
 ----
 ovn-controller ovn-acl-logging kube-rbac-proxy-node kube-rbac-proxy-ovn-metrics northd nbdb sbdb ovnkube-controller
 ----
-The `ovnkube-node` pod is made up of several containers. It is responsible for hosting the northbound database (`nbdb` container), the southbound database (`sbdb` container), the north daemon (`northd` container), `ovn-controller` and the `ovnkube-controller`container. The `ovnkube-controller` container watches for API objects like pods, egress IPs, namespaces, services, endpoints, egress firewall, and network policies. It is also responsible for allocating pod IP from the available subnet pool for that node.
+The `ovnkube-node` pod is made up of several containers. It is responsible for hosting the northbound database (`nbdb` container), the southbound database (`sbdb` container), the north daemon (`northd` container), `ovn-controller` and the `ovnkube-controller` container. The `ovnkube-controller` container watches for API objects like pods, egress IPs, namespaces, services, endpoints, egress firewall, and network policies. It is also responsible for allocating pod IP from the available subnet pool for that node.
 
 . List all the containers in the `ovnkube-control-plane` pods by running the following command:
 +

--- a/modules/nw-ovn-kubernetes-readiness-probes.adoc
+++ b/modules/nw-ovn-kubernetes-readiness-probes.adoc
@@ -27,7 +27,7 @@ $ oc get pods -n openshift-ovn-kubernetes -l app=ovnkube-node \
 The readiness probe for the northbound and southbound database containers in the `ovnkube-node` pod checks for the health of the databases and the `ovnkube-controller` container.
 
 +
-The `ovnkube-node` container in the `ovnkube-node` pod has a readiness probe to verify the presence of the OVN-Kubernetes CNI configuration file, the absence of which would indicate that the pod is not running or is not ready to accept requests to configure pods.
+The `ovnkube-controller` container in the `ovnkube-node` pod has a readiness probe to verify the presence of the OVN-Kubernetes CNI configuration file, the absence of which would indicate that the pod is not running or is not ready to accept requests to configure pods.
 
 . Show all events including the probe failures, for the namespace by using the following command:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+ 
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OCPBUGS-29959
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://73503--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/ovn-kubernetes-architecture-assembly#:~:text=and%20the%20ovnkube%2Dcontroller%20container.
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
PTAL @anuragthehatter 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
