### PR TITLE
[enterprise-4.13] Manual CP OBSDOCS-846 Logging 5.7.12 Release Notes

### DIFF
--- a/logging/logging_release_notes/logging-5-7-release-notes.adoc
+++ b/logging/logging_release_notes/logging-5-7-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-7-12.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-7-11.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-7-10.adoc[leveloffset=+1]

--- a/modules/logging-release-notes-5-7-12.adoc
+++ b/modules/logging-release-notes-5-7-12.adoc
@@ -1,0 +1,54 @@
+// module included in logging/logging-5-7-release-notes
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-5-7-12_{context}"]
+= Logging 5.7.12
+This release includes link:https://access.redhat.com/errata/RHSA-2024:1508[OpenShift Logging Bug Fix 5.7.12].
+
+[id="logging-release-notes-5-7-12-bug-fixes"]
+== Bug fixes
+
+* Before this update, the Loki Operator checked if the pods were running to decide if the `LokiStack` was ready. With this update, it also checks if the pods are ready, so that the readiness of the `LokiStack` reflects the state of its components.  (link:https://issues.redhat.com/browse/LOG-5172[LOG-5172])
+
+
+* Before this update, the Red Hat build pipeline didn't use the existing build details in Loki builds and omitted information such as revision, branch, and version. With this update, the Red Hat build pipeline now adds these details to the Loki builds, fixing the issue. (link:https://issues.redhat.com/browse/LOG-5202[LOG-5202])
+
+
+* Before this update, the configuration of the Loki Operator's `ServiceMonitor` could match many Kubernetes services, resulting in the Loki Operator's metrics being collected multiple times. With this update, the configuration of `ServiceMonitor` now only matches the dedicated metrics service. (link:https://issues.redhat.com/browse/LOG-5251[LOG-5251])
+
+
+* Before this update, the build pipeline did not include linker flags for the build date, causing Loki builds to show empty strings for `buildDate` and `goVersion`. With this update, adding the missing linker flags in the build pipeline fixes the issue. (link:https://issues.redhat.com/browse/LOG-5275[LOG-5275])
+
+* Before this update, the Loki Operator `ServiceMonitor` in the `openshift-operators-redhat` namespace used static token and CA files for authentication, causing errors in the Prometheus Operator in the User Workload Monitoring spec on the `ServiceMonitor` configuration. With this update, the Loki Operator `ServiceMonitor` in `openshift-operators-redhat` namespace now references a service account token secret by a `LocalReference` object. This approach allows the User Workload Monitoring spec in the Prometheus Operator to handle the Loki Operator `ServiceMonitor` successfully, enabling Prometheus to scrape the Loki Operator metrics. (link:https://issues.redhat.com/browse/LOG-5241[LOG-5241])
+
+[id="logging-release-notes-5-7-12-CVEs"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2021-35937[CVE-2021-35937]
+* link:https://access.redhat.com/security/cve/CVE-2021-35938[CVE-2021-35938]
+* link:https://access.redhat.com/security/cve/CVE-2021-35939[CVE-2021-35939]
+* link:https://access.redhat.com/security/cve/CVE-2022-3545[CVE-2022-3545]
+* link:https://access.redhat.com/security/cve/CVE-2022-41858[CVE-2022-41858]
+* link:https://access.redhat.com/security/cve/CVE-2023-1073[CVE-2023-1073]
+* link:https://access.redhat.com/security/cve/CVE-2023-1838[CVE-2023-1838]
+* link:https://access.redhat.com/security/cve/CVE-2023-2166[CVE-2023-2166]
+* link:https://access.redhat.com/security/cve/CVE-2023-2176[CVE-2023-2176]
+* link:https://access.redhat.com/security/cve/CVE-2023-4623[CVE-2023-4623]
+* link:https://access.redhat.com/security/cve/CVE-2023-4921[CVE-2023-4921]
+* link:https://access.redhat.com/security/cve/CVE-2023-5717[CVE-2023-5717]
+* link:https://access.redhat.com/security/cve/CVE-2023-6135[CVE-2023-6135]
+* link:https://access.redhat.com/security/cve/CVE-2023-6356[CVE-2023-6356]
+* link:https://access.redhat.com/security/cve/CVE-2023-6535[CVE-2023-6535]
+* link:https://access.redhat.com/security/cve/CVE-2023-6536[CVE-2023-6536]
+* link:https://access.redhat.com/security/cve/CVE-2023-6606[CVE-2023-6606]
+* link:https://access.redhat.com/security/cve/CVE-2023-6610[CVE-2023-6610]
+* link:https://access.redhat.com/security/cve/CVE-2023-6817[CVE-2023-6817]
+* link:https://access.redhat.com/security/cve/CVE-2023-7104[CVE-2023-7104]
+* link:https://access.redhat.com/security/cve/CVE-2023-27043[CVE-2023-27043]
+* link:https://access.redhat.com/security/cve/CVE-2023-40283[CVE-2023-40283]
+* link:https://access.redhat.com/security/cve/CVE-2023-45871[CVE-2023-45871]
+* link:https://access.redhat.com/security/cve/CVE-2023-46813[CVE-2023-46813]
+* link:https://access.redhat.com/security/cve/CVE-2023-48795[CVE-2023-48795]
+* link:https://access.redhat.com/security/cve/CVE-2023-51385[CVE-2023-51385]
+* link:https://access.redhat.com/security/cve/CVE-2024-0553[CVE-2024-0553]
+* link:https://access.redhat.com/security/cve/CVE-2024-0646[CVE-2024-0646]
+* link:https://access.redhat.com/security/cve/CVE-2024-24786[CVE-2024-24786]


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/openshift-docs/pull/73272

Fix version: 4.13

Doc Preview: https://73851--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/logging_release_notes/logging-5-7-release-notes#logging-release-notes-5-7-12_logging-5-7-release-notes

cherry picked from: a1fe2b39a58b9ae5615d158baad33f7afc616385