### PR TITLE
[OCPBUGS-9302] This method does not provide an option for bare metal

### DIFF
--- a/modules/installation-initializing-manual.adoc
+++ b/modules/installation-initializing-manual.adoc
@@ -263,13 +263,6 @@ Because of this behavior, you must always keep a backup of these files in case y
 
 endif::restricted,restricted-upi[]
 
-ifndef::aws-china,aws-gov,aws-secret,azure-gov,ash,ash-default,ash-network,gcp-shared,ibm-cloud-private,ibm-power-vs-private,ibm-cloud-restricted[]
-+
-[NOTE]
-====
-For some platform types, you can alternatively run `./openshift-install create install-config --dir <installation_directory>` to generate an `install-config.yaml` file. You can provide details about your cluster configuration at the prompts.
-====
-endif::aws-china,aws-gov,aws-secret,azure-gov,ash,ash-default,ash-network,gcp-shared,ibm-cloud-private,ibm-power-vs-private,ibm-cloud-restricted[]
 ifdef::ash[]
 +
 Make the following modifications for Azure Stack Hub:


### PR DESCRIPTION
This PR removes a NOTE that has become superfluous in the Bare Metal install docs (and does not appear in any other install docs).

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-9302
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://74542--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal#installation-initializing-manual_installing-bare-metal
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X ] 

Additional information: 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
