### PR TITLE
OADP-3904: fix and update the velero commands in openshift doc for [d…

### DIFF
--- a/modules/migration-debugging-velero-resources.adoc
+++ b/modules/migration-debugging-velero-resources.adoc
@@ -42,6 +42,7 @@ $ oc -n {namespace} exec deployment/velero -c velero -- ./velero \
   --help
 ----
 
+
 [discrete]
 [id="velero-describe-command_{context}"]
 == Describe command

--- a/modules/oadp-self-signed-certificate.adoc
+++ b/modules/oadp-self-signed-certificate.adoc
@@ -56,6 +56,7 @@ You might want to use the Velero CLI without installing it locally on your syste
 ----
 $ alias velero='oc -n openshift-adp exec deployment/velero -c velero -it -- ./velero'
 ----
+
 . Check that the alias is working by running the following command:
 +
 [source,terminal]
@@ -80,9 +81,18 @@ $ [[ -n $CA_CERT ]] && echo "$CA_CERT" | base64 -d | oc exec -n openshift-adp -i
 +
 [source,terminal]
 ----
-$ velero -n openshift-adp describe backup <backup-name> --details --cacert /tmp/your-cacert.txt
+$ velero describe backup <backup_name> --details --cacert /tmp/<your_cacert>.txt
+----
+
+. To fetch the backup logs, run the following command:
++
+[source,terminal]
+----
+$ velero backup logs  <backup_name>  --cacert /tmp/<your_cacert.txt>
 ----
 +
+You can use these logs to view failures and warnings for the resources that you cannot back up.
+
 . If the Velero pod restarts, the `/tmp/your-cacert.txt` file disappears, and you must re-create the `/tmp/your-cacert.txt` file by re-running the commands from the previous step.
 
 . You can check if the `/tmp/your-cacert.txt` file still exists, in the file location where you stored it, by running the following command:


### PR DESCRIPTION
### JIRA

* [OADP-3904](https://issues.redhat.com/browse/OADP-3904)

### Version(s):

* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16

### Link to docs preview:

* [Enabling self-signed CA certificates](https://74658--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.html#oadp-self-signed-certificate_installing-oadp-ocs)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
