### PR TITLE
OSDOCS-10041 broken link in cloudfront doc fix

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-using-cloudfront-and-waf.adoc
+++ b/cloud_experts_tutorials/cloud-experts-using-cloudfront-and-waf.adoc
@@ -355,5 +355,5 @@ The expected result is a `403 Forbidden` error, which means the AWS WAF is prote
 [id="additional-resources_{context}"]
 == Additional resources
 
-* link:https://docs.openshift.com/rosa/applications/deployments/osd-config-custom-domains-applications.html[Custom domains for applications] in the Red Hat documentation
+* link:https://docs.openshift.com/rosa/applications/deployments/rosa-config-custom-domains-applications.html[Custom domains for applications] in the Red Hat documentation
 * link:https://youtu.be/-HorEsl2ho4[Adding Extra Security with AWS WAF, CloudFront and ROSA | Amazon Web Services] on YouTube


### PR DESCRIPTION
Fixes a broken link in the cloud experts Cloudfront doc. 

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.15+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-10041
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://74441--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-using-cloudfront-and-waf.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
