### PR TITLE
OSDOCS-10072: Documented the 4.12.54 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -3290,7 +3290,7 @@ To work around this issue: If your control plane nodes are schedulable, and the 
 
 * When installing an {product-title} cluster with static IP addressing and Tang encryption, nodes start without network settings. This condition prevents nodes from accessing the Tang server, causing installation to fail. To address this condition, you must set the network settings for each node as `ip` installer arguments.
 +
-. For installer-provisioned infrastructure, before installation provide the network settings as `ip` installer arguments for each node by executing the following steps. 
+. For installer-provisioned infrastructure, before installation provide the network settings as `ip` installer arguments for each node by executing the following steps.
 .. Create the manifests.
 
 .. For each node, modify the `BareMetalHost` custom resource with annotations to include the network settings. For example:
@@ -3364,7 +3364,7 @@ For the previous network settings, replace:
 <2> `<gateway>` with the IP address of your network's gateway, for example, `192.168.1.1`
 <3> `<netmask>` with the network mask, for example, `255.255.255.0`
 <4> `<hostname_1>` with the node's hostname, for example, `node1.example.com`
-<5> `<interface>` with the name of the network interface, for example, `eth0`. 
+<5> `<interface>` with the name of the network interface, for example, `eth0`.
 
 Contact Red Hat Support for additional details and assistance.
 
@@ -4609,6 +4609,26 @@ $ oc adm release info 4.12.53 --pullspecs
 ----
 
 [id="ocp-4-12-53-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+// 4.12.54
+[id="ocp-4-12-54"]
+=== RHSA-2024:1572 - {product-title} 4.12.54 bug fix and security update
+
+Issued: 2024-04-03
+
+{product-title} release 4.12.54, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:1572[RHSA-2024:1572] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1574[RHSA-2024:1574] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.54 --pullspecs
+----
+
+[id="ocp-4-12-54-updating"]
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-10072](https://issues.redhat.com/browse/OSDOCS-10072)

Link to docs preview:
[4.12.54](https://74028--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-54)

QE review:
- [ ] QE not requried. See the peer-review checklist.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
