### PR TITLE
[enterprise-4.14] Manual CP OBSDOCS-904 Logging 5.8.5 Release Notes

### DIFF
--- a/logging/logging_release_notes/logging-5-8-release-notes.adoc
+++ b/logging/logging_release_notes/logging-5-8-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-8-5.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-8-4.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-8-3.adoc[leveloffset=+1]

--- a/modules/logging-release-notes-5-8-5.adoc
+++ b/modules/logging-release-notes-5-8-5.adoc
@@ -1,0 +1,43 @@
+// module included in /logging/logging-5-8-release-notes
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-5-8-5_{context}"]
+= Logging 5.8.5
+This release includes link:https://access.redhat.com/errata/RHSA-2024:1474[OpenShift Logging Bug Fix Release 5.8.5].
+
+[id="logging-release-notes-5-8-5-bug-fixes"]
+== Bug fixes
+
+* Before this update, the configuration of the Loki Operator's `ServiceMonitor` could match many Kubernetes services, resulting in the Loki Operator's metrics being collected multiple times. With this update, the configuration of `ServiceMonitor` now only matches the dedicated metrics service. (link:https://issues.redhat.com/browse/LOG-5250[LOG-5250])
+
+
+* Before this update, the Red Hat build pipeline did not use the existing build details in Loki builds and omitted information such as revision, branch, and version. With this update, the Red Hat build pipeline now adds these details to the Loki builds, fixing the issue. (link:https://issues.redhat.com/browse/LOG-5201[LOG-5201])
+
+
+* Before this update, the Loki Operator checked if the pods were running to decide if the `LokiStack` was ready. With this update, it also checks if the pods are ready, so that the readiness of the `LokiStack` reflects the state of its components.  (link:https://issues.redhat.com/browse/LOG-5171[LOG-5171])
+
+
+* Before this update, running a query for log metrics caused an error in the histogram. With this update, the histogram toggle function and the chart are disabled and hidden because the histogram doesn't work with log metrics. (link:https://issues.redhat.com/browse/LOG-5044[LOG-5044])
+
+
+* Before this update, the Loki and Elasticsearch bundle had the wrong `maxOpenShiftVersion`, resulting in `IncompatibleOperatorsInstalled` alerts. With this update, including 4.16 as the `maxOpenShiftVersion` property in the bundle fixes the issue. (link:https://issues.redhat.com/browse/LOG-5272[LOG-5272])
+
+
+* Before this update, the build pipeline did not include linker flags for the build date, causing Loki builds to show empty strings for `buildDate` and `goVersion`. With this update, adding the missing linker flags in the build pipeline fixes the issue. (link:https://issues.redhat.com/browse/LOG-5274[LOG-5274])
+
+
+* Before this update, a bug in LogQL parsing left out some line filters from the query. With this update, the parsing now includes all the line filters while keeping the original query unchanged. (link:https://issues.redhat.com/browse/LOG-5270[LOG-5270])
+
+* Before this update, the Loki Operator `ServiceMonitor` in the `openshift-operators-redhat` namespace used static token and CA files for authentication, causing errors in the Prometheus Operator in the User Workload Monitoring spec on the `ServiceMonitor` configuration. With this update, the Loki Operator `ServiceMonitor` in `openshift-operators-redhat` namespace now references a service account token secret by a `LocalReference` object. This approach allows the User Workload Monitoring spec in the Prometheus Operator to handle the Loki Operator `ServiceMonitor` successfully, enabling Prometheus to scrape the Loki Operator metrics. (link:https://issues.redhat.com/browse/LOG-5240[LOG-5240])
+
+[id="logging-release-notes-5-8-5-CVEs"]
+== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2023-5363[CVE-2023-5363]
+* link:https://access.redhat.com/security/cve/CVE-2023-5981[CVE-2023-5981]
+* link:https://access.redhat.com/security/cve/CVE-2023-6135[CVE-2023-6135]
+* link:https://access.redhat.com/security/cve/CVE-2023-46218[CVE-2023-46218]
+* link:https://access.redhat.com/security/cve/CVE-2023-48795[CVE-2023-48795]
+* link:https://access.redhat.com/security/cve/CVE-2023-51385[CVE-2023-51385]
+* link:https://access.redhat.com/security/cve/CVE-2024-0553[CVE-2024-0553]
+* link:https://access.redhat.com/security/cve/CVE-2024-0567[CVE-2024-0567]
+* link:https://access.redhat.com/security/cve/CVE-2024-24786[CVE-2024-24786]
+* link:https://access.redhat.com/security/cve/CVE-2024-28849[CVE-2024-28849]


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/openshift-docs/pull/73271

Fix version: 4.14

Doc Preview: https://73848--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/logging_release_notes/logging-5-8-release-notes#logging-release-notes-5-8-5_logging-5-8-release-notes

cherry picked from: 549dc12c88a526915f026be88a4b04b6349e22d1