### PR TITLE
TELCODOCS-1819: Rename controller-manager to controller

### DIFF
--- a/modules/kmm-gathering-data-for-kmm-hub.adoc
+++ b/modules/kmm-gathering-data-for-kmm-hub.adoc
@@ -14,7 +14,7 @@
 +
 [source,terminal]
 ----
-$ export MUST_GATHER_IMAGE=$(oc get deployment -n openshift-kmm-hub kmm-operator-hub-controller-manager -ojsonpath='{.spec.template.spec.containers[?(@.name=="manager")].env[?(@.name=="RELATED_IMAGES_MUST_GATHER")].value}')
+$ export MUST_GATHER_IMAGE=$(oc get deployment -n openshift-kmm-hub kmm-operator-hub-controller -ojsonpath='{.spec.template.spec.containers[?(@.name=="manager")].env[?(@.name=="RELATED_IMAGES_MUST_GATHER")].value}')
 ----
 +
 [NOTE]
@@ -33,7 +33,7 @@ $ oc adm must-gather --image="${MUST_GATHER_IMAGE}" -- /usr/bin/gather -u
 +
 [source,terminal]
 ----
-$ oc logs -fn openshift-kmm-hub deployments/kmm-operator-hub-controller-manager
+$ oc logs -fn openshift-kmm-hub deployments/kmm-operator-hub-controller
 ----
 +
 .Example output

--- a/modules/kmm-gathering-data-for-kmm.adoc
+++ b/modules/kmm-gathering-data-for-kmm.adoc
@@ -14,7 +14,7 @@
 +
 [source,terminal]
 ----
-$ export MUST_GATHER_IMAGE=$(oc get deployment -n openshift-kmm kmm-operator-controller-manager -ojsonpath='{.spec.template.spec.containers[?(@.name=="manager")].env[?(@.name=="RELATED_IMAGES_MUST_GATHER")].value}')
+$ export MUST_GATHER_IMAGE=$(oc get deployment -n openshift-kmm kmm-operator-controller -ojsonpath='{.spec.template.spec.containers[?(@.name=="manager")].env[?(@.name=="RELATED_IMAGES_MUST_GATHER")].value}')
 ----
 +
 [NOTE]
@@ -33,7 +33,7 @@ $ oc adm must-gather --image="${MUST_GATHER_IMAGE}" -- /usr/bin/gather
 +
 [source,terminal]
 ----
-$ oc logs -fn openshift-kmm deployments/kmm-operator-controller-manager
+$ oc logs -fn openshift-kmm deployments/kmm-operator-controller
 ----
 +
 .Example output

--- a/modules/kmm-installing-older-versions.adoc
+++ b/modules/kmm-installing-older-versions.adoc
@@ -82,7 +82,7 @@ $ oc apply -f kmm-security-constraint.yaml
 +
 [source,terminal]
 ----
-$ oc adm policy add-scc-to-user kmm-security-constraint -z kmm-operator-controller-manager -n openshift-kmm
+$ oc adm policy add-scc-to-user kmm-security-constraint -z kmm-operator-controller -n openshift-kmm
 ----
 
 .. Create the following `OperatorGroup` CR and save the YAML file, for example, `kmm-op-group.yaml`:
@@ -127,14 +127,14 @@ $ oc create -f kmm-sub.yaml
 +
 [source,terminal]
 ----
-$ oc get -n openshift-kmm deployments.apps kmm-operator-controller-manager
+$ oc get -n openshift-kmm deployments.apps kmm-operator-controller
 ----
 +
 .Example output
 [source,terminal]
 ----
 NAME                              READY UP-TO-DATE  AVAILABLE AGE
-kmm-operator-controller-manager   1/1   1           1         97s
+kmm-operator-controller           1/1   1           1         97s
 ----
 +
 The Operator is available.

--- a/modules/kmm-installing-using-cli.adoc
+++ b/modules/kmm-installing-using-cli.adoc
@@ -70,14 +70,14 @@ $ oc create -f kmm-sub.yaml
 +
 [source,terminal]
 ----
-$ oc get -n openshift-kmm deployments.apps kmm-operator-controller-manager
+$ oc get -n openshift-kmm deployments.apps kmm-operator-controller
 ----
 +
 .Example output
 [source,terminal]
 ----
 NAME                              READY UP-TO-DATE  AVAILABLE AGE
-kmm-operator-controller-manager   1/1   1           1         97s
+kmm-operator-controller           1/1   1           1         97s
 ----
 +
 The Operator is available.


### PR DESCRIPTION
D/S Docs: [MGMT-17316] Doc updates for v2.x 

Jira: https://issues.redhat.com/browse/MGMT-17316 (Rename controller-manager to controller)

Version(s): KMM 2.1,  openshift-4.15, openshift-4.14 

Link to docs preview: https://73714--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management

SME review: @qbarrand
QE review: @cdvultur