### PR TITLE
OSDOCS-10116 Kube bump to 1.29 in 4.16 RNs

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -14,7 +14,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 == About this release
 
 // TODO: Update with the relevant information closer to release.
-{product-title} (link:https://access.redhat.com/errata/RHSA-2023:7198[RHSA-2023:7198]) is now available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md[Kubernetes 1.28] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
+{product-title} (link:https://access.redhat.com/errata/RHSA-2023:7198[RHSA-2023:7198]) is now available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.29.md[Kubernetes 1.29] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
 
 {product-title} {product-version} clusters are available at https://console.redhat.com/openshift. With the {cluster-manager-first} application for {product-title}, you can deploy {product-title} clusters to either on-premises or cloud environments.
 
@@ -407,14 +407,14 @@ In the following tables, features are marked with the following statuses:
 
 [id="ocp-4-16-removed-features"]
 === Removed features
-//.APIs removed from Kubernetes 1.27
+//.APIs removed from Kubernetes 1.29
 //[cols="2,2,2",options="header",]
 //|===
 //|Resource |Removed API |Migrate to
 
-//|`CSIStorageCapacity`
-//|`storage.k8s.io/v1beta1`
-//|`storage.k8s.io/v1`
+//|`kube-scheduler`
+//|`selectorSpread`
+//|`podTopologySpread`
 
 //|===
 [id="ocp-4-16-future-deprecation"]


### PR DESCRIPTION
Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-10116](https://issues.redhat.com/browse/OSDOCS-10116)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Preview](https://74228--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-about-this-release)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
