### PR TITLE
Example output  of machine name should start with <infrastructure_id>

### DIFF
--- a/modules/cpmso-limitations.adoc
+++ b/modules/cpmso-limitations.adoc
@@ -25,9 +25,9 @@ $ oc get machine \
 [source,text]
 ----
 NAME                    PHASE     TYPE         REGION      ZONE         AGE
-<cluster_id>-master-0   Running   m6i.xlarge   us-west-1   us-west-1a   5h19m
-<cluster_id>-master-1   Running   m6i.xlarge   us-west-1   us-west-1b   5h19m
-<cluster_id>-master-2   Running   m6i.xlarge   us-west-1   us-west-1a   5h19m
+<infrastructure_id>-master-0   Running   m6i.xlarge   us-west-1   us-west-1a   5h19m
+<infrastructure_id>-master-1   Running   m6i.xlarge   us-west-1   us-west-1b   5h19m
+<infrastructure_id>-master-2   Running   m6i.xlarge   us-west-1   us-west-1a   5h19m
 ----
 +
 .Example output missing preexisting control plane machines


### PR DESCRIPTION
Example output  of machine name should start with <infrastructure_id> not by <cluster_id>

```
bash-4.4$ oc get machine -n openshift-machine-api -l machine.openshift.io/cluster-api-machine-role=master
NAME                               PHASE     TYPE        REGION       ZONE          AGE
bshawocp414-9j9qw-master-fn6h6-2   Running   m5.xlarge   ap-south-1   ap-south-1c   18m
bshawocp414-9j9qw-master-qsdmb-0   Running   m5.xlarge   ap-south-1   ap-south-1a   37m
bshawocp414-9j9qw-master-w7l4l-1   Running   m5.xlarge   ap-south-1   ap-south-1b   68m
bash-4.4$ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
bshawocp414-9j9qw
bash-4.4$ 
bash-4.4$ oc get clusterversion -o jsonpath='{.items[].spec.clusterID}{"\n"}'
405c0a4e-2a9f-414b-a733-2e3f54f7166b
```

Version(s):
4.12, 4.13, 4.14, 4.15

Issue:
https://issues.redhat.com/browse/OCPBUGS-31659

Link to docs preview:
https://docs.openshift.com/container-platform/4.12/machine_management/control_plane_machine_management/cpmso-about.html#cpmso-limitations_cpmso-about

