### PR TITLE
HCIDOCS-22-new: Cluster scale down

### DIFF
--- a/edge_computing/ztp-sno-additional-worker-node.adoc
+++ b/edge_computing/ztp-sno-additional-worker-node.adoc
@@ -28,6 +28,8 @@ include::snippets/technology-preview.adoc[]
 
 * For more information about worker nodes, see xref:../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno} clusters].
 
+* For information about removing a worker node from an expanded {sno} cluster, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#auto-remove-host-steps-cli[Removing managed cluster nodes by using the command line interface].
+
 include::modules/ztp-worker-node-applying-du-profile.adoc[leveloffset=+1]
 
 include::modules/ztp-worker-node-daemon-selector-compatibility.adoc[leveloffset=+1]


### PR DESCRIPTION
Replaces https://github.com/openshift/openshift-docs/pull/71016 because the source file moved. See https://github.com/openshift/openshift-docs/pull/71016 for previous reviewer comments.

Summary of change:
Added a link to the ACM documentation.

Issue:
Jira: https://issues.redhat.com/browse/HCIDOCS-22

SMEs: Ian Miller, Nick Carboni
QE: Trey West

Version(s):
main, 4.16, 4.15, 4.14, 4.13

Link to docs preview:
https://74627--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-sno-additional-worker-node.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
