### PR TITLE
[enterprise-4.13] OCPBUGS-8365: OVN-Kubernetes network plugin

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -341,7 +341,7 @@ $ oc -n openshift-ovn-kubernetes get ds/ovnkube-master -o yaml | grep -E '<non-r
 It can take at least 5-10 minutes for the OVN-Kubernetes control plane to be redeployed and the previous command to return empty output.
 ====
 
-. Restart the Open Virtual Network (OVN) Kubernetes pods on all the hosts.
+. If you are using the OVN-Kubernetes network plugin, restart the Open Virtual Network (OVN) Kubernetes pods on all of the hosts.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OCPBUGS-8365

Link to docs preview:
https://73639--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
