### PR TITLE
OBSDOCS-972: Logging- Remove confusing support statement for splunk fields deprecation

### DIFF
--- a/modules/logging-release-notes-5-9-0.adoc
+++ b/modules/logging-release-notes-5-9-0.adoc
@@ -14,7 +14,7 @@ The {logging-uc} 5.9 release does not contain an updated version of the {es-op}.
 
 * In {logging-uc} 5.9, Fluentd, and Kibana are deprecated and are planned to be removed in {logging-uc} 6.0, which is expected to be shipped alongside a future release of {product-title}. Red Hat will provide critical and above CVE bug fixes and support for these components during the current release lifecycle, but these components will no longer receive feature enhancements. The Vector-based collector provided by the {clo} and LokiStack provided by the {loki-op} are the preferred Operators for log collection and storage. We encourage all users to adopt the Vector and Loki log stack, as this will be the stack that will be enhanced going forward.
 
-* In {logging-uc} 5.9, the `Fields` option for the Splunk output type is deprecated and is planned to be removed in a future release. Red Hat will provide bug fixes and support for this feature during the current release lifecycle, but this feature will no longer receive enhancements and will be removed.
+* In {logging-uc} 5.9, the `Fields` option for the Splunk output type was never implemented and is now deprecated. It will be removed in a future release.
 
 [id="logging-release-notes-5-9-0-enhancements"]
 == Enhancements


### PR DESCRIPTION
Change type: Doc update; Logging- Remove confusing support statement for splunk fields deprecation

Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-972

Fix Version: 4.13+

Doc Preview: https://74643--ocpdocs-pr.netlify.app/openshift-dedicated/latest/logging/logging_release_notes/logging-5-9-release-notes.html#logging-release-notes-5-9-0-deprecation-notice

SME Review: @jcantrill 
QE Review: @kabirbhartiRH 
Peer Review: @bhardesty 