### PR TITLE
OSDOCS#10246: Hosted control planes: Enabling feature gates

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2314,6 +2314,8 @@ Topics:
   File: hcp-getting-started
 - Name: Managing hosted control planes
   File: hcp-managing
+- Name: Using feature gates in a hosted cluster
+  File: hcp-using-feature-gates
 - Name: Backup, restore, and disaster recovery for hosted control planes
   File: hcp-backup-restore-dr
 - Name: Troubleshooting hosted control planes

--- a/hosted_control_planes/hcp-using-feature-gates.adoc
+++ b/hosted_control_planes/hcp-using-feature-gates.adoc
@@ -1,0 +1,16 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="hcp-using-feature-gates"]
+= Using feature gates in a hosted cluster
+include::_attributes/common-attributes.adoc[]
+:context: hcp-using-feature-gates
+
+toc::[]
+
+You can use feature gates in a hosted cluster to enable features that are not part of the default set of features. You can enable the `TechPreviewNoUpgrade` feature set by using feature gates in your hosted cluster.
+
+include::modules/hcp-enable-feature-sets.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../rest_api/config_apis/featuregate-config-openshift-io-v1.adoc#featuregate-config-openshift-io-v1[FeatureGate [config.openshift.io/v1]]

--- a/modules/hcp-enable-feature-sets.adoc
+++ b/modules/hcp-enable-feature-sets.adoc
@@ -1,0 +1,56 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-using-feature-gates.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-enable-feature-sets_{context}"]
+= Enabling feature sets by using feature gates
+
+You can enable the `TechPreviewNoUpgrade` feature set in a hosted cluster by editing the `HostedCluster` custom resource (CR) with the OpenShift CLI.
+
+.Prerequisites
+
+* You installed the OpenShift CLI (`oc`).
+
+.Procedure
+
+. Open the `HostedCluster` CR for editing on the hosting cluster by running the following command:
++
+[source,terminal]
+----
+$ oc edit <hosted_cluster_name> -n <hosted_cluster_namespace>
+----
+
+. Define the feature set by entering a value in the `featureSet` field. For example:
++
+[source,yaml]
+----
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  name: <hosted_cluster_name> <1>
+  namespace: <hosted_cluster_namespace> <2>
+spec:
+  configuration:
+    featureGate:
+      featureSet: TechPreviewNoUpgrade <3>
+----
+<1> Specifies your hosted cluster name.
+<2> Specifies your hosted cluster namespace.
+<3> This feature set is a subset of the current Technology Preview features.
++
+[WARNING]
+====
+Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. This feature set allows you to enable these Technology Preview features on test clusters, where you can fully test them. Do not enable this feature set on production clusters.
+====
+
+. Save the file to apply the changes.
+
+.Verification
+
+* Verify that the `TechPreviewNoUpgrade` feature gate is enabled in your hosted cluster by running the following command:
++
+[source,terminal]
+----
+$ oc get featuregate cluster -o yaml
+----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> ---> This PR documents how to enable a `TechPreviewNoUpgrade` feature set by using feature gates for hosted control planes.
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-10246
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:  https://74617--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-using-feature-gates.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.

<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
