### PR TITLE
CherryPick-4.13-OADP-3084-GCP-WIF-VSL-backup-PartiallyFailed-for-PR#72963

### DIFF
--- a/modules/oadp-gcp-wif-cloud-authentication.adoc
+++ b/modules/oadp-gcp-wif-cloud-authentication.adoc
@@ -12,10 +12,9 @@ With Google's workload identity federation you can use Identity and Access Manag
 
 Workload identity federation handles encrypting and decrypting certificates, extracting user attributes, and validation. Identity federation externalizes authentication, passing it over to Security Token Services (STS), and reduces the demands on individual developers. Authorization and controlling access to resources remain the responsibility of the application.
 
-[NOTE]
-====
-Google workload identity federation is available for OADP 1.3.x and later.
-====
+When backing up volumes, OADP on GCP with Google workload identity federation authentication only supports CSI snapshots.
+
+OADP on GCP with Google workload identity federation authentication does not support Volume Snapshot Locations (VSL) backups. For more details, see xref:oadp-gcp-wif-known-issues[Google workload identity federation known issues].
 
 If you do not use Google workload identity federation cloud authentication, continue to _Installing the Data Protection Application_.
 
@@ -92,4 +91,8 @@ $ oc create namespace <OPERATOR_INSTALL_NS>
 $ oc apply -f manifests/openshift-adp-cloud-credentials-gcp-credentials.yaml
 ----
 
+[id="oadp-gcp-wif-known-issues"]
+== Google workload identity federation known issues
+
+* Volume Snapshot Location (VSL) backups finish with a `PartiallyFailed` phase when GCP workload identity federation is configured. Google workload identity federation authentication does not support VSL backups.
 


### PR DESCRIPTION
### Cherry pick for 4.13

* [See PR](https://github.com/openshift/openshift-docs/pull/72963) - Applies to 4.13 

Cherry Picked from 72963 xref: https://github.com/openshift/openshift-docs/pull/72963

### JIRA

* [OADP-3084](https://issues.redhat.com/browse/OADP-3084)



### Version(s):

* enterprise-4.13

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
