### PR TITLE
Admin Defined Node Disruptions: Tech Preview

### DIFF
--- a/architecture/control-plane.adoc
+++ b/architecture/control-plane.adoc
@@ -62,6 +62,8 @@ ifndef::openshift-dedicated,openshift-rosa[]
 * For more information about detecting configuration drift, see xref:../post_installation_configuration/machine-configuration-tasks.adoc#machine-config-drift-detection_post-install-machine-configuration-tasks[Understanding configuration drift detection].
 
 * For information about preventing the control plane machines from rebooting after the Machine Config Operator makes changes to the machine configuration, see xref:../support/troubleshooting/troubleshooting-operator-issues.adoc#troubleshooting-disabling-autoreboot-mco_troubleshooting-operator-issues[Disabling Machine Config Operator from automatically rebooting].
+
+* xref:../post_installation_configuration/machine-configuration-tasks.adoc#machine-config-node-disruption_post-install-machine-configuration-tasks[Understanding node restart behaviors after machine config changes]
 endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/etcd-overview.adoc[leveloffset=+1]

--- a/modules/machine-config-node-disruption-config.adoc
+++ b/modules/machine-config-node-disruption-config.adoc
@@ -1,0 +1,132 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/machine-configuration-tasks.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="machine-config-node-disruption-config_{context}"]
+= Configuring node restart behaviors upon machine config changes
+
+You can create a node disruption policy to define the machine configuration changes that cause a disruption to your cluster, and which changes do not.
+
+You can control how your nodes respond to changes in the files in the `/var` or `/etc` directory, the systemd units, the SSH keys, and the `registries.conf` file.
+
+include::snippets/machine-config-node-disruption-actions.adoc[]
+
+.Prerequisites
+
+* You have enabled the `TechPreviewNoUpgrade` feature set by using the feature gates. For more information, see "Enabling features using feature gates".
++
+[WARNING]
+====
+Enabling the `TechPreviewNoUpgrade` feature set on your cluster prevents minor version updates. The `TechPreviewNoUpgrade` feature set cannot be disabled. Do not enable this feature set on production clusters.
+====
+
+.Procedure
+
+. Edit the `machineconfigurations.operator.openshift.io` object to define the node disruption policy:
++
+[source,terminal]
+----
+$ oc edit MachineConfiguration cluster -n openshift-machine-config-operator
+----
+
+. Add a node disruption policy similar to the following:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: MachineConfiguration
+metadata:
+  name: cluster
+# ...
+spec:
+  nodeDisruptionPolicy: <1>
+    files: # <2>
+    - actions: # <3>
+      - reload: # <4>
+          serviceName: chronyd.service # <5>
+        type: Reload
+      path: /etc/chrony.conf # <6>
+    sshkey: # <7>
+      actions:
+      - type: Drain
+      - reload:
+          serviceName: crio.service
+        type: Reload
+      - type: DaemonReload
+      - restart:
+          serviceName: crio.service
+        type: Restart
+    units: # <8>
+    - actions:
+      - type: Drain
+      - reload:
+          serviceName: crio.service
+        type: Reload
+      - type: DaemonReload
+      - restart:
+          serviceName: crio.service
+        type: Restart
+      name: test.service
+----
+<1> Specifies the node disruption policy. 
+<2> Specifies a list of machine config file definitions and actions to take to changes on those paths. This list supports a maximum of 50 entries.
+<3> Specifies the series of actions to be executed upon changes to the specified files. Actions are applied in the order that they are set in this list. This list supports a maximum of 10 entries.
+<4> Specifies that the listed service is to be reloaded upon changes to the specified files. 
+<5> Specifies the full name of the service to be acted upon. 
+<6> Specifies the location of a file that is managed by a machine config. The actions in the policy apply when changes are made to the file in `path`.
+<7> Specifies a list of service names and actions to take upon changes to the SSH keys in the cluster.
+<8> Specifies a list of systemd unit names and actions to take upon changes to those units.
+
+.Verification
+
+* View the `MachineConfiguration` object file that you created:
++
+----
+$ oc get MachineConfiguration/cluster -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: MachineConfiguration
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: cluster
+# ...
+status:
+  nodeDisruptionPolicyStatus: <1>
+    clusterPolicies:
+      files:
+# ...
+      - actions:
+        - reload:
+            serviceName: chronyd.service
+          type: Reload
+        path: /etc/chrony.conf
+      sshkey:
+        actions:
+        - type: Drain
+        - reload:
+            serviceName: crio.service
+          type: Reload
+        - type: DaemonReload
+        - restart:
+            serviceName: crio.service
+          type: Restart
+      units:
+      - actions:
+        - type: Drain
+        - reload:
+            serviceName: crio.service
+          type: Reload
+        - type: DaemonReload
+        - restart:
+            serviceName: crio.service
+          type: Restart
+        name: test.se
+# ...
+----
+<1> Specifies the current cluster-validated policies.

--- a/modules/machine-config-node-disruption.adoc
+++ b/modules/machine-config-node-disruption.adoc
@@ -1,0 +1,182 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/machine-configuration-tasks.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="machine-config-node-disruption_{context}"]
+= Understanding node restart behaviors after machine config changes
+
+By default, when you make certain changes to the fields in a `MachineConfig` object, the Machine Config Operator (MCO) drains and reboots the nodes associated with that machine config. However, you can create a _node disruption policy_ that defines a set of changes to some Ignition config objects that would require little or no disruption to your workloads.
+
+A node disruption policy allows you to define the configuration changes that cause a disruption to your cluster, and which changes do not. This allows you to reduce node downtime when making small machine configuration changes in your cluster. To configure the policy, you modify the `MachineConfiguration` object, which is in the `openshift-machine-config-operator` namespace. See the example node disruption policies in the `MachineConfiguration` objects that follow.
+
+[NOTE]
+====
+There are machine configuration changes that always require a reboot, regardless of any node disruption policies. For more information, see _About the Machine Config Operator_.
+====
+
+After you create the node disruption policy, the MCO validates the policy to search for potential issues in the file, such as problems with formatting. The MCO then merges the policy with the cluster defaults and populates the `status.nodeDisruptionPolicyStatus` fields in the machine config with the actions to be performed upon future changes to the machine config. The configurations in your policy always overwrite the cluster defaults.
+
+[IMPORTANT]
+====
+The MCO does not validate whether a change can be successfully applied by your node disruption policy. Therefore, you are responsible to ensure the accuracy of your node disruption policies.
+====
+
+For example, you can configure a node disruption policy so that sudo configurations do not require a node drain and reboot. Or, you can configure your cluster so that updates to `sshd` are applied with only a reload of that one service.
+
+:FeatureName: The node disruption policy feature
+include::snippets/technology-preview.adoc[]
+
+You can control the behavior of the MCO when making the changes to the following Ignition configuration objects:
+
+// I used this wording for the objects to match the previous section in the assembly: file:///home/mburke/openshift-docs/_preview/openshift-enterprise/mco-node-disruption-policy/post_installation_configuration/machine-configuration-tasks.html#what-can-you-change-with-machine-configs.
+* *configuration files*: You add to or update the files in the `/var` or `/etc` directory.
+* *systemd units*: You create and set the status of a systemd service or modify an existing systemd service.
+* *users and groups*: You change SSH keys in the `passwd` section post-installation.
+* *ICSP*, *ITMS*, *IDMS* objects: You can remove mirroring rules from an `ImageContentSourcePolicy` (ICSP), `ImageTagMirrorSet` (ITMS), and `ImageDigestMirrorSet` (IDMS) object.
+
+include::snippets/machine-config-node-disruption-actions.adoc[]
+
+// Examples taken from the test cases: https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitems/testcase?query=trello%3AMCO%5C-507
+
+[id="machine-config-node-disruption-example_{context}"]
+== Example node disruption policies
+
+The following example `MachineConfiguration` objects contain a node disruption policy.
+
+[TIP]
+====
+A `MachineConfiguration` object and a `MachineConfig` object are different objects. A `MachineConfiguration` object is a singleton object in the MCO namespace that contains configuration parameters for the MCO operator. A `MachineConfig` object defines changes that are applied to a machine config pool.
+====
+
+The following example `MachineConfiguration` object shows no user defined policies. The default node disruption policy values are shown in the `status` stanza.
+
+.Default node disruption policy
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: MachineConfiguration
+  name: cluster
+spec:
+  logLevel: Normal
+  managementState: Managed
+  operatorLogLevel: Normal
+status:
+  nodeDisruptionPolicyStatus:
+    clusterPolicies:
+      files:
+      - actions:
+        - type: None
+        path: /etc/mco/internal-registry-pull-secret.json
+      - actions:
+        - type: None
+        path: /var/lib/kubelet/config.json
+      - actions:
+        - reload:
+            serviceName: crio.service
+          type: Reload
+        path: /etc/machine-config-daemon/no-reboot/containers-gpg.pub
+      - actions:
+        - reload:
+            serviceName: crio.service
+          type: Reload
+        path: /etc/containers/policy.json
+      - actions:
+        - type: Special
+        path: /etc/containers/registries.conf
+      sshkey:
+        actions:
+        - type: None
+  readyReplicas: 0
+----
+
+In the following example, when changes are made to the SSH keys, the MCO drains the cluster nodes, reloads the `crio.service`, reloads the systemd configuration, and restarts the `crio-service`.
+
+.Example node disruption policy for an SSH key change
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: MachineConfiguration
+metadata:
+  name: cluster
+  namespace: openshift-machine-config-operator
+# ...
+spec:
+  nodeDisruptionPolicy:
+    sshkey:
+      actions:
+      - type: Drain
+      - reload:
+          serviceName: crio.service
+        type: Reload
+      - type: DaemonReload
+      - restart:
+          serviceName: crio.service
+        type: Restart
+# ...
+----
+
+In the following example, when changes are made to the files in the `/etc/chrony.conf` directory, the MCO reloads the `chronyd.service` on the cluster nodes.
+
+.Example node disruption policy for a configuration file change
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: MachineConfiguration
+metadata:
+  name: cluster
+  namespace: openshift-machine-config-operator
+# ...
+spec:
+  nodeDisruptionPolicy:
+    files:
+    - actions:
+      - reload:
+          serviceName: chronyd.service
+        type: Reload
+      path: /etc/chrony.conf
+----
+
+In the following example, when changes are made to the `auditd.service`	systemd unit, the MCO drains the cluster nodes, reloads the `crio.service`, reloads the systemd manager configuration, and restarts the `crio.service`.
+
+.Example node disruption policy for a configuration file change
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: MachineConfiguration
+metadata:
+  name: cluster
+  namespace: openshift-machine-config-operator
+# ...
+spec:
+  nodeDisruptionPolicy:
+    units:
+      - name: auditd.service
+        actions:
+          - type: Drain
+          - type: Reload
+            reload:
+              serviceName: crio.service
+          - type: DaemonReload
+          - type: Restart
+            restart:
+              serviceName: crio.service
+----
+
+In the following example, when changes are made to the files in the `registries.conf` directory, the MCO does not drain or reboot the nodes and applies the changes with no further action.
+
+.Example node disruption policy for a configuration file change
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: MachineConfiguration
+metadata:
+  name: cluster
+  namespace: openshift-machine-config-operator
+# ...
+spec:
+  nodeDisruptionPolicy:
+      - actions:
+        - type: None
+        path: /etc/containers/registries.conf
+----

--- a/modules/machine-config-overview.adoc
+++ b/modules/machine-config-overview.adoc
@@ -70,7 +70,11 @@ endif::openshift-origin[]
 
 The MCO is not the only Operator that can change operating system components on {product-title} nodes. Other Operators can modify operating system-level features as well. One example is the Node Tuning Operator, which allows you to do node-level tuning through Tuned daemon profiles.
 
-Tasks for the MCO configuration that can be done postinstallation are included in the following procedures. See descriptions of {op-system} bare metal installation for system configuration tasks that must be done during or before {product-title} installation.
+Tasks for the MCO configuration that can be done after installation are included in the following procedures. See descriptions of {op-system} bare metal installation for system configuration tasks that must be done during or before {product-title} installation. By default, many of the changes you make with the MCO require a reboot. 
+
+include::snippets/node-icsp-no-drain.adoc[]
+
+In other cases, you can mitigate the disruption to your workload when the MCO makes changes by using _node disruption policies_. For information, see _Understanding node restart behaviors after machine config changes_.  
 
 There might be situations where the configuration on a node does not fully match what the currently-applied machine config specifies. This state is called _configuration drift_. The Machine Config Daemon (MCD) regularly checks the nodes for configuration drift. If the MCD detects configuration drift, the MCO marks the node `degraded` until an administrator corrects the node configuration. A degraded node is online and operational, but, it cannot be updated. For more information on configuration drift, see _Understanding configuration drift detection_.
 

--- a/modules/understanding-machine-config-operator.adoc
+++ b/modules/understanding-machine-config-operator.adoc
@@ -44,7 +44,9 @@ When you perform node management operations, you create or modify a
 ====
 When changes are made to a machine configuration, the Machine Config Operator (MCO) automatically reboots all corresponding nodes in order for the changes to take effect.
 
-To prevent the nodes from automatically rebooting after machine configuration changes, before making the changes, you must pause the autoreboot process by setting the `spec.paused` field to `true` in the corresponding machine config pool. When paused, machine configuration changes are not applied until you set the `spec.paused` field to `false` and the nodes have rebooted into the new configuration.
+You can mitigate the disruption caused by some machine config changes by using a node disruption policy. See _Understanding node restart behaviors after machine config changes_.
+
+Alternatively, you can prevent the nodes from automatically rebooting after machine configuration changes before making the changes. Pause the autoreboot process by setting the `spec.paused` field to `true` in the corresponding machine config pool. When paused, machine configuration changes are not applied until you set the `spec.paused` field to `false` and the nodes have rebooted into the new configuration.
 
 include::snippets/node-icsp-no-drain.adoc[]
 ====

--- a/post_installation_configuration/machine-configuration-tasks.adoc
+++ b/post_installation_configuration/machine-configuration-tasks.adoc
@@ -24,6 +24,11 @@ Previously, NetworkManager stored new network configurations to `/etc/sysconfig/
 
 include::modules/machine-config-operator.adoc[leveloffset=+2]
 include::modules/machine-config-overview.adoc[leveloffset=+2]
+
+.Additional resources
+
+* xref:../post_installation_configuration/machine-configuration-tasks.adoc#machine-config-node-disruption_post-install-machine-configuration-tasks[Understanding node restart behaviors after machine config changes]
+
 include::modules/machine-config-drift-detection.adoc[leveloffset=+2]
 include::modules/checking-mco-status.adoc[leveloffset=+2]
 include::modules/checking-mco-node-status.adoc[leveloffset=+2]
@@ -37,6 +42,20 @@ include::modules/mco-update-boot-images.adoc[leveloffset=+1]
 * xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
 
 include::modules/mco-update-boot-images-disable.adoc[leveloffset=+2]
+
+include::modules/machine-config-node-disruption.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../architecture/control-plane.adoc#about-machine-config-operator_control-plane[About the Machine Config Operator]
+
+include::modules/machine-config-node-disruption-config.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
 
 [id="using-machineconfigs-to-change-machines"]
 == Using MachineConfig objects to configure nodes

--- a/snippets/machine-config-node-disruption-actions.adoc
+++ b/snippets/machine-config-node-disruption-actions.adoc
@@ -1,0 +1,22 @@
+// Text snippet included in the following modules:
+//
+// * modules/machine-config-node-disruption.adoc
+// * modules/machine-config-node-disruption-config.adoc
+
+When you make any of these changes, the node disruption policy determines which of the following actions are required when the MCO implements the changes: 
+
+* *Reboot*: The MCO drains and reboots the nodes. This is the default behavior.
+* *None*: The MCO does not drain or reboot the nodes. The MCO applies the changes with no further action. 
+* *Drain*: The MCO cordons and drains the nodes of their workloads. The workloads restart with the new configurations.
+* *Reload*: For services, the MCO reloads the specified services without restarting the service.
+* *Restart*: For services, the MCO fully restarts the specified services.
+* *DaemonReload*: The MCO reloads the systemd manager configuration.
+* *Special*: This is an internal MCO-only action and cannot be set by the user.
+
+[NOTE]
+====
+* The `Reboot` and `None` actions cannot be used with with any other actions, as the `Reboot` and `None` actions override the others. 
+* Actions are applied in the order that they are set in the node disruption policy list. 
+* If you make other machine config changes that do require a reboot or other disruption to the nodes, that reboot supercedes the node disruption policy actions.
+====
+


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-10096

* Post-install -> Machine tasks -> [Understanding node restart behaviors after machine config changes](https://74562--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#machine-config-node-disruption_post-install-machine-configuration-tasks) -- New concept module to describe Admin Defined Node Disruptions.
* Post-install -> Machine tasks -> [Configuring node restart behaviors after machine config changes](https://74562--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#machine-config-node-disruption-config_post-install-machine-configuration-tasks) -- New procedure module to describe configuring Admin Defined Node Disruptions. Added Additional Ref to newly added snippet. 
* Post-install -> Machine tasks -> [What can you change with machine configs?](https://74562--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#what-can-you-change-with-machine-configs) -- Included existing snippet about configurations that do not trigger a node reboot by MCO (it seemed relevant to the new material). Starting with _The following modifications do not trigger a node reboot_ and including the two bullets that follow. 
* Post-install -> Machine tasks -> [Machine config overview](https://74562--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#machine-config-overview-post-install-machine-configuration-tasks) - Added Additional Ref to new node disruption module  
* Architecture -> Control plane -> [About the Machine Config Operator](https://74562--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#machine-config-node-disruption_post-install-machine-configuration-tasks) - New link to _Understanding node restart behaviors_.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
