### PR TITLE
OSDOCS#10164:Adjusted ROSA HCP max worker nodes from 51 to 90

### DIFF
--- a/modules/rosa-sdpolicy-am-compute.adoc
+++ b/modules/rosa-sdpolicy-am-compute.adoc
@@ -13,7 +13,7 @@ endif::[]
 = Instance types
 
 ifdef::rosa-with-hcp[]
-All {hcp-title} clusters require a minimum of 2 worker nodes. All {hcp-title} clusters support a maximum of 51 worker nodes. Shutting down the underlying infrastructure through the cloud provider console is unsupported and can lead to data loss.
+All {hcp-title} clusters require a minimum of 2 worker nodes. All {hcp-title} clusters support a maximum of 90 worker nodes. Shutting down the underlying infrastructure through the cloud provider console is unsupported and can lead to data loss.
 endif::rosa-with-hcp[]
 ifndef::rosa-with-hcp[]
 Single availability zone clusters require a minimum of 3 control plane nodes, 2 infrastructure nodes, and 2 worker nodes deployed to a single availability zone.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15+

Issue:
[OSDOCS-10164](https://issues.redhat.com/browse/OSDOCS-10164)

Link to docs preview:
[Instance types](https://74218--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html)

Peer reviewer:
- [x] Peer reviewer has approved this change.

SME review:
- [x] SME has approved this change.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
