### PR TITLE
OSDOCS-10222: Documented 4.13.40 z-stream notes

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -4048,3 +4048,23 @@ $ oc adm release info 4.13.39 --pullspecs
 [id="ocp-4-13-39-updating"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-13-40"]
+=== RHBA-2024:1761 - {product-title} 4.13.40 bug fix update
+
+Issued: 2024-04-18
+
+{product-title} release 4.13.40 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1761[RHBA-2024:1761] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1763[RHSA-2024:1763] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.40 --pullspecs
+----
+
+[id="ocp-4-13-40-updating"]
+==== Updating
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OSDOCS-10222](https://issues.redhat.com/browse/OSDOCS-10222)

Link to docs preview:
[4.13.40 z-stream notes](https://74629--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-40)

QE review:
- [x] QE not required as per peer-review checklist.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
