### PR TITLE
OSDOCS-9614: Created documentation to create a ROSA with HCP cluster that uses external auth for OIDC

### DIFF
--- a/_attributes/attributes-openshift-dedicated.adoc
+++ b/_attributes/attributes-openshift-dedicated.adoc
@@ -5,6 +5,7 @@
 :experimental:
 :imagesdir: images
 :OCP: OpenShift Container Platform
+:OCP-short: OpenShift
 :ocp-version: 4.14
 :op-system-first: Red Hat Enterprise Linux CoreOS (RHCOS)
 :cluster-manager-first: Red Hat OpenShift Cluster Manager
@@ -21,6 +22,9 @@
 :rhq-short: Red Hat Quay
 :SMProductName: Red Hat OpenShift Service Mesh
 :pipelines-title: Red Hat OpenShift Pipelines
+:sts-first: Security Token Service (STS)
+:sts-full: Security Token Service
+:sts-short: STS
 //logging
 :logging-title: logging for Red Hat OpenShift
 :logging-title-uc: Logging for Red Hat OpenShift
@@ -47,4 +51,3 @@
 :hcp-title: ROSA with HCP
 :hcp-title-first: {product-title} (ROSA) with {hcp} (HCP)
 //ROSA CLI variables
-:word: Testing this variable let's go www.google.com

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -227,6 +227,8 @@ Topics:
   File: rosa-hcp-creating-cluster-with-aws-kms-key
 - Name: Creating a private cluster on ROSA with HCP
   File: rosa-hcp-aws-private-creating-cluster
+- Name: Creating ROSA with HCP clusters with external authentication
+  File: rosa-hcp-sts-creating-a-cluster-ext-auth
 - Name: Using the Node Tuning Operator on ROSA with HCP
   File: rosa-tuning-config
 - Name: Deleting a ROSA with HCP cluster

--- a/modules/rosa-create-objects.adoc
+++ b/modules/rosa-create-objects.adoc
@@ -273,6 +273,84 @@ Create a cluster with autoscaling enabled on the default worker machine pool.
 $ rosa create cluster --cluster-name=mycluster -region=us-east-1 --enable-autoscaling --min-replicas=2 --max-replicas=5
 ----
 
+[id="rosa-create-external-auth-provider_{context}"]
+== create external-auth-provider
+
+Add an external identity provider instead of the {OCP-short} OAuth2 server.
+
+[IMPORTANT]
+====
+You can only use external authentication providers on {hcp-title} clusters.
+====
+
+.Syntax
+[source,terminal]
+----
+$ rosa create external-auth-provider --cluster=<cluster_name> | <cluster_id> [arguments]
+----
+
+.Arguments
+[cols="30,70"]
+|===
+|Option |Definition
+
+|--claim-mapping-groups-claim <string>     
+|Required. Describes rules on how to transform information from an ID token into a cluster identity.
+
+|--claim-validation-rule <strings>
+|Rules that are applied to validate token claims to authenticate users. The input will be in a `<claim>:<required_value>` format. To have multiple claim validation rules, you can separate the values by `,`. For example, `<claim>:<required_value>,<claim>:<required_value>`.
+
+|--claim-mapping-username-claim <string>
+|The name of the claim that should be used to construct user names for the cluster identity.
+
+a|--cluster <cluster_name>\|<cluster_id>
+|Required. The name or ID of the cluster to which the IDP will be added.
+
+|--console-client-id <string>
+|The identifier of the OIDC client from the OIDC provider for the {cluster-manager-url} web console.
+
+|--console-client-secret <string>          
+|The secret that is associated with the console application registration.
+
+|--issuer-audiences <strings>
+|An array of audiences to check the incoming tokens against. Valid tokens must include at least one of these values in their audience claim.
+
+|--issuer-ca-file <string>
+|The path to the PEM-encoded certificate file to use when making requests to the server.
+
+|--issuer-url <string>
+|The serving URL of the token issuer.
+
+|--name <string>
+|A name that is used to refer to the external authentication provider.
+|===
+
+.Optional arguments inherited from parent commands
+[cols="30,70"]
+|===
+|Option |Definition
+
+|--help
+|Shows help for this command.
+
+|--debug
+|Enables debug mode.
+
+|--interactive
+|Enables interactive mode.
+
+|--profile
+|Specifies an AWS profile string from your credentials file.
+|===
+
+.Examples
+Add a Microsoft Entra ID identity provider to a cluster named `mycluster`.
+
+[source,terminal]
+----
+$ rosa create external-auth-provider --cluster=mycluster --name <provider_name> --issuer-audiences <audience_id> --issuer-url <issuing id> --claim-mapping-username-claim email --claim-mapping-groups-claim groups
+----
+
 [id="rosa-create-idp_{context}"]
 == create idp
 

--- a/modules/rosa-delete-objects.adoc
+++ b/modules/rosa-delete-objects.adoc
@@ -109,6 +109,55 @@ Delete a cluster named `mycluster`.
 $ rosa delete cluster --cluster=mycluster
 ----
 
+[id="rosa-delete-external-auth-provider_{context}"]
+== delete external-auth-provider
+
+Deletes an external authentication provider from a cluster.
+
+.Syntax
+[source,terminal]
+----
+$ rosa delete external-auth-provider <name_of_external_auth_provider> --cluster=<cluster_name> | <cluster_id> [arguments]
+----
+
+.Arguments
+[cols="30,70"]
+|===
+|Option |Definition
+
+|--cluster
+|Required. The name or ID string of the cluster the external auth provider will be deleted from.
+|===
+
+.Optional arguments inherited from parent commands
+[cols="30,70"]
+|===
+|Option |Definition
+
+|--help
+|Shows help for this command.
+
+|--debug
+|Enables debug mode.
+
+|--interactive
+|Enables interactive mode.
+
+|--profile
+|Specifies an AWS profile string from your credentials file.
+
+|--yes
+|Automatically answers `yes` to confirm the operation.
+|===
+
+.Example
+Delete an identity provider named `exauth-1` from a cluster named `mycluster`.
+
+[source,terminal]
+----
+$ rosa delete external-auth-provider exauth-1 --cluster=mycluster
+----
+
 [id="rosa-delete-idp_{context}"]
 == delete idp
 

--- a/modules/rosa-hcp-sts-creating-a-cluster-cli.adoc
+++ b/modules/rosa-hcp-sts-creating-a-cluster-cli.adoc
@@ -58,16 +58,18 @@ If you specified custom ARN paths when you created the associated account-wide r
 +
 [source,terminal]
 ----
-$ rosa create cluster --private --cluster-name=<cluster_name> \ 
-  --mode=auto --hosted-cp --operator-roles-prefix=$OPERATOR_ROLES_PREFIX \ 
-  --oidc-config-id=$OIDC_ID --subnet-ids=$SUBNET_IDS
+$ rosa create cluster --private --cluster-name=<cluster_name> \
+    --mode=auto --hosted-cp --operator-roles-prefix=$OPERATOR_ROLES_PREFIX \
+    --oidc-config-id=$OIDC_ID --subnet-ids=$SUBNET_IDS
 ----
 +
 * If you set the environmental variables, create a cluster with a single, initial machine pool, a publicly available API, and a publicly available Ingress by running the following command:
 +
 [source,terminal]
 ----
-$ rosa create cluster --cluster-name=<cluster_name> --mode=auto --hosted-cp --operator-roles-prefix=$OPERATOR_ROLES_PREFIX --oidc-config-id=$OIDC_CONFIG --subnet-ids=$SUBNET_IDS
+$ rosa create cluster --cluster-name=<cluster_name> --mode=auto \ 
+    --hosted-cp --operator-roles-prefix=$OPERATOR_ROLES_PREFIX \
+    --oidc-config-id=$OIDC_CONFIG --subnet-ids=$SUBNET_IDS
 ----
 +
 . Check the status of your cluster by running the following command:

--- a/modules/rosa-hcp-sts-creating-a-cluster-ext-auth-cluster-cli.adoc
+++ b/modules/rosa-hcp-sts-creating-a-cluster-ext-auth-cluster-cli.adoc
@@ -1,0 +1,112 @@
+// Module included in the following assemblies:
+//
+// * rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-hcp-sts-creating-a-cluster-external-auth-cluster-cli_{context}"]
+= Creating a {hcp-title} cluster that uses external authentication providers
+:source-highlighter: pygments
+:pygments-style: emacs
+:icons: font
+ 
+Use the `--external-auth-providers-enabled` flag in the ROSA CLI to create a cluster that uses an external authentication service.
+
+[NOTE]
+====
+When creating a {hcp-title} cluster, the default machine Classless Inter-Domain Routing (CIDR) is `10.0.0.0/16`. If this does not correspond to the CIDR range for your VPC subnets, add `--machine-cidr <address_block>` to the following commands.
+====
+
+.Procedure
+
+* If you used the `OIDC_ID`, `SUBNET_IDS`, and `OPERATOR_ROLES_PREFIX` variables to prepare your environment, you can continue to use those variables when creating your cluster. For example, run the following command:
++
+[source,terminal]
+----
+$ rosa create cluster --hosted-cp --subnet-ids=$SUBNET_IDS \ 
+   --oidc-config-id=$OIDC_ID --cluster-name=<cluster_name> \
+   --operator-roles-prefix=$OPERATOR_ROLES_PREFIX \
+   --external-auth-providers-enabled
+----
+
+* If you did not set environmental variables, run the following command:
++
+[source,terminal]
+----
+$ rosa create cluster --cluster-name=<cluster_name> --sts --mode=auto \
+    --hosted-cp --operator-roles-prefix <operator-role-prefix> \
+    --oidc-config-id <ID-of-OIDC-configuration> \
+    --external-auth-providers-enabled \
+    --subnet-ids=<public-subnet-id>,<private-subnet-id>
+----
+
+.Verification
+. Verify that your external authentication is enabled in the cluster details by running the following command:
++
+[source,terminal]
+----
+$ rosa describe cluster --cluster=<cluster_name>
+----
++
+.Example output
+[source,terminal,highlight='50']
+----
+Name:                       rosa-ext-test
+Display Name:               rosa-ext-test
+ID:                         <cluster_id>
+External ID:                <cluster_ext_id>
+Control Plane:              ROSA Service Hosted
+OpenShift Version:          4.Y.Z
+Channel Group:              stable
+DNS:                        <dns>
+AWS Account:                <AWS_id>
+AWS Billing Account:        <AWS_id>
+API URL:                    <ocm_api>
+Console URL:
+Region:                     us-east-1
+Availability:
+ - Control Plane:           MultiAZ
+ - Data Plane:              SingleAZ
+
+Nodes:
+ - Compute (desired):       2
+ - Compute (current):       0
+Network:
+ - Type:                    OVNKubernetes
+ - Service CIDR:            <service_cidr>
+ - Machine CIDR:            <machine_cidr>
+ - Pod CIDR:                <pod_cidr>
+ - Host Prefix:             /23
+ - Subnets:                 <subnet_ids>
+EC2 Metadata Http Tokens:   optional
+Role (STS) ARN:             arn:aws:iam::<AWS_id>:role/<account_roles_prefix>-HCP-ROSA-Installer-Role
+Support Role ARN:           arn:aws:iam::<AWS_id>:role/<account_roles_prefix>-HCP-ROSA-Support-Role
+Instance IAM Roles:
+ - Worker:                  arn:aws:iam::<AWS_id>:role/<account_roles_prefix>-HCP-ROSA-Worker-Role
+Operator IAM Roles:
+ - arn:aws:iam::<AWS_id>:role/<operator_roles_prefix>-openshift-cloud-network-config-controller-clo
+ - arn:aws:iam::<AWS_id>:role/<operator_roles_prefix>-kube-system-capa-controller-manager
+ - arn:aws:iam::<AWS_id>:role/<operator_roles_prefix>-kube-system-control-plane-operator
+ - arn:aws:iam::<AWS_id>:role/<operator_roles_prefix>-kube-system-kms-provider
+ - arn:aws:iam::<AWS_id>:role/<operator_roles_prefix>-kube-system-kube-controller-manager
+ - arn:aws:iam::<AWS_id>:role/<operator_roles_prefix>-openshift-image-registry-installer-cloud-cred
+ - arn:aws:iam::<AWS_id>:role/<operator_roles_prefix>-openshift-ingress-operator-cloud-credentials
+ - arn:aws:iam::<AWS_id>:role/<operator_roles_prefix>-openshift-cluster-csi-drivers-ebs-cloud-crede
+Managed Policies:           Yes
+State:                      ready
+Private:                    No
+Created:                    Jan 01 2030 14:25:52 UTC
+User Workload Monitoring:   Enabled
+Details Page:               https://<url>
+OIDC Endpoint URL:          https://<endpoint> (Managed)
+Audit Log Forwarding:       Disabled
+External Authentication:    Enabled <1>
+----
+<1> The `External Authentication` flag is enabled, and you can now create an external authentication provider.
+
+. Watch the {hcp-title} installation program logs to track the progress of the cluster creation by running the following command:
++
+[source,terminal]
+----
+$ rosa logs install --cluster=<cluster_name> --watch <1>
+----
+<1> Optional: To watch for new log messages as the installation progresses, use the `--watch` argument.

--- a/modules/rosa-hcp-sts-creating-a-cluster-ext-auth-provider-cli.adoc
+++ b/modules/rosa-hcp-sts-creating-a-cluster-ext-auth-provider-cli.adoc
@@ -1,0 +1,142 @@
+// Module included in the following assemblies:
+//
+// * rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-hcp-sts-creating-a-cluster-external-auth-provider-cli_{context}"]
+= Creating an external authentication provider
+:source-highlighter: pygments
+:pygments-style: emacs
+:icons: font
+ 
+After you have created a {hcp-title} cluster with external authentication providers, you must create a provider using the ROSA CLI.
+
+[NOTE]
+====
+Similar to the `rosa create|delete|list idp[s]` command in the ROSA CLI, you cannot edit an existing identity provider that you created using `rosa create external-auth-provider`. Instead, you must delete the external authentication provider and create a new one.
+====
+
+The following table shows the possible CLI flags you can use when creating your external authentication provider:
+
+[cols="1,1", options="header"]
+|===
+
+|CLI Flag
+|Description
+
+|`--cluster` 
+|The name or the ID of your cluster
+
+|`--name`
+|A name that is used to refer to the external authentication provider.
+
+|`--console-client-secret`
+|This string is the client secret that is used to associate your account with the application. If you do not include the client secret, this command uses a public OIDC OAuthClient.
+
+|`--issuer-audiences` 
+|This is a comma-separated list of token audiences.
+
+|`--issuer-url`
+|The URL of the token issuer.
+
+|`--claim-mapping-username-claim` 
+|The name of the claim that should be used to construct user names for the cluster identity.
+
+|`--claim-mapping-groups-claim`
+|The name of the claim that should be used to construct group names for the cluster identity.
+
+|===
+
+.Procedure
+
+* To use the interactive command interface, run the following commands:
++
+[source,terminal]
+----
+$ rosa create external-auth-provider -c <cluster_name>
+----
++
+.Example output
+--
+[source,terminal]
+----
+I: Enabling interactive mode
+? Name: <1>
+? Issuer audiences: <2>
+? The serving url of the token issuer: <3>
+? CA file path (optional): <4>
+? Claim mapping username: <5>
+? Claim mapping groups: <6>
+? Claim validation rule (optional): <7>
+? Console client id (optional): <8>
+----
+<1> The name of your external authentication provider. This name should be a lower-case with numbers and dashes.
+<2> The audience IDs that this authentication provider issues tokens for.
+<3> The issuer's URL that serves the token.
+<4> Optional: The certificate file to use when making requests.
+<5> The name of the claim that is used to construct the user names for cluster identity, such as using `email`.
+<6> The method with which to transform the ID token into a cluster identity, such as using `groups`.
+<7> Optional: The rules that help validate token claims which authenticate your users. This field should be formatted as `:<required_value>`.
+<8> Optional: The application or client ID that your app registration uses for the console.
+--
+
+* You can include the required IDs to create your external authentication provider with the following command:
++
+[source,terminal]
+----
+rosa create external-auth-provider --cluster=<cluster_id> \
+    --name=<provider_name> --issuer-url=<issuing_url> \
+    --issuer-audiences=<audience_id> \ 
+    --claim-mapping-username-claim=email \ 
+    --claim-mapping-groups-claim=groups \
+    --console-client-id=<client_id_for_app_registration> \
+    --console-client-secret=<client_secret>
+----
++
+.Example output
++
+[source,terminal]
+----
+I: Successfully created an external authentication provider for cluster '<cluster_id>'
+----
+
+.Verification 
+
+* View the external authentication configuration on your cluster by running the following commands:
+
+* List the external authentication configuration on a specified cluster with the following command:
++ 
+[source,terminal]
+----
+$ rosa list external-auth-provider -c <cluster_name> 
+----  
++
+.Example output
++
+The following example shows a configured Microsoft Entra ID external authentication provider:
++
+[source,terminal]
+----
+NAME        ISSUER URL
+m-entra-id  https://login.microsoftonline.com/<group_id>/v2.0
+----
+
+* Display the external authentication configuration on a specified cluster by using the following command:
++ 
+[source,terminal]
+----
+$ rosa describe external-auth-provider \
+    -c <cluster_name> --name <name_of_external_authentication>
+----  
++
+.Example output
++
+[source,terminal]
+----
+ID:                          ms-entra-id
+Cluster ID:                  <cluster_id>
+Issuer audiences:
+                             - <audience_id>
+Issuer Url:                  https://login.microsoftonline.com/<group_id>/v2.0
+Claim mappings group:        groups
+Claim mappings username:     email
+----

--- a/modules/rosa-hcp-sts-creating-a-cluster-ext-auth-provider-delete-cli.adoc
+++ b/modules/rosa-hcp-sts-creating-a-cluster-ext-auth-provider-delete-cli.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// * rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-hcp-sts-creating-a-cluster-external-auth-provider-delete-cli_{context}"]
+= Deleting an external authentication provider
+:source-highlighter: pygments
+:pygments-style: emacs
+:icons: font
+ 
+Delete external authentication providers by using the ROSA CLI.
+
+.Procedure
+
+. Run the following command to display your external authentication provider on your cluster:
++
+[source,terminal]
+----
+$ rosa list external-auth-provider -c <cluster_name>
+----
++
+.Example output
+[source,terminal]
+----
+NAME        ISSUER URL
+entra-test  https://login.microsoftonline.com/<group_id>/v2.0
+----
+
+. Delete the external authentication provider by running the following command:
++
+[source,terminal]
+----
+$ rosa delete external-auth-provider <name_of_provider> -c <cluster_name>
+----
++
+.Example output
+[source,terminal]
+----
+? Are you sure you want to delete external authentication provider entra-test on cluster rosa-ext-test? Yes
+I: Successfully deleted external authentication provider 'entra-test' from cluster 'rosa-ext-test'
+----
+
+.Verification
+* Run the following command to query for any external authentication providers on your cluster:
++
+[source,terminal]
+----
+$ rosa list external-auth-provider -c <cluster_name>
+----
++
+.Example output
+[source,terminal]
+----
+E: there are no external authentication providers for this cluster
+----

--- a/modules/rosa-list-objects.adoc
+++ b/modules/rosa-list-objects.adoc
@@ -77,6 +77,49 @@ $ rosa list clusters [arguments]
 |Specifies an AWS profile (string) from your credentials file.
 |===
 
+[id="rosa-list-external-auth-provider_{context}"]
+== list external-auth-provider
+
+List any external authentication providers for a cluster.
+
+.Syntax
+[source,terminal]
+----
+$ rosa list external-auth-provider --cluster=<cluster_name> | <cluster_id> [arguments]
+----
+
+.Arguments
+[cols="30,70"]
+|===
+|Option |Definition
+
+|--cluster
+|Required: The name or ID string of the cluster that the external authentication provider will be listed for.
+|===
+
+.Optional arguments inherited from parent commands
+[cols="30,70"]
+|===
+|Option |Definition
+
+|--help
+|Shows help for this command.
+
+|--debug
+|Enables debug mode.
+
+|--profile
+|Specifies an AWS profile string from your credentials file.
+|===
+
+.Example
+List any external authentication providers for a cluster named `mycluster`.
+
+[source,terminal]
+----
+$ rosa list external-auth-provider --cluster=mycluster
+----
+
 [id="rosa-list-idps_{context}"]
 == list idps
 

--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc
@@ -1,0 +1,66 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="rosa-hcp-sts-creating-a-cluster-ext-auth"]
+= Creating ROSA with HCP clusters with external authentication
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: rosa-hcp-sts-creating-a-cluster-ext-auth
+
+toc::[]
+
+You can create {hcp-title-first} clusters that use external authentication to issue your access tokens.
+
+[IMPORTANT]
+====
+Since it is not possible to upgrade or convert existing ROSA clusters to a {hcp} architecture, you must create a new cluster to use {hcp-title} functionality. You also cannot convert a cluster that was created to use external authentication providers to use the internal OAuth2 server. You must also create a new cluster.
+====
+
+[NOTE]
+====
+{hcp-title} clusters only support {sts-first} authentication.
+====
+
+.Further reading
+* For a comparison between {hcp-title} and ROSA Classic, see the xref:../architecture/rosa-architecture-models.adoc#rosa-hcp-classic-comparison_rosa-architecture-models[Comparing architecture models] documentation.
+* See the AWS documentation for information about link:https://docs.aws.amazon.com/rosa/latest/userguide/getting-started-hcp.html[Getting started with ROSA with HCP using the ROSA CLI in auto mode].
+
+.Additional resources
+
+For a full list of the supported certificates, see the xref:../rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.adoc#rosa-policy-compliance_rosa-policy-process-security[Compliance] section of "Understanding process and security for Red Hat OpenShift Service on AWS".
+
+[id="rosa-hcp-external-auth-prereqs"]
+== {hcp-title} Prerequisites
+
+To create a {hcp-title} cluster, you must have completed the following steps:
+
+* Completed the xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prereqs[AWS prerequisites]
+* xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-creating-vpc[Configured virtual private cloud (VPC)]
+* Created xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-account-wide-sts-roles-and-policies_rosa-hcp-sts-creating-a-cluster-quickly[Account-wide roles]
+* Created an xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-sts-byo-oidc_rosa-hcp-sts-creating-a-cluster-quickly[OIDC configuration]
+* Created xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-operator-config_rosa-hcp-sts-creating-a-cluster-quickly[Operator roles]
+
+// Step 1 Prepare HCP cluster with  --external-auth-providers-enabled 	
+include::modules/rosa-hcp-sts-creating-a-cluster-ext-auth-cluster-cli.adoc[leveloffset=+1]
+//Step 2 Create/list/delete external_provider  to HCP cluster that external_auth_config is not enable
+include::modules/rosa-hcp-sts-creating-a-cluster-ext-auth-provider-cli.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* For more information about configuring Entra ID for your IDP, see link:https://learn.microsoft.com/en-us/entra/fundamentals/whatis[What is Microsoft Entra ID?] in the Azure documentation or the xref:../cloud_experts_tutorials/cloud-experts-entra-id-idp.adoc#cloud-experts-entra-id-idp[Configuring Microsoft Entra ID (formerly Azure Active Directory) as an identity provider] tutorial section of the documentation.
+* For information on the similar `idps` tool in the ROSA CLI, see xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-idp_rosa-managing-objects-cli[`create idp`].
+* For more information on options in the ROSA CLI, see xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-external-auth-provider_rosa-managing-objects-cli[`create external-auth-provider`], xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-list-external-auth-provider_rosa-managing-objects-cli[`list external-auth-provider`], and xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-delete-external-auth-provider_rosa-managing-objects-cli[`delete external-auth-provider`]
+
+//Step 3 delete external_provider  to HCP cluster that external_auth_config is not enable
+include::modules/rosa-hcp-sts-creating-a-cluster-ext-auth-provider-delete-cli.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_rosa-sts-creating-a-cluster-ext-auth"]
+== Additional resources
+
+* For steps to deploy a ROSA cluster using manual mode, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-sts-creating-cluster-using-customizations_rosa-sts-creating-a-cluster-with-customizations[Creating a cluster using customizations].
+* For more information about the AWS Identity Access Management (IAM) resources required to deploy {product-title} with STS, see xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-iam-resources[About IAM resources for clusters that use STS].
+* To learn more about the default CIDR ranges for {product-title}, see xref:../networking/cidr-range-definitions.adoc#cidr-range-definitions[CIDR range definitions].
+* For details about optionally setting an Operator role name prefix, see xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-operator-role-prefixes_rosa-sts-about-iam-resources[About custom Operator IAM role prefixes].
+* For information about the prerequisites to installing ROSA with STS, see xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prereqs[AWS prerequisites for ROSA with STS].
+* For details about using the `auto` and `manual` modes to create the required STS resources, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-understanding-deployment-modes_rosa-sts-creating-a-cluster-with-customizations[Understanding the auto and manual deployment modes].
+* For more information about using OpenID Connect (OIDC) identity providers in AWS IAM, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html[Creating OpenID Connect (OIDC) identity providers] in the AWS documentation.
+* For more information about troubleshooting ROSA cluster installations, see xref:../support/troubleshooting/rosa-troubleshooting-installations.adoc#rosa-troubleshooting-installations[Troubleshooting installations].
+* For steps to contact Red Hat Support for assistance, see xref:../support/getting-support.adoc#getting-support[Getting support for Red Hat OpenShift Service on AWS].


### PR DESCRIPTION
Version(s):
`enterprise-4.15+`

Issue:
**[OSDOCS-9614](https://issues.redhat.com/browse/OSDOCS-9614)**

Link to docs preview:
- **[Creating a ROSA with HCP cluster with external authentication](https://file.rdu.redhat.com/eponvell/OSDOCS-9614_External-OIDC-Auth-HCP/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.html)**
- Additions to ROSA CLI:
    - **[rosa create external-auth-provider](https://file.rdu.redhat.com/eponvell/OSDOCS-9614_External-OIDC-Auth-HCP/cli_reference/rosa_cli/rosa-manage-objects-cli.html#rosa-create-external-auth-provider_rosa-managing-objects-cli)**
    - **[rosa list external-auth-provider](https://file.rdu.redhat.com/eponvell/OSDOCS-9614_External-OIDC-Auth-HCP/cli_reference/rosa_cli/rosa-manage-objects-cli.html#rosa-list-external-auth-provider_rosa-managing-objects-cli)** 
    - **[rosa delete external-auth-provider](https://file.rdu.redhat.com/eponvell/OSDOCS-9614_External-OIDC-Auth-HCP/cli_reference/rosa_cli/rosa-manage-objects-cli.html#rosa-delete-external-auth-provider_rosa-managing-objects-cli)**

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR adds new documentation for external auth 