### PR TITLE
Remove kube-reserved which is no longer supported

### DIFF
--- a/modules/cnf-deploying-the-numa-aware-scheduler-with-manual-performance-settings.adoc
+++ b/modules/cnf-deploying-the-numa-aware-scheduler-with-manual-performance-settings.adoc
@@ -44,8 +44,6 @@ spec:
     memoryManagerPolicy: "Static" <2>
     evictionHard:
       memory.available: "100Mi"
-    kubeReserved:
-      memory: "512Mi"
     reservedMemory:
       - numaNode: 0
         limits:

--- a/modules/nodes-nodes-resources-cpus-reserve.adoc
+++ b/modules/nodes-nodes-resources-cpus-reserve.adoc
@@ -6,7 +6,7 @@
 [id="nodes-nodes-resources-cpus-reserve_{context}"]
 = Reserving CPUs for nodes
 
-To explicitly define a list of CPUs that are reserved for specific nodes, create a `KubeletConfig` custom resource (CR) to define the `reservedSystemCPUs` parameter. This list supersedes the CPUs that might be reserved using the `systemReserved` and `kubeReserved` parameters.
+To explicitly define a list of CPUs that are reserved for specific nodes, create a `KubeletConfig` custom resource (CR) to define the `reservedSystemCPUs` parameter. This list supersedes the CPUs that might be reserved using the `systemReserved` parameter.
 
 .Procedure
 
@@ -64,4 +64,3 @@ spec:
 ----
 $ oc create -f <file_name>.yaml
 ----
-

--- a/nodes/nodes/nodes-nodes-resources-cpus.adoc
+++ b/nodes/nodes/nodes-nodes-resources-cpus.adoc
@@ -19,4 +19,4 @@ include::modules/nodes-nodes-resources-cpus-reserve.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* For more information on the `systemReserved` and `kubeReserved` parameters, see xref:../../nodes/nodes/nodes-nodes-resources-configuring.adoc#nodes-nodes-resources-configuring-about_nodes-nodes-resources-configuring[Allocating resources for nodes in an {product-title} cluster].
+* For more information on the `systemReserved` parameter, see xref:../../nodes/nodes/nodes-nodes-resources-configuring.html#nodes-nodes-resources-configuring-about_nodes-nodes-resources-configuring[Allocating resources for nodes in an {product-title} cluster].


### PR DESCRIPTION
Remove kubeReserved from the docs. This setting is [not used with OpenShift Container Platform](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html-single/nodes/index#nodes-nodes-resources-configuring-about_nodes-nodes-resources-configuring).

https://issues.redhat.com/browse/OCPBUGS-31542

Previews:

Scalability -> NUMA aware -> [Deploying the NUMA-aware secondary pod scheduler with manual performance settings](https://73939--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-numa-aware-scheduling#cnf-deploying-the-numa-aware-scheduler-with-manual-performance-settings_numa-aware) -- Removed `kube-reserved` from code example in Step 1a.
[Reserving CPUs for nodes](https://73939--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-resources-cpus#nodes-nodes-resources-cpus-reserve_nodes-nodes-resources-cpus) -- Removed `kube-reserved` from first paragraph and additional resources.

