### PR TITLE
Clarify the role of compliance operator

### DIFF
--- a/security/compliance_operator/co-overview.adoc
+++ b/security/compliance_operator/co-overview.adoc
@@ -4,12 +4,21 @@
 include::_attributes/common-attributes.adoc[]
 :context: co-overview
 
-{product-title} Compliance Operator (CO) runs compliance scans and provides remediations to assist users in meeting compliance standards. For the latest updates, see the xref:../../security/compliance_operator/compliance-operator-release-notes.adoc#compliance-operator-release-notes[Compliance Operator release notes]. If needed, you can engage link:https://access.redhat.com/support/[Red Hat support].
+The {product-title} Compliance Operator assists users by automating the
+inspection of numerous technical implementations and compares those against
+certain aspects of industry standards, benchmarks, and baselines; the
+Compliance Operator is not an auditor. In order to be compliant or certified
+under these various standards, you need to engage an authorized auditor such as
+a Qualified Security Assessor (QSA), Joint Authorization Board (JAB), or other
+industry recognized regulatory authority to assess your environment.
 
-[IMPORTANT]
-====
-The Compliance Operator does not automatically perform remediations. Ensuring compliance standards are met is required by the user.
-====
+The Compliance Operator makes recommendations based on generally available
+information and practices regarding such standards and may assist with
+remediations, but actual compliance is your responsibility. You are required to
+work with an authorized auditor to achieve compliance with a standard. For the
+latest updates, see the
+xref:../../security/compliance_operator/compliance-operator-release-notes.adoc#compliance-operator-release-notes[Compliance
+Operator release notes]
 
 [discrete]
 ==== Compliance Operator concepts

--- a/security/compliance_operator/co-scans/compliance-operator-supported-profiles.adoc
+++ b/security/compliance_operator/co-scans/compliance-operator-supported-profiles.adoc
@@ -4,7 +4,16 @@
 include::_attributes/common-attributes.adoc[]
 :context: compliance-operator-supported-profiles
 
-There are several profiles available as part of the Compliance Operator (CO) installation. While you can use the following profiles to assess gaps in a cluster, usage alone does not infer or guarantee compliance with a particular profile.
+There are several profiles available as part of the Compliance Operator (CO)
+installation. While you can use the following profiles to assess gaps in a
+cluster, usage alone does not infer or guarantee compliance with a particular
+profile and is not an auditor.
+
+In order to be compliant or certified under these various standards, you need
+to engage an authorized auditor such as a Qualified Security Assessor (QSA),
+Joint Authorization Board (JAB), or other industry recognized regulatory
+authority to assess your environment. You are required to work with an
+authorized auditor to achieve compliance with a standard.
 
 
 [IMPORTANT]
@@ -18,4 +27,4 @@ include::modules/compliance-supported-profiles.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-* xref:../../../security/compliance_operator/co-concepts/compliance-operator-understanding.html#compliance_profile_types_understanding-compliance[Compliance Operator profile types]
+* xref:../../../security/compliance_operator/co-concepts/compliance-operator-understanding.adoc#compliance_profile_types_understanding-compliance[Compliance Operator profile types]


### PR DESCRIPTION
It's important to note that the compliance operator is a useful tool, but not a complete replacement for an auditor, or regulatory authority required in some industries.

This commit tries to bring that message to the front of the OpenShift Compliance Operator book.

Version(s):
The Compliance Operator is compatible with all supported versions of OpenShift, so this commit would be applicable to all supported versions of the OpenShift documentation.

Issue:

None - just an improvement to the documentation.

Link to docs preview:
[Compliance Operator overview](https://74381--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/co-overview.html)

QE review:
Not required

Additional information:
None
