### PR TITLE
OSDOCS-9723: adds 4.15.5 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -199,12 +199,16 @@ Issued: 2024-02-27
 
 {product-title} release 4.15.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:7200[RHSA-2023:7200] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7198[RHSA-2023:7198] advisory.
 
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
 [id="microshift-4-15-2-dp"]
 === RHBA-2024:1212 - {microshift-short} 4.15.2 bug fix and enhancement update advisory
 
 Issued: 2024-03-13
 
 {product-title} release 4.15.2 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1212[RHBA-2024:1212] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1210[RHSA-2024:1210] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [discrete]
 [id="microshift-4-15-2-bug-fixes"]
@@ -230,3 +234,21 @@ Adds OLM image references in dedicated file::
 Issued: 2024-03-20
 
 {product-title} release 4.15.3 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1257[RHBA-2024:1257] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1255[RHSA-2024:1255] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-15-5-dp"]
+=== RHBA-2024:1451 - {microshift-short} 4.15.5 bug fix and enhancement update advisory
+
+Issued: 2024-03-27
+
+{product-title} release 4.15.5 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1451[RHBA-2024:1451] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1449[RHSA-2024:1449] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[discrete]
+[id="microshift-4-15-5-enhancements"]
+==== Enhancements
+
+Change in openshift-marketplace namespace security::
+* With this release, the `openshift-marketplace` namespace security defaults to `baseline`. See the OLM documentation for specifics on how this change impacts your operator deployments. See xref:../microshift_running_apps/microshift-operators-olm.adoc#microshift-operators-olm[Using Operator Lifecycle Manager with {microshift-short}]. (link:https://issues.redhat.com/browse/OCPBUGS-30034[OCPBUGS-30034])


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-9723](https://issues.redhat.com/browse/OSDOCS-9723)

Link to docs preview:
[4.15.5 async release note](https://73614--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes#microshift-4-15-5-dp)

QE review:
- [x] QE has approved this change.
