### PR TITLE
73939 follow up to switch `html` for `adoc`

### DIFF
--- a/nodes/nodes/nodes-nodes-resources-cpus.adoc
+++ b/nodes/nodes/nodes-nodes-resources-cpus.adoc
@@ -19,4 +19,4 @@ include::modules/nodes-nodes-resources-cpus-reserve.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* For more information on the `systemReserved` parameter, see xref:../../nodes/nodes/nodes-nodes-resources-configuring.html#nodes-nodes-resources-configuring-about_nodes-nodes-resources-configuring[Allocating resources for nodes in an {product-title} cluster].
+* For more information on the `systemReserved` parameter, see xref:../../nodes/nodes/nodes-nodes-resources-configuring.adoc#nodes-nodes-resources-configuring-about_nodes-nodes-resources-configuring[Allocating resources for nodes in an {product-title} cluster].


### PR DESCRIPTION
Not sure how the [`html` got replaced with `adoc` in the 73939](https://github.com/openshift/openshift-docs/pull/73939/files#diff-3f071bdb2111f5eb2f59b5a1dedd5bcfe845c708c98c353832fcb76b31f5a97cR21-R22). (While I have copied and pasted an `html` link, but I wouldn't manually make the change.) I missed this error in the original PR. Hat tip @gaurav-nelson 

https://github.com/openshift/openshift-docs/pull/73939

Preview: [Additional resources](https://74052--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-resources-cpus.html) at end of this assembly.