### PR TITLE
RHDEVDOCS 5960 Errata RN update for GitOps 1.9.4, 1.10.2, 1.11.1 - 1.11 and gitops-docs

### DIFF
--- a/modules/gitops-release-notes-1-10-2.adoc
+++ b/modules/gitops-release-notes-1-10-2.adoc
@@ -8,12 +8,31 @@
 
 {gitops-title} 1.10.2 is now available on {OCP} 4.12, 4.13, and 4.14.
 
+[id="errata-updates-1-10-2_{context}"]
+== Errata updates
+
+[id="rhsa-2024-0692-gitops-1-10-2-security-update-advisory_{context}"]
+=== RHSA-2024-0692 - {gitops-title} 1.10.2 security update advisory
+
+Issued: 2024-02-05
+
+The list of security fixes that are included in this release is documented in the following advisory:
+
+* link:https://access.redhat.com/errata/RHSA-2024:0692[RHSA-2024-0692]
+
+If you have installed the {gitops-title} Operator, view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-operators
+----
+
 [id="fixed-issues-1-10-2_{context}"]
 == Fixed issues
 
 The following issue has been resolved in the current release:
 
-* Before this update, all versions of Argo CD `v2.8.3` and later were vulnerable to cross-server request forgery (CSRF) attacks. As a result, Argo CD would accept non-GET requests even if they did not specify their content type. This update fixes the issue by upgrading the Argo CD to `v.2.8.9` and patching this vulnerability in the Argo CD API. link:https://issues.redhat.com/browse/GITOPS-3922[GITOPS-3922]
+* Before this update, all versions of Argo CD `v2.8.3` and later were vulnerable to cross-server request forgery (CSRF) attacks. As a result, Argo CD accepted non-GET requests even if they did not specify a content type. This update fixes the issue by upgrading the Argo CD version to `v.2.8.9` and patches this vulnerability in the Argo CD API. link:https://issues.redhat.com/browse/GITOPS-3922[GITOPS-3922]
 +
 [IMPORTANT]
 ====

--- a/modules/gitops-release-notes-1-11-1.adoc
+++ b/modules/gitops-release-notes-1-11-1.adoc
@@ -8,12 +8,31 @@
 
 {gitops-title} 1.11.1 is now available on {OCP} 4.12, 4.13, and 4.14.
 
+[id="errata-updates-1-11-1_{context}"]
+== Errata updates
+
+[id="rhsa-2024-0689-gitops-1-11-1-security-update-advisory_{context}"]
+=== RHSA-2024-0689 - {gitops-title} 1.11.1 security update advisory
+
+Issued: 2024-02-05
+
+The list of security fixes that are included in this release is documented in the following advisory:
+
+* link:https://access.redhat.com/errata/RHSA-2024:0689[RHSA-2024-0689]
+
+If you have installed the {gitops-title} Operator, view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-operators
+----
+
 [id="fixed-issues-1-11-1_{context}"]
 == Fixed issues
 
 The following issue has been resolved in the current release:
 
-* Before this update, all versions of Argo CD `v2.9.2` and later were vulnerable to cross-server request forgery (CSRF) attacks. As a result, Argo CD would accept non-GET requests even if they did not specify their content type. This update fixes the issue by upgrading the Argo CD to `v.2.9.5` and patching this vulnerability in the Argo CD API. link:https://issues.redhat.com/browse/GITOPS-3923[GITOPS-3923]
+* Before this update, all versions of Argo CD `v2.9.2` and later were vulnerable to cross-server request forgery (CSRF) attacks. As a result, Argo CD accepted non-GET requests even if they did not specify a content type. This update fixes the issue by upgrading the Argo CD version to `v.2.9.5` and patches this vulnerability in the Argo CD API. link:https://issues.redhat.com/browse/GITOPS-3923[GITOPS-3923]
 +
 [IMPORTANT]
 ====

--- a/modules/gitops-release-notes-1-9-4.adoc
+++ b/modules/gitops-release-notes-1-9-4.adoc
@@ -8,12 +8,31 @@
 
 {gitops-title} 1.9.4 is now available on {OCP} 4.12, 4.13, and 4.14.
 
+[id="errata-updates-1-9-4_{context}"]
+== Errata updates
+
+[id="rhsa-2024-0691-gitops-1-9-4-security-update-advisory_{context}"]
+=== RHSA-2024-0691 - {gitops-title} 1.9.4 security update advisory
+
+Issued: 2024-02-05
+
+The list of security fixes that are included in this release is documented in the following advisory:
+
+* link:https://access.redhat.com/errata/RHSA-2024:0691[RHSA-2024-0691]
+
+If you have installed the {gitops-title} Operator, view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-operators
+----
+
 [id="fixed-issues-1-9-4_{context}"]
 == Fixed issues
 
 The following issue has been resolved in the current release:
 
-* Before this update, all versions of Argo CD `v2.7.2` and later were vulnerable to cross-server request forgery (CSRF) attacks. As a result, Argo CD would accept non-GET requests even if they did not specify their content type. This update fixes the issue by upgrading the Argo CD to `v.2.7.16` and patching this vulnerability in the Argo CD API. link:https://issues.redhat.com/browse/GITOPS-3921[GITOPS-3921]
+* Before this update, all versions of Argo CD `v2.7.2` and later were vulnerable to cross-server request forgery (CSRF) attacks. As a result, Argo CD accepted non-GET requests even if they did not specify a content type. This update fixes the issue by upgrading the Argo CD version to `v.2.7.16` and patches this vulnerability in the Argo CD API. link:https://issues.redhat.com/browse/GITOPS-3921[GITOPS-3921]
 +
 [IMPORTANT]
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
please cp to gitops-docs

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
[RHDEVDOCS-5960](https://issues.redhat.com//browse/RHDEVDOCS-5960)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://73653--ocpdocs-pr.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes#gitops-release-notes-1-11-1_gitops-release-notes
https://73653--ocpdocs-pr.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes#gitops-release-notes-1-10-2_gitops-release-notes
https://73653--ocpdocs-pr.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes#gitops-release-notes-1-9-4_gitops-release-notes


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

A respin of #73216 with a one-word style correction and correct version destinations - this version is for gitops-docs-1.11 and gitops-docs. See #73216 for Dev and QE approvals.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
