### PR TITLE
Custom Machine Config Pool role must match the MCP name

### DIFF
--- a/modules/create-a-containerruntimeconfig-crd.adoc
+++ b/modules/create-a-containerruntimeconfig-crd.adoc
@@ -92,7 +92,7 @@ spec:
    overlaySize: 8G <3>
    defaultRuntime: "crun" <4>
 ----
-<1> Specifies the machine config pool label.
+<1> Specifies the machine config pool label. For a container runtime config, the role must match the name of the associated machine config pool.
 <2> Optional: Specifies the level of verbosity for log messages.
 <3> Optional: Specifies the maximum size of a container image.
 <4> Optional: Specifies the container runtime to deploy to new containers. The default value is `runc`.

--- a/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
+++ b/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
@@ -16,11 +16,31 @@ As the fields in the `kubeletConfig` object are passed directly to the kubelet f
 
 Consider the following guidance:
 
-* Create one `KubeletConfig` CR for each machine config pool with all the config changes you want for that pool. If you are applying the same content to all of the pools, you need only one `KubeletConfig` CR for all of the pools.
-
 * Edit an existing `KubeletConfig` CR to modify existing settings or add new settings, instead of creating a CR for each change. It is recommended that you create a CR only to modify a different machine config pool, or for changes that are intended to be temporary, so that you can revert the changes.
 
+* Create one `KubeletConfig` CR for each machine config pool with all the config changes you want for that pool.
+
 * As needed, create multiple `KubeletConfig` CRs with a limit of 10 per cluster. For the first `KubeletConfig` CR, the Machine Config Operator (MCO) creates a machine config appended with `kubelet`. With each subsequent CR, the controller creates another `kubelet` machine config with a numeric suffix. For example, if you have a `kubelet` machine config with a `-2` suffix, the next `kubelet` machine config is appended with `-3`.
+
+[NOTE]
+====
+If you are applying a kubelet or container runtime config to a custom machine config pool, the custom role in the `machineConfigSelector` must match the name of the custom machine config pool. 
+
+For example, because the following custom machine config pool is named `infra`, the custom role must also be `infra`:
+
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: infra
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker,infra]}
+# ...
+----
+====
 
 If you want to delete the machine configs, delete them in reverse order to avoid exceeding the limit. For example, you delete the `kubelet-3` machine config before deleting the `kubelet-2` machine config.
 


### PR DESCRIPTION
If the user creates a MachineConfigPool with a name different than the `spec.machineConfigSelector.matchExpressions.machineconfiguration.openshift.io/role` a configuration issue with the KubeletConfig like https://issues.redhat.com/browse/OCPBUGS-10682 can happen

https://issues.redhat.com/browse/OCPBUGS-29784

Previews:
Creating a ContainerRuntimeConfig CR to edit CRI-O parameters -> [Example ContainerRuntimeConfig CR](https://73709--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#create-a-containerruntimeconfig_post-install-machine-configuration-tasks) -- Callout 1
Creating a KubeletConfig CRD to edit kubelet parameters -> [Consider the following guidance ](https://73709--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#create-a-kubeletconfig-crd-to-edit-kubelet-parameters_post-install-machine-configuration-tasks)-> Note after 3rd bullet. 


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
