### PR TITLE
Fixing baremetal vsphere offset

### DIFF
--- a/installing/installing_bare_metal/installing-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal.adoc
@@ -61,7 +61,7 @@ include::modules/csr-management.adoc[leveloffset=+2]
 * See xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installation-approve-csrs_installing-bare-metal[Approving the certificate signing requests for your machines] for more information about approving cluster certificate signing requests after installation.
 
 [id="installation-requirements-baremetal-vsphere_{context}"]
-== Requirements for baremetal clusters on vSphere
+=== Requirements for baremetal clusters on vSphere
 
 Ensure you enable the `disk.EnableUUID` parameter on all virtual machines in your cluster.
 


### PR DESCRIPTION
Version(s):
4.12+

Link to docs preview:
https://73817--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal#installation-requirements-baremetal-vsphere_installing-bare-metal

QE review:
N/A

```[id="installation-requirements-baremetal-vsphere_{context}"]
== Requirements for baremetal clusters on vSphere
```
 should be a sub-section of
```
[id="installation-requirements-user-infra_{context}"]
== Requirements for a cluster with user-provisioned infrastructure
```
requiring `===` offset.