### PR TITLE
OSDOCS-10048: Expand on vsphere versions and CSI migration

### DIFF
--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -5,16 +5,21 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="installation-vsphere-infrastructure_{context}"]
-= VMware vSphere infrastructure requirements
+= {vmw-full} infrastructure requirements
 
-You must install an {product-title} cluster on one of the following versions of a VMware vSphere instance that meets the requirements for the components that you use:
+You can install an {product-title} cluster on a supported version of a {vmw-full} instance that meets the requirements for the components that you use.
+
+If you want to upgrade a {product-title} cluster from an earlier release that does not support automatic CSI migration to {product-title} {product-version}, you must initially update your {vmw-full} instance to one of the following versions:
 
 * Version 7.0 Update 3 or later
 * Version 8.0 Update 2 or later
 
-Both of these releases support Container Storage Interface (CSI) migration, which is enabled by default on {product-title} {product-version}.
+[IMPORTANT]
+====
+If you do not upgrade your {vmw-full} instance to one of the previously listed versions, the cluster upgrade operation fails because of a known issue. For certain situations, you can take manual steps to resolve the known issue. For more information, see link:https://access.redhat.com/node/7011683[Knowledgebase article 7011683].
+====
 
-You can host the VMware vSphere infrastructure on-premise or on a link:https://cloud.vmware.com/providers[VMware Cloud Verified provider] that meets the requirements outlined in the following tables:
+You can host the {vmw-full} infrastructure on-premise or on a link:https://cloud.vmware.com/providers[VMware Cloud Verified provider] that meets the requirements outlined in the following tables:
 
 .Version requirements for vSphere virtual environments
 [cols=2, options="header"]


### PR DESCRIPTION
Version(s):
4.16 to 4.14

Issue:
[OCPBUGS-31451](https://issues.redhat.com/browse/OCPBUGS-31451)

Link to docs preview:
[VMware vSphere infrastructure requirements](https://73799--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs#installation-vsphere-infrastructure_ipi-vsphere-installation-reqs)

- [ ] SME has approved this change
- [ ] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
