### PR TITLE
[enterprise-4.12] OCPBUGS-24557: Explain spec.clusterImageSetNameRef and spec.clusters.clusterImageSetNameRef

### DIFF
--- a/modules/ztp-precaching-ztp-config.adoc
+++ b/modules/ztp-precaching-ztp-config.adoc
@@ -29,7 +29,6 @@ spec:
   sshPublicKey: "ssh-rsa ..."
   clusters:
   - clusterName: "sno-worker-0"
-    clusterImageSetNameRef: "eko4-img4.11.5-x86-64-appsub"
     clusterLabels:
       group-du-sno: ""
       common-411: true

--- a/modules/ztp-sno-siteconfig-config-reference.adoc
+++ b/modules/ztp-sno-siteconfig-config-reference.adoc
@@ -1,0 +1,79 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ztp-sno-siteconfig-config-reference_{context}"]
+= {sno-caps} SiteConfig CR installation reference
+
+.SiteConfig CR installation options for {sno} clusters
+[cols="1,3", options="header"]
+|====
+|SiteConfig CR field
+|Description
+
+|`metadata.name`
+|Set `name` to `assisted-deployment-pull-secret` and create the `assisted-deployment-pull-secret` CR in the same namespace as the `SiteConfig` CR.
+
+|`spec.clusterImageSetNameRef`
+|Configure the image set available on the hub cluster for all the clusters in the site.
+To see the list of supported versions on your hub cluster, run `oc get clusterimagesets`.
+
+|`installConfigOverrides`
+a|Set the `installConfigOverrides` field to enable or disable optional components prior to cluster installation.
+[IMPORTANT]
+====
+Use the reference configuration as specified in the example `SiteConfig` CR.
+Adding additional components back into the system might require additional reserved CPU capacity.
+====
+
+|`spec.clusters.clusterLabels`
+|Configure cluster labels to correspond to the `bindingRules` field in the `PolicyGenTemplate` CRs that you define.
+For example, `policygentemplates/common-ranGen.yaml` applies to all clusters with `common: true` set, `policygentemplates/group-du-sno-ranGen.yaml` applies to all clusters with `group-du-sno: ""` set.
+
+|`spec.clusters.crTemplates.KlusterletAddonConfig`
+|Optional. Set `KlusterletAddonConfig` to `KlusterletAddonConfigOverride.yaml to override the default `KlusterletAddonConfig` that is created for the cluster.
+
+|`spec.clusters.nodes.hostName`
+|For single-node deployments, define a single host.
+For three-node deployments, define three hosts.
+For standard deployments, define three hosts with `role: master` and two or more hosts defined with `role: worker`.
+
+|`spec.clusters.nodes.bmcAddress`
+|BMC address that you use to access the host. Applies to all cluster types. {ztp} supports iPXE and virtual media booting by using Redfish or IPMI protocols. To use iPXE booting, you must use {rh-rhacm} 2.8 or later. For more information about BMC addressing, see the "Additional resources" section.
+
+|`spec.clusters.nodes.bmcAddress`
+a|BMC address that you use to access the host.
+Applies to all cluster types.
+{ztp} supports iPXE and virtual media booting by using Redfish or IPMI protocols.
+To use iPXE booting, you must use {rh-rhacm} 2.8 or later.
+For more information about BMC addressing, see the "Additional resources" section.
+[NOTE]
+====
+In far edge Telco use cases, only virtual media is supported for use with {ztp}.
+====
+
+|`spec.clusters.nodes.bmcCredentialsName`
+|Configure the `bmh-secret` CR that you separately create with the host BMC credentials.
+When creating the `bmh-secret` CR, use the same namespace as the `SiteConfig` CR that provisions the host.
+
+|`spec.clusters.nodes.bootMode`
+|Set the boot mode for the host to `UEFI`.
+The default value is `UEFI`. Use `UEFISecureBoot` to enable secure boot on the host.
+
+|`spec.clusters.nodes.rootDeviceHints`
+|Specifies the device for deployment. Identifiers that are stable across reboots are recommended, for example, `wwn: <disk_wwn>` or `deviceName: /dev/disk/by-path/<device_path>`. For a detailed list of stable identifiers, see the "About root device hints section".
+
+|`spec.clusters.nodes.diskPartition`
+|Optional. The provided example `diskPartition` is used to configure additional disk partitions.
+
+|`spec.clusters.nodes.cpuset`
+|Configure `cpuset` to match value that you set in the cluster `PerformanceProfile` CR `spec.cpu.reserved` field for workload partitioning.
+
+|`spec.clusters.nodes.nodeNetwork`
+|Configure the network settings for the node.
+
+|`spec.clusters.nodes.nodeNetwork.config.interfaces.ipv6`
+|Configure the IPv6 address for the host.
+For {sno} clusters with static IP addresses, the node-specific API and Ingress IPs should be the same.
+|====

--- a/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc
@@ -36,6 +36,8 @@ include::modules/ztp-deploying-a-site.adoc[leveloffset=+1]
 
 * xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#bmc-addressing_ipi-install-installation-workflow[BMC addressing]
 
+include::modules/ztp-sno-siteconfig-config-reference.adoc[leveloffset=+2]
+
 include::modules/ztp-monitoring-installation-progress.adoc[leveloffset=+1]
 
 include::modules/ztp-troubleshooting-ztp-gitops-installation-crs.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-24557
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 

https://73516--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites#ztp-sno-siteconfig-config-reference_ztp-deploying-far-edge-sites

https://73516--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-precaching-tool#ztp-pre-caching-config-con_pre-caching

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
