### PR TITLE
OSDOCS#10069 fixing Additional Resources formatting in GCP install doc

### DIFF
--- a/installing/installing_gcp/installing-gcp-network-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-network-customizations.adoc
@@ -57,7 +57,7 @@ include::modules/installation-gcp-enabling-confidential-vms.adoc[leveloffset=+2]
 include::modules/installation-gcp-config-yaml.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-== Additional resources
+.Additional resources
 
 * xref:../../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-enabling-customer-managed-encryption_creating-machineset-gcp[Enabling customer-managed encryption keys for a compute machine set]
 

--- a/installing/installing_gcp/installing-gcp-private.adoc
+++ b/installing/installing_gcp/installing-gcp-private.adoc
@@ -53,13 +53,12 @@ include::modules/installation-gcp-enabling-confidential-vms.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-config-yaml.adoc[leveloffset=+2]
 
-include::modules/nw-gcp-installing-global-access-configuration.adoc[leveloffset=+2]
-
-
 [role="_additional-resources"]
-== Additional resources
+.Additional resources
 
 * xref:../../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-enabling-customer-managed-encryption_creating-machineset-gcp[Enabling customer-managed encryption keys for a compute machine set]
+
+include::modules/nw-gcp-installing-global-access-configuration.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 

--- a/installing/installing_gcp/installing-gcp-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-vpc.adoc
@@ -49,13 +49,12 @@ include::modules/installation-gcp-enabling-confidential-vms.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-config-yaml.adoc[leveloffset=+2]
 
-include::modules/nw-gcp-installing-global-access-configuration.adoc[leveloffset=+2]
-
-
 [role="_additional-resources"]
-== Additional resources
+.Additional resources
 
 * xref:../../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-enabling-customer-managed-encryption_creating-machineset-gcp[Enabling customer-managed encryption keys for a compute machine set]
+
+include::modules/nw-gcp-installing-global-access-configuration.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-10069

Link to docs preview:
https://73925--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-network-customizations#installation-gcp-config-yaml_installing-gcp-network-customizations

QE review:
N/A, formatting only

The additional resources heading under the config yaml file was interrupting the right hand ToC and setting things out of order.