### PR TITLE
OSDOCS-9846: adds 4.14.21 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -486,3 +486,12 @@ Issued: 2024-04-08
 {product-title} release 4.14.20 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1682[RHBA-2024:1682] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1681[RHSA-2024:1681] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-14-21-dp"]
+=== RHBA-2024:1767 - {microshift-short} 4.14.21 bug fix and enhancement advisory
+
+Issued: 2024-04-18
+
+{product-title} release 4.14.21 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1767[RHBA-2024:1767] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1765[RHSA-2024:1765] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.14 only

Issue:
[OSDOCS-9846](https://issues.redhat.com/browse/OSDOCS-9846)

Link to docs preview:
[4.14.21 release note](https://74574--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes.html#microshift-4-14-21-dp)

QE review:
- [x] N/A stock text, no bug text or new technical information

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
