### PR TITLE
HCIDOCS-283: Issue in file installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc

### DIFF
--- a/modules/ipi-install-creating-an-rhcos-images-cache.adoc
+++ b/modules/ipi-install-creating-an-rhcos-images-cache.adoc
@@ -104,12 +104,10 @@ $ ls -Z /home/kni/rhcos_image_cache
 $ podman run -d --name rhcos_image_cache \ <1>
 -v /home/kni/rhcos_image_cache:/var/www/html \
 -p 8080:8080/tcp \
-quay.io/centos7/httpd-24-centos7:latest
+registry.access.redhat.com/ubi9/httpd-24
 ----
-ifndef::upstream[]
 +
 <1> Creates a caching webserver with the name `rhcos_image_cache`. This pod serves the `bootstrapOSImage` image in the `install-config.yaml` file for deployment.
-endif::[]
 
 . Generate the `bootstrapOSImage` configuration:
 +

--- a/modules/ipi-install-creating-an-rhcos-images-cache.adoc
+++ b/modules/ipi-install-creating-an-rhcos-images-cache.adoc
@@ -101,7 +101,7 @@ $ ls -Z /home/kni/rhcos_image_cache
 +
 [source,terminal]
 ----
-$ podman run -d --name rhcos_image_cache \ <1>
+$ podman run -d --name rhcos_image_cache \// <1>
 -v /home/kni/rhcos_image_cache:/var/www/html \
 -p 8080:8080/tcp \
 registry.access.redhat.com/ubi9/httpd-24


### PR DESCRIPTION
Updated the image from centos7 to ubi9.

Fixes: HCIDCOS-283

See https://issues.redhat.com/browse/HCIDOCS-283 for additional details.

Preview URL: http://184.23.213.161:8080/HCIDOCS-283/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#ipi-install-creating-an-rhcos-images-cache_ipi-install-installation-workflow see step 10.

For release(s): 4.12-4.16
QE Review: 

- [ ] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
