### PR TITLE
Fix arch for prow-smoke-test.sh

### DIFF
--- a/scripts/prow-smoke-test.sh
+++ b/scripts/prow-smoke-test.sh
@@ -33,12 +33,11 @@ DISTRO=$2
 PRODUCT_NAME=$3
 VERSION=$4
 ARCH=$(uname -m)
-if [[ $ARCH == x86_64 ]]; then
-    TAG=latest
-elif [[ $ARCH == aarch64 ]]; then
+TAG=latest # default tag
+if [[ $ARCH == "aarch64" || $ARCH == "arm64" ]]; then
     TAG=multiarch
 fi
-CONTAINER_IMAGE=quay.io/redhat-docs/openshift-docs-asciidoc:$TAG
+CONTAINER_IMAGE="quay.io/redhat-docs/openshift-docs-asciidoc:$TAG"
 SCRIPT_HEADSIZE=$(head -30 ${0} |grep -n "^# END_OF_HEADER" | cut -f1 -d:)
 
 if [[ "$1" == "--help" || "$1" == "-h" ]]; then


### PR DESCRIPTION
I encountered an issue running the script on my M2 Mac. If neither `x86_64` nor `aarch64` is detected, the TAG variable remains unset. I've added the default tag as `latest` and added `arm64` arch type.

<img width="529" alt="Screenshot 2024-04-08 at 11 11 43 PM" src="https://github.com/openshift/openshift-docs/assets/23069445/08893121-7b45-4cd0-8c40-51fd0c54eb31">

<img width="356" alt="Screenshot 2024-04-08 at 11 12 57 PM" src="https://github.com/openshift/openshift-docs/assets/23069445/7654b05c-63e5-4c4a-b40e-3a3c7e374c8e">


Cherrypick:
- `pipelines-docs-main`
- `serverless-docs-main`
- `gitops-docs-main`
- `build-docs-main`
- `service-mesh-docs-main`
- `opp-docs-main`
- `rhacs-docs-main`
- `rhde-docs-main`
- `rhde-docs-main`
