### PR TITLE
OSDOCS-9954: oc (CLI) needs to be functional or fail gracefully without oauth server

### DIFF
--- a/modules/oc-by-example-content.adoc
+++ b/modules/oc-by-example-content.adoc
@@ -1856,11 +1856,40 @@ Log in to a server
   # Log in to the given server through a browser
   oc login localhost:8443 --web --callback-port 8280
 
+ifdef::openshift-dedicated,openshift-rosa[]
   # Log in to the external OIDC issuer through Auth Code + PKCE by starting a local server listening port 8080
-  oc login localhost:8443 --exec-plugin=oc-oidc --client-id=client-id --extra-scopes=email,profile --callback-port=8080
+  oc login --exec-plugin=oc-oidc --issuer-url=<issuer_url> --client-id=<client_id> --extra-scopes=email,profile --callback-port=8080
+
+  # Log in with an external OIDC if the external OIDC certificate is not publically trusted
+  oc login --exec-plugin=oc-oidc --issuer-url=<issuer_url> --client-id=<client_id> --extra-scopes=email --callback-port=8080 --oidc-certificate-authority <CA for external OIDC certificate>
+endif::openshift-dedicated,openshift-rosa[]  
 ----
 
+ifdef::openshift-dedicated,openshift-rosa[]
+.Arguments
+[cols="30,70"]
+|===
+|Option |Definition
 
+|`--exec-plugin`
+|Specifies the type of exec plugin credentials used to authenticate the external OIDC issuer. Currently, only `oc-oidc` is supported.
+
+|`--issuer-url`
+|Issuer URL for the external issuer. Required.
+
+|`--client-id`
+|Client ID for the external OIDC issuer. Only supports Auth Code and PKCE. Required.
+
+|`--extra-scopes`
+|Extra scopes for the external OIDC issuer. Optional.
+
+|`--callback-port`
+|The port that the callback server is redirected to after authentication flow is complete. The default is any random, open port.
+
+|`--oidc-certificate-authority`
+|Path to a certificate file for the external OIDC certificate authority.
+|===
+endif::openshift-dedicated,openshift-rosa[]
 
 == oc logout
 End the current server session


### PR DESCRIPTION
[OSDOCS-9954](https://issues.redhat.com//browse/OSDOCS-9954): oc (CLI) needs to be functional or fail gracefully without oauth server

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15+

Issue:
[OSDOCS-9954](https://issues.redhat.com//browse/OSDOCS-9954)
[OSDOCS-8164](https://issues.redhat.com//browse/OSDOCS-8164)
OCPBUGS-27859 (https://issues.redhat.com/browse/OCPBUGS-27859)

Link to docs preview:
OSD: https://74184--ocpdocs-pr.netlify.app/openshift-dedicated/latest/cli_reference/openshift_cli/developer-cli-commands.html#oc-login
ROSA: https://74184--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/openshift_cli/developer-cli-commands.html#oc-login

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
