### PR TITLE
Update OSC "moved" page

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2582,11 +2582,11 @@ Topics:
 - Name: Disabling Windows container workloads
   File: disabling-windows-container-workloads
 ---
-Name: Sandboxed Containers Support for OpenShift
+Name: OpenShift sandboxed containers
 Dir: sandboxed_containers
 Distros: openshift-enterprise
 Topics:
-- Name: OpenShift sandboxed containers documentation has been moved
+- Name: Documentation moved
   File: sandboxed-containers-moved
 ---
 Name: Observability

--- a/sandboxed_containers/sandboxed-containers-moved.adoc
+++ b/sandboxed_containers/sandboxed-containers-moved.adoc
@@ -1,11 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="sandboxed-containers-moved"]
-= {sandboxed-containers-first} documentation has been moved
+= Documentation moved
 include::_attributes/common-attributes.adoc[]
 :context: sandboxed-containers-moved
 
-Starting from {product-title} 4.13, {sandboxed-containers-first} documentation has moved to a new location. See the following:
-
-* link:https://access.redhat.com/documentation/en-us/openshift_sandboxed_containers/{sandboxed-containers-version}/html-single/openshift_sandboxed_containers_release_notes/[{sandboxed-containers-first} release notes]
-
-* link:https://access.redhat.com/documentation/en-us/openshift_sandboxed_containers/{sandboxed-containers-version}/html-single/openshift_sandboxed_containers_user_guide/[{sandboxed-containers-first} user guide]
+The {sandboxed-containers-first} user guide and release notes have moved to a new link:https://access.redhat.com/documentation/en-us/openshift_sandboxed_containers/[location].


### PR DESCRIPTION
- Simplified the title and wording.
- Updated link to point to splash page so that we do not have to update the links for new versions.
- Change does not need to be CPed to 4.12 because that version was updated recently.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: None
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Docs moved](https://74320--ocpdocs-pr.netlify.app/openshift-enterprise/latest/sandboxed_containers/sandboxed-containers-moved.html)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
