### PR TITLE
OCPBUGS-31451-OCP-12: Added note about vSphere instance versions

### DIFF
--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -45,22 +45,20 @@ endif::[]
 [id="installation-vsphere-infrastructure_{context}"]
 = VMware vSphere infrastructure requirements
 
-You must install the {product-title} cluster on a VMware vSphere version 7 update 2 or later instance that meets the requirements for the components that you use.
+You must install an {product-title} cluster on one of the following versions of a VMware vSphere instance that meets the requirements for the components that you use:
 
-[NOTE]
-====
-{product-title} version {product-version} supports VMware vSphere version 8.0.
-====
+* Version 7.0 Update 2 or later
+* Version 8.0 Update 1 or later
 
-You can host the VMware vSphere infrastructure on-premise or on a link:https://cloud.vmware.com/providers[VMware Cloud Verified provider] that meets the requirements outlined in the following table:
+You can host the {vmw-full} infrastructure on-premise or on a link:https://cloud.vmware.com/providers[VMware Cloud Verified provider] that meets the requirements outlined in the following table:
 
 .Version requirements for vSphere virtual environments
 [cols=2, options="header"]
 |===
 |Virtual environment product |Required version
 |VMware virtual hardware | 15 or later
-|vSphere ESXi hosts | 7.0 Update 2 or later
-|vCenter host   | 7.0 Update 2 or later
+|vSphere ESXi hosts | 7.0 Update 2 or later; 8.0 Update 1 or later
+|vCenter host   | 7.0 Update 2 or later; 8.0 Update 1 or later
 |===
 
 [IMPORTANT]
@@ -73,17 +71,17 @@ Installing a cluster on VMware vSphere versions 7.0 and 7.0 Update 1 is deprecat
 |Component | Minimum supported versions |Description
 
 |Hypervisor
-|vSphere 7.0 Update 2 and later with virtual hardware version 15
+|vSphere 7.0 Update 2 (or later) or vSphere 8.0 Update 1 (or later) with virtual hardware version 15
 |This version is the minimum version that {op-system-first} supports. For more information about supported hardware on the latest version of {op-system-base-full} that is compatible with {op-system}, see link:https://catalog.redhat.com/hardware/search[Hardware] on the Red Hat Customer Portal.
 
 |Storage with in-tree drivers
-|vSphere 7.0 Update 2 and later
+|vSphere 7.0 Update 2 or later; 8.0 Update 1 or later
 |This plugin creates vSphere storage by using the in-tree storage drivers for vSphere included in {product-title}.
 
 ifndef::vmc[]
 |Optional: Networking (NSX-T)
-|vSphere 7.0 Update 2 and later
-|vSphere 7.0 Update 2 is required for {product-title}. For more information about the compatibility of NSX and {product-title}, see the Release Notes section of VMware's link:https://docs.vmware.com/en/VMware-NSX-Container-Plugin/index.html[NSX container plugin documentation].
+|vSphere 7.0 Update 2 or later; vSphere 8.0 Update 1
+|At a minimum, vSphere 7.0 Update 2 or vSphere 8.0 Update 1 is required for {product-title}. For more information about the compatibility of NSX and {product-title}, see the Release Notes section of VMware's link:https://docs.vmware.com/en/VMware-NSX-Container-Plugin/index.html[NSX container plugin documentation].
 endif::vmc[]
 |===
 

--- a/modules/vmware-csi-driver-reqs.adoc
+++ b/modules/vmware-csi-driver-reqs.adoc
@@ -24,8 +24,8 @@
 
 To install the vSphere CSI Driver Operator, the following requirements must be met:
 
-* VMware vSphere version 7.0 Update 2 or later
-* vCenter 7.0 Update 2 or later
+* {vmw-full} version: 7.0 Update 2 or later; 8.0 Update 1 or later
+* vCenter version: 7.0 Update 2 or later; 8.0 Update 1 or later
 * Virtual machines of hardware version 15 or later
 * No third-party vSphere CSI driver already installed in the cluster
 
@@ -33,5 +33,5 @@ If a third-party vSphere CSI driver is present in the cluster, {product-title} d
 
 [NOTE]
 ====
-The VMware vSphere CSI Driver Operator is supported only on clusters deployed with `platform: vsphere` in the installation manifest.
+The {vmw-full} CSI Driver Operator is supported only on clusters deployed with `platform: vsphere` in the installation manifest.
 ====


### PR DESCRIPTION
Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OCPBUGS-31451

Link to docs preview:
* [VMware vSphere infrastructure requirements](https://74210--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned#installation-vsphere-infrastructure_installing-vsphere-installer-provisioned)
* [VMware vSphere CSI Driver Operator requirements](https://74210--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned#vsphere-csi-driver-reqs_installing-vsphere-installer-provisioned)

[x] SME has approved this change.
[x] QE has approved this change.

Additional information:
* https://docs.google.com/document/d/1Y6aCc-F4Wc11sdJtwqL-DYKCQKCY_xJs68tEh8S3v5c/edit
