### PR TITLE
OCPBUGS#24317 Correcting maxunavailablestatefulset status in RNs

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -1112,9 +1112,11 @@ The `matchLabelKeys` parameter for configuring pod topology spread constraints i
 For more information, see xref:../nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.adoc#nodes-scheduler-pod-topology-spread-constraints[Controlling pod placement by using pod topology spread constraints].
 
 [id="ocp-4-14-MaxUnavailableStatefulSet"]
-==== MaxUnavailableStatefulSet enabled
+==== MaxUnavailableStatefulSet enabled (Technology Preview)
 
-With this release, the `MaxUnavailableStatefulSet` featureSet configuration parameter is enabled by default. You can now define the maximum number of `StatefulSet` pods that can be unavailable during updates; thereby, reducing application downtime when upgrading.
+With this release, the `MaxUnavailableStatefulSet` featureSet configuration parameter is available as Technology Preview feature by enabling the `TechPreviewNoUpgrade` feature set. You can now define the maximum number of `StatefulSet` pods that can be unavailable during updates, thereby reducing application downtime when upgrading.
+
+For more information, see xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-about_nodes-cluster-enabling[Understanding feature gates].
 
 [id="ocp-4-14-pdb-unhealthy-pod-eviction-policy"]
 ==== Pod disruption budget (PDB) unhealthy pod eviction policy


### PR DESCRIPTION
Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUGS-24317](https://issues.redhat.com/browse/OCPBUGS-24317)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Preview](https://73706--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-MaxUnavailableStatefulSet)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR will need Change Management.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
