### PR TITLE
OSDOCS-10066 OCP 4.15.6 Release Notes

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2678,6 +2678,32 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+[id="ocp-4-15-6"]
+=== RHSA-2024:1559 - {product-title} 4.15.6 bug fix and security update
+
+Issued: 2024-04-02
+
+{product-title} release 4.15.6, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:1559[RHSA-2024:1559] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1563[RHSA-2024:1563] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.6 --pullspecs
+----
+
+[id="ocp-4-15-6-known-issues"]
+==== Known issue
+
+* There is a known issue in this release which causes the `oc-mirror` binary to fail on Red Hat Enterprise Linux (RHEL) 8 systems.
+Workaround: Use the Red Hat OpenShift Container Platform 4.15.5 `oc-mirror` binary or extract `oc-mirror.rhel8`. (link:https://issues.redhat.com/browse/OCPBUGS-31609[*OCPBUGS-31609*])
+
+[id="ocp-4-15-6-updating"]
+==== Updating
+To update an existing {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 [id="ocp-4-15-5"]
 === RHSA-2024:1449 - {product-title} 4.15.5 bug fix and security update
 


### PR DESCRIPTION
Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-10066](https://issues.redhat.com/browse/OSDOCS-10066)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Preview](https://73968--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-6)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
Not needed
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Errata links will not work until merge day (April 2nd).
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
