### PR TITLE
OSDOCS-9826: adds Y+2 update paths MicroShift

### DIFF
--- a/_attributes/attributes-microshift.adoc
+++ b/_attributes/attributes-microshift.adoc
@@ -4,21 +4,21 @@
 :experimental:
 :imagesdir: images
 :OCP: OpenShift Container Platform
-:ocp-version: 4.15
+:ocp-version: 4.16
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
 :product-title-first: Red Hat build of MicroShift (MicroShift)
 :microshift-short: MicroShift
 :product-registry: OpenShift image registry
-:product-version: 4.15
+:product-version: 4.16
 :rhel-major: rhel-9
 :op-system-base-full: Red Hat Enterprise Linux (RHEL)
 :op-system: RHEL
 :op-system-base: RHEL
 :op-system-ostree-first: Red Hat Enterprise Linux for Edge (RHEL for Edge)
 :op-system-ostree: RHEL for Edge
-:op-system-version: 9.2
+:op-system-version: 9.4
 :op-system-version-major: 9
 :op-system-bundle: Red Hat Device Edge
+:rpm-repo-version: rhocp-4.16
 :rhde-version: 4
-:rpm-repo-version: rhocp-4.15
 :VirtProductName: OpenShift Virtualization

--- a/microshift_updating/microshift-about-updates.adoc
+++ b/microshift_updating/microshift-about-updates.adoc
@@ -6,14 +6,18 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-Updates are supported on {product-title} beginning with the General Availability version 4.14. Supported updates include those from one minor version to the next in sequence, for example, from 4.14 to 4.15. Patch updates are also supported from z-stream to z-stream, for example 4.14.1 to 4.14.2.
+Updates are supported on {product-title} beginning with the General Availability version 4.14. With the 4.16 release, the following updates are supported:
+
+* A maximum of two minor versions to the next in sequence, for example, from 4.14 to 4.16.
+* One minor version to the next in sequence, for example, from 4.15 to 4.16.
+* Patch updates are also supported from z-stream to z-stream, for example 4.14.1 to 4.14.2.
 
 [id="microshift-about-updates-understanding-microshift-updates_{context}"]
 == Understanding {microshift-short} updates
 {product-title} updates are supported on both `rpm-ostree` edge-deployed hosts and non-OSTree hosts. You can complete updates using the following methods:
 
-* Embed the latest version of {microshift-short} in a new `rpm-ostree` system image such as {op-system-ostree-first}. See * xref:../microshift_updating/microshift-update-rpms-ostree.adoc#microshift-update-rpms-ostree[Applying updates on an OSTree system]
-* Manually update the RPMs on a non-OSTree system such as {op-system-base-full}. See * xref:../microshift_updating/microshift-update-rpms-manually.adoc#microshift-update-rpms-manually[Applying updates manually with RPMs]
+* Embed the latest version of {microshift-short} in a new `rpm-ostree` system image such as {op-system-ostree-first}. See xref:../microshift_updating/microshift-update-rpms-ostree.adoc#microshift-update-rpms-ostree[Applying updates on an OSTree system]
+* Manually update the RPMs on a non-OSTree system such as {op-system-base-full}. See xref:../microshift_updating/microshift-update-rpms-manually.adoc#microshift-update-rpms-manually[Applying updates manually with RPMs]
 
 [NOTE]
 ====
@@ -31,5 +35,10 @@ include::snippets/microshift-rhde-compatibility-table-snip.adoc[leveloffset=+1]
 [id="microshift-about-updates-rpm-updates_{context}"]
 === Manual RPM updates
 You can use the manual RPM update path to replace your existing version of {microshift-short}. The versions of {op-system} and {microshift-short} must be compatible. Ensuring system health and completing additional system backups are manual processes.
+
+[IMPORTANT]
+====
+Ensure that your version of {op-system-base} is compatible with the version of {microshift-short} you are updating to, especially if you are updating {microshift-short} across two minor versions.
+====
 
 include::snippets/microshift-update-paths-snip.adoc[leveloffset=+2]

--- a/microshift_updating/microshift-update-options.adoc
+++ b/microshift_updating/microshift-update-options.adoc
@@ -14,15 +14,16 @@ include::snippets/microshift-update-paths-snip.adoc[leveloffset=+1]
 
 [IMPORTANT]
 ====
-Updates of {microshift-short} from one minor version to the next must be in sequence. For example, you cannot update from 4.14 to 4.16. You must update 4.14 to 4.15 and so on.
+Updates of {microshift-short} are supported with a maximum of two minor versions. For example, you can update from 4.14 to 4.16 in a single step. Updating 4.14 to 4.15 first is not required.
 ====
 
 [id="microshift-update-options-standalone-updates_{context}"]
 == Standalone {microshift-short} updates
+Consider the following when planning to update {microshift-short}:
 
-You can update {microshift-short} without reinstalling your applications. {op-system} or {op-system-ostree} updates are also not required to update {microshift-short}, as long as the existing operating system is compatible with the new version of {microshift-short} that you want to use.
-
-{microshift-short} operates as an in-place update and does not require removal of the previous version. Data backups beyond those required for the usual functioning of your applications are also not required.
+* You can potentially update {microshift-short} without reinstalling your applications and Operators.
+* {op-system} or {op-system-ostree} updates are only required to update {microshift-short} if the existing operating system is not compatible with the new version of {microshift-short} that you want to use.
+* {microshift-short} operates as an in-place update and does not require removal of the previous version. Data backups beyond those required for the usual functioning of your applications are also not required.
 
 [id="microshift-update-options-rpm-ostree-updates_{context}"]
 === RPM-OSTree updates
@@ -32,6 +33,7 @@ The following features are available in the {op-system-ostree} update path:
 
 * The system automatically rolls back to a previous healthy system state if the update fails.
 * Applications do not need to be reinstalled.
+* Operators do not need to be reinstalled.
 * You can update an application without updating {microshift-short} using this update type.
 * The image you build can contain other updates as needed.
 

--- a/microshift_updating/microshift-update-rpms-manually.adoc
+++ b/microshift_updating/microshift-update-rpms-manually.adoc
@@ -10,10 +10,13 @@ Updating {product-title} for non-OSTree systems such as {op-system-base-full} re
 
 [IMPORTANT]
 ====
-{microshift-short} updates are supported from one minor version to the next in sequence. For example, you must update 4.14 to 4.15.
+{microshift-short} updates are supported with a maximum of two minor versions. For example, you can update to 4.16 from 4.14 in a single step. Updating 4.14 to 4.15 first is not required.
 ====
 
-For either upgrading with patch updates or a minor-version update, you can back up application data as needed and move the data copy to a secure location.
+[NOTE]
+====
+You can back up application data as needed and move the data copy to a secure location when using any update type.
+====
 
 include::modules/microshift-updating-rpms-z.adoc[leveloffset=+1]
 

--- a/microshift_updating/microshift-update-rpms-ostree.adoc
+++ b/microshift_updating/microshift-update-rpms-ostree.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 Updating {product-title} on an `rpm-ostree` system such as {op-system-ostree-first} requires building a new operating system image containing the new version of {product-title}. After you have the `rpm-ostree` image with {product-title} embedded, direct your system to boot into that operating system image.
 
-The procedures are the same for minor-version and patch updates. For example, use the same steps to upgrade from 4.14 to 4.15 or from 4.15.0 to 4.15.1.
+The procedures are the same for minor-version and patch updates. For example, use the same steps to upgrade from 4.14 to 4.16 or from 4.15.0 to 4.15.1.
 
 include::snippets/microshift-rhde-compatibility-table-snip.adoc[leveloffset=+1]
 

--- a/snippets/microshift-rhde-compatibility-table-snip.adoc
+++ b/snippets/microshift-rhde-compatibility-table-snip.adoc
@@ -7,7 +7,7 @@
 
 .{op-system-bundle} release compatibility matrix
 
-The two products of {op-system-bundle} work together as a single solution for device-edge computing. To successfully pair your products, use the verified releases together for each as listed in the following table:
+{op-system-base-full} and {microshift-short} work together as a single solution for device-edge computing. Supported configurations of {op-system-bundle} use verified releases for each together as listed in the following table:
 
 [cols="4",%autowidth]
 |===
@@ -16,15 +16,20 @@ The two products of {op-system-bundle} work together as a single solution for de
 ^|*{microshift-short} Release Status*
 ^|*{microshift-short} Supported Updates*
 
+^|9.4
+^|4.16
+^|Generally Available
+^|4.16.0&#8594;4.16.z and 4.16&#8594;maximum two minor versions
+
 ^|9.2, 9.3
 ^|4.15
 ^|Generally Available
-^|4.15.0&#8594;4.15.z and 4.15&#8594;future minor version
+^|4.15.0&#8594;4.15.z and 4.15&#8594;maximum two minor versions
 
 ^|9.2, 9.3
 ^|4.14
 ^|Generally Available
-^|4.14.0&#8594;4.14.z and 4.14&#8594;4.15
+^|4.14.0&#8594;4.14.z and 4.14&#8594;maximum two minor versions
 
 ^|9.2
 ^|4.13

--- a/snippets/microshift-update-paths-snip.adoc
+++ b/snippets/microshift-update-paths-snip.adoc
@@ -8,12 +8,18 @@
 [id="microshift-about-updates-checking-version-update-path_{context}"]
 = Checking version update path
 
-Before attempting an update of either {op-system-bundle} component, determine which versions of {microshift-short} and {op-system-ostree} or {op-system} are installed. Plan for the versions of each that you intend to use.
+Before updating {microshift-short} or {op-system}, determine the compatibilities. Plan for the versions of each that you intend to use.
 
 *{product-title} update paths*
 
-* Generally Available Version 4.14 to 4.14.z or 4.15 on {op-system-ostree} 9.2 or 9.3
-* Generally Available Version 4.14 to 4.14.z or 4.15 on {op-system} 9.2 or 9.3
+{microshift-short} version 4.16::
+* Version 4.16 to 4.16.z on {op-system} or {op-system-ostree} 9.4
 
-* Generally Available Version 4.15 to 4.15.z on {op-system-ostree} 9.2 or 9.3
-* Generally Available Version 4.15 to 4.15.z on {op-system} 9.2 or 9.3
+{microshift-short} version 4.15::
+* Version 4.15 on {op-system} or {op-system-ostree} 9.2 or 9.3 to 4.16 on {op-system} or {op-system-ostree} 9.4
+* Version 4.15 to 4.15.z on {op-system} or {op-system-ostree} 9.2 or 9.3
+
+{microshift-short} version 4.14::
+* Version 4.14 on {op-system} or {op-system-ostree} 9.2 or 9.3 to 4.16 on {op-system} or {op-system-ostree} 9.4
+* Version 4.14 to 4.15 on {op-system} or {op-system-ostree} 9.2 or 9.3
+* Version 4.14 to 4.14.z on {op-system} or {op-system-ostree} 9.2 or 9.3


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-9826](https://issues.redhat.com//browse/OSDOCS-9826)

Link to docs preview:
[Updates - all](https://73988--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-about-updates)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional info:
Release note: https://github.com/openshift/openshift-docs/pull/73997
