### PR TITLE
[RHACS] Removed tech-preview, added module intro

### DIFF
--- a/modules/using-the-build-time-network-policy-generator.adoc
+++ b/modules/using-the-build-time-network-policy-generator.adoc
@@ -5,8 +5,7 @@
 [id="using-the-build-time-network-policy-generator_{context}"]
 = Using the build-time network policy generator
 
-:FeatureName: Build-time network policy generation
-include::snippets/technology-preview.adoc[]
+You can generate network policies by using the built-in network policy generator in the `roxctl` CLI.
 
 .Prerequisites
 


### PR DESCRIPTION
Build-time network policy generator is GA in 4.4

Cherrypick in `rhacs-docs-4.4`