### PR TITLE
[enterprise-4.12] OCPBUGS-24202: Added two vSphere FD parameters

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -226,6 +226,8 @@ ifeval::["{context}" == "installing-restricted-networks-nutanix-installer-provis
 :nutanix:
 endif::[]
 
+// You can issue a command such as `openshift-install explain installconfig.platform.vsphere.failureDomains` to see information about a parameter. You must store the `openshift-install` binary in your bin directory.
+
 :_mod-docs-content-type: CONCEPT
 [id="installation-configuration-parameters_{context}"]
 = Installation configuration parameters
@@ -244,7 +246,6 @@ endif::bare,ibm-power,ibm-z,ash[]
 ====
 After installation, you cannot modify these parameters in the `install-config.yaml` file.
 ====
-
 
 [id="installation-configuration-parameters-required_{context}"]
 == Required configuration parameters
@@ -1811,6 +1812,10 @@ The `platform.vsphere` parameter prefixes each parameter listed in the table.
 |The name of the failure domain. The machine pools use this name to reference the failure domain.
 |String
 
+|`failureDomains.server`
+|Specifies the fully-qualified hostname or IP address of the VMware vCenter server, so that a client can access failure domain resources. You must apply the server role to the vSphere vCenter server location.
+|String
+
 |`failureDomains.region`
 |You define a region by using a tag from the `openshift-region` tag category. The tag must be attached to the vCenter datacenter.
 |String
@@ -1832,11 +1837,11 @@ The `platform.vsphere` parameter prefixes each parameter listed in the table.
 |String
 
 |`failureDomains.topology.datastore`
-| The name of the datastore to use for provisioning volumes. If you do not define this parameter in your configuration, the datastore takes the value of `platform.vsphere.defaultDatastore`.
+|Specifies the path to a vSphere datastore that stores virtual machines files for a failure domain. You must apply the datastore role to the vSphere vCenter datastore location.
 |String
 
 |`failureDomains.topology.networks`
-| Lists any network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured. If you do not define this parameter in your configuration, the network takes the value of `platform.vsphere.network`.
+|Lists any network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured. If you do not define this parameter in your configuration, the network takes the value of `platform.vsphere.network`.
 |String
 
 |`failureDomains.topology.resourcePool`


### PR DESCRIPTION
Cherry picked from PR #70233, commit ID 5fb2e2e22198b32527f3045947ea0311d64d32a1

Version(s):
4.12

Issue:
[OCPBUGS-24202](https://issues.redhat.com/browse/OCPBUGS-24202)

Link to docs preview:
[Region and zone enablement configuration parameters](https://73603--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations#installation-parameters-region-zone-technology-preview-vsphere_installing-vsphere-installer-provisioned-network-customizations)

