### PR TITLE
OADP 3355 - 1.3.1 Release Notes

### DIFF
--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
@@ -7,8 +7,9 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-The release notes for OpenShift API for Data Protection (OADP) 1.3 describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
+The release notes for OpenShift API for Data Protection (OADP) describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
 
+include::modules/oadp-release-notes-1-3-1.adoc[leveloffset=+1]
 include::modules/oadp-release-notes-1-3-0.adoc[leveloffset=+1]
 include::modules/oadp-upgrade-from-oadp-data-mover-1-2-0.adoc[leveloffset=+3]
 include::modules/oadp-backing-up-dpa-configuration-1-3-0.adoc[leveloffset=+3]

--- a/modules/oadp-release-notes-1-3-1.adoc
+++ b/modules/oadp-release-notes-1-3-1.adoc
@@ -45,7 +45,7 @@ link:https://issues.redhat.com/browse/OADP-3486[OADP-3486]
 
 .Added FIPS Mode flag to the OADP Operator listing
 
-By setting the `fips-compliant` flag to `true`, the FIPS mode flag is now added to the OADP Operator listing in OperatorHub. This feature was enabled since OADP 1.3.0 but did not show up in the Red Hat Container catalog as being FIPS enabled.
+By setting the `fips-compliant` flag to `true`, the FIPS mode flag is now added to the OADP Operator listing in OperatorHub. This feature was enabled in OADP 1.3.0 but did not show up in the Red Hat Container catalog as being FIPS enabled.
 
 link:https://issues.redhat.com/browse/OADP-3495[OADP-3495]
 
@@ -61,7 +61,7 @@ With this fix, the following scenarios are possible:
 link:https://issues.redhat.com/browse/OADP-3069[OADP-3069]
 
 
-//For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12422837[OADP 1.3.1 resolved issues] in Jira.
+For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12432794[OADP 1.3.1 resolved issues] in Jira.
 
 [id="known-issues-1-3-1_{context}"]
 == Known issues

--- a/modules/oadp-release-notes-1-3-1.adoc
+++ b/modules/oadp-release-notes-1-3-1.adoc
@@ -1,0 +1,95 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-release-notes-1-3.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="oadp-release-notes-1-3-1_{context}"]
+= OADP 1.3.1 release notes
+
+The {oadp-first} 1.3.1 release notes lists new features, resolved issues and bugs, and known issues.
+
+[id="new-features-1-3-1_{context}"]
+== New features
+
+.Velero built-in DataMover
+
+OADP 1.3 includes a built-in Data Mover that you can use to move Container Storage Interface (CSI) volume snapshots to a remote object store. The built-in Data Mover allows you to restore stateful applications from the remote object store if a failure, accidental deletion, or corruption of the cluster occurs. It uses Kopia as the uploader mechanism to read the snapshot data and to write to the Unified Repository.
+
+
+:FeatureName: Velero built-in DataMover
+include::snippets/technology-preview.adoc[]
+
+.Backing up applications with File System Backup: Kopia or Restic
+
+Velero’s File System Backup (FSB) supports two backup libraries: the Restic path and the Kopia path.
+
+Velero allows users to select between the two paths.
+
+For backup, specify the path during the installation through the `uploader-type` flag. The valid value is either `restic` or `kopia`. This field defaults to `kopia` if the value is not specified. The selection cannot be changed after the installation.
+
+.GCP Cloud authentication
+
+Google Cloud Platform (GCP) authentication enables you to use short-lived Google credentials.
+
+GCP with Workload Identity Federation enables you to use Identity and Access Management (IAM) to grant external identities IAM roles, including the ability to impersonate service accounts. This eliminates the maintenance and security risks associated with service account keys.
+
+.AWS ROSA STS authentication
+
+You can use {oadp-first} with {product-rosa} (ROSA) clusters to backup and restore application data.
+
+ROSA provides seamless integration with a wide range of AWS compute, database, analytics, machine learning, networking, mobile, and other services to speed up the building and delivering of differentiating experiences to your customers.
+
+You can subscribe to the service directly from your AWS account.
+
+After the clusters are created, you can operate your clusters by using the OpenShift web console. The ROSA service also uses OpenShift APIs and command-line interface (CLI) tools.
+
+[id="resolved-issues-1-3-1_{context}"]
+== Resolved issues
+
+.ACM applications were removed and re-created on managed clusters after restore
+Applications on managed clusters were deleted and re-created upon restore activation. {oadp-full} (OADP 1.2) backup and restore process is faster than the older versions. The OADP performance change caused this behavior when restoring ACM resources. Therefore, some resources were restored before other resources, which caused the removal of the applications from managed clusters.
+link:https://issues.redhat.com/browse/OADP-2686[OADP-2686]
+
+
+.Restic restore was partially failing due to Pod Security standard
+
+During interoperability testing, {product-title} 4.14 had the pod Security mode set to `enforce`, which caused the pod to be denied. This was caused due to the restore order. The pod was getting created before the security context constraints (SCC) resource, since the pod violated the `podSecurity` standard, it denied the pod. When setting the restore priority field on the Velero server, restore is successful. link:https://issues.redhat.com/browse/OADP-2688[OADP-2688]
+
+.Possible pod volume backup failure if Velero is installed in several namespaces
+
+There was a regresssion in Pod Volume Backup (PVB) functionality when Velero was installed in several namespaces. The PVB controller was not properly limiting itself to PVBs in its own namespace.
+link:https://issues.redhat.com/browse/OADP-2308[OADP-2308]
+
+.OADP Velero plugins returning "received EOF, stopping recv loop" message
+
+In OADP, Velero plugins were started as separate processes. When the Velero operation completes, either successfully or not, they exit. Therefore, if you see a `received EOF, stopping recv loop` messages in debug logs, it does not mean an error occurred, it means that a plugin operation has completed. link:https://issues.redhat.com/browse/OADP-2176[OADP-2176]
+
+.CVE-2023-39325 Multiple HTTP/2 enabled web servers are vulnerable to a DDoS attack (Rapid Reset Attack)
+In previous releases of OADP, the HTTP/2 protocol was susceptible to a denial of service attack because request cancellation could reset multiple streams quickly. The server had to set up and tear down the streams while not hitting any server-side limit for the maximum number of active streams per connection. This resulted in a denial of service due to server resource consumption.
+
+For more information, see link:https://access.redhat.com/security/cve/cve-2023-39325[CVE-2023-39325 (Rapid Reset Attack)]
+
+
+For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12422837[OADP 1.3.0 resolved issues] in Jira.
+
+[id="known-issues-1-3-1_{context}"]
+== Known issues
+
+.CSI plugin errors on nil pointer when csiSnapshotTimeout is set to a short duration
+The CSI plugin errors on nil pointer when `csiSnapshotTimeout` is set to a short duration. Sometimes it succeeds to complete the snapshot within a short duration, but often it panics with the backup `PartiallyFailed` with the following error: `plugin panicked: runtime error: invalid memory address or nil pointer dereference`.
+
+.Backup is marked as PartiallyFailed when volumeSnapshotContent CR has an error
+If any of the `VolumeSnapshotContent` CRs have an error related to removing the `VolumeSnapshotBeingCreated` annotation, it moves the backup to the `WaitingForPluginOperationsPartiallyFailed` phase. link:https://issues.redhat.com/browse/OADP-2871[OADP-2871]
+
+.Performance issues when restoring 30,000 resources for the first time
+When restoring 30,000 resources for the first time, without an existing-resource-policy, it takes twice as long to restore them, than it takes during the second and third try with an existing-resource-policy set to `update`. link:https://issues.redhat.com/browse/OADP-3071[OADP-3071]
+
+.Post restore hooks might start running before Datadownload operation has released the related PV
+Due to the asynchronous nature of the Data Mover operation, a post-hook might be attempted before the related pods persistent volumes (PVs) are released by the Data Mover persistent volume claim (PVC).
+
+
+.GCP-Workload Identity Federation VSL backup PartiallyFailed
+VSL backup `PartiallyFailed` when GCP workload identity is configured on GCP.
+
+
+For a complete list of all known issues in this release, see the list of link:https://issues.redhat.com/issues/?filter=12422838[OADP 1.3.0 known issues] in Jira.

--- a/modules/oadp-release-notes-1-3-1.adoc
+++ b/modules/oadp-release-notes-1-3-1.adoc
@@ -6,90 +6,64 @@
 [id="oadp-release-notes-1-3-1_{context}"]
 = OADP 1.3.1 release notes
 
-The {oadp-first} 1.3.1 release notes lists new features, resolved issues and bugs, and known issues.
+The {oadp-first} 1.3.1 release notes lists new features and resolved issues.
 
 [id="new-features-1-3-1_{context}"]
 == New features
 
-.Velero built-in DataMover
+.OADP 1.3 Data Mover is now fully supported
 
-OADP 1.3 includes a built-in Data Mover that you can use to move Container Storage Interface (CSI) volume snapshots to a remote object store. The built-in Data Mover allows you to restore stateful applications from the remote object store if a failure, accidental deletion, or corruption of the cluster occurs. It uses Kopia as the uploader mechanism to read the snapshot data and to write to the Unified Repository.
-
-
-:FeatureName: Velero built-in DataMover
-include::snippets/technology-preview.adoc[]
-
-.Backing up applications with File System Backup: Kopia or Restic
-
-Velero’s File System Backup (FSB) supports two backup libraries: the Restic path and the Kopia path.
-
-Velero allows users to select between the two paths.
-
-For backup, specify the path during the installation through the `uploader-type` flag. The valid value is either `restic` or `kopia`. This field defaults to `kopia` if the value is not specified. The selection cannot be changed after the installation.
-
-.GCP Cloud authentication
-
-Google Cloud Platform (GCP) authentication enables you to use short-lived Google credentials.
-
-GCP with Workload Identity Federation enables you to use Identity and Access Management (IAM) to grant external identities IAM roles, including the ability to impersonate service accounts. This eliminates the maintenance and security risks associated with service account keys.
-
-.AWS ROSA STS authentication
-
-You can use {oadp-first} with {product-rosa} (ROSA) clusters to backup and restore application data.
-
-ROSA provides seamless integration with a wide range of AWS compute, database, analytics, machine learning, networking, mobile, and other services to speed up the building and delivering of differentiating experiences to your customers.
-
-You can subscribe to the service directly from your AWS account.
-
-After the clusters are created, you can operate your clusters by using the OpenShift web console. The ROSA service also uses OpenShift APIs and command-line interface (CLI) tools.
+The OADP built-in Data Mover, introduced in OADP 1.3 as a Technology Preview, is now fully supported for both containerized and virtual machine workloads.
 
 [id="resolved-issues-1-3-1_{context}"]
 == Resolved issues
 
-.ACM applications were removed and re-created on managed clusters after restore
-Applications on managed clusters were deleted and re-created upon restore activation. {oadp-full} (OADP 1.2) backup and restore process is faster than the older versions. The OADP performance change caused this behavior when restoring ACM resources. Therefore, some resources were restored before other resources, which caused the removal of the applications from managed clusters.
-link:https://issues.redhat.com/browse/OADP-2686[OADP-2686]
+.OADP operator now correctly reports the missing region error
+
+Previously, when a user specified `profile:default` without specifying the `region` in AWS Backup Storage Location (BSL) configuration, the OADP operator failed to report the `missing region` error on the Data Protection Application (DPA) custom resource (CR). This update corrects validation of DPA BSL specification for the AWS provider. As a result, the OADP operator reports the `missing region` error.
+
+link:https://issues.redhat.com/browse/OADP-3044[OADP-3044]
+
+.Custom labels are not removed from the namespace, where OADP is installed
+
+Previously, the `openshift-adp-controller-manager` pod would reset the labels on the namespace, where OADP is installed. Consequently, this caused synchronization issues for applications requiring custom labels such as Argo CD, leading to improper functionality. With this update, this issue is fixed and custom labels are not removed from the namespace, where OADP is installed.
+
+link:https://issues.redhat.com/browse/OADP-3189[OADP-3189]
+
+.OADP `must-gather` image collects CRD’s
+
+Previously, the OADP `must-gather` image did not collect the Custom Resource Definitions (CRD’s) shipped by OADP. Consequently, it was not possible to use the `omg` tool to extract data on the support shell. For example, the `omg get backup` command did not work because `must-gather` was unable to collect CRD’s.
+With this fix, `must-gather` now collects CRD’s shipped by OADP and can use the `omg` tool to extract data.
+
+link:https://issues.redhat.com/browse/OADP-3229[OADP-3229]
+
+.Garbage collection has the required default frequency
+
+Previously, the `garbage-collection-frequency` field had a wrong description for the default frequency. With this update, the `gc-controller` correctly executes its reconciliation loop every hour by default. As a result, garbage collection now has the expected default frequency.
+
+link:https://issues.redhat.com/browse/OADP-3486[OADP-3486]
+
+.Added FIPS Mode flag to the OADP Operator listing
+
+By setting the `fips-compliant` flag to `true`, the FIPS mode flag is now added to the OADP Operator listing in OperatorHub. This feature was enabled since OADP 1.3.0 but did not show up in the Red Hat Container catalog as being FIPS enabled.
+
+link:https://issues.redhat.com/browse/OADP-3495[OADP-3495]
+
+.CSI plugin does not panics with nil pointer when `csiSnapshotTimeout` is set to a short duration
+
+Previously, when the `csiSnapshotTimeout` parameter was set to a short duration, the CSI plugin encountered errors on a nil pointer. Sometimes there was a successful completion of a snapshot within a short duration but often it panicked with the partially failed backup, along with the `plugin panicked: runtime error: invalid memory address or nil pointer dereference` error:
+
+With this fix, the following scenarios are possible:
+
+* Sometimes the backup does not fail without any panic errors.
+* The backup fails with the `Timed out awaiting reconciliation of volumesnapshot` timeout error and without panic.
+
+link:https://issues.redhat.com/browse/OADP-3069[OADP-3069]
 
 
-.Restic restore was partially failing due to Pod Security standard
-
-During interoperability testing, {product-title} 4.14 had the pod Security mode set to `enforce`, which caused the pod to be denied. This was caused due to the restore order. The pod was getting created before the security context constraints (SCC) resource, since the pod violated the `podSecurity` standard, it denied the pod. When setting the restore priority field on the Velero server, restore is successful. link:https://issues.redhat.com/browse/OADP-2688[OADP-2688]
-
-.Possible pod volume backup failure if Velero is installed in several namespaces
-
-There was a regresssion in Pod Volume Backup (PVB) functionality when Velero was installed in several namespaces. The PVB controller was not properly limiting itself to PVBs in its own namespace.
-link:https://issues.redhat.com/browse/OADP-2308[OADP-2308]
-
-.OADP Velero plugins returning "received EOF, stopping recv loop" message
-
-In OADP, Velero plugins were started as separate processes. When the Velero operation completes, either successfully or not, they exit. Therefore, if you see a `received EOF, stopping recv loop` messages in debug logs, it does not mean an error occurred, it means that a plugin operation has completed. link:https://issues.redhat.com/browse/OADP-2176[OADP-2176]
-
-.CVE-2023-39325 Multiple HTTP/2 enabled web servers are vulnerable to a DDoS attack (Rapid Reset Attack)
-In previous releases of OADP, the HTTP/2 protocol was susceptible to a denial of service attack because request cancellation could reset multiple streams quickly. The server had to set up and tear down the streams while not hitting any server-side limit for the maximum number of active streams per connection. This resulted in a denial of service due to server resource consumption.
-
-For more information, see link:https://access.redhat.com/security/cve/cve-2023-39325[CVE-2023-39325 (Rapid Reset Attack)]
-
-
-For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12422837[OADP 1.3.0 resolved issues] in Jira.
+//For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12422837[OADP 1.3.1 resolved issues] in Jira.
 
 [id="known-issues-1-3-1_{context}"]
 == Known issues
 
-.CSI plugin errors on nil pointer when csiSnapshotTimeout is set to a short duration
-The CSI plugin errors on nil pointer when `csiSnapshotTimeout` is set to a short duration. Sometimes it succeeds to complete the snapshot within a short duration, but often it panics with the backup `PartiallyFailed` with the following error: `plugin panicked: runtime error: invalid memory address or nil pointer dereference`.
-
-.Backup is marked as PartiallyFailed when volumeSnapshotContent CR has an error
-If any of the `VolumeSnapshotContent` CRs have an error related to removing the `VolumeSnapshotBeingCreated` annotation, it moves the backup to the `WaitingForPluginOperationsPartiallyFailed` phase. link:https://issues.redhat.com/browse/OADP-2871[OADP-2871]
-
-.Performance issues when restoring 30,000 resources for the first time
-When restoring 30,000 resources for the first time, without an existing-resource-policy, it takes twice as long to restore them, than it takes during the second and third try with an existing-resource-policy set to `update`. link:https://issues.redhat.com/browse/OADP-3071[OADP-3071]
-
-.Post restore hooks might start running before Datadownload operation has released the related PV
-Due to the asynchronous nature of the Data Mover operation, a post-hook might be attempted before the related pods persistent volumes (PVs) are released by the Data Mover persistent volume claim (PVC).
-
-
-.GCP-Workload Identity Federation VSL backup PartiallyFailed
-VSL backup `PartiallyFailed` when GCP workload identity is configured on GCP.
-
-
-For a complete list of all known issues in this release, see the list of link:https://issues.redhat.com/issues/?filter=12422838[OADP 1.3.0 known issues] in Jira.
+In this release there are no known issues.


### PR DESCRIPTION
OADP 1.3.1
OCP 4.13+

Resolves - https://issues.redhat.com/browse/OADP-3355

Deploy preview - https://73979--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3#oadp-release-notes-1-3-1_oadp-release-notes
