### PR TITLE
OCPBUGS-30994: Removing bad hyphen and removing overlapping CPUs

### DIFF
--- a/modules/cnf-adjusting-nic-queues-with-the-performance-profile.adoc
+++ b/modules/cnf-adjusting-nic-queues-with-the-performance-profile.adoc
@@ -67,7 +67,7 @@ metadata:
   name: manual
 spec:
   cpu:
-    isolated: 3-51,54-103
+    isolated: 3-51,55-103
     reserved: 0-2,52-54
   net:
     userLevelNetworking: true
@@ -85,7 +85,7 @@ metadata:
   name: manual
 spec:
   cpu:
-    isolated: 3-51,54-103
+    isolated: 3-51,55-103
     reserved: 0-2,52-54
   net:
     userLevelNetworking: true
@@ -93,7 +93,7 @@ spec:
     - interfaceName: "eth0"
     - interfaceName: "eth1"
     - vendorID: "0x1af4"
-    - deviceID: "0x1000"
+      deviceID: "0x1000"
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""
 ----
@@ -108,7 +108,7 @@ metadata:
   name: manual
 spec:
   cpu:
-    isolated: 3-51,54-103
+    isolated: 3-51,55-103
     reserved: 0-2,52-54
   net:
     userLevelNetworking: true
@@ -128,7 +128,7 @@ metadata:
   name: manual
 spec:
   cpu:
-    isolated: 3-51,54-103
+    isolated: 3-51,55-103
     reserved: 0-2,52-54
   net:
     userLevelNetworking: true
@@ -148,14 +148,14 @@ metadata:
   name: manual
 spec:
   cpu:
-    isolated: 3-51,54-103
+    isolated: 3-51,55-103
     reserved: 0-2,52-54
   net:
     userLevelNetworking: true
     devices:
     - interfaceName: "eth0"
     - vendorID: "0x1af4"
-    - deviceID: "0x1000"
+      deviceID: "0x1000"
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""
 ----


### PR DESCRIPTION
OCPBUGS-30994: Fixing bad YAML and overlapping CPUs

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-30994

Link to docs preview:
https://73561--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-low-latency-tuning.html#adjusting-nic-queues-with-the-performance-profile_cnf-master

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
