### PR TITLE
OADP 3470 - DOC improvement - Must Gather Tool

### DIFF
--- a/modules/migration-using-must-gather.adoc
+++ b/modules/migration-using-must-gather.adoc
@@ -8,9 +8,17 @@
 [id="migration-using-must-gather_{context}"]
 = Using the must-gather tool
 
+When opening a support case, it is helpful to provide debugging information about your cluster to Red Hat Support.
+
+It is recommended to provide:
+
+* Data gathered using the `oc adm must-gather` command
+
+* The unique cluster ID
+
 You can collect logs, metrics, and information about {local-product} custom resources by using the `must-gather` tool.
 
-The `must-gather` data must be attached to all customer cases.
+The `must-gather` data must be attached to all customer support cases.
 
 ifdef::troubleshooting-3-4,troubleshooting-mtc[]
 You can collect data for a one-hour or a 24-hour period and view the data with the Prometheus console.


### PR DESCRIPTION
OADP 1.3.1

OCP 4.13+

Resolves - https://issues.redhat.com/browse/OADP-3470

Deploy preview - https://74328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting.html#migration-using-must-gather_oadp-troubleshooting
