### PR TITLE
HCIDOCS-246: modify supported firmware for baremetal deployment on Dell

### DIFF
--- a/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
+++ b/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
@@ -27,9 +27,8 @@ Red Hat does not test every combination of firmware, hardware, or other third-pa
 |====
 | Model | Management | Firmware versions
 
-| 15th Generation | iDRAC 9 | v6.10.30.00
+| 15th Generation | iDRAC 9 | v6.10.30.00 and v7.00.60.00
 | 14th Generation | iDRAC 9 | v6.10.30.00
-
 | 13th Generation .2+| iDRAC 8 | v2.75.75.75 or later
 
 |====


### PR DESCRIPTION
Added a new firmware version for 15th Gen Dell hardware.

Fixes: [HCIDOCS-246](https://issues.redhat.com//browse/HCIDOCS-246)

See https://issues.redhat.com/browse/HCIDOCS-246 for additional details.

Preview URL: http://jowilkin.com:8080/HCIDOCS-246/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#ipi-install-firmware-requirements-for-installing-with-virtual-media_ipi-install-prerequisites

For release(s): 4.16, 4.15
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
