### PR TITLE
OSDOCS-8990-RN: temp remove xref from release notes MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -119,7 +119,8 @@ You can configure your network settings to run {microshift-short} on a fully dis
 
 [id="microshift-4-15-olm"]
 ==== Operator Lifecyle Manager
-With this release, you can use Operator Lifecyle Manager (OLM) to create, apply, and administer add-on Operators. See xref:../microshift_running_apps/microshift-operators-olm.adoc#microshift-operators-olm[Using Operator Lifecycle Manager with {microshift-short}].
+With this release, you can use Operator Lifecyle Manager (OLM) to create, apply, and administer add-on Operators.
+//TODO replace xref once refactor merges
 
 [id="microshift-4-15-deprecated-and-removed"]
 == Deprecated and removed features


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-8990](https://issues.redhat.com//browse/OSDOCS-8990)


Additional information:
To fix https://github.com/openshift/openshift-docs/pull/74256 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
