### PR TITLE
Add important symlinks to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,15 @@
- @abhatt-rh @abrennan89 @adellape @aireilly @apinnick @bburt-rh @bergerhoffer @bscott-rh @gabriel-rh @jab-rh @jeana-redhat @JoeAldinger @kalexand-rh @kcarmichael08 @kelbrown20 @michaelryanpeter @mjpytlak @opayne1 @ousleyp @rolfedh @sjhala-ccs @snarayan-redhat @Srivaralakshmi
+##############################################################
+#
+# List of owners + files or folders that require explicit approval in order to be changed
+#
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+##############################################################
+#
+# Owners
+@abhatt-rh @abrennan89 @adellape @aireilly @apinnick @bburt-rh @bergerhoffer @bscott-rh @gabriel-rh @jab-rh @jeana-redhat @JoeAldinger @kalexand-rh @kcarmichael08 @kelbrown20 @michaelryanpeter @opayne1 @ousleyp @rolfedh @sjhala-ccs @snarayan-redhat @Srivaralakshmi
+
+# These files or folders require explicit approval to be changed
+modules/_attributes @adellape @bergerhoffer @kalexand-rh
+modules/images @adellape @bergerhoffer @kalexand-rh
+modules/snippets @adellape @bergerhoffer @kalexand-rh


### PR DESCRIPTION
We can use CODEOWNERS to protect certain files and folders from accidental changes which introduce errors. See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax

1. Add important symlinks to CODEOWNER
2. Remove @mjpytlak from CODEOWNERS