### PR TITLE
OBSDOCS-892: Improve the release notes text in response to user feedback

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -121,6 +121,7 @@ endif::[]
 :DTProductVersion: 3.1
 :JaegerName: Red Hat OpenShift distributed tracing platform (Jaeger)
 :JaegerShortName: distributed tracing platform (Jaeger)
+:JaegerOperator: Red Hat OpenShift distributed tracing platform
 :JaegerVersion: 1.53.0
 :OTELName: Red Hat build of OpenTelemetry
 :OTELShortName: Red Hat build of OpenTelemetry

--- a/modules/distr-tracing-product-overview.adoc
+++ b/modules/distr-tracing-product-overview.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// * distr_tracing/distr_tracing_rn/distr-tracing-rn-3-1.adoc
-// * distr_tracing/distr_tracing_rn/distr-tracing-rn-past-releases.adoc
-// * distr_tracing_arch/distr-tracing-architecture.adoc
+// * observability/distr_tracing/distr_tracing_rn/distr-tracing-rn-3-1-1.adoc
+// * observability/distr_tracing/distr_tracing_rn/distr-tracing-rn-past-releases.adoc
+// * observability/distr_tracing_arch/distr-tracing-architecture.adoc
 // * service_mesh/v2x/ossm-architecture.adoc
 // * serverless/serverless-tracing.adoc
 
@@ -20,16 +20,3 @@ With the {DTShortName}, you can perform the following functions:
 * Optimize performance and latency
 
 * Perform root cause analysis
-
-The {DTShortName} consists of three components:
-
-* *{TempoName}*, which is based on the open source link:https://grafana.com/oss/tempo/[Grafana Tempo project].
-
-* *{OTELNAME}*, which is based on the open source link:https://opentelemetry.io/[OpenTelemetry project].
-
-* *{JaegerName}*, which is based on the open source link:https://www.jaegertracing.io/[Jaeger project].
-+
-[IMPORTANT]
-====
-Jaeger does not use FIPS validated cryptographic modules.
-====

--- a/observability/distr_tracing/distr_tracing_rn/distr-tracing-rn-3-1-1.adoc
+++ b/observability/distr_tracing/distr_tracing_rn/distr-tracing-rn-3-1-1.adoc
@@ -8,27 +8,9 @@ toc::[]
 
 include::modules/distr-tracing-product-overview.adoc[leveloffset=+1]
 
-[id="distributed-tracing-rn_3-1-1_component-versions"]
-== Component versions in the {DTProductName} 3.1.1
+You can use the {DTShortName} xref:../../otel/otel-forwarding.adoc#otel-forwarding-traces[in combination with] the xref:../../otel/otel-installing.adoc#install-otel[{OTELName}].
 
-[options="header"]
-|===
-|Operator |Component |Version
-
-|{TempoName}
-|Tempo
-|2.3.1
-
-//for each new release, update the release number in the xref path on the following line
-|xref:../../otel/otel_rn/otel-rn-3-1-1.adoc#otel-rn-3-1-1[{OTELName}]
-|OpenTelemetry
-|0.93.0
-
-|{JaegerName} (deprecated)
-|Jaeger
-|1.53.0
-
-|===
+This release of the {DTProductName} includes the {TempoName} and the deprecated {JaegerName}.
 
 [id="distributed-tracing-rn_3-1-1_cves"]
 == CVEs
@@ -38,6 +20,8 @@ This release fixes link:https://access.redhat.com/security/cve/cve-2023-39326[CV
 // Tempo section
 [id="distributed-tracing-rn_3-1-1_tempo-release-notes"]
 == {TempoName}
+
+The {TempoName} is provided through the {TempoOperator}.
 
 [id="distributed-tracing-rn_3-1-1_tempo-release-notes_known-issues"]
 === Known issues
@@ -51,6 +35,13 @@ There are currently known issues:
 // Jaeger section
 [id="distributed-tracing-rn_3-1-1_jaeger-release-notes"]
 == {JaegerName}
+
+The {JaegerName} is provided through the {JaegerOperator} Operator.
+
+[IMPORTANT]
+====
+Jaeger does not use FIPS validated cryptographic modules.
+====
 
 [id="distributed-tracing-rn_3-1-1_jaeger-release-notes_support-for-elasticsearch-operator"]
 === Support for {es-op}

--- a/observability/distr_tracing/distr_tracing_rn/distr-tracing-rn-past-releases.adoc
+++ b/observability/distr_tracing/distr_tracing_rn/distr-tracing-rn-past-releases.adoc
@@ -8,34 +8,18 @@ toc::[]
 
 include::modules/distr-tracing-product-overview.adoc[leveloffset=+1]
 
+You can use the {DTShortName} xref:../../otel/otel-forwarding.adoc#otel-forwarding-traces[in combination with] the xref:../../otel/otel-installing.adoc#install-otel[{OTELName}].
+
 [id="distributed-tracing-rn-3-1"]
 == Release notes for {DTProductName} 3.1
 
-[id="distributed-tracing-rn_3-1_component-versions"]
-=== Component versions in the {DTProductName} 3.1
-
-[options="header"]
-|===
-|Operator |Component |Version
-
-|{TempoName}
-|Tempo
-|2.3.1
-
-//for each new release, update the release number in the xref path on the following line
-|xref:../../otel/otel_rn/otel-rn-past-releases.adoc#otel-rn-past-releases[{OTELName}]
-|OpenTelemetry
-|0.93.0
-
-|{JaegerName} (deprecated)
-|Jaeger
-|1.53.0
-
-|===
+This release of the {DTProductName} includes the {TempoName} and the deprecated {JaegerName}.
 
 // Tempo section
 [id="distributed-tracing-rn_3-1_tempo-release-notes"]
 === {TempoName}
+
+The {TempoName} is provided through the {TempoOperator}.
 
 ////
 [id="technology-preview-features_jaeger-release-notes_distributed-tracing-rn-3-1"]
@@ -54,6 +38,7 @@ include::snippets/technology-preview.adoc[leveloffset=+1]
 
 This update introduces the following enhancements for the {TempoShortName}:
 
+* {TempoName} 3.1 is based on the open source link:https://grafana.com/oss/tempo/[Grafana Tempo] 2.3.1.
 * Support for cluster-wide proxy environments.
 * Support for TraceQL to Gateway component.
 
@@ -78,6 +63,13 @@ There are currently known issues:
 [id="distributed-tracing-rn_3-1_jaeger-release-notes"]
 === {JaegerName}
 
+The {JaegerName} is provided through the {JaegerOperator} Operator.
+
+[IMPORTANT]
+====
+Jaeger does not use FIPS validated cryptographic modules.
+====
+
 [id="distributed-tracing-rn_3-1_jaeger-release-notes_support-for-elasticsearch-operator"]
 ==== Support for {es-op}
 
@@ -90,12 +82,12 @@ In the {DTProductName} 3.1, Jaeger and support for Elasticsearch remain deprecat
 
 In the {DTProductName} 3.1, Tempo provided by the {TempoOperator} and the OpenTelemetry Collector provided by the {OTELName} are the preferred Operators for distributed tracing collection and storage. The OpenTelemetry and Tempo distributed tracing stack is to be adopted by all users because this will be the stack that will be enhanced going forward.
 
-////
 [id="distributed-tracing-rn_3-1_jaeger-release-notes_new-features-and-enhancements"]
 ==== New features and enhancements
+
 This update introduces the following enhancements for the {JaegerShortName}:
-* Support for ...
-////
+
+* {JaegerName} 3.1 is based on the open source link:https://www.jaegertracing.io/[Jaeger] release 1.53.0.
 
 [id="distributed-tracing-rn_3-1_jaeger-release-notes_bug-fixes"]
 ==== Bug fixes

--- a/observability/otel/otel_rn/otel-rn-3-1-1.adoc
+++ b/observability/otel/otel_rn/otel-rn-3-1-1.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 include::modules/otel-product-overview.adoc[leveloffset=+1]
 
+The {OTELName} is provided through the {OTELOperator}.
+
 [id="otel-rn_3-1-1_cves"]
 == CVEs
 

--- a/observability/otel/otel_rn/otel-rn-past-releases.adoc
+++ b/observability/otel/otel_rn/otel-rn-past-releases.adoc
@@ -11,13 +11,15 @@ include::modules/otel-product-overview.adoc[leveloffset=+1]
 [id="otel-rn-3-1"]
 == Release notes for {OTELName} 3.1
 
+The {OTELName} is provided through the {OTELOperator}.
+
 [id="otel-rn_3-1_new-features-and-enhancements"]
 === New features and enhancements
 
 //plural: `enhancements:`
 This update introduces the following enhancements:
 
-* {OTELName} 3.1 is based on link:https://opentelemetry.io/[OpenTelemetry] 0.93.0.
+* {OTELName} 3.1 is based on the open source link:https://opentelemetry.io/[OpenTelemetry] release 0.93.0.
 
 * Support for the target allocator in the OpenTelemetry Collector. The target allocator is an optional component of the OpenTelemetry Operator that shards Prometheus receiver scrape targets across the deployed fleet of OpenTelemetry Collector instances. The target allocator provides integration with the Prometheus `PodMonitor` and `ServiceMonitor` custom resources.
 
@@ -49,7 +51,7 @@ This update introduces the following bug fixes:
 
 This update introduces the following enhancements:
 
-* {OTELName} 3.0 is based on link:https://opentelemetry.io/[OpenTelemetry] 0.89.0.
+* {OTELName} 3.0 is based on the open source link:https://opentelemetry.io/[OpenTelemetry] release 0.89.0.
 * The *OpenShift distributed tracing data collection Operator* is renamed as the *{OTELOperator}*.
 * Support for the ARM architecture.
 * Support for the Prometheus receiver for metrics collection.
@@ -150,7 +152,7 @@ subjects:
 :FeatureName: The {OTELName}
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
-{OTELName} 2.9.2 is based on link:https://opentelemetry.io/[OpenTelemetry] 0.81.0.
+{OTELName} 2.9.2 is based on the open source link:https://opentelemetry.io/[OpenTelemetry] release 0.81.0.
 
 [id="otel-rn_2-9-2_cves"]
 === CVEs
@@ -171,7 +173,7 @@ There is currently a known issue:
 :FeatureName: The {OTELName}
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
-{OTELName} 2.9.1 is based on link:https://opentelemetry.io/[OpenTelemetry] 0.81.0.
+{OTELName} 2.9.1 is based on the open source link:https://opentelemetry.io/[OpenTelemetry] release 0.81.0.
 
 [id="otel-rn_2-9-1_cves"]
 === CVEs
@@ -192,7 +194,7 @@ There is currently a known issue:
 :FeatureName: The {OTELName}
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
-{OTELName} 2.9 is based on link:https://opentelemetry.io/[OpenTelemetry] 0.81.0.
+{OTELName} 2.9 is based on the open source link:https://opentelemetry.io/[OpenTelemetry] release 0.81.0.
 
 [id="otel-rn_2-9_new-features-and-enhancements"]
 === New features and enhancements
@@ -235,7 +237,7 @@ There is currently a known issue:
 :FeatureName: The {OTELName}
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
-{OTELName} 2.8 is based on link:https://opentelemetry.io/[OpenTelemetry] 0.74.0.
+{OTELName} 2.8 is based on the open source link:https://opentelemetry.io/[OpenTelemetry] release 0.74.0.
 
 [id="otel-rn_2-8_bug-fixes"]
 === Bug fixes
@@ -254,7 +256,7 @@ None.
 :FeatureName: The {OTELName}
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
-{OTELName} 2.7 is based on link:https://opentelemetry.io/[OpenTelemetry] 0.63.1.
+{OTELName} 2.7 is based on the open source link:https://opentelemetry.io/[OpenTelemetry] release 0.63.1.
 
 [id="otel-rn_2-7_bug-fixes"]
 === Bug fixes
@@ -267,7 +269,7 @@ This release addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes
 :FeatureName: The {OTELName}
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
-{OTELName} 2.6 is based on link:https://opentelemetry.io/[OpenTelemetry] 0.60.
+{OTELName} 2.6 is based on the open source link:https://opentelemetry.io/[OpenTelemetry] release 0.60.
 
 [id="otel-rn_2-6_bug-fixes"]
 === Bug fixes
@@ -280,7 +282,7 @@ This release addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes
 :FeatureName: The {OTELName}
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
-{OTELName} 2.5 is based on link:https://opentelemetry.io/[OpenTelemetry] 0.56.
+{OTELName} 2.5 is based on the open source link:https://opentelemetry.io/[OpenTelemetry] release 0.56.
 
 [id="otel-rn_2-5_new-features-and-enhancements"]
 === New features and enhancements
@@ -300,7 +302,7 @@ This release addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes
 :FeatureName: The {OTELName}
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
-{OTELName} 2.4 is based on link:https://opentelemetry.io/[OpenTelemetry] 0.49.
+{OTELName} 2.4 is based on the open source link:https://opentelemetry.io/[OpenTelemetry] release 0.49.
 
 [id="otel-rn_2-4_bug-fixes"]
 === Bug fixes
@@ -319,9 +321,9 @@ None.
 :FeatureName: The {OTELName}
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
-{OTELName} 2.3.1 is based on link:https://opentelemetry.io/[OpenTelemetry] 0.44.1.
+{OTELName} 2.3.1 is based on the open source link:https://opentelemetry.io/[OpenTelemetry] release 0.44.1.
 
-{OTELName} 2.3.0 is based on link:https://opentelemetry.io/[OpenTelemetry] 0.44.0.
+{OTELName} 2.3.0 is based on the open source link:https://opentelemetry.io/[OpenTelemetry] release 0.44.0.
 
 [id="otel-rn_2-3_bug-fixes"]
 === Bug fixes
@@ -340,7 +342,7 @@ None.
 :FeatureName: The {OTELName}
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
-{OTELName} 2.2 is based on link:https://opentelemetry.io/[OpenTelemetry] 0.42.0.
+{OTELName} 2.2 is based on the open source link:https://opentelemetry.io/[OpenTelemetry] release 0.42.0.
 
 [id="otel-rn_2-2_technology-preview-features"]
 === Technology Preview features
@@ -364,7 +366,7 @@ None.
 :FeatureName: The {OTELName}
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
-{OTELName} 2.1 is based on link:https://opentelemetry.io/[OpenTelemetry] 0.41.1.
+{OTELName} 2.1 is based on the open source link:https://opentelemetry.io/[OpenTelemetry] release 0.41.1.
 
 [id="otel-rn_2-1_technology-preview-features"]
 === Technology Preview features
@@ -415,7 +417,7 @@ None.
 :FeatureName: The {OTELName}
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
-{OTELName} 2.0 is based on link:https://opentelemetry.io/[OpenTelemetry] 0.33.0.
+{OTELName} 2.0 is based on the open source link:https://opentelemetry.io/[OpenTelemetry] release 0.33.0.
 
 This release adds the {OTELName} as a link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview], which you install using the {OTELName} Operator. {OTELName} is based on the link:https://opentelemetry.io/[OpenTelemetry] APIs and instrumentation. The {OTELName} includes the OpenTelemetry Operator and Collector. You can use the Collector to receive traces in the OpenTelemetry or Jaeger protocol and send the trace data to the {OTELName}. Other capabilities of the Collector are not supported at this time. The OpenTelemetry Collector allows developers to instrument their code with vendor agnostic APIs, avoiding vendor lock-in and enabling a growing ecosystem of observability tooling.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Because the OTEL docs are no longer part of the distributed tracing docs, I replaced the list of three components (Tempo, OTEL, Jaeger) by linking to OTEL in a separate sentence and by mentioning Tempo and (deprecated) Jaeger together to preare for the removal of the soon-to-be-removed Jeager docs.

I combined the per-component links to the upstream projects with the per-component "Component versions" table, and moved this information to a list item in the per-component section "New features and enhancements". This resulted in removal of the "Component versions" section.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.16, 4.15, 4.14, 4.13, 4.12

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OBSDOCS-892

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://73592--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/distr_tracing/distr_tracing_rn/distr-tracing-rn-3-1-1

https://73592--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/distr_tracing/distr_tracing_rn/distr-tracing-rn-past-releases#distributed-tracing-rn_3-1_tempo-release-notes_new-features-and-enhancements

https://73592--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/distr_tracing/distr_tracing_rn/distr-tracing-rn-past-releases#distributed-tracing-rn_3-1_jaeger-release-notes_new-features-and-enhancements

https://73592--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel_rn/otel-rn-past-releases#otel-rn_3-1_new-features-and-enhancements

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
