### PR TITLE
OSDOCS-9433-2: corrects cluster ID MicroShift

### DIFF
--- a/microshift_support/microshift-getting-cluster-id.adoc
+++ b/microshift_support/microshift-getting-cluster-id.adoc
@@ -6,12 +6,13 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-When opening a support case, you can give information about your cluster to Red Hat Support by providing the unique identifier (UID) of your cluster. To uniquely identify a {microshift-short} cluster, use the `kube-system` namespace metadata UID.
+When providing information to Red{nbsp}Hat Support, it is helpful to provide the unique identifier of your cluster. For {microshift-short}, you can get your cluster ID manually by using the {oc-first} or by retrieving the ID from a file.
 
 [NOTE]
 ====
-The cluster ID for a cluster gets created only after the {microshift-short} service runs for the first time after its installation.
+A cluster ID is created only after the {microshift-short} service runs for the first time after installation.
 ====
 
 include::modules/microshift-get-cluster-id-kubesystem.adoc[leveloffset=+1]
+
 include::modules/microshift-get-nonrunning-cluster-id-kubesystem.adoc[leveloffset=+1]

--- a/modules/microshift-get-cluster-id-kubesystem.adoc
+++ b/modules/microshift-get-cluster-id-kubesystem.adoc
@@ -6,11 +6,11 @@
 [id="microshift-get-cluster-id-kubesystem_{context}"]
 = Getting the cluster ID of a running cluster
 
-For a cluster that is running, you can use either step1 or step2 to get the cluster ID.
+Use either the of the following steps to get the ID of a running cluster.
 
 .Procedure
 
-. Get the cluster ID of the cluster that is running by entering the following command:
+* Get the ID of a running cluster using `oc get` by entering the following command:
 +
 [source,terminal]
 ----
@@ -22,7 +22,8 @@ $ oc get namespaces kube-system -o jsonpath={.metadata.uid}
 ----
 7cf13853-68f4-454e-8f5c-1af748cbfb1a
 ----
-. Optional. Get the cluster ID of the cluster that is running by entering the following command:
+
+* Get the ID of a running cluster by retrieving it from the `cluster-id` file by entering the following command:
 +
 [source,terminal]
 ----

--- a/modules/microshift-get-nonrunning-cluster-id-kubesystem.adoc
+++ b/modules/microshift-get-nonrunning-cluster-id-kubesystem.adoc
@@ -4,13 +4,13 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="microshift-get-nonrunning-cluster-id-kubesystem_{context}"]
-= Getting the cluster ID of a nonrunning cluster
+= Getting the cluster ID of a stopped cluster
 
-For a cluster that is not running, you can get the cluster ID from the `cluster-id` file found in `/var/lib/microshift` directory.
+For a cluster that ran before, but is not running now, you can get the cluster ID from the `cluster-id` file in the `/var/lib/microshift` directory.
 
 .Procedure
 
-. Get the cluster ID of the cluster that is not running by entering the following command:
+* Get the ID of a stopped cluster by retrieving it from the `cluster-id` file by entering the following command:
 +
 [source,terminal]
 ----
@@ -21,22 +21,4 @@ $ sudo cat /var/lib/microshift/cluster-id
 [source,terminal]
 ----
 7cf13853-68f4-454e-8f5c-1af748cbfb1a
-----
-+
-[NOTE]
-====
-The {microshift-short} service copies the `kube-system` namespace metadata UID to the `cluster-id` file so that the UID is accessible when the cluster is not running. You can find the `cluster-id` file in the `/var/lib/microshift` directory.
-====
-
-. You can view the {microshift-short} database files in the `/var/lib/microshift` directory by entering the following command:
-+
-[source,terminal]
-----
-$ sudo ls -l /var/lib/microshift
-----
-.Example output
-+
-[source,terminal]
-----
--r-------- 1 root root 36 Mar  7 11:49 /var/lib/microshift/cluster-id
 ----


### PR DESCRIPTION
Version(s):
4.16+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[Getting the cluster ID](https://74538--ocpdocs-pr.netlify.app/microshift/latest/microshift_support/microshift-getting-cluster-id.html)

SME review:
- [x] SME has approved this change.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[Addresses post-merge comments for 73364](https://github.com/openshift/openshift-docs/pull/73364)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
