### PR TITLE
[TRACING-4067] Add documentation for kubelet stats receiver

### DIFF
--- a/modules/otel-collector-components.adoc
+++ b/modules/otel-collector-components.adoc
@@ -113,6 +113,23 @@ env:
           receivers: [kubeletstats]
 ----
 
+Note that the service account used for running the OpenTelemetry Collector instance will need some extra permissions. The `get` permissions are needed for the `nodes/stats` resource. Also, extra permissions for `nodes/proxy` are needed when using `extra_metadata_labels` or the `request_utilization` or `limit_utilization` metrics:
+
+.Permissions needed by the service account.
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otel-collector
+rules:
+  - apiGroups: [""]
+    resources: ["nodes/stats"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["nodes/proxy"]
+    verbs: ["get"]
+----
 
 [id="prometheus-receiver_{context}"]
 === Prometheus Receiver

--- a/modules/otel-collector-components.adoc
+++ b/modules/otel-collector-components.adoc
@@ -82,6 +82,38 @@ The Jaeger receiver ingests traces in the Jaeger formats.
 <4> The Jaeger Thrift Binary endpoint. If omitted, the default `+0.0.0.0:6832+` is used.
 <5> The  server-side TLS configuration. See the OTLP receiver configuration section for more details.
 
+[id="kubeletstats-receiver_{context}"]
+=== Kubelet Stats Receiver
+
+The Kubelet Stats Receiver extracts metrics related to nodes, pods, containers, and volumes from the kubelet's API server. These metrics are then channeled through the metrics processing pipeline for additional analysis.
+
+Add this to your OpenTelemetry Collector instance to set the `K8S_NODE_NAME` to authenticate to the API:
+[source,yaml]
+----
+env:
+  - name: K8S_NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+----
+
+.OpenTelemetry Collector custom resource with an enabled Kubelet Stats receiver
+[source,yaml]
+----
+  config: |
+    receivers:
+      kubeletstats:
+        collection_interval: 20s
+        auth_type: "serviceAccount"
+        endpoint: "https://${env:K8S_NODE_NAME}:10250"
+        insecure_skip_verify: true
+    service:
+      pipelines:
+        metrics:
+          receivers: [kubeletstats]
+----
+
+
 [id="prometheus-receiver_{context}"]
 === Prometheus Receiver
 


### PR DESCRIPTION
Version(s): 4.16, 4.15, 4.14, 4.13, 4.12

Issue:  [TRACING-4067](https://issues.redhat.com//browse/TRACING-4067)

Link to docs preview: https://73626--ocpdocs-pr.netlify.app/

QE review:
- [x] QE has approved this change.

