### PR TITLE
Remove redundant option from command inside persistent-storage-csi-vsphere-top-aware-infra-top.adoc

### DIFF
--- a/modules/persistent-storage-csi-vsphere-top-aware-infra-top.adoc
+++ b/modules/persistent-storage-csi-vsphere-top-aware-infra-top.adoc
@@ -25,7 +25,7 @@ For more information about vSphere categories and tags, see the VMware vSphere d
 +
 [source,terminal]
 ----
-~ $ oc edit clustercsidriver csi.vsphere.vmware.com -o yaml
+~ $ oc edit clustercsidriver csi.vsphere.vmware.com
 ----
 +
 .Example output


### PR DESCRIPTION
Removing redundant option from command, ` -o yaml` not needed on `oc edit`

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): ALL 
<!--- Specify the version or versions of OpenShift your PR applies to. -->



Issue: N/A
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:  https://docs.openshift.com/container-platform/4.12/storage/container_storage_interface/persistent-storage-csi-vsphere.html#persistent-storage-csi-vsphere-top-aware_persistent-storage-csi-vsphere 
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:  Removing redundant option from command, ` -o yaml` not needed on `oc edit`
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
