### PR TITLE
HCIDOCS-122: SNO Networking Requirements Update

### DIFF
--- a/installing/installing_sno/install-sno-installing-sno.adoc
+++ b/installing/installing_sno/install-sno-installing-sno.adoc
@@ -67,6 +67,7 @@ include::modules/install-sno-generating-the-install-iso-manually.adoc[leveloffse
 [role="_additional-resources"]
 .Additional resources
 
+* See xref:../../installing/installing_sno/install-sno-preparing-to-install-sno.adoc#preparing-to-install-sno[Requirements for installing OpenShift on a single node] for more information about installing {product-title} on a single node.
 * See xref:../../post_installation_configuration/enabling-cluster-capabilities.adoc[Enabling cluster capabilities] for more information about enabling cluster capabilities that were disabled prior to installation.
 * See xref:../../installing/cluster-capabilities.adoc#explanation_of_capabilities_cluster-capabilities[Optional cluster capabilities in {product-title} {product-version}] for more information about the features provided by each capability.
 

--- a/modules/install-sno-generating-the-install-iso-manually.adoc
+++ b/modules/install-sno-generating-the-install-iso-manually.adoc
@@ -12,6 +12,11 @@ Installing {product-title} on a single node requires an installation ISO, which 
 
 * Install `podman`.
 
+[NOTE]
+====
+See "Requirements for installing OpenShift on a single node" for networking requirements, including DNS records.
+====
+
 .Procedure
 
 ifndef::openshift-origin[]

--- a/modules/install-sno-requirements-for-installing-on-a-single-node.adoc
+++ b/modules/install-sno-requirements-for-installing-on-a-single-node.adoc
@@ -55,9 +55,12 @@ BMC is not supported on {ibm-z-name} and {ibm-power-name}.
 [options="header"]
 |====
 |Usage|FQDN|Description
-|Kubernetes API|`api.<cluster_name>.<base_domain>`| Add a DNS A/AAAA or CNAME record. This record must be resolvable by clients external to the cluster.
+|Kubernetes API|`api.<cluster_name>.<base_domain>`| Add a DNS A/AAAA or CNAME record. This record must be resolvable by both clients external to the cluster and within the cluster.
 |Internal API|`api-int.<cluster_name>.<base_domain>`| Add a DNS A/AAAA or CNAME record when creating the ISO manually. This record must be resolvable by nodes within the cluster.
-|Ingress route|`*.apps.<cluster_name>.<base_domain>`| Add a wildcard DNS A/AAAA or CNAME record that targets the node. This record must be resolvable by clients external to the cluster.
+|Ingress route|`*.apps.<cluster_name>.<base_domain>`| Add a wildcard DNS A/AAAA or CNAME record that targets the node. This record must be resolvable by both clients external to the cluster and within the cluster.
 |====
 +
+[IMPORTANT]
+====
 Without persistent IP addresses, communications between the `apiserver` and `etcd` might fail.
+====


### PR DESCRIPTION
**Fixes:** [HCIDOCS-122](https://issues.redhat.com/browse/HCIDOCS-122)

**For:** Version 4.13+

**Doc Previews:**
[Requirements for installing OpenShift on a single node](https://74541--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-preparing-to-install-sno.html)
[Generating the installation ISO with coreos-installer](https://74541--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-installing-sno#generating-the-install-iso-manually_install-sno-installing-sno-with-the-assisted-installer)

**QE review:**
- [x] QE has approved this change.

**Signed-off-by:** Katie Drake kdrake@redhat.com