### PR TITLE
Adding 4.14 edge_computing reverse redirects

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -233,6 +233,22 @@ AddType text/vtt                            vtt
     RewriteRule ^container-platform/(4\.15|4\.16)/scalability_and_performance/ztp_far_edge/ztp-updating-gitops.html /container-platform/$1/edge_computing/ztp-updating-gitops.html [NE,R=302]
     RewriteRule ^container-platform/(4\.15|4\.16)/scalability_and_performance/ztp_far_edge/ztp-vdu-validating-cluster-tuning.html /container-platform/$1/edge_computing/ztp-vdu-validating-cluster-tuning.html [NE,R=302]
 
+    # Reverse redirects for new ZTP edge computing section
+    RewriteRule ^container-platform/(4\.12|4\.13|4\.14)/edge_computing/cnf-talm-for-cluster-upgrades.html /container-platform/$1/scalability_and_performance/ztp_far_edge/cnf-talm-for-cluster-upgrades.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.12|4\.13|4\.14)/edge_computing/ztp-advanced-install-ztp.html /container-platform/$1/scalability_and_performance/ztp_far_edge/ztp-advanced-install-ztp.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.12|4\.13|4\.14)/edge_computing/ztp-advanced-policy-config.html /container-platform/$1/scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.12|4\.13|4\.14)/edge_computing/ztp-configuring-managed-clusters-policies.html /container-platform/$1/scalability_and_performance/ztp_far_edge/ztp-configuring-managed-clusters-policies.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.12|4\.13|4\.14)/edge_computing/ztp-deploying-far-edge-clusters-at-scale.html /container-platform/$1/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-clusters-at-scale.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.12|4\.13|4\.14)/edge_computing/ztp-deploying-far-edge-sites.html /container-platform/$1/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.12|4\.13|4\.14)/edge_computing/ztp-manual-install.html /container-platform/$1/scalability_and_performance/ztp_far_edge/ztp-manual-install.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.12|4\.13|4\.14)/edge_computing/ztp-precaching-tool.html /container-platform/$1/scalability_and_performance/ztp_far_edge/ztp-precaching-tool.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.12|4\.13|4\.14)/edge_computing/ztp-preparing-the-hub-cluster.html /container-platform/$1/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.12|4\.13|4\.14)/edge_computing/ztp-reference-cluster-configuration-for-vdu.html /container-platform/$1/scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.12|4\.13|4\.14)/edge_computing/ztp-sno-additional-worker-node.html /container-platform/$1/scalability_and_performance/ztp_far_edge/ztp-sno-additional-worker-node.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.12|4\.13|4\.14)/edge_computing/ztp-talm-updating-managed-policies.html /container-platform/$1/scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.12|4\.13|4\.14)/edge_computing/ztp-updating-gitops.html /container-platform/$1/scalability_and_performance/ztp_far_edge/ztp-updating-gitops.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.12|4\.13|4\.14)/edge_computing/ztp-vdu-validating-cluster-tuning.html /container-platform/$1/scalability_and_performance/ztp_far_edge/ztp-vdu-validating-cluster-tuning.html [NE,R=302]
+
     # redirect for scalability and performance per Shane Lovern 7/19
     RewriteRule ^container-platform/4\.13/scalability_and_performance/sno-du-enabling-workload-partitioning-on-single-node-openshift.html /container-platform/4.13/scalability_and_performance/enabling-workload-partitioning.html [NE,R=302]
 


### PR DESCRIPTION
Adds redirects to allow the updated edge computing pages to redirect to older versions when the version selector is changed. 

![image](https://github.com/openshift/openshift-docs/assets/74046732/51310a4e-73fc-4913-9b61-eb17cb0e8e2a)
