### PR TITLE
Hyperlink for Microsoft Azure documentation "listing user-assigned managed identities" is incorrect

### DIFF
--- a/modules/installation-using-azure-managed-identities.adoc
+++ b/modules/installation-using-azure-managed-identities.adoc
@@ -17,5 +17,5 @@ If you are unable to use a managed identity, you can use a service principal.
 .. Assign it to the virtual machine that you will run the installation program from.
 .. Record its client ID. You require this value when installing the cluster.
 +
-For more information about viewing the details of a user-assigned managed identity, see the Microsoft Azure documentation for link:https:https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp#list-user-assigned-managed-identities[listing user-assigned managed identities].
+For more information about viewing the details of a user-assigned managed identity, see the Microsoft Azure documentation for link:https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp#list-user-assigned-managed-identities[listing user-assigned managed identities].
 . Verify that the required permissions are assigned to the managed identity.


### PR DESCRIPTION
The hyperlink for Microsoft Azure documentation "listing user-assigned managed identities" is incorrect in doc[1]. In Using Azure managed identities , procedure 2.b 


[1] https://docs.openshift.com/container-platform/4.14/installing/installing_azure/installing-azure-account.html#installation-using-azure-managed-identities_installing-azure-account

Current link : 

link:https:https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp#list-user-assigned-managed-identities[listing user-assigned managed identities].


Actual link : 

link:https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp#list-user-assigned-managed-identities[listing user-assigned managed identities].


Version(s):
4.14,4.15

Issue:
https://issues.redhat.com/browse/OCPBUGS-32052

Link to docs preview:
https://docs.openshift.com/container-platform/4.15/installing/installing_azure/installing-azure-account.html#installation-using-azure-managed-identities_installing-azure-account