### PR TITLE
OSDOCS#10104:Removed warning from Networking docs as transparent forward proxies now supported in OSD/ROSA

### DIFF
--- a/modules/cluster-wide-proxy-preqs.adoc
+++ b/modules/cluster-wide-proxy-preqs.adoc
@@ -86,10 +86,4 @@ When using a cluster-wide proxy, you must configure the `s3.<aws_region>.amazona
 |Used by the splunk-forwarder-operator as a log forwarding endpoint to be used by Red Hat SRE for log-based alerting.
 |===
 --
-+
-[IMPORTANT]
-====
-The use of a proxy server to perform TLS re-encryption is currently not supported if the server is acting as a transparent forward proxy where it is not configured on-cluster via the `--http-proxy` or `--https-proxy` arguments.
 
-A transparent forward proxy intercepts the cluster traffic, but it is not actually configured on the cluster itself.
-====

--- a/modules/configuring-a-proxy-after-installation-cli.adoc
+++ b/modules/configuring-a-proxy-after-installation-cli.adoc
@@ -29,22 +29,21 @@ The cluster applies the proxy configuration to the control plane and compute nod
 $ rosa edit cluster \
  --cluster $CLUSTER_NAME \
  --additional-trust-bundle-file <path_to_ca_bundle_file> \ <1> <2> <3>
- --http-proxy http://<username>:<password>@<ip>:<port> \ <1> <4>
- --https-proxy https://<username>:<password>@<ip>:<port> \ <1> <4>
-  --no-proxy example.com <5>
+ --http-proxy http://<username>:<password>@<ip>:<port> \ <1> <3>
+ --https-proxy https://<username>:<password>@<ip>:<port> \ <1> <3>
+  --no-proxy example.com <4>
 ----
 +
 --
 <1> The `additional-trust-bundle-file`, `http-proxy`, and `https-proxy` arguments are all optional.
-<2> If you use the `additional-trust-bundle-file` argument without an `http-proxy` or `https-proxy` argument, the trust bundle is added to the trust store and used to verify cluster system egress traffic. In that scenario, the bundle is not configured to be used with a proxy.
-<3> The `additional-trust-bundle-file` argument is a file path pointing to a bundle of PEM-encoded X.509 certificates, which are all concatenated together. The `additionalTrustBundle` parameter is required unless the identity certificate of the proxy is signed by an authority from the {op-system} trust bundle. If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional CAs, you must provide the MITM CA certificate.
+<2> The `additional-trust-bundle-file` argument is a file path pointing to a bundle of PEM-encoded X.509 certificates, which are all concatenated together. The `additionalTrustBundle` parameter is required unless the identity certificate of the proxy is signed by an authority from the {op-system} trust bundle. If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional CAs, you must provide the MITM CA certificate.
 +
 [NOTE]
 ====
 You should not attempt to change the proxy or additional trust bundle configuration on the cluster directly. These changes must be applied by using the ROSA CLI (`rosa`) or {cluster-manager-first}. Any changes that are made directly to the cluster will be reverted automatically.
 ====
-<4> The `http-proxy` and `https-proxy` arguments must point to a valid URL.
-<5> A comma-separated list of destination domain names, IP addresses, or network CIDRs to exclude proxying.
+<3> The `http-proxy` and `https-proxy` arguments must point to a valid URL.
+<4> A comma-separated list of destination domain names, IP addresses, or network CIDRs to exclude proxying.
 +
 Preface a domain with `.` to match subdomains only. For example, `.y.com` matches `x.y.com`, but not `y.com`. Use `*` to bypass proxy for all destinations.
 If you scale up workers that are not included in the network defined by the `networking.machineNetwork[].cidr` field from the installation configuration, you must add them to this list to prevent connection issues.

--- a/modules/configuring-a-proxy-after-installation-ocm.adoc
+++ b/modules/configuring-a-proxy-after-installation-ocm.adoc
@@ -41,10 +41,6 @@ endif::openshift-dedicated[]
 +
 If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional certificate authorities (CAs), you must provide the MITM CA certificate.
 +
-[NOTE]
-====
-If you upload an additional trust bundle file without specifying an HTTP or HTTPS proxy URL, the bundle is set on the cluster but is not configured to be used with the proxy.
-====
 .. Click *Confirm*.
 
 .Verification

--- a/modules/configuring-a-proxy-during-installation-cli.adoc
+++ b/modules/configuring-a-proxy-during-installation-cli.adoc
@@ -23,17 +23,16 @@ The following procedure provides details about the ROSA CLI (`rosa`) arguments t
 $ rosa create cluster \
  <other_arguments_here> \
  --additional-trust-bundle-file <path_to_ca_bundle_file> \ <1> <2> <3>
- --http-proxy http://<username>:<password>@<ip>:<port> \ <1> <4>
- --https-proxy https://<username>:<password>@<ip>:<port> \ <1> <4>
- --no-proxy example.com <5>
+ --http-proxy http://<username>:<password>@<ip>:<port> \ <1> <3>
+ --https-proxy https://<username>:<password>@<ip>:<port> \ <1> <3>
+ --no-proxy example.com <4>
 ----
 +
 --
 <1> The `additional-trust-bundle-file`, `http-proxy`, and `https-proxy` arguments are all optional.
-<2> If you use the `additional-trust-bundle-file` argument without an `http-proxy` or `https-proxy` argument, the trust bundle is added to the trust store and used to verify cluster system egress traffic. In that scenario, the bundle is not configured to be used with a proxy.
-<3> The `additional-trust-bundle-file` argument is a file path pointing to a bundle of PEM-encoded X.509 certificates, which are all concatenated together. The `additionalTrustBundle` parameter is required unless the identity certificate of the proxy is signed by an authority from the {op-system} trust bundle. If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional CAs, you must provide the MITM CA certificate.
-<4> The `http-proxy` and `https-proxy` arguments must point to a valid URL.
-<5> A comma-separated list of destination domain names, IP addresses, or network CIDRs to exclude proxying.
+<2> The `additional-trust-bundle-file` argument is a file path pointing to a bundle of PEM-encoded X.509 certificates, which are all concatenated together. The `additionalTrustBundle` parameter is required unless the identity certificate of the proxy is signed by an authority from the {op-system} trust bundle. If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional CAs, you must provide the MITM CA certificate.
+<3> The `http-proxy` and `https-proxy` arguments must point to a valid URL.
+<4> A comma-separated list of destination domain names, IP addresses, or network CIDRs to exclude proxying.
 +
 Preface a domain with `.` to match subdomains only. For example, `.y.com` matches `x.y.com`, but not `y.com`. Use `*` to bypass proxy for all destinations.
 If you scale up workers that are not included in the network defined by the `networking.machineNetwork[].cidr` field from the installation configuration, you must add them to this list to prevent connection issues.

--- a/modules/osd-create-cluster-ccs.adoc
+++ b/modules/osd-create-cluster-ccs.adoc
@@ -311,11 +311,6 @@ endif::osd-on-aws[]
 ** In the *Additional trust bundle* field, provide a PEM encoded X.509 certificate bundle. The bundle is added to the trusted certificate store for the cluster nodes. An additional trust bundle file is required unless the identity certificate for the proxy is signed by an authority from the {op-system-first} trust bundle.
 +
 If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional certificate authorities (CAs), you must provide the MITM CA certificate.
-+
-[NOTE]
-====
-If you upload an additional trust bundle file without specifying an HTTP or HTTPS proxy URL, the bundle is set on the cluster but is not configured to be used with the proxy.
-====
 .. Click *Next*.
 --
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15+

Issue:
[OSDOCS-10104](https://issues.redhat.com/browse/OSDOCS-10104)

Link to docs preview:
[Configuring a cluster-wide proxy](https://74572--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/configuring-cluster-wide-proxy.html#configuring-a-proxy-after-installation-ocm_configuring-a-cluster-wide-proxy)
[Creating a cluster on AWS with CCS](https://74572--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-an-aws-cluster#osd-create-aws-cluster-ccs_osd-creating-a-cluster-on-aws)

Peer reviewer:
- [x] Peer reviewer has approved this change.

SME review:
- [x] SME has approved this change.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
