### PR TITLE
CMA 2.12.1-376 Release Notes

### DIFF
--- a/nodes/cma/nodes-cma-autoscaling-custom-rn.adoc
+++ b/nodes/cma/nodes-cma-autoscaling-custom-rn.adoc
@@ -30,22 +30,37 @@ The following table defines the Custom Metrics Autoscaler Operator versions for 
 |{product-title} version
 |General availability
 
-|2.11.2
+|2.12.1
 |4.15
 |General availability
 
-|2.11.2
+|2.12.1
 |4.14
 |General availability
 
-|2.11.2
+|2.12.1
 |4.13
 |General availability
 
-|2.11.2
+|2.12.1
 |4.12
 |General availability
 |===
+
+[id="nodes-pods-autoscaling-custom-rn-2121-376_{context}"]
+== Custom Metrics Autoscaler Operator 2.12.1-376 release notes
+
+This release of the Custom Metrics Autoscaler Operator 2.12.1-376 provides security updates and bug fixes for running the Operator in an {product-title} cluster. The following advisory is available for the link:https://access.redhat.com/errata/RHSA-TBD[RHSA-TBD].
+
+[IMPORTANT]
+====
+Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of KEDA.
+====
+
+[id="nodes-pods-autoscaling-custom-rn-2121-376-bugs_{context}"]
+=== Bug fixes
+
+* Previously, if invalid values, such as nonexistent namespaces, were specified in scaled object metadata, the underlying scaler clients would not close their client descriptors, resulting in a slow memory leak. With this fix, the Operator properly closes the underlying client descriptors when there are errors, preventing this memory leak. (link:https://issues.redhat.com/browse/OCPBUGS-30145[*OCPBUGS-30145*])
 
 [id="nodes-pods-autoscaling-custom-rn-2112-322_{context}"]
 == Custom Metrics Autoscaler Operator 2.11.2-322 release notes
@@ -60,7 +75,9 @@ Before installing this version of the Custom Metrics Autoscaler Operator, remove
 [id="nodes-pods-autoscaling-custom-rn-2112-332-bugs_{context}"]
 === Bug fixes
 
-* Because the Custom Metrics Autoscaler Operator version 3.11.2-311 was released without a required volume mount in the Operator deployment, the Custom Metrics Autoscaler Operator pod would restart every 15 minutes. This fix adds the required volume mount to the operator deployment. As a result, the Operator no longer restarts every 15 minutes.  (link:https://issues.redhat.com/browse/OCPBUGS-22361[*OCPBUGS-22361*])
+* Because the Custom Metrics Autoscaler Operator version 3.11.2-311 was released without a required volume mount in the Operator deployment, the Custom Metrics Autoscaler Operator pod would restart every 15 minutes. This fix adds the required volume mount to the operator deployment. As a result, the Operator no longer restarts every 15 minutes. (link:https://issues.redhat.com/browse/OCPBUGS-22361[*OCPBUGS-22361*])
+
+* Previously the `ServiceMonitor` custom resource (CR) for the `keda-metrics-apiserver` pod was not functioning, because the CR referenced an incorrect metrics port name of "http". This fix corrects the `ServiceMonitor` CR to reference the proper port name of "metrics". As a result, the Service Monitor functions properly. (link:https://issues.redhat.com/browse/OCPBUGS-25806[*OCPBUGS-25806*])
 
 [id="nodes-pods-autoscaling-custom-rn-2112_{context}"]
 == Custom Metrics Autoscaler Operator 2.11.2-311 release notes


### PR DESCRIPTION
Errata tool: https://errata.devel.redhat.com/docs/show/129656

The link to the errata will not work until the product GAs (planned 4/8/24).

Preview: https://73952--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-rn#nodes-pods-autoscaling-custom-rn-versions_nodes-cma-autoscaling-custom-removing
