### PR TITLE
OCPBUGS#31707: replace pwd hash with user-input fields

### DIFF
--- a/modules/microshift-provisioning-ostree.adoc
+++ b/modules/microshift-provisioning-ostree.adoc
@@ -61,9 +61,9 @@ part pv.01 --grow
 volgroup rhel pv.01
 logvol / --vgname=rhel --fstype=xfs --size=10000 --name=root
 # To add users, use a line such as the following
-user --name=user \
---password=$6$HFVVV521NB4kOKVG$0.hM652uIOBNsC45kvFpMuRVkfNGHToMdQ6PDTU8DcEF30Gz/3DUwW153Gc9EvNMkH50qYfBO5os/FJsXTLLt. \
---iscrypted --groups=wheel
+user --name=<YOUR_USER_NAME> \
+--password=<YOUR_HASHED_PASSWORD> \
+--iscrypted --groups=<YOUR_USER_GROUPS>
 ----
 
 . In the `%post` section of the Kickstart file, add your pull secret and the mandatory firewall rules.


### PR DESCRIPTION
Version(s):
4.13+

Issue:
[OCPBUGS#31707](https://issues.redhat.com/browse/OCPBUGS-31707)

Link to docs preview:
[Provisioning a machine for MicroShift](https://74208--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree.html#provisioning-a-machine_microshift-embed-in-rpm-ostree)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
