### PR TITLE
[SRVCOM-2727] Change name to OpenShift Serverless in TOC 

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1,29 +1,29 @@
 ---
-Name: About Serverless
+Name: About OpenShift Serverless
 Dir: about
 Distros: openshift-serverless
 Topics:
 - Name: Release notes
   File: serverless-release-notes
-- Name: Serverless overview
+- Name: OpenShift Serverless overview
   File: about-serverless
 - Name: Knative Serving overview
   File: about-knative-serving
 - Name: Knative Eventing overview
   File: about-knative-eventing
-- Name: Serverless Functions overview
+- Name: OpenShift Serverless Functions overview
   File: serverless-functions-about
 # Support
-- Name: Serverless support
+- Name: OpenShift Serverless support
   File: serverless-support
 ---
-Name: Installing Serverless
+Name: Installing OpenShift Serverless
 Dir: install
 Distros: openshift-serverless
 Topics:
 - Name: Preparing to install OpenShift Serverless
   File: preparing-serverless-install
-- Name: Installing the Serverless Operator
+- Name: Installing the OpenShift Serverless Operator
   File: install-serverless-operator
 - Name: Installing the Knative CLI
   File: installing-kn
@@ -35,9 +35,9 @@ Topics:
   File: serverless-kafka-admin
 - Name: Configuring kube-rbac-proxy resources for Knative for Apache Kafka
   File: kube-rbac-proxy-kafka
-- Name: Configuring Serverless Functions
+- Name: Configuring OpenShift Serverless Functions
   File: configuring-serverless-functions
-- Name: Serverless upgrades
+- Name: OpenShift Serverless upgrades
   File: serverless-upgrades
 ---
 # Functions
@@ -98,7 +98,7 @@ Topics:
 - Name: Getting started with Knative Serving
   Dir: getting-started
   Topics:
-  - Name: Creating Serverless applications
+  - Name: Creating OpenShift Serverless applications
     File: serverless-applications
   - Name: Verifying application deployment
     File: verifying-application-deployment
@@ -113,7 +113,7 @@ Topics:
     File: serverless-concurrency
   - Name: Scale-to-zero
     File: serverless-autoscaling-scale-to-zero
-- Name: Configuring Serverless applications
+- Name: Configuring OpenShift Serverless applications
   Dir: config-applications
   Topics:
   #- Name: Overriding system deployment configurations
@@ -134,7 +134,7 @@ Topics:
     File: configuring-kourier
   - Name: Restrictive network policies
     File: restrictive-network-policies
-- Name: Debugging Serverless applications
+- Name: Debugging OpenShift Serverless applications
   File: debugging-serverless-applications
 - Name: Kourier and Istio ingresses
   File: kourier-and-istio-ingresses
@@ -401,7 +401,7 @@ Topics:
 - Name: Cluster logging
   Dir: cluster-logging
   Topics:
-  - Name: Using OpenShift Logging with Serverless
+  - Name: Using OpenShift Logging with OpenShift Serverless
     File: cluster-logging-serverless
   - Name: Finding logs for Knative Serving components
     File: finding-serving-logs-components
@@ -426,26 +426,26 @@ Topics:
   File: serverless-ossm-setup
 - Name: Using Service Mesh to isolate network traffic with OpenShift Serverless
   File: serverless-ossm-traffic-isolation
-- Name: Integrating Serverless with the cost management service
+- Name: Integrating OpenShift Serverless with the cost management service
   File: serverless-cost-management-integration
-- Name: Integrating Serverless with OpenShift Pipelines
+- Name: Integrating OpenShift Serverless with OpenShift Pipelines
   File: serverless-pipelines-integration
 - Name: Using NVIDIA GPU resources with serverless applications
   File: gpu-resources
 
 ---
 # Removing
-Name: Removing Serverless
+Name: Removing OpenShift Serverless
 Dir: removing
 Distros: openshift-serverless
 Topics:
-- Name: Removing Serverless overview
+- Name: Removing OpenShift Serverless overview
   File: removing-openshift-serverless
 - Name: Uninstalling Knative Eventing
   File: uninstalling-knative-eventing
 - Name: Uninstalling Knative Serving
   File: uninstalling-knative-serving
-- Name: Removing Serverless Operator
+- Name: Removing OpenShift Serverless Operator
   File: removing-serverless-operator
-- Name: Deleting Serverless CRDs
+- Name: Deleting OpenShift Serverless CRDs
   File: deleting-serverless-crds


### PR DESCRIPTION
Version(s):
 serverless-docs-1.32+

Issue:
https://issues.redhat.com/browse/SRVCOM-2727

Link to docs preview:
https://74571--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/about-serverless (TOC)

QE review:
- [x] QE has approved this change.
