### PR TITLE
OSDOCS-10128: Fixing terminology of 4.15.5 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -250,5 +250,5 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-15-5-enhancements"]
 ==== Enhancements
 
-Change in openshift-marketplace namespace security::
-* With this release, the `openshift-marketplace` namespace security defaults to `baseline`. See the OLM documentation for specifics on how this change impacts your operator deployments. See xref:../microshift_running_apps/microshift-operators-olm.adoc#microshift-operators-olm[Using Operator Lifecycle Manager with {microshift-short}]. (link:https://issues.redhat.com/browse/OCPBUGS-30034[OCPBUGS-30034])
+Change in openshift-marketplace pod security admission definition::
+* With this release, the `openshift-marketplace` pod security admission definition defaults to `baseline`. See the OLM documentation for specifics on how this change impacts your operator deployments. See xref:../microshift_running_apps/microshift-operators-olm.adoc#microshift-operators-olm[Using Operator Lifecycle Manager with {microshift-short}]. (link:https://issues.redhat.com/browse/OCPBUGS-30034[OCPBUGS-30034])


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-10128](https://issues.redhat.com/browse/OSDOCS-10128)

Link to docs preview:
[4.15.5 async release note](https://74063--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-5-dp)

QE review:
- [ ] QE approval not required for this change.
