### PR TITLE
OPCBUGS-31451-14pr: Updated the vSphere versions info for cluster upg…

### DIFF
--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -10,16 +10,21 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="installation-vsphere-infrastructure_{context}"]
-= VMware vSphere infrastructure requirements
+= {vmw-full} infrastructure requirements
 
 You must install an {product-title} cluster on one of the following versions of a VMware vSphere instance that meets the requirements for the components that you use:
 
 * Version 7.0 Update 3 or later
 * Version 8.0 Update 2 or later
 
-Both of these releases support Container Storage Interface (CSI) migration, which is enabled by default on {product-title} {product-version}.
+Both of these releases support Container Storage Interface (CSI) migration.
 
-You can host the VMware vSphere infrastructure on-premise or on a link:https://cloud.vmware.com/providers[VMware Cloud Verified provider] that meets the requirements outlined in the following tables:
+[IMPORTANT]
+====
+If you need to upgrade an {product-title} 4.13 cluster to {product-title} {product-version}, you must ensure that your {vmw-full} instance was updated to one of the previously listed versions, because CSI migration is enabled by default on {product-title} {product-version}. If you do not upgrade your {vmw-full} instance for this upgrade situation, the cluster upgrade operation fails because of a known issue. For certain situations, you can take manual steps to resolve the known issue. For more information, see link:https://access.redhat.com/node/7011683[Knowledgebase article 7011683].
+====
+
+You can host the {vmw-full} infrastructure on-premise or on a link:https://cloud.vmware.com/providers[VMware Cloud Verified provider] that meets the requirements outlined in the following tables:
 
 .Version requirements for vSphere virtual environments
 [cols=2, options="header"]


### PR DESCRIPTION
Version(s):
4.16 to 4.14

Issue:
[OCPBUGS-31451](https://issues.redhat.com/browse/OCPBUGS-31451)

Link to docs preview:
[VMware vSphere infrastructure requirements](https://73869--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned#installation-vsphere-infrastructure_installing-vsphere-installer-provisioned)

- [ ] SME has approved this change
- [ ] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
