### PR TITLE
OSDOCS-9845: adds 4.14.20 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -477,3 +477,12 @@ Issued: 2024-04-03
 {product-title} release 4.14.19 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:1566[RHSA-2024:1566] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:1564[RHBA-2024:1564] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-14-20-dp"]
+=== RHBA-2024:1682 - {microshift-short} 4.14.20 security update and bug fix update advisory
+
+Issued: 2024-04-08
+
+{product-title} release 4.14.20 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1682[RHBA-2024:1682] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1681[RHSA-2024:1681] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-9845](https://issues.redhat.com/browse/OSDOCS-9845)

Link to docs preview:
[4.14.20](https://74290--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
