### PR TITLE
OCPBUGS-31460: Updated docs to expand multiple vSphere failure domain…

### DIFF
--- a/modules/configuring-vsphere-regions-zones.adoc
+++ b/modules/configuring-vsphere-regions-zones.adoc
@@ -24,7 +24,7 @@ The example uses the `govc` command. The `govc` command is an open source comman
 +
 [IMPORTANT]
 ====
-You must specify at least one failure domain for your {product-title} cluster, so that you can provision datacenter objects for your VMware vCenter server. Consider specifying multiple failure domains if you need to provision virtual machine nodes in different datacenters, clusters, datastores, and other components.
+You must specify at least one failure domain for your {product-title} cluster, so that you can provision datacenter objects for your VMware vCenter server. Consider specifying multiple failure domains if you need to provision virtual machine nodes in different datacenters, clusters, datastores, and other components. To enable regions and zones, you must define multiple failure domains for your {product-title} cluster.
 ====
 
 .Procedure

--- a/modules/installation-vsphere-regions-zones.adoc
+++ b/modules/installation-vsphere-regions-zones.adoc
@@ -11,7 +11,7 @@
 [id="installation-vsphere-regions-zones_{context}"]
 = VMware vSphere region and zone enablement
 
-You can deploy an {product-title} cluster to multiple vSphere datacenters that run in a single VMware vCenter. Each datacenter can run multiple clusters. This configuration reduces the risk of a hardware failure or network outage that can cause your cluster to fail.
+You can deploy an {product-title} cluster to multiple vSphere datacenters that run in a single VMware vCenter. Each datacenter can run multiple clusters. This configuration reduces the risk of a hardware failure or network outage that can cause your cluster to fail. To enable regions and zones, you must define multiple failure domains for your {product-title} cluster.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-31460](https://issues.redhat.com/browse/OCPBUGS-31460)

Link to docs preview:
* [VMware vSphere region and zone enablement](https://73830--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations#installation-vsphere-regions-zones_installing-vsphere-installer-provisioned-customizations)
* [Configuring regions and zones for a VMware vCenter](https://73830--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations#configuring-vsphere-regions-zones_installing-vsphere-installer-provisioned-customizations)

- [x] SME has approved this change.
- [X] QE has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
