### PR TITLE
OSDOCS-10013: Documented the 4.14.18 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3286,6 +3286,37 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+[id="ocp-4-14-18"]
+=== RHSA-2024:1458 - {product-title} 4.14.18 bug fix update and security update
+
+Issued: 2024-03-27
+
+{product-title} release 4.14.18, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:1458[RHSA-2024:1458] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1461[RHSA-2024:1461] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.18 --pullspecs
+----
+
+[id="ocp-4-14-18-bug-fixes"]
+==== Bug fixes
+
+* Previously, under certain conditions the installation program would fail with the error message: `unexpected end of JSON input`. With this release, the error message is clarified and suggests users set the `serviceAccount` field in the `install-config.yaml` configuration file to fix the issue. (link:https://issues.redhat.com/browse/OCPBUGS-30027[*OCPBUGS-30027*])
+
+[id="ocp-4-14-18-known-issue"]
+==== Known issues
+
+* Currently, providing a performance profile as an extra manifest when installing a {product-title} cluster is not supported. (link:https://issues.redhat.com/browse/OCPBUGS-18640[*OCPBUGS-18640*])
+
+[id="ocp-4-14-18-updating"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 [id="ocp-4-14-17"]
 === RHBA-2024:1260 - {product-title} 4.14.17 bug fix update
 
@@ -3347,7 +3378,7 @@ $ oc adm release info 4.14.15 --pullspecs
 [id="ocp-4-14-15-bug-fixes"]
 ==== Bug fixes
 
-* Previously, the `manila-csi-driver-controller-metrics` service had empty endpoints because of an incorrect name for the app selector. With this release the app selector name is changed to `openstack-manila-csi` and the issue is fixed.. (link:https://issues.redhat.com/browse/OCPBUGS-23443[*OCPBUGS-23443*])
+* Previously, the `manila-csi-driver-controller-metrics` service had empty endpoints because of an incorrect name for the app selector. With this release the app selector name is changed to `openstack-manila-csi` and the issue is fixed. (link:https://issues.redhat.com/browse/OCPBUGS-23443[*OCPBUGS-23443*])
 
 * Previously, an Amazon Web Services (AWS) code that provided image credentials was removed from the kubelet in {product-title} {product-version}. Consequently, pulling images from Amazon Elastic Container Registry (ECR) failed without a specified pull secret, because the kubelet could no longer authenticate itself and pass credentials to the container runtime. With this update, a separate credential provider has been configured, which is now responsible for providing ECR credentials for the kubelet. As a result, the kubelet can now pull private images from ECR. (link:https://issues.redhat.com/browse/OCPBUGS-29630[*OCPBUGS-29630*])
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-10013](https://issues.redhat.com/browse/OSDOCS-10013)

Link to docs preview:
[4.14.18 z-stream release notes](https://73669--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-18)

QE review:
- [x] QE approval is not required. See peer-review checklist.
