### PR TITLE
OTA oc mirror docs changes

### DIFF
--- a/modules/update-mirror-repository.adoc
+++ b/modules/update-mirror-repository.adoc
@@ -3,8 +3,8 @@
 // * updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="update-mirror-repository-adm-release-mirror_{context}"]
-= Mirroring images using the oc adm release mirror command
+[id="update-mirroring-images-to-registry_{context}"]
+= Mirroring images to a mirror registry
 
 [IMPORTANT]
 ====

--- a/updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc
+++ b/updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc
@@ -53,8 +53,20 @@ Compared to using the `oc adm release mirror` command, the oc-mirror plugin has 
 
 * The oc-mirror plugin provides an automated way to mirror the release payload from Quay, and also builds the latest graph data image for the OpenShift Update Service running in the disconnected environment.
 
+[id=mirroring-ocp-resources-ocmirror]
+== Mirroring resources using the oc-mirror plugin
+
+You can use the oc-mirror OpenShift CLI (`oc`) plugin to mirror images to a mirror registry in your fully or partially disconnected environments. You must run oc-mirror from a system with internet connectivity to download the required images from the official Red{nbsp}Hat registries.
+
+See xref:../../../installing/disconnected_install/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin] for additional details.
+
+[id="update-mirror-repository-adm-release-mirror_{context}"]
+== Mirroring images using the oc adm release mirror command
+
+You can use the `oc adm release mirror` command to mirror images to your mirror registry.
+
 [id="prerequisites_updating-mirroring-disconnected"]
-== Prerequisites
+=== Prerequisites
 
 * You must have a container image registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2[Docker v2-2] in the location that will host the {product-title} cluster, such as Red Hat Quay.
 +
@@ -66,12 +78,12 @@ If you use Red Hat Quay, you must use version 3.6 or later with the oc-mirror pl
 If you do not have an existing solution for a container image registry, the xref:../../../installing/disconnected_install/installing-mirroring-creating-registry.adoc#installing-mirroring-creating-registry[mirror registry for Red Hat OpenShift] is included in {product-title} subscriptions. The _mirror registry for Red Hat OpenShift_ is a small-scale container registry that you can use to mirror {product-title} container images in disconnected installations and updates.
 
 [id="updating-restricted-network-mirror-host"]
-== Preparing your mirror host
+=== Preparing your mirror host
 
 Before you perform the mirror procedure, you must prepare the host to retrieve content and push it to the remote location.
 
 // Installing the OpenShift CLI by downloading the binary
-include::modules/cli-installing-cli.adoc[leveloffset=+2]
+include::modules/cli-installing-cli.adoc[leveloffset=+3]
 
 [role="_additional-resources"]
 .Additional resources
@@ -79,109 +91,7 @@ include::modules/cli-installing-cli.adoc[leveloffset=+2]
 * xref:../../../cli_reference/openshift_cli/extending-cli-plugins.adoc#cli-installing-plugins_cli-extend-plugins[Installing and using CLI plugins]
 
 // Configuring credentials that allow images to be mirrored
-include::modules/installation-adding-registry-pull-secret.adoc[leveloffset=+2]
-
-[id=mirroring-ocp-resources-ocmirror]
-== Mirroring resources using the oc-mirror plugin
-
-You can use the oc-mirror OpenShift CLI (`oc`) plugin to mirror images to a mirror registry in your fully or partially disconnected environments. You must run oc-mirror from a system with internet connectivity to download the required images from the official Red Hat registries.
-
-// About the oc-mirror plugin
-include::modules/oc-mirror-about.adoc[leveloffset=+2]
-
-// oc-mirror compatibility and support
-include::modules/oc-mirror-support.adoc[leveloffset=+2]
-
-// About the mirror registry
-include::modules/installation-about-mirror-registry.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-
-* For information about viewing the CRI-O logs to view the image source, see xref:../../../installing/validating-an-installation.adoc#viewing-the-image-pull-source_validating-an-installation[Viewing the image pull source].
-
-// Installing the oc-mirror OpenShift CLI plugin
-include::modules/oc-mirror-installing-plugin.adoc[leveloffset=+2]
-
-// Creating the image set configuration
-include::modules/oc-mirror-creating-image-set-config.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../../updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc#oc-mirror-imageset-config-params_mirroring-ocp-image-repository[Image set configuration parameters]
-* xref:../../../updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc#oc-mirror-image-set-examples_mirroring-ocp-image-repository[Image set configuration examples]
-* xref:../../../updating/understanding_updates/intro-to-updates.adoc#update-service-about_understanding-openshift-updates[About the OpenShift Update Service]
-
-[id="mirroring-image-set"]
-=== Mirroring an image set to a mirror registry
-
-You can use the oc-mirror CLI plugin to mirror images to a mirror registry in a xref:../../../updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc#mirroring-image-set-partial[partially disconnected environment] or in a xref:../../../updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc#mirroring-image-set-full[fully disconnected environment].
-
-The following procedures assume that you already have your mirror registry set up.
-
-[id="mirroring-image-set-partial"]
-==== Mirroring an image set in a partially disconnected environment
-
-In a partially disconnected environment, you can mirror an image set directly to the target mirror registry.
-
-// Mirroring from mirror to mirror
-include::modules/oc-mirror-mirror-to-mirror.adoc[leveloffset=+4]
-
-[id="mirroring-image-set-full"]
-==== Mirroring an image set in a fully disconnected environment
-
-To mirror an image set in a fully disconnected environment, you must first xref:../../../updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc#oc-mirror-mirror-to-disk_mirroring-ocp-image-repository[mirror the image set to disk], then xref:../../../updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc#oc-mirror-disk-to-mirror_mirroring-ocp-image-repository[mirror the image set file on disk to a mirror].
-
-// Mirroring from mirror to disk
-include::modules/oc-mirror-mirror-to-disk.adoc[leveloffset=+4]
-
-// Mirroring from disk to mirror in a disconnected environment
-include::modules/oc-mirror-disk-to-mirror.adoc[leveloffset=+4]
-
-// Configuring your cluster to use the resources generated by oc-mirror
-include::modules/oc-mirror-updating-cluster-manifests.adoc[leveloffset=+2]
-
-[id="updating-mirror-registry-content"]
-=== Keeping your mirror registry content updated
-
-After you populate your target mirror registry with the initial image set, you must update it regularly so that it has the latest content. If possible, you can set up a cron job to update the mirror registry on a regular basis.
-
-Update your image set configuration to add or remove {product-title} and Operator releases as necessary. Removed images are pruned from the mirror registry.
-
-// About updating your mirror registry content
-include::modules/oc-mirror-updating-registry-about.adoc[leveloffset=+3]
-
-// Updating your mirror registry content
-include::modules/oc-mirror-differential-updates.adoc[leveloffset=+3]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../../updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc#oc-mirror-image-set-examples_mirroring-ocp-image-repository[Image set configuration examples]
-* xref:../../../updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc#mirroring-image-set-partial[Mirroring an image set in a partially disconnected environment]
-* xref:../../../updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc#mirroring-image-set-full[Mirroring an image set in a fully disconnected environment]
-* xref:../../../updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc#oc-mirror-updating-cluster-manifests_mirroring-ocp-image-repository[Configuring your cluster to use the resources generated by oc-mirror]
-
-// Performing a dry run
-include::modules/oc-mirror-dry-run.adoc[leveloffset=+2]
-
-// Mirroring Operator images in OCI format
-include::modules/oc-mirror-oci-format.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs-fb[File-based catalogs]
-
-// Image set configuration parameters
-include::modules/oc-mirror-imageset-config-params.adoc[leveloffset=+2]
-
-// Image set configuration examples
-include::modules/oc-mirror-image-set-config-examples.adoc[leveloffset=+2]
-
-// Command reference for oc-mirror
-include::modules/oc-mirror-command-reference.adoc[leveloffset=+2]
+include::modules/installation-adding-registry-pull-secret.adoc[leveloffset=+3]
 
 // Mirroring images using the oc adm release mirror command
-include::modules/update-mirror-repository.adoc[leveloffset=+1]
+include::modules/update-mirror-repository.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s): 4.13+

This PR removes duplicate oc mirror content in the updating clusters docs and instead links users to the original location of the docs in the installing section.

QE review:
- [x] QE has approved this change.

Preview: [Mirroring OpenShift Container Platform images](https://74178--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository)