### PR TITLE
[enterprise-4.13] OCPBUGS-19453: add admonition about node reboot

### DIFF
--- a/modules/customize-certificates-replace-default-router.adoc
+++ b/modules/customize-certificates-replace-default-router.adoc
@@ -25,6 +25,11 @@ followed with any intermediate certificates, and the file should end with the
 root CA certificate.
 * Copy the root CA certificate into an additional PEM format file.
 
+[IMPORTANT]
+====
+Updating the certificate authority (CA) causes the nodes in your cluster to reboot.
+====
+
 .Procedure
 
 . Create a config map that includes only the root CA certificate used to sign the wildcard certificate:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12, 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-19453
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://73711--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificates/replacing-default-ingress-certificate#replacing-default-ingress_replacing-default-ingress
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
