### PR TITLE
TRACING-4071: add documentation for oidcauth extension

### DIFF
--- a/modules/otel-collector-components.adoc
+++ b/modules/otel-collector-components.adoc
@@ -871,6 +871,51 @@ This extension supports traces, metrics, and logs.
 <12> You can assign the authenticator configuration to an OTLP exporter.
 
 
+[id="oidcauth-extension_{context}"]
+=== OIDC Auth extension
+
+The OIDC Auth extension is currently a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] feature only.
+
+The OIDC Auth extension authenticates incoming requests to receivers via OpenID Connect (OIDC).
+It validates the ID token in the authorization header against the specified issuer, and updates the authentication context of the incoming request.
+
+.OpenTelemetry Collector custom resource with receiver authentication configured
+[source,yaml]
+----
+  config: |
+    extensions:
+      oidc:
+        attribute: authorization # <1>
+        issuer_url: https://example.com/auth/realms/opentelemetry # <2>
+        issuer_ca_path: /var/run/tls/issuer.pem # <3>
+        audience: otel-collector # <4>
+        username_claim: email # <5>
+
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            auth:
+              authenticator: oidc
+
+    exporters:
+      otlp:
+        endpoint: <endpoint>
+
+    service:
+      extensions: [oidc]
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [otlp]
+----
+<1> Name of the header containing the ID token. Default: `authorization`
+<2> Base URL of the OIDC provider.
+<3> Path to the issuer's CA certificate. This field is optional.
+<4> Audience of the token.
+<5> Name of the claim containing the username. Default: `sub`
+
+
 [id="jaegerremotesampling-extension_{context}"]
 === Jaeger Remote Sampling extension
 


### PR DESCRIPTION
Version(s):
all supported

Issue:
https://issues.redhat.com/browse/TRACING-4071

Link to docs preview:
https://73780--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-configuration-of-otel-collector#oidcauth-extension_otel-configuration-of-otel-collector

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

@max-cx 