### PR TITLE
Correct the information regarding enabling IMDSv2 in existing machines

### DIFF
--- a/modules/machineset-imds-options.adoc
+++ b/modules/machineset-imds-options.adoc
@@ -18,9 +18,8 @@ You can use machine sets to create machines that use a specific version of the A
 Using IMDSv2 is only supported on AWS clusters that were created with {product-title} version 4.7 or later.
 ====
 
-To change the IMDS configuration for existing machines, edit the machine set YAML file that manages those machines.
 ifndef::cpmso[]
-To deploy new compute machines with your preferred IMDS configuration, create a compute machine set YAML file with the appropriate values.
+To deploy new compute machines with your preferred IMDS configuration, create a compute machine set YAML file with the appropriate values. You can also edit an existing machine set to create new machines with your preferred IMDS configuration when the machine set is scaled up. 
 endif::cpmso[]
 
 [IMPORTANT]


### PR DESCRIPTION
Corretcing information regarding  enabling IMDSv2 in existing machines.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.15, 4.14, 4.13, 4.12
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-31403
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://74443--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws.html#machineset-imds-options_creating-machineset-aws
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
IMDSv2 can't be enabled for existing machines by editing a machineset. But the doc implies that it can be, which is wrong. Only new machines created after scaling the machineset will have the setting enabled.
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
