### PR TITLE
OSDOCS-9843: adds 4.14.18 release note MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -12,23 +12,19 @@ toc::[]
 
 [id="microshift-4-14-about-this-release"]
 == About this release
-// TODO: Update with the relevant information closer to release.
 {microshift-short} was introduced as Technology Preview in version 4.13 and is now Generally Available with {microshift-short} 4.14. Support for {microshift-short} 4.13 is planned to end in a future {microshift-short} release. You should plan to update to the latest version of {microshift-short}. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md[Kubernetes 1.27] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {microshift-short} are included in this topic.
 
 You can deploy {microshift-short} clusters to either on-premise, cloud, or disconnected environments.
 
-// Double check OP system versions
 {microshift-short} {product-version} is supported on {op-system-ostree-first} and {op-system-base-full} 9.2 and 9.3.
 
-//TODO: update link after GA; KCS article will not be live until then
-//For lifecycle information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
+For lifecycle information, see the link:https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{product-title} Life Cycle Policy].
 
 [id="microshift-4-14-new-features-and-enhancements"]
 == New features and enhancements
 
 This release adds improvements related to the following components and concepts.
 
-//L3 major categories with features in each as L4s, for example:
 [id="microshift-4-14-rhel"]
 === {op-system-base-full}
 * {microshift-short} now runs on {op-system-base} versions 9.2 and 9.3.
@@ -52,9 +48,6 @@ The following list provides update details:
 * Updates of the RPMs on a non-OSTree system such as {op-system} are also supported.
 * Updates from preview versions such as {microshift-short} 4.13 and earlier are not supported.
 
-//[id="microshift-4-14-new-feat-based-on-{op-system-ostree}"]
-//==== Placeholder for new feat bases on RHEL Edge
-
 [id="microshift-4-14-installation"]
 === Installation
 
@@ -62,13 +55,6 @@ The following list provides update details:
 ==== Adding a certificate authority bundle to an ostree image
 
 You can now include additional trusted certificate authorities (CAs) to the {op-system-ostree-first} `rpm-ostree` image by adding them to the blueprint that you use to create the image. For more information on how to set up additional CAs to be trusted by the operatng ystem while pulling images from an image registry, see xref:../microshift_install/microshift-embed-in-rpm-ostree.adoc#microshift-ca-adding-bundle_microshift-embed-in-rpm-ostree[Adding a certificate authority bundle to an ostree image].
-
-//[id="microshift-4-14-new-feature-for-use-at-installation"]
-//==== New feature for use during installation here
-//can include a note about a change in base RHEL image
-
-//[id="microshift-4-14-support"]
-//=== Support
 
 [id="microshift-4-14-post-installation"]
 === Post-installation configuration
@@ -81,21 +67,6 @@ With this release, configuration options have changed.
 * The `advertiseAddress` field was added.
 
 See xref:../microshift_configuring/microshift-using-config-tools.adoc#microshift-yaml-default_microshift-using-config-tools[using configuration tools] for details.
-
-//[id="microshift-4-14-administrator-perspective"]
-//==== Administrator Perspective
-//admin perspectives go here
-
-//[id="microshift-4-14-security"]
-//=== Security and compliance
-//
-// This content will be added post-GA, as it is asynchronous content.
-
-//[id="microshift-4-14-networking"]
-//=== Networking
-
-//[id="microshift-4-14-load-balancer"]
-//==== Deploying network load balancers on {product-title}
 
 [id="microshift-4-14-storage"]
 === Storage
@@ -126,9 +97,6 @@ The capability to back up and restore the {microshift-short} database is now ava
 [id="microshift-4-14-override-manifest-paths"]
 ==== Override manifest paths
 With this release, you can override the list of default manifest paths by using a new single path, or by using a new glob pattern for multiple files. For more information, see xref:../microshift_running_apps/microshift-applications.adoc#microshift-manifests-override-paths_applications-microshift[Override the lost of manifest paths].
-
-//[id="microshift-4-14-lvms-system-requirements"]
-//==== LVMS system requirements
 
 [id="microshift-4-14-notable-technical-changes"]
 == Notable technical changes
@@ -320,7 +288,7 @@ Issued: 2023-10-31
 
 {product-title} release 4.14.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:5008[RHSA-2023:5008] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:5006[RHSA-2023:5006] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-1-dp"]
 === RHSA-2023:6155 - {microshift-short} 4.14.1 bug fix advisory
@@ -329,7 +297,7 @@ Issued: 2023-11-1
 
 {product-title} release 4.14.1 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:6155[RHBA-2023:6155] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:6153[RHBA-2023:6153] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-2-dp"]
 === RHSA-2023:6839 - {microshift-short} 4.14.2 bug fix and security update advisory
@@ -338,7 +306,7 @@ Issued: 2023-11-16
 
 {product-title} release 4.14.2, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:6839[RHSA-2023:6839] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:6837[RHSA-2023:6837] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-3-dp"]
 === RHBA-2023:7319 - {microshift-short} 4.14.3 bug fix update advisory
@@ -347,7 +315,7 @@ Issued: 2023-11-21
 
 {product-title} release 4.14.3, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:7319[RHBA-2023:7319] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7315[RHSA-2023:7315] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-4-dp"]
 === RHBA-2023:7472 - {microshift-short} 4.14.4 bug fix update advisory
@@ -356,7 +324,7 @@ Issued: 2023-11-29
 
 {product-title} release 4.14.4, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:7472[RHBA-2023:7472] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7470[RHSA-2023:7470] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-4-bug-fixes"]
 ==== Bug fixes
@@ -372,7 +340,7 @@ Issued: 2023-12-05
 
 {product-title} release 4.14.5, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:7601[RHBA-2023:7601] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7599[RHSA-2023:7599] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-5-bug-fixes"]
 ==== Bug fixes
@@ -386,7 +354,7 @@ Issued: 2023-12-12
 
 {product-title} release 4.14.6, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:7684[RHBA-2023:7684] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7682[RHSA-2023:7682] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-7-dp"]
 === RHBA-2023:7833 - {microshift-short} 4.14.7 bug fix update advisory
@@ -395,7 +363,7 @@ Issued: 2024-01-03
 
 {product-title} release 4.14.7, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:7833[RHBA-2023:7833] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7831[RHSA-2023:7831] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-8-dp"]
 === RHBA-2024:0052 - {microshift-short} 4.14.8 bug fix update advisory
@@ -404,7 +372,7 @@ Issued: 2024-01-09
 
 {product-title} release 4.14.8, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0052[RHBA-2024:0052] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0050[RHSA-2024:0050] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-9-dp"]
 === RHBA-2024:0206 - {microshift-short} 4.14.9 bug fix update advisory
@@ -413,7 +381,7 @@ Issued: 2024-01-17
 
 {product-title} release 4.14.9, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0206[RHBA-2024:0206] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0204[RHSA-2024:0204] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-10-dp"]
 === RHSA-2024:0292 - {microshift-short} 4.14.10 bug fix update and security advisory
@@ -422,7 +390,7 @@ Issued: 2024-01-24
 
 {product-title} release 4.14.10, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:0292[RHSA-2024:0292] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0290[RHSA-2024:0290] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-11-dp"]
 === RHBA-2024:0644 - {microshift-short} 4.14.11 bug fix update and security advisory
@@ -431,7 +399,7 @@ Issued: 2024-02-07
 
 {product-title} release 4.14.11, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0644[RHBA-2024:0644] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0642[RHSA-2024:0642] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-12-dp"]
 === RHBA-2024:0737 - {microshift-short} 4.14.12 bug fix update and security advisory
@@ -440,7 +408,7 @@ Issued: 2024-02-13
 
 {product-title} release 4.14.12, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0737[RHBA-2024:0737] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0735[RHSA-2024:0735] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-13-dp"]
 === RHBA-2024:0839 - {microshift-short} 4.14.13 bug fix update and security advisory
@@ -449,7 +417,7 @@ Issued: 2024-02-20
 
 {product-title} release 4.14.13, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0839[RHBA-2024:0839] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0837[RHSA-2024:0837] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-13-bug-fixes"]
 ==== Enhancement and bug fix
@@ -463,7 +431,7 @@ Issued: 2024-02-28
 
 {product-title} release 4.14.14, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0943[RHBA-2024:0943] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0941[RHSA-2024:0941] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-15-dp"]
 === RHBA-2024:1048 - {microshift-short} 4.14.15 bug fix update advisory
@@ -472,7 +440,7 @@ Issued: 2024-03-05
 
 {product-title} release 4.14.15 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1048[RHBA-2024:1048] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:1046[RHBA-2024:1046] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-16-dp"]
 === RHBA-2024:1207 - {microshift-short} 4.14.16 bug fix update advisory
@@ -481,7 +449,7 @@ Issued: 2024-03-13
 
 {product-title} release 4.14.16 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1207[RHBA-2024:1207] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:1205[RHBA-2024:1205] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-17-dp"]
 === RHBA-2024:1262 - {microshift-short} 4.14.17 bug fix update advisory
@@ -490,4 +458,13 @@ Issued: 2024-03-20
 
 {product-title} release 4.14.17 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1262[RHBA-2024:1262] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:1260[RHBA-2024:1260] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-14-18-dp"]
+=== RHBA-2024:1460 - {microshift-short} 4.14.18 bug fix update advisory
+
+Issued: 2024-03-27
+
+{product-title} release 4.14.18 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1460[RHBA-2024:1460] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1458[RHSA-2024:1458] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.14

Issue:
[4.14.18 issue](https://issues.redhat.com/browse/OSDOCS-9843)

Link to docs preview:
[4.14.18 async release note](https://73671--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes#microshift-4-14-18-dp)

QE review:
- N/A stock text only, no bugs

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
