### PR TITLE
[enterprise-4.12] OSSM-6174 OSSM 2.5 release notes should indicate support from 4.12 and later

### DIFF
--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -15,6 +15,131 @@ Module included in the following assemblies:
 
 This release adds improvements related to the following components and concepts.
 
+[id="new-features-ossm-2-5"]
+== New features {SMProductName} version 2.5
+
+This release of {SMProductName} adds new features, addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.12 and later.
+
+This release ends maintenance support for OpenShift {SMProductShortName} version 2.2. If you are using OpenShift {SMProductShortName} version 2.2, you should update to a supported version.
+
+=== Component versions for {SMProductName} version 2.5
+
+|===
+|Component |Version
+
+|Istio
+|1.18.5
+
+|Envoy Proxy
+|1.26.8
+
+|Kiali
+|1.73.4
+|===
+
+=== Istio 1.18 support
+
+Service Mesh 2.5 is based on Istio 1.18, which brings in new features and product enhancements. While {SMProductName} supports many Istio 1.18 features, the following exceptions should be noted:
+
+* Ambient mesh is not supported
+* QuickAssist Technology (QAT) PrivateKeyProvider in Istio is not supported
+
+=== Cluster-Wide mesh migration
+
+This release adds documentation for migrating from a multitenant mesh to a cluster-wide mesh. For more information, see the following documentation:
+
+* "About migrating to a cluster-wide mesh"
+* "Excluding namespaces from a cluster-wide mesh"
+* "Defining which namespaces receive sidecar injection in a cluster-wide mesh"
+* "Excluding individual pods from a cluster-wide mesh"
+
+=== {SMProductName} Operator on ARM-based clusters
+
+This release provides the {SMProductName} Operator on ARM-based clusters as a generally available feature.
+
+=== Integration with {DTProductName} (Tempo) Stack
+
+This release introduces a generally available integration of the tracing extension provider(s). You can expose tracing data to the {DTProductName} (Tempo) stack by appending a named element and the `zipkin` provider to the `spec.meshConfig.extensionProviders` specification. Then, a telemetry custom resource configures Istio proxies to collect trace spans and send them to the Tempo distributor service endpoint.
+
+[NOTE]
+====
+{DTProductName} (Tempo) Stack is not supported on {ibm-z-title}.
+====
+
+=== OpenShift Service Mesh Console plugin
+
+This release introduces a generally available version of the OpenShift {SMProductShortName} Console (OSSMC) plugin.
+
+The OSSMC plugin is an extension to the OpenShift Console that provides visibility into your Service Mesh. With the OSSMC plugin installed, a new Service Mesh menu option is available on the navigation pane of the web console, as well as new Service Mesh tabs that enhance existing Workloads and Service console pages.
+
+The features of the OSSMC plugin are very similar to those of the standalone Kiali Console. The OSSMC plugin does not replace the Kiali Console, and after installing the OSSMC plugin, you can still access the standalone Kiali Console.
+
+=== Istio OpenShift Routing (IOR) default setting change
+
+The default setting for Istio OpenShift Routing (IOR) has changed. Starting with this release, automatic routes are disabled by default for new instances of the `ServiceMeshControlPlane` resource.
+
+For new  instances of the `ServiceMeshControlPlane` resources, you can use automatic routes by setting the `enabled` field to `true` in the `gateways.openshiftRoute` specification of the `ServiceMeshControlPlane` resource.
+
+.Example `ServiceMeshControlPlane` resource
+[source,yaml]
+----
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+spec:
+  gateways:
+    openshiftRoute:
+      enabled: true
+----
+
+When updating existing instances of the `ServiceMeshControlPlane` resource to {SMProductName} version 2.5, automatic routes remain enabled by default.
+
+=== Istio proxy concurrency configuration enhancement
+
+The `concurrency` parameter in the `networking.istio` API configures how many worker threads the Istio proxy runs.
+
+For consistency across deployments, Istio now configures the `concurrency` parameter based upon the CPU limit allocated to the proxy container. For example, a limit of 2500m would set the `concurrency` parameter to `3`. If you set the `concurrency` parameter to a different value, then Istio uses that value to configure how many threads the proxy runs instead of using the CPU limit.
+
+Previously, the default setting for the parameter was `2`.
+
+=== Gateway API CRD versions
+:FeatureName: {product-title} Gateway API support
+include::snippets/technology-preview.adoc[]
+
+A new version of the Gateway API custom resource definition (CRD) is now available. Refer to the following table to determine which Gateway API version should be installed with the OpenShift {SMProductShortName} version you are using:
+
+|===
+|Service Mesh Version | Istio Version | Gateway API Version | Notes
+
+|2.5.x
+|1.18.x
+|0.6.2
+|Use the experimental branch because `ReferenceGrand` is missing in v0.6.2
+
+|2.4.x
+|1.16.x
+|0.5.1
+|For multitenant mesh deployment, all Gateway API CRDs must be present. Use the experimental branch.
+|===
+
+[id="new-features-ossm-2-4-6"]
+== New features {SMProductName} version 2.4.6
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.13 and later.
+
+=== Component versions for {SMProductName} version 2.4.6
+|===
+|Component |Version
+
+|Istio
+|1.16.7
+
+|Envoy Proxy
+|1.24.12
+
+|Kiali
+|1.65.11
+|===
+
 == New features {SMProductName} version 2.4.5
 
 This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.11 and later versions.
@@ -50,8 +175,8 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 //Istio stays the same
 //Envoy updated to 1.24.12
 //According to distributed tracing release 2.9, the latest at time of OSSM 2.4.4, Jaeger has been updated to 1.47.0
-//Kiali updated to 1.65.9 
-//Kiali updated to 1.65.10 on 10/31/2023 due to security fix 
+//Kiali updated to 1.65.9
+//Kiali updated to 1.65.10 on 10/31/2023 due to security fix
 |===
 |Component |Version
 
@@ -281,6 +406,24 @@ spec:
 * HBONE protocol for sidecars is an experimental feature that is not supported.
 * {SMProductShortName} on ARM64 architecture is not supported.
 * OpenTelemetry API remains a Technology Preview feature.
+
+== New features {SMProductName} version 2.3.10
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.11 and later versions.
+
+=== Component versions for {SMProductName} version 2.3.10
+|===
+|Component |Version
+
+|Istio
+|1.14.5
+
+|Envoy Proxy
+|1.22.11
+
+|Kiali
+|1.57.14
+|===
 
 == New features {SMProductName} version 2.3.9
 //Update with 2.4.5


### PR DESCRIPTION
[enterprise-4.12] [OSSM-6174](https://issues.redhat.com//browse/OSSM-6174) OSSM 2.5 release notes should indicate support from 4.12 and later

Cherry Picked from 11c234c350d4e8021749027c0d52845389d1362f xref: https://github.com/openshift/openshift-docs/pull/73816

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

