### PR TITLE
OSDOCS#10129: Remove TP notice for etcd tuning profiles

### DIFF
--- a/modules/etcd-tuning-parameters.adoc
+++ b/modules/etcd-tuning-parameters.adoc
@@ -12,16 +12,11 @@ The default setting allows the system to decide which speed to use. This value e
 
 By selecting one of the other values, you are overriding the default. If you see many leader elections due to timeouts or missed heartbeats and your system is set to `""` or `"Standard"`, set the hardware speed to `"Slower"` to make the system more tolerant to the increased latency.
 
-:FeatureName: Tuning etcd latency tolerances
-include::snippets/technology-preview.adoc[]
-
 [id="etcd-changing-hardware-speed-tolerance_{context}"]
 == Changing hardware speed tolerance
 
 To change the hardware speed tolerance for etcd, complete the following steps.
 
-.Prerequisites
-* You have edited the cluster instance to enable Technology Preview features. For more information, see "Understanding feature gates".
 
 .Procedure
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-10129](https://issues.redhat.com/browse/OSDOCS-10129)

Link to docs preview:
[Setting tuning parameters for etcd](https://74620--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.html#etcd-changing-hardware-speed-tolerance_recommended-etcd-practices)  Updated 4/16/24

QE review:
- [x ] QE has approved this change.
