### PR TITLE
OADP-3847 - Fixing broken ifdef statement

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
@@ -3,8 +3,9 @@
 = Configuring the OpenShift API for Data Protection with OpenShift Data Foundation
 include::_attributes/common-attributes.adoc[]
 :context: installing-oadp-ocs
+:installing-oadp-ocs:
 :credentials: cloud-credentials
-:provider: gcp
+:provider: oadp-ocs
 
 toc::[]
 
@@ -45,3 +46,5 @@ include::modules/oadp-installing-dpa-1-3.adoc[leveloffset=+1]
 include::modules/oadp-creating-object-bucket-claim.adoc[leveloffset=+2]
 include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
 
+
+:installing-oadp-ocs!:

--- a/modules/oadp-installing-dpa-1-3.adoc
+++ b/modules/oadp-installing-dpa-1-3.adoc
@@ -6,6 +6,7 @@
 // * backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
 // * backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
 
+
 :_mod-docs-content-type: PROCEDURE
 [id="oadp-installing-dpa-1-3_{context}"]
 = Installing the Data Protection Application 1.3
@@ -24,6 +25,7 @@ ifdef::installing-oadp-azure,installing-oadp-gcp,installing-oadp-mcg,installing-
 ** `Secret` with a custom name for the backup location. You add this `Secret` to the `DataProtectionApplication` CR.
 ** `Secret` with another custom name for the snapshot location. You add this `Secret` to the `DataProtectionApplication` CR.
 endif::[]
+
 ifdef::installing-oadp-aws[]
 * If the backup and snapshot locations use different credentials, you must create a `Secret` with the default name, `{credentials}`, which contains separate profiles for the backup and snapshot location credentials.
 endif::[]
@@ -39,6 +41,7 @@ If you do not want to specify backup or snapshot locations during the installati
 . Under *Provided APIs*, click *Create instance* in the *DataProtectionApplication* box.
 
 . Click *YAML View* and update the parameters of the `DataProtectionApplication` manifest:
+
 ifdef::installing-oadp-aws[]
 +
 [source,yaml,subs="attributes+"]
@@ -95,6 +98,7 @@ spec:
 <11> Specify a snapshot location, unless you use CSI snapshots or a File System Backup (FSB) to back up PVs.
 <12> The snapshot location must be in the same region as the PVs.
 endif::[]
+
 ifdef::installing-oadp-azure[]
 +
 [source,yaml,subs="attributes+"]
@@ -155,6 +159,7 @@ spec:
 <13> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
 <14> You do not need to specify a snapshot location if you use CSI snapshots or Restic to back up PVs.
 endif::[]
+
 ifdef::installing-oadp-gcp[]
 +
 [source,yaml,subs="attributes+"]
@@ -210,6 +215,7 @@ spec:
 <13> The snapshot location must be in the same region as the PVs.
 <14> Google workload identity federation supports internal image backup. Set this field to `false` if you do not want to use image backup.
 endif::[]
+
 ifdef::installing-oadp-mcg[]
 +
 [source,yaml,subs="attributes+"]
@@ -260,6 +266,7 @@ spec:
 <10> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
 <11> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
 endif::[]
+
 ifdef::installing-oadp-ocs[]
 +
 [source,yaml,subs="attributes+"]
@@ -296,7 +303,7 @@ spec:
 ----
 <1> The default namespace for OADP is `openshift-adp`. The namespace is a variable and is configurable.
 <2> Optional: The `kubevirt` plugin is used with {VirtProductName}.
-<32> Specify the default plugin for the backup provider, for example, `gcp`, if appropriate.
+<3> Specify the default plugin for the backup provider, for example, `gcp`, if appropriate.
 <4> Specify the `csi` default plugin if you use CSI snapshots to back up PVs. The `csi` plugin uses the link:https://{velero-domain}/docs/main/csi/[Velero CSI beta snapshot APIs]. You do not need to configure a snapshot location.
 <5> The `openshift` plugin is mandatory.
 <6> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.
@@ -309,6 +316,7 @@ spec:
 <13> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
 <14> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
 endif::[]
+
 ifdef::virt-installing-configuring-oadp[]
 +
 [source,yaml,subs="attributes+"]
@@ -404,8 +412,8 @@ replicaset.apps/velero-588db7f655                              1         1      
 $ oc get dpa dpa-sample -n openshift-adp -o jsonpath='{.status}'
 ----
 .Example output
-[source,yaml]
 +
+[source,yaml]
 ----
 {"conditions":[{"lastTransitionTime":"2023-10-27T01:23:57Z","message":"Reconcile complete","reason":"Complete","status":"True","type":"Reconciled"}]}
 ----
@@ -419,8 +427,8 @@ $ oc get dpa dpa-sample -n openshift-adp -o jsonpath='{.status}'
 $ oc get backupStorageLocation -n openshift-adp
 ----
 .Example output
-[source,yaml]
 +
+[source,yaml]
 ----
 NAME           PHASE       LAST VALIDATED   AGE     DEFAULT
 dpa-sample-1   Available   1s               3d16h   true


### PR DESCRIPTION
### JIRA

* [OADP-3847](https://issues.redhat.com/browse/OADP-3847)

The content of the documentation has not changed, only formatting has been fixed

The 1.3 DPA -  [Configuring the OpenShift API for Data Protection with OpenShift Data Foundation  - Installing the Data Protection Application 1.3](https://docs.openshift.com/container-platform/4.15/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.html#oadp-installing-dpa-1-3_installing-oadp-ocs) is not formatted correctly because of an issue in the ifdef statement for [modules/oadp-installing-dpa-1-3.adoc](https://github.com/openshift/openshift-docs/pull/74243/files#diff-2f91f15b6ce12fc8e1733468735fa0f6f31a4a38c7f75f2cf4cba4c20afa7fa6)

![image](https://github.com/openshift/openshift-docs/assets/106804821/432cbc21-4c74-401c-a6ee-8b224d1f763e)

See doc preview for correction in formatting

### Versions

* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16

### Link to docs preview:

* [Installing the Data Protection Application 1.3](https://74243--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.html#oadp-installing-dpa-1-3_installing-oadp-ocs)

    The DPA for OADP 1.3 with callouts is now shown:

    ![image](https://github.com/openshift/openshift-docs/assets/106804821/7ec7b8ce-b576-4aca-b4e4-038058c7d1e8)



QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
