### PR TITLE
[OSDOCS-6940]:(phase-1) new standard, non-GPU instances for OSD on GCP

### DIFF
--- a/modules/sdpolicy-am-gcp-compute-types.adoc
+++ b/modules/sdpolicy-am-gcp-compute-types.adoc
@@ -6,6 +6,10 @@
 = Google Cloud compute types
 
 {product-title} offers the following worker node types and sizes on Google Cloud that are chosen to have a common CPU and memory capacity that are the same as other cloud instance types:
+[NOTE]
+====
+`e2`, `ns` and `c2` compute types are available for CCS only.
+====
 
 .General purpose
 [%collapsible]
@@ -17,6 +21,19 @@
 * custom-48-199608 (48 vCPU, 192 GiB)
 * custom-64-262144 (64 vCPU, 256 GiB)
 * custom-96-393216 (96 vCPU, 384 GiB)
+* e2-standard-4 (4 vCPU, 16 GiB)
+* n2-standard-4 (4 vCPU, 16 GiB)
+* e2-standard-8 (8 vCPU, 32 GiB)
+* n2-standard-8 (8 vCPU, 32 GiB)
+* e2-standard-16 (16 vCPU, 64 GiB)
+* n2-standard-16 (16 vCPU, 64 GiB)
+* e2-standard-32 (32 vCPU, 128 GiB)
+* n2-standard-32 (32 vCPU, 128 GiB)
+* n2-standard-48 (48 vCPU, 192 GiB)
+* n2-standard-64 (64 vCPU, 256 GiB)
+* n2-standard-80 (80 vCPU, 320 GiB)
+* n2-standard-96 (96 vCPU, 384 GiB)
+* n2-standard-128 (128 vCPU, 512 GiB)
 ====
 
 .Memory-optimized
@@ -25,6 +42,18 @@
 * custom-4-32768-ext (4 vCPU, 32 GiB)
 * custom-8-65536-ext (8 vCPU, 64 GiB)
 * custom-16-131072-ext (16 vCPU, 128 GiB)
+* e2-highmem-4 (4 vCPU, 32 GiB)
+* e2-highmem-8 (8 vCPU, 64 GiB)
+* e2-highmem-16 (16 vCPU, 128 GiB)
+* n2-highmem-4 (4 vCPU, 32 GiB)
+* n2-highmem-8 (8 vCPU, 64 GiB)
+* n2-highmem-16 (16 vCPU, 128 GiB)
+* n2-highmem-32 (32 vCPU, 256 GiB)
+* n2-highmem-48 (48 vCPU, 384 GiB)
+* n2-highmem-64 (64 vCPU, 512 GiB)
+* n2-highmem-80 (80 vCPU, 640 GiB)
+* n2-highmem-96 (96 vCPU, 768 GiB)
+* n2-highmem-128 (128 vCPU, 864 GiB)
 ====
 
 .Compute-optimized
@@ -36,4 +65,19 @@
 * custom-48-98304 (48 vCPU, 96 GiB)
 * custom-72-147456 (72 vCPU, 144 GiB)
 * custom-96-196608 (96 vCPU, 192 GiB)
+* c2-standard-4 (4 vCPU, 16 GiB)
+* c2-standard-8 (8 vCPU, 32 GiB)
+* c2-standard-16 (16 vCPU, 64 GiB)
+* c2-standard-30 (30 vCPU, 120 GiB)
+* c2-standard-60 (60 vCPU, 240 GiB)
+* e2-highcpu-8 (8 vCPU, 8 GiB)
+* e2-highcpu-16 (16 vCPU, 16 GiB)
+* e2-highcpu-32 (32 vCPU, 32 GiB)
+* n2-highcpu-8 (8 vCPU, 8 GiB)
+* n2-highcpu-16 (16 vCPU, 16 GiB)
+* n2-highcpu-32 (32 vCPU, 32 GiB)
+* n2-highcpu-48 (48 vCPU, 48 GiB)
+* n2-highcpu-64 (64 vCPU, 64 GiB)
+* n2-highcpu-80 (80 vCPU, 80 GiB)
+* n2-highcpu-96 (96 vCPU, 96 GiB)
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.15+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-6940
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://74436--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-service-definition.html#gcp-compute-types_osd-service-definition
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
