### PR TITLE
[RHACS] [4.4 Release notes] [rhacs-docs] ROX-23366: Adding tech preview label to Scanner V4

### DIFF
--- a/release_notes/44-release-notes.adoc
+++ b/release_notes/44-release-notes.adoc
@@ -15,7 +15,7 @@ toc::[]
 
 |{product-title-short} version |Released on
 
-|`4.4.0` | 18 March 2024
+|`4.4.0` | 28 March 2024
 
 |====
 
@@ -47,7 +47,7 @@ Policy::
 * xref:../release_notes/44-release-notes.adoc#authentication-of-aws-and-gcp-integrations-by-using-short-lived-tokens_release-notes-44[Authentication of AWS and GCP integrations by using short-lived tokens (Technology Preview)]
 
 Vulnerability Management::
-* xref:../release_notes/44-release-notes.adoc#vulnerability-scanner-v4-that-uses-upstream-claircore_release-notes-44[Scanner V4 that uses upstream ClairCore]
+* xref:../release_notes/44-release-notes.adoc#vulnerability-scanner-v4-that-uses-upstream-claircore_release-notes-44[Scanner V4 that uses upstream ClairCore (Technology preview)]
 * xref:../release_notes/44-release-notes.adoc#filter-workload-cves-by-using-component-and-component-source_release-notes-44[Filter workload CVEs by using component and component source]
 
 [id="new-features_{context}"]
@@ -56,7 +56,10 @@ Vulnerability Management::
 This release adds improvements related to the following components and concepts:
 
 [id="vulnerability-scanner-v4-that-uses-upstream-claircore_{context}"]
-=== Scanner V4 that uses upstream ClairCore 
+=== Scanner V4 that uses upstream ClairCore (Technology preview)
+
+:FeatureName: Scanner V4
+include::snippets/technology-preview.adoc[]
 
 In {product-title-short} 4.4, the new Scanner V4 integrates the best features of the existing StackRox Scanner and the link:https://quay.github.io/clair/whatis.html[upstream Clair V4 Scanner] that ships with Red Hat Quay, providing enhanced functionality.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.4
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/ROX-23366
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://73779--docspreview.netlify.app/openshift-acs/latest/release_notes/44-release-notes#vulnerability-scanner-v4-that-uses-upstream-claircore_release-notes-44
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- Merge into `rhacs-docs` and cherry-pick to:
    - `rhacs-docs-4.4` 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
