### PR TITLE
OCPBUGS-31451-rev: Revert vSphere instance support versions

### DIFF
--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -9,8 +9,8 @@
 
 You must install an {product-title} cluster on one of the following versions of a VMware vSphere instance that meets the requirements for the components that you use:
 
-* Version 7.0 Update 3 or later
-* Version 8.0 Update 2 or later
+* Version 7.0 Update 2 or later
+* Version 8.0 Update 1 or later
 
 Both of these releases support Container Storage Interface (CSI) migration, which is enabled by default on {product-title} {product-version}.
 
@@ -21,8 +21,8 @@ You can host the VMware vSphere infrastructure on-premise or on a link:https://c
 |===
 |Virtual environment product |Required version
 |VMware virtual hardware | 15 or later
-|vSphere ESXi hosts | 7.0 Update 3 or later; 8.0 Update 2 or later
-|vCenter host | 7.0 Update 3 or later; 8.0 Update 2 or later
+|vSphere ESXi hosts | 7.0 Update 2 or later; 8.0 Update 1 or later
+|vCenter host | 7.0 Update 2 or later; 8.0 Update 1 or later
 |===
 
 [IMPORTANT]
@@ -35,12 +35,12 @@ You must ensure that the time on your ESXi hosts is synchronized before you inst
 |Component | Minimum supported versions |Description
 
 |Hypervisor
-|vSphere 7.0 Update 3 (or later) or vSphere 8.0 Update 2 (or later) with virtual hardware version 15
+|vSphere 7.0 Update 2 (or later) or vSphere 8.0 Update 1 (or later) with virtual hardware version 15
 |This hypervisor version is the minimum version that {op-system-first} supports. For more information about supported hardware on the latest version of {op-system-base-full} that is compatible with {op-system}, see link:https://catalog.redhat.com/hardware/search[Hardware] on the Red Hat Customer Portal.
 
 |Optional: Networking (NSX-T)
-|vSphere 7.0 Update 3 or later; vSphere 8.0 Update 2 or later
-|At a minimum, vSphere 7.0 Update 3 or vSphere 8.0 Update 2 is required for {product-title}. For more information about the compatibility of NSX and {product-title}, see the Release Notes section of VMware's link:https://docs.vmware.com/en/VMware-NSX-Container-Plugin/index.html[NSX container plugin documentation].
+|vSphere 7.0 Update 2 or later; vSphere 8.0 Update 1 or later
+|At a minimum, vSphere 7.0 Update 2 or vSphere 8.0 Update 1 is required for {product-title}. For more information about the compatibility of NSX and {product-title}, see the Release Notes section of VMware's link:https://docs.vmware.com/en/VMware-NSX-Container-Plugin/index.html[NSX container plugin documentation].
 |===
 
 [IMPORTANT]

--- a/modules/vmware-csi-driver-reqs.adoc
+++ b/modules/vmware-csi-driver-reqs.adoc
@@ -10,8 +10,8 @@
 
 To install the vSphere Container Storage Interface (CSI) Driver Operator, the following requirements must be met:
 
-* VMware vSphere version 7.0 Update 2 or later
-* vCenter 7.0 Update 2 or later
+* VMware vSphere version: 7.0 Update 2 or later; 8.0 Update 1 or later
+* vCenter version: 7.0 Update 2 or later; 8.0 Update 1 or later
 * Virtual machines of hardware version 15 or later
 * No third-party vSphere CSI driver already installed in the cluster
 
@@ -26,6 +26,6 @@ You can create a custom role for the Container Storage Interface (CSI) driver, t
 
 [IMPORTANT]
 ====
-Installing an {product-title} cluster in a vCenter is tested against a full list of privileges as described in the "Required vCenter account privileges" section. By adhering to the full list of privileges, you can reduce the possibility of unexpected and unsupported behaviors that might occur when creating a custom role with a set of restricted privileges. 
+Installing an {product-title} cluster in a vCenter is tested against a full list of privileges as described in the "Required vCenter account privileges" section. By adhering to the full list of privileges, you can reduce the possibility of unexpected and unsupported behaviors that might occur when creating a custom role with a set of restricted privileges.
 ====
 


### PR DESCRIPTION
Version(s):
4.16 to 4.14

Issue:
https://issues.redhat.com/browse/OCPBUGS-31451

Link to docs preview:
* [VMware vSphere infrastructure requirements](https://74049--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.html)
* [VMware vSphere CSI Driver Operator requirements](https://74049--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-vsphere#vsphere-csi-driver-reqs_persistent-storage-csi-vsphere)

- [X] SME has approved this change.
- [X] QE has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
