### PR TITLE
TELCODOCS-1705-416 MetalLB: Drop the legacy AddressPool

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -97,6 +97,11 @@ This release introduces the following updates to the *Developer* perspective of 
 
 With this release, IP addresses and ranges are handled more efficiently in NSGs for {product-title} clusters hosted on Azure. As a result, the maximum limit of CIDRs for all Ingress Controllers in Azure clusters, using the `allowedSourceRanges` field, increases from approximately 1000 to 4000 CIDRs.
 
+[id="ocp-4-16-metallb-addresspool-removed"]
+==== MetalLB AddressPool custom resource definition (CRD) removed
+
+The MetalLB `AddressPool` custom resource definition (CRD) has been deprecated for several versions. However, in this release, the CRD is completely removed. The sole supported method of configuring MetalLB address pools is by using the `IPAddressPools` CRD. 
+
 [id="ocp-4-16-registry"]
 === Registry
 


### PR DESCRIPTION
[TELCODOCS-1705]: MetalLB: Drop the legacy AddressPool

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16 RN
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-1705
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://74330--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-metallb-addresspool-removed
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
