### PR TITLE
OADP-3327: DPA does not reconcile when credentials secret updated

### DIFF
--- a/modules/oadp-release-notes-1-2-3.adoc
+++ b/modules/oadp-release-notes-1-2-3.adoc
@@ -34,5 +34,12 @@ For a complete list of all issues resolved in the release of OADP 1.2.3, see the
 [id="known-issues-1-2-3_{context}"]
 == Known issues
 
-There are no known issues in the release of OADP 1.2.3.
+The {oadp-short} 1.2.3 has the following known issue:
 
+.Data Protection Application (DPA) does not reconcile when the credentials secret is updated
+
+Currently, the {oadp-short} Operator does not reconcile when you update the `cloud-credentials` secret. This occurs because there are no {oadp-short} specific labels or owner references on the `cloud-credentials` secret. If you create a `cloud-credentials` secret with incorrect credentials, such as empty data, the Operator reconciles and creates a Backup Storage Location (BSL) and registry deployment with the empty data. As a result, when you update the `cloud-credentials` secret with the correct credentials, the Operator does not immediately reconcile to catch the new credentials. 
+
+Workaround: Update to {oadp-short} 1.3.
+
+link:https://issues.redhat.com/browse/OADP-3327[(OADP-3327)]


### PR DESCRIPTION
### JIRA

* [OADP-3327](https://issues.redhat.com/browse/OADP-3327)

### Version(s):

* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16


### Link to docs preview:

* [OADP 1.2.3 release notes](https://73975--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-2.html)

QE review:
- [X ] QE has approved this change. See [comment](https://github.com/openshift/openshift-docs/pull/73975#issuecomment-2068478699)


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
