### PR TITLE
OCPBUGS#23172 RN RODOO can't run on hypershift clusters

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3154,6 +3154,8 @@ To avoid this issue, you can enable confidential VMs on an existing cluster by u
 
 * In {product-title} {product-version}, assigning an IPv6 egress IP to a network interface that is not the primary network interface is unsupported. This is a known issue and will be fixed in a future version of {product-title}. (link:https://issues.redhat.com/browse/OCPBUGS-17637[*OCPBUGS-17637*])
 
+* {run-once-operator} (RODOO) cannot be installed on clusters managed by the HyperShift Operator. (link:https://issues.redhat.com/browse/OCPBUGS-17533[*OCPBUGS-17533*])
+
 [id="ocp-telco-ran-4-14-known-issues"]
 * When you run CNF latency tests on an {product-title} cluster, the `oslat` test can sometimes return results greater than 20 microseconds. This results in an `oslat` test failure.
 (link:https://issues.redhat.com/browse/RHEL-9279[*RHEL-9279*])


### PR DESCRIPTION
Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUGS-23172](https://issues.redhat.com/browse/OCPBUGS-23172)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Preview](https://74608--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-known-issues) (scroll to the end of Known Issues, or ctrl+f "run once duration override")
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Needs change management.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
