### PR TITLE
HCIDOCS-189: Add note with link to OCP docs about exposed CoreDNS port

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-prerequisites.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-prerequisites.adoc
@@ -39,6 +39,11 @@ xref:../../installing/installing_bare_metal_ipi/ipi-install-troubleshooting.adoc
 
 include::modules/ipi-install-network-requirements.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../networking/dns-operator#nw-dns-forward_dns-operator[Using DNS forwarding]
+
 include::modules/ipi-install-configuring-nodes.adoc[leveloffset=+1]
 
 include::modules/ipi-install-out-of-band-management.adoc[leveloffset=+1]

--- a/installing/installing_bare_metal_ipi/ipi-install-prerequisites.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-prerequisites.adoc
@@ -42,7 +42,7 @@ include::modules/ipi-install-network-requirements.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../networking/dns-operator#nw-dns-forward_dns-operator[Using DNS forwarding]
+* xref:../../networking/dns-operator.adoc#nw-dns-forward_dns-operator[Using DNS forwarding]
 
 include::modules/ipi-install-configuring-nodes.adoc[leveloffset=+1]
 

--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -44,6 +44,11 @@ Certain ports must be open between cluster nodes for installer-provisioned insta
 
 |====
 
+[NOTE]
+====
+For installer-provisioned infrastructure installations, CoreDNS exposes port 53 at the node level, making it accessible from other routable networks.
+====
+
 [id="network-requirements-increase-mtu_{context}"]
 == Increase the network MTU
 


### PR DESCRIPTION
Added a comment from [OSDOCS-8613](https://issues.redhat.com//browse/OSDOCS-8613) to the IPI docs regarding port 53 being open at the node level.

Fixes: [HCIDOCS-189](https://issues.redhat.com//browse/HCIDOCS-189)

See https://issues.redhat.com/browse/HCIDOCS-189 for additional details.

Preview URL: http://jowilkin.com:8080/HCIDOCS-189/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#network-requirements-ensuring-required-ports-are-open_ipi-install-prerequisites port 53 note and http://jowilkin.com:8080/HCIDOCS-189/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#network-requirements-out-of-band_ipi-install-prerequisites additional resources note.

For release(s): 4.16, 4.15, 4.14
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
