### PR TITLE
ROX#18370: add pull secret definitions and make show up on kubernetes instructions

### DIFF
--- a/modules/acs-quick-install-secured-cluster-using-helm.adoc
+++ b/modules/acs-quick-install-secured-cluster-using-helm.adoc
@@ -45,10 +45,8 @@ $ helm install -n stackrox --create-namespace \
     -f <path_to_pull_secret.yaml> \// <2>
     --set clusterName=<name_of_the_secured_cluster> \
     --set centralEndpoint=<endpoint_of_central_service> <3>
-ifdef::cloud-svc[]
---set imagePullSecrets.username=<your redhat.com username> \
---set imagePullSecrets.password=<your redhat.com password>
-endif::[]
+    --set imagePullSecrets.username=<your redhat.com username> \//<4>
+    --set imagePullSecrets.password=<your redhat.com password>//<5>
 ----
 <1> Use the `-f` option to specify the path for the init bundle.
 <2> Use the -f option to specify the path for the pull secret for Red{nbsp}Hat Container Registry authentication.
@@ -58,6 +56,8 @@ endif::[]
 ifdef::cloud-svc[]
 <3> Enter the Central API Endpoint, including the address and the port number. You can view this information again in the Red{nbsp}Hat Hybrid Cloud Console console by choosing Advanced Cluster Security → ACS Instances, and then clicking the ACS instance you created.
 endif::[]
+<4> Include the user name for your pull secret for Red Hat Container Registry authentication.
+<5> Include the password for your pull secret for Red Hat Container Registry authentication.
 endif::[]
 
 ifndef::cloud-svc,k8[]


### PR DESCRIPTION
Version(s):
4.3+

[Issue](https://issues.redhat.com/browse/ROX-18370)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Links to docs previews:

- [Installing RHACS on Kubernetes w/o customizations](https://73647--docspreview.netlify.app/openshift-acs/latest/installing/installing_other/install-secured-cluster-other#installing-sc-helm-default-other)
- [Installing ACS Cloud Service on Kubernetes w/o customizations](https://73647--docspreview.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_ocp/install-secured-cluster-cloud-ocp#installing-sc-helm-default-cloud-ocp)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Due to incorrect conditionals, and a mistake, pull secret info not showing up on Helm installation method for secured clusters for Kubernetes systems

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
