### PR TITLE
[enterprise-4.13] OCPBUGS-24202: Added two vSphere FD parameters

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -254,6 +254,8 @@ ifeval::["{context}" == "installing-restricted-networks-nutanix-installer-provis
 :nutanix:
 endif::[]
 
+// You can issue a command such as `openshift-install explain installconfig.platform.vsphere.failureDomains` to see information about a parameter. You must store the `openshift-install` binary in your bin directory.
+
 :_mod-docs-content-type: CONCEPT
 [id="installation-configuration-parameters_{context}"]
 = Installation configuration parameters
@@ -272,7 +274,6 @@ endif::bare,ibm-power,ibm-power-vs,ibm-z,ash[]
 ====
 After installation, you cannot modify these parameters in the `install-config.yaml` file.
 ====
-
 
 [id="installation-configuration-parameters-required_{context}"]
 == Required configuration parameters
@@ -1957,8 +1958,16 @@ The `platform.vsphere` parameter prefixes each parameter listed in the table.
 |Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
 |String
 
+|`failureDomains.topology.datastore`
+|Specifies the path to a vSphere datastore that stores virtual machines files for a failure domain. You must apply the datastore role to the vSphere vCenter datastore location.
+|String
+
 |`failureDomains.topology.networks`
 |Lists any network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured.
+|String
+
+|`failureDomains.server`
+|Specifies the fully-qualified hostname or IP address of the VMware vCenter server, so that a client can access failure domain resources. You must apply the server role to the vSphere vCenter server location.
 |String
 
 |`failureDomains.region`


### PR DESCRIPTION
Cherry picked from PR #70233, commit ID 5fb2e2e22198b32527f3045947ea0311d64d32a1

Version(s):
4.13

Issue:
[OCPBUGS-24202](https://issues.redhat.com/browse/OCPBUGS-24202)

Link to docs preview:
[Additional VMware vSphere configuration parameters](https://73602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations#installation-configuration-parameters-additional-vsphere_installing-vsphere-installer-provisioned-network-customizations)

