### PR TITLE
OSDOCS-10042: fix missing backtick MicroShift manifests module

### DIFF
--- a/modules/microshift-manifests-overview.adoc
+++ b/modules/microshift-manifests-overview.adoc
@@ -19,7 +19,7 @@ At every start, {microshift-short} searches the following manifest directories f
 
 * `/etc/microshift/manifests`
 * `/etc/microshift/manifests.d/++*++`
-* `/usr/lib/microshift/
+* `/usr/lib/microshift/`
 * `/usr/lib/microshift/manifests.d/++*++`
 
 {microshift-short} automatically runs the equivalent of the `kubectl apply -k` command to apply the manifests to the cluster if any of the following file types exists in the searched directories:


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-10042](https://issues.redhat.com/browse/OSDOCS-10042)

Link to docs preview:
[Using applications bullet fix](https://74209--ocpdocs-pr.netlify.app/microshift/latest/microshift_running_apps/microshift-applications.html#how-microshift-uses-manifests)

QE review:
- N/A copy edit only, no technical changes

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
