### PR TITLE
OCPBUGS#23172 4.13 RN RODOO can't be installed on Hypershift

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -2872,6 +2872,8 @@ mount: /var/lib/kubelet/plugins/kubernetes.io/local-volume/mounts/local-pv-bc42d
 To workaround the issue, delete the `cloud-event-proxy-store-storage-class-http-events` `PVC` CR and re-deploy the PTP Operator.
 (link:https://issues.redhat.com/browse/OCPBUGS-12358[*OCPBUGS-12358*])
 
+* {run-once-operator} (RODOO) cannot be installed on clusters managed by the Hypershift Operator. (link:https://issues.redhat.com/browse/OCPBUGS-17533[*OCPBUGS-17533*])
+
 [id="ocp-4-13-ran-known-issues-post-ga"]
 * During {ztp-first} provisioning of a {sno} managed cluster with secure boot enabled in the `SiteConfig` CR, multiple `ProvisioningError` errors are reported for the `BareMetalHost` CR during host provisioning.
 The error indicates that the secure boot setting is successfully applied in the Baseboard Management Controller (BMC), but the host is not powered on after the `BareMetalHost` CR is applied.


### PR DESCRIPTION
Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:[OCPBUGS-23172](https://issues.redhat.com/browse/OCPBUGS-23172)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Preview ](https://74610--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-known-issues)(fastest way to find it is ctrl+f "run once duration override)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Needs change management
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
