### PR TITLE
[enterprise-4.12] OBSDOCS-901: rename-accessing-monitoring-apis-heading

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2605,7 +2605,7 @@ Topics:
   File: reviewing-monitoring-dashboards
 - Name: The NVIDIA GPU administration dashboard
   File: nvidia-gpu-admin-dashboard
-- Name: Accessing third-party monitoring APIs
+- Name: Accessing monitoring APIs by using the CLI
   File: accessing-third-party-monitoring-apis
 - Name: Troubleshooting monitoring issues
   File: troubleshooting-monitoring-issues

--- a/modules/accessing-metrics-outside-cluster.adoc
+++ b/modules/accessing-metrics-outside-cluster.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * monitoring/enabling-monitoring-for-user-defined-projects.adoc
+// * monitoring/accessing-third-party-monitoring-apis.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="accessing-metrics-from-outside-cluster_{context}"]

--- a/modules/monitoring-about-accessing-monitoring-web-service-apis.adoc
+++ b/modules/monitoring-about-accessing-monitoring-web-service-apis.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * monitoring/accessing-third-party-monitoring-uis-and-apis.adoc
+// * monitoring/accessing-third-party-monitoring-apis.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="about-accessing-monitoring-web-service-apis_{context}"]

--- a/modules/monitoring-accessing-third-party-monitoring-web-service-apis.adoc
+++ b/modules/monitoring-accessing-third-party-monitoring-web-service-apis.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * monitoring/accessing-third-party-monitoring-uis-and-apis.adoc
+// * monitoring/accessing-third-party-monitoring-apis.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="accessing-a-monitoring-web-service-api_{context}"]

--- a/monitoring/accessing-third-party-monitoring-apis.adoc
+++ b/monitoring/accessing-third-party-monitoring-apis.adoc
@@ -1,13 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="accessing-third-party-monitoring-apis"]
-= Accessing third-party monitoring APIs
+= Accessing monitoring APIs by using the CLI
 include::_attributes/common-attributes.adoc[]
-:context: accessing-third-party-monitoring-apis
+:context: accessing-monitoring-apis-by-using-the-cli
 
 toc::[]
 
 [role="_abstract"]
-In {product-title} {product-version}, you can access web service APIs for some third-party monitoring components from the command line interface (CLI).
+In {product-title} {product-version}, you can access web service APIs for some monitoring components from the command line interface (CLI).
 
 [IMPORTANT]
 ====
@@ -34,7 +34,7 @@ include::modules/monitoring-querying-metrics-by-using-the-federation-endpoint-fo
 include::modules/accessing-metrics-outside-cluster.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="additional-resources_accessing-third-party-monitoring-apis"]
+[id="additional-resources_accessing-monitoring-apis-by-using-the-cli"]
 == Additional resources
 
 ifndef::openshift-dedicated,openshift-rosa[]

--- a/monitoring/reviewing-monitoring-dashboards.adoc
+++ b/monitoring/reviewing-monitoring-dashboards.adoc
@@ -50,4 +50,4 @@ include::modules/monitoring-reviewing-monitoring-dashboards-developer.adoc[level
 [id="next-steps_reviewing-monitoring-dashboards"]
 == Next steps
 
-* xref:../monitoring/accessing-third-party-monitoring-apis.adoc#accessing-third-party-monitoring-apis[Accessing third-party monitoring APIs]
+* xref:../monitoring/accessing-third-party-monitoring-apis.adoc#accessing-third-party-monitoring-apis[Accessing monitoring APIs by using the CLI]


### PR DESCRIPTION
Manual CP from #73593 to enterprise-4.12