### PR TITLE
RHDEVDOCS-5900 Update changes to the OpenShift mirror registry links

### DIFF
--- a/installing_gitops/installing-argocd-gitops-cli.adoc
+++ b/installing_gitops/installing-argocd-gitops-cli.adoc
@@ -17,16 +17,16 @@ Both the compressed archives and the RPMs contain the `argocd` executable binary
 ====
 
 // Install GitOps argocd CLI on Linux
-include::modules/gitops-installing-argocd-cli-on-linux.adoc[leveloffset=+1]
+// include::modules/gitops-installing-argocd-cli-on-linux.adoc[leveloffset=+1]
 
 // Install GitOps argocd CLI on Linux using RPM
 include::modules/gitops-installing-argocd-cli-on-linux-using-rpm.adoc[leveloffset=+1]
 
 //Install GitOps argocd CLI on Windows
-include::modules/gitops-installing-argocd-cli-on-windows.adoc[leveloffset=+1]
+// include::modules/gitops-installing-argocd-cli-on-windows.adoc[leveloffset=+1]
 
 //Install GitOps argocd CLI on macOS
-include::modules/gitops-installing-argocd-cli-on-macos.adoc[leveloffset=+1]
+// include::modules/gitops-installing-argocd-cli-on-macos.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources_installing-argocd-gitops-cli"]

--- a/modules/gitops-installing-argocd-cli-on-linux.adoc
+++ b/modules/gitops-installing-argocd-cli-on-linux.adoc
@@ -12,13 +12,13 @@ For Linux distributions, you can download the {gitops-shortname} `argocd` CLI as
 
 . Download the relevant CLI tool.
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/1.12.0/argocd-cli-darwin-amd64.tar.gz[Linux (x86_64, amd64)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/v1.12.0/argocd-linux-amd64.tar.gz[Linux (x86_64, amd64)]
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/1.12.0/argocd-cli-darwin-s390x.tar.gz[Linux on {ibmzProductName} and {linuxoneProductName} (s390x)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/v1.12.0/argocd-linux-s390x.tar.gz[Linux on {ibmzProductName} and {linuxoneProductName} (s390x)]
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/1.12.0/argocd-cli-darwin-ppc64le.tar.gz[Linux on {ibmpowerProductName} (ppc64le)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/v1.12.0/argocd-linux-ppc64le.tar.gz[Linux on {ibmpowerProductName} (ppc64le)]
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/1.12.0/argocd-cli-darwin-arm64.tar.gz[Linux on ARM (aarch64, arm64)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/v1.12.0/argocd-linux-arm64.tar.gz[Linux on ARM (aarch64, arm64)]
 
 +
 You can also download any version of the {gitops-shortname} `argocd` CLI by navigating to the corresponding directory for the version that you want in the link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/[`argocd` CLI client download mirror].

--- a/modules/gitops-installing-argocd-cli-on-macos.adoc
+++ b/modules/gitops-installing-argocd-cli-on-macos.adoc
@@ -12,9 +12,9 @@ For macOS, you can download the {gitops-shortname} `argocd` CLI as a `tar.gz` ar
 
 . Download the relevant CLI tool.
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/1.12.0/argocd-cli-darwin-amd64.tar.gz[macOS on Intel]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/v1.12.0/argocd-darwin-amd64.tar.gz[macOS on Intel]
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/1.12.0/argocd-cli-darwin-arm64.tar.gz[macOS on ARM]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/v1.12.0/argocd-darwin-arm64.tar.gz[macOS on ARM]
 
 +
 You can also download any version of the {gitops-shortname} `argocd` CLI by navigating to the corresponding directory for the version that you want in the link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/[`argocd` CLI client download mirror].

--- a/modules/gitops-installing-argocd-cli-on-windows.adoc
+++ b/modules/gitops-installing-argocd-cli-on-windows.adoc
@@ -10,7 +10,7 @@ For Windows, you can download the {gitops-shortname} `argocd` CLI as a compresse
 
 .Procedure
 
-. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/1.12.0/argocd-cli-windows-amd64.zip[CLI tool].
+. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/v1.12.0/argocd-windows-amd64.zip[CLI tool].
 
 +
 You can also download any version of the {gitops-shortname} `argocd` CLI by navigating to the corresponding directory for the version that you want in the link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/[`argocd` CLI client download mirror].


### PR DESCRIPTION
Jira issue : [RHDEVDOCS-5900](https://issues.redhat.com/browse/RHDEVDOCS-5900)

Aligned team: DevTools 
Cherry-pick to versions: `gitops-docs-1.12`

Docs preview:

- [Installing the GitOps CLI](https://73529--docspreview.netlify.app/openshift-gitops/latest/installing_gitops/installing-argocd-gitops-cli)

SME review: Completed @anandf

QE review: Completed @varshab1210 

Peer review: Completed @shipsing 