### PR TITLE
Removing accept Vocab entry and adjust vale config

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -4,11 +4,11 @@ MinAlertLevel = suggestion
 
 Packages = RedHat, AsciiDoc, OpenShiftAsciiDoc
 
+Vocab = OpenShiftDocs
+
 # Ignore files in dirs starting with `.` to avoid raising errors for `.vale/fixtures/*/testinvalid.adoc` files
 [[!.]*.adoc]
 BasedOnStyles = RedHat, AsciiDoc, OpenShiftAsciiDoc
-
-Vocab = OpenShiftDocs
 
 # Disabling rules (NO)
 RedHat.ReleaseNotes = NO

--- a/.vale/styles/config/vocabularies/OpenShiftDocs/accept.txt
+++ b/.vale/styles/config/vocabularies/OpenShiftDocs/accept.txt
@@ -1,7 +1,5 @@
 # Regex terms added to accept.txt are ignored by the Vale linter and override RedHat Vale rules.
 # Add terms that have a corresponding incorrectly capitalized form to reject.txt.
-# URL slugs
-(.*/)+
 [Ff]ronthaul
 [Mm]idhaul
 [Pp]assthrough

--- a/modules/.vale.ini
+++ b/modules/.vale.ini
@@ -2,10 +2,10 @@ StylesPath = ../.vale/styles
 
 MinAlertLevel = suggestion
 
+Vocab = OpenShiftDocs
+
 [[!.]*.adoc]
 BasedOnStyles = OpenShiftAsciiDoc, AsciiDoc, RedHat
-
-Vocab = OpenShiftDocs
 
 # Use local OpenShiftDocs Vocab terms
 Vale.Terms = YES


### PR DESCRIPTION
The Vocab should be a global option above the style config.

````
Packages = RedHat, AsciiDoc, OpenShiftAsciiDoc

Vocab = OpenShiftDocs

# Ignore files in dirs starting with `.` to avoid raising errors for `.vale/fixtures/*/testinvalid.adoc` files
[[!.]*.adoc]
BasedOnStyles = RedHat, AsciiDoc, OpenShiftAsciiDoc
````
This entry in the accept.txt was causing xrefs to be accepted. They should be flagged in modules
`(.*/)+`

Apply to main only.