### PR TITLE
OCPBUGS-31247: Remove "(for user-provisioned installations)" reference

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -298,8 +298,8 @@ csr-4hl85   13m    kubernetes.io/kube-apiserver-client-kubelet   system:servicea
 csr-zhhhp   3m8s   kubernetes.io/kube-apiserver-client-kubelet   system:serviceaccount:openshift-machine-config-operator:node-bootstrapper   Pending <2>
 ...
 ----
-<1> A pending kubelet service CSR (for user-provisioned installations).
-<2> A pending `node-bootstrapper` CSR.
+<1> A pending kubelet serving CSR, requested by the node for the kubelet serving endpoint.
+<2> A pending kubelet client CSR, requested with the `node-bootstrapper` node bootstrap credentials.
 
 .. Review the details of a CSR to verify that it is valid by running:
 +


### PR DESCRIPTION
This PR removes the above mentioned parenthesis from the etcd restore procedure, because it goes against documentation guidelines of avoiding parenthesis. It also improves the technical description of the CSRs mentioned at that step.

Version(s):
4.16,4.15, 4.14

Issue:
https://issues.redhat.com/browse/OCPBUGS-31247

Link to docs preview:

https://73512--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state

QE review:
- [x] QE has approved this change.

Additional information:

(none)