### PR TITLE
OSDOCS#10121: Release notes for admin-ack for 4.15 to 4.16

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -86,6 +86,17 @@ For more information, see xref:../installing/installing_vsphere/ipi/installing-r
 You can define tags for compute or control plane machines on an existing cluster by using machine sets.
 For more information, see "Adding tags to machines by using machine sets" for xref:../machine_management/creating_machinesets/creating-machineset-vsphere.adoc#machine-api-vmw-add-tags_creating-machineset-vsphere[compute] or xref:../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.adoc#machine-api-vmw-add-tags_cpmso-config-options-vsphere[control plane] machine sets.
 
+[id="ocp-4-16-admin-ack-updating_{context}"]
+==== Required administrator acknowledgment when updating from {product-title} 4.15 to 4.16
+
+{product-title} 4.16 uses Kubernetes 1.29, which removed several xref:../release_notes/ocp-4-16-release-notes.adoc#ocp-4-16-removed-kube-1-29-apis_{context}[deprecated APIs].
+
+A cluster administrator must provide manual acknowledgment before the cluster can be updated from {product-title} 4.15 to 4.16. This is to help prevent issues after updating to {product-title} 4.16, where APIs that have been removed are still in use by workloads, tools, or other components running on or interacting with the cluster. Administrators must evaluate their cluster for any APIs in use that will be removed and migrate the affected components to use the appropriate new API version. After this is done, the administrator can provide the administrator acknowledgment.
+
+All {product-title} 4.15 clusters require this administrator acknowledgment before they can be updated to {product-title} 4.16.
+
+For more information, see xref:../updating/preparing_for_updates/updating-cluster-prepare.adoc#updating-cluster-prepare[Preparing to update to {product-title} 4.16].
+
 [id="ocp-4-16-web-console_{context}"]
 === Web console
 
@@ -152,7 +163,7 @@ If you attempt an upgrade, the Cluster Network Operator reports the following st
     to OVN-Kubernetes in order to be able to upgrade. https://docs.openshift.com/container-platform/4.16/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html
   reason: OpenShiftSDNConfigured
   status: "False"
-  type: Upgradeable 
+  type: Upgradeable
 ----
 
 [id="ocp-4-16-networking-multiple-cidr_{context}"]
@@ -277,7 +288,7 @@ For more information, see xref:../storage/container_storage_interface/persistent
 
 [id="ocp-4-16-storage-rwop-selinux-context-mode"]
 ==== RWOP with SELinux context mount is generally available
-{product-title} 4.14 introduced a new access mode with Technical Preview status for persistent volumes (PVs) and persistent volume claims (PVCs) called ReadWriteOncePod (RWOP). RWOP can be used only in a single pod on a single node compared to the existing ReadWriteOnce access mode where a PV or PVC can be used on a single node by many pods. If the driver enables it, RWOP uses the SELinux context mount set in the `PodSpec` or container, which allows the driver to mount the volume directly with the correct SELinux labels. This eliminates the need to recursively relabel the volume, and pod startup can be significantly faster. 
+{product-title} 4.14 introduced a new access mode with Technical Preview status for persistent volumes (PVs) and persistent volume claims (PVCs) called ReadWriteOncePod (RWOP). RWOP can be used only in a single pod on a single node compared to the existing ReadWriteOnce access mode where a PV or PVC can be used on a single node by many pods. If the driver enables it, RWOP uses the SELinux context mount set in the `PodSpec` or container, which allows the driver to mount the volume directly with the correct SELinux labels. This eliminates the need to recursively relabel the volume, and pod startup can be significantly faster.
 
 In {product-title} 4.16, this feature is generally available.
 
@@ -307,7 +318,7 @@ For information about configuring the `LVMCluster` CR, see xref:../storage/persi
 [id="ocp-4-16-storage-no-deviceselector-warning-message_{context}"]
 ==== Support for a new warning message when device selector is not configured in the LVMCluster custom resource
 
-This update provides a new warning message when you do not configure the `deviceSelector` field in the `LVMCluster` custom resource (CR). 
+This update provides a new warning message when you do not configure the `deviceSelector` field in the `LVMCluster` custom resource (CR).
 
 The `LVMCluster` CR supports a new field, `deviceDiscoveryPolicy`, which indicates whether the `deviceSelector` field is configured. If you do not configure the `deviceSelector` field, {lvms} automatically sets the `deviceDiscoveryPolicy` field to `RuntimeDynamic`. Otherwise, the `deviceDiscoveryPolicy` field is set to `Preconfigured`.
 
@@ -423,19 +434,19 @@ With this release, you can increase the disk quota in etcd. This is a Technology
 ====  Reserved core frequency tuning
 
 With this release, the Node Tuning Operator supports setting CPU frequencies in the `PerformanceProfile` for reserved and isolated core CPUs.
-This is an optional feature that you can use to define specific frequencies. 
+This is an optional feature that you can use to define specific frequencies.
 The Node Tuning Operator then sets those frequencies by enabling the `intel_pstate` CPUFreq driver in the Intel hardware.
 You must follow Intel's recommendations on frequencies for FlexRAN-like applications, which require the default CPU frequency to be set to a lower value than the default running frequency.
 
 [id="ocp-4-16-node-tuning-operator-intel_{context}"]
 ====  Node Tuning Operator intel_pstate driver default setting
 
-Previously, for the RAN DU-profile, setting the `realTime` workload hint to `true` in the `PerformanceProfile` always disabled the `intel_pstate`. 
-With this release, the Node Tuning Operator detects the underlying Intel hardware using `TuneD` and appropriately sets the `intel_pstate` kernel parameter based on the processor’s generation. 
-This decouples the `intel_pstate` from the `realTime` and `highPowerConsumption` workload hints. 
+Previously, for the RAN DU-profile, setting the `realTime` workload hint to `true` in the `PerformanceProfile` always disabled the `intel_pstate`.
+With this release, the Node Tuning Operator detects the underlying Intel hardware using `TuneD` and appropriately sets the `intel_pstate` kernel parameter based on the processor’s generation.
+This decouples the `intel_pstate` from the `realTime` and `highPowerConsumption` workload hints.
 The `intel_pstate` now depends only on the underlying processor generation.
 
-For pre-IceLake processors, the `intel_pstate` is deactivated by default, whereas for IceLake and later generation processors, the `intel_pstate` is set to `active`. 
+For pre-IceLake processors, the `intel_pstate` is deactivated by default, whereas for IceLake and later generation processors, the `intel_pstate` is set to `active`.
 
 [id="ocp-4-16-edge-computing_{context}"]
 === Edge computing
@@ -882,6 +893,28 @@ With this release, the documentation for the Service Binding Operator (SBO) has 
 [id="ocp-4-16-alicloud-csi-driver-removed_{context}"]
 ==== AliCloud CSI Driver Operator is no longer supported
 {product-title} 4.16 no longer supports AliCloud Container Storage Interface (CSI) Driver Operator.
+
+[id="ocp-4-16-removed-kube-1-29-apis_{context}"]
+==== Beta APIs removed from Kubernetes 1.29
+
+Kubernetes 1.29 removed the following deprecated APIs, so you must migrate manifests and API clients to use the appropriate API version. For more information about migrating removed APIs, see the link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-29[Kubernetes documentation].
+
+.APIs removed from Kubernetes 1.29
+[cols="2,2,2,1",options="header",]
+|===
+|Resource |Removed API |Migrate to |Notable changes
+
+|`FlowSchema`
+|`flowcontrol.apiserver.k8s.io/v1beta2`
+|`flowcontrol.apiserver.k8s.io/v1` or `flowcontrol.apiserver.k8s.io/v1beta3`
+|No
+
+|`PriorityLevelConfiguration`
+|`flowcontrol.apiserver.k8s.io/v1beta2`
+|`flowcontrol.apiserver.k8s.io/v1` or `flowcontrol.apiserver.k8s.io/v1beta3`
+|link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#flowcontrol-resources-v129[Yes]
+
+|===
 
 [id="ocp-4-16-future-deprecation"]
 === Notice of future deprecation


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-10121

Link to docs preview:
* https://74141--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-14-admin-ack-updating
* https://74141--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes#ocp-4-16-removed-kube-1-29-apis

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This adds wording almost exactly as existed in the 4.14 release notes: https://docs.openshift.com/container-platform/4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-admin-ack-updating

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
