### PR TITLE
[enterprise-4.12] OCPBUGS-31295: fixed typo

### DIFF
--- a/modules/setting-up-topology-manager.adoc
+++ b/modules/setting-up-topology-manager.adoc
@@ -9,13 +9,13 @@
 
 To use Topology Manager, you must configure an allocation policy in the `KubeletConfig` custom resource (CR) named `cpumanager-enabled`. This file might exist if you have set up CPU Manager. If the file does not exist, you can create the file.
 
-.Prequisites
+.Prerequisites
 
 * Configure the CPU Manager policy to be `static`.
 
 .Procedure
 
-To activate Topololgy Manager:
+To activate Topology Manager:
 
 . Configure the Topology Manager allocation policy in the custom resource.
 +


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/73724