### PR TITLE
[enterprise-4.14] OSDOCS#10068 missing anchor in the vSphere install section

### DIFF
--- a/installing/installing_vsphere/preparing-to-install-on-vsphere.adoc
+++ b/installing/installing_vsphere/preparing-to-install-on-vsphere.adoc
@@ -51,7 +51,7 @@ Installer-provisioned infrastructure allows the installation program to preconfi
 
 User-provisioned infrastructure requires the user to provision all resources required by {product-title}.
 
-* **xref:../../installing/installing_vsphere/installing-vsphere.adoc#[Installing a cluster on vSphere with user-provisioned infrastructure]**: You can install {product-title} on VMware vSphere infrastructure that you provision.
+* **xref:../../installing/installing_vsphere/installing-vsphere.adoc#installing-vsphere[Installing a cluster on vSphere with user-provisioned infrastructure]**: You can install {product-title} on VMware vSphere infrastructure that you provision.
 
 * **xref:../../installing/installing_vsphere/installing-vsphere-network-customizations.adoc#installing-vsphere-network-customizations[Installing a cluster on vSphere with network customizations with user-provisioned infrastructure]**: You can install {product-title} on VMware vSphere infrastructure that you provision with customized network configuration options.
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-10068

Main PR: https://github.com/openshift/openshift-docs/pull/73924