### PR TITLE
OCPBUGS-29262-redo: Updated the vSphere add parameters to include mis…

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -58,7 +58,7 @@ ifeval::["{context}" == "installation-config-parameters-agent"]
 :agent:
 endif::[]
 
-// You can issue a command such as `openshift-install explain installconfig.platform.vsphere.failureDomains` to see information about a parameter. You must store the `openshift-install` binary in your bin directory.
+// You can issue a command such as `openshift-install explain installconfig.platform.vsphere.failureDomains` to see information about a parameter. You must store the `openshift-install` binary in your bin directory. Also, consider viewing the installer/pkg/types/vsphere/platform.go for information about supported parameters.
 
 :_mod-docs-content-type: CONCEPT
 [id="installation-configuration-parameters_{context}"]
@@ -2642,18 +2642,16 @@ ifdef::agent,vsphere[]
 Additional VMware vSphere configuration parameters are described in the following table:
 
 .Additional VMware vSphere cluster parameters
-[cols=".^2l,.^3a,.^3",options="header,word-wrap",subs="+quotes,+attributes"]
+[cols=".^2l,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
 |====
 |Parameter|Description|Values
-ifdef::agent[]
 
 |platform:
   vsphere:
-| Describes your account on the cloud platform that hosts your cluster. You can use the parameter to customize the platform. If you provide additional configuration settings for compute and control plane machines in the machine pool, the parameter is not required. You can only specify one vCenter server for your {product-title} cluster.
+|Describes your account on the cloud platform that hosts your cluster. You can use the parameter to customize the platform. If you provide additional configuration settings for compute and control plane machines in the machine pool, the parameter is not required. You can only specify one vCenter server for your {product-title} cluster.
 |A dictionary of vSphere configuration objects
-endif::agent[]
-ifdef::vsphere[]
 
+ifdef::vsphere[]
 |platform:
   vsphere:
     apiVIPs:
@@ -2665,16 +2663,9 @@ ifdef::vsphere[]
 |platform:
   vsphere:
     diskType:
-|Optional. The disk provisioning method. This value defaults to the vSphere default storage policy if not set.
+|Optional: The disk provisioning method. This value defaults to the vSphere default storage policy if not set.
 |Valid values are `thin`, `thick`, or `eagerZeroedThick`.
-
-|platform:
-  vsphere:
-    failureDomains:
-|Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
-|String
 endif::vsphere[]
-ifdef::agent[]
 
 |platform:
   vsphere:
@@ -2692,27 +2683,23 @@ ifdef::agent[]
 |platform:
   vsphere:
     failureDomains:
+      region:
+|If you define multiple failure domains for your cluster, you must attach the tag to each vCenter datacenter. To define a region, use a tag from the `openshift-region` tag category. For a single vSphere datacenter environment, you do not need to attach a tag, but you must enter an alphanumeric value, such as `datacenter`, for the parameter.
+|String
+
+|platform:
+  vsphere:
+    failureDomains:
       server:
-|The fully qualified domain name (FQDN) of the vCenter server.
-|An FQDN such as example.com
-endif::agent[]
-
-|platform:
-  vsphere:
-    failureDomains:
-      topology:
-        datastore:
-|Specifies the path to a vSphere datastore that stores virtual machines files for a failure domain. You must apply the `datastore` role to the vSphere vCenter datastore location.
+|Specifies the fully-qualified hostname or IP address of the VMware vCenter server, so that a client can access failure domain resources. You must apply the `server` role to the vSphere vCenter server location.
 |String
 
 |platform:
   vsphere:
     failureDomains:
-      topology:
-        networks:
-|Lists any network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured.
+      zone:
+|If you define multiple failure domains for your cluster, you must attach a tag to each vCenter cluster. To define a zone, use a tag from the `openshift-zone` tag category. For a single vSphere datacenter environment, you do not need to attach a tag, but you must enter an alphanumeric value, such as `cluster`, for the parameter.
 |String
-ifdef::agent[]
 
 |platform:
   vsphere:
@@ -2736,27 +2723,18 @@ The list of datacenters must match the list of datacenters specified in the `vce
     failureDomains:
       topology:
         datastore:
+ifdef::vsphere[]
+|Specifies the path to a vSphere datastore that stores virtual machines files for a failure domain. You must apply the `datastore` role to the vSphere vCenter datastore location.
+endif::vsphere[]
+ifdef::agent[]
 |The path to the vSphere datastore that holds virtual machine files, templates, and ISO images.
-[IMPORTANT]
-====
-You can specify the path of any datastore that exists in a datastore cluster.
+
+*Important:* You can specify the path of any datastore that exists in a datastore cluster.
 By default, Storage vMotion is automatically enabled for a datastore cluster.
 Red{nbsp}Hat does not support Storage vMotion, so you must disable Storage vMotion to avoid data loss issues for your {product-title} cluster.
 
-If you must specify VMs across multiple datastores, use a `datastore` object to specify a failure domain in your cluster's `install-config.yaml` configuration file.
-For more information, see "VMware vSphere region and zone enablement".
-====
-|String
-
-|platform:
-  vsphere:
-    failureDomains:
-      topology:
-        resourcePool:
-// When this content is added to vSphere docs, the line below should likely say "where the installation program creates the virtual machines".
-|Optional: The absolute path of an existing resource pool where the user creates the virtual machines, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
-// Commenting out the line below because it doesn't apply to Agent, but it may be needed when this content is brought into the regular vSphere docs.
-// If you do not specify a value, resources are installed in the root of the cluster, for example `/example_datacenter/host/example_cluster/Resources`.
+If you must specify VMs across multiple datastores, use a `datastore` object to specify a failure domain in your cluster's `install-config.yaml` configuration file. For more information, see "VMware vSphere region and zone enablement".
+endif::agent[]
 |String
 
 |platform:
@@ -2764,43 +2742,41 @@ For more information, see "VMware vSphere region and zone enablement".
     failureDomains:
       topology:
         folder:
-// When this content is added to vSphere docs, the line below should likely say "where the installation program creates the virtual machines", and should be Optional.
-|The absolute path of an existing folder where the user creates the virtual machines, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
-// Commenting out the two lines below because they don't apply to Agent, but they may be needed when this content is brought into the regular vSphere docs.
-// If you do not provide this value, the installation program creates a top-level folder in the datacenter virtual machine folder that is named with the infrastructure ID.
-// If you are providing the infrastructure for the cluster and you do not want to use the default `StorageClass` object, named `thin`, you can omit the `folder` parameter from the `install-config.yaml` file.
-|String
-endif::agent[]
-
-|platform:
-  vsphere:
-    failureDomains:
-      server:
-|Specifies the fully-qualified hostname or IP address of the VMware vCenter server, so that a client can access failure domain resources. You must apply the `server` role to the vSphere vCenter server location.
-|String
-
-|platform:
-  vsphere:
-    failureDomains:
-      region:
-|If you define multiple failure domains for your cluster, you must attach the tag to each vCenter datacenter. To define a region, use a tag from the `openshift-region` tag category. For a single vSphere datacenter environment, you do not need to attach a tag, but you must enter an alphanumeric value, such as `datacenter`, for the parameter.
-|String
-
-|platform:
-  vsphere:
-    failureDomains:
-      zone:
-|If you define multiple failure domains for your cluster, you must attach the tag to each vCenter cluster. To define a zone, use a tag from the `openshift-zone` tag category. For a single vSphere datacenter environment, you do not need to attach a tag, but you must enter an alphanumeric value, such as `cluster`, for the parameter.
-|String
-
-|platform:
-  vsphere:
-    failureDomains:
-      template:
-|Specify the absolute path to a pre-existing {op-system-first} image template or virtual machine. The installation program can use the image template or virtual machine to quickly install {op-system} on vSphere hosts. Consider using this parameter as an alternative to uploading an {op-system} image on vSphere hosts. The parameter is available for use only on installer-provisioned infrastructure.
-|String
+|Optional: The absolute path of an existing folder where the user creates the virtual machines, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
 ifdef::vsphere[]
+If you do not provide this value, the installation program creates a top-level folder in the datacenter virtual machine folder that is named with the infrastructure ID. If you are providing the infrastructure for the cluster and you do not want to use the default `StorageClass` object, named `thin`, you can omit the `folder` parameter from the `install-config.yaml` file.
+endif::vsphere[]
+|String
 
+|platform:
+  vsphere:
+    failureDomains:
+      topology:
+        networks:
+|Lists any network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured.
+|String
+
+|platform:
+  vsphere:
+    failureDomains:
+      topology:
+        resourcePool:
+
+|Optional: The absolute path of an existing resource pool where the installation program creates the virtual machines, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
+ifdef::vsphere[]
+If you do not specify a value, the installation program installs the resources in the root of the cluster under `/<datacenter_name>/host/<cluster_name>/Resources`.
+endif::vsphere[]
+|String
+
+|platform:
+  vsphere:
+    failureDomains:
+      topology
+        template:
+|Specifies the absolute path to a pre-existing {op-system-first} image template or virtual machine. The installation program can use the image template or virtual machine to quickly install {op-system} on vSphere hosts. Consider using this parameter as an alternative to uploading an {op-system} image on vSphere hosts. This parameter is available for use only on installer-provisioned infrastructure.
+|String
+
+ifdef::vsphere[]
 |platform:
   vsphere:
     ingressVIPs:
@@ -2808,27 +2784,13 @@ ifdef::vsphere[]
 
 *Note:* This parameter applies only to installer-provisioned infrastructure.
 |Multiple IP addresses
-
-|platform:
-  vsphere:
-| Describes your account on the cloud platform that hosts your cluster. You can use the parameter to customize the platform. When providing additional configuration settings for compute and control plane machines in the machine pool, the parameter is optional. You can only specify one vCenter server for your {product-title} cluster.
-|String
-
-|platform:
-  vsphere:
-    vcenters:
-|Lists any fully-qualified hostname or IP address of a vCenter server.
-|String
 endif::vsphere[]
-ifdef::agent[]
 
 |platform:
   vsphere:
     vcenters:
-|Configures the connection details so that services can communicate with vCenter.
-Currently, only a single vCenter is supported.
+|Configures the connection details so that services can communicate with a vCenter server. Currently, only a single vCenter server is supported.
 |An array of vCenter configuration objects.
-endif::agent[]
 
 |platform:
   vsphere:
@@ -2836,7 +2798,6 @@ endif::agent[]
       datacenters:
 |Lists and defines the datacenters where {product-title} virtual machines (VMs) operate. The list of datacenters must match the list of datacenters specified in the `failureDomains` field.
 |String
-ifdef::agent[]
 
 |platform:
   vsphere:
@@ -2865,7 +2826,6 @@ ifdef::agent[]
       user:
 |The username associated with the vSphere user.
 |String
-endif::agent[]
 |====
 
 [id="deprecated-parameters-vsphere_{context}"]
@@ -2911,11 +2871,10 @@ endif::vsphere[]
 |platform:
   vsphere:
     folder:
-|Optional. The absolute path of an existing folder where the installation program creates the virtual machines. If you do not provide this value, the installation program creates a folder that is named with the infrastructure ID in the data center virtual machine folder.
+|Optional: The absolute path of an existing folder where the installation program creates the virtual machines. If you do not provide this value, the installation program creates a folder that is named with the infrastructure ID in the data center virtual machine folder.
 |String, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
 
 ifdef::vsphere[]
-
 |platform:
   vsphere:
     ingressVIP:
@@ -2940,7 +2899,7 @@ endif::vsphere[]
 |platform:
   vsphere:
     resourcePool:
-|Optional. The absolute path of an existing resource pool where the installation program creates the virtual machines. If you do not specify a value, the installation program installs the resources in the root of the cluster under `/<datacenter_name>/host/<cluster_name>/Resources`.
+|Optional: The absolute path of an existing resource pool where the installation program creates the virtual machines. If you do not specify a value, the installation program installs the resources in the root of the cluster under `/<datacenter_name>/host/<cluster_name>/Resources`.
 a|String, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
 
 |platform:
@@ -2958,6 +2917,7 @@ in vSphere.
 |The fully-qualified hostname or IP address of a vCenter server.
 |String
 |====
+endif::agent,vsphere[]
 
 ifdef::vsphere[]
 [id="installation-configuration-parameters-optional-vsphere_{context}"]
@@ -3002,7 +2962,6 @@ Optional VMware vSphere machine pool configuration parameters are described in t
 |Integer
 |====
 endif::vsphere[]
-endif::agent,vsphere[]
 
 ifdef::ash[]
 [id="installation-configuration-parameters-additional-azure-stack-hub_{context}"]
@@ -3297,7 +3256,7 @@ If defined, the parameters `compute.platform.alibabacloud` and `controlPlane.pla
 endif::alibaba-cloud[]
 
 ifdef::nutanix[]
-[id="installation-configuration-parameters-additional-vsphere_{context}"]
+[id="installation-configuration-parameters-additional-nutanix_{context}"]
 == Additional Nutanix configuration parameters
 
 Additional Nutanix configuration parameters are described in the following table:


### PR DESCRIPTION
Version(s):
4.12 to 4.16

Issue:
[OCPBUGS-29262](https://issues.redhat.com/browse/OCPBUGS-29262)

Link to docs preview:
* [Additional VMware vSphere configuration parameters](https://74339--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere#installation-configuration-parameters-additional-vsphere_installation-config-parameters-vsphere)
* [Agent-based installer additional parameters](https://74339--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installation-config-parameters-agent#installation-configuration-parameters-additional-vsphere_installation-config-parameters-agent)

QE review:
- [x] SME has approved this change.
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* https://github.com/openshift/openshift-docs/pull/70551#issuecomment-1930706031
* https://github.com/openshift/openshift-docs/pull/72733
