### PR TITLE
OSDOCS#9762: Applications for GitOps on MicroShift

### DIFF
--- a/microshift_running_apps/microshift-gitops.adoc
+++ b/microshift_running_apps/microshift-gitops.adoc
@@ -19,6 +19,13 @@ By using the GitOps with Argo CD agent with {microshift-short}, you can utilize 
 * The Git repository contains a declarative description of the infrastructure you need in your specified environment and contains an automated process to make your environment match the described state.
 * You can also use the Git repository as an audit trail of changes so that you can create processes based on Git flows such as review and approval for merging pull requests that implement configuration changes.
 
+include::modules/microshift-gitops-adding-apps.adoc[leveloffset=+1]
+
+[id="additional-resourcess{context}"]
+.Additional resources
+
+* xref:../microshift_install/microshift-install-rpm.adoc#microshift-installing-rpms-for-gitops_microshift-install-rpm[Installing the GitOps Argo CD manifests from an RPM package]
+
 [id="microshift-gitops-cannot-do_{context}"]
 == Limitations of using the GitOps agent with {microshift-short}
 GitOps with Argo CD for {microshift-short} has the following differences from the Red Hat OpenShift GitOps Operator:

--- a/modules/microshift-gitops-adding-apps.adoc
+++ b/modules/microshift-gitops-adding-apps.adoc
@@ -1,0 +1,120 @@
+// Module included in the following assemblies:
+//
+// microshift_running_apps/microshift-gitops.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-gitops-adding-apps_{context}"]
+= Creating GitOps applications on {microshift-short}
+
+You can create a custom YAML configuration to deploy and manage applications in your {microshift-short} service. To install the necessary packages to run GitOps applications, follow the documentation in "Installing the GitOps Argo CD manifests from an RPM package".
+
+.Prerequisites 
+
+* You installed the `microshift-gitops` packages and the Argo CD pods are running in the `openshift-gitops` namespace.
+
+.Procedure 
+
+. Create a YAML file and add your customized configurations for the application: 
++
+.Example YAML for a `cert-manager` application
+[source,yaml]
+----
+kind: AppProject
+apiVersion: argoproj.io/v1alpha1
+metadata:
+  name: default
+  namespace: openshift-gitops
+spec:
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
+  destinations:
+  - namespace: '*'
+    server: '*'
+  sourceRepos:
+  - '*'
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager
+  namespace: openshift-gitops
+spec:
+  destination:
+    namespace: cert-manager
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: cert-manager
+    repoURL: https://github.com/anandf/microshift-install
+  syncPolicy:
+    automated: {}
+    syncOptions:
+    - CreateNamespace=true
+    - ServerSideApply=true
+----
++
+.Example YAML for a `spring-petclinic` application
+[source,yaml]
+----
+kind: AppProject
+apiVersion: argoproj.io/v1alpha1
+metadata:
+  name: default
+  namespace: openshift-gitops
+spec:
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
+  destinations:
+  - namespace: '*'
+    server: '*'
+  sourceRepos:
+  - '*'
+---
+kind: Application
+apiVersion: argoproj.io/v1alpha1
+metadata:
+  name: spring-petclinic
+  namespace: openshift-gitops
+spec:
+  destination:
+    namespace: spring-petclinic
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    directory:
+      recurse: true
+    path: app
+    repoURL: https://github.com/siamaksade/openshift-gitops-getting-started
+  syncPolicy:
+    automated: {}
+    syncOptions:
+    - CreateNamespace=true
+    - ServerSideApply=true
+----
+
+. To deploy the applications defined in the YAML file, run the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
+
+.Verification 
+
+* To verify your application is deployed and synced, run the following command:
++
+[source,terminal]
+----
+$ oc get applications -A
+----
+It might take a few minutes for the application to show the `Healthy` status.
++
+.Example output 
+[source,terminal]
+----
+NAMESPACE          NAME               SYNC STATUS   HEALTH STATUS
+openshift-gitops   cert-manager       Synced        Healthy
+openshift-gitops   spring-petclinic   Synced        Healthy
+----


### PR DESCRIPTION
**Versions:**  4.15+
**Issue:** [OSDOCS-9762](https://issues.redhat.com//browse/OSDOCS-9762)

Link to docs preview:
[Creating a GitOps application on MicroShift](https://73761--ocpdocs-pr.netlify.app/microshift/latest/microshift_running_apps/microshift-gitops#microshift-gitops-adding-apps_microshift-gitops)

QE review:
- [x] QE has approved this change.
