### PR TITLE
OADP-3788: Adding that IBM Cloud Object Storage S3 is supported

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3043,7 +3043,7 @@ Topics:
       File: about-installing-oadp
     - Name: Installing the OADP Operator
       File: oadp-installing-operator
-    - Name: Configuring OADP with AWS
+    - Name: Configuring OADP with AWS S3 compatible storage
       File: installing-oadp-aws
     - Name: Configuring OADP with Azure
       File: installing-oadp-azure

--- a/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
@@ -16,6 +16,7 @@ To back up Kubernetes resources and internal images, you must have object storag
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc#installing-oadp-azure[Microsoft Azure]
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc#installing-oadp-gcp[Google Cloud Platform]
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc#installing-oadp-mcg[Multicloud Object Gateway]
+* {ibm-cloud-name} Object Storage S3
 * AWS S3 compatible object storage, such as Multicloud Object Gateway or MinIO
 
 You can configure multiple backup storage locations within the same namespace for each individual OADP deployment.

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-oadp-aws"]
-= Configuring the OpenShift API for Data Protection with Amazon Web Services
+= Configuring the OpenShift API for Data Protection with AWS S3 compatible storage
 include::_attributes/common-attributes.adoc[]
 :context: installing-oadp-aws
 :installing-oadp-aws:
@@ -9,13 +9,16 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You install the OpenShift API for Data Protection (OADP) with Amazon Web Services (AWS) by installing the OADP Operator. The Operator installs link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}].
+You install the OpenShift API for Data Protection (OADP) with Amazon Web Services (AWS) S3 compatible storage by installing the OADP Operator. The Operator installs link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}].
+
+{ibm-cloud-name} S3 is supported as an AWS S3 compatible backup storage provider.
 
 include::snippets/oadp-mtc-operator.adoc[]
 
 You configure AWS for Velero, create a default `Secret`, and then install the Data Protection Application. For more details, see xref:../../..//backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc#oadp-installing-operator-doc[Installing the OADP Operator].
 
 To install the OADP Operator in a restricted network environment, you must first disable the default OperatorHub sources and mirror the Operator catalog. See xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks] for details.
+
 
 //include::modules/oadp-installing-operator.adoc[leveloffset=+1]
 include::modules/migration-configuring-aws-s3.adoc[leveloffset=+1]

--- a/backup_and_restore/index.adoc
+++ b/backup_and_restore/index.adoc
@@ -53,6 +53,7 @@ OADP has the following requirements:
 ** Microsoft Azure
 ** Google Cloud Platform
 ** S3-compatible object storage
+** {ibm-cloud-name} Object Storage S3
 
 include::snippets/oadp-ocp-compat.adoc[]
 

--- a/modules/oadp-installing-dpa-1-2-and-earlier.adoc
+++ b/modules/oadp-installing-dpa-1-2-and-earlier.adoc
@@ -79,14 +79,16 @@ spec:
         config:
           region: <region>
           profile: "default"
+          s3ForcePathStyle: "true" <7>
+          s3Url: <s3_url> <8>
         credential:
           key: cloud
-          name: {credentials} <7>
-  snapshotLocations: <8>
+          name: {credentials} <9>
+  snapshotLocations: <10>
     - velero:
         provider: {provider}
         config:
-          region: <region> <9>
+          region: <region> <11>
           profile: "default"
 ----
 <1> The `openshift` plugin is mandatory.
@@ -95,9 +97,11 @@ spec:
 <4> Specify on which nodes Restic is available. By default, Restic runs on all nodes.
 <5> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
 <6> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
-<7> Specify the name of the `Secret` object that you created. If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
-<8> Specify a snapshot location, unless you use CSI snapshots or Restic to back up PVs.
-<9> The snapshot location must be in the same region as the PVs.
+<7> Specify whether to force path style URLs for S3 objects (Boolean). Not Required for AWS S3. Required only for S3 compatible storage.
+<8> Specify the URL of the object store that you are using to store backups. Not required for AWS S3. Required only for S3 compatible storage.
+<9> Specify the name of the `Secret` object that you created. If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
+<10> Specify a snapshot location, unless you use CSI snapshots or Restic to back up PVs.
+<11> The snapshot location must be in the same region as the PVs.
 endif::[]
 ifdef::installing-oadp-azure[]
 +

--- a/modules/oadp-installing-dpa-1-3.adoc
+++ b/modules/oadp-installing-dpa-1-3.adoc
@@ -71,15 +71,17 @@ spec:
         config:
           region: <region>
           profile: "default"
+          s3ForcePathStyle: "true" <10>
+          s3Url: <s3_url> <11>
         credential:
           key: cloud
-          name: {credentials} <10>
-  snapshotLocations: <11>
+          name: {credentials} <12>
+  snapshotLocations: <13>
     - name: default
       velero:
         provider: {provider}
         config:
-          region: <region> <12>
+          region: <region> <14>
           profile: "default"
 ----
 <1> The default namespace for OADP is `openshift-adp`. The namespace is a variable and is configurable.
@@ -91,9 +93,11 @@ spec:
 <7> Specify the nodes on which Kopia or Restic are available. By default, Kopia or Restic run on all nodes.
 <8> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
 <9> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
-<10> Specify the name of the `Secret` object that you created. If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
-<11> Specify a snapshot location, unless you use CSI snapshots or a File System Backup (FSB) to back up PVs.
-<12> The snapshot location must be in the same region as the PVs.
+<10> Specify whether to force path style URLs for S3 objects (Boolean). Not Required for AWS S3. Required only for S3 compatible storage.
+<11> Specify the URL of the object store that you are using to store backups. Not required for AWS S3. Required only for S3 compatible storage.
+<12> Specify the name of the `Secret` object that you created. If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
+<13> Specify a snapshot location, unless you use CSI snapshots or a File System Backup (FSB) to back up PVs.
+<14> The snapshot location must be in the same region as the PVs.
 endif::[]
 ifdef::installing-oadp-azure[]
 +

--- a/modules/oadp-s3-compatible-backup-storage-providers.adoc
+++ b/modules/oadp-s3-compatible-backup-storage-providers.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
+// * backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="oadp-s3-compatible-backup-storage-providers_{context}"]
@@ -16,6 +17,7 @@ The following AWS S3 compatible object storage providers are fully supported by 
 * MinIO
 * Multicloud Object Gateway (MCG)
 * Amazon Web Services (AWS) S3
+* {ibm-cloud-name} Object Storage S3
 
 [NOTE]
 ====
@@ -30,7 +32,6 @@ The following compatible object storage providers are supported and have their o
 
 The following AWS S3 compatible object storage providers, are known to work with Velero through the AWS plugin, for use as backup storage locations, however, they are unsupported and have not been tested by Red Hat:
 
-* {ibm-cloud-name}
 * Oracle Cloud
 * DigitalOcean
 * NooBaa, unless installed using Multicloud Object Gateway (MCG)


### PR DESCRIPTION
### JIRA

* [OADP-3788](https://issues.redhat.com/browse/OADP-3788)

### VERSION

* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16

### Link to docs preview:

* [About installing OADP](https://73981--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp)



QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
