### PR TITLE
OSDOCS#10150: Update  OPP user guide to latest supported product versions

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -37,11 +37,11 @@
 :ocp: OpenShift Container Platform
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:ocp-supported-version: 4.14
-:rhacs-version: 4.3
-:quay-version: 3.10
-:rhacm-version: 2.9
-:odf-version: 4.14
+:ocp-supported-version: 4.15
+:rhacs-version: 4.4
+:quay-version: 3.11
+:rhacm-version: 2.10
+:odf-version: 4.15
 // Following variables are required for publishing using PV2
 :product-title: OpenShift Platform Plus
 :product-version: .1

--- a/architecture/_attributes
+++ b/architecture/_attributes
@@ -1,0 +1,1 @@
+../_attributes

--- a/architecture/opp-architecture.adoc
+++ b/architecture/opp-architecture.adoc
@@ -17,8 +17,8 @@ include::modules/opp-architecture-architecture.adoc[leveloffset=+1]
 include::modules/opp-architecture-installation.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/installing/installing-preparing#supported-installation-methods-for-different-platforms[Supported installation methods for different platforms]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/install/installing[Installing {rh-rhacm}]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/installing/installing-preparing#supported-installation-methods-for-different-platforms[Supported installation methods for different platforms]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/install/installing[Installing {rh-rhacm}]
 
 include::modules/opp-architecture-installing-policyset.adoc[leveloffset=+2]
 include::modules/opp-architecture-relnotes.adoc[leveloffset=+1]

--- a/modules/opp-architecture-relnotes.adoc
+++ b/modules/opp-architecture-relnotes.adoc
@@ -8,8 +8,8 @@
 
 The release note information for each product is accessible from the following list:
 
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/release_notes/index[{ocp}]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/release_notes/index[{rh-rhacm} for Kubernetes]
-* https://access.redhat.com/documentation/en-us/red_hat_quay/3.10/html/red_hat_quay_release_notes/index[{quay} Release Notes]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/4.3[{acs} for 4.3]
-* link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.14/html/4.14_release_notes/index[{rh-storage-data-foundation}]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/release_notes/ocp-4-15-release-notes[{ocp}]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/release_notes/release-notes[{rh-rhacm} for Kubernetes]
+* link:https://access.redhat.com/documentation/en-us/red_hat_quay/3.11/html/red_hat_quay_release_notes/release-notes-311[{quay} Release Notes]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/4.4/html/release_notes/release-notes-44[{acs} for Kubernetes 4.4]
+* link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.15/html/4.15_release_notes/index[{rh-storage-data-foundation}]


### PR DESCRIPTION
Version(s):
This PR is based on the ‘opp-docs-main’ repo and when merged, it should be in that branch only. The OPP doc is not versioned. Add this PR to the ‘Continuous Release’ milestone.

Issue:
https://issues.redhat.com/browse/OSDOCS-10150

Link to docs preview:
[OpenShift Platform Plus overview](https://74549--ocpdocs-pr.netlify.app/openshift-opp/latest/architecture/opp-architecture.html) (Updated 4/17/2024)

QE review:
- [ x] QE has approved this change.
