### PR TITLE
OSDOCS-9844: adds 4.14.19 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -468,3 +468,12 @@ Issued: 2024-03-27
 {product-title} release 4.14.18 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1460[RHBA-2024:1460] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1458[RHSA-2024:1458] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-14-19-dp"]
+=== RHSA-2024:1566 - {microshift-short} 4.14.19 security update and bug fix update advisory
+
+Issued: 2024-04-03
+
+{product-title} release 4.14.19 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:1566[RHSA-2024:1566] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:1564[RHBA-2024:1564] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.14 only

Issue:
[OSDOCS-9844](https://issues.redhat.com/browse/OSDOCS-9844)

Link to docs preview:
[4.14.19 async release note](https://73933--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes#microshift-4-14-19-dp)

QE review:
- N/A stock text, no other release notes

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
