### PR TITLE
fix: add missing OpenShift Auth and claim mappings to declarative config examples

### DIFF
--- a/modules/declarative-configuration-examples.adoc
+++ b/modules/declarative-configuration-examples.adoc
@@ -31,25 +31,30 @@ groups: <4>
 requiredAttributes: <7>
     - key: org_id
       value: "12345"
-oidc: <8>
-    issuer: sample.issuer.com <9>
-    mode: auto <10>
+claimMappings: <8>
+    - path: org_id
+      value: my_org_id
+oidc: <9>
+    issuer: sample.issuer.com <10>
+    mode: auto <11>
     clientID: CLIENT_ID
     clientSecret: CLIENT_SECRET
 clientSecret: CLIENT_SECRET
-iap: <11>
+iap: <12>
     audience: audience
-saml: <12>
-    spIssuer: sample.issuer.com
-    metadataURL: sample.provider.com/metadata
 saml: <13>
     spIssuer: sample.issuer.com
-    cert: | <14>
+    metadataURL: sample.provider.com/metadata
+saml: <14>
+    spIssuer: sample.issuer.com
+    cert: | <15>
     ssoURL: saml.provider.com
     idpIssuer: idp.issuer.com
 userpki:
-    certificateAuthorities: | <15>
-    certificate <16>
+    certificateAuthorities: | <16>
+    certificate <17>
+openshift: <18>
+    enable: true
 ----
 <1> Identifies the minimum role that will be assigned by default to any user logging in. If left blank, the value is `None`.
 <2> Use the user interface endpoint of your Central instance.
@@ -58,15 +63,17 @@ userpki:
 <5> The key can be any claim returned from the authentication provider.
 <6> Identifies the role that the users are given. You can use a default role or a declaratively-created role.
 <7> Optional: Use these fields if attributes returned from the authentication provider are required; for example, if the audience is limited to a specific organization or group.
-<8> This section is required only for OpenID Connect (OIDC) authentication providers.
-<9> Identifies the expected issuer for the token.
-<10> Identifies the OIDC callback mode. Possible values are `auto`, `post`, `query`, and `fragment`. The preferred value is `auto`.
-<11> This section is required only for Google Identity-Aware Proxy (IAP) authentication providers.
-<12> This section is required only for Security Assertion Markup Language (SAML) 2.0 dynamic configuration authentication providers.
-<13> This section is required only for SAML 2.0 static configuration authentication providers.
-<14> Include the certificate in Privacy Enhanced Mail (PEM) format.
-<15> This section is required only for authentication with user certificates.
-<16> Include the certificate in PEM format.
+<8> Optional: Use these fields if claims returned from the identity provider should be mapped to custom claims.
+<9> This section is required only for OpenID Connect (OIDC) authentication providers.
+<10> Identifies the expected issuer for the token.
+<11> Identifies the OIDC callback mode. Possible values are `auto`, `post`, `query`, and `fragment`. The preferred value is `auto`.
+<12> This section is required only for Google Identity-Aware Proxy (IAP) authentication providers.
+<13> This section is required only for Security Assertion Markup Language (SAML) 2.0 dynamic configuration authentication providers.
+<14> This section is required only for SAML 2.0 static configuration authentication providers.
+<15> Include the certificate in Privacy Enhanced Mail (PEM) format.
+<16> This section is required only for authentication with user certificates.
+<17> Include the certificate in PEM format.
+<18> This section is required only for OpenShift Auth authentication providers.
 
 [id="declarative-config-example-permission-set"]
 == Declarative configuration permission set example


### PR DESCRIPTION
Add the missing OpenShift Auth auth provider and the claim mappings setting to the declarative config examples.

Versions:
- RHACS 4.2-4.5

Link to docs preview:
https://74451--ocpdocs-pr.netlify.app/openshift-acs/latest/configuration/declarative-configuration-using.html


