### PR TITLE
OCPBUGS#32048: Remove tech preview banner

### DIFF
--- a/hosted_control_planes/hcp-troubleshooting.adoc
+++ b/hosted_control_planes/hcp-troubleshooting.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 If you encounter issues with hosted control planes, see the following information to guide you through troubleshooting.
 
-:FeatureName: Hosted control planes
-include::snippets/technology-preview.adoc[]
-
 include::modules/hosted-control-planes-troubleshooting.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-32048
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://74480--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-troubleshooting.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Approved

<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
