### PR TITLE
OSDOCS-9848: adds 4.15.8 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -261,3 +261,12 @@ Issued: 2024-04-02
 {product-title} release 4.15.6 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:1561[RHSA-2024:1561] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1559[RHSA-2024:1559] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-15-8-dp"]
+=== RHBA-2024:1670 - {microshift-short} 4.15.8 bug fix and security update advisory
+
+Issued: 2024-04-08
+
+{product-title} release 4.15.8 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1670[RHBA-2024:1670] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1668[RHSA-2024:1668] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-9848](https://issues.redhat.com/browse/OSDOCS-9845)

Link to docs preview:
[4.15.8](https://74289--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-8-dp)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
