### PR TITLE
OSDOCS-9675: Add procedure for initial role creation and account association

### DIFF
--- a/rosa_planning/rosa-cloud-expert-prereq-checklist.adoc
+++ b/rosa_planning/rosa-cloud-expert-prereq-checklist.adoc
@@ -49,6 +49,7 @@ Accounts and CLIs you must install to deploy the cluster.
 ** AWS Secret Access Key
 * Ensure that you have the right permissions as detailed link:https://docs.aws.amazon.com/ROSA/latest/userguide/security-iam-awsmanpol.html[AWS managed IAM policies for ROSA] and xref:../rosa_architecture/rosa-sts-about-iam-resources.html[About IAM resources for ROSA clusters that use STS].
 * See xref:../rosa_planning/rosa-sts-aws-prereqs.html#rosa-account_rosa-sts-aws-prereqs[Account] for more details.
+* See xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-associating-your-aws-account_rosa-sts-creating-a-cluster-quickly[Associating your AWS account with your Red Hat organization] for intructions on associating your account. 
 
 === AWS CLI (`aws`)
 
@@ -142,6 +143,9 @@ $ rosa verify openshift-client
 ----
 
 Once you have the above prerequisites installed and enabled, proceed to the next steps.
+
+//This content is pulled from rosa-sts-associating-your-aws-account.adoc
+include::modules/rosa-sts-associating-your-aws-account.adoc[leveloffset=+2]
 
 
 == SCP Prerequisites


### PR DESCRIPTION
Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-9675

Link to docs preview:
Added link to checklist: https://74561--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-cloud-expert-prereq-checklist.html#aws-account 
Added module: https://74561--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-cloud-expert-prereq-checklist.html#rosa-sts-associating-your-aws-account_rosa-cloud-expert-prereq-checklist


QE review:
Adding existing module for additional context. No procedural changes involved. No QE review required. 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
