### PR TITLE
OCPBUGS-17767: Add warning about machine configs

### DIFF
--- a/modules/nw-cluster-mtu-change.adoc
+++ b/modules/nw-cluster-mtu-change.adoc
@@ -185,6 +185,11 @@ $ for manifest in control-plane-interface worker-interface; do
     butane --files-dir . $manifest.bu > $manifest.yaml
   done
 ----
++
+[WARNING]
+====
+Do not apply these machine configs until explicitly instructed later in this procedure. Applying these machine configs now causes a loss of stability for the cluster.
+====
 endif::local-zone,wavelength-zone,post-aws-zones,outposts[]
 
 . To begin the MTU migration, specify the migration configuration by entering the following command. The Machine Config Operator performs a rolling reboot of the nodes in the cluster in preparation for the MTU change.


### PR DESCRIPTION
- https://issues.redhat.com/browse/OCPBUGS-17767

This applies to 4.12+, but due to changes to this file, this PR can be applied on to 4.15+. A separate PR must address earlier OCP versions.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://74554--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/changing-cluster-network-mtu.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
