### PR TITLE
OBSDOCS-834: Put logging 5.9 docs live

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2801,10 +2801,10 @@ Topics:
   Topics:
   - Name: Flow control mechanisms
     File: logging-flow-control-mechanisms
-#  - Name: Filtering logs by content
-#    File: logging-content-filtering
-#  - Name: Filtering logs by metadata
-#    File: logging-input-spec-filtering
+  - Name: Filtering logs by content
+    File: logging-content-filtering
+  - Name: Filtering logs by metadata
+    File: logging-input-spec-filtering
 - Name: Scheduling resources
   Dir: scheduling_resources
   Topics:

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -1210,10 +1210,10 @@ Topics:
   Topics:
   - Name: Flow control mechanisms
     File: logging-flow-control-mechanisms
-#  - Name: Filtering logs by content
-#    File: logging-content-filtering
-#  - Name: Filtering logs by metadata
-#    File: logging-input-spec-filtering
+  - Name: Filtering logs by content
+    File: logging-content-filtering
+  - Name: Filtering logs by metadata
+    File: logging-input-spec-filtering
 - Name: Scheduling resources
   Dir: scheduling_resources
   Topics:

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1454,10 +1454,10 @@ Topics:
   Topics:
   - Name: Flow control mechanisms
     File: logging-flow-control-mechanisms
-#  - Name: Filtering logs by content
-#    File: logging-content-filtering
-#  - Name: Filtering logs by metadata
-#    File: logging-input-spec-filtering
+  - Name: Filtering logs by content
+    File: logging-content-filtering
+  - Name: Filtering logs by metadata
+    File: logging-input-spec-filtering
 - Name: Scheduling resources
   Dir: scheduling_resources
   Topics:

--- a/logging/log_collection_forwarding/configuring-log-forwarding.adoc
+++ b/logging/log_collection_forwarding/configuring-log-forwarding.adoc
@@ -13,8 +13,7 @@ include::modules/cluster-logging-collector-log-forwarding-about.adoc[leveloffset
 
 include::modules/logging-create-clf.adoc[leveloffset=+1]
 
-// uncomment for 5.9 release
-// include::modules/logging-delivery-tuning.adoc[leveloffset=+1]
+include::modules/logging-delivery-tuning.adoc[leveloffset=+1]
 
 include::modules/logging-multiline-except.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OBSDOCS-834

Link to docs preview:
- https://74168--ocpdocs-pr.netlify.app/openshift-dedicated/latest/logging/log_collection_forwarding/configuring-log-forwarding.html#logging-delivery-tuning_configuring-log-forwarding
- https://74168--ocpdocs-pr.netlify.app/openshift-dedicated/latest/logging/performance_reliability/logging-content-filtering
- https://74168--ocpdocs-pr.netlify.app/openshift-dedicated/latest/logging/performance_reliability/logging-input-spec-filtering

**NOTE: Adding links to docs for completeness, but the content has already been reviewed and merged. No new content has been added or modified in this PR**

QE review:
N/A - uncommenting docs that are already reviewed and merged.