### PR TITLE
OSDOCS-10015 OCP z-stream RNs 4.11.59

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -3958,3 +3958,22 @@ $ oc adm release info 4.11.58 --pullspecs
 ==== Updating
 
 To update an {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-11-59"]
+=== RHSA-2024:1464 {product-title} 4.11.59 bug fix update and security update
+
+Issued: 2024-03-27
+
+{product-title} release 4.11.59, which includes security updates, is now available. Bug fixes included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2024:1464[RHSA-2024:1464] advisory. RPM packages included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:1466[RHBA-2024:1466] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.59 --pullspecs
+----
+
+[id="ocp-4-11-59-upgrading"]
+==== Updating
+
+To update an {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s): 4.11
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-10015](https://issues.redhat.com/browse/OSDOCS-10015)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Preview](https://73571--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes#ocp-4-11-59)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
Not needed
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Errata links will not work until merge day, March 27. This is a security update going out despite 4.11 being out of support.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
