### PR TITLE
OBSDOCS-950: COO 0.1.3 Release Notes

### DIFF
--- a/modules/monitoring-specifying-how-a-service-is-monitored-by-cluster-observability-operator.adoc
+++ b/modules/monitoring-specifying-how-a-service-is-monitored-by-cluster-observability-operator.adoc
@@ -6,9 +6,9 @@
 [id="specifying-how-a-service-is-monitored-by-cluster-observability-operator_{context}"]
 = Specifying how a service is monitored by {coo-full}
 
-To use the metrics exposed by the sample service you created in the "Deploying a sample service for {coo-full}" section, you must configure monitoring components to scrape metrics from the `/metrics` endpoint. 
+To use the metrics exposed by the sample service you created in the "Deploying a sample service for {coo-full}" section, you must configure monitoring components to scrape metrics from the `/metrics` endpoint.
 
-You can create this configuration by using a `ServiceMonitor` object that specifies how the service is to be monitored, or a `PodMonitor` object that specifies how a pod is to be monitored. 
+You can create this configuration by using a `ServiceMonitor` object that specifies how the service is to be monitored, or a `PodMonitor` object that specifies how a pod is to be monitored.
 The `ServiceMonitor` object requires a `Service` object. The `PodMonitor` object does not, which enables the `MonitoringStack` object to scrape metrics directly from the metrics endpoint exposed by a pod.
 
 This procedure shows how to create a `ServiceMonitor` object for a sample service named `prometheus-coo-example-app` in the `ns1-coo` namespace.
@@ -21,7 +21,7 @@ This procedure shows how to create a `ServiceMonitor` object for a sample servic
 +
 [NOTE]
 ====
-The `prometheus-coo-example-app` sample service does not support TLS authentication. 
+The `prometheus-coo-example-app` sample service does not support TLS authentication.
 ====
 
 .Procedure
@@ -30,7 +30,7 @@ The `prometheus-coo-example-app` sample service does not support TLS authenticat
 +
 [source,yaml]
 ----
-apiVersion: monitoring.rhobs/v1alpha1
+apiVersion: monitoring.rhobs/v1
 kind: ServiceMonitor
 metadata:
   labels:

--- a/monitoring/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
+++ b/monitoring/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
@@ -16,11 +16,23 @@ The {coo-short} complements the built-in monitoring capabilities of {product-tit
 
 These release notes track the development of the {coo-full} in {product-title}.
 
+[id="cluster-observability-operator-release-notes-0-1-3"]
+== {coo-full} 0.1.3
+The following advisory is available for {coo-full} 0.1.3:
+
+* link:https://access.redhat.com/errata/RHEA-2024:1744[RHEA-2024:1744 Cluster Observability Operator 0.1.3]
+
+[id="cluster-observability-operator-0-1-3-bug-fixes"]
+=== Bug fixes
+
+* Previously, if you tried to access the Prometheus web user interface (UI) at `\http://<prometheus_url>:9090/graph`, the following error message would display: `Error opening React index.html: open web/ui/static/react/index.html: no such file or directory`.
+This release resolves the issue, and the Prometheus web UI now displays correctly. (link:https://issues.redhat.com/browse/COO-34[*COO-34*])
+
 [id="cluster-observability-operator-release-notes-0-1-2"]
 == {coo-full} 0.1.2
 The following advisory is available for {coo-full} 0.1.2:
 
-* link:https://access.redhat.com/errata/RHEA-2024:1534[2024:1534 Cluster Observability Operator 0.1.2]
+* link:https://access.redhat.com/errata/RHEA-2024:1534[RHEA-2024:1534 Cluster Observability Operator 0.1.2]
 
 [id="cluster-observability-operator-0-1-2-CVEs"]
 === CVEs


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issues:
- https://issues.redhat.com/browse/OBSDOCS-950
- https://issues.redhat.com/browse/OBSDOCS-956
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://74346--ocpdocs-pr.netlify.app/openshift-enterprise/latest/monitoring/cluster_observability_operator/cluster-observability-operator-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR makes the following changes:
- adds release notes for Cluster Observability Operation 0.1.3
- fixes the incorrect `apiVersion` value in the sample YAML for the example service monitor
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
