### PR TITLE
DOCS OBSDOCS-922 Logging: Elastisearch removal notice

### DIFF
--- a/snippets/logging-elastic-dep-snip.adoc
+++ b/snippets/logging-elastic-dep-snip.adoc
@@ -10,5 +10,5 @@
 
 [NOTE]
 ====
-The {es-op} is deprecated and is planned to be removed in a future release. Red{nbsp}Hat provides bug fixes and support for this feature during the current release lifecycle, but this feature no longer receives enhancements. As an alternative to using the {es-op} to manage the default log storage, you can use the {loki-op}.
+The {logging-uc} 5.9 release does not contain an updated version of the {es-op}. If you currently use the {es-op} released with {logging-uc} 5.8, it will continue to work with {logging-uc} until the EOL of {logging-uc} 5.8. As an alternative to using the {es-op} to manage the default log storage, you can use the {loki-op}. For more information on the {logging-uc} lifecycle dates, see link:https://access.redhat.com/support/policy/updates/openshift_operators#platform-agnostic[Platform Agnostic Operators].
 ====


### PR DESCRIPTION
Change type: Doc update; Elastisearch removal notice

Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-922

Fix Version: 4.12+

Doc Preview: https://73856--ocpdocs-pr.netlify.app/openshift-enterprise/latest/logging/log_storage/logging-config-es-store#configuring-log-storage-cr_logging-config-es-store

SME Review: @xperimental @periklis 
QE Review: @anpingli 
Peer Review: @mburke5678 