### PR TITLE
[OSDOCS-10212] Changed notes to warnings to top of the docs for the deprecated Custom Domain Operator

### DIFF
--- a/applications/deployments/osd-config-custom-domains-applications.adoc
+++ b/applications/deployments/osd-config-custom-domains-applications.adoc
@@ -6,7 +6,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-[NOTE]
+[WARNING]
 ====
 Starting with {product-title} 4.14, the Custom Domain Operator is deprecated. To manage Ingress in {product-title} 4.14, use the Ingress Operator. The functionality is unchanged for {product-title} 4.13 and earlier versions.
 ====

--- a/applications/deployments/rosa-config-custom-domains-applications.adoc
+++ b/applications/deployments/rosa-config-custom-domains-applications.adoc
@@ -6,7 +6,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-[NOTE]
+[WARNING]
 ====
 Starting with {product-title} 4.14, the Custom Domain Operator is deprecated. To manage Ingress in {product-title} 4.14, use the Ingress Operator. The functionality is unchanged for {product-title} 4.13 and earlier versions.
 ====

--- a/cloud_experts_tutorials/cloud-experts-external-dns.adoc
+++ b/cloud_experts_tutorials/cloud-experts-external-dns.adoc
@@ -18,7 +18,7 @@ toc::[]
 //  - Dustin Scott
 //---
 
-[NOTE]
+[WARNING]
 ====
 Starting with {product-title} 4.14, the Custom Domain Operator is deprecated. To manage Ingress in {product-title} 4.14, use the Ingress Operator. The functionality is unchanged for {product-title} 4.13 and earlier versions.
 ====

--- a/modules/rosa-sdpolicy-networking.adoc
+++ b/modules/rosa-sdpolicy-networking.adoc
@@ -15,12 +15,12 @@ This section provides information about the service definition for {product-titl
 
 [id="rosa-sdpolicy-custom-domains_{context}"]
 == Custom domains for applications
-To use a custom hostname for a route, you must update your DNS provider by creating a canonical name (CNAME) record. Your CNAME record should map the OpenShift canonical router hostname to your custom domain. The OpenShift canonical router hostname is shown on the _Route Details_ page after a route is created. Alternatively, a wildcard CNAME record can be created once to route all subdomains for a given hostname to the cluster's router.
 
-[NOTE]
+[WARNING]
 ====
 Starting with {product-title} 4.14, the Custom Domain Operator is deprecated. To manage Ingress in {product-title} 4.14 or later, use the Ingress Operator. The functionality is unchanged for {product-title} 4.13 and earlier versions.
 ====
+To use a custom hostname for a route, you must update your DNS provider by creating a canonical name (CNAME) record. Your CNAME record should map the OpenShift canonical router hostname to your custom domain. The OpenShift canonical router hostname is shown on the _Route Details_ page after a route is created. Alternatively, a wildcard CNAME record can be created once to route all subdomains for a given hostname to the cluster's router.
 
 [id="rosa-sdpolicy-validated-certificates_{context}"]
 == Domain validated certificates

--- a/modules/sdpolicy-networking.adoc
+++ b/modules/sdpolicy-networking.adoc
@@ -8,7 +8,7 @@
 [id="custom-domains_{context}"]
 == Custom domains for applications
 
-[NOTE]
+[WARNING]
 ====
 Starting with {product-title} 4.14, the Custom Domain Operator is deprecated. To manage Ingress in {product-title} 4.14 or later, use the Ingress Operator. The functionality is unchanged for {product-title} 4.13 and earlier versions.
 ====


### PR DESCRIPTION
[OSDOCS-10212] Changed notes to warnings to top of the docs for the deprecated Custom Domain Operator

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-10212

Link to docs preview:
https://74644--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition#rosa-sdpolicy-custom-domains_rosa-service-definition
https://74644--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-service-definition.html#custom-domains_osd-service-definition
https://74644--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-external-dns
https://74644--ocpdocs-pr.netlify.app/openshift-rosa/latest/applications/deployments/rosa-config-custom-domains-applications
https://74644--ocpdocs-pr.netlify.app/openshift-dedicated/latest/applications/deployments/osd-config-custom-domains-applications



