### PR TITLE
[TRACING-4026] Replace tracegen by telemetrygen

### DIFF
--- a/observability/otel/otel-forwarding.adoc
+++ b/observability/otel/otel-forwarding.adoc
@@ -115,26 +115,25 @@ spec:
 
 [TIP]
 ====
-You can deploy `tracegen` as a test:
+You can deploy `telemetrygen` as a test:
 [source,yaml]
 ----
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: tracegen
+  name: telemetrygen
 spec:
   template:
     spec:
       containers:
-        - name: tracegen
-          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/tracegen:latest
-          command:
-            - "./tracegen"
+        - name: telemetrygen
+          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:latest
           args:
-            - -otlp-endpoint=otel-collector:4317
-            - -otlp-insecure
-            - -duration=30s
-            - -workers=1
+            - traces
+            - --otlp-endpoint=otel-collector:4317
+            - --otlp-insecure
+            - --duration=30s
+            - --workers=1
       restartPolicy: Never
   backoffLimit: 4
 ----


### PR DESCRIPTION
Version(s):   4.16, 4.15, 4.14, 4.13, 4.12

Issue: [TRACING-4026](https://issues.redhat.com//browse/TRACING-4026)

Link to docs preview: https://74350--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-forwarding.html

QE review:
- [x] QE has approved this change.
