### PR TITLE
OSDOCS-9847: adds 4.15.6 relnotes MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -250,5 +250,14 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-15-5-enhancements"]
 ==== Enhancements
 
-Change in openshift-marketplace pod security admission definition::
-* With this release, the `openshift-marketplace` pod security admission definition defaults to `baseline`. See the OLM documentation for specifics on how this change impacts your operator deployments. See xref:../microshift_running_apps/microshift-operators-olm.adoc#microshift-operators-olm[Using Operator Lifecycle Manager with {microshift-short}]. (link:https://issues.redhat.com/browse/OCPBUGS-30034[OCPBUGS-30034])
+Change in openshift-marketplace namespace security::
+* With this release, the `openshift-marketplace` namespace security defaults to `baseline`. See the OLM documentation for specifics on how this change impacts your operator deployments. See xref:../microshift_running_apps/microshift-operators-olm.adoc#microshift-operators-olm[Using Operator Lifecycle Manager with {microshift-short}]. (link:https://issues.redhat.com/browse/OCPBUGS-30034[OCPBUGS-30034])
+
+[id="microshift-4-15-6-dp"]
+=== RHSA-2024:1561 - {microshift-short} 4.15.6 bug fix and security update advisory
+
+Issued: 2024-04-02
+
+{product-title} release 4.15.6 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:1561[RHSA-2024:1561] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1559[RHSA-2024:1559] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-9847](https://issues.redhat.com/browse/OSDOCS-9847)

Link to docs preview:
[4.15.6 async release note](https://73934--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes#microshift-4-15-6-dp)

QE review:
- N/A stock text, no bugs or enhancements

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
