### PR TITLE
Tweaking Vale config to ensure ocpasciidoc rules fire

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -4,11 +4,11 @@ MinAlertLevel = suggestion
 
 Packages = RedHat, AsciiDoc, OpenShiftAsciiDoc
 
-Vocab = OpenShiftDocs
-
 # Ignore files in dirs starting with `.` to avoid raising errors for `.vale/fixtures/*/testinvalid.adoc` files
 [[!.]*.adoc]
 BasedOnStyles = RedHat, AsciiDoc, OpenShiftAsciiDoc
+
+Vocab = OpenShiftDocs
 
 # Disabling rules (NO)
 RedHat.ReleaseNotes = NO

--- a/modules/.vale.ini
+++ b/modules/.vale.ini
@@ -2,10 +2,10 @@ StylesPath = ../.vale/styles
 
 MinAlertLevel = suggestion
 
-Vocab = OpenShiftDocs
-
 [[!.]*.adoc]
 BasedOnStyles = OpenShiftAsciiDoc, AsciiDoc, RedHat
+
+Vocab = OpenShiftDocs
 
 # Use local OpenShiftDocs Vocab terms
 Vale.Terms = YES

--- a/scripts/prow-vale-review.sh
+++ b/scripts/prow-vale-review.sh
@@ -42,11 +42,18 @@ function get_vale_errors {
 # Run vale with the custom template on updated files and determine if a review comment should be posted
 for FILE in ${FILES};
 do
+    # Check if Vale should use the modules config or the root config. Ensures correct rule enabling/disabling
+    if [[ $FILE == modules/* ]]; then
+        INI="modules/.vale.ini"
+    else
+        INI=".vale.ini"
+    fi
+
     # Update conditional markup in place
     sed -i 's/ifdef::.*/ifdef::temp-ifdef[]/; s/ifeval::.*/ifeval::["{temp-ifeval}" == "temp"]/; s/ifndef::.*/ifndef::temp-ifndef[]/; s/endif::.*/endif::[]/;' "$FILE"
 
     # Parse for vale errors
-    vale_json=$(vale --minAlertLevel=error --output=.vale/templates/bot-comment-output.tmpl "$FILE" | jq)
+    vale_json=$(vale --minAlertLevel=error --output=.vale/templates/bot-comment-output.tmpl --config="$INI" "$FILE" | jq)
 
     # Check if there are Vale errors before processing the file further.
     if [[ "$vale_json" != "[]" ]]; then


### PR DESCRIPTION
Fixing issue where some OCP AsciiDoc Vale rules didn't fire.

- Move OCP Vocab line in .ini files below BasedOnStyles line because this causes some issue with processing otherwise.
- Updated the prow-vale-review script to check if the path points to the modules folder, and if so uses the vale.ini file in the modules folder. 
