### PR TITLE
OSDOCS-10064: Broken links edited in upgrade paths for Red Hat Device…

### DIFF
--- a/modules/about-rhde.adoc
+++ b/modules/about-rhde.adoc
@@ -88,4 +88,4 @@ For more information about the {product-title} products, see the following docum
 
 For details about {microshift} upgrade paths, see the following documentation:
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/{microshift-version}/html/updates/index[{microshift} updates]
+* link:https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/{microshift-version}/html/updating/index[{microshift} updates]


### PR DESCRIPTION
Version(s):
Versionless, no cherry-picks
rhde-docs is an unversioned branch of openshift-docs

Issue:
[OSDOCS-10064](https://issues.redhat.com/browse/OSDOCS-10064)

Link to docs preview:
[upgrade paths ](https://73987--ocpdocs-pr.netlify.app/openshift-rhde/latest/overview/rhde-overview)

QE review:
- QE approval not required.

Additional information:
RHDE 4 is indicated on the Customer Portal for build purposes only.