### PR TITLE
OSSM-6174 OSSM 2.5 release notes should indicate support from 4.12 and later

### DIFF
--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -18,7 +18,7 @@ This release adds improvements related to the following components and concepts.
 [id="new-features-ossm-2-5"]
 == New features {SMProductName} version 2.5
 
-This release of {SMProductName} adds new features, addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.13 and later.
+This release of {SMProductName} adds new features, addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.12 and later.
 
 This release ends maintenance support for OpenShift {SMProductShortName} version 2.2. If you are using OpenShift {SMProductShortName} version 2.2, you should update to a supported version.
 
@@ -55,7 +55,7 @@ This release adds documentation for migrating from a multitenant mesh to a clust
 
 === {SMProductName} Operator on ARM-based clusters
 
-This release provides the {SMProductName} Operator on ARM-based clusters as a generally available feature. 
+This release provides the {SMProductName} Operator on ARM-based clusters as a generally available feature.
 
 === Integration with {DTProductName} (Tempo) Stack
 
@@ -63,20 +63,20 @@ This release introduces a generally available integration of the tracing extensi
 
 [NOTE]
 ====
-{DTProductName} (Tempo) Stack is not supported on {ibm-z-title}. 
+{DTProductName} (Tempo) Stack is not supported on {ibm-z-title}.
 ====
 
 === OpenShift Service Mesh Console plugin
 
-This release introduces a generally available version of the OpenShift {SMProductShortName} Console (OSSMC) plugin. 
+This release introduces a generally available version of the OpenShift {SMProductShortName} Console (OSSMC) plugin.
 
-The OSSMC plugin is an extension to the OpenShift Console that provides visibility into your Service Mesh. With the OSSMC plugin installed, a new Service Mesh menu option is available in the left-hand navigation of the web console, as well as new Service Mesh tabs that enhance existing Workloads and Service console pages. 
+The OSSMC plugin is an extension to the OpenShift Console that provides visibility into your Service Mesh. With the OSSMC plugin installed, a new Service Mesh menu option is available on the navigation pane of the web console, as well as new Service Mesh tabs that enhance existing Workloads and Service console pages.
 
-The features of the OSSMC plugin are very similar to those of the standalone Kiali Console. The OSSMC plugin does not replace the Kiali Console, and after installing the OSSMC plugin, you can still access the standalone Kiali Console. 
+The features of the OSSMC plugin are very similar to those of the standalone Kiali Console. The OSSMC plugin does not replace the Kiali Console, and after installing the OSSMC plugin, you can still access the standalone Kiali Console.
 
 === Istio OpenShift Routing (IOR) default setting change
 
-The default setting for Istio OpenShift Routing (IOR) has changed. Starting with this release, automatic routes are disabled by default for new instances of the `ServiceMeshControlPlane` resource. 
+The default setting for Istio OpenShift Routing (IOR) has changed. Starting with this release, automatic routes are disabled by default for new instances of the `ServiceMeshControlPlane` resource.
 
 For new  instances of the `ServiceMeshControlPlane` resources, you can use automatic routes by setting the `enabled` field to `true` in the `gateways.openshiftRoute` specification of the `ServiceMeshControlPlane` resource.
 
@@ -95,11 +95,11 @@ When updating existing instances of the `ServiceMeshControlPlane` resource to {S
 
 === Istio proxy concurrency configuration enhancement
 
-The `concurrency` parameter in the `networking.istio` API configures how many worker threads the Istio proxy runs. 
+The `concurrency` parameter in the `networking.istio` API configures how many worker threads the Istio proxy runs.
 
-For consistency across deployments, Istio now configures the `concurrency` parameter based upon the CPU limit allocated to the proxy container. For example, a limit of 2500m would set the `concurrency` parameter to `3`. If you set the `concurrency` parameter to a different value, then Istio uses that value to configure how many threads the proxy runs instead of using the CPU limit. 
+For consistency across deployments, Istio now configures the `concurrency` parameter based upon the CPU limit allocated to the proxy container. For example, a limit of 2500m would set the `concurrency` parameter to `3`. If you set the `concurrency` parameter to a different value, then Istio uses that value to configure how many threads the proxy runs instead of using the CPU limit.
 
-Previously, the default setting for the parameter was `2`. 
+Previously, the default setting for the parameter was `2`.
 
 === Gateway API CRD versions
 :FeatureName: {product-title} Gateway API support
@@ -172,8 +172,8 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 //Istio stays the same
 //Envoy updated to 1.24.12
 //According to distributed tracing release 2.9, the latest at time of OSSM 2.4.4, Jaeger has been updated to 1.47.0
-//Kiali updated to 1.65.9 
-//Kiali updated to 1.65.10 on 10/31/2023 due to security fix 
+//Kiali updated to 1.65.9
+//Kiali updated to 1.65.10 on 10/31/2023 due to security fix
 |===
 |Component |Version
 


### PR DESCRIPTION
[OSSM-6174](https://issues.redhat.com//browse/OSSM-6174) OSSM 2.5 release notes should indicate support from 4.12 and later

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSSM-6174

Link to docs preview:
https://73816--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes

QE review:
QE approval is not needed for this PR.

Additional information:

Also update language for the OSSMC plugin to be consistent with the language used elsewhere, and it seems changing a setting in VSCode caught extra spaces that seems to have been automatically removed in this PR.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
