### PR TITLE
TELCODOCS-1388: Add IPI troubleshooting information to our documentation

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-troubleshooting.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-troubleshooting.adoc
@@ -7,35 +7,41 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 
-== Troubleshooting the installer workflow
+== Troubleshooting the installation program workflow
 
 Prior to troubleshooting the installation environment, it is critical to understand the overall flow of the installer-provisioned installation on bare metal. The diagrams below provide a troubleshooting flow with a step-by-step breakdown for the environment.
 
 image:flow1.png[Flow-Diagram-1]
 
-_Workflow 1 of 4_ illustrates a troubleshooting workflow when the `install-config.yaml` file has errors or the {op-system-first} images are inaccessible.  Troubleshooting suggestions can be found at xref:ipi-install-troubleshooting-install-config_{context}[Troubleshooting `install-config.yaml`].
+_Workflow 1 of 4_ illustrates a troubleshooting workflow when the `install-config.yaml` file has errors or the {op-system-first} images are inaccessible. Troubleshooting suggestions can be found at xref:ipi-install-troubleshooting-install-config_ipi-install-troubleshooting[Troubleshooting `install-config.yaml`].
 
 image:flow2.png[Flow-Diagram-2]
 
-_Workflow 2 of 4_ illustrates a troubleshooting workflow for xref:ipi-install-troubleshooting-bootstrap-vm_{context}[ bootstrap VM issues], xref:ipi-install-troubleshooting-bootstrap-vm-cannot-boot_{context}[ bootstrap VMs that cannot boot up the cluster nodes], and  xref:ipi-install-troubleshooting-bootstrap-vm-inspecting-logs_{context}[ inspecting logs]. When installing an {product-title} cluster without the `provisioning` network, this workflow does not apply.
+_Workflow 2 of 4_ illustrates a troubleshooting workflow for xref:ipi-install-troubleshooting-bootstrap-vm_ipi-install-troubleshooting[ bootstrap VM issues], xref:ipi-install-troubleshooting-bootstrap-vm-cannot-boot_ipi-install-troubleshooting[ bootstrap VMs that cannot boot up the cluster nodes], and  xref:ipi-install-troubleshooting-bootstrap-vm-inspecting-logs_ipi-install-troubleshooting[ inspecting logs]. When installing an {product-title} cluster without the `provisioning` network, this workflow does not apply.
 
 image:flow3.png[Flow-Diagram-3]
 
-_Workflow 3 of 4_ illustrates a troubleshooting workflow for xref:ipi-install-troubleshooting-cluster-nodes-will-not-pxe_{context}[ cluster nodes that will not PXE boot]. If installing using RedFish Virtual Media, each node must meet minimum firmware requirements for the installer to deploy the node. See *Firmware requirements for installing with virtual media* in the *Prerequisites* section for additional details.
+_Workflow 3 of 4_ illustrates a troubleshooting workflow for xref:ipi-install-troubleshooting-cluster-nodes-will-not-pxe_ipi-install-troubleshooting[ cluster nodes that will not PXE boot]. If installing using RedFish Virtual Media, each node must meet minimum firmware requirements for the installation program to deploy the node. See *Firmware requirements for installing with virtual media* in the *Prerequisites* section for additional details.
 
 image:flow4.png[Flow-Diagram-4]
 
 _Workflow 4 of 4_ illustrates a troubleshooting workflow from
-xref:ipi-install-troubleshooting-api-not-accessible_{context}[ a non-accessible API] to a xref:ipi-install-troubleshooting-reviewing-the-installation_{context}[validated installation].
+xref:investigating-an-unavailable-kubernetes-api_ipi-install-troubleshooting[ a non-accessible API] to a xref:ipi-install-troubleshooting-reviewing-the-installation_ipi-install-troubleshooting[validated installation].
 
 
 include::modules/ipi-install-troubleshooting-install-config.adoc[leveloffset=+1]
 include::modules/ipi-install-troubleshooting-bootstrap-vm.adoc[leveloffset=+1]
 include::modules/ipi-install-troubleshooting-bootstrap-vm-cannot-boot.adoc[leveloffset=+2]
 include::modules/ipi-install-troubleshooting-bootstrap-vm-inspecting-logs.adoc[leveloffset=+2]
+include::modules/ipi-install-troubleshooting-investigating-an-unavailable-kubernetes-api.adoc[leveloffset=+1]
+include::modules/ipi-install-troubleshooting-troubleshooting-failure-to-initialize-the-cluster.adoc[leveloffset=+1]
+include::modules/ipi-install-troubleshooting-troubleshooting-failure-to-fetch-the-console-url.adoc[leveloffset=+1]
+include::modules/ipi-install-troubleshooting-troubleshooting-failure-to-add-the-ingress-certificate-to-kubeconfig.adoc[leveloffset=+1]
+include::modules/ipi-install-troubleshooting-troubleshooting-ssh-access-to-cluster-nodes.adoc[leveloffset=+1]
 include::modules/ipi-install-troubleshooting-cluster-nodes-will-not-pxe.adoc[leveloffset=+1]
+include::modules/ipi-install-troubleshooting-installing-creates-no-worker-nodes.adoc[leveloffset=+1]
+include::modules/ipi-install-troubleshooting-troubleshooting-the-cluster-network-operator.adoc[leveloffset=+1]
 include::modules/ipi-install-troubleshooting_unable-to-discover-new-bare-metal-hosts-using-the-bmc.adoc[leveloffset=+1]
-include::modules/ipi-install-troubleshooting-api-not-accessible.adoc[leveloffset=+1]
 include::modules/ipi-install-troubleshooting_proc_worker-nodes-cannot-join-the-cluster.adoc[leveloffset=+1]
 include::modules/ipi-install-troubleshooting-cleaning-up-previous-installations.adoc[leveloffset=+1]
 include::modules/ipi-install-troubleshooting-registry-issues.adoc[leveloffset=+1]

--- a/modules/ipi-install-establishing-communication-between-subnets.adoc
+++ b/modules/ipi-install-establishing-communication-between-subnets.adoc
@@ -143,7 +143,7 @@ Adjust the commands to match your actual interface names and gateway.
 $ ping <remote_worker_node_ip_address>
 ----
 +
-If the ping is successful, it means the control plane nodes in the first subnet can reach the remote worker nodes in the second subnet. If you don't receive a response, review the network configurations and repeat the procedure for the node.
+If the ping is successful, it means the control plane nodes in the first subnet can reach the remote worker nodes in the second subnet. If you do not receive a response, review the network configurations and repeat the procedure for the node.
 
 .. From the remote worker nodes in the second subnet, ping a control plane node in the first subnet by running the following command:
 +
@@ -152,4 +152,4 @@ If the ping is successful, it means the control plane nodes in the first subnet 
 $ ping <control_plane_node_ip_address>
 ----
 +
-If the ping is successful, it means the remote worker nodes in the second subnet can reach the control plane in the first subnet. If you don't receive a response, review the network configurations and repeat the procedure for the node.
+If the ping is successful, it means the remote worker nodes in the second subnet can reach the control plane in the first subnet. If you do not receive a response, review the network configurations and repeat the procedure for the node.

--- a/modules/ipi-install-modifying-install-config-for-slaac-dual-stack-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-slaac-dual-stack-network.adoc
@@ -6,7 +6,7 @@
 [id='ipi-install-modifying-install-config-for-slaac-dual-stack-network_{context}']
 = Optional: Configuring address generation modes for SLAAC in dual-stack networks
 
-For dual-stack clusters that use Stateless Address AutoConfiguration (SLAAC), you must specify a global value for the `ipv6.addr-gen-mode` network setting. You can set this value using NMState to configure the ramdisk and the cluster configuration files. If you don't configure a consistent `ipv6.addr-gen-mode` in these locations, IPv6 address mismatches can occur between CSR resources and `BareMetalHost` resources in the cluster.
+For dual-stack clusters that use Stateless Address AutoConfiguration (SLAAC), you must specify a global value for the `ipv6.addr-gen-mode` network setting. You can set this value using NMState to configure the RAM disk and the cluster configuration files. If you do not configure a consistent `ipv6.addr-gen-mode` in these locations, IPv6 address mismatches can occur between CSR resources and `BareMetalHost` resources in the cluster.
 
 .Prerequisites
 

--- a/modules/ipi-install-troubleshooting-bootstrap-vm.adoc
+++ b/modules/ipi-install-troubleshooting-bootstrap-vm.adoc
@@ -4,7 +4,7 @@
 :_mod-docs-content-type: PROCEDURE
 [id="ipi-install-troubleshooting-bootstrap-vm_{context}"]
 
-= Bootstrap VM issues
+= Troubleshooting bootstrap VM issues
 
 The {product-title} installation program spawns a bootstrap node virtual machine, which handles provisioning the {product-title} cluster nodes.
 
@@ -28,10 +28,8 @@ $ sudo virsh list
 ====
 The name of the bootstrap VM is always the cluster name followed by a random set of characters and ending in the word "bootstrap."
 ====
-+
-If the bootstrap VM is not running after 10-15 minutes, troubleshoot why it is not running. Possible issues include:
 
-. Verify `libvirtd` is running on the system:
+. If the bootstrap VM is not running after 10-15 minutes, verify `libvirtd` is running on the system by executing the following command:
 +
 [source,terminal]
 ----
@@ -79,7 +77,6 @@ localhost login:
 When deploying an {product-title} cluster without the `provisioning` network, you must use a public IP address and not a private IP address like `172.22.0.2`.
 ====
 
-
 . After you obtain the IP address, log in to the bootstrap VM using the `ssh` command:
 +
 [NOTE]
@@ -95,12 +92,8 @@ $ ssh core@172.22.0.2
 If you are not successful logging in to the bootstrap VM, you have likely encountered one of the following scenarios:
 
 * You cannot reach the `172.22.0.0/24` network. Verify the network connectivity between the provisioner and the `provisioning` network bridge. This issue might occur if you are using a `provisioning` network.
-`
-* You cannot reach the bootstrap VM through the public network. When attempting
-to SSH via `baremetal` network, verify connectivity on the
+
+* You cannot reach the bootstrap VM through the public network. When attempting to SSH via `baremetal` network, verify connectivity on the
 `provisioner` host specifically around the `baremetal` network bridge.
 
-* You encountered `Permission denied (publickey,password,keyboard-interactive)`. When
-attempting to access the bootstrap VM, a `Permission denied` error
-might occur. Verify that the SSH key for the user attempting to log
-in to the VM is set within the `install-config.yaml` file.
+* You encountered `Permission denied (publickey,password,keyboard-interactive)`. When attempting to access the bootstrap VM, a `Permission denied` error might occur. Verify that the SSH key for the user attempting to log in to the VM is set within the `install-config.yaml` file.

--- a/modules/ipi-install-troubleshooting-installing-creates-no-worker-nodes.adoc
+++ b/modules/ipi-install-troubleshooting-installing-creates-no-worker-nodes.adoc
@@ -1,0 +1,40 @@
+// This module is included in the following assemblies: 
+//
+// installing/installing_bare_metal_ipi/ipi-install-troubleshooting.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="installing-creates-no-worker-nodes_{context}"]
+= Installing creates no worker nodes
+
+The installation program does not provision worker nodes directly. Instead, the Machine API Operator scales nodes up and down on supported platforms. If worker nodes are not created after 15 to 20 minutes, depending on the speed of the cluster's internet connection, investigate the Machine API Operator.
+
+.Procedure
+
+. Check the Machine API Operator by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig \
+   --namespace=openshift-machine-api get deployments
+----
++
+If `${INSTALL_DIR}` is not set in your environment, replace the value with the name of the installation directory.
++
+.Example output
+[source,terminal]
+----
+NAME                          READY   UP-TO-DATE   AVAILABLE   AGE
+cluster-autoscaler-operator   1/1     1            1           86m
+cluster-baremetal-operator    1/1     1            1           86m
+machine-api-controllers       1/1     1            1           85m
+machine-api-operator          1/1     1            1           86m
+----
+
+. Check the machine controller logs by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig \
+     --namespace=openshift-machine-api logs deployments/machine-api-controllers \
+     --container=machine-controller
+----

--- a/modules/ipi-install-troubleshooting-investigating-an-unavailable-kubernetes-api.adoc
+++ b/modules/ipi-install-troubleshooting-investigating-an-unavailable-kubernetes-api.adoc
@@ -1,16 +1,32 @@
-// Module included in the following assemblies:
-// //installing/installing_bare_metal_ipi/installing_bare_metal_ipi/ipi-install-troubleshooting.adoc
+// This module is included in the following assemblies: 
+//
+// installing/installing_bare_metal_ipi/ipi-install-troubleshooting.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="ipi-install-troubleshooting-api-not-accessible_{context}"]
+[id="investigating-an-unavailable-kubernetes-api_{context}"]
+= Investigating an unavailable Kubernetes API
 
-= The API is not accessible
-
-When the cluster is running and clients cannot access the API, domain name resolution issues might impede access to the API.
+When the Kubernetes API is unavailable, check the control plane nodes to ensure that they are running the correct components. Also, check the hostname resolution.
 
 .Procedure
 
-. **Hostname Resolution:** Check the cluster nodes to ensure they have a fully qualified domain name, and not just `localhost.localdomain`. For example:
+.  Ensure that `etcd` is running on each of the control plane nodes by running the following command:
++
+[source,terminal]
+----
+$ sudo crictl logs $(sudo crictl ps --pod=$(sudo crictl pods --name=etcd-member --quiet) --quiet)
+----
+
+. If the previous command fails, ensure that Kublet created the `etcd` pods by running the following command:
++
+[source,terminal]
+----
+$ sudo crictl pods --name=etcd-member
+----
++
+If there are no pods, investigate `etcd`.
+
+. Check the cluster nodes to ensure they have a fully qualified domain name, and not just `localhost.localdomain`, by using the following command:
 +
 [source,terminal]
 ----
@@ -21,10 +37,10 @@ If a hostname is not set, set the correct hostname. For example:
 +
 [source,terminal]
 ----
-$ hostnamectl set-hostname <hostname>
+$ sudo hostnamectl set-hostname <hostname>
 ----
 
-. **Incorrect Name Resolution:** Ensure that each node has the correct name resolution in the DNS server using `dig` and `nslookup`. For example:
+. Ensure that each node has the correct name resolution in the DNS server using the `dig` command:
 +
 [source,terminal]
 ----

--- a/modules/ipi-install-troubleshooting-misc-issues.adoc
+++ b/modules/ipi-install-troubleshooting-misc-issues.adoc
@@ -14,7 +14,7 @@ After the deployment of a cluster you might receive the following error:
 `runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: Missing CNI default network`
 ----
 
-The Cluster Network Operator is responsible for deploying the networking components in response to a special object created by the installer. It runs very early in the installation process, after the control plane (master) nodes have come up, but before the bootstrap control plane has been torn down. It can be indicative of more subtle installer issues, such as long delays in bringing up control plane (master) nodes or issues with `apiserver` communication.
+The Cluster Network Operator is responsible for deploying the networking components in response to a special object created by the installation program. It runs very early in the installation process, after the control plane (master) nodes have come up, but before the bootstrap control plane has been torn down. It can be indicative of more subtle installation program issues, such as long delays in bringing up control plane (master) nodes or issues with `apiserver` communication.
 
 .Procedure
 
@@ -54,7 +54,7 @@ spec:
   networkType: OVNKubernetes
 ----
 +
-If it does not exist, the installer did not create it. To determine why the installer did not create it, execute the following:
+If it does not exist, the installation program did not create it. To determine why the installation program did not create it, execute the following:
 +
 [source,terminal]
 ----
@@ -75,7 +75,7 @@ $ kubectl -n openshift-network-operator get pods
 $ kubectl -n openshift-network-operator logs -l "name=network-operator"
 ----
 +
-On high availability clusters with three or more control plane (master) nodes, the Operator will perform leader election and all other Operators will sleep. For additional details, see https://github.com/openshift/installer/blob/master/docs/user/troubleshooting.md[Troubleshooting].
+On high availability clusters with three or more control plane nodes, the Operator will perform leader election and all other Operators will sleep. For additional details, see https://github.com/openshift/installer/blob/master/docs/user/troubleshooting.md[Troubleshooting].
 
 == Addressing the "No disk found with matching rootDeviceHints" error message
 

--- a/modules/ipi-install-troubleshooting-reviewing-the-installation.adoc
+++ b/modules/ipi-install-troubleshooting-reviewing-the-installation.adoc
@@ -6,7 +6,7 @@
 
 = Reviewing the installation
 
-After installation, ensure the installer deployed the nodes and pods successfully.
+After installation, ensure the installation program deployed the nodes and pods successfully.
 
 .Procedure
 
@@ -25,7 +25,7 @@ master-1.example.com   Ready    master,worker   4h   v1.28.5
 master-2.example.com   Ready    master,worker   4h   v1.28.5
 ----
 
-. Confirm the installer deployed all pods successfully. The following command
+. Confirm the installation program deployed all pods successfully. The following command
 removes any pods that are still running or have completed as part of the output.
 +
 [source,terminal]

--- a/modules/ipi-install-troubleshooting-troubleshooting-failure-to-add-the-ingress-certificate-to-kubeconfig.adoc
+++ b/modules/ipi-install-troubleshooting-troubleshooting-failure-to-add-the-ingress-certificate-to-kubeconfig.adoc
@@ -1,0 +1,44 @@
+// This module is included in the following assemblies: 
+//
+// installing/installing_bare_metal_ipi/ipi-install-troubleshooting.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="troubleshooting-failure-to-add-the-ingress-certificate-to-kubeconfig_{context}"]
+= Troubleshooting a failure to add the ingress certificate to kubeconfig
+
+The installation program adds the default ingress certificate to the list of trusted client certificate authorities in `${INSTALL_DIR}/auth/kubeconfig`. If the installation program fails to add the ingress certificate to the `kubeconfig` file, you can retrieve the certificate from the cluster and add it.
+
+.Procedure
+
+. Retrieve the certificate from the cluster using the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig get configmaps default-ingress-cert \
+     -n openshift-config-managed -o=jsonpath='{.data.ca-bundle\.crt}'
+----
++
+[source,terminal]
+----
+-----BEGIN CERTIFICATE-----
+MIIC/TCCAeWgAwIBAgIBATANBgkqhkiG9w0BAQsFADAuMSwwKgYDVQQDDCNjbHVz
+dGVyLWluZ3Jlc3Mtb3BlcmF0b3JAMTU1MTMwNzU4OTAeFw0xOTAyMjcyMjQ2Mjha
+Fw0yMTAyMjYyMjQ2MjlaMC4xLDAqBgNVBAMMI2NsdXN0ZXItaW5ncmVzcy1vcGVy
+YXRvckAxNTUxMzA3NTg5MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
+uCA4fQ+2YXoXSUL4h/mcvJfrgpBfKBW5hfB8NcgXeCYiQPnCKblH1sEQnI3VC5Pk
+2OfNCF3PUlfm4i8CHC95a7nCkRjmJNg1gVrWCvS/ohLgnO0BvszSiRLxIpuo3C4S
+EVqqvxValHcbdAXWgZLQoYZXV7RMz8yZjl5CfhDaaItyBFj3GtIJkXgUwp/5sUfI
+LDXW8MM6AXfuG+kweLdLCMm3g8WLLfLBLvVBKB+4IhIH7ll0buOz04RKhnYN+Ebw
+tcvFi55vwuUCWMnGhWHGEQ8sWm/wLnNlOwsUz7S1/sW8nj87GFHzgkaVM9EOnoNI
+gKhMBK9ItNzjrP6dgiKBCQIDAQABoyYwJDAOBgNVHQ8BAf8EBAMCAqQwEgYDVR0T
+AQH/BAgwBgEB/wIBADANBgkqhkiG9w0BAQsFAAOCAQEAq+vi0sFKudaZ9aUQMMha
+CeWx9CZvZBblnAWT/61UdpZKpFi4eJ2d33lGcfKwHOi2NP/iSKQBebfG0iNLVVPz
+vwLbSG1i9R9GLdAbnHpPT9UG6fLaDIoKpnKiBfGENfxeiq5vTln2bAgivxrVlyiq
++MdDXFAWb6V4u2xh6RChI7akNsS3oU9PZ9YOs5e8vJp2YAEphht05X0swA+X8V8T
+C278FFifpo0h3Q0Dbv8Rfn4UpBEtN4KkLeS+JeT+0o2XOsFZp7Uhr9yFIodRsnNo
+H/Uwmab28ocNrGNiEVaVH6eTTQeeZuOdoQzUbClElpVmkrNGY0M42K0PvOQ/e7+y
+AQ==
+-----END CERTIFICATE-----
+----
+
+. Add the certificate to the `client-certificate-authority-data` field in the `${INSTALL_DIR}/auth/kubeconfig` file.

--- a/modules/ipi-install-troubleshooting-troubleshooting-failure-to-fetch-the-console-url.adoc
+++ b/modules/ipi-install-troubleshooting-troubleshooting-failure-to-fetch-the-console-url.adoc
@@ -1,0 +1,72 @@
+// This module is included in the following assemblies: 
+//
+// installing/installing_bare_metal_ipi/ipi-install-troubleshooting.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="troubleshooting-failure-to-fetch-the-console-url_{context}"]
+= Troubleshooting a failure to fetch the console URL
+
+The installation program retrieves the URL for the {product-title} console by using `[route][route-object]` within the `openshift-console` namespace. If the installation program fails the retrieve the URL for the console, use the following procedure.
+
+.Procedure
+
+. Check if the console router is in the `Available` or `Failing` state by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig get clusteroperator console -oyaml
+----
++
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: ClusterOperator
+metadata:
+  creationTimestamp: 2019-02-27T22:46:57Z
+  generation: 1
+  name: console
+  resourceVersion: "19682"
+  selfLink: /apis/config.openshift.io/v1/clusteroperators/console
+  uid: 960364aa-3ae1-11e9-bad4-0a97b6ba9358
+spec: {}
+status:
+  conditions:
+  - lastTransitionTime: 2019-02-27T22:46:58Z
+    status: "False"
+    type: Failing
+  - lastTransitionTime: 2019-02-27T22:50:12Z
+    status: "False"
+    type: Progressing
+  - lastTransitionTime: 2019-02-27T22:50:12Z
+    status: "True"
+    type: Available
+  - lastTransitionTime: 2019-02-27T22:46:57Z
+    status: "True"
+    type: Upgradeable
+  extension: null
+  relatedObjects:
+  - group: operator.openshift.io
+    name: cluster
+    resource: consoles
+  - group: config.openshift.io
+    name: cluster
+    resource: consoles
+  - group: oauth.openshift.io
+    name: console
+    resource: oauthclients
+  - group: ""
+    name: openshift-console-operator
+    resource: namespaces
+  - group: ""
+    name: openshift-console
+    resource: namespaces
+  versions: null
+----
+
+. Manually retrieve the console URL by executing the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig get route console -n openshift-console \
+     -o=jsonpath='{.spec.host}' console-openshift-console.apps.adahiya-1.devcluster.openshift.com
+----

--- a/modules/ipi-install-troubleshooting-troubleshooting-failure-to-initialize-the-cluster.adoc
+++ b/modules/ipi-install-troubleshooting-troubleshooting-failure-to-initialize-the-cluster.adoc
@@ -1,0 +1,192 @@
+// This module is included in the following assemblies: 
+//
+// installing/installing_bare_metal_ipi/ipi-install-troubleshooting.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="troubleshooting-failure-to-initialize-the-cluster_{context}"]
+= Troubleshooting a failure to initialize the cluster
+
+The installation program uses the Cluster Version Operator to create all the components of an {product-title} cluster. When the installation program fails to initialize the cluster, you can retrieve the most important information from the `ClusterVersion` and `ClusterOperator` objects.
+
+.Procedure
+
+. Inspect the `ClusterVersion` object by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig get clusterversion -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+metadata:
+  creationTimestamp: 2019-02-27T22:24:21Z
+  generation: 1
+  name: version
+  resourceVersion: "19927"
+  selfLink: /apis/config.openshift.io/v1/clusterversions/version
+  uid: 6e0f4cf8-3ade-11e9-9034-0a923b47ded4
+spec:
+  channel: stable-4.1
+  clusterID: 5ec312f9-f729-429d-a454-61d4906896ca
+status:
+  availableUpdates: null
+  conditions:
+  - lastTransitionTime: 2019-02-27T22:50:30Z
+    message: Done applying 4.1.1
+    status: "True"
+    type: Available
+  - lastTransitionTime: 2019-02-27T22:50:30Z
+    status: "False"
+    type: Failing
+  - lastTransitionTime: 2019-02-27T22:50:30Z
+    message: Cluster version is 4.1.1
+    status: "False"
+    type: Progressing
+  - lastTransitionTime: 2019-02-27T22:24:31Z
+    message: 'Unable to retrieve available updates: unknown version 4.1.1
+    reason: RemoteFailed
+    status: "False"
+    type: RetrievedUpdates
+  desired:
+    image: registry.svc.ci.openshift.org/openshift/origin-release@sha256:91e6f754975963e7db1a9958075eb609ad226968623939d262d1cf45e9dbc39a
+    version: 4.1.1
+  history:
+  - completionTime: 2019-02-27T22:50:30Z
+    image: registry.svc.ci.openshift.org/openshift/origin-release@sha256:91e6f754975963e7db1a9958075eb609ad226968623939d262d1cf45e9dbc39a
+    startedTime: 2019-02-27T22:24:31Z
+    state: Completed
+    version: 4.1.1
+  observedGeneration: 1
+  versionHash: Wa7as_ik1qE=
+----
+
+. View the conditions by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig get clusterversion version \
+     -o=jsonpath='{range .status.conditions[*]}{.type}{" "}{.status}{" "}{.message}{"\n"}{end}'
+----
++ 
+Some of most important conditions include `Failing`, `Available` and `Progressing`.
++
+.Example output
+[source,terminal]
+----
+Available True Done applying 4.1.1
+Failing False
+Progressing False Cluster version is 4.0.0-0.alpha-2019-02-26-194020
+RetrievedUpdates False Unable to retrieve available updates: unknown version 4.1.1
+----
+
+. Inspect the `ClusterOperator` object by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig get clusteroperator
+----
++
+The command returns the status of the cluster Operators.
++
+.Example output
+[source,terminal]
+----
+NAME                                  VERSION   AVAILABLE   PROGRESSING   FAILING   SINCE
+cluster-baremetal-operator                      True        False         False     17m
+cluster-autoscaler                              True        False         False     17m
+cluster-storage-operator                        True        False         False     10m
+console                                         True        False         False     7m21s
+dns                                             True        False         False     31m
+image-registry                                  True        False         False     9m58s
+ingress                                         True        False         False     10m
+kube-apiserver                                  True        False         False     28m
+kube-controller-manager                         True        False         False     21m
+kube-scheduler                                  True        False         False     25m
+machine-api                                     True        False         False     17m
+machine-config                                  True        False         False     17m
+marketplace-operator                            True        False         False     10m
+monitoring                                      True        False         False     8m23s
+network                                         True        False         False     13m
+node-tuning                                     True        False         False     11m
+openshift-apiserver                             True        False         False     15m
+openshift-authentication                        True        False         False     20m
+openshift-cloud-credential-operator             True        False         False     18m
+openshift-controller-manager                    True        False         False     10m
+openshift-samples                               True        False         False     8m42s
+operator-lifecycle-manager                      True        False         False     17m
+service-ca                                      True        False         False     30m
+----
+
+. Inspect individual cluster Operators by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig get clusteroperator <operator> -oyaml <1>
+----
+<1> Replace `<operator>` with the name of a cluster Operator. This command is useful for identifying why an cluster Operator has not achieved the `Available` state or is in the `Failed` state.
++
+.Example output
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: ClusterOperator
+metadata:
+  creationTimestamp: 2019-02-27T22:47:04Z
+  generation: 1
+  name: monitoring
+  resourceVersion: "24677"
+  selfLink: /apis/config.openshift.io/v1/clusteroperators/monitoring
+  uid: 9a6a5ef9-3ae1-11e9-bad4-0a97b6ba9358
+spec: {}
+status:
+  conditions:
+  - lastTransitionTime: 2019-02-27T22:49:10Z
+    message: Successfully rolled out the stack.
+    status: "True"
+    type: Available
+  - lastTransitionTime: 2019-02-27T22:49:10Z
+    status: "False"
+    type: Progressing
+  - lastTransitionTime: 2019-02-27T22:49:10Z
+    status: "False"
+    type: Failing
+  extension: null
+  relatedObjects: null
+  version: ""
+----
+
+. To get the cluster Operator's status condition, run the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig get clusteroperator <operator> \
+     -o=jsonpath='{range .status.conditions[*]}{.type}{" "}{.status}{" "}{.message}{"\n"}{end}'
+----
++
+Replace `<operator>` with the name of one of the operators above. 
++
+.Example output
+[source,terminal]
+----
+Available True Successfully rolled out the stack
+Progressing False
+Failing False
+----
+
+. To retrieve the list of objects owned by the cluster Operator, execute the following command:
++
+[source,terminal]
+----
+oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig get clusteroperator kube-apiserver \
+   -o=jsonpath='{.status.relatedObjects}'
+----
++
+.Example output
+[source,javascript]
+----
+[map[resource:kubeapiservers group:operator.openshift.io name:cluster] map[group: name:openshift-config resource:namespaces] map[group: name:openshift-config-managed resource:namespaces] map[group: name:openshift-kube-apiserver-operator resource:namespaces] map[group: name:openshift-kube-apiserver resource:namespaces]]
+----

--- a/modules/ipi-install-troubleshooting-troubleshooting-ssh-access-to-cluster-nodes.adoc
+++ b/modules/ipi-install-troubleshooting-troubleshooting-ssh-access-to-cluster-nodes.adoc
@@ -1,0 +1,15 @@
+// This module is included in the following assemblies: 
+//
+// installing/installing_bare_metal_ipi/ipi-install-troubleshooting.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="troubleshooting-ssh-access-to-cluster-nodes_{context}"]
+= Troubleshooting SSH access to cluster nodes
+
+For added security, you cannot SSH into the cluster from outside the cluster by default. However, you can access control plane and worker nodes from the provisioner node. If you cannot SSH into the cluster nodes from the provisioner node, the nodes might be waiting on the bootstrap VM. The control plane nodes retrieve their boot configuration from the bootstrap VM, and they cannot boot successfully if they do not retrieve the boot configuration.
+
+.Procedure
+
+. If you have physical access to the nodes, check their console output to determine if they have successfully booted. If the nodes are still retrieving their boot configuration, there might be problems with the bootstrap VM .
+
+. Ensure you have configured the `sshKey: '<ssh_pub_key>'` setting in the `install-config.yaml` file, where `<ssh_pub_key>` is the public key of the `kni` user on the provisioner node.

--- a/modules/ipi-install-troubleshooting-troubleshooting-the-cluster-network-operator.adoc
+++ b/modules/ipi-install-troubleshooting-troubleshooting-the-cluster-network-operator.adoc
@@ -1,0 +1,35 @@
+// This module is included in the following assemblies: 
+//
+// installing/installing_bare_metal_ipi/ipi-install-troubleshooting.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="troubleshooting-the-cluster-network-operator_{context}"]
+= Troubleshooting the Cluster Network Operator
+
+The Cluster Network Operator is responsible for deploying the networking components. It runs early in the installation process, after the control plane nodes have come up but before the installation program removes the bootstrap control plane. Issues with this Operator might indicate installation program issues.
+
+.Procedure
+
+. Ensure the network configuration exists by running the following command:
++
+[source,terminal]
+----
+$ oc get network -o yaml cluster
+----
++
+If it does not exist, the installation program did not create it. To find out why, run the following command:
++
+[source,terminal]
+----
+$ openshift-install create manifests
+----
++
+Review the manifests to determine why the installation program did not create the network configuration.
+
+. Ensure the network is running by entering the following command:
++
+[source,terminal]
+----
+$ oc get po -n openshift-network-operator
+----
+


### PR DESCRIPTION
Added new troubleshooting modules from available upstream docs.

Fixes: [TELCODOCS-1388](https://issues.redhat.com/browse/HCIDOCS-77)

See https://issues.redhat.com/browse/HCIDOCS-77 for additional details.

Preview URL: http://184.23.213.161:8080/TELCODOCS-1388/installing/installing_bare_metal_ipi/ipi-install-troubleshooting.html

For release(s): 4.16, 4.15
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
