### PR TITLE
OSDOCS-9809: Adding cluster ID notes in microshift releasenotes

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -77,8 +77,12 @@ The following list provides update details:
 With this release, you can use the GitOps with Argo CD agent derived from GitOps 1.12 with {microshift-short}. Using GitOps means you can update a single Git repository and automate the deployment of new applications or updates to existing ones. You can also use your Git repository as an audit trail of changes so that you can create processes such as review and approval for merging pull requests that implement configuration changes.
 //TODO add xrefs once docs merge
 
-//[id="microshift-4-16-support"]
-//=== Support
+[id="microshift-4-16-support"]
+=== Support
+
+[id="microshift-4-16-support-updates"]
+==== Getting a cluster ID
+With this release, you can get the cluster ID of a {microshift-short} cluster. When opening a support case, you can provide the cluster ID to Red{nbsp}Hat Support to help in identifying issues with your cluster.
 
 //[id="microshift-4-16-security"]
 //=== Security and compliance


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-9809](https://issues.redhat.com/browse/OSDOCS-9809)

Link to docs preview:
[support](https://74115--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html)

QE review:
- [x] QE has to approve this change.
