### PR TITLE
OSDOCS-9915 machine pool grace periods during upgrades

### DIFF
--- a/modules/rosa-edit-objects.adoc
+++ b/modules/rosa-edit-objects.adoc
@@ -230,6 +230,9 @@ $ rosa edit machinepool --cluster=<cluster_name> | <cluster_id> <machinepool_ID>
 |--min-replicas
 |Specifies the minimum number of compute nodes when enabling autoscaling.
 
+|--node-drain-grace-period
+|Specifies the node drain grace period when upgrading or replacing the machine pool. (This is for {hcp-title} clusters only.)
+
 |--replicas
 |Required when autoscaling is not configured. The number (integer) of machines for this machine pool.
 

--- a/modules/rosa-node-drain-grace-period.adoc
+++ b/modules/rosa-node-drain-grace-period.adoc
@@ -1,0 +1,82 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc
+//this module applies to ROSA HCP only
+
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-node-drain-grace-period_{context}"]
+= Configuring node drain grace periods in {hcp-title} clusters
+
+You can configure the node drain grace period for machine pools in your cluster. The node drain grace period for a machine pool is how long the cluster respects the Pod Disruption Budget protected workloads when upgrading or replacing the machine pool. After this grace period, all remaining workloads are forcibly evicted. The value range for the node drain grace period is from `0` to `1 week`. With the default value `0`, or empty value, the machine pool drains without any time limitation until complete.
+
+
+.Prerequisites
+
+* You installed and configured the latest {product-title} (ROSA) CLI, `rosa`, on your workstation.
+* You created a {hcp-title-first} cluster.
+* You have an existing machine pool.
+
+.Procedure
+
+. List all of the machine pools in the cluster by running the following command:
++
+[source,terminal]
+----
+$ rosa list machinepools --cluster=<cluster_name>
+----
++
+.Example output
+[source,terminal]
+----
+ID          AUTOSCALING  REPLICAS  INSTANCE TYPE [...] AVAILABILITY ZONES  SUBNET  VERSION  AUTOREPAIR  TUNING CONFIGS
+workers      No           2         m5.xlarge    [...] us-east-1a          N/A     4.14.18  Yes
+db-nodes-mp  No           2         m5.xlarge    [...] us-east-1a          No      4.14.18  Yes
+----
+
+. Check the node drain grace period for a machine pool by running the following command:
++
+[source,terminal]
+----
+$ rosa describe machinepool --cluster <cluster_name> <machinepool_name>
+----
++
+.Example output
+[source,terminal]
+----
+ID:                                    workers
+Cluster ID:                            2a90jdl0i4p9r9k9956v5ocv40se1kqs       
+Node drain grace period:               <1>
+----
++
+<1> If this value is empty, the machine pool drains without any time limitation until complete.
+
+. Optional: Update the node drain grace period for a machine pool by running the following command:
++
+[source,terminal]
+----
+$ rosa edit machinepool --node-drain-grace-period="<node_drain_grace_period_value>" --cluster=<cluster_name>  <machinepool_name>
+----
++
+[NOTE]
+====
+Changing the node drain grace period during a machine pool upgrade applies to future upgrades, not in progress upgrades.
+====
+
+.Verification
+
+. Check the node drain grace period for a machine pool by running the following command:
++
+[source,terminal]
+----
+$ rosa describe machinepool --cluster <cluster_name> <machinepool_name>
+----
++
+.Example output
+[source,terminal]
+----
+ID:                                    workers
+Cluster ID:                            2a90jdl0i4p9r9k9956v5ocv40se1kqs       
+Node drain grace period:               30 minutes
+----
+
+. Verify the correct `Node drain grace period` for your machine pool in the output.

--- a/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc
+++ b/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc
@@ -56,8 +56,8 @@ include::modules/rosa-adding-node-labels.adoc[leveloffset=+2]
 include::modules/rosa-adding-taints.adoc[leveloffset=+1]
 include::modules/rosa-adding-taints-ocm.adoc[leveloffset=+2]
 include::modules/rosa-adding-taints-cli.adoc[leveloffset=+2]
-
 include::modules/rosa-adding-tuning.adoc[leveloffset=+1]
+include::modules/rosa-node-drain-grace-period.adoc[leveloffset=+1]
 
 == Additional resources
 * xref:../../rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.adoc#rosa-nodes-machinepools-about[About machine pools]

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -32,6 +32,10 @@ For more information on region availabilities, see xref:../rosa_architecture/ros
 
 * **Node management improvements.** Now, you can perform specific tasks to make clusters more efficient. You can cordon, uncordon, and drain a specific node. For more information, see xref:../nodes/nodes/nodes-nodes-working.adoc[Working with nodes].
 
+* **Node drain grace periods.** You can now configure node drain grace periods in {hcp-title-first} clusters with the `rosa` CLI. 
++
+For more information about configuring node drain grace periods, see xref:../rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc#rosa-node-drain-grace-period_rosa-managing-worker-nodes[Configuring node drain grace periods in {hcp-title-first}].
+
 [id="rosa-q1-2024_{context}"]
 === Q1 2024
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Updated the upgrade documentation for the node drain grace period. 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.15+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-9915
Link to docs preview:
Link to new procedure:
https://73909--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes#rosa-node-drain-grace-period_rosa-managing-worker-nodes


CLI doc:
https://73909--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli#rosa-edit-machinepool_rosa-managing-objects-cli

QE review:

- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
