### PR TITLE
[WIP] OSDOCS#10130: x86 compute nodes with ARM64 control plane docs

### DIFF
--- a/modules/multi-architecture-modify-machine-set-aws.adoc
+++ b/modules/multi-architecture-modify-machine-set-aws.adoc
@@ -7,23 +7,25 @@
 
 = Adding an ARM64 compute machine set to your cluster
 
-To configure a cluster with multi-architecture compute machines, you must create a AWS ARM64 compute machine set. This adds ARM64 compute nodes to your cluster so that your cluster has multi-architecture compute machines.
+To configure a cluster with multi-architecture compute machines, you must create a AWS ARM64 or AMD64 compute machine set. This adds ARM64 or AMD64 compute nodes to your cluster so that your cluster has multi-architecture compute machines.
 
 .Prerequisites
 
 * You installed the OpenShift CLI (`oc`).
-* You used the installation program to create an AMD64 single-architecture AWS cluster with the multi-architecture installer binary.
+* You used the installation program to create an AMD64 or ARM64 single-architecture AWS cluster with the multi-architecture installer binary.
 
 
 .Procedure
-* Create and modify a compute machine set, this will control the ARM64 compute nodes in your cluster.
+* Create and modify a compute machine set, this will control the ARM64 or AMD64 compute nodes in your cluster.
 +
 --
 [source,terminal]
 ----
 $ oc create -f aws-arm64-machine-set-0.yaml
 ----
-.Sample YAML compute machine set to deploy an ARM64 compute node
+The following YAML configuration is an example for an ARM64 compute node:
+
+.Example YAML compute machine
 
 [source,yaml]
 ----

--- a/modules/multi-architecture-modify-machine-set-gcp.adoc
+++ b/modules/multi-architecture-modify-machine-set-gcp.adoc
@@ -6,12 +6,12 @@
 [id="multi-architecture-modify-machine-set-gcp_{context}"]
 = Adding an ARM64 compute machine set to your GCP cluster
 
-To configure a cluster with multi-architecture compute machines, you must create a GCP ARM64 compute machine set. This adds ARM64 compute nodes to your cluster.
+To configure a cluster with multi-architecture compute machines, you must create a GCP ARM64 or AMD64 compute machine set. This adds ARM64 or AMD64 compute nodes to your cluster.
 
 .Prerequisites
 
 * You installed the {oc-first}.
-* You used the installation program to create an AMD64 single-architecture AWS cluster with the multi-architecture installer binary.
+* You used the installation program to create an AMD64 or ARM64 single-architecture AWS cluster with the multi-architecture installer binary.
 
 .Procedure
 * Create and modify a compute machine set, this controls the ARM64 compute nodes in your cluster:

--- a/modules/multi-architecture-modify-machine-set.adoc
+++ b/modules/multi-architecture-modify-machine-set.adoc
@@ -7,21 +7,25 @@
 
 = Adding a multi-architecture compute machine set to your cluster
 
-To add ARM64 compute nodes to your cluster, you must create an Azure compute machine set that uses the ARM64 boot image. To create your own custom compute machine set on Azure, see "Creating a compute machine set on Azure".
+You can add ARM64 or AMD64 compute nodes to your cluster. To add ARM64 compute nodes to your cluster, you must create an Azure compute machine set that uses the ARM64 boot image. To create your own custom compute machine set on Azure, see "Creating a compute machine set on Azure".
 
 .Prerequisites
 
 * You installed the OpenShift CLI (`oc`).
+* You used the installation program to create an AMD64 or ARM64 single-architecture AWS cluster with the multi-architecture installer binary.
 
 .Procedure
-* Create a compute machine set and modify the `resourceID` and `vmSize` parameters with the following command. This compute machine set will control the `arm64` worker nodes in your cluster:
+
+* Create a compute machine set and modify the `resourceID` and `vmSize` parameters with the following command. This compute machine set will control the ARM64 or AMD64 compute nodes in your cluster:
 +
 [source,terminal]
 ----
 $ oc create -f arm64-machine-set-0.yaml
 ----
-.Sample YAML compute machine set with `arm64` boot image
 +
+The following YAML configuration is an example for an ARM64 compute node:
++
+.Example YAML compute machine
 [source,yaml]
 ----
 apiVersion: machine.openshift.io/v1beta1

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-aws.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-aws.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-To create an AWS cluster with multi-architecture compute machines, you must first create a single-architecture AWS installer-provisioned cluster with the multi-architecture installer binary. For more information on AWS installations, refer to xref:../../installing/installing_aws/installing-aws-customizations.adoc[Installing a cluster on AWS with customizations]. You can then add a ARM64 compute machine set to your AWS cluster.
+To create an AWS cluster with multi-architecture compute machines, you must first create a single-architecture AWS installer-provisioned cluster with the multi-architecture installer binary. For more information on AWS installations, refer to xref:../../installing/installing_aws/installing-aws-customizations.adoc[Installing a cluster on AWS with customizations]. You can then add a ARM64 or AMD64 compute machine set to your AWS cluster.
 
 include::modules/multi-architecture-verifying-cluster-compatibility.adoc[leveloffset=+1]
 
@@ -15,4 +15,3 @@ include::modules/multi-architecture-modify-machine-set-aws.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../installing/installing_aws/installing-aws-customizations.adoc#installation-aws-arm-tested-machine-types_installing-aws-customizations[Tested instance types for AWS 64-bit ARM]
-

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-azure.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-azure.adoc
@@ -6,9 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-To deploy an Azure cluster with multi-architecture compute machines, you must first create a single-architecture Azure installer-provisioned cluster that uses the multi-architecture installer binary. For more information on Azure installations, see xref:../../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-customizations[Installing a cluster on Azure with customizations]. You can then add an ARM64 compute machine set to your cluster to create a cluster with multi-architecture compute machines.
+To deploy an Azure cluster with multi-architecture compute machines, you must first create a single-architecture Azure installer-provisioned cluster that uses the multi-architecture installer binary. For more information on Azure installations, see xref:../../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-customizations[Installing a cluster on Azure with customizations]. You can then add an ARM64 or AMD64 compute machine set to your cluster to create a cluster with multi-architecture compute machines.
 
-The following procedures explain how to generate an ARM64 boot image and create an Azure compute machine set that uses the ARM64 boot image. This adds ARM64 compute nodes to your cluster and deploys the amount of ARM64 virtual machines (VM) that you need.
+For a cluster with ARM64 compute machines, the following procedure explain how to generate an ARM64 boot image and create an Azure compute machine set that uses the ARM64 boot image. You can add compute nodes to your cluster and deploys the amount of ARM64 or AMD64 virtual machines (VM) that you need.
 
 include::modules/multi-architecture-verifying-cluster-compatibility.adoc[leveloffset=+1]
 

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-bare-metal.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-bare-metal.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-To create a cluster with multi-architecture compute machines on bare metal (`x86_64`), {ibm-power-name} (`ppc64le`), or {ibm-z-name} (`s390x`) you must have an existing single-architecture cluster on one of these platforms. Follow the installations procedures for your platform:
+To create a cluster with multi-architecture compute machines on bare metal (`x86_64` or `aarch64`), {ibm-power-name} (`ppc64le`), or {ibm-z-name} (`s390x`) you must have an existing single-architecture cluster on one of these platforms. Follow the installations procedures for your platform:
 
 * xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[Installing a user provisioned cluster on bare metal]. You can then add 64-bit ARM compute machines to your {product-title} cluster on bare metal.
 * xref:../../installing/installing_ibm_power/preparing-to-install-on-ibm-power.adoc#preparing-to-install-on-ibm-power[Installing a cluster on {ibm-power-name}]. You can then add `x86_64` compute machines to your {product-title} cluster on {ibm-power-name}.

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-gcp.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-gcp.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-To create a Google Cloud Platform (GCP) cluster with multi-architecture compute machines, you must first create a single-architecture GCP installer-provisioned cluster with the multi-architecture installer binary. For more information on AWS installations, refer to xref:../../installing/installing_gcp/installing-gcp-customizations.adoc[Installing a cluster on GCP with customizations]. You can then add ARM64 compute machines sets to your GCP cluster.
+To create a Google Cloud Platform (GCP) cluster with multi-architecture compute machines, you must first create a single-architecture GCP installer-provisioned cluster with the multi-architecture installer binary. For more information on AWS installations, refer to xref:../../installing/installing_gcp/installing-gcp-customizations.adoc[Installing a cluster on GCP with customizations]. You can then add ARM64 or AMD64 compute machines sets to your GCP cluster.
 
 [NOTE]
 ====

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-configuration.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-configuration.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-An {product-title} cluster with multi-architecture compute machines is a cluster that supports compute machines with different architectures. Clusters with multi-architecture compute machines are available only on Amazon Web Services (AWS) or Microsoft Azure installer-provisioned infrastructures and bare metal, {ibm-power-name}, and {ibm-z-name} user-provisioned infrastructures with 64-bit x86 control plane machines.
+An {product-title} cluster with multi-architecture compute machines is a cluster that supports compute machines with different architectures. 
 
 [NOTE]
 ====
@@ -33,29 +33,29 @@ To create a cluster with multi-architecture compute machines with different inst
 |Microsoft Azure
 |
 |&#10003;
-|`x86_64`
-|`aarch64`
+|`x86_64` or `aarch64`
+|`aarch64`, `x86_64` 
 
 |xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-aws.adoc#creating-multi-arch-compute-nodes-aws[Creating a cluster with multi-architecture compute machines on AWS]
 |Amazon Web Services (AWS)
 |
 |&#10003;
-|`x86_64`
-|`aarch64`
+|`x86_64` or `aarch64`
+|`aarch64`, `x86_64` 
 
 |xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-gcp.adoc#creating-multi-arch-compute-nodes-gcp[Creating a cluster with multi-architecture compute machines on GCP]
 |Google Cloud Platform (GCP)
 |
 |&#10003;
-|`x86_64`
-|`aarch64`
+|`x86_64` or `aarch64`
+|`aarch64`, `x86_64` 
 
 .3+|xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-bare-metal.adoc#creating-multi-arch-compute-nodes-bare-metal[Creating a cluster with multi-architecture compute machines on bare metal, {ibm-power-title}, or {ibm-z-title}]
 |Bare metal
 |&#10003;
 |
-|`x86_64`
-|`aarch64`
+|`x86_64` or `aarch64`
+|`aarch64`, `x86_64` 
 
 |{ibm-power-title}
 |&#10003;


### PR DESCRIPTION
**Version(s):** 4.16+
**Issue:** [OSDOCS-10130](https://issues.redhat.com//browse/OSDOCS-10130)

**Link to docs preview:**
- [About clusters with multi-architecture compute machines](https://74067--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-configuration)
- [Creating a cluster with multi-architecture compete machines on Azure](https://74067--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-azure.html)
- [Creating a cluster with multi-architecture compute machines on AWS](https://74067--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-aws)
- [Creating a cluster with multi-architecture compute machines on GCP](https://74067--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-gcp)
- [Creating a cluster with multi-architecture compute machines on bare metal, IBM Power, or IBM Z](https://74067--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-bare-metal)

**QE review:**
- [ ] QE has approved this change.