### PR TITLE
OSSM-6247 Add Kiali and OSSMC plugin attributes to common-attributes.adoc

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -170,6 +170,9 @@ endif::[]
 :SMProductShortName: Service Mesh
 :SMProductVersion: 2.5
 :MaistraVersion: 2.5
+:KialiProduct: Kiali Operator provided by Red Hat
+:SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin
+:SMPluginShort: OSSMC plugin
 //Service Mesh v1
 :SMProductVersion1x: 1.1.18.2
 //Windows containers
@@ -198,7 +201,7 @@ endif::[]
 //:openshift-networking: OKD Networking
 //endif::[]
 // logical volume manager storage
-:lvms-first: Logical Volume Manager (LVM) Storage 
+:lvms-first: Logical Volume Manager (LVM) Storage
 :lvms: LVM Storage
 //Operator SDK version
 :osdk_ver: 1.31.0


### PR DESCRIPTION
[OSSM-6247](https://issues.redhat.com//browse/OSSM-6247) Add Kiali and OSSMC plugin attributes to common-attributes.adoc

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSSM-6247

Link to docs preview:
N/A

QE review:
QE review is not needed for this PR.

Additional information:
Adds 3 attributes under //service mesh v2:

:KialiProduct: Kiali Operator provided by Red Hat
:SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin
:SMPluginShort: OSSMC plugin


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
