### PR TITLE
OBSDOCS-901: rename-accessing-monitoring-apis-heading

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2821,7 +2821,7 @@ Topics:
   File: managing-alerts
 - Name: Reviewing monitoring dashboards
   File: reviewing-monitoring-dashboards
-- Name: Accessing third-party monitoring APIs
+- Name: Accessing monitoring APIs by using the CLI
   File: accessing-third-party-monitoring-apis
 - Name: Troubleshooting monitoring issues
   File: troubleshooting-monitoring-issues

--- a/modules/accessing-metrics-outside-cluster.adoc
+++ b/modules/accessing-metrics-outside-cluster.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * monitoring/enabling-monitoring-for-user-defined-projects.adoc
+// * monitoring/accessing-third-party-monitoring-apis.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="accessing-metrics-from-outside-cluster_{context}"]

--- a/modules/monitoring-about-accessing-monitoring-web-service-apis.adoc
+++ b/modules/monitoring-about-accessing-monitoring-web-service-apis.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * monitoring/accessing-third-party-monitoring-uis-and-apis.adoc
+// * monitoring/accessing-third-party-monitoring-apis.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="about-accessing-monitoring-web-service-apis_{context}"]

--- a/modules/monitoring-accessing-third-party-monitoring-web-service-apis.adoc
+++ b/modules/monitoring-accessing-third-party-monitoring-web-service-apis.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * monitoring/accessing-third-party-monitoring-uis-and-apis.adoc
+// * monitoring/accessing-third-party-monitoring-apis.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="accessing-a-monitoring-web-service-api_{context}"]

--- a/monitoring/accessing-third-party-monitoring-apis.adoc
+++ b/monitoring/accessing-third-party-monitoring-apis.adoc
@@ -1,13 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="accessing-third-party-monitoring-apis"]
-= Accessing third-party monitoring APIs
+= Accessing monitoring APIs by using the CLI
 include::_attributes/common-attributes.adoc[]
-:context: accessing-third-party-monitoring-apis
+:context: accessing-monitoring-apis-by-using-the-cli
 
 toc::[]
 
 [role="_abstract"]
-In {product-title} {product-version}, you can access web service APIs for some third-party monitoring components from the command line interface (CLI).
+In {product-title} {product-version}, you can access web service APIs for some monitoring components from the command line interface (CLI).
 
 [IMPORTANT]
 ====
@@ -34,7 +34,7 @@ include::modules/monitoring-querying-metrics-by-using-the-federation-endpoint-fo
 include::modules/accessing-metrics-outside-cluster.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="additional-resources_accessing-third-party-monitoring-apis"]
+[id="additional-resources_accessing-monitoring-apis-by-using-the-cli"]
 == Additional resources
 
 ifndef::openshift-dedicated,openshift-rosa[]

--- a/monitoring/reviewing-monitoring-dashboards.adoc
+++ b/monitoring/reviewing-monitoring-dashboards.adoc
@@ -59,4 +59,4 @@ endif::openshift-dedicated,openshift-rosa[]
 [id="next-steps_reviewing-monitoring-dashboards"]
 == Next steps
 
-* xref:../monitoring/accessing-third-party-monitoring-apis.adoc#accessing-third-party-monitoring-apis[Accessing third-party monitoring APIs]
+* xref:../monitoring/accessing-third-party-monitoring-apis.adoc#accessing-third-party-monitoring-apis[Accessing monitoring APIs by using the CLI]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-901
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://73593--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/accessing-third-party-monitoring-apis
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: not required because technical content is not changing
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR changes the heading name from "Accessing third-party monitoring APIs" to "Accessing monitoring APIs by using the CLI" and updates some related content to remove a reference to "third-party" components. 

It also updates some incorrect metadata in modules included in this assembly.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
