### PR TITLE
Command "oc sa get-token" is deprecated in RHOCP4

### DIFF
--- a/modules/service-accounts-as-oauth-clients.adoc
+++ b/modules/service-accounts-as-oauth-clients.adoc
@@ -22,7 +22,7 @@ When using a service account as an OAuth client:
 +
 [source,terminal]
 ----
-$ oc sa get-token <service_account_name>
+$ oc create token <service_account_name>
 ----
 
 * To get `WWW-Authenticate` challenges, set an


### PR DESCRIPTION
Command "$ oc sa get-token <service_account_name>" is deprecated and throwing error : 
Command "get-token" is deprecated, and will be removed in the future version. Use oc create token instead.
error: could not find a service account token for service account <service_account_name>

Use command "$ oc create token <service_account_name>" instead to get the token for service account.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Command "oc sa get-token" is deprecated in RHOCP4

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
All the RHOCP 4 versions

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-10189

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://docs.openshift.com/container-platform/4.15/authentication/using-service-accounts-as-oauth-client.html#service-accounts-as-oauth-clients_using-service-accounts-as-oauth-client

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
I tried reproducing the steps and observed error for the command mentioned in our OpenShift Documentation . However the command is throwing error and is not working as expected  -
[root@sdharma ~]# oc create sa test-sa
serviceaccount/test-sa created
[root@sdharma ~]# oc sa get-token test-sa
Command "get-token" is deprecated, and will be removed in the future version. Use oc create token instead.
error: could not find a service account token for service account "test-sa"

The "oc create token" command works as expected :
[root@sdharma ~]# oc create token test-sa
abcdefghijklmnopqrs-token
[root@sdharma ~]# oc sa get-token test-sa
Command "get-token" is deprecated, and will be removed in the future version. Use oc create token instead.
error: could not find a service account token for service account "test-sa"

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
