### PR TITLE
OSDOCS-10166: Documented the 4.15.8 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2342,7 +2342,6 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.13 |4.14 |4.15
 
-
 |Alerting rules based on platform monitoring metrics
 |Technology Preview
 |General Availability
@@ -2677,6 +2676,29 @@ This section will continue to be updated over time to provide notes on enhanceme
 ====
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
+
+// 4.15.8
+[id="ocp-4-15-8"]
+=== RHSA-2024:1668 - {product-title} 4.15.8 bug fix and security update
+
+Issued: 2024-04-08
+
+{product-title} release 4.15.8, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:1668[RHSA-2024:1668] advisory. There are no RPM packages for this update.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.8 --pullspecs
+----
+
+[id="ocp-4-15-8-updating"]
+==== Updating
+To update an existing {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+// 4.15.7 was skipped.
 
 [id="ocp-4-15-6"]
 === RHSA-2024:1559 - {product-title} 4.15.6 bug fix and security update


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-10166](https://issues.redhat.com/browse/OSDOCS-10166)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] Not required for z-stream release notes. See the peer-review checklist.

Additional information:
4.15.7 was dropped·
