### PR TITLE
COS-1706 Add partition number when referencing var in butane examples

### DIFF
--- a/modules/installation-disk-partitioning-upi-templates.adoc
+++ b/modules/installation-disk-partitioning-upi-templates.adoc
@@ -98,7 +98,8 @@ storage:
     partitions:
     - label: var
       start_mib: <partition_start_offset> <2>
-      size_mib: <partition_size> <3>
+      size_mib: <partition_size> <3> 
+      number: 5
   filesystems:
     - device: /dev/disk/by-partlabel/var
       path: /var

--- a/modules/installation-disk-partitioning.adoc
+++ b/modules/installation-disk-partitioning.adoc
@@ -96,7 +96,8 @@ storage:
     partitions:
     - label: var
       start_mib: <partition_start_offset> <2>
-      size_mib: <partition_size> <3>
+      size_mib: <partition_size> <3> 
+      number: 5
   filesystems:
     - device: /dev/disk/by-partlabel/var
       path: /var

--- a/modules/installation-user-infra-machines-advanced.adoc
+++ b/modules/installation-user-infra-machines-advanced.adoc
@@ -161,7 +161,8 @@ storage:
     partitions:
     - label: var
       start_mib: <partition_start_offset> <2>
-      size_mib: <partition_size> <3>
+      size_mib: <partition_size> <3> 
+      number: 5
   filesystems:
     - device: /dev/disk/by-partlabel/var
       path: /var


### PR DESCRIPTION
Fixes: [COS-1706](https://issues.redhat.com//browse/COS-1706)

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10,4.11,4.12,4.13,.4.14,4.15

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/COS-1706
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
Sorry first time contributer to the docs, I have tried to to ascii build with some errors from the bin it's self. Is there a way to run it via a container like fcos docs? 

QE review:
- [x] QE has approved this change.

Additional information:
Really a simple change. Want to include the part number 5 for var partition, as it is the only part number var should be. Otherwise it might be confusing to end users. 

