### PR TITLE
[OSDOCS-10175]:Missing Permission in EFS ROSA DOC elasticfilesystem:TagResource

### DIFF
--- a/modules/osd-persistent-storage-csi-efs-sts.adoc
+++ b/modules/osd-persistent-storage-csi-efs-sts.adoc
@@ -40,7 +40,8 @@ If you perform this procedure after installing the driver and creating volumes, 
         "elasticfilesystem:DescribeAccessPoints",
         "elasticfilesystem:DescribeFileSystems",
         "elasticfilesystem:DescribeMountTargets",
-        "ec2:DescribeAvailabilityZones"
+        "ec2:DescribeAvailabilityZones",
+        "elasticfilesystem:TagResource"
       ],
       "Resource": "*"
     },


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.15+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-10175
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
 https://74291--ocpdocs-pr.netlify.app/openshift-rosa/latest/storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.html#efs-sts_osd-persistent-storage-aws-efs-csi

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
