### PR TITLE
OSDOCS-9827: adds two-version update release note MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -15,10 +15,10 @@ toc::[]
 == About this release
 Version 4.16 of {product-title} includes new features and enhancements. {microshift-short} was introduced as Generally Available with {microshift-short} 4.14. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md[Kubernetes 1.28] with the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
 
-You can deploy {microshift-short} clusters to on-premise, cloud, disconnected, or offline environments.
+You can deploy {microshift-short} clusters to on-premise, cloud, or disconnected environments.
 
 //TODO: Update OP system versions
-{microshift-short} {product-version} is supported on {op-system-ostree-first} and {op-system-base-full} 9.2 and 9.3.
+{microshift-short} {product-version} is supported on {op-system-base-full} or {op-system-ostree-first} 9.4.
 
 For lifecycle information, see the link:https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{product-title} Life Cycle Policy].
 
@@ -30,7 +30,7 @@ This release adds improvements related to the following components and concepts.
 //L3 major categories with features in each as L4s
 [id="microshift-4-16-rhel"]
 === {op-system-base-full}
-//* {microshift-short} now runs on {op-system-base-full} versions 9.2 and 9.3. Compatibility with {op-system} 9.3 is an enhancement for {microshift-short} version 4.16.
+//* {microshift-short} now runs on {op-system-base-full} 9.4
 
 // Some details of the next note are adapted from https://kubernetes.io/blog/2022/08/31/cgroupv2-ga-1-25/
 * {microshift-short} uses crun and Control Group v2 (cgroup v2). If workloads rely on the cgroup file system layout, they might need to be updated to be compatible with cgroup v2.
@@ -41,15 +41,18 @@ This release adds improvements related to the following components and concepts.
 
 [id="microshift-4-16-updating"]
 === Updating
-Updates for both minor releases and patch releases are supported.
+Updating two minor versions in a single step is now supported. Updates for both single-version minor releases and patch releases are also still supported.
 
 [id="microshift-4-16-updates-supported"]
-==== The following updates are supported
-The following list provides update details:
+==== Update two minor versions in a single step
+See the following list for details:
 
+* You can update from one long-life-cycle version of {microshift-short} directly to another, without applying the intermediate version. For example, you can update directly to 4.16 from 4.14. Updating 4.14 to 4.15 before updating to 4.16 is no longer required.
+* Now, you can focus on developing applications for your devices in remote locations and with limited bandwidth, rather than planning for updates.
 * {microshift-short} offers in-place updates on {op-system-ostree} systems with automatic system rollback capabilities and automatic back up and restore functions.
 * Updates of the RPMs on a non-OSTree system such as {op-system} are also supported.
-//* Updates from the 4.14 version are supported.
+* See xref:../microshift_updating/microshift-update-options.adoc#microshift-update-options[Update options with {product-title} and {op-system-bundle}] for details.
+
 //TODO: verify update paths to 4.16 and list
 
 //TODO add new features and enhancements as needed, L4 [discrete] headings


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-9827](https://issues.redhat.com/browse/OSDOCS-9827)

Link to docs preview:
[Updates Y+2](https://73997--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes#microshift-4-16-updating)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Feature PR https://github.com/openshift/openshift-docs/pull/73988

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
