### PR TITLE
INTERNAL-FIX: vsphere-refactor-follow-up

### DIFF
--- a/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc
+++ b/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc
@@ -99,5 +99,5 @@ include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+2]
 
 * xref:../../../installing/install_config/installing-customizing.adoc#installing-customizing[Customize your cluster].
 * If necessary, you can xref:../../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, see xref:../../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]
+* If necessary, see xref:../../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster].
 * xref:../../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#configuring-registry-storage-vsphere[Set up your registry and configure registry storage].

--- a/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.adoc
+++ b/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.adoc
@@ -12,6 +12,7 @@ VMware vSphere instance by using installer-provisioned infrastructure. To custom
 
 include::snippets/vcenter-support.adoc[]
 
+[id="prerequisites_installing-vsphere-installer-provisioned-customizations"]
 == Prerequisites
 
 * You have completed the tasks in xref:../../../installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc#ipi-vsphere-preparing-to-install[Preparing to install a cluster using installer-provisioned infrastructure].
@@ -86,7 +87,7 @@ include::modules/nw-osp-services-external-load-balancer.adoc[leveloffset=+1]
 // Configuring an external load balancer
 include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+2]
 
-
+[id="next-steps_installing-vsphere-installer-provisioned-customizations"]
 == Next steps
 
 * xref:../../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].

--- a/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations.adoc
+++ b/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations.adoc
@@ -13,6 +13,7 @@ You must set most of the network configuration parameters during installation, a
 
 include::snippets/vcenter-support.adoc[]
 
+[id="prerequisites_installing-vsphere-installer-provisioned-network-customizations"]
 == Prerequisites
 
 * You have completed the tasks in xref:../../../installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc#ipi-vsphere-preparing-to-install[Preparing to install a cluster using installer-provisioned infrastructure].
@@ -98,6 +99,7 @@ include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+2]
 
 include::modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc[leveloffset=+1]
 
+[id="next-steps_installing-vsphere-installer-provisioned-network-customizations"]
 == Next steps
 
 * xref:../../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].

--- a/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned.adoc
+++ b/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned.adoc
@@ -11,6 +11,7 @@ VMware vSphere instance by using installer-provisioned infrastructure.
 
 include::snippets/vcenter-support.adoc[]
 
+[id="prerequisites_installing-vsphere-installer-provisioned_{context}"]
 == Prerequisites
 
 * You have completed the tasks in xref:../../../installing/installing_vsphere/ipi/ipi-vsphere-preparing-to-install.adoc#ipi-vsphere-preparing-to-install[Preparing to install a cluster using installer-provisioned infrastructure].
@@ -55,6 +56,7 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 * See xref:../../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
 
+[id="next-steps_installing-vsphere-installer-provisioned"]
 == Next steps
 
 * xref:../../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].

--- a/installing/installing_vsphere/upi/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/upi/installing-restricted-networks-vsphere.adoc
@@ -16,6 +16,7 @@ include::snippets/vcenter-support.adoc[]
 The steps for performing a user-provisioned infrastructure installation are provided as an example only. Installing a cluster with infrastructure you provide requires knowledge of the vSphere platform and the installation process of {product-title}. Use the user-provisioned infrastructure installation instructions as a guide; you are free to create the required resources through other methods.
 ====
 
+[id="prerequisites_installing-restricted-networks-vsphere_{context}"]
 == Prerequisites
 
 * You have completed the tasks in xref:../../../installing/installing_vsphere/upi/upi-vsphere-preparing-to-install.adoc#upi-vsphere-preparing-to-install[Preparing to install a cluster using user-provisioned infrastructure].
@@ -119,6 +120,7 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 * See xref:../../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
 
+[id="next-steps_installing-restricted-networks-vsphere"]
 == Next steps
 
 * xref:../../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].

--- a/installing/installing_vsphere/upi/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/upi/installing-vsphere-network-customizations.adoc
@@ -23,6 +23,7 @@ cluster.
 The steps for performing a user-provisioned infrastructure installation are provided as an example only. Installing a cluster with infrastructure you provide requires knowledge of the vSphere platform and the installation process of {product-title}. Use the user-provisioned infrastructure installation instructions as a guide; you are free to create the required resources through other methods.
 ====
 
+[id="prerequisites_installing-vsphere-network-customizations_{context}"]
 == Prerequisites
 
 * You have completed the tasks in xref:../../../installing/installing_vsphere/upi/upi-vsphere-preparing-to-install.adoc#upi-vsphere-preparing-to-install[Preparing to install a cluster using user-provisioned infrastructure].
@@ -104,6 +105,7 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 * See xref:../../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
 
+[id="next-steps_installing-vsphere-network-customizations"]
 == Next steps
 
 * xref:../../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].

--- a/installing/installing_vsphere/upi/installing-vsphere.adoc
+++ b/installing/installing_vsphere/upi/installing-vsphere.adoc
@@ -17,6 +17,7 @@ include::snippets/vcenter-support.adoc[]
 The steps for performing a user-provisioned infrastructure installation are provided as an example only. Installing a cluster with infrastructure you provide requires knowledge of the vSphere platform and the installation process of {product-title}. Use the user-provisioned infrastructure installation instructions as a guide; you are free to create the required resources through other methods.
 ====
 
+[id="prerequisites_installing-vsphere_{context}"]
 == Prerequisites
 
 * You have completed the tasks in xref:../../../installing/installing_vsphere/upi/upi-vsphere-preparing-to-install.adoc#upi-vsphere-preparing-to-install[Preparing to install a cluster using user-provisioned infrastructure].
@@ -105,6 +106,7 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 * See xref:../../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
 
+[id="next-steps_installing-vsphere"]
 == Next steps
 
 * xref:../../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].


### PR DESCRIPTION
INTERNAL FIX that addresses feedback from PR https://github.com/openshift/openshift-docs/pull/73685

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-10048

Link to docs preview:
* [installing-restricted-networks-installer-provisioned-vsphere.adoc](https://74511--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere)
* [Prereq+Next steps installing-vsphere-installer-provisioned-network-customizations](https://74511--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations#prerequisites_installing-vsphere-installer-provisioned-network-customizations)
* [Prereq+Next steps installing-vsphere-installer-provisioned-customizations](https://74511--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations#prerequisites_installing-vsphere-installer-provisioned-customizations)
* [Prereq+Next steps installing-vsphere-installer-provisioned](https://74511--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned)
* [Prereq+Next steps installing-restricted-networks-vsphere ](https://74511--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/installing-restricted-networks-vsphere#prerequisites_installing-restricted-networks-vsphere_installing-restricted-networks-vsphere)
* [Prereq+Next steps installing-vsphere-network-customizations](https://74511--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/installing-vsphere-network-customizations)
* [Prereq+Next stepsinstalling-vsphere](https://74511--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/installing-vsphere#prerequisites_installing-vsphere_installing-vsphere)
