### PR TITLE
[OSDOCS-10156] Fix broken OL and admonition in local ShiftStack page

### DIFF
--- a/installing/installing_openstack/deploying-openstack-with-rootVolume-etcd-on-local-disk.adoc
+++ b/installing/installing_openstack/deploying-openstack-with-rootVolume-etcd-on-local-disk.adoc
@@ -14,5 +14,7 @@ As a day 2 operation, you can resolve and prevent performance issues of your {rh
 include::modules/installation-osp-local-disk-deployment.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+[id="additional-resources_deploying-openstack-on-local-disk"]
+== Additional resources
 * xref:../../scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.adoc#recommended-etcd-practices[Recommended etcd practices]
+* xref:../../backup_and_restore/index.adoc#backup-restore-operations-overview[Overview of backup and restore options]

--- a/modules/installation-osp-local-disk-deployment.adoc
+++ b/modules/installation-osp-local-disk-deployment.adoc
@@ -6,6 +6,13 @@
 [id="installation-osp-local-disk-deployment_{context}"]
 = Deploying {rh-openstack} on local disk
 
+If you have an existing {rh-openstack} cloud, you can move etcd from that cloud to a dedicated ephemeral local disk.
+
+[WARNING]
+====
+This procedure is for testing etcd on a local disk only and should not be used on production clusters. In certain cases, complete loss of the control plane can occur. For more information, see "Overview of backup and restore operation" under "Backup and restore".
+====
+
 .Prerequisites
 
 * You have an OpenStack cloud with a working Cinder.
@@ -16,11 +23,6 @@
 
 
 .Procedure
-
-[WARNING]
-====
-This procedure is for testing etcd on a local disk only and should not be used on production clusters. In certain cases, complete loss of the control plane can occur. For more information, see "Overview of backup and restore operation" under "Backup and restore".
-====
 
 . Create a Nova flavor for the control plane with at least 10 GB of ephemeral disk by running the following command, replacing the values for `--ram`, `--disk`, and <flavor_name> based on your environment:
 +
@@ -154,13 +156,12 @@ done
 <3> Outputs the name of every control plane machine which has an `additionalBlockDevice` named `etcd`.
 
 . Create a file named `98-var-lib-etcd.yaml` by using the following YAML file:
-
++
 [WARNING]
 ====
 This procedure is for testing etcd on a local disk and should not be used on a production cluster. In certain cases, complete loss of the control plane can occur. For more information, see "Overview of backup and restore operation" under "Backup and restore".
 ====
-
-
++
 [%collapsible]
 ====
 [source,yaml]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-10156](https://issues.redhat.com/browse/OSDOCS-10156)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://74183--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_openstack/deploying-openstack-with-rootVolume-etcd-on-local-disk.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: n/a. This PR fixes an OL, adds a description to a module, and corrects an admonition that has melted into a label. 

- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
