### PR TITLE
OSDOCS-10171: Deduper merge mode

### DIFF
--- a/modules/network-observability-quickfilter.adoc
+++ b/modules/network-observability-quickfilter.adoc
@@ -11,7 +11,6 @@ Query Options::
 You can use *Query Options* to optimize the search results, as listed below:
 
 ** *Log Type*: The available options *Conversation* and *Flows* provide the ability to query flows by log type, such as flow log, new conversation, completed conversation, and a heartbeat, which is a periodic record with updates for long conversations. A conversation is an aggregation of flows between the same peers.
-** *Duplicated flows*: A flow might be reported from several interfaces, and from both source and destination nodes, making it appear in the data several times. By selecting this query option, you can choose to show duplicated flows. Duplicated flows have the same sources and destinations, including ports, and also have the same protocols, with the exception of `Interface` and `Direction` fields. Duplicates are hidden by default. Use the *Direction* filter in the *Common* section of the dropdown list to switch between ingress and egress traffic.
 ** *Match filters*: You can determine the relation between different filter parameters selected in the advanced filter. The available options are *Match all* and *Match any*. *Match all*  provides results that match all the values, and *Match any* provides results that match any of the values entered. The default value is *Match all*.
 ** *Drops filter*: You can view different levels of dropped packets with the following query options:
 *** *Fully dropped* shows flow records with fully dropped packets.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
Only merge to `no-1.6`
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-10171
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
Remove Show Duplicates: https://74435--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/observing-network-traffic.html#network-observability-quickfilternw-observe-network-traffic
QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
Merge to only the `no-1.6` branch - no cherrypicks are required.
This PR is part of an experiment for simplifying merges for asynchronous content, and I will open one PR against main to incorporate all of the Network Observability 1.6 content just before its GA

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
