### PR TITLE
OCPBUGS-18770: GCP passthrough roles req

### DIFF
--- a/modules/installation-gcp-permissions.adoc
+++ b/modules/installation-gcp-permissions.adoc
@@ -17,7 +17,14 @@ endif::[]
 [id="installation-gcp-permissions_{context}"]
 = Required GCP roles
 
-When you attach the `Owner` role to the service account that you create, you grant that service account all permissions, including those that are required to install {product-title}. If your organization's security policies require a more restrictive set of permissions, you can create a service account with the following permissions. If you deploy your cluster into an existing virtual private cloud (VPC), the service account does not require certain networking permissions, which are noted in the following lists:
+When you attach the `Owner` role to the service account that you create, you grant that service account all permissions, including those that are required to install {product-title}. If the security policies for your organization require a more restrictive set of permissions, you can create a service account with the following permissions.
+
+[IMPORTANT]
+====
+If you configure the Cloud Credential Operator to operate in passthrough mode, you must use roles rather than granular permissions.
+====
+
+If you deploy your cluster into an existing virtual private cloud (VPC), the service account does not require certain networking permissions, which are noted in the following lists:
 
 .Required roles for the installation program
 * Compute Admin

--- a/modules/minimum-required-permissions-ipi-gcp.adoc
+++ b/modules/minimum-required-permissions-ipi-gcp.adoc
@@ -7,7 +7,13 @@
 
 When you attach the `Owner` role to the service account that you create, you grant that service account all permissions, including those that are required to install {product-title}.
 
-If your organization’s security policies require a more restrictive set of permissions, you can create link:https://cloud.google.com/iam/docs/creating-custom-roles[custom roles] with the necessary permissions. The following permissions are required for the installer-provisioned infrastructure for creating and deleting the {product-title} cluster.
+If the security policies for your organization require a more restrictive set of permissions, you can create link:https://cloud.google.com/iam/docs/creating-custom-roles[custom roles] with the necessary permissions. The following permissions are required for the installer-provisioned infrastructure for creating and deleting the {product-title} cluster.
+
+[IMPORTANT]
+====
+If you configure the Cloud Credential Operator to operate in passthrough mode, you must use roles rather than granular permissions.
+For more information, see "Required roles for using passthrough credentials mode" in the "Required GCP roles" section.
+====
 
 .Required permissions for creating network resources
 [%collapsible]

--- a/modules/minimum-required-permissions-upi-gcp.adoc
+++ b/modules/minimum-required-permissions-upi-gcp.adoc
@@ -9,7 +9,13 @@
 
 When you attach the `Owner` role to the service account that you create, you grant that service account all permissions, including those that are required to install {product-title}.
 
-If your organization’s security policies require a more restrictive set of permissions, you can create link:https://cloud.google.com/iam/docs/creating-custom-roles[custom roles] with the necessary permissions. The following permissions are required for the user-provisioned infrastructure for creating and deleting the {product-title} cluster.
+If the security policies for your organization require a more restrictive set of permissions, you can create link:https://cloud.google.com/iam/docs/creating-custom-roles[custom roles] with the necessary permissions. The following permissions are required for the user-provisioned infrastructure for creating and deleting the {product-title} cluster.
+
+[IMPORTANT]
+====
+If you configure the Cloud Credential Operator to operate in passthrough mode, you must use roles rather than granular permissions.
+For more information, see "Required roles for using passthrough credentials mode" in the "Required GCP roles" section.
+====
 
 .Required permissions for creating network resources
 [%collapsible]


### PR DESCRIPTION
Version(s):
4.12-4.14

Issue:
[OCPBUGS-18770](https://issues.redhat.com/browse/OCPBUGS-18770)

Link to docs preview:
- [Required GCP roles](https://73841--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#installation-gcp-permissions_installing-gcp-account) (IPI/general)
- [Required GCP permissions for installer-provisioned infrastructure](https://73841--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#minimum-required-permissions-ipi-gcp_installing-gcp-account) (IPI)
- [Required GCP roles](https://73841--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra#installation-gcp-permissions_installing-gcp-user-infra) (UPI)
- [Required GCP permissions for user-provisioned infrastructure](https://73841--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra#minimum-required-permissions-upi-gcp_installing-gcp-user-infra) (UPI)

QE review:
- [x] QE has approved this change.

Additional information:
This applies to 4.12-4.14. Should cherrypick cleanly from 4.14 back down.