### PR TITLE
TELCODOCS-1509: Adding content for improved SR-IOV Network Operator node draining

### DIFF
--- a/modules/nw-sriov-configuring-multiple-nodes.adoc
+++ b/modules/nw-sriov-configuring-multiple-nodes.adoc
@@ -1,0 +1,171 @@
+:_mod-docs-content-type: PROCEDURE
+[id="configure-sr-iov-operator-parallel-nodes_{context}"]
+= Configuring parallel node draining during SR-IOV network policy updates
+
+By default, the SR-IOV Network Operator drains workloads from a node before every policy change.
+The Operator performs this action, one node at a time, to ensure that no workloads are affected by the reconfiguration.
+
+In large clusters, draining nodes sequentially can be time-consuming, taking hours or even days. In time-sensitive environments, you can enable parallel node draining in an `SriovNetworkPoolConfig` custom resource (CR) for faster rollouts of SR-IOV network configurations. 
+
+To configure parallel draining, use the `SriovNetworkPoolConfig` CR to create a node pool. You can then add nodes to the pool and define the maximum number of nodes in the pool that the Operator can drain in parallel. With this approach, you can enable parallel draining for faster reconfiguration while ensuring you still have enough nodes remaining in the pool to handle any running workloads.
+
+[NOTE]
+====
+A node can only belong to one SR-IOV network pool configuration. If a node is not part of a pool, it is added to a virtual, default, pool that is configured to drain one node at a time only.
+
+The node might restart during the draining process.
+====
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+* Install the SR-IOV Network Operator.
+* Nodes have hardware that support SR-IOV.
+
+.Procedure
+
+. Create a `SriovNetworkPoolConfig` resource:
+
+.. Create a YAML file that defines the `SriovNetworkPoolConfig` resource:
++
+.Example `sriov-nw-pool.yaml` file
+[source,yaml]
+----
+apiVersion: v1
+kind: SriovNetworkPoolConfig
+metadata:
+  name: pool-1 <1>
+  namespace: openshift-sriov-network-operator <2>
+spec:
+  maxUnavailable: 2 <3>
+  nodeSelector: <4>
+    matchLabels:
+      node-role.kubernetes.io/worker: ""
+----
+<1> Specify the name of the `SriovNetworkPoolConfig` object.
+<2> Specify namespace where the SR-IOV Network Operator is installed.
+<3> Specify an integer number, or percentage value, for nodes that can be unavailable in the pool during an update. For example, if you have 10 nodes and you set the maximum unavailable to 2, then only 2 nodes can be drained in parallel at any time, leaving 8 nodes for handling workloads.
+<4> Specify the nodes to add the pool by using the node selector. This example adds all nodes with the `worker` role to the pool.
+
+.. Create the `SriovNetworkPoolConfig` resource by running the following command:
++
+[source,terminal]
+----
+$ oc create -f sriov-nw-pool.yaml
+----
+
+. Create the `sriov-test` namespace by running the following comand:
++
+[source,terminal]
+----
+$ oc create namespace sriov-test
+----
+
+. Create a `SriovNetworkNodePolicy` resource:
+
+..  Create a YAML file that defines the `SriovNetworkNodePolicy` resource:
++
+.Example `sriov-node-policy.yaml` file
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: sriov-nic-1
+  namespace: openshift-sriov-network-operator
+spec:
+  deviceType: netdevice
+  nicSelector:
+    pfNames: ["ens1"]
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+  numVfs: 5
+  priority: 99
+  resourceName: sriov_nic_1
+----
+
+.. Create the `SriovNetworkNodePolicy` resource by running the following command:
++
+[source,terminal]
+----
+$ oc create -f sriov-node-policy.yaml
+----
+
+. Create a `SriovNetwork` resource:
+
+.. Create a YAML file that defines the `SriovNetwork` resource:
++
+.Example `sriov-network.yaml` file
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: sriov-nic-1
+  namespace: openshift-sriov-network-operator
+spec:
+  linkState: auto
+  networkNamespace: sriov-test
+  resourceName: sriov_nic_1
+  capabilities: '{ "mac": true, "ips": true }'
+  ipam: '{ "type": "static" }'
+----
+
+.. Create the `SriovNetwork` resource by running the following command:
++
+[source,terminal]
+----
+$ oc create -f sriov-network.yaml
+----
+
+.Verification 
+
+* View the node pool you created by running the following command:
++
+[source,terminal]
+----
+$ oc get sriovNetworkpoolConfig -n openshift-sriov-network-operator
+----
++
+.Example output
+[source,terminal]
+----
+NAME     AGE
+pool-1   67s <1>
+----
+<1> In this example, `pool-1` contains all the nodes with the `worker` role.
+
+To demonstrate the node draining process using the example scenario from the above procedure, complete the following steps:
+
+. Update the number of virtual functions in the `SriovNetworkNodePolicy` resource to trigger workload draining in the cluster:
++
+[source,terminal]
+----
+$ oc patch SriovNetworkNodePolicy sriov-nic-1 -n openshift-sriov-network-operator --type merge -p '{"spec": {"numVfs": 4}}'
+----
+
+. Monitor the draining status on the target cluster by running the following command:
++
+[source,terminal]
+----
+$ oc get sriovNetworkNodeState -n openshift-sriov-network-operator
+----
++
+.Example output
+[source,terminal]
+----
+NAMESPACE                          NAME       SYNC STATUS   DESIRED SYNC STATE   CURRENT SYNC STATE   AGE
+openshift-sriov-network-operator   worker-0   InProgress    Drain_Required       DrainComplete        3d10h
+openshift-sriov-network-operator   worker-1   InProgress    Drain_Required       DrainComplete        3d10h
+----
++
+When the draining process is complete, the `SYNC STATUS` changes to `Succeeded`, and the `DESIRED SYNC STATE` and `CURRENT SYNC STATE` values return to `IDLE`.
++
+.Example output
+[source,terminal]
+----
+NAMESPACE                          NAME       SYNC STATUS   DESIRED SYNC STATE   CURRENT SYNC STATE   AGE
+openshift-sriov-network-operator   worker-0   Succeeded     Idle                 Idle                 3d10h
+openshift-sriov-network-operator   worker-1   Succeeded     Idle                 Idle                 3d10h
+----

--- a/networking/hardware_networks/configuring-sriov-device.adoc
+++ b/networking/hardware_networks/configuring-sriov-device.adoc
@@ -14,13 +14,14 @@ include::modules/nw-sriov-networknodepolicy-object.adoc[leveloffset=+1]
 
 include::modules/nw-sriov-nic-partitioning.adoc[leveloffset=+2]
 
-
 include::modules/nw-sriov-configuring-device.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-updating_nodes-nodes-working[Understanding how to update labels on nodes].
+
+include::modules/nw-sriov-configuring-multiple-nodes.adoc[leveloffset=+2]
 
 include::modules/nw-sriov-troubleshooting.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[TELCODOCS-1509](https://issues.redhat.com//browse/TELCODOCS-1509): The SR-IOV Node Operator drains nodes to make SR-IOV node updates. These updates allow it to do this in parallel instead of in sequence for quicker rollout.

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1509

Link to docs preview:
https://74464--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-device.html#configure-sr-iov-operator-parallel-nodes_configuring-sriov-device

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
