### PR TITLE
OCPBUGS-31295: fixed typo

### DIFF
--- a/modules/ipi-install-configuring-host-dual-network-interfaces-in-the-install-config.yaml-file.adoc
+++ b/modules/ipi-install-configuring-host-dual-network-interfaces-in-the-install-config.yaml-file.adoc
@@ -11,7 +11,7 @@ include::snippets/technology-preview.adoc[leveloffset=+1]
 
 Before installation, you can set the `networkConfig` configuration setting in the `install-config.yaml` file to configure host network interfaces using NMState to support dual port NIC.
 
-.Prequisites
+.Prerequisites
 
 * Configure a `PTR` DNS record with a valid hostname for each node with a static IP address.
 * Install the NMState CLI (`nmstate`).

--- a/modules/setting-up-topology-manager.adoc
+++ b/modules/setting-up-topology-manager.adoc
@@ -9,13 +9,13 @@
 
 To use Topology Manager, you must configure an allocation policy in the `KubeletConfig` custom resource (CR) named `cpumanager-enabled`. This file might exist if you have set up CPU Manager. If the file does not exist, you can create the file.
 
-.Prequisites
+.Prerequisites
 
 * Configure the CPU Manager policy to be `static`.
 
 .Procedure
 
-To activate Topololgy Manager:
+To activate Topology Manager:
 
 . Configure the Topology Manager allocation policy in the custom resource.
 +


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-31295

Link to docs preview:
[Setting up Topology Manager](https://file.rdu.redhat.com/antaylor/OCPBUGS-31295/scalability_and_performance/using-cpu-manager.html#setting_up_topology_manager_using-cpu-manager-and-topology_manager)

