### PR TITLE
OADP 3765 Updated PR Data Mover new parameters

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3117,7 +3117,7 @@ Topics:
     Topics:
     - Name: About the OADP 1.3 Data Mover
       File: about-oadp-1-3-data-mover
-    - Name: Backing up and restoring volumes by using CSI snapshots
+    - Name: Backing up and restoring volumes by using CSI snapshots data movement
       File: oadp-backup-restore-csi-snapshots
   - Name: Troubleshooting
     File: troubleshooting

--- a/backup_and_restore/application_backup_and_restore/installing/about-oadp-1-3-data-mover.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/about-oadp-1-3-data-mover.adoc
@@ -38,11 +38,16 @@ spec:
       - openshift
       - aws
       - csi <3>
+      defaultSnapshotMoveData: true
+      defaultVolumesToFSBackup: <4>
+      featureFlags:
+      - EnableCSI
 # ...
 ----
 <1> The flag to enable the node agent.
 <2> The type of uploader. The possible values are `restic` or `kopia`. The built-in Data Mover uses Kopia as the default uploader mechanism regardless of the value of the `uploaderType` field.
 <3> The CSI plugin included in the list of default plugins.
+<4> In OADP 1.3.1 and later, set to `true` if you use Data Mover only for volumes that opt out of `fs-backup`. Set to `false` if you use Data Mover by default for volumes.
 
 [id="built-in-data-mover-crs"]
 == Built-in Data Mover controller and custom resource definitions (CRDs)

--- a/backup_and_restore/application_backup_and_restore/installing/oadp-backup-restore-csi-snapshots.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/oadp-backup-restore-csi-snapshots.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="oadp-backup-restore-csi-snapshots"]
-= Backing up and restoring CSI snapshots
+= Backing up and restoring CSI snapshots data movement
 include::_attributes/common-attributes.adoc[]
 :context: oadp-backup-restore-csi-snapshots
 

--- a/modules/oadp-1-3-backing-csi-snapshots.adoc
+++ b/modules/oadp-1-3-backing-csi-snapshots.adoc
@@ -29,18 +29,19 @@ metadata:
   namespace: openshift-adp
 spec:
   csiSnapshotTimeout: 10m0s
-  defaultVolumesToFsBackup: false
+  defaultVolumesToFsBackup: <1>
   includedNamespaces:
   - mysql-persistent
   itemOperationTimeout: 4h0m0s
-  snapshotMoveData: true <1>
+  snapshotMoveData: true <2>
   storageLocation: default
   ttl: 720h0m0s
   volumeSnapshotLocations:
   - dpa-sample-1
 # ...
 ----
-<1> Set to `true` to enable movement of CSI snapshots to remote object storage.
+<1> Set to `true` if you use Data Mover only for volumes that opt out of `fs-backup`. Set to `false` if you use Data Mover by default for volumes.
+<2> Set to `true` to enable movement of CSI snapshots to remote object storage.
 
 . Apply the manifest:
 +


### PR DESCRIPTION
OADP 1.3.1

OCP 4.13 +

GA April 16th 2024

Resolves - https://issues.redhat.com/browse/OADP-3765

Preview - 

https://74205--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/oadp-backup-restore-csi-snapshots.html#oadp-1-3-backing-csi-snapshots_oadp-backup-restore-csi-snapshots

https://74205--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/oadp-backup-restore-csi-snapshots

