### PR TITLE
OSDOCS-10010: Agent basic install procedure

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -413,7 +413,9 @@ Topics:
     File: preparing-to-install-with-agent-based-installer
   - Name: Understanding disconnected installation mirroring
     File: understanding-disconnected-installation-mirroring
-  - Name: Installing a cluster with Agent-based Installer
+  - Name: Installing a cluster
+    File: installing-with-agent-basic
+  - Name: Installing a cluster with customizations
     File: installing-with-agent-based-installer
   - Name: Preparing PXE assets for OCP
     File: prepare-pxe-assets-agent

--- a/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
@@ -1,12 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-with-agent-based-installer"]
-= Installing an {product-title} cluster with the Agent-based Installer
+= Installing a cluster with customizations
 include::_attributes/common-attributes.adoc[]
 :context: installing-with-agent-based-installer
 
 toc::[]
 
-Use the following procedures to install an {product-title} cluster using the Agent-based Installer.
+Use the following procedures to install an {product-title} cluster with customizations using the Agent-based Installer.
 
 [id="prerequisites_{context}"]
 == Prerequisites

--- a/installing/installing_with_agent_based_installer/installing-with-agent-basic.adoc
+++ b/installing/installing_with_agent_based_installer/installing-with-agent-basic.adoc
@@ -1,0 +1,41 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="installing-with-agent-basic"]
+= Installing a cluster
+include::_attributes/common-attributes.adoc[]
+:context: installing-with-agent-basic
+
+toc::[]
+
+You can install a basic {product-title} cluster using the Agent-based Installer.
+
+For procedures that include optional customizations you can make while using the Agent-based Installer, see xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-with-agent-based-installer[Installing a cluster with customizations].
+
+[id="prerequisites_{context}"]
+== Prerequisites
+
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* If you use a firewall or proxy, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+
+[id="installing-ocp-agent_{context}"]
+== Installing {product-title} with the Agent-based Installer
+
+The following procedures deploy a single-node {product-title} in a disconnected environment. You can use these procedures as a basis and modify according to your requirements.
+
+// Downloading the Agent-based Installer
+include::modules/installing-ocp-agent-download.adoc[leveloffset=+2]
+
+// Creating the configuration inputs
+include::modules/installing-ocp-agent-basic-inputs.adoc[leveloffset=+2]
+
+// Creating and booting the agent image
+include::modules/installing-ocp-agent-boot.adoc[leveloffset=+2]
+
+// Verifying that the current installation host can pull release images
+include::modules/installing-ocp-agent-tui.adoc[leveloffset=+2]
+
+// Tracking and verifying installation progress
+include::modules/installing-ocp-agent-verify.adoc[leveloffset=+2]
+
+// Gathering log data from a failed Agent-based installation
+include::modules/installing-ocp-agent-gather-log.adoc[leveloffset=+1]

--- a/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
@@ -111,4 +111,6 @@ include::modules/validations-before-agent-iso-creation.adoc[leveloffset=+1]
 [id="agent-based-installation-next-steps_{context}"]
 == Next steps
 
-* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-with-agent-based-installer[Installing a cluster with the Agent-based Installer]
+* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-basic.adoc#installing-with-agent-basic[Installing a cluster]
+
+* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-with-agent-based-installer[Installing a cluster with customizations]

--- a/modules/installing-ocp-agent-basic-inputs.adoc
+++ b/modules/installing-ocp-agent-basic-inputs.adoc
@@ -1,0 +1,110 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_with_agent_based_installer/installing-with-agent-basic.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="installing-ocp-agent-basic-inputs_{context}"]
+= Creating the configuration inputs
+
+
+You must create the configuration files that are used by the installation program to create the agent image.
+
+.Procedure
+
+. Place the `openshift-install` binary in a directory that is on your PATH.
+
+. Create a directory to store the install configuration by running the following command:
++
+[source,terminal]
+----
+$ mkdir ~/<directory_name>
+----
+
+. Create the `install-config.yaml` file by running the following command:
++
+--
+[source,terminal]
+----
+$ cat << EOF > ./my-cluster/install-config.yaml
+apiVersion: v1
+baseDomain: test.example.com
+compute:
+- architecture: amd64 // <1>
+  hyperthreading: Enabled
+  name: worker
+  replicas: 0
+controlPlane:
+  architecture: amd64
+  hyperthreading: Enabled
+  name: master
+  replicas: 1
+metadata:
+  name: sno-cluster // <2>
+networking:
+  clusterNetwork:
+  - cidr: fd01::/48
+    hostPrefix: 64
+  machineNetwork:
+  - cidr: fd2e:6f44:5dd8:c956::/120
+  networkType: OVNKubernetes // <3>
+  serviceNetwork:
+  - fd02::/112
+platform: <4>
+  none: {}
+pullSecret: '<pull_secret>' // <5>
+sshKey: '<ssh_pub_key>' // <6>
+additionalTrustBundle: | // <7>
+  -----BEGIN CERTIFICATE-----
+  ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+  -----END CERTIFICATE-----
+imageContentSources: // <8>
+- mirrors:
+  - <local_registry>/<local_repository_name>/release
+  source: quay.io/openshift-release-dev/ocp-release
+- mirrors:
+  - <local_registry>/<local_repository_name>/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+EOF
+----
+<1> Specify the system architecture. Valid values are `amd64`, `arm64`, `ppc64le`, and `s390x`.
++
+If you are using the release image with the `multi` payload, you can install the cluster on different architectures such as `arm64`, `amd64`, `s390x`, and `ppc64le`. Otherwise, you can install the cluster only on the `release architecture` displayed in the output of the `openshift-install version` command. For more information, see "Verifying the supported architecture for installing an Agent-based Installer cluster".
+<2> Required. Specify your cluster name.
+<3> The cluster network plugin to install. The default value `OVNKubernetes` is the only supported value.
+<4> Specify your platform.
++
+[NOTE]
+====
+For bare metal platforms, host settings made in the platform section of the `install-config.yaml` file are used by default, unless they are overridden by configurations made in the `agent-config.yaml` file.
+====
+<5> Specify your pull secret.
+<6> Specify your SSH public key.
+<7> Provide the contents of the certificate file that you used for your mirror registry.
+The certificate file can be an existing, trusted certificate authority or the self-signed certificate that you generated for the mirror registry.
+You must specify this parameter if you are using a disconnected mirror registry.
+<8> Provide the `imageContentSources` section according to the output of the command that you used to mirror the repository.
+You must specify this parameter if you are using a disconnected mirror registry.
++
+[IMPORTANT]
+====
+* When using the `oc adm release mirror` command, use the output from the `imageContentSources` section.
+* When using the `oc mirror` command, use the `repositoryDigestMirrors` section of the `ImageContentSourcePolicy` file that results from running the command.
+* The `ImageContentSourcePolicy` resource is deprecated.
+====
+--
+
+. Create the `agent-config.yaml` file by running the following command:
++
+[source,terminal]
+----
+$ cat > agent-config.yaml << EOF
+apiVersion: v1beta1
+kind: AgentConfig
+metadata:
+  name: sno-cluster
+rendezvousIP: fd2e:6f44:5dd8:c956::50 // <1>
+EOF
+----
++
+<1> This IP address is used to determine which node performs the bootstrapping process as well as running the `assisted-service` component.
+You must provide the rendezvous IP address when you do not specify at least one host IP address in the `networkConfig` parameter. If this address is not provided, one IP address is selected from the provided host `networkConfig` parameter.

--- a/modules/installing-ocp-agent-boot.adoc
+++ b/modules/installing-ocp-agent-boot.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/installing-with-agent-based-installer/installing-with-agent-based-installer.adoc
+// * installing/installing_with_agent_based_installer/installing-with-agent-basic.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="installing-ocp-agent-boot_{context}"]

--- a/modules/installing-ocp-agent-download.adoc
+++ b/modules/installing-ocp-agent-download.adoc
@@ -3,6 +3,7 @@
 // * installing/installing-with-agent-based-installer/installing-with-agent-based-installer.adoc
 // * installing/installing_with_agent_based_installer/prepare-pxe-infra-agent.adoc
 // * installing/installing_with_agent_based_installer/installing-using-iscsi.adoc
+// * installing/installing_with_agent_based_installer/installing-with-agent-basic.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="installing-ocp-agent-retrieve_{context}"]

--- a/modules/installing-ocp-agent-gather-log.adoc
+++ b/modules/installing-ocp-agent-gather-log.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/installing-with-agent-based-installer/installing-with-agent-based-installer.adoc
+// * installing/installing_with_agent_based_installer/installing-with-agent-basic.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="installing-ocp-agent-gather-log_{context}"]

--- a/modules/installing-ocp-agent-tui.adoc
+++ b/modules/installing-ocp-agent-tui.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/installing-with-agent-based-installer/installing-with-agent-based-installer.adoc
+// * installing/installing_with_agent_based_installer/installing-with-agent-basic.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="installing-ocp-agent-tui_{context}"]

--- a/modules/installing-ocp-agent-verify.adoc
+++ b/modules/installing-ocp-agent-verify.adoc
@@ -1,6 +1,11 @@
 // Module included in the following assemblies:
 //
 // * installing/installing-with-agent-based-installer/installing-with-agent-based-installer.adoc
+// * installing/installing_with_agent_based_installer/installing-with-agent-basic.adoc
+
+ifeval::["{context}" == "installing-with-agent-basic"]
+:basic:
+endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="installing-ocp-agent-verify_{context}"]
@@ -59,6 +64,8 @@ INFO Access the OpenShift web-console here: https://console-openshift-console.ap
 ----
 
 
+// Note for a later doc effort - now that there is a section for ztp manifests, maybe this NOTE can be moved to that section?
+ifndef::basic[]
 [NOTE]
 ====
 If you are using the optional method of {ztp} manifests, you can configure IP address endpoints for cluster nodes through the `AgentClusterInstall.yaml` file in three ways:
@@ -92,3 +99,8 @@ networking:
   - fd03::/112
   networkType: OVNKubernetes
 ----
+endif::basic[]
+
+ifeval::["{context}" == "installing-with-agent-basic"]
+:!basic:
+endif::[]


### PR DESCRIPTION
[OSDOCS-10010](https://issues.redhat.com/browse/OSDOCS-10010)

Versions: 4.13+

This PR creates a new Agent install assembly that contains only the bare minimum needed to complete the installation. The current installation page will be renamed to "installing a cluster with customizations", and thus can be expanded upon with further optional steps without as much concern that the workflow might be too burdensome to navigate for users wanting to do a basic install.

QE review:
- [x] QE has approved this change.

Preview: 
[Installing a cluster](https://73553--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-basic)
[Installing a cluster with customizations](https://73553--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer)