### PR TITLE
OBSDOCS-68: How to send monitoring alerts to different receivers for …

### DIFF
--- a/modules/monitoring-configuring-different-alert-receivers-for-default-platform-alerts-and-user-defined-alerts.adoc
+++ b/modules/monitoring-configuring-different-alert-receivers-for-default-platform-alerts-and-user-defined-alerts.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * observability/monitoring/managing-alerts.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="configuring-different-alert-receivers-for-default-platform-alerts-and-user-defined-alerts_{context}"]
+= Configuring different alert receivers for default platform alerts and user-defined alerts
+
+You can configure different alert receivers for default platform alerts and user-defined alerts to ensure the following results:
+
+* All default platform alerts are sent to a receiver owned by the team in charge of these alerts.
+* All user-defined alerts are sent to another receiver so that the team can focus only on platform alerts.
+
+You can achieve this by using the `openshift_io_alert_source="platform"` label that is added by the Cluster Monitoring Operator to all platform alerts:
+
+* Use the `openshift_io_alert_source="platform"` matcher to match default platform alerts.
+* Use the `openshift_io_alert_source!="platform"` or `'openshift_io_alert_source=""'` matcher to match user-defined alerts.
+
+[NOTE]
+====
+This configuration does not apply if you have enabled a separate instance of Alertmanager dedicated to user-defined alerts.
+====

--- a/observability/monitoring/managing-alerts.adoc
+++ b/observability/monitoring/managing-alerts.adoc
@@ -92,6 +92,8 @@ include::modules/monitoring-sending-notifications-to-external-systems.adoc[level
 ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/monitoring-configuring-alert-receivers.adoc[leveloffset=+2]
 endif::openshift-dedicated,openshift-rosa[]
+// Configuring different alert receivers for default platform alerts and user-defined alerts
+include::modules/monitoring-configuring-different-alert-receivers-for-default-platform-alerts-and-user-defined-alerts.adoc[leveloffset=+2]
 // Creating alert routing for user-defined projects
 include::modules/monitoring-creating-alert-routing-for-user-defined-projects.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s): `enterprise-4.12` and later

Issue: [OBSDOCS-68](https://issues.redhat.com/browse/OBSDOCS-68)

Link to docs preview: [Configuring different alert receivers for default platform alerts and user-defined alerts](https://74329--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/managing-alerts#configuring-different-alert-receivers-for-default-platform-alerts-and-user-defined-alerts_managing-alerts)

QE review:
- [x] QE has approved this change.

**Additional information:**