### PR TITLE
Updates link in OMR docs

### DIFF
--- a/modules/mirror-registry-ssl-cert-replace.adoc
+++ b/modules/mirror-registry-ssl-cert-replace.adoc
@@ -31,7 +31,7 @@ $ ./mirror-registry install \
 +
 This installs the _mirror registry for Red Hat OpenShift_ to the `$HOME/quay-install` directory.
 
-. Prepare a new certificate authority (CA) bundle and generate new `ssl.key` and `ssl.crt` key files. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/deploy_red_hat_quay_for_proof-of-concept_non-production_purposes/index#introduction-using-ssl[Using SSL/TLS].
+. Prepare a new certificate authority (CA) bundle and generate new `ssl.key` and `ssl.crt` key files. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/manage_red_hat_quay/using-ssl-to-protect-quay/[Using SSL/TLS to protect connections to {quay}].
 
 . Assign `/$HOME/quay-install` an environment variable, for example, `QUAY`, by entering the following command:
 +


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-31700

Link to docs preview:
https://74154--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-creating-registry.html#mirror-registry-ssl-cert-replace_installing-mirroring-creating-registry

Link update. QE not needed.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
