### PR TITLE
OSSM-6194 Update Kiali docs for Tracing port

### DIFF
--- a/modules/ossm-configuring-distr-tracing-tempo.adoc
+++ b/modules/ossm-configuring-distr-tracing-tempo.adoc
@@ -68,9 +68,11 @@ spec:
     tracing:
       query_timeout: 30
       enabled: true
-      in_cluster_url: 'http://tempo-sample-query-frontend.tracing-system.svc.cluster.local:16686'
+      in_cluster_url: 'http://tempo-sample-query-frontend.tracing-system.svc.cluster.local:16685'
       url: '[Tempo query frontend Route url]'
+      use_grpc: true # <1>
 ----
+<1> If you are not using the default HTTP or gRPC port for Jaeger or Tempo, replace the `in_cluster_url:` port with your custom port.
 +
 [NOTE]
 ====


### PR DESCRIPTION
[OSSM-6194](https://issues.redhat.com//browse/OSSM-6194) Update Kiali docs for Tracing port

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSSM-6194

Link to docs preview:
https://74090--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-observability#ossm-configuring-distr-tracing-tempo_observability 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
