### PR TITLE
OCPBUGS-29005: Adding reference to grandmaster clocks

### DIFF
--- a/modules/cnf-about-ptp-and-clock-synchronization.adoc
+++ b/modules/cnf-about-ptp-and-clock-synchronization.adoc
@@ -14,7 +14,7 @@ The PTP Operator generates fast event notifications for every PTP-capable networ
 
 [NOTE]
 ====
-PTP fast event notifications are available for network interfaces configured to use PTP ordinary clocks or PTP boundary clocks.
+PTP fast event notifications are available for network interfaces configured to use PTP ordinary clocks, PTP grandmaster clocks, or PTP boundary clocks.
 ====
 
 include::snippets/ptp-amq-interconnect-eol.adoc[]


### PR DESCRIPTION
OCPBUGS-29005: Adding missing reference to grandmaster clocks

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OCPBUGS-29005

Link to docs preview:
https://73618--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ptp/using-ptp-events.html#cnf-about-ptp-and-clock-synchronization_using-ptp-hardware-fast-events-framework

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
