### PR TITLE
OBSDOCS-732: Update monitoring glossary for logging components

### DIFF
--- a/modules/monitoring-common-terms.adoc
+++ b/modules/monitoring-common-terms.adoc
@@ -33,7 +33,11 @@ etcd::
 etcd is the key-value store for {product-title}, which stores the state of all resource objects.
 
 Fluentd::
-Fluentd gathers logs from nodes and feeds them to Elasticsearch.
+Fluentd is a log collector that resides on each {product-title} node. It gathers application, infrastructure, and audit logs and forwards them to different outputs.
++
+--
+include::snippets/logging-fluentd-dep-snip.adoc[]
+--
 
 Kubelets::
 Runs on nodes and reads the container manifests. Ensures that the defined containers have started and are running.
@@ -94,6 +98,9 @@ You can manage container storage for persistent and non-persistent data in an {p
 
 Thanos Ruler::
 The Thanos Ruler is a rule evaluation engine for Prometheus that is deployed as a separate process. In {product-title}, Thanos Ruler provides rule and alerting evaluation for the monitoring of user-defined projects.
+
+Vector::
+Vector is a log collector that deploys to each {product-title} node. It collects log data from each node, transforms the data, and forwards it to configured outputs.
 
 web console::
 A user interface (UI) to manage {product-title}.

--- a/snippets/logging-fluentd-dep-snip.adoc
+++ b/snippets/logging-fluentd-dep-snip.adoc
@@ -10,5 +10,5 @@
 
 [NOTE]
 ====
-Fluentd is deprecated and is planned to be removed in a future release. Red Hat provides bug fixes and support for this feature during the current release lifecycle, but this feature no longer receives enhancements. As an alternative to Fluentd, you can use Vector instead.
+Fluentd is deprecated and is planned to be removed in a future release. Red{nbsp}Hat provides bug fixes and support for this feature during the current release lifecycle, but this feature no longer receives enhancements. As an alternative to Fluentd, you can use Vector instead.
 ====


### PR DESCRIPTION
Version(s): `enterprise-4.12` and later

Issue: [OBSDOCS-732](https://issues.redhat.com/browse/OBSDOCS-732)

Link to docs preview: [Glossary of common terms for OpenShift Container Platform monitoring](https://73793--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/monitoring-overview#openshift-monitoring-common-terms_monitoring-overview)

QE review:
- [x] QE has approved this change.

**Additional information:**