### PR TITLE
OBSDOCS-197: Clarify information about secrets in custom Alertmanager…

### DIFF
--- a/modules/monitoring-creating-cluster-monitoring-configmap.adoc
+++ b/modules/monitoring-creating-cluster-monitoring-configmap.adoc
@@ -6,7 +6,7 @@
 [id="creating-cluster-monitoring-configmap_{context}"]
 = Creating a cluster monitoring config map
 
-To configure core {product-title} monitoring components, you must create the `cluster-monitoring-config` `ConfigMap` object in the `openshift-monitoring` project.
+You can configure the core {product-title} monitoring components by creating the `cluster-monitoring-config` `ConfigMap` object in the `openshift-monitoring` project. The Cluster Monitoring Operator (CMO) then configures the core components of the monitoring stack.
 
 [NOTE]
 ====

--- a/modules/monitoring-creating-user-defined-workload-monitoring-configmap.adoc
+++ b/modules/monitoring-creating-user-defined-workload-monitoring-configmap.adoc
@@ -6,7 +6,7 @@
 [id="creating-user-defined-workload-monitoring-configmap_{context}"]
 = Creating a user-defined workload monitoring config map
 
-To configure the components that monitor user-defined projects, you must create the `user-workload-monitoring-config` `ConfigMap` object in the `openshift-user-workload-monitoring` project.
+You can configure the user workload monitoring components by creating the `user-workload-monitoring-config` `ConfigMap` object in the `openshift-user-workload-monitoring` project. The Cluster Monitoring Operator (CMO) then configures the components that monitor user-defined projects.
 
 [NOTE]
 ====

--- a/modules/monitoring-support-considerations.adoc
+++ b/modules/monitoring-support-considerations.adoc
@@ -14,8 +14,8 @@ ifndef::openshift-dedicated,openshift-rosa[]
 +
 [NOTE]
 ====
-The Alertmanager configuration is deployed as a secret resource in the `openshift-monitoring` namespace.
-If you have enabled a separate Alertmanager instance for user-defined alert routing, an Alertmanager configuration is also deployed as a secret resource in the `openshift-user-workload-monitoring` namespace.
+The Alertmanager configuration is deployed as the `alertmanager-main` secret resource in the `openshift-monitoring` namespace.
+If you have enabled a separate Alertmanager instance for user-defined alert routing, an Alertmanager configuration is also deployed as the `alertmanager-user-workload` secret resource in the `openshift-user-workload-monitoring` namespace.
 To configure additional routes for any instance of Alertmanager, you need to decode, modify, and then encode that secret.
 This procedure is a supported exception to the preceding statement.
 ====

--- a/monitoring/configuring-the-monitoring-stack.adoc
+++ b/monitoring/configuring-the-monitoring-stack.adoc
@@ -37,7 +37,7 @@ ifndef::openshift-dedicated,openshift-rosa[]
 [id="preparing-to-configure-the-monitoring-stack"]
 == Preparing to configure the monitoring stack
 
-You can configure the monitoring stack by creating and updating monitoring config maps.
+You can configure the monitoring stack by creating and updating monitoring config maps. These config maps configure the Cluster Monitoring Operator (CMO), which in turn configures the components of the monitoring stack.
 
 include::modules/monitoring-creating-cluster-monitoring-configmap.adoc[leveloffset=+2]
 include::modules/monitoring-creating-user-defined-workload-monitoring-configmap.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s): `enterprise-4.12` and later

Issue: [OBSDOCS-197](https://issues.redhat.com/browse/OBSDOCS-197)

Links to docs preview: 
* [Preparing to configure the monitoring stack](https://73723--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack#preparing-to-configure-the-monitoring-stack)
* [Support considerations for monitoring](https://73723--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack#support-considerations_configuring-the-monitoring-stack)

QE review:
- [x] QE has approved this change.

**Additional information:**