### PR TITLE
OSDOCS-9429-FIX: address peer review comment on related PR

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -41,7 +41,7 @@ This release adds improvements related to the following components and concepts.
 
 [id="microshift-4-16-updating"]
 === Updating
-Updating two minor versions in a single step is now supported. Updates for both single-version minor releases and patch releases are also still supported.
+Updating two minor versions in a single step is now supported. Updates for both single-version minor releases and patch releases are still supported.
 
 [id="microshift-4-16-updates-supported"]
 ==== Update two minor versions in a single step
@@ -155,7 +155,7 @@ This section is updated over time to provide notes on enhancements and bug fixes
 [id="microshift-4-16-0-dp"]
 === RHEA-2024:0043 - {microshift-short} 4.16.0 bug fix and security update advisory
 
-Issued: 2024-06-03
+//Issued: 2024-MM-DD
 
 {product-title} release 4.16.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHEA-2024:0043[RHEA-2024:0043] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHEA-2024:0041[RHEA-2024:0041] advisory.
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-9429](https://issues.redhat.com/browse/OSDOCS-9429)

Link to docs preview:
[4.16 release notes](https://74465--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html)

Additional information:
Addresses peer review comment on https://github.com/openshift/openshift-docs/pull/74216

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
