### PR TITLE
OSDOCS-8990-RNS3: replace xrefs with corrected MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -107,8 +107,7 @@ Various networking documentation improvements are now available in the {microshi
 
 * *Adding and closing ports.* This release also improved the documentation for adding and closing ports and services in your {microshift-short} firewall, see xref:../microshift_networking/microshift-firewall.adoc#microshift-firewall-optional-settings_microshift-firewall[Using optional port settings].
 
-* *Network policies introduction.* With this release, an introduction to setting network policies has been added to the {microshift-short} documentation. More details are expected to follow in z-stream releases.
-//TODO replace xref once refactor merges
+* *Network policies introduction.* With this release, an introduction to setting network policies has been added to the {microshift-short} documentation. More details are expected to follow in z-stream releases. See xref:../microshift_networking/microshift_network_policy/microshift-creating-network-policy.adoc#microshift-creating-network-policy[Creating network policies]
 
 [id="microshift-4-15-networking-disconnected"]
 ==== Configuring {microshift-short} on disconnected hosts
@@ -120,8 +119,7 @@ You can configure your network settings to run {microshift-short} on a fully dis
 
 [id="microshift-4-15-olm"]
 ==== Operator Lifecyle Manager
-With this release, you can use Operator Lifecyle Manager (OLM) to create, apply, and administer add-on Operators.
-//TODO replace xref once refactor merges
+With this release, you can use Operator Lifecyle Manager (OLM) to create, apply, and administer add-on Operators. See xref:../microshift_running_apps/microshift_operators/microshift-operators-olm.adoc#microshift-operators-olm[Using Operator Lifecycle Manager with {microshift-short}]
 
 [id="microshift-4-15-deprecated-and-removed"]
 == Deprecated and removed features
@@ -172,7 +170,7 @@ In the following tables, features are marked with the following statuses:
 [discrete]
 [id="microshift-4-15-networking-bug-fixes"]
 === Networking
-* Whenever `advertiseAddress` is configured with an IP address, any network interfaces must also be configured. Previously, manually setting the `advertiseAddress` in the {microshift-short} `config.yaml` to the IP address value that is expected to be set by default, but not manually setting the same IP address for the `br-ex` network bridge on the host, caused the `ovnkube-master` container in the `ovnkube-master` pod to crash. With this release, the {microshift-short} service verifies whether `advertiseAddress` is set in the `config.yaml` and whether any interface has the same IP address set. If the two settings are not the same, {microshift-short} prints an error, for example, `Advertise address: %s not present in any interface, advertiseAddress` and fails. This helps ensure the proper configuration before the system starts. (link:https://issues.redhat.com/browse/OCPBUGS-27398[*OCPBUGS-27398*]
+* Whenever `advertiseAddress` is configured with an IP address, any network interfaces must also be configured. Previously, manually setting the `advertiseAddress` in the {microshift-short} `config.yaml` to the IP address value that is expected to be set by default, but not manually setting the same IP address for the `br-ex` network bridge on the host, caused the `ovnkube-master` container in the `ovnkube-master` pod to crash. With this release, the {microshift-short} service verifies whether `advertiseAddress` is set in the `config.yaml` and whether any interface has the same IP address set. If the two settings are not the same, {microshift-short} prints an error, for example, `Advertise address: %s not present in any interface, advertiseAddress` and fails. This helps ensure the proper configuration before the system starts. (link:https://issues.redhat.com/browse/OCPBUGS-27398[*OCPBUGS-27398*])
 
 [discrete]
 [id="microshift-4-15-support-bug-fixes"]
@@ -253,8 +251,7 @@ For the latest images included with {microshift-short}, view the contents of the
 ==== Enhancements
 
 Change in openshift-marketplace namespace security::
-* With this release, the `openshift-marketplace` namespace security defaults to `baseline`. See the OLM documentation for specifics on how this change impacts your operator deployments. (link:https://issues.redhat.com/browse/OCPBUGS-30034[OCPBUGS-30034])
-//TODO replace xref once refactor merges
+* With this release, the `openshift-marketplace` namespace security defaults to `baseline`. See the Operator documentation for specifics on how this change impacts your Operator deployments. See xref:../microshift_running_apps/microshift_operators/microshift-operators-oc-mirror.adoc#microshift-operators-oc-mirror[Creating custom catalogs using the oc-mirror plugin] (link:https://issues.redhat.com/browse/OCPBUGS-30034[OCPBUGS-30034])
 
 [id="microshift-4-15-6-dp"]
 === RHSA-2024:1561 - {microshift-short} 4.15.6 bug fix and security update advisory


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-8990](https://issues.redhat.com//browse/OSDOCS-8990)

Link to docs preview:
[4.15 relnotes xrefs](https://74275--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html)

QE review:
- N/A

Additional information:
Replaces xrefs removed during Docs refactor work https://github.com/openshift/openshift-docs/pull/71992

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
