### PR TITLE
OBSDOCS-936: fix-link-for-COO-0.1.2-RN

### DIFF
--- a/monitoring/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
+++ b/monitoring/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
@@ -20,7 +20,7 @@ These release notes track the development of the {coo-full} in {product-title}.
 == {coo-full} 0.1.2
 The following advisory is available for {coo-full} 0.1.2:
 
-* link:https://access.redhat.com/errata/RHEA-2024:127118[2024:127118 Cluster Observability Operator 0.1.2]
+* link:https://access.redhat.com/errata/RHEA-2024:1534[2024:1534 Cluster Observability Operator 0.1.2]
 
 [id="cluster-observability-operator-0-1-2-CVEs"]
 === CVEs


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-936
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://73795--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/cluster_observability_operator/cluster-observability-operator-release-notes#cluster-observability-operator-release-notes-0-1-2
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: N/A because no technical content is changing
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- Fixes an incorrect link to the advisory for COO 0.1.2
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
