### PR TITLE
[gitops-docs-1.9]: Removal of Fixed Issues and JIRA links from GitOps 1.9.4

### DIFF
--- a/modules/gitops-release-notes-1-9-4.adoc
+++ b/modules/gitops-release-notes-1-9-4.adoc
@@ -26,15 +26,3 @@ If you have installed the {gitops-title} Operator, view the container images in 
 ----
 $ oc describe deployment gitops-operator-controller-manager -n openshift-operators
 ----
-
-[id="fixed-issues-1-9-4_{context}"]
-== Fixed issues
-
-The following issue has been resolved in the current release:
-
-* Before this update, all versions of Argo CD `v2.7.2` and later were vulnerable to cross-server request forgery (CSRF) attacks. As a result, Argo CD accepted non-GET requests even if they did not specify a content type. This update fixes the issue by upgrading the Argo CD version to `v.2.7.16` and patches this vulnerability in the Argo CD API. link:https://issues.redhat.com/browse/GITOPS-3921[GITOPS-3921]
-+
-[IMPORTANT]
-====
-Breaking change: The Argo CD API will no longer accept non-GET requests that do not specify application or JSON as their content type. Although the accepted content types list is configurable, do not disable the content type check completely.
-====


### PR DESCRIPTION
Manual CP from https://github.com/openshift/openshift-docs/pull/74190 to gitops-docs-1.9