### PR TITLE
OADP -3768 Doc Improvement Double Stacked Admonitions ROSA AWS STS

### DIFF
--- a/modules/installing-oadp-aws-sts.adoc
+++ b/modules/installing-oadp-aws-sts.adoc
@@ -220,7 +220,7 @@ $ cat << EOF | oc create -f -
 EOF
 ----
 <1> Set this field to `false` if you do not want to use image backup.
-<2> See the first note regarding the `nodeAgent` attribute.
+<2> See the important note regarding the `nodeAgent` attribute.
 <3> The `credentialsFile` field is the mounted location of the bucket credential on the pod.
 <4> The `enableSharedConfig` field allows the `snapshotLocations` to share or reuse the credential defined for the bucket.
 <5> Use the profile name set in the {aws-short} credentials file.
@@ -228,7 +228,7 @@ EOF
 +
 You are now ready to back up and restore {product-title} applications, as described in _Backing up applications_.
 
-[NOTE]
+[IMPORTANT]
 ====
 If you use OADP 1.2, replace this configuration:
 
@@ -247,7 +247,4 @@ restic:
 ----
 ====
 
-[NOTE]
-====
 If you want to use two different clusters for backing up and restoring, the two clusters must have the same {aws-short} S3 storage names in both the cloud storage CR and the OADP `DataProtectionApplication` configuration.
-====

--- a/modules/installing-oadp-rosa-sts.adoc
+++ b/modules/installing-oadp-rosa-sts.adoc
@@ -13,10 +13,7 @@ AWS Security Token Service (AWS STS) is a global web service that provides short
 ====
 Restic and Kopia are not supported in the OADP on ROSA with {aws-short} {sts-short} environment. Verify that the Restic and Kopia node agent is disabled.
 For backing up volumes, OADP on ROSA with {aws-short} {sts-short} supports only native snapshots and Container Storage Interface (CSI) snapshots.
-====
 
-[IMPORTANT]
-====
 In an Amazon ROSA cluster that uses STS authentication, restoring backed-up data in a different {aws-short} region is not supported.
 
 The Data Mover feature is not currently supported in ROSA clusters. You can use native {aws-short} S3 tools for moving data.
@@ -229,7 +226,7 @@ $ cat << EOF | oc create -f -
 EOF
 ----
 <1> ROSA supports internal image backup. Set this field to false if you do not want to use image backup.
-<2> See the following note.
+<2> See the important note regarding the `nodeAgent` attribute.
 <3> The `credentialsFile` field is the mounted location of the bucket credential on the pod.
 <4> The `enableSharedConfig` field allows the `snapshotLocations` to share or reuse the credential defined for the bucket.
 <5> Use the profile name set in the {aws-short} credentials file.
@@ -237,7 +234,7 @@ EOF
 +
 You are now ready to back up and restore {product-title} applications, as described in _Backing up applications_.
 
-[NOTE]
+[IMPORTANT]
 ====
 The `enable` parameter of `restic` is set to `false` in this configuration, because OADP does not support Restic in ROSA environments.
 
@@ -258,7 +255,5 @@ restic:
 ----
 ====
 
-[NOTE]
-====
 If you want to use two different clusters for backing up and restoring, the two clusters must have the same {aws-short} S3 storage names in both the cloud storage CR and the OADP `DataProtectionApplication` configuration.
-====
+


### PR DESCRIPTION
OADP 1.3.1

OCP 4.13+

Resolves - https://issues.redhat.com/browse/OADP-3768

Deploy preview - 

https://74137--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.html#installing-oadp-rosa-sts_oadp-rosa-backing-up-applications

https://74137--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/aws-sts/oadp-aws-sts#installing-oadp-aws-sts_oadp-aws-sts-backing-up-applications


