### PR TITLE
OCPBUGS-31272: Changing PrometheusRule to AlertingRule

### DIFF
--- a/modules/network-observability-includelist-example.adoc
+++ b/modules/network-observability-includelist-example.adoc
@@ -4,7 +4,7 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-netobserv-dashboard-high-traffic-alert_{context}"]
 = Creating alerts
-You can create custom Prometheus rules for the Netobserv dashboard metrics to trigger alerts when some defined conditions are met.
+You can create custom alerting rules for the Netobserv dashboard metrics to trigger alerts when some defined conditions are met.
 
 .Prerequisites
 
@@ -18,11 +18,11 @@ You can create custom Prometheus rules for the Netobserv dashboard metrics to tr
 +
 [source,yaml]
 ----
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
+apiVersion: monitoring.openshift.io/v1
+kind: AlertingRule
 metadata:
   name: netobserv-alerts
-  namespace: openshift-netobserv-operator
+  namespace: openshift-monitoring
 spec:
   groups:
   - name: NetObservAlerts

--- a/modules/network-observability-rate-limit-alert.adoc
+++ b/modules/network-observability-rate-limit-alert.adoc
@@ -4,7 +4,7 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-netobserv-dashboard-rate-limit-alerts_{context}"]
 = Creating Loki rate limit alerts for the NetObserv dashboard
-You can create custom Prometheus rules for the *Netobserv* dashboard metrics to trigger alerts when Loki rate limits have been reached.
+You can create custom alerting rules for the *Netobserv* dashboard metrics to trigger alerts when Loki rate limits have been reached.
 
 .Prerequisites
 
@@ -18,11 +18,11 @@ You can create custom Prometheus rules for the *Netobserv* dashboard metrics to 
 +
 [source,yaml]
 ----
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
+apiVersion: monitoring.openshift.io/v1
+kind: AlertingRule
 metadata:
   name: loki-alerts
-  namespace: openshift-netobserv-operator
+  namespace: openshift-monitoring
 spec:
   groups:
   - name: LokiRateLimitAlerts


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-31272
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
Monitoring the Network Observability Operator: https://74099--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-monitoring.html#network-observability-netobserv-dashboard-rate-limit-alerts_network_observability

Using Metrics with Dashboards and Alerts: https://74099--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/metrics-alerts-dashboards#network-observability-netobserv-dashboard-high-traffic-alert_metrics-dashboards-alerts

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
Related PR https://github.com/openshift/openshift-docs/pull/74100 removes PrometheusRule from 4.12, 4.13
