### PR TITLE
OCPBUGS#31264: Warning to not use htpasswd in production

### DIFF
--- a/modules/identity-provider-htpasswd-about.adoc
+++ b/modules/identity-provider-htpasswd-about.adoc
@@ -6,3 +6,8 @@
 = About htpasswd authentication
 
 Using htpasswd authentication in {product-title} allows you to identify users based on an htpasswd file. An htpasswd file is a flat file that contains the user name and hashed password for each user. You can use the `htpasswd` utility to create this file.
+
+[WARNING]
+====
+Do not use htpasswd authentication in {product-title} for production environments. Use htpasswd authentication only for development environments.
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-31264

Link to docs preview:
https://73572--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/identity_providers/configuring-htpasswd-identity-provider#identity-provider-htpasswd-about_configuring-htpasswd-identity-provider

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
