### PR TITLE
[enterprise-4.14] CNV-38476: Update runbooks VirtualMachineCRCErrors

### DIFF
--- a/modules/virt-runbook-vmstorageclasswarning.adoc
+++ b/modules/virt-runbook-vmstorageclasswarning.adoc
@@ -5,11 +5,11 @@
 // * virt/monitoring/virt-runbooks.adoc
 
 :_mod-docs-content-type: REFERENCE
-[id="virt-runbook-VirtualMachineCRCErrors"]
-= VirtualMachineCRCErrors
+[id="virt-runbook-VMStorageClassWarning"]
+= VMStorageClassWarning
 
 [discrete]
-[id="meaning-virtualmachinecrcerrors"]
+[id="meaning-vmstorageclasswarning"]
 == Meaning
 
 This alert fires when the storage class is incorrectly configured.
@@ -17,14 +17,14 @@ A system-wide, shared dummy page causes CRC errors when data is
 written and read across different processes or threads.
 
 [discrete]
-[id="impact-virtualmachinecrcerrors"]
+[id="impact-vmstorageclasswarning"]
 == Impact
 
 A large number of CRC errors might cause the cluster to display
 severe performance degradation.
 
 [discrete]
-[id="diagnosis-virtualmachinecrcerrors"]
+[id="diagnosis-vmstorageclasswarning"]
 == Diagnosis
 
 . Navigate to *Observe* -> *Metrics* in the web console.
@@ -54,34 +54,10 @@ $ oc get pv <pv_name> -o=jsonpath='{.spec.storageClassName}'
 ----
 
 [discrete]
-[id="mitigation-virtualmachinecrcerrors"]
+[id="mitigation-vmstorageclasswarning"]
 == Mitigation
 
-Add the `krbd:rxbounce` map option to the storage class configuration to use
-a bounce buffer when receiving data:
-
-[source,yaml]
-----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: vm-sc
-parameters:
-  # ...
-  mounter: rbd
-  mapOptions: "krbd:rxbounce"
-provisioner: openshift-storage.rbd.csi.ceph.com
-# ...
-----
-
-The `krbd:rxbounce` option creates a bounce buffer to receive data. The default
-behavior is for the destination buffer to receive data directly. A bounce buffer
-is required if the stability of the destination buffer cannot be guaranteed.
-
-ifndef::openshift-rosa,openshift-dedicated[]
-See link:https://access.redhat.com/articles/6978371[Optimizing ODF PersistentVolumes for Windows VMs]
-for details.
-endif::openshift-rosa,openshift-dedicated[]
+Create a default OpenShift Virtualization storage class with the `krbd:rxbounce` map option. See  link:https://access.redhat.com/articles/6978371[Optimizing ODF PersistentVolumes for Windows VMs] for details.
 
 If you cannot resolve the issue, log in to the
 link:https://access.redhat.com[Customer Portal] and open a support case,

--- a/virt/monitoring/virt-runbooks.adoc
+++ b/virt/monitoring/virt-runbooks.adoc
@@ -110,7 +110,6 @@ include::modules/virt-runbook-virtoperatorresterrorsburst.adoc[leveloffset=+1]
 
 include::modules/virt-runbook-virtoperatorresterrorshigh.adoc[leveloffset=+1]
 
-include::modules/virt-runbook-virtualmachinecrcerrors.adoc[leveloffset=+1]
-
 include::modules/virt-runbook-vmcannotbeevicted.adoc[leveloffset=+1]
 
+include::modules/virt-runbook-vmstorageclasswarning.adoc[leveloffset=+1]

--- a/virt/release_notes/virt-4-14-release-notes.adoc
+++ b/virt/release_notes/virt-4-14-release-notes.adoc
@@ -124,7 +124,7 @@ For more information, see xref:../../virt/install/preparing-cluster-for-virt.ado
 
 // CNV-30800 Release note: CHANGE
 * The following runbooks have been changed:
-** xref:../../virt/monitoring/virt-runbooks.adoc#virt-runbook-SingleStackIPv6Unsupported[`SingleStackIPv6Unsupported`] and xref:../../virt/monitoring/virt-runbooks.adoc#virt-runbook-VirtualMachineCRCErrors[`VirtualMachineCRCErrors`] have been added.
+** xref:../../virt/monitoring/virt-runbooks.adoc#virt-runbook-SingleStackIPv6Unsupported[`SingleStackIPv6Unsupported`] and xref:../../virt/monitoring/virt-runbooks.adoc#virt-runbook-VMStorageClassWarning[`VMStorageClassWarning`] have been added.
 ** `KubeMacPoolDown` has been renamed xref:../../virt/monitoring/virt-runbooks.adoc#virt-runbook-KubemacpoolDown[`KubemacpoolDown`].
 ** `KubevirtHyperconvergedClusterOperatorInstallationNotCompletedAlert` has been renamed xref:../../virt/monitoring/virt-runbooks.adoc#virt-runbook-HCOInstallationIncomplete[`HCOInstallationIncomplete`].
 ** `KubevirtHyperconvergedClusterOperatorCRModification` has been renamed xref:../../virt/monitoring/virt-runbooks.adoc#virt-runbook-KubeVirtCRModified[`KubeVirtCRModified`].


### PR DESCRIPTION
Manaual cherrypick of https://github.com/openshift/openshift-docs/pull/73108

Because the renamed module in this PR is linked in the Virt 4.14 release notes, we need to update that link.  