### PR TITLE
[prow build] - fix small bug in scripts/get-updated-preview-urls.sh

### DIFF
--- a/scripts/get-updated-preview-urls.sh
+++ b/scripts/get-updated-preview-urls.sh
@@ -46,9 +46,6 @@ done
 # Make the HTML URL slug
 if [ ${#assemblies[@]} -gt 0 ]; then
     updated_pages=$(echo "${assemblies[@]}" | sed 's/\.adoc$/.html/' | sort | uniq)
-else
-    # No updated pages, just add default URL
-    pages+=("${preview_url}")
 fi
 
 # Search built_pages for every entry in updated_pages and add to pages array when it is found


### PR DESCRIPTION
When the PR contains non-source updates, the preview comment URL is malformed. This PR fixes the error.