### PR TITLE
Added --overwrite to both the command of $ oc label namespace

### DIFF
--- a/modules/security-context-constraints-psa-opting.adoc
+++ b/modules/security-context-constraints-psa-opting.adoc
@@ -26,7 +26,7 @@ Run the following command:
 +
 [source,terminal]
 ----
-$ oc label namespace <namespace> security.openshift.io/scc.podSecurityLabelSync=false
+$ oc label namespace <namespace> --overwrite security.openshift.io/scc.podSecurityLabelSync=false
 ----
 
 ** To enable pod security admission label synchronization in a namespace, set the value of the `security.openshift.io/scc.podSecurityLabelSync` label to `true`.
@@ -35,5 +35,5 @@ Run the following command:
 +
 [source,terminal]
 ----
-$ oc label namespace <namespace> security.openshift.io/scc.podSecurityLabelSync=true
+$ oc label namespace <namespace> --overwrite security.openshift.io/scc.podSecurityLabelSync=true
 ----


### PR DESCRIPTION
I have added --overwrite parameter to the **documentation** command to reflect overwriting of label. When enabling pod security admission label synchronization the command $ oc label namespace <namespace> security.openshift.io/scc.podSecurityLabelSync=true   results in an unsuccessful result if the podSecurityLabelSync is already set to false. 

$ oc label namespace demos security.openshift.io/scc.podSecurityLabelSync=true 
 **error: 'security.openshift.io/scc.podSecurityLabelSync' already has a value (false), and --overwrite is false**

It solves bug [OCPBUGS-29653](https://issues.redhat.com/browse/OCPBUGS-29653)

Version(s):
4.16
4.15
4.14
4.13
4.12

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
