### PR TITLE
OBSDOCS-863: LokiStack size can't be modified

### DIFF
--- a/modules/create-lokistack-cr-cli.adoc
+++ b/modules/create-lokistack-cr-cli.adoc
@@ -18,6 +18,7 @@ You can create a `LokiStack` custom resource (CR) by using the {oc-first}.
 
 . Create a `LokiStack` CR:
 +
+--
 .Example `LokiStack` CR
 [source,yaml]
 ----
@@ -40,10 +41,16 @@ spec:
     mode: openshift-logging # <5>
 ----
 <1> Specify the deployment size. In the {logging} 5.8 and later versions, the supported size options for production instances of Loki are `1x.extra-small`, `1x.small`, or `1x.medium`.
++
+[IMPORTANT]
+====
+It is not possible to change the number `1x` for the deployment size.
+====
 <2> Specify the name of your log store secret.
 <3> Specify the type of your log store secret.
 <4> Specify the name of a storage class for temporary storage. For best performance, specify a storage class that allocates block storage. Available storage classes for your cluster can be listed by using the `oc get storageclasses` command.
 <5> LokiStack defaults to running in multi-tenant mode, which cannot be modified. One tenant is provided for each log type: audit, infrastructure, and application logs. This enables access control for individual users and user groups to different log streams.
+--
 
 . Apply the `LokiStack` CR by running the following command:
 +

--- a/modules/create-lokistack-cr-console.adoc
+++ b/modules/create-lokistack-cr-console.adoc
@@ -22,6 +22,7 @@ You can create a `LokiStack` custom resource (CR) by using the {product-title} w
 
 . Select *YAML view*, and then use the following template to create a `LokiStack` CR:
 +
+--
 [source,yaml]
 ----
 apiVersion: loki.grafana.com/v1
@@ -44,7 +45,15 @@ spec:
 ----
 <1> Use the name `logging-loki`.
 <2> Specify the deployment size. In the {logging} 5.8 and later versions, the supported size options for production instances of Loki are `1x.extra-small`, `1x.small`, or `1x.medium`.
++
+[IMPORTANT]
+====
+It is not possible to change the number `1x` for the deployment size.
+====
 <3> Specify the secret used for your log storage.
 <4> Specify the corresponding storage type.
 <5> Enter the name of a storage class for temporary storage. For best performance, specify a storage class that allocates block storage. Available storage classes for your cluster can be listed by using the `oc get storageclasses` command.
 <6> LokiStack defaults to running in multi-tenant mode, which cannot be modified. One tenant is provided for each log type: audit, infrastructure, and application logs. This enables access control for individual users and user groups to different log streams.
+--
+
+. Click *Create*.

--- a/modules/loki-deployment-sizing.adoc
+++ b/modules/loki-deployment-sizing.adoc
@@ -10,7 +10,12 @@ endif::[]
 [id="loki-deployment-sizing_{context}"]
 = Loki deployment sizing
 
-Sizing for Loki follows the format of `<N>x.<size>` where the value `<N>` is number of instances and `<size>` specifies performance capabilities.
+Sizing for Loki follows the format of `1x.<size>` where the value `1x` is number of instances and `<size>` specifies performance capabilities.
+
+[IMPORTANT]
+====
+It is not possible to change the number `1x` for the deployment size.
+====
 
 .Loki sizing
 [cols="1h,4*",options="header"]

--- a/modules/network-observability-lokistack-create.adoc
+++ b/modules/network-observability-lokistack-create.adoc
@@ -6,7 +6,7 @@
 [id="network-observability-lokistack-create_{context}"]
 = Creating a LokiStack custom resource
 
-You can deploy a LokiStack using the web console or CLI to create a namespace, or new project.
+You can deploy a `LokiStack` custom resource (CR) by using the web console or {oc-first} to create a namespace, or new project.
 
 .Procedure
 
@@ -15,15 +15,16 @@ You can deploy a LokiStack using the web console or CLI to create a namespace, o
 . Click *Create LokiStack*.
 . Ensure the following fields are specified in either *Form View* or *YAML view*:
 +
+--
 [source,yaml]
 ----
 apiVersion: loki.grafana.com/v1
 kind: LokiStack
 metadata:
   name: loki
-  namespace: netobserv   <1>
+  namespace: netobserv # <1>
 spec:
-  size: 1x.small
+  size: 1x.small # <2>
   storage:
     schemas:
     - version: v12
@@ -31,15 +32,23 @@ spec:
     secret:
       name: loki-s3
       type: s3
-  storageClassName: gp3  <2>
+  storageClassName: gp3 # <3>
   tenants:
     mode: openshift-network
 ----
 <1> The installation examples in this documentation use the same namespace, `netobserv`, across all components. You can optionally use a different namespace.
-<2> Use a storage class name that is available on the cluster for `ReadWriteOnce` access mode. You can use `oc get storageclasses` to see what is available on your cluster.
+<2> Specify the deployment size. In the {logging} 5.8 and later versions, the supported size options for production instances of Loki are `1x.extra-small`, `1x.small`, or `1x.medium`.
 +
 [IMPORTANT]
 ====
-You must not reuse the same `LokiStack` that is used for cluster logging.
+It is not possible to change the number `1x` for the deployment size.
 ====
+<3> Use a storage class name that is available on the cluster for `ReadWriteOnce` access mode. You can use `oc get storageclasses` to see what is available on your cluster.
++
+[IMPORTANT]
+====
+You must not reuse the same `LokiStack` CR that is used for {logging}.
+====
+--
+
 . Click *Create*.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OBSDOCS-863

Link to docs preview:
- https://73744--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_storage/installing-log-storage#create-lokistack-cr-console_installing-log-storage
- https://73744--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_storage/installing-log-storage#create-lokistack-cr-cli_installing-log-storage
- https://73744--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/installing-operators#network-observability-lokistack-create_network_observability
- https://73744--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_storage/installing-log-storage#loki-deployment-sizing_installing-log-storage

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
