### PR TITLE
ROX#23461: Change or add links for support matrix and support policy

### DIFF
--- a/cloud_service/acscs-default-requirements.adoc
+++ b/cloud_service/acscs-default-requirements.adoc
@@ -6,6 +6,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-include::modules/acs-requirements.adoc[leveloffset=+1]
+include::modules/acs-cloud-requirements.adoc[leveloffset=+1]
 
 include::modules/default-requirements-secured-cluster-services.adoc[leveloffset=+1]

--- a/cloud_service/acscs-recommended-requirements.adoc
+++ b/cloud_service/acscs-recommended-requirements.adoc
@@ -18,6 +18,6 @@ During the analysis of results, the number of deployments was identified as a pr
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../cloud_service/acscs-default-requirements.adoc#acs-general-requirements_acscs-default-requirements[Default resource requirements]
+* xref:../cloud_service/acscs-default-requirements.adoc#acs-cloud-requirements_acscs-default-requirements[Default resource requirements]
 
 include::modules/recommended-requirements-secured-cluster-services.adoc[leveloffset=+1]

--- a/installing/acs-high-level-overview.adoc
+++ b/installing/acs-high-level-overview.adoc
@@ -9,7 +9,7 @@ toc::[]
 [role="_abstract"]
 {product-title} ({product-title-short}) provides security services for your self-managed {osp} Kubernetes systems or platforms such as {ocp}, Amazon Elastic Kubernetes Service (Amazon EKS), Google Kubernetes Engine (Google GKE), and Microsoft Azure Kubernetes Service (Microsoft AKS).
 
-For information on supported platforms and architecture, see the link:https://access.redhat.com/articles/7045053[{product-title} Support Matrix]. For life cycle support information for {product-title-short}, see the link:https://access.redhat.com/support/policy/updates/rhacs[{product-title} Support Policy].
+For information about supported platforms and architecture, see the link:https://access.redhat.com/articles/7045053[{product-title} Support Matrix]. For life cycle support information for {product-title-short}, see the link:https://access.redhat.com/support/policy/updates/rhacs[{product-title} Support Policy].
 
 [id="general-guidelines_{context}"]
 == General installation guidelines

--- a/modules/acs-cloud-requirements.adoc
+++ b/modules/acs-cloud-requirements.adoc
@@ -1,16 +1,16 @@
 // Module included in the following assemblies:
 //
-// * installing/acs-default-requirements.adoc
+// * cloud_service/acscs-default-requirements.adoc
 :_mod-docs-content-type: CONCEPT
-[id="acs-general-requirements_{context}"]
-= General RHACS requirements
+[id="acs-cloud-requirements_{context}"]
+= General requirements for RHACS Cloud Service
 
 [role="_abstract"]
-Before you can install {product-title-short}, your system must meet several requirements.
+Before you can install {product-title-managed}, your system must meet several requirements.
 
 [WARNING]
 ====
-You must not install {product-title-short} on:
+You must not install {product-title-managed-short} on:
 
 * Amazon Elastic File System (Amazon EFS). Use the Amazon Elastic Block Store (Amazon EBS) with the default *gp2* volume type instead.
 * Older CPUs that do not have the Streaming SIMD Extensions (SSE) 4.2 instruction set.
@@ -18,20 +18,20 @@ For example, Intel processors older than _Sandy Bridge_ and AMD processors older
 These processors were released in 2011.
 ====
 
-To install {product-title-short}, you must have one of the following systems:
+To install {product-title-managed-short}, you must have one of the following systems:
 
 * {ocp} version {ocp-supported-version} or later, and cluster nodes with a supported operating system of {op-system-first} or {op-system-base-full}
 * A supported managed Kubernetes platform, and cluster nodes with a supported operating system of Amazon Linux, CentOS, Container-Optimized OS from Google, {op-system-first}, Debian, {op-system-base-full}, or Ubuntu
 +
-For information about supported platforms and architecture, see the link:https://access.redhat.com/articles/7045053[{product-title} Support Matrix]. For life cycle support information for {product-title-short}, see the link:https://access.redhat.com/support/policy/updates/rhacs[{product-title} Support Policy].
+For information about supported platforms and architecture, see the link:https://access.redhat.com/articles/7045053[{product-title} Support Matrix].
 
 The following minimum requirements and suggestions apply to cluster nodes.
 
-Architecture:: `amd64`, `ppc64le`, or `s390x`
+Architecture:: Supported architectures are `amd64`, `ppc64le`, or `s390x`.
 +
 [NOTE]
 ====
-Starting with {product-title-short} 4.3, both Central and secured cluster services are supported on {ibm-power}(`ppc64le`), {ibm-z}(`s390x`), and {ibm-linuxone}(`s390x`) clusters.
+Secured cluster services are supported on {ibm-power} (`ppc64le`), {ibm-z} (`s390x`), and {ibm-linuxone} (`s390x`) clusters.
 ====
 
 Processor:: 3 CPU cores are required.
@@ -43,16 +43,16 @@ Memory:: 6 GiB of RAM is required.
 See the default memory and CPU requirements for each component and ensure that the node size can support them.
 ====
 
-Storage:: A persistent volume claim (PVC) is required on the cluster where Central is installed. It is strongly recommended on the secured clusters where Scanner V4 is enabled. Use Solid-State Drives (SSDs) for best performance. However, you can use another storage type if you do not have SSDs available.
+Storage:: For {product-title-managed-short}, a persistent volume claim (PVC) is not required. However, a PVC is strongly recommended if you have secured clusters with Scanner V4 enabled. Use Solid-State Drives (SSDs) for best performance. However, you can use another storage type if you do not have SSDs available.
 +
 [IMPORTANT]
 ====
-You must not use Ceph FS storage with {product-title}. Red{nbsp}Hat recommends using RBD block mode PVCs for {product-title}.
+You must not use Ceph FS storage with {product-title-managed-short}. Red{nbsp}Hat recommends using RBD block mode PVCs for {product-title-managed-short}.
 ====
 
-If you plan to install {product-title-short} by using Helm charts, you must meet the following requirements:
+If you plan to install {product-title-managed-short} by using Helm charts, you must meet the following requirements:
 
-* You must have Helm command-line interface (CLI) v3.2 or newer, if you are installing or configuring {product-title-short} using Helm charts.
+* You must have Helm command-line interface (CLI) v3.2 or newer, if you are installing or configuring {product-title-managed-short} using Helm charts.
 Use the `helm version` command to verify the version of Helm you have installed.
 ifdef::op[]
 * You must have the required permissions to configure deployments in the Central cluster.

--- a/modules/install-acs-operator-cloud.adoc
+++ b/modules/install-acs-operator-cloud.adoc
@@ -10,7 +10,7 @@ Using the OperatorHub provided with {ocp} is the easiest way to install the {pro
 
 .Prerequisites
 * You have access to an {ocp} cluster using an account with Operator installation permissions.
-* You must be using {ocp} {ocp-supported-version} or later. For more information, see link:https://access.redhat.com/support/policy/updates/rhacs[{product-title} Support Policy].
+* You must be using {ocp} {ocp-supported-version} or later. For information about supported platforms and architecture, see the link:https://access.redhat.com/articles/7045053[{product-title} Support Matrix].
 
 .Procedure
 . In the web console, go to the *Operators* -> *OperatorHub* page.

--- a/modules/install-acs-operator.adoc
+++ b/modules/install-acs-operator.adoc
@@ -10,7 +10,7 @@ Using the OperatorHub provided with {ocp} is the easiest way to install {product
 
 .Prerequisites
 * You have access to an {ocp} cluster using an account with Operator installation permissions.
-* You must be using {ocp} {ocp-supported-version} or later. For more information, see link:https://access.redhat.com/support/policy/updates/rhacs[{product-title} Support Policy].
+* You must be using {ocp} {ocp-supported-version} or later. For information about supported platforms and architecture, see the link:https://access.redhat.com/articles/7045053[{product-title} Support Matrix]. For life cycle support information for {product-title-short}, see the link:https://access.redhat.com/support/policy/updates/rhacs[{product-title} Support Policy].
 
 .Procedure
 . In the web console, go to the *Operators* -> *OperatorHub* page.

--- a/modules/install-central-operator-external-db.adoc
+++ b/modules/install-central-operator-external-db.adoc
@@ -14,8 +14,10 @@ The main component of {product-title} is called Central. You can install Central
 When you install {product-title} for the first time, you must first install the `Central` custom resource because the `SecuredCluster` custom resource installation is dependent on certificates that Central generates.
 ====
 
+For more information about {product-title-short} databases, see the link:https://access.redhat.com/articles/7045053#database-scope-of-coverage-7[Database Scope of Coverage].
+
 .Prerequisites
-* You must be using {ocp} {ocp-supported-version} or later. For more information, see link:https://access.redhat.com/support/policy/updates/rhacs[{product-title} Support Policy].
+* You must be using {ocp} {ocp-supported-version} or later. For more information about supported {ocp} versions, see the link:https://access.redhat.com/articles/7045053[Red Hat Advanced Cluster Security for Kubernetes Support Matrix].
 * You must have a database in your database instance that supports PostgreSQL 13 and a user with the following permissions:
 ** Connection rights to the database.
 ** `Usage` and `Create` on the schema.

--- a/modules/install-central-operator.adoc
+++ b/modules/install-central-operator.adoc
@@ -14,7 +14,7 @@ When you install {product-title} for the first time, you must first install the 
 ====
 
 .Prerequisites
-* You must be using {ocp} {ocp-supported-version} or later. For more information, see link:https://access.redhat.com/support/policy/updates/rhacs[{product-title} Support Policy].
+* You must be using {ocp} {ocp-supported-version} or later. For information about supported platforms and architecture, see the link:https://access.redhat.com/articles/7045053[{product-title} Support Matrix]. For life cycle support information for {product-title-short}, see the link:https://access.redhat.com/support/policy/updates/rhacs[{product-title} Support Policy].
 
 .Procedure
 . On the {ocp} web console, go to the *Operators* -> *Installed Operators* page.

--- a/modules/install-secured-cluster-services-helm-chart.adoc
+++ b/modules/install-secured-cluster-services-helm-chart.adoc
@@ -3,7 +3,7 @@
 // * installing/installing_helm/install-helm-customization.adoc
 :_mod-docs-content-type: PROCEDURE
 [id="install-secured-cluster-services-helm-chart_{context}"]
-= Installing the secured-cluster-services Helm chart
+= Installing the secured-cluster-services Helm chart with customizations
 
 After you configure the `values-public.yaml` and `values-private.yaml` files, install the `secured-cluster-services` Helm chart to deploy the following per-cluster and per-node components:
 
@@ -13,7 +13,7 @@ After you configure the `values-public.yaml` and `values-private.yaml` files, in
 * Scanner: optional for secured clusters when the StackRox Scanner is installed
 * Scanner DB: optional for secured clusters when the StackRox Scanner is installed
 * Scanner V4 Indexer and Scanner V4 DB: optional for secured clusters when Scanner V4 is installed
-+
+
 :FeatureName: Scanner V4
 include::snippets/technology-preview.adoc[]
 

--- a/modules/rhcos-enable-node-scan.adoc
+++ b/modules/rhcos-enable-node-scan.adoc
@@ -9,7 +9,7 @@
 If you use {ocp}, you can enable scanning of {op-system-first} nodes for vulnerabilities by using {rh-rhacs-first}.
 
 .Prerequisites
-* For scanning {op-system} node hosts of the Secured cluster, you must have installed Secured cluster on {ocp} {ocp-supported-version} or later. For more information on supported managed and self-managed {ocp} versions, see link:https://access.redhat.com/support/policy/updates/rhacs[{product-title} Support Policy].
+* For scanning {op-system} node hosts of the Secured cluster, you must have installed Secured cluster on {ocp} {ocp-supported-version} or later. For information about supported platforms and architecture, see the link:https://access.redhat.com/articles/7045053[{product-title} Support Matrix]. For life cycle support information for {product-title-short}, see the link:https://access.redhat.com/support/policy/updates/rhacs[{product-title} Support Policy].
 
 .Procedure
 . Run one of the following commands to update the compliance container.

--- a/modules/secured-cluster-services-config.adoc
+++ b/modules/secured-cluster-services-config.adoc
@@ -120,7 +120,7 @@ Since the volume of object updates is usually higher than the object creates, le
 
 | `admissionControl.listenOnEvents`
 | This setting controls whether the cluster is configured to contact {product-title} with `AdmissionReview` requests for Kubernetes `exec` and `portforward` events.
-{product-title} does not support this feature on {ocp} 3.11. For more information, see link:https://access.redhat.com/support/policy/updates/rhacs[{product-title} Support Policy].
+{product-title-short} does not support this feature on {ocp} 3.11.
 
 | `admissionControl.dynamic.enforceOnCreates`
 | This setting controls whether {product-title} evaluates policies;


### PR DESCRIPTION
Version(s):

4.4+

[Issue
](https://issues.redhat.com/browse/ROX-23461)

Link to docs preview:

Regular ACS - support matrix link added, refers to both support matrix and support policy:

- [high-level overview ACS](https://74621--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/acs-high-level-overview)
- [resource requirements ACS](https://74621--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/acs-default-requirements)
- https://74621--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-ocp#install-acs-operator_install-central-ocp
- https://74621--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-vulnerabilities/scan-rhcos-node-host.html

Cloud (only refers to Support Matrix, not support policy)
 
- https://74621--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/acscs-default-requirements
- https://74621--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_ocp/cloud-install-operator#install-acs-operator-cloud_cloud-install-operator

ACS with external database - added link to database section in support matrix:

- https://74621--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-ocp#install-central-operator-external-db_install-central-ocp

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

- Created a separate file for Cloud requirements, as there are enough differences to warrant its own file and not reusing the ACS file. 
- Added support matrix and support policy links depending on version (ACS regular or ACS Cloud).
- Fixed a couple other style issues/typos.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
