### PR TITLE
ROX#21163: Update docs for clarity around enforcement and scaling

### DIFF
--- a/integration/integrate-with-ci-systems.adoc
+++ b/integration/integrate-with-ci-systems.adoc
@@ -7,33 +7,49 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-{product-title} ({product-title-short}) integrates with a variety of continuous integration (CI) products and allows you to apply build-time and deploy-time security rules before you deploy images.
+{product-title} ({product-title-short}) integrates with a variety of continuous integration (CI) products. Before you deploy images, you can use {product-title-short} to apply build-time and deploy-time security rules to your images.
 
-{product-title} integrates into CI pipelines after images are built and pushed to a registry.
+After images are built and pushed to a registry, {product-title-short} integrates into CI pipelines.
 Pushing the image first allows developers to continue testing their artifacts while dealing with any policy violations alongside any other CI test failures, linter violations, or other problems.
 
-If possible, you should configure the version control system to block pull or merge requests from being merged if the build stage, which includes {product-title} checks, fails.
+If possible, configure the version control system to block pull or merge requests from being merged if the build stage, which includes {product-title-short} checks, fails.
 
-The integration with your CI product functions by contacting your {product-title} installation to check whether the image complies with build-phase policies you have configured.
-If there are policy violations, a detailed message is displayed on the console log, including the policy description, rationale, and remediation instructions.
-Each policy includes an optional enforcement setting;
-if you mark a policy for build-phase enforcement, failure of that policy causes the client to exit with a nonzero error code.
+The integration with your CI product functions by contacting your {product-title-short} installation to check whether the image complies with build-time policies you have configured. If there are policy violations, a detailed message is displayed on the console log, including the policy description, rationale, and remediation instructions.
+
+Each policy includes an optional enforcement setting. If you mark a policy for build-time enforcement, failure of that policy causes the client to exit with a nonzero error code.
 
 To integrate {product-title} with your CI system, follow these steps:
 
 . xref:../integration/integrate-with-ci-systems.adoc#configure-build-policies[Configure build policies].
 . xref:../integration/integrate-with-ci-systems.adoc#configure-registry-integration[Configure a registry integration].
-. xref:../integration/integrate-with-ci-systems.adoc#configure-access[Configure access] to your {product-title} instance.
+. xref:../integration/integrate-with-ci-systems.adoc#configure-access[Configure access] to your {product-title-short} instance.
 . xref:../integration/integrate-with-ci-systems.adoc#integrate-with-your-ci-pipeline[Integrate with your CI pipeline].
 
 [id="configure-build-policies"]
 == Configuring build policies
 
-To check {product-title} policies during builds, you must first configure policies that apply to the build phase of the container lifecycle. And then you must integrate with the registry that images are pushed to during the build.
+You can check {product-title-short} policies during builds.
+
+.Procedure
+
+. Configure policies that apply to the build time of the container lifecycle.
+. Integrate with the registry that images are pushed to during the build.
+
+[role="_additional-resources"]
+.Additional resources
+
+xref:../integration/integrate-with-image-registries.adoc#integrate-with-image-registries[Integrating with image registries]
 
 include::modules/integrate-ci-check-existing-build-phase-policies.adoc[leveloffset=+2]
 
 include::modules/create-new-system-policy.adoc[leveloffset=+2]
+
+include::modules/policy-enforcement-deploy.adoc[leveloffset=+3]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../operating/use-admission-controller-enforcement.adoc#use-admission-controller-enforcement[Using admission controller enforcement]
 
 [id="configure-registry-integration"]
 == Configuring registry integration
@@ -49,7 +65,7 @@ include::modules/check-for-existing-registry-integration.adoc[leveloffset=+2]
 [id="configure-access"]
 == Configuring access
 
-{product-title} provides a command-line interface (CLI) `roxctl` to make it easy to integrate {product-title} policies into your build pipeline.
+{product-title-short} provides the `roxctl` command-line interface (CLI) to make it easy to integrate {product-title-short} policies into your build pipeline.
 The `roxctl` CLI prints detailed information about problems and how to fix them so that developers can maintain high standards in the early phases of the container lifecycle.
 
 To securely authenticate to the {product-title} API server, you must create an API token.

--- a/modules/configure-policy-notifications.adoc
+++ b/modules/configure-policy-notifications.adoc
@@ -10,7 +10,7 @@
 Enable alert notifications for system policies.
 
 .Procedure
-. In the {product-title-short} portal, go to *Platform Configuration* -> *Policies*.
+. In the {product-title-short} portal, go to *Platform Configuration* -> *Policy Management*.
 . Select one or more policies for which you want to send alerts.
 . Under **Bulk actions**, select *Enable notification*.
 . In the **Enable notification** window, select the {toolname} notifier.

--- a/modules/create-new-system-policy.adoc
+++ b/modules/create-new-system-policy.adoc
@@ -8,7 +8,7 @@
 In addition to using the default policies, you can also create custom policies in {product-title}.
 
 .Procedure
-. In the {product-title-short} portal, go to *Platform Configuration* -> *Policies*.
+. In the {product-title-short} portal, go to *Platform Configuration* -> *Policy Management*.
 . Click *+ New Policy*.
 . Enter the *Name* for the policy.
 . Select a *Severity* level for the policy: Critical, High, Medium, or Low.
@@ -20,7 +20,7 @@ If you create a new policy for integrating with a CI system, select *Build* as t
 ====
 ** Build-time policies apply to image fields such as CVEs and Dockerfile instructions.
 ** Deploy-time policies can include all build-time policy criteria. They can also have data from your cluster configurations, such as running in privileged mode or mounting the Docker daemon socket.
-** Runtime policies can include all build-time and deploy-time policy criteria, as well as data about process executions during runtime.
+** Runtime policies can include all build-time and deploy-time policy criteria, and data about process executions during runtime.
 . Enter information about the policy in the *Description*, *Rationale*, and *Remediation* fields.
 When CI validates the build, the data from these fields is displayed.
 Therefore, include all information explaining the policy.
@@ -29,7 +29,7 @@ Therefore, include all information explaining the policy.
 +
 [NOTE]
 ====
-You must integrate {product-title} with your notification providers, such as webhooks, Jira, or PagerDuty, to receive alert notifications. Notifiers only show up if you have integrated any notification providers with {product-title}.
+You must integrate {product-title-short} with your notification providers, such as webhooks, Jira, or PagerDuty, to receive alert notifications. Notifiers only show up if you have integrated any notification providers with {product-title-short}.
 ====
 . Use *Restrict to Scope* to enable this policy only for a specific cluster, namespace, or label.
 You can add multiple scopes and also use regular expressions in RE2 Syntax for namespaces and labels.
@@ -57,9 +57,11 @@ Select *ON* to enforce policy and report a violation. Select *OFF* to only repor
 ====
 The enforcement behavior is different for each lifecycle stage.
 
-* For the *Build* stage, {product-title} fails your CI builds when images match the conditions of the policy.
-* For the *Deploy* stage, {product-title} blocks the creation of deployments that match the conditions of the policy. In clusters with admission controller enforcement, the Kubernetes or {ocp} API server blocks all noncompliant deployments. In other clusters, {product-title} edits noncompliant deployments to prevent pods from being scheduled.
-* For the *Runtime* stage, {product-title} stops all pods that match the conditions of the policy.
+* For the *Build* stage, {product-title-short} fails your CI builds when images match the conditions of the policy.
+* For the *Deploy* stage, {product-title-short} blocks the creation and update of deployments that match the conditions of the policy if the {product-title-short} admission controller is configured and running.
+** In clusters with admission controller enforcement, the Kubernetes or {ocp} API server blocks all noncompliant deployments. In other clusters, {product-title-short} edits noncompliant deployments to prevent pods from being scheduled.
+** For existing deployments, policy changes only result in enforcement at the next detection of the criteria, when a Kubernetes event occurs. For more information about enforcement, see "Security policy enforcement for the deploy stage".
+* For the *Runtime* stage, {product-title-short} stops all pods that match the conditions of the policy.
 ====
 +
 [WARNING]

--- a/modules/create-policy-from-system-policies-view.adoc
+++ b/modules/create-policy-from-system-policies-view.adoc
@@ -42,11 +42,11 @@ You can select more than one stage.
 . Optional: If you selected *Inform and enforce*, in *Configure enforcement behavior*, select the enforcement behavior for the policy by using the toggle for each lifecycle.
 It is only available for the stages you select when configuring *Lifecycle stages*.
 The enforcement behavior is different for each lifecycle stage.
-**** *Build* - {product-title-short} fails your continuous integration (CI) builds when images match the criteria of the policy.
-**** *Deploy* - {product-title-short} blocks creation of deployments that match the conditions of the policy.
-In clusters with admission controller enforcement, the Kubernetes or {ocp} API server blocks all noncompliant deployments.
-In other clusters, {product-title-short} edits noncompliant deployments to prevent pods from being scheduled.
-**** *Runtime* - {product-title-short} deletes all pods when an event in the pods matches the criteria of the policy.
+* *Build*: {product-title-short} fails your continuous integration (CI) builds when images match the criteria of the policy.
+* *Deploy*: For the *Deploy* stage, {product-title-short} blocks the creation and update of deployments that match the conditions of the policy if the {product-title-short} admission controller is configured and running.
+** In clusters with admission controller enforcement, the Kubernetes or {ocp} API server blocks all noncompliant deployments. In other clusters, {product-title-short} edits noncompliant deployments to prevent pods from being scheduled.
+** For existing deployments, policy changes only result in enforcement at the next detection of the criteria, when a Kubernetes event occurs. For more information about enforcement, see "Security policy enforcement for the deploy stage".
+* *Runtime* - {product-title-short} deletes all pods when an event in the pods matches the criteria of the policy.
 +
 [WARNING]
 ====

--- a/modules/disable-associated-policies.adoc
+++ b/modules/disable-associated-policies.adoc
@@ -9,8 +9,8 @@
 You can turn off the enforcement on relevant policies, which in turn instructs the admission controller to skip enforcements.
 
 .Procedure
-. In the {product-title-short} portal, go to *Platform Configuration* -> *Policies*.
+. In the {product-title-short} portal, go to *Platform Configuration* -> *Policy Management*.
 . Disable enforcement on the default policies:
-** In the policies view, scroll down and select the power icon next to the *Kubernetes Actions: Exec into Pod* policy to disable that policy.
-** In the policies view, scroll down and select the power icon next to the *Kubernetes Actions: Port Forward to Pod* policy to disable that policy.
+** In the policies view, locate the *Kubernetes Actions: Exec into Pod* policy. Click the overflow menu, {kebab}, and then select *Disable policy*.
+** In the policies view, locate the *Kubernetes Actions: Port Forward to Pod* policy. Click the overflow menu, {kebab}, and then select *Disable policy*.
 . Disable enforcement on any other custom policies that you have created by using criteria from the default *Kubernetes Actions: Port Forward to Pod* and *Kubernetes Actions: Exec into Pod* policies.

--- a/modules/disable-the-webhook.adoc
+++ b/modules/disable-the-webhook.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * dir/filename.adoc
+// * operating/use-admission-controller-enforcement.adoc
 :_mod-docs-content-type: PROCEDURE
 [id="disable-the-webhook_{context}"]
 = Disabling the webhook
@@ -17,8 +17,8 @@ If you disable the admission controller by turning off the webhook, you must red
 . Select an existing cluster from the list.
 . Turn off the *Enable Admission Controller Webhook to listen on exec and port-forward events* toggle in the *Static Configuration* section.
 . Select *Next* to continue with Sensor setup.
-. Click *Download YAML File and Keys*.
-. From a system that has access to the monitored cluster, unzip and run the `sensor` script:
+. Click *Download YAML file and keys*.
+. From a system that has access to the monitored cluster, extract and run the `sensor` script:
 +
 [source,terminal]
 ----
@@ -32,7 +32,7 @@ $ ./sensor/sensor.sh
 +
 [NOTE]
 ====
-If you get a warning that you do not have the required permissions to deploy the sensor, follow the on-screen instructions, or contact your cluster administrator for assistance.
+If you get a warning that you do not have the required permissions to deploy the sensor, follow the on-screen instructions, or contact your cluster administrator for help.
 ====
 After the sensor is deployed, it contacts Central and provides cluster information.
 . Return to the {product-title-short} portal and check if the deployment is successful.
@@ -54,7 +54,7 @@ $ kubectl get pod -n stackrox -w
 
 [NOTE]
 ====
-When you disable the admission controller, {product-title} does not delete the `ValidatingWebhookConfiguration`.
+When you disable the admission controller, {product-title-short} does not delete the `ValidatingWebhookConfiguration` parameter.
 However, instead of checking requests for violations, it accepts all `AdmissionReview` requests.
 
 To remove the `ValidatingWebhookConfiguration` object, run the following command in the secured cluster:

--- a/modules/enable-admission-controller-enforcement.adoc
+++ b/modules/enable-admission-controller-enforcement.adoc
@@ -10,25 +10,25 @@ You can enable admission controller enforcement from the *Clusters* view when yo
 
 .Procedure
 . In the {product-title-short} portal, go to *Platform Configuration* -> *Clusters*.
-. Select an existing cluster from the list or select *+ New Cluster*.
-. In the cluster configuration panel, enter the details for your cluster.
-. Red{nbsp}Hat recommends that you only turn on the *Configure Admission Controller Webhook to listen on creates* toggle if you are planning to use the admission controller to enforce on object create events.
-. Red{nbsp}Hat recommends that you only turn on the *Configure Admission Controller Webhook to listen on updates* toggle if you are planning to use the admission controller to enforce on update events.
+. Select an existing cluster from the list or secure a new cluster by selecting *Secure a cluster* -> *Legacy installation method*.
+. If you are securing a new cluster, in the *Static Configuration* section of the cluster configuration panel, enter the details for your cluster.
+. Red{nbsp}Hat recommends that you only turn on the *Configure Admission Controller Webhook to listen on Object Creates* toggle if you are planning to use the admission controller to enforce on object create events.
+. Red{nbsp}Hat recommends that you only turn on the *Configure Admission Controller Webhook to listen on Object Updates* toggle if you are planning to use the admission controller to enforce on update events.
 . Red{nbsp}Hat recommends that you only turn on the *Enable Admission Controller Webhook to listen on exec and port-forward events* toggle if you are planning to use the admission controller to enforce on pod execution and pod port forwards events.
-. Configure the following options:
+. Configure the following options in the *Dynamic Configuration* section:
 ** *Enforce on Object Creates*: This toggle controls the behavior of the admission control service.
-You must have the *Configure Admission Controller Webhook to listen on creates* toggle turned on for this to work.
+You must have the *Configure Admission Controller Webhook to listen on Object Creates* toggle turned on for this to work.
 ** *Enforce on Object Updates*: This toggle controls the behavior of the admission control service.
-You must have the *Configure Admission Controller Webhook to listen on updates* toggle turned on for this to work.
+You must have the *Configure Admission Controller Webhook to listen on Object Updates* toggle turned on for this to work.
 . Select *Next*.
-. In the *Download files* section, select *Download YAML Files and Keys*.
+. In the *Download files* section, select *Download YAML files and keys*.
 +
 [NOTE]
 ====
-When enabling admission controller for an existing cluster, if you make any changes in the:
+When enabling admission controller for an existing cluster, follow this guidance:
 
-* *Static Configuration* section, you must download the YAML files and redeploy the Sensor.
-* *Dynamic Configuration* section, you can skip downloading the files and deployment, as {product-title} automatically syncs the Sensor and applies the changes.
+* If you make any changes in the *Static Configuration* section, you must download the YAML files and redeploy the Sensor.
+* If you make any changes in the *Dynamic Configuration* section, you can skip downloading the files and deployment, as {product-title-short} automatically synchronizes the Sensor and applies the changes.
 ====
 . Select *Finish*.
 

--- a/modules/export-security-policy.adoc
+++ b/modules/export-security-policy.adoc
@@ -9,6 +9,6 @@
 When you export a policy, it includes all the policy contents and also includes cluster scopes, cluster exclusions, and all configured notifications.
 
 .Procedure
-. In the {product-title-short} portal, go to *Platform Configuration* -> *Policies*.
+. In the {product-title-short} portal, go to *Platform Configuration* -> *Policy Management*.
 . From the *Policies* page, select the policy you want to edit.
 . Select *Actions* -> *Export policy to JSON*.

--- a/modules/import-security-policy.adoc
+++ b/modules/import-security-policy.adoc
@@ -6,35 +6,35 @@
 = Importing a security policy
 
 [role="_abstract"]
-You can import a security policy from the *System Policies* view in the {product-title-short} portal.
+You can import a security policy from the *System Policies* view on the {product-title-short} portal.
 
 .Procedure
-. In the {product-title-short} portal, go to *Platform Configuration* -> *Policies*.
+. In the {product-title-short} portal, go to *Platform Configuration* -> *Policy Management*.
 . Click *Import  policy*.
 . In the *Import policy JSON* dialog, click *Upload* and select the JSON file you want to upload.
 . Click *Begin import*.
 
-Each security policy in {product-title} has a unique ID (UID) and a unique name.
-When you import a policy, {product-title} handles the uploaded policy as follows:
+Each security policy in {product-title-short} has a unique ID (UID) and a unique name.
+When you import a policy, {product-title-short} handles the uploaded policy as follows:
 
-* If the imported policy UID and name do not match any existing policy, {product-title} creates a new policy.
+* If the imported policy UID and name do not match any existing policy, {product-title-short} creates a new policy.
 * If the imported policy has the same UID as an existing policy, but a different name, you can either:
 ** Keep both policies.
-{product-title} saves the imported policy with a new UID.
+{product-title-short} saves the imported policy with a new UID.
 ** Replace the existing policy with the imported policy.
 * If the imported policy has the same name as an existing policy, but a different UID, you can either:
 ** Keep both policies by providing a new name for the imported policy.
 ** Replace the existing policy with the imported policy.
 * If the imported policy has the same name and UID as an existing policy, the {product-title} checks if the policy criteria match to the existing policy.
-If the policy criteria match, {product-title} keeps the existing policy and shows a success message.
+If the policy criteria match, {product-title-short} keeps the existing policy and shows a success message.
 If the policy criteria do not match, you can either:
 ** Keep both policies by providing a new name for the imported policy.
 ** Replace the existing policy with the imported policy.
 
 [IMPORTANT]
 ====
-* If you import into the same Central instance, {product-title} uses all the exported fields.
-* If you import into a different Central instance, {product-title} omits certain fields, such as cluster scopes, cluster exclusions, and notifications.
-{product-title} shows these omitted fields in a message.
+* If you import into the same Central instance, {product-title-short} uses all the exported fields.
+* If you import into a different Central instance, {product-title-short} omits certain fields, such as cluster scopes, cluster exclusions, and notifications.
+{product-title-short} shows these omitted fields in a message.
 These fields vary for every installation, and you cannot migrate them from one Central instance to another.
 ====

--- a/modules/integrate-ci-check-existing-build-phase-policies.adoc
+++ b/modules/integrate-ci-check-existing-build-phase-policies.adoc
@@ -3,12 +3,12 @@
 // * integration/integrate-with-ci-systems.adoc
 :_mod-docs-content-type: PROCEDURE
 [id="integrate-ci-check-existing-build-phase-policies_{context}"]
-= Checking existing build-phase policies
+= Checking existing build-time policies
 
-Use the {product-title-short} portal to check any existing build-phase policies that you have configured in {product-title}.
+Use the {product-title-short} portal to check any existing build-time policies that you have configured in {product-title}.
 
 .Procedure
 
-. In the {product-title-short} portal, go to *Platform Configuration* -> *Policies*.
+. In the {product-title-short} portal, go to *Platform Configuration* -> *Policy Management*.
 . Use global search to search for `Lifecycle Stage:Build`.
 //TODO: Add link for global search

--- a/modules/integrate-circle-ci.adoc
+++ b/modules/integrate-circle-ci.adoc
@@ -7,7 +7,7 @@
 
 You can integrate {product-title} with CircleCI.
 
-.Prerequisetes
+.Prerequisites
 * You have a token with `read` and `write` permissions for the `Image` resource.
 * You have a username and password for your Docker Hub account.
 
@@ -23,7 +23,7 @@ You can integrate {product-title} with CircleCI.
 . Create a directory called `.circleci` in the root directory of your local code repository for your selected project, if you do not already have a CircleCI configuration file.
 . Create a `config.yml` configuration file with the following lines in the `.circleci` directory:
 +
-[source,yml]
+[source,yaml]
 ----
 version: 2
 jobs:

--- a/modules/mark-violations-resolved.adoc
+++ b/modules/mark-violations-resolved.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * operating/respond-to-violations.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="mark-violations-resolved_{context}"]
+= Marking violations as resolved
+
+[role="_abstract"]
+
+If a policy that has runtime violations is deleted, attempted violations are not deleted from the *Violations* page. You can manually remove the violation by marking it as resolved.
+
+.Procedure
+
+. Select *Violations* and locate the violation in the list of violations.
+. Click the overflow menu, {kebab}, and then select one of the following options:
+* *Resolve and add to process baseline*: Resolves the violation and adds the associated process to the process baseline. If the process is executed again, a new violation will be displayed.
+* *Mark as resolved*: Resolves the violation.

--- a/modules/modify-existing-security-policies.adoc
+++ b/modules/modify-existing-security-policies.adoc
@@ -9,7 +9,7 @@
 You can edit the policies you have created and the existing default policies provided by {product-title}.
 
 .Procedure
-. In the {product-title-short} portal, go to *Platform Configuration* -> *Policies*.
+. In the {product-title-short} portal, go to *Platform Configuration* -> *Policy Management*.
 . From the *Policies* page, select the policy you want to edit.
 . Select *Actions* -> *Edit policy*.
 . Modify the *Policy details*. You can modify the policy name, severity, categories, description, rationale, and guidance.

--- a/modules/policy-criteria.adoc
+++ b/modules/policy-criteria.adoc
@@ -592,7 +592,7 @@ AND, OR
 *Runtime* (when used with a Runtime criterion)
 
 | Replicas
-| The number of deployment replicas.
+| The number of deployment replicas. If you use `oc scale` to scale the deployment replicas from 0 to a number, then the admission controller blocks this action if the deployment violates a policy.
 | Replicas
 | <, >, <=, >= or nothing (which implies equal to) +
 

--- a/modules/policy-enforcement-deploy.adoc
+++ b/modules/policy-enforcement-deploy.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * integration/integrate-with-ci-systems.adoc
+// * operating/manage-security-policies.adoc
+// * operating/respond-to-violations.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="policy-enforcement-deploy_{context}"]
+= Security policy enforcement for the deploy stage
+
+{product-title} supports two forms of security policy enforcement for deploy-time policies: hard enforcement through the admission controller and soft enforcement by {product-title-short} Sensor. The admission controller blocks creation or updating of deployments that violate policy. If the admission controller is disabled or unavailable, Sensor can perform enforcement by scaling down replicas for deployments that violate policy to `0`.
+
+[WARNING]
+====
+Policy enforcement can impact running applications or development processes. Before you enable enforcement options, inform all stakeholders and plan how to respond to the automated enforcement actions.
+====
+
+[id="hard-enforcement_{context}"]
+== Hard enforcement
+
+Hard enforcement is performed by the {product-title-short} admission controller. In clusters with admission controller enforcement, the Kubernetes or {ocp} API server blocks all noncompliant deployments. The admission controller blocks `CREATE` and `UPDATE` operations. Any pod create or update request that satisfies a policy configured with deploy-time enforcement enabled will fail.
+
+[NOTE]
+====
+Kubernetes admission webhooks support only `CREATE`, `UPDATE`, `DELETE`, or `CONNECT` operations. The {product-title-short} admission controller supports only `CREATE` and `UPDATE` operations. Operations such as `kubectl patch`, `kubectl set`, and `kubectl scale` are PATCH operations, not UPDATE operations. Because PATCH operations are not supported in Kubernetes, {product-title-short} cannot perform enforcement on PATCH operations.
+====
+
+For blocking enforcement, you must enable the following settings for the cluster in {product-title-short}:
+
+* *Enforce on Object Creates*: This toggle in the *Dynamic Configuration* section controls the behavior of the admission control service.
+You must have the *Configure Admission Controller Webhook to listen on Object Creates* toggle in the *Static Configuration* section turned on for this to work.
+* *Enforce on Object Updates*: This toggle in the *Dynamic Configuration* section controls the behavior of the admission control service.
+You must have the *Configure Admission Controller Webhook to listen on Object Updates* toggle in the *Static Configuration* section turned on for this to work.
+
+If you make changes to settings in the *Static Configuration* setting, you must redeploy the secured cluster for those changes to take effect.
+
+[id="soft-enforcement_{context}"]
+== Soft enforcement
+
+Soft enforcement is performed by {product-title-short} Sensor. This enforcement prevents an operation from being initiated. With soft enforcement, Sensor scales the replicas to 0, and prevents pods from being scheduled. In this enforcement, a non-ready deployment is available in the cluster.
+
+If soft enforcement is configured, and Sensor is down, then {product-title-short} cannot perform enforcement.
+
+[id="namespace-exclusions_{context}"]
+== Namespace exclusions
+
+By default, {product-title-short} excludes certain administrative namespaces, such as the `stackrox`, `kube-system`, and `istio-system` namespaces, from enforcement blocking. The reason for this is that some items in these namespaces must be deployed for {product-title-short} to work correctly.
+
+[id="enforcement-existing-deployments_{context}"]
+== Enforcement on existing deployments
+
+For existing deployments, policy changes only result in enforcement at the next detection of the criteria, when a Kubernetes event occurs. If you make changes to a policy, you must reassess policies by selecting *Policy Management* and clicking *Reassess All*. This action applies deploy policies on all existing deployments regardless of whether there are any new incoming Kubernetes events. If a policy is violated, then {product-title-short} performs enforcement.

--- a/modules/scan-inactive-images.adoc
+++ b/modules/scan-inactive-images.adoc
@@ -15,8 +15,8 @@ You can also configure {product-title-short} to scan inactive (not deployed) ima
 
 . In the {product-title-short} portal, go to *Vulnerability Management (2.0) -> Workload CVEs (Tech preview)*.
 . Click *<number> Images* to display a list of images and locate the image you want to watch.
-. Click {kebab}, and then select *Watch image*. {product-title-short} then scans the image and shows an error or success message.
-. (Optional) To remove a watched image, click {kebab}, and then select *Unwatch image*.
+. Click the overflow menu, {kebab}, and then select *Watch image*. {product-title-short} then scans the image and shows an error or success message.
+. (Optional) To remove a watched image, click the overflow menu, {kebab}, and then select *Unwatch image*.
 . (Optional) You can view the list of all watched images and add additional images to watch by clicking *Manage watched images* in the page header.
 +
 [IMPORTANT]

--- a/modules/understand-admission-controller-enforcement.adoc
+++ b/modules/understand-admission-controller-enforcement.adoc
@@ -12,7 +12,7 @@ Many standard Kubernetes libraries, such as fabric8, have short Kubernetes or {o
 Also, consider API timeouts in any custom automation you might be using.
 * *Image scanning*: You can choose whether the admission controller scans images while reviewing requests by setting the *Contact Image Scanners* option in the cluster configuration panel.
 ** If you enable this setting, {product-title} contacts the image scanners if the scan or image signature verification results are not already available, which adds considerable latency.
-** If you disable this setting, the enforcement decision only considers image scan criteria if cached scan and signature verfication results are available.
+** If you disable this setting, the enforcement decision only considers image scan criteria if cached scan and signature verification results are available.
 * You can use admission controller enforcement for:
 ** Options in the pod `securityContext`.
 ** Deployment configurations.
@@ -20,8 +20,8 @@ Also, consider API timeouts in any custom automation you might be using.
 * You cannot use admission controller enforcement for:
 ** Any runtime behavior, such as processes.
 ** Any policies based on port exposure.
-* The admission controller might fail if there are connectivity issues between the Kubernetes or {ocp} API server and {product-title} Sensor.
+* The admission controller might fail if there are connectivity issues between the Kubernetes or {ocp} API server and {product-title-short} Sensor.
 To resolve this issue, delete the `ValidatingWebhookConfiguration` object as described in the disabling admission controller enforcement section.
 //link to Disable admission controller enforcement
-* If you have deploy-time enforcement enabled for a policy and you enable the admission controller, {product-title} attempts to block deployments that violate the policy.
-If a non-compliant deployment is not rejected by the admission controller, for example, in case of a timeout, {product-title} still applies other deploy-time enforcement mechanisms, such as scaling to zero replicas.
+* If you have deploy-time enforcement enabled for a policy and you enable the admission controller, {product-title-short} attempts to block deployments that violate the policy.
+If a noncompliant deployment is not rejected by the admission controller, for example, in case of a timeout, {product-title-short} still applies other deploy-time enforcement mechanisms, such as scaling to zero replicas.

--- a/modules/validatingwebhookconfiguration-yaml-changes.adoc
+++ b/modules/validatingwebhookconfiguration-yaml-changes.adoc
@@ -5,7 +5,7 @@
 [id="validatingwebhookconfiguration-yaml-changes_{context}"]
 = ValidatingWebhookConfiguration YAML file changes
 
-With {product-title} you can enfore security policies on:
+With {product-title} you can enforce security policies on:
 
 * Object creation
 * Object update

--- a/modules/view-network-baselines-ng20.adoc
+++ b/modules/view-network-baselines-ng20.adoc
@@ -13,7 +13,7 @@ You can view network baselines from the network graph view.
 . In the network graph, click on a deployment to view the information panel.
 . Select the *Baseline* tab. Use the *filter by entity name* field to further restrict the flows that are displayed.
 . Optional: You can mark baseline flows as anomalous by performing one of the following actions:
-* Select an individual entity, and then click {kebab} and select *Mark as anomalous*.
+* Select an individual entity. Click the overflow menu, {kebab}, and then select *Mark as anomalous*.
 * Select multiple entities, and then click *Bulk actions* and select *Mark as anomalous*.
 . Optional: Check the box to exclude ports and protocols.
 . Optional: To save the baseline as a network policy YAML file, click *Download baseline as network policy*.

--- a/modules/violation-view-policy-tab.adoc
+++ b/modules/violation-view-policy-tab.adoc
@@ -35,7 +35,9 @@ The *Policy behavior* section provides the following information:
 ** *Inform and enforce*: The violation is enforced.
 * *Enforcement*: If the response is set to *Inform and enforce*, lists the type of enforcement that is set for the following stages:
 ** *Build*: {product-title-short} fails your continuous integration (CI) builds when images match the criteria of the policy.
-** *Deploy*: {product-title-short} blocks creation of deployments that match the conditions of the policy. In clusters with admission controller enforcement, the Kubernetes or {ocp} API server blocks all noncompliant deployments. In other clusters, {product-title-short} edits noncompliant deployments to prevent pods from being scheduled.
+** *Deploy*: For the *Deploy* stage, {product-title-short} blocks the creation and update of deployments that match the conditions of the policy if the {product-title-short} admission controller is configured and running.
+*** In clusters with admission controller enforcement, the Kubernetes or {ocp} API server blocks all noncompliant deployments. In other clusters, {product-title-short} edits noncompliant deployments to prevent pods from being scheduled.
+*** For existing deployments, policy changes only result in enforcement at the next detection of the criteria, when a Kubernetes event occurs. For more information about enforcement, see "Security policy enforcement for the deploy stage".
 ** *Runtime*: {product-title-short} deletes all pods when an event in the pods matches the criteria of the policy.
 
 [discrete]

--- a/modules/vulnerability-management-accept-risks.adoc
+++ b/modules/vulnerability-management-accept-risks.adoc
@@ -18,7 +18,8 @@ To accept risk with or without mitigation:
 . On the *Dashboard* view header, select *Images*.
 . From the list of images, select the image you already assessed.
 . Find the row which lists the CVE you would like to take action on.
-. Click {kebab} on the right for the CVE you identified and click *Defer CVE*.
+. Click the overflow menu, {kebab}, for the CVE you identified.
+. Click *Defer CVE*.
 . Select the date and time till you want to defer the CVE.
 . Select if you want to defer the CVE for the selected image tag or all tags for this image.
 . Enter the reason for the deferral.

--- a/modules/vulnerability-management20-delete-reports.adoc
+++ b/modules/vulnerability-management20-delete-reports.adoc
@@ -10,4 +10,4 @@ Deleting a report configuration deletes the configuration and any reports that w
 
 .Procedure
 . In the {product-title-short} web portal, go to *Vulnerability Management (2.0)* -> *Vulnerability Reporting* and locate the report configuration that you want to delete in the list of reports.
-. Click {kebab}. Then, select *Delete report*.
+. Click the overflow menu, {kebab}, and then select *Delete report*.

--- a/modules/vulnerability-management20-download-reports.adoc
+++ b/modules/vulnerability-management20-download-reports.adoc
@@ -17,8 +17,7 @@ You can only download reports that you have generated; you cannot download repor
 . In the {product-title-short} web portal, go to *Vulnerability Management (2.0)* -> *Vulnerability Reporting* and, in the list of report configurations, locate the report configuration that you want to use to create the downloadable report.
 . Generate the vulnerability report by using one of the following methods:
 * To generate the report from the list:
-.. Click {kebab}.
-.. Select *Generate download*. The *My active job status* column displays the status of your report creation. After the *Processing* status goes away, you can download the report.
+.. Click the overflow menu, {kebab}, and then select *Generate download*. The *My active job status* column displays the status of your report creation. After the *Processing* status goes away, you can download the report.
 * To generate the report from the report window:
 .. Click the report configuration name to open the configuration detail window.
 .. Click *Actions* and select *Generate download*.

--- a/modules/vulnerability-management20-edit-reports.adoc
+++ b/modules/vulnerability-management20-edit-reports.adoc
@@ -10,6 +10,6 @@ You can edit existing vulnerability report configurations from the list of repor
 
 .Procedure
 . To edit an existing vulnerability report configuration, in the {product-title-short} web portal, go to *Vulnerability Management (2.0)* -> *Vulnerability Reporting* and choose one of the following methods:
-* Locate the report configuration that you want to edit in the list of report configurations and click {kebab}. Then, select *Edit report*.
-* Click on the report configuration name in the list of report configurations. Then, click *Actions* and select *Edit report*.
+* Locate the report configuration that you want to edit in the list of report configurations. Click the overflow menu, {kebab}, and then select *Edit report*.
+* Click the report configuration name in the list of report configurations. Then, click *Actions* and select *Edit report*.
 . Make changes to the report configuration and save.

--- a/modules/vulnerability-management20-send-reports.adoc
+++ b/modules/vulnerability-management20-send-reports.adoc
@@ -10,4 +10,4 @@ You can send vulnerability reports immediately, rather than waiting for the sche
 
 .Procedure
 . In the {product-title-short} web portal, go to *Vulnerability Management (2.0)* -> *Vulnerability Reporting* and, in the list of report configurations, locate the report configuration for the report that you want to send.
-. Click {kebab}. Then, select *Send report now*.
+. Click the overflow menu, {kebab}, and then select *Send report now*.

--- a/operating/manage-security-policies.adoc
+++ b/operating/manage-security-policies.adoc
@@ -40,9 +40,12 @@ To build a new policy, you can clone an existing policy or create a new one from
 
 include::modules/create-policy-from-system-policies-view.adoc[leveloffset=+2]
 
+include::modules/policy-enforcement-deploy.adoc[leveloffset=+3]
+
 [role="_additional-resources"]
 .Additional resources
 * xref:../operating/manage-security-policies.adoc#policy-criteria_manage-security-policies[Policy criteria]
+* xref:../operating/use-admission-controller-enforcement.adoc#use-admission-controller-enforcement[Using admission controller enforcement]
 
 include::modules/create-policy-from-risk-view.adoc[leveloffset=+2]
 

--- a/operating/respond-to-violations.adoc
+++ b/operating/respond-to-violations.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 [id="respond-to-violations"]
 = Responding to violations
 include::modules/common-attributes.adoc[]
@@ -13,6 +14,8 @@ Whether you use the default out-of-box security policies or use your own custom 
 
 include::modules/violations-view.adoc[leveloffset=+1]
 
+include::modules/mark-violations-resolved.adoc[leveloffset=+2]
+
 [id="view-violation-details"]
 == Viewing violation details
 When you select a violation in the *Violations* view, a window opens with more information about the violation. It provides detailed information grouped by multiple tabs.
@@ -25,3 +28,11 @@ include::modules/violation-view-violation-tab.adoc[leveloffset=+2]
 include::modules/violations-view-deployment-tab.adoc[leveloffset=+2]
 
 include::modules/violation-view-policy-tab.adoc[leveloffset=+2]
+
+include::modules/policy-enforcement-deploy.adoc[leveloffset=+3]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../operating/use-admission-controller-enforcement.adoc#use-admission-controller-enforcement[Using admission controller enforcement]
+

--- a/operating/use-admission-controller-enforcement.adoc
+++ b/operating/use-admission-controller-enforcement.adoc
@@ -9,13 +9,13 @@ toc::[]
 //note that link below to OCP docs has to be done this way because the branch is separate from the {product-title-short} branch so an xref cannot be used.
 {product-title} works with link:https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/[Kubernetes admission controllers] and link:https://docs.openshift.com/container-platform/4.12/architecture/admission-plug-ins.html[{ocp} admission plugins] to allow you to enforce security policies before Kubernetes or {ocp} creates workloads, for example, deployments, daemon sets or jobs.
 
-The {product-title} admission controller prevents users from creating workloads that violate policies you configure in {product-title}.
-Beginning from the {product-title} version 3.0.41, you can also configure the admission controller to prevent updates to workloads that violate policies.
+The {product-title-short} admission controller prevents users from creating workloads that violate policies you configure in {product-title-short}.
+Beginning from the {product-title-short} version 3.0.41, you can also configure the admission controller to prevent updates to workloads that violate policies.
 
-{product-title} uses the `ValidatingAdmissionWebhook` controller to verify that the resource being provisioned complies with the specified security policies.
-To handle this, {product-title} creates a `ValidatingWebhookConfiguration` which contains multiple webhook rules.
+{product-title-short} uses the `ValidatingAdmissionWebhook` controller to verify that the resource being provisioned complies with the specified security policies.
+To handle this, {product-title-short} creates a `ValidatingWebhookConfiguration` which contains multiple webhook rules.
 
-When the Kubernetes or {ocp} API server receives a request that matches one of the webhook rules, the API server sends an `AdmissionReview` request to {product-title}. {product-title} then accepts or rejects the request based on the configured security policies.
+When the Kubernetes or {ocp} API server receives a request that matches one of the webhook rules, the API server sends an `AdmissionReview` request to {product-title-short}. {product-title-short} then accepts or rejects the request based on the configured security policies.
 
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):
4.4+

Issues:

- [ROX-21163](https://issues.redhat.com/browse/ROX-21163)
- [ROX-16486](https://issues.redhat.com/browse/ROX-16486)
- [ROX-14410](https://issues.redhat.com/browse/ROX-14410)

Link to docs previews:

Item about new inform/enforce behavior & scaling:

- https://74060--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-security-policies#policy-criteria_manage-security-policies - Look at "Replicas" item in table.

Changes to clarify when ACS scales down deployments when enforcing policies:

- https://74060--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-security-policies#policy-enforcement-deploy_manage-security-policies
- https://74060--ocpdocs-pr.netlify.app/openshift-acs/latest/integration/integrate-with-ci-systems#create-new-system-policy_integrate-with-ci-systems
- https://74060--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-security-policies#create-policy-from-system-policies-view_manage-security-policies
- https://74060--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/respond-to-violations

Changes to mark violations that aren't deleted as resolved:

- https://74060--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/respond-to-violations#mark-violations-resolved_respond-to-violations

Other minor changes:
- https://74060--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/use-admission-controller-enforcement#understand-admission-controller-enforcement_use-admission-controller-enforcement
- https://74060--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/use-admission-controller-enforcement#disable-associated-policies_use-admission-controller-enforcement
- https://74060--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/use-admission-controller-enforcement#disable-the-webhook_use-admission-controller-enforcement
- https://74060--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/use-admission-controller-enforcement#enable-admission-controller-enforcement_use-admission-controller-enforcement
- https://74060--ocpdocs-pr.netlify.app/openshift-acs/latest/integration/integrate-with-email#configure-policy-notifications_integrate-with-email
- https://74060--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-security-policies#export-security-policy_manage-security-policies
- https://74060--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-security-policies#import-security-policy_manage-security-policies
- https://74060--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-security-policies#modify-existing-security-policies_manage-security-policies

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Also fixed style issues, typos.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
