### PR TITLE
OSSM-6147 Add deprecation callout for automatic routes documentation

### DIFF
--- a/service_mesh/v2x/ossm-traffic-manage.adoc
+++ b/service_mesh/v2x/ossm-traffic-manage.adoc
@@ -24,6 +24,9 @@ include::modules/ossm-routing-gateways.adoc[leveloffset=+2]
 [id="ossm-auto-route_{context}"]
 == Understanding automatic routes
 
+:FeatureName: Istio OpenShift Routing (IOR)
+include::modules/deprecated-feature.adoc[leveloffset=+1]
+
 OpenShift routes for gateways are automatically managed in {SMProductShortName}. Every time an Istio Gateway is created, updated or deleted inside the service mesh, an OpenShift route is created, updated or deleted.
 
 [NOTE]


### PR DESCRIPTION
[OSSM-6147](https://issues.redhat.com//browse/OSSM-6147) Add deprecation callout for automatic routes documentation

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSSM-6147

Link to docs preview:
https://74299--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-traffic-manage#ossm-auto-route_traffic-management 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
