### PR TITLE
Revise 4.13 Node Tuning Operator Section

### DIFF
--- a/nodes/containers/nodes-containers-sysctls.adoc
+++ b/nodes/containers/nodes-containers-sysctls.adoc
@@ -20,7 +20,7 @@ user.
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../scalability_and_performance/using-node-tuning-operator.adoc#using-node-tuning-operator[Node Tuning Operator]
+If you are setting the sysctl and it is not node-level, you can find information on this procedure in the section xref:../../scalability_and_performance/using-node-tuning-operator.adoc#using-node-tuning-operator[Using the Node Tuning Operator].
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
@@ -52,3 +52,5 @@ include::modules/nodes-containers-sysctls-unsafe.adoc[leveloffset=+1]
 == Additional resources
 
 * xref:../../networking/setting-interface-level-network-sysctls.adoc#nodes-setting-interface-level-network-sysctls[Setting interface-level network sysctls]
+
+* xref:../../scalability_and_performance/using-node-tuning-operator.adoc#using-node-tuning-operator[Using the Node Tuning Operator]


### PR DESCRIPTION
Version(s): 4.13

Issue:https://issues.redhat.com/browse/ocpbugs-25871
Original PR by TSE @anandrece : https://github.com/openshift/openshift-docs/pull/69655

This is a manual cherrypick to 4.13 from https://github.com/openshift/openshift-docs/pull/73213

Link to docs preview: https://73959--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-sysctls#namespaced-and-node-level-sysctls

QE review:
NO QE requested for this PR - it is only a change to the form of the document to increase clarity and allow the requested link to be made more visible for the customer.

Additional information: re: https://github.com/openshift/openshift-docs/pull/69655
NO QE NEEDED for this PR, there is no new information being added, existing documentation is being altered to accommodate the requested link. This PR seeks to clarify and resolve those other problems while allowing the update requested by the prior PR. (which also needs no QE as there is no new information requested.)