### PR TITLE
OCPBUGS-31382: added special character handling table

### DIFF
--- a/modules/nw-route-specific-annotations.adoc
+++ b/modules/nw-route-specific-annotations.adoc
@@ -51,7 +51,7 @@ The maximum number of IP addresses and CIDR ranges directly visible in the `hapr
 
 `Strict`: the browser sends cookies only for same-site requests.
 
-`None`: the browser sends cookies for both cross-site and same-site requests. 
+`None`: the browser sends cookies for both cross-site and same-site requests.
 
 This value is applicable to re-encrypt and edge routes only. For more information, see the link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite[SameSite cookies documentation].|
 
@@ -188,3 +188,16 @@ The following table provides examples of the path rewriting behavior for various
 |/foo/|/foo/|/|/
 |/foo/|/foo/bar|/|/bar
 |===
+
+Certain special characters in `haproxy.router.openshift.io/rewrite-target` require special handling because they must be escaped properly. Refer to the following table to understand how these characters are handled.
+
+.Special character handling:
+[cols="3*", options="header"]
+|===
+|For character|Use characters|Notes
+|#|\#|Avoid # because it terminates the rewrite expression
+|%|% or %%|Avoid odd sequences such as %%%
+|‘| \’|Avoid ‘ because it is ignored
+|===
+
+All other valid URL characters can be used without escaping.


### PR DESCRIPTION
Version(s):
4.16+
Backports for other versions (4.11+) are not yet approved. Those will be done separately and tracked in https://issues.redhat.com/browse/OSDOCS-10058

Issue:
https://issues.redhat.com/browse/OCPBUGS-31382

Link to docs preview:
https://73764--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration#nw-route-specific-annotations_route-configuration

QE review:
- [x] QE has approved this change.