### PR TITLE
[OCPBUGS-28552] Determining required perms per component via oc

### DIFF
--- a/installing/installing_alibaba/installing-alibaba-customizations.adoc
+++ b/installing/installing_alibaba/installing-alibaba-customizations.adoc
@@ -31,6 +31,12 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
+//Installing the OpenShift CLI by downloading the binary: Moved up to precede component permissions steps, which require the use of `oc`
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
+//Determining component permissions requirements
+include::modules/determining-component-permissions-requirements.adoc[leveloffset=+1,tags=!*;provAlibaba]
+
 include::modules/installation-initializing.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -46,8 +52,6 @@ include::modules/installation-alibaba-config-yaml.adoc[leveloffset=+2]
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
-
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/ipi/installing-aws-customizations.adoc
+++ b/installing/installing_aws/ipi/installing-aws-customizations.adoc
@@ -37,6 +37,12 @@ include::modules/installation-aws-marketplace-subscribe.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
+//Installing the OpenShift CLI by downloading the binary: Moved up to precede component permissions steps, which require the use of `oc`
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
+//Determining component permissions requirements
+include::modules/determining-component-permissions-requirements.adoc[leveloffset=+1,tags=!*;provAWS]
+
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -57,9 +63,6 @@ include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
 include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
-
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 [id="installing-aws-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project

--- a/installing/installing_azure/installing-azure-customizations.adoc
+++ b/installing/installing_azure/installing-azure-customizations.adoc
@@ -28,6 +28,12 @@ include::modules/installation-azure-marketplace-subscribe.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
+//Installing the OpenShift CLI by downloading the binary: Moved up to precede component permissions steps, which require the use of `oc`
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
+//Determining component permissions requirements
+include::modules/determining-component-permissions-requirements.adoc[leveloffset=+1,tags=!*;provAzure]
+
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -60,9 +66,6 @@ include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 include::modules/installation-user-defined-tags-azure.adoc[leveloffset=+1]
 
 include::modules/querying-user-defined-tags-azure.adoc[leveloffset=+1]
-
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede manual cred (short and long) steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 [id="installing-azure-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project

--- a/installing/installing_azure_stack_hub/installing-azure-stack-hub-default.adoc
+++ b/installing/installing_azure_stack_hub/installing-azure-stack-hub-default.adoc
@@ -30,6 +30,12 @@ include::modules/installation-azure-user-infra-uploading-rhcos.adoc[leveloffset=
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
+//Installing the OpenShift CLI by downloading the binary: Moved up to precede component permissions steps, which require the use of `oc`
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
+//Determining component permissions requirements
+include::modules/determining-component-permissions-requirements.adoc[leveloffset=+1,tags=!*;provAzure]
+
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -48,8 +54,6 @@ include::modules/manually-create-identity-access-management.adoc[leveloffset=+1]
 include::modules/azure-stack-hub-internal-ca.adoc[leveloffset=+1]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
-
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 

--- a/installing/installing_gcp/installing-gcp-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-customizations.adoc
@@ -25,6 +25,12 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
+//Installing the OpenShift CLI by downloading the binary: Moved up to precede component permissions steps, which require the use of `oc`
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
+//Determining component permissions requirements
+include::modules/determining-component-permissions-requirements.adoc[leveloffset=+1,tags=!*;provGCP]
+
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -64,9 +70,6 @@ include::modules/installing-gcp-cluster-creation.adoc[leveloffset=+2]
 
 //Querying user-defined labels and tags for GCP
 include::modules/installing-gcp-querying-labels-tags-gcp.adoc[leveloffset=+2]
-
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 [id="installing-gcp-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project

--- a/installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
+++ b/installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
@@ -23,6 +23,12 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
+//Installing the OpenShift CLI by downloading the binary: Moved up to precede component permissions steps, which require the use of `oc`
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
+//Determining component permissions requirements
+include::modules/determining-component-permissions-requirements.adoc[leveloffset=+1,tags=!*;provIBMcloud]
+
 include::modules/installation-ibm-cloud-export-variables.adoc[leveloffset=+1]
 
 include::modules/installation-initializing.adoc[leveloffset=+1]
@@ -49,8 +55,6 @@ include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 include::modules/manually-create-iam-ibm-cloud.adoc[leveloffset=+1]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
-
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 

--- a/installing/installing_ibm_powervs/installing-ibm-power-vs-customizations.adoc
+++ b/installing/installing_ibm_powervs/installing-ibm-power-vs-customizations.adoc
@@ -23,6 +23,12 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
+//Installing the OpenShift CLI by downloading the binary: Moved up to precede component permissions steps, which require the use of `oc`
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
+//Determining component permissions requirements
+include::modules/determining-component-permissions-requirements.adoc[leveloffset=+1,tags=!*;provIBMpowerVS]
+
 include::modules/installation-ibm-cloud-export-variables.adoc[leveloffset=+1]
 
 include::modules/installation-initializing.adoc[leveloffset=+1]
@@ -38,8 +44,6 @@ include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 include::modules/manually-create-iam-ibm-cloud.adoc[leveloffset=+1]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
-
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 

--- a/installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
+++ b/installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
@@ -38,6 +38,12 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
+//Installing the OpenShift CLI by downloading the binary: Moved up to precede component permissions steps, which require the use of `oc`
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
+//Determining component permissions requirements
+include::modules/determining-component-permissions-requirements.adoc[leveloffset=+1,tags=!*;provNutanix]
+
 include::modules/installation-adding-nutanix-root-certificates.adoc[leveloffset=+1]
 
 include::modules/installation-initializing.adoc[leveloffset=+1]
@@ -49,8 +55,6 @@ include::modules/installation-initializing.adoc[leveloffset=+1]
 include::modules/installation-nutanix-config-yaml.adoc[leveloffset=+2]
 include::modules/installation-configuring-nutanix-failure-domains.adoc[leveloffset=+2]
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
-
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/manually-configure-iam-nutanix.adoc[leveloffset=+1]
 

--- a/installing/installing_openstack/installing-openstack-installer-custom.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-custom.adoc
@@ -29,6 +29,11 @@ include::modules/installation-osp-verifying-external-network.adoc[leveloffset=+1
 include::modules/installation-osp-describing-cloud-parameters.adoc[leveloffset=+1]
 include::modules/installation-osp-setting-cloud-provider-options.adoc[leveloffset=+1]
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
+//Installing the OpenShift CLI by downloading the binary: Added to precede component permissions steps, which require the use of `oc`
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
+//Determining component permissions requirements
+include::modules/determining-component-permissions-requirements.adoc[leveloffset=+1,tags=!*;provOpenStack]
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc
+++ b/installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc
@@ -27,6 +27,9 @@ include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
+//Determining component permissions requirements
+include::modules/determining-component-permissions-requirements.adoc[leveloffset=+1,tags=!*;provVMW]
+
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-adding-vcenter-root-certificates.adoc[leveloffset=+1]

--- a/modules/determining-component-permissions-requirements.adoc
+++ b/modules/determining-component-permissions-requirements.adoc
@@ -67,6 +67,8 @@ $ ls <path_to_directory_for_credentials_requests>
 0000_50_cluster-ingress-operator_00-ingress-credentials-request.yaml
 0000_50_cluster-network-operator_02-cncc-credentials.yaml
 0000_50_cluster-storage-operator_03_credentials_request_aws.yaml
+
+//todo: make this output correct per-platform
 ----
 +
 Each YAML file is a `CredentialsRequest` manifest for an {product-title} component in your cluster configuration. Each manifest contains the permissions requirements for its component.
@@ -276,7 +278,7 @@ spec:
     name: ibmcloud-credentials
     namespace: openshift-machine-api
 end::provIBMcloud[]
-tag::provIBMpower[]
+tag::provIBMpowerVS[]
     include.release.openshift.io/self-managed-high-availability: "true"
   labels:
     controller-tools.k8s.io: "1.0"
@@ -309,8 +311,8 @@ spec:
   secretRef:
     namespace: openshift-machine-api
     name: powervs-credentials
-end::provIBMpower[]
-tag::provOSH[]
+end::provIBMpowerVS[]
+tag::provOpenStack[]
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   labels:
@@ -324,7 +326,7 @@ spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: OpenStackProviderSpec
-end::provOSH[]
+end::provOpenStack[]
 tag::provovirt[]
     include.release.openshift.io/self-managed-high-availability: "true"
   labels:

--- a/modules/determining-component-permissions-requirements.adoc
+++ b/modules/determining-component-permissions-requirements.adoc
@@ -1,0 +1,410 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-customizations.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="determining-component-permissions-requirements_{context}"]
+= Determining component permissions requirements
+
+In addition to the permissions that the installation program requires, the service account that you use during installation must include permissions for the {product-title} components in your cluster configuration.
+
+If the security policies of your organization require more restrictive access than the installation process uses by default, you can add any missing access requirements for components to the service account.
+You can determine the required permissions by inspecting the contents of the `CredentialsRequest` manifests for each component.
+
+.Prerequisites
+
+* You have created a cloud provider account for the installation program that has the required permissions to create the {product-title} cluster.
+* You have downloaded the installation program file.
+* You have installed the {oc-first}.
+* You have access to an {product-title} account with cluster administrator access
+
+.Procedure
+
+. Change to the directory that contains the installation program.
+
+. Set a `$RELEASE_IMAGE` variable with the release image from your installation file by running the following command:
++
+[source,terminal]
+----
+$ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}')
+----
+
+. Extract the list of `CredentialsRequest` objects from the {product-title} release image by running the following command:
++
+[source,terminal]
+----
+$ oc adm release extract \
+  --from=$RELEASE_IMAGE \
+  --credentials-requests \
+  --included \// <1>
+  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \// <2>
+  --to=<path_to_directory_for_credentials_requests> <3>
+----
+<1> The `--included` parameter includes only the manifests that your specific cluster configuration requires.
+<2> Specify the location of the `install-config.yaml` file.
+<3> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
++
+[NOTE]
+====
+This command might take a few moments to run.
+====
+
+. Verify the contents of the directory where you want to store the `CredentialsRequest` objects by running the following command:
++
+[source,terminal]
+----
+$ ls <path_to_directory_for_credentials_requests>
+----
++
+.Example output
++
+[source,text]
+----
+0000_30_cluster-api_00_credentials-request.yaml
+0000_30_machine-api-operator_00_credentials-request.yaml
+0000_50_cloud-credential-operator_05-iam-ro-credentialsrequest.yaml
+0000_50_cluster-image-registry-operator_01-registry-credentials-request.yaml
+0000_50_cluster-ingress-operator_00-ingress-credentials-request.yaml
+0000_50_cluster-network-operator_02-cncc-credentials.yaml
+0000_50_cluster-storage-operator_03_credentials_request_aws.yaml
+----
++
+Each YAML file is a `CredentialsRequest` manifest for an {product-title} component in your cluster configuration. Each manifest contains the permissions requirements for its component.
+
+. To view the permissions requirements for a specific component, run the following command:
++
+[source,terminal]
+----
+$ cat <component_credentials_request>
+----
++
+where `<component_credentials_request>` is a file in `<path_to_directory_for_credentials_requests>`.
++
+.Example output for the Machine API `CredentialsRequest` manifest
++
+[source,yaml]
+----
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  annotations:
+    capability.openshift.io/name: MachineAPI+CloudCredential
+tag::provAlibaba[]
+  name: openshift-machine-api-alibabacloud
+  namespace: openshift-cloud-credential-operator
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AlibabaCloudProviderSpec
+    statementEntries:
+    - action:
+      - ecs:DeleteInstances
+      - ecs:DescribeImages
+      - ecs:DescribeInstances
+      - ecs:DescribeSecurityGroups
+      - ecs:RunInstances
+      - ecs:StopInstances
+      - ecs:TagResources
+      effect: Allow
+      resource: '*'
+    - action:
+      - vpc:DescribeVpcs
+      - vpc:DescribeVSwitches
+      - ram:PassRole
+      effect: Allow
+      resource: '*'
+  secretRef:
+    name: alibabacloud-credentials
+    namespace: openshift-machine-api
+end::provAlibaba[]
+tag::provAWS[]
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: openshift-machine-api-aws
+  namespace: openshift-cloud-credential-operator
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AWSProviderSpec
+    statementEntries:
+    - action:
+      - ec2:CreateTags
+      - ec2:DescribeAvailabilityZones
+      - ec2:DescribeDhcpOptions
+      - ec2:DescribeImages
+      - ec2:DescribeInstances
+      - ec2:DescribeInstanceTypes
+      - ec2:DescribeInternetGateways
+      - ec2:DescribeSecurityGroups
+      - ec2:DescribeRegions
+      - ec2:DescribeSubnets
+      - ec2:DescribeVpcs
+      - ec2:RunInstances
+      - ec2:TerminateInstances
+      - elasticloadbalancing:DescribeLoadBalancers
+      - elasticloadbalancing:DescribeTargetGroups
+      - elasticloadbalancing:DescribeTargetHealth
+      - elasticloadbalancing:RegisterInstancesWithLoadBalancer
+      - elasticloadbalancing:RegisterTargets
+      - elasticloadbalancing:DeregisterTargets
+      - iam:PassRole
+      - iam:CreateServiceLinkedRole
+      effect: Allow
+      resource: '*'
+    - action:
+      - kms:Decrypt
+      - kms:Encrypt
+      - kms:GenerateDataKey
+      - kms:GenerateDataKeyWithoutPlainText
+      - kms:DescribeKey
+      effect: Allow
+      resource: '*'
+    - action:
+      - kms:RevokeGrant
+      - kms:CreateGrant
+      - kms:ListGrants
+      effect: Allow
+      policyCondition:
+        Bool:
+          kms:GrantIsForAWSResource: true
+      resource: '*'
+  secretRef:
+    name: aws-cloud-credentials
+    namespace: openshift-machine-api
+  serviceAccountNames:
+  - machine-api-controllers
+end::provAWS[]
+tag::provAzure[]
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: openshift-machine-api-azure
+  namespace: openshift-cloud-credential-operator
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AzureProviderSpec
+    permissions:
+    - Microsoft.Compute/availabilitySets/delete
+    - Microsoft.Compute/availabilitySets/read
+    - Microsoft.Compute/availabilitySets/write
+    - Microsoft.Compute/diskEncryptionSets/read
+    - Microsoft.Compute/disks/delete
+    - Microsoft.Compute/galleries/images/versions/read
+    - Microsoft.Compute/skus/read
+    - Microsoft.Compute/virtualMachines/delete
+    - Microsoft.Compute/virtualMachines/extensions/delete
+    - Microsoft.Compute/virtualMachines/extensions/read
+    - Microsoft.Compute/virtualMachines/extensions/write
+    - Microsoft.Compute/virtualMachines/read
+    - Microsoft.Compute/virtualMachines/write
+    - Microsoft.ManagedIdentity/userAssignedIdentities/assign/action
+    - Microsoft.Network/applicationSecurityGroups/read
+    - Microsoft.Network/loadBalancers/backendAddressPools/join/action
+    - Microsoft.Network/loadBalancers/read
+    - Microsoft.Network/loadBalancers/write
+    - Microsoft.Network/networkInterfaces/delete
+    - Microsoft.Network/networkInterfaces/join/action
+    - Microsoft.Network/networkInterfaces/loadBalancers/read
+    - Microsoft.Network/networkInterfaces/read
+    - Microsoft.Network/networkInterfaces/write
+    - Microsoft.Network/networkSecurityGroups/read
+    - Microsoft.Network/networkSecurityGroups/write
+    - Microsoft.Network/publicIPAddresses/delete
+    - Microsoft.Network/publicIPAddresses/join/action
+    - Microsoft.Network/publicIPAddresses/read
+    - Microsoft.Network/publicIPAddresses/write
+    - Microsoft.Network/routeTables/read
+    - Microsoft.Network/virtualNetworks/delete
+    - Microsoft.Network/virtualNetworks/read
+    - Microsoft.Network/virtualNetworks/subnets/join/action
+    - Microsoft.Network/virtualNetworks/subnets/read
+    - Microsoft.Resources/subscriptions/resourceGroups/read
+  secretRef:
+    name: azure-cloud-credentials
+    namespace: openshift-machine-api
+  serviceAccountNames:
+  - machine-api-controllers
+end::provAzure[]
+tag::provGCP[]
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: openshift-machine-api-gcp
+  namespace: openshift-cloud-credential-operator
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: GCPProviderSpec
+    predefinedRoles:
+    - roles/compute.admin
+    - roles/iam.serviceAccountUser
+  secretRef:
+    name: gcp-cloud-credentials
+    namespace: openshift-machine-api
+  serviceAccountNames:
+  - machine-api-controllers
+end::provGCP[]
+tag::provIBMcloud[]
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: openshift-machine-api-ibmcloud
+  namespace: openshift-cloud-credential-operator
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: IBMCloudProviderSpec
+    policies:
+    - attributes:
+      - name: serviceName
+        value: is
+      roles:
+      - crn:v1:bluemix:public:iam::::role:Operator
+      - crn:v1:bluemix:public:iam::::role:Editor
+      - crn:v1:bluemix:public:iam::::role:Viewer
+    - attributes:
+      - name: resourceType
+        value: resource-group
+      roles:
+      - crn:v1:bluemix:public:iam::::role:Viewer
+  secretRef:
+    name: ibmcloud-credentials
+    namespace: openshift-machine-api
+end::provIBMcloud[]
+tag::provIBMpower[]
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: openshift-machine-api-powervs
+  namespace: openshift-cloud-credential-operator
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: IBMCloudPowerVSProviderSpec
+    policies:
+      - roles:
+          - "crn:v1:bluemix:public:iam::::role:Viewer"
+          - "crn:v1:bluemix:public:iam::::serviceRole:Reader"
+          - "crn:v1:bluemix:public:iam::::serviceRole:Manager"
+        attributes:
+          - name: "serviceName"
+            value: "power-iaas"
+      - roles:
+          - "crn:v1:bluemix:public:iam::::role:Viewer"
+        attributes:
+          - name: "resourceType"
+            value: "resource-group"
+      - roles:
+          - "crn:v1:bluemix:public:iam::::role:Editor"
+          - "crn:v1:bluemix:public:iam::::role:Operator"
+          - "crn:v1:bluemix:public:iam::::role:Viewer"
+        attributes:
+          - name: serviceName
+            value: is
+  secretRef:
+    namespace: openshift-machine-api
+    name: powervs-credentials
+end::provIBMpower[]
+tag::provOSH[]
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: openshift-machine-api-openstack
+  namespace: openshift-cloud-credential-operator
+spec:
+  secretRef:
+    name: openstack-cloud-credentials
+    namespace: openshift-machine-api
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: OpenStackProviderSpec
+end::provOSH[]
+tag::provovirt[]
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: openshift-machine-api-ovirt
+  namespace: openshift-cloud-credential-operator
+spec:
+  secretRef:
+    name: ovirt-credentials
+    namespace: openshift-machine-api
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: OvirtProviderSpec
+end::provovirt[]
+tag::provNutanix[]
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: openshift-machine-api-nutanix
+  namespace: openshift-cloud-credential-operator
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: NutanixProviderSpec
+  secretRef:
+    name: nutanix-credentials
+    namespace: openshift-machine-api
+end::provNutanix[]
+tag::provVMW[]
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: openshift-machine-api-vsphere
+  namespace: openshift-cloud-credential-operator
+spec:
+  secretRef:
+    name: vsphere-cloud-credentials
+    namespace: openshift-machine-api
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: VSphereProviderSpec
+end::provVMW[]
+----
++
+The `providerSpec` stanza contains the permissions requirements. The format of this data varies by component and cloud provider.
+
+
+
+////
+//pre-4.14
+//
+. Extract the list of `CredentialsRequest` objects from the {product-title} release image by running the following command:
++
+--
+[source,terminal]
+----
+$ oc adm release extract \
+  --from=$RELEASE_IMAGE \
+  --credentials-requests \
+  --cloud=<cloud_provider_name> \// <1>
+  --to=<path_to_directory_for_credentials_requests> <2>
+----
+<1> Specify the value that corresponds to your cloud provider. The following values are valid:
+* alibabacloud: Alibaba Cloud
+* aws: {aws-full}
+* azure: {azure-full}
+* gcp: {gcp-full}
+* ibmcloud: {ibm-cloud-title}
+* nutanix: Nutanix
+* openstack: {rh-openstack-first}
+* ovirt: {VirtProductName}
+* powervs: {ibm-power-server-title}
+* vsphere: {vmw-full}
+<2> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
+--
++
+[NOTE]
+====
+This command might take a few moments to run.
+====
+//
+//Note: pre-4.14, the lack of the --included flag means there will be unnecessary manifests for any optional component (capability) the user will not use.
+////


### PR DESCRIPTION
Version(s):
4.14+
4.12-4.13 via manual backport due to content changes in 4.14

Issue:
https://issues.redhat.com/browse/OCPBUGS-28552

Link to docs preview:

**Determining component permissions requirements** in
* [Alibaba](https://74008--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_alibaba/installing-alibaba-customizations#determining-component-permissions-requirements_installing-alibaba-customizations)
* [AWS](https://74008--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations#determining-component-permissions-requirements_installing-aws-customizations)
* [Azure](https://74008--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-customizations#determining-component-permissions-requirements_installing-azure-customizations)
* [ASH](https://74008--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installing-azure-stack-hub-default#determining-component-permissions-requirements_installing-azure-stack-hub-default)
* [GCP](https://74008--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations#determining-component-permissions-requirements_installing-gcp-customizations)
* [IBM Cloud](https://74008--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations#determining-component-permissions-requirements_installing-ibm-cloud-customizations)
* [IBM Power VS](https://74008--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/installing-ibm-power-vs-customizations#determining-component-permissions-requirements_installing-ibm-power-vs-customizations)
* [Nutanix](https://74008--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned#determining-component-permissions-requirements_installing-nutanix-installer-provisioned)
* [OpenStack](https://74008--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-custom#determining-component-permissions-requirements_installing-openstack-installer-custom)
* [vSphere](https://74008--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install#determining-component-permissions-requirements_ipi-vsphere-preparing-to-install)

QE review:
- [ ] QE has approved this change.

Additional information:
WIP/POC

todo: 
- expunge other permissions lists to use this method instead (not installer, but any component lists)
- apply to all clouds
- "Module included in" header