### PR TITLE
OSDOCS-9798: adds GitOps release note 4.16

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -69,8 +69,13 @@ The following list provides update details:
 //[id="microshift-4-16-updating"]
 //=== Updating
 
-//[id="microshift-4-16-running-apps"]
-//=== Running applications
+[id="microshift-4-16-running-apps"]
+=== Running applications
+
+[id="microshift-4-16-gitops"]
+==== GitOps with Argo CD now available
+With this release, you can use the GitOps with Argo CD agent derived from GitOps 1.12 with {microshift-short}. Using GitOps means you can update a single Git repository and automate the deployment of new applications or updates to existing ones. You can also use your Git repository as an audit trail of changes so that you can create processes such as review and approval for merging pull requests that implement configuration changes.
+//TODO add xrefs once docs merge
 
 //[id="microshift-4-16-support"]
 //=== Support


### PR DESCRIPTION
Version(s):
4.16

Issue:
[GitOps release note](https://issues.redhat.com/browse/OSDOCS-9798)

Link to docs preview:
[GitOps release note](https://73800--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes#microshift-4-16-gitops)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
https://github.com/openshift/openshift-docs/pull/73201
https://github.com/openshift/openshift-docs/pull/72974

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
