### PR TITLE
TELCODOCS-1683 QinQ support in SR-IOV Network Operator 1

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1408,6 +1408,8 @@ Topics:
     File: add-pod
   - Name: Configuring interface-level network sysctl settings and all-multicast mode for SR-IOV networks
     File: configuring-interface-sysctl-sriov-device
+  - Name: Configuring QinQ support for SR-IOV networks
+    File: configuring-sriov-qinq-support
   - Name: Using high performance multicast
     File: using-sriov-multicast
   - Name: Using DPDK and RDMA

--- a/modules/nw-configuring-qinq-sriov-proc.adoc
+++ b/modules/nw-configuring-qinq-sriov-proc.adoc
@@ -1,0 +1,178 @@
+// Module included in the following assemblies:
+//
+// * networking/hardware_networks/configuring-sriov-qinq-support.adoc
+// * 
+// * 
+
+:_mod-docs-content-type: PROCEDURE
+
+[id="nw-configuring-qinq-sriov-proc_{context}"]
+= Configuring QinQ support for SR-IOV enabled workloads
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the SR-IOV Network Operator.
+
+.Procedure
+
+. Create a file named `sriovnetpolicy-810-sriov-node-network.yaml` by using the following content:
++
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: sriovnetpolicy-810
+  namespace: openshift-sriov-network-operator
+spec:
+  deviceType: netdevice
+  nicSelector:
+    pfNames:
+      - ens5f0#0-9
+  nodeSelector:
+    node-role.kubernetes.io/worker-cnf: ""
+  numVfs: 10
+  priority: 99
+  resourceName: resource810
+----
+
+. Create the `SriovNetworkNodePolicy` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f sriovnetpolicy-810-sriov-node-network.yaml
+----
+
+. Open a separate terminal window and monitor the synchronization status of the SR-IOV network node state for the node specified in the `openshift-sriov-network-operator` namespace by running the following command:  
++
+[source,terminal]
+----
+$ watch -n 1 'oc get sriovnetworknodestates -n openshift-sriov-network-operator <node_name> -o jsonpath="{.status.syncStatus}"'
+----
++
+The synchronization status indicates a change from `InProgress` to `Succeeded`.
+
+. Create a `SriovNetwork` object, and set the outer VLAN called the S-tag, or `Service Tag`, as it belongs to the infrastructure.
++
+[IMPORTANT]
+====
+You must configure the VLAN on the trunk interface of the switch. In addition, you might need to further configure some switches to support QinQ tagging.
+====
+
+.. Create a file named `nad-sriovnetwork-1ad-810.yaml` by using the following content:
++
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: sriovnetwork-1ad-810
+  namespace: openshift-sriov-network-operator
+spec:
+  ipam: '{}'
+  vlan: 171 <1>
+  vlanProto: "802.1ad" <2>
+  networkNamespace: default
+  resourceName: resource810
+----
++
+<1> Sets the S-tag VLAN tag to `171`. 
+<2> Specifies the VLAN protocol to assign to the virtual function (VF). Supported values are `802.1ad` and `802.1q`. The default value is `802.1q`. 
+
+.. Create the object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f nad-sriovnetwork-1ad-810.yaml
+----
+
+. Create a `NetworkAttachmentDefinition` object with an inner VLAN. The inner VLAN is often referred to as the C-tag, or `Customer Tag`, as it belongs to the Network Function:
+
+.. Create a file named `nad-cvlan100.yaml` by using the following content:
++
+[source,yaml]
+----
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: nad-cvlan100
+  namespace: default
+spec:
+  config: '{
+    "name": "vlan-100",
+    "cniVersion": "0.3.1",
+    "type": "vlan",
+    "linkInContainer": true,
+    "master": "net1", <1>
+    "vlanId": 100,
+    "ipam": {"type": "static"}
+  }'
+----
++
+<1> Specifies the VF interface inside the pod. The default name is `net1` as the name is not set in the pod annotation. 
+
+.. Apply the YAML file by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f nad-cvlan100.yaml
+----
+
+.Verification
+
+* Verify QinQ is active on the node by following this procedure: 
+
+. Create a file named `test-qinq-pod.yaml` by using the following content:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  annotations:
+    k8s.v1.cni.cncf.io/networks: sriovnetwork-1ad-810, nad-cvlan100
+spec:
+  containers:
+    - name: test-container
+      image: quay.io/ocp-edge-qe/cnf-gotests-client:v4.10
+      imagePullPolicy: Always
+      securityContext:
+        privileged: true
+----
+
+. Create the test pod by running the following command:
++
+[source,terminal]
+----
+$ oc create -f test-qinq-pod.yaml
+---- 
+
+. Enter into a debug session on the target node where the pod is present and display information about the network interface `ens5f0` by running the following command:
++
+[source,terminal]
+----
+$ oc debug node/my-cluster-node -- bash -c "ip link show ens5f0"
+----
++
+.Example output
+
+[source,terminal]
+----
+6: ens5f0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
+link/ether b4:96:91:a5:22:10 brd ff:ff:ff:ff:ff:ff
+vf 0 link/ether a2:81:ba:d0:6f:f3 brd ff:ff:ff:ff:ff:ff, spoof checking on, link-state auto, trust off
+vf 1 link/ether 8a:bb:0a:36:f2:ed brd ff:ff:ff:ff:ff:ff, vlan 171, vlan protocol 802.1ad, spoof checking on, link-state auto, trust off
+vf 2 link/ether ca:0e:e1:5b:0c:d2 brd ff:ff:ff:ff:ff:ff, spoof checking on, link-state auto, trust off
+vf 3 link/ether ee:6c:e2:f5:2c:70 brd ff:ff:ff:ff:ff:ff, spoof checking on, link-state auto, trust off
+vf 4 link/ether 0a:d6:b7:66:5e:e8 brd ff:ff:ff:ff:ff:ff, spoof checking on, link-state auto, trust off
+vf 5 link/ether da:d5:e7:14:4f:aa brd ff:ff:ff:ff:ff:ff, spoof checking on, link-state auto, trust off
+vf 6 link/ether d6:8e:85:75:12:5c brd ff:ff:ff:ff:ff:ff, spoof checking on, link-state auto, trust off
+vf 7 link/ether d6:eb:ce:9c:ea:78 brd ff:ff:ff:ff:ff:ff, spoof checking on, link-state auto, trust off
+vf 8 link/ether 5e:c5:cc:05:93:3c brd ff:ff:ff:ff:ff:ff, spoof checking on, link-state auto, trust on
+vf 9 link/ether a6:5a:7c:1c:2a:16 brd ff:ff:ff:ff:ff:ff, spoof checking on, link-state auto, trust off   
+----
++
+The `vlan protocol 802.1ad` ID in the output indicates that the interface supports VLAN tagging with protocol 802.1ad (QinQ). The VLAN ID is 171.

--- a/modules/nw-sriov-about-qinq.adoc
+++ b/modules/nw-sriov-about-qinq.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assembly:
+//
+// * networking/hardware_networks/configuring-sriov-qinq-support.adocance/configuring-sriov-qinq-support.adoc
+
+
+:_mod-docs-content-type: CONCEPT
+[id="nw-about-qinq-support_{context}"]
+= About 802.1Q-in-802.1Q support
+
+In traditional VLAN setups, frames typically contain a single VLAN tag, such as VLAN-100, as well as other metadata such as Quality of Service (QoS) bits and protocol information. QinQ introduces a second VLAN tag, where the service provider designates the outer tag for their use, offering them flexibility, while the inner tag remains dedicated to the customer's VLAN.
+
+QinQ facilitates the creation of nested VLANs by using double VLAN tagging, enabling finer segmentation and isolation of traffic within a network environment. This approach is particularly valuable in service provider networks where you need to deliver VLAN-based services to multiple customers over a common infrastructure, while ensuring separation and isolation of traffic.
+
+When two VLAN tags are present in a packet, the outer VLAN tag can be either 802.1Q or 802.1ad. The inner VLAN tag must always be 802.1Q.
+
+The {product-title} SR-IOV solution already supports setting the VLAN protocol on the `SriovNetwork` custom resource (CR). The virtual function (VF) can use this protocol to set the VLAN tag, also known as the outer tag. Pods can then use the VLAN CNI plugin to configure the inner tag.
+
+.Supported network interface cards 
+[cols="30%,30%,40%",options="header"]
+|===
+| NIC | 802.1ad/802.1Q | 802.1Q/802.1Q
+
+| Intel X710 | No
+a|Supported 
+
+| Intel E810 | Supported 
+a| Supported 
+
+| Mellanox | No
+a| Supported 
+|===

--- a/networking/hardware_networks/configuring-sriov-qinq-support.adoc
+++ b/networking/hardware_networks/configuring-sriov-qinq-support.adoc
@@ -1,0 +1,18 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="configuring-qinq-support"]
+= Configuring QinQ support for SR-IOV enabled workloads
+include::_attributes/common-attributes.adoc[]
+:context: configuring-qinq-support
+
+toc::[]
+
+QinQ, formally known as 802.1Q-in-802.1Q, is a networking technique defined by IEEE 802.1ad. IEEE 802.1ad extends the IEEE 802.1Q-1998 standard and enriches VLAN capabilities by introducing an additional 802.1Q tag to packets already tagged with 802.1Q. This method is also referred to as VLAN stacking or double VLAN.
+
+include::modules/nw-sriov-about-qinq.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-vlan-object_configuring-additional-network[Configuration for an VLAN additional network]
+
+include::modules/nw-configuring-qinq-sriov-proc.adoc[leveloffset=+1]


### PR DESCRIPTION
[TELCODOCS-1683]: Docs and RN: [CNF-9990](https://issues.redhat.com//browse/CNF-9990) QinQ support in SR-IOV Network Operator (GA)

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-1683
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://74534--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-qinq-support.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
