### PR TITLE
OSDOCS-9429: update docs for MicroShift rebase 4.16

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -13,9 +13,9 @@ toc::[]
 //TODO verify K8s version and another other relevant notes
 [id="microshift-4-16-about-this-release"]
 == About this release
-Version 4.16 of {product-title} includes new features and enhancements. {microshift-short} was introduced as Generally Available with {microshift-short} 4.14. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md[Kubernetes 1.28] with the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
+Version 4.16 of {product-title} includes new features and enhancements. {microshift-short} was introduced as Generally Available with {microshift-short} 4.14. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. {microshift-short} is derived from {OCP} {OCP-version} and uses the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
 
-You can deploy {microshift-short} clusters to on-premise, cloud, or disconnected environments.
+You can deploy {microshift-short} clusters to on-premise, cloud, disconnected, and offline environments.
 
 //TODO: Update OP system versions
 {microshift-short} {product-version} is supported on {op-system-base-full} or {op-system-ostree-first} 9.4.
@@ -53,8 +53,6 @@ See the following list for details:
 * Updates of the RPMs on a non-OSTree system such as {op-system} are also supported.
 * See xref:../microshift_updating/microshift-update-options.adoc#microshift-update-options[Update options with {product-title} and {op-system-bundle}] for details.
 
-//TODO: verify update paths to 4.16 and list
-
 //TODO add new features and enhancements as needed, L4 [discrete] headings
 
 //[id="microshift-4-16-installation"]
@@ -78,7 +76,7 @@ See the following list for details:
 [id="microshift-4-16-gitops"]
 ==== GitOps with Argo CD now available
 With this release, you can use the GitOps with Argo CD agent derived from GitOps 1.12 with {microshift-short}. Using GitOps means you can update a single Git repository and automate the deployment of new applications or updates to existing ones. You can also use your Git repository as an audit trail of changes so that you can create processes such as review and approval for merging pull requests that implement configuration changes.
-//TODO add xrefs once docs merge
+See xref:../microshift_running_apps/microshift-gitops.adoc#microshift-gitops[Automating application management with the GitOps controller].
 
 //[id="microshift-4-16-support"]
 //=== Support
@@ -151,14 +149,14 @@ Red Hat Customer Portal users can enable errata notifications in the account set
 Red Hat Customer Portal user accounts must have systems registered and consuming {microshift-short} entitlements for {microshift-short} errata notification emails to generate.
 ====
 
-This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, will be detailed in the following subsections.
+This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections.
 
-//TODO uncomment and verify info prior to merge freeze
-//[id="microshift-4-16-0-dp"]
-//=== RHEA-2024:0043 - {microshift-short} 4.16.0 bug fix and security update advisory
+//TODO verify info prior to merge freeze
+[id="microshift-4-16-0-dp"]
+=== RHEA-2024:0043 - {microshift-short} 4.16.0 bug fix and security update advisory
 
-//Issued: 2024-04-03
+Issued: 2024-06-03
 
-//{product-title} release 4.16.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHEA-2024:0043[RHEA-2024:0043] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHEA-2024:0041[RHEA-2024:0041] advisory.
+{product-title} release 4.16.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHEA-2024:0043[RHEA-2024:0043] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHEA-2024:0041[RHEA-2024:0041] advisory.
 
-//For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.16 only

Issue:
[OSDOCS-9429](https://issues.redhat.com/browse/OSDOCS-9429)

Link to docs preview:
[4.16 Release Notes, general text](https://74216--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html)
[RHEL section](https://74216--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-rhel)
[About this release](https://74216--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-about-this-release)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
