### PR TITLE
Remove kube-reserved which is no longer supported

### DIFF
--- a/modules/cnf-deploying-the-numa-aware-scheduler-with-manual-performance-settings.adoc
+++ b/modules/cnf-deploying-the-numa-aware-scheduler-with-manual-performance-settings.adoc
@@ -8,11 +8,11 @@
 
 After you install the NUMA Resources Operator, do the following to deploy the NUMA-aware secondary pod scheduler:
 
-* Configure the pod admittance policy for the required machine profile
+* Configure the pod admittance policy for the required machine profile.
 
-* Create the required machine config pool
+* Create the required machine config pool.
 
-* Deploy the NUMA-aware secondary scheduler
+* Deploy the NUMA-aware secondary scheduler.
 
 .Prerequisites
 
@@ -44,8 +44,6 @@ spec:
     memoryManagerPolicy: "Static" <2>
     evictionHard:
       memory.available: "100Mi"
-    kubeReserved:
-      memory: "512Mi"
     reservedMemory:
       - numaNode: 0
         limits:

--- a/modules/cnf-deploying-the-numa-aware-scheduler.adoc
+++ b/modules/cnf-deploying-the-numa-aware-scheduler.adoc
@@ -8,9 +8,11 @@
 
 After you install the NUMA Resources Operator, do the following to deploy the NUMA-aware secondary pod scheduler:
 
-* Configure the performance profile.
+* Configure the pod admittance policy for the required machine profile
 
-* Deploy the NUMA-aware secondary scheduler.
+* Create the required machine config pool
+
+* Deploy the NUMA-aware secondary scheduler
 
 .Prerequisites
 
@@ -18,44 +20,48 @@ After you install the NUMA Resources Operator, do the following to deploy the NU
 
 * Log in as a user with `cluster-admin` privileges.
 
-* Create the required machine config pool.
-
 * Install the NUMA Resources Operator.
 
 .Procedure
+. Create the `KubeletConfig` custom resource that configures the pod admittance policy for the machine profile:
 
-. Create the `PerformanceProfile` custom resource (CR):
-
-.. Save the following YAML in the `nro-perfprof.yaml` file:
+.. Save the following YAML in the `nro-kubeletconfig.yaml` file:
 +
 [source,yaml]
 ----
-apiVersion: performance.openshift.io/v2
-kind: PerformanceProfile
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
 metadata:
-  name: perfprof-nrop
+  name: cnf-worker-tuning
 spec:
-  cpu: <1>
-    isolated: "4-51,56-103"
-    reserved: "0,1,2,3,52,53,54,55"
-  nodeSelector:
-    node-role.kubernetes.io/worker: ""
-  numa:
-    topologyPolicy: single-numa-node
+  machineConfigPoolSelector:
+    matchLabels:
+      cnf-worker-tuning: enabled
+  kubeletConfig:
+    cpuManagerPolicy: "static" <1>
+    cpuManagerReconcilePeriod: "5s"
+    reservedSystemCPUs: "0,1"
+    memoryManagerPolicy: "Static" <2>
+    evictionHard:
+      memory.available: "100Mi"
+    reservedMemory:
+      - numaNode: 0
+        limits:
+          memory: "1124Mi"
+    systemReserved:
+      memory: "512Mi"
+    topologyManagerPolicy: "single-numa-node" <3>
+    topologyManagerScope: "pod"
 ----
-<1> The `cpu.isolated` and `cpu.reserved` specifications define ranges for isolated and reserved CPUs. Enter valid values for your CPU configuration. See the _Additional resources_ section for more information about configuring a performance profile.
+<1> For `cpuManagerPolicy`, `static` must use a lowercase `s`.
+<2> For `memoryManagerPolicy`, `Static` must use an uppercase `S`.
+<3> `topologyManagerPolicy` must be set to `single-numa-node`.
 
-.. Create the `PerformanceProfile` CR by running the following command:
+.. Create the `KubeletConfig` custom resource (CR) by running the following command:
 +
 [source,terminal]
 ----
-$ oc create -f nro-perfprof.yaml
-----
-+
-.Example output
-[source,terminal]
-----
-performanceprofile.performance.openshift.io/perfprof-nrop created
+$ oc create -f nro-kubeletconfig.yaml
 ----
 
 . Create the `NUMAResourcesScheduler` custom resource that deploys the NUMA-aware custom pod scheduler:
@@ -64,22 +70,13 @@ performanceprofile.performance.openshift.io/perfprof-nrop created
 +
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: nodetopology.openshift.io/v1
+apiVersion: nodetopology.openshift.io/v1alpha1
 kind: NUMAResourcesScheduler
 metadata:
   name: numaresourcesscheduler
 spec:
-  imageSpec: "registry.redhat.io/openshift4/noderesourcetopology-scheduler-rhel9:v{product-version}"
-  cacheResyncPeriod: "5s" <1>
+  imageSpec: "registry.redhat.io/openshift4/noderesourcetopology-scheduler-container-rhel8:v{product-version}"
 ----
-<1> Enter an interval value in seconds for synchronization of the scheduler cache. A value of `5s` is typical for most implementations.
-+
-[NOTE]
-====
-* Enable the `cacheResyncPeriod` specification to help the NUMA Resource Operator report more exact resource availability by monitoring pending resources on nodes and synchronizing this information in the scheduler cache at a defined interval. This also helps to minimize `Topology Affinity Error` errors because of sub-optimal scheduling decisions. The lower the interval the greater the network load. The `cacheResyncPeriod` specification is disabled by default.
-
-* Setting a value of `Enabled` for the `podsFingerprinting` specification in the `NUMAResourcesOperator` CR is a requirement for the implementation of the `cacheResyncPeriod` specification.
-====
 
 .. Create the `NUMAResourcesScheduler` CR by running the following command:
 +
@@ -90,20 +87,13 @@ $ oc create -f nro-scheduler.yaml
 
 .Verification
 
-. Verify that the performance profile was applied by running the following command:
-+
-[source,terminal]
-----
-$ oc describe performanceprofile <performance-profile-name>
-----
+Verify that the required resources deployed successfully by running the following command:
 
-. Verify that the required resources deployed successfully by running the following command:
-+
 [source,terminal]
 ----
 $ oc get all -n openshift-numaresources
 ----
-+
+
 .Example output
 [source,terminal]
 ----

--- a/modules/nodes-nodes-resources-cpus-reserve.adoc
+++ b/modules/nodes-nodes-resources-cpus-reserve.adoc
@@ -6,7 +6,7 @@
 [id="nodes-nodes-resources-cpus-reserve_{context}"]
 = Reserving CPUs for nodes
 
-To explicitly define a list of CPUs that are reserved for specific nodes, create a `KubeletConfig` custom resource (CR) to define the `reservedSystemCPUs` parameter. This list supersedes the CPUs that might be reserved using the `systemReserved` and `kubeReserved` parameters.
+To explicitly define a list of CPUs that are reserved for specific nodes, create a `KubeletConfig` custom resource (CR) to define the `reservedSystemCPUs` parameter. This list supersedes the CPUs that might be reserved using the `systemReserved` parameter.
 
 .Procedure
 
@@ -64,4 +64,3 @@ spec:
 ----
 $ oc create -f <file_name>.yaml
 ----
-

--- a/nodes/nodes/nodes-nodes-resources-cpus.adoc
+++ b/nodes/nodes/nodes-nodes-resources-cpus.adoc
@@ -19,4 +19,4 @@ include::modules/nodes-nodes-resources-cpus-reserve.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* For more information on the `systemReserved` and `kubeReserved` parameters, see xref:../../nodes/nodes/nodes-nodes-resources-configuring.adoc#nodes-nodes-resources-configuring-about_nodes-nodes-resources-configuring[Allocating resources for nodes in an {product-title} cluster].
+* For more information on the `systemReserved` parameter, see xref:../../nodes/nodes/nodes-nodes-resources-configuring.html#nodes-nodes-resources-configuring-about_nodes-nodes-resources-configuring[Allocating resources for nodes in an {product-title} cluster].


### PR DESCRIPTION
Remove kubeReserved from the docs. This setting is [not used with OpenShift Container Platform](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html-single/nodes/index#nodes-nodes-resources-configuring-about_nodes-nodes-resources-configuring). 