### PR TITLE
OCPBUGS#23172 4.15 RN RODOO can't run on hypershift

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2592,6 +2592,8 @@ In the following tables, features are marked with the following statuses:
 // TODO: This known issue should carry forward to 4.9 and beyond!
 * The `oc annotate` command does not work for LDAP group names that contain an equal sign (`=`), because the command uses the equal sign as a delimiter between the annotation name and value. As a workaround, use `oc patch` or `oc edit` to add the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917280[*BZ#1917280*])
 
+* {run-once-operator} (RODOO) cannot be installed on clusters managed by the HyperShift Operator. (link:https://issues.redhat.com/browse/OCPBUGS-17533[*OCPBUGS-17533*])
+
 * When installing a cluster on VMware vSphere with static IP addresses (Tech Preview), the installation program can apply an incorrect configuration to the control plane machine sets (CPMS). This can result in control plane machines being recreated without static IP addresses defined. (link:https://issues.redhat.com/browse/OCPBUGS-29236[*OCPBUGS-28236*])
 
 * Specifying a standard Ebdsv5 or Ebsv5 family machine type instance is not supported when installing an Azure cluster. This limitation is the result of the Azure terraform provider not supporting these machine types. (link:https://issues.redhat.com/browse/OCPBUGS-18690[*OCPBUGS-18690*])


### PR DESCRIPTION
Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUGS-23172](https://issues.redhat.com/browse/OCPBUGS-23172)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Preview](https://74611--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-known-issues) (second Known Issue)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Needs change management
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
