### PR TITLE
HCIDOCS-217: Baremetal IPI Installation - DNS setting for bootstrap static ip network configuration

### DIFF
--- a/modules/ipi-install-additional-install-config-parameters.adoc
+++ b/modules/ipi-install-additional-install-config-parameters.adoc
@@ -26,7 +26,7 @@ and the `bmc` parameter for the `install-config.yaml` file.
 
 | `bootstrapExternalStaticDNS`
 |
-| The static network DNS of the bootstrap node. This can be useful in environments without a DHCP server.
+| The static network DNS of the bootstrap node. You must set this value when deploying a cluster with static IP addresses when there is no Dynamic Host Configuration Protocol (DHCP) server on the bare-metal network. If you do not set this value, the installation program will use the value from `bootstrapExternalStaticGateway`, which causes problems when the IP address values of the gateway and DNS are different.
 
 | `bootstrapExternalStaticIP`
 |

--- a/modules/ipi-install-configuring-the-install-config-file.adoc
+++ b/modules/ipi-install-configuring-the-install-config-file.adoc
@@ -43,16 +43,17 @@ platform:
     provisioningNetworkCIDR: <CIDR>
     bootstrapExternalStaticIP: <bootstrap_static_ip_address> <2>
     bootstrapExternalStaticGateway: <bootstrap_static_gateway> <3>
+    bootstrapExternalStaticDNS: <bootstrap_static_dns> <4>
     hosts:
       - name: openshift-master-0
         role: master
         bmc:
-          address: ipmi://<out_of_band_ip> <4>
+          address: ipmi://<out_of_band_ip> <5>
           username: <user>
           password: <password>
         bootMACAddress: <NIC1_mac_address>
         rootDeviceHints:
-         deviceName: "<installation_disk_drive_path>" <5>
+         deviceName: "<installation_disk_drive_path>" <6>
       - name: <openshift_master_1>
         role: master
         bmc:
@@ -95,8 +96,9 @@ sshKey: '<ssh_pub_key>'
 <1> Scale the worker machines based on the number of worker nodes that are part of the {product-title} cluster. Valid options for the `replicas` value are `0` and integers greater than or equal to `2`. Set the number of replicas to `0` to deploy a three-node cluster, which contains only three control plane machines. A three-node cluster is a smaller, more resource-efficient cluster that can be used for testing, development, and production. You cannot install the cluster with only one worker.
 <2> When deploying a cluster with static IP addresses, you must set the `bootstrapExternalStaticIP` configuration setting to specify the static IP address of the bootstrap VM when there is no DHCP server on the bare-metal network.
 <3> When deploying a cluster with static IP addresses, you must set the `bootstrapExternalStaticGateway` configuration setting to specify the gateway IP address for the bootstrap VM when there is no DHCP server on the bare-metal network.
-<4> See the BMC addressing sections for more options.
-<5> To set the path to the installation disk drive, enter the kernel name of the disk. For example, `/dev/sda`.
+<4> When deploying a cluster with static IP addresses, you must set the `bootstrapExternalStaticDNS` configuration setting to specify the DNS address for the bootstrap VM when there is no DHCP server on the bare-metal network.
+<5> See the BMC addressing sections for more options.
+<6> To set the path to the installation disk drive, enter the kernel name of the disk. For example, `/dev/sda`.
 +
 [IMPORTANT]
 ====


### PR DESCRIPTION
Added additional details regarding bootstrapExternalStaticDNS.

Fixes: [HCIDOCS-217](https://issues.redhat.com//browse/HCIDOCS-217)

See https://issues.redhat.com/browse/HCIDOCS-217 for additional details.

Preview URL: http://184.23.213.161:8080/HCIDOCS-216/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-the-install-config-file_ipi-install-installation-workflow and http://184.23.213.161:8080/HCIDOCS-216/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#additional-install-config-parameters_ipi-install-installation-workflow

For release(s): 4.16, 4.15, 4.14, 4.13, 4.12
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
