### PR TITLE
RHDEVDOCS-5627: Adds missing 4.15 release note for builds

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -1535,13 +1535,15 @@ With {product-title} {product-version}, the `inspector.ipxe` configuration has b
 
 * Previously, the termination handler prematurely exited before marking a node for termination. This condition occurred based on the timing of when the termination signal was received by the controller. With this release, the possibility of early termination is accounted for by introducing an additional check for termination. (link:https://issues.redhat.com/browse/OCPBUGS-2117[*OCPBUGS-2117*])
 
+* Previously, when the `Build` cluster capability was not enabled, the cluster version Operator (CVO) failed to synchronize the build informer, and did not start successfully. With this release, the CVO successfully starts when the `Build` capability is not enabled. (link:https://issues.redhat.com/browse/OCPBUGS-22956[*OCPBUGS-22956*])
+
 [discrete]
 [id="ocp-4-15-cloud-cred-operator-bug-fixes"]
 ==== Cloud Credential Operator
 
 * Previously, the Cloud Credential Operator utility (`ccoctl`) created custom GCP roles at the cluster level, so each cluster contributed to the quota limit on the number of allowed custom roles. Because of GCP deletion policies, deleted custom roles continue to contribute to the quota limit for many days after they are deleted. With this release, custom roles are added at the project level instead of the cluster level to reduce the total number of custom roles created. Additionally, an option to clean up custom roles is now available when deleting the GCP resources that the `ccoctl` utility creates during installation. These changes can help avoid reaching the quota limit on the number of allowed custom roles. (link:https://issues.redhat.com/browse/OCPBUGS-28850[*OCPBUGS-28850*])
 
-* Previously, when the Cloud Credential Operator (CCO) was in default mode, CCO used an incorrect client for root credential queries. The CCO failed to find the intended secret and wrongly reported a `credsremoved` mode in the `cco_credentials_mode` metric. With this release, the CCO now uses the correct client to ensure accurate reporting of the `cco_credentials_mode` metric. (link:https://issues.redhat.com/browse/OCPBUGS-26510[*OCPBUGS-26510*])
+* Previously, when the `Build` cluster capability was not enabled, the Cluster Version Operator (CVO) failed to synchronize the build informer and did not start successfully. With this release, the CVO successfully starts when the `Build` capability is not enabled. (link:https://issues.redhat.com/browse/OCPBUGS-26510[*OCPBUGS-26510*])
 
 * Previously, buckets created by running the `ccoctl azure create` command were prohibited from allowing public blob access due to a change in the default behavior of Microsoft Azure buckets. With this release, buckets created by running the `ccoctl azure create` command are explicitly set to allow public blob access. (link:https://issues.redhat.com/browse/OCPBUGS-22369[*OCPBUGS-22369*])
 


### PR DESCRIPTION
Adds missing 4.15 release note for builds

Version(s):
4.15

Issue:
https://issues.redhat.com/browse/RHDEVDOCS-5627

Link to docs preview:
https://73708--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-administrator-perspective

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This will need change management 
@invincibleJai @jerolimov @Preeticp @joaedwar
