### PR TITLE
OCPBUGS-10640-follow-up Address disk parition BM review comments

### DIFF
--- a/modules/installation-user-infra-machines-advanced.adoc
+++ b/modules/installation-user-infra-machines-advanced.adoc
@@ -73,11 +73,11 @@ The `--copy-network` option only copies networking configuration found under `/e
 [id="installation-user-infra-machines-advanced_disk_{context}"]
 == Disk partitioning
 
-The disk partitions are created on {product-title} cluster nodes during the {op-system-first} installation. Each {op-system} node of a particular architecture uses the same partition layout, unless the default partitioning configuration is overridden. During the {op-system} installation, the size of the root file system is increased to use the remaining available space on the target device.
+Disk partitions are created on {product-title} cluster nodes during the {op-system-first} installation. Each {op-system} node of a particular architecture uses the same partition layout, unless you override the default partitioning configuration. During the {op-system} installation, the size of the root file system is increased to use any remaining available space on the target device.
 
 [IMPORTANT]
 ====
-The use of a custom partition scheme on your node could result in {product-title} not monitoring or alerting on some node partitions. If you override the default partitioning, see link:https://access.redhat.com/articles/4766521[Understanding OpenShift File System Monitoring (eviction conditions)] for more information about how {product-title} monitors your host file systems.
+The use of a custom partition scheme on your node might result in {product-title} not monitoring or alerting on some node partitions. If you override the default partitioning, see link:https://access.redhat.com/articles/4766521[Understanding OpenShift File System Monitoring (eviction conditions)] for more information about how {product-title} monitors your host file systems.
 ====
 
 {product-title} monitors the following two filesystem identifiers:
@@ -87,11 +87,11 @@ The use of a custom partition scheme on your node could result in {product-title
 
 For the default partition scheme, `nodefs` and `imagefs` monitor the same root filesystem, `/`.
 
-To override the default partitioning when installing {op-system} on an {product-title} cluster node, you must create separate partitions. You might want to add a separate storage partition for your containers and container images. For example, by mounting `/var/lib/containers` in a separate partition, the kubelet separately monitors `/var/lib/containers` as the `imagefs` directory and the root file system as the `nodefs` directory.
+To override the default partitioning when installing {op-system} on an {product-title} cluster node, you must create separate partitions. Consider a situation where you want to add a separate storage partition for your containers and container images. For example, by mounting `/var/lib/containers` in a separate partition, the kubelet separately monitors `/var/lib/containers` as the `imagefs` directory and the root file system as the `nodefs` directory.
 
 [IMPORTANT]
 ====
-If you resized your disk size to host a larger file system, consider creating a separate `/var/lib/containers` partition. This is important for a disk formatted to `xfs`, where a high number of allocation groups might cause CPU time issues.
+If you have resized your disk size to host a larger file system, consider creating a separate `/var/lib/containers` partition. Consider resizing a disk that has an `xfs` format to reduce CPU time issues caused by a high number of allocation groups.
 ====
 
 [id="installation-user-infra-machines-advanced_vardisk_{context}"]


### PR DESCRIPTION
Version(s):
4.16 to 4.12

Issue:
[OCPBUGS-10640](https://issues.redhat.com/browse/OCPBUGS-10640)

Link to docs preview:
[Disk partioning](https://73670--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal#installation-user-infra-machines-advanced_disk_installing-bare-metal)

Additional information:

Address peer-review comments on a final cherry-picked PR. See Brian Burt's comment on https://github.com/openshift/openshift-docs/pull/73361/files
