### PR TITLE
Update ifdef handling in prow-test script

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -11,8 +11,11 @@ Vocab = OpenShiftDocs
 BasedOnStyles = RedHat, AsciiDoc, OpenShiftAsciiDoc
 
 # Optional: pass doc attributes to asciidoctor before linting
-#[asciidoctor]
-#openshift-enterprise = YES
+# Temp values are used for Prow CI comment linting only
+[asciidoctor]
+temp-ifdef = YES
+temp-ifndef  = NO
+temp-ifeval = temp
 
 # Disabling rules (NO)
 RedHat.ReleaseNotes = NO

--- a/modules/.vale.ini
+++ b/modules/.vale.ini
@@ -7,6 +7,12 @@ Vocab = OpenShiftDocs
 [[!.]*.adoc]
 BasedOnStyles = OpenShiftAsciiDoc, AsciiDoc, RedHat
 
+# Temp values are used for Prow CI comment linting only
+[asciidoctor]
+temp-ifdef = YES
+temp-ifndef  = NO
+temp-ifeval = temp
+
 # Use local OpenShiftDocs Vocab terms
 Vale.Terms = YES
 Vale.Avoid = YES

--- a/scripts/prow-vale-review.sh
+++ b/scripts/prow-vale-review.sh
@@ -42,8 +42,10 @@ function get_vale_errors {
 # Run vale with the custom template on updated files and determine if a review comment should be posted
 for FILE in ${FILES};
 do
-    # Clean out conditional markup in place and parse for vale errors
-    sed -i 's/ifdef::.*\|ifndef::.*\|ifeval::.*\|endif::.*/ /' "$FILE"
+    # Update conditional markup in place
+    sed -i 's/ifdef::.*/ifdef::temp-ifdef[]/; s/ifeval::.*/ifeval::["{temp-ifeval}" == "temp"]/; s/ifndef::.*/ifndef::temp-ifndef[]/; s/endif::.*/endif::[]/;' "$FILE"
+
+    # Parse for vale errors
     vale_json=$(vale --minAlertLevel=error --output=.vale/templates/bot-comment-output.tmpl "$FILE" | jq)
 
     # Check if there are Vale errors before processing the file further.


### PR DESCRIPTION
Previously, the prow vale script cleaned out conditional content completely before linting. This is not ideal, and will cause ifdef errors to be ignored. This update applies temp values to ifdefs allowing the ifdefs to be evaluated.

The two vale.ini files are updated to pass asciidoctor attributes for the linting run.

This update applies similar to the following in linted files:

```
ifdef::ifdeftemp[]
Blah.
endif::[]
ifndef::ifndeftemp[]
Something.
endif::[]
ifeval::["{ifevaltemp}" == "test"]
Some text!
endif::[]
```