### PR TITLE
OSDOCS-10139 RODOO 1.1.1 RNs

### DIFF
--- a/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
+++ b/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
@@ -14,16 +14,23 @@ These release notes track the development of the {run-once-operator} for {produc
 
 For an overview of the {run-once-operator}, see xref:../../../nodes/pods/run_once_duration_override/index.adoc#run-once-about_run-once-duration-override-about[About the {run-once-operator}].
 
-[id="run-once-duration-override-operator-release-notes-1-1-0"]
-== Run Once Duration Override Operator 1.1.0
+[id="run-once-duration-override-operator-release-notes-1-1-1"]
+== Run Once Duration Override Operator 1.1.1
 
-Issued: 2024-02-28
+Issued: 2024-07-01
 
-The following advisory is available for the {run-once-operator} 1.1.0:
+The following advisory is available for the {run-once-operator} 1.1.1: link:https://access.redhat.com/errata/RHSA-2024:1616[RHSA-2024:1616]
 
-* link:https://access.redhat.com/errata/RHSA-2024:0269[RHSA-2024:0269]
+[id="RODOO-operator-1-1-1-new-features-and-enhancements"]
+=== New features and enhancements
 
-[id="run-once-duration-override-operator-1-1-0-bug-fixes"]
+* You can install and use the {run-once-operator} in an {product-title} cluster running in FIPS mode.
++
+--
+include::snippets/fips-snippet.adoc[]
+--
+
+[id="run-once-duration-override-operator-1-1-1-bug-fixes"]
 === Bug fixes
 
 * This release of the {run-once-operator} addresses several Common Vulnerabilities and Exposures (CVEs).


### PR DESCRIPTION
Version(s): 4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-10139](https://issues.redhat.com/browse/OSDOCS-10139)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Preview](https://74426--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.html#run-once-duration-override-operator-release-notes-1-1-1)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
