### PR TITLE
Garbage Collect old rendered MachineConfigs

### DIFF
--- a/modules/machineconfig-garbage-collect-removing.adoc
+++ b/modules/machineconfig-garbage-collect-removing.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/machine-configuration-tasks.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="machineconfig-garbage-collect-removing_{context}"]
+= Removing unused rendered machine configs
+
+You can remove unused rendered machine configs by using the `oc adm prune renderedmachineconfigs` command with the `--confirm` command.  If any rendered machine config is not deleted, the command output indicates which was not deleted and lists the reason for skipping the deletion.
+
+.Procedure 
+
+. Optional: List the rendered machine configs that you can remove automatically by running the following command. Any rendered machine config marked with `as it's currently in use` in the command output is not removed. 
++
+[source,terminal]
+----
+$ oc adm prune renderedmachineconfigs --pool-name=worker
+----
++
+.Example output
+[source,terminal]
+----
+Dry run enabled - no modifications will be made. Add --confirm to remove rendered machine configs.
+DRY RUN: Deleted rendered MachineConfig rendered-worker-23d7322831a57f02998e7e1600a0865f
+DRY RUN: Deleted rendered MachineConfig rendered-worker-fc94397dc7c43808c7014683c208956e
+DRY RUN: Skipping deletion of rendered MachineConfig rendered-worker-ad5a3cad36303c363cf458ab0524e7c0 as it's currently in use
+----
++
+--
+where:
+
+pool-name:: Optional: Specifies the machine config pool where you want to delete the machine configs from.
+--
+
+. Remove the unused rendered machine configs by running the following command. The command in the following procedure would delete the two oldest unused rendered machine configs in the `worker` machine config pool.
++
+[source,terminal]
+----
+$ oc adm prune renderedmachineconfigs --pool-name=worker --count=2 --confirm
+----
++
+--
+where: 
+
+`--count`:: Optional: Specifies the maximum number of unused rendered machine configs you want to delete, starting with the oldest.
+
+`--confirm`:: Optional: Specifies the maximum number of unused rendered machine configs you want to delete, starting with the oldest.
+
+`--pool-name`:: Optional: Specifies the machine config pool from which you want to delete the machine. If not specified, all the pools are evaluated.
+
+--

--- a/modules/machineconfig-garbage-collect-viewing.adoc
+++ b/modules/machineconfig-garbage-collect-viewing.adoc
@@ -1,0 +1,62 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/machine-configuration-tasks.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="machineconfig-garbage-collect-viewing_{context}"]
+= Viewing rendered machine configs
+
+You can view a list of rendered machine configs by using the `oc adm prune renderedmachineconfigs` command with the `list` subcommand.  
+
+For example, the command in the following procedure would list all rendered machine configs for the `worker` machine config pool.
+
+.Procedure
+
+* Optional: List the rendered machine configs by using the following command:
++
+[source,terminal]
+----
+$ oc adm prune renderedmachineconfigs list --in-use=false --pool-name=worker
+----
++
+--
+where:
+
+list:: Displays a list of rendered machine configs in your cluster.
+
+`--in-use`:: Optional: Specifies whether to display only the used machine configs or all machine configs from the specified pool. If `true`, the output lists the rendered machine configs that are being used by a machine config pool. If `false`, the output lists all rendered machine configs in the cluster. The default value is `false`.
+
+`--pool-name`:: Optional: Specifies the machine config pool from which to display the machine configs.
+--
++
+.Example output
+[source,terminal]
+----
+worker
+status: rendered-worker-ae115e2b5e6ae05e0e6e5d62c7d0dd81
+spec: rendered-worker-ae115e2b5e6ae05e0e6e5d62c7d0dd81
+----
+
+* List the rendered machine configs that you can remove automatically by running the following command. Any rendered machine config marked with `as it's currently in use` in the command output is not removed.
++
+[source,terminal]
+----
+$ oc adm prune renderedmachineconfigs --pool-name=worker
+----
++
+The command runs in dry-run mode, and no machine configs are removed. 
++
+--
+where:
+
+`--pool-name`:: Optional: Displays the machine configs in the specified machine config pool.
+--
++
+.Example output
+[source,terminal]
+----
+Dry run enabled - no modifications will be made. Add --confirm to remove rendered machine configs.
+DRY RUN: Deleted rendered MachineConfig rendered-worker-23d7322831a57f02998e7e1600a0865f
+DRY RUN: Deleted rendered MachineConfig rendered-worker-fc94397dc7c43808c7014683c208956e
+DRY RUN: Skipping deletion of rendered MachineConfig rendered-worker-ad5a3cad36303c363cf458ab0524e7c0 as it's currently in use
+----

--- a/modules/machineconfig-garbage-collect.adoc
+++ b/modules/machineconfig-garbage-collect.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/machine-configuration-tasks.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="machineconfig-garbage-collect_{context}"]
+= Managing unused rendered machine configs
+
+The Machine Config Operator (MCO) does not perform any garbage collection activities. This means that all rendered machine configs remain in the cluster. Each time a user or controller applies a new machine config, the MCO creates new rendered configs for each affected machine config pool. Over time, this can lead to a large number of rendered machine configs, which can make working with machine configs confusing. Having too many rendered machine configs can also contribute to disk space issues and performance issues with etcd. 
+
+You can remove old, unused rendered machine configs by using the `oc adm prune renderedmachineconfigs` command with the `--confirm` flag. With this command, you can remove all unused rendered machine configs or only those in a specific machine config pool. You can also remove a specified number of unused rendered machine configs in order to keep some older machine configs, in case you want to check older configurations.
+
+You can use the `oc adm prune renderedmachineconfigs` command without the `--confirm` flag to see which rendered machine configs would be removed.
+
+Use the `list` subcommand to display all the rendered machine configs in the cluster or a specific machine config pool.
+
+[NOTE]
+====
+The `oc adm prune renderedmachineconfigs` command deletes only rendered machine configs that are not in use. If a rendered machine configs are in use by a machine config pool, the rendered machine config is not deleted. In this case, the command output specifies the reason that the rendered machine config was not deleted.
+====

--- a/post_installation_configuration/machine-configuration-tasks.adoc
+++ b/post_installation_configuration/machine-configuration-tasks.adoc
@@ -86,4 +86,6 @@ include::modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc[leve
 include::modules/create-a-containerruntimeconfig-crd.adoc[leveloffset=+2]
 include::modules/set-the-default-max-container-root-partition-size-for-overlay-with-crio.adoc[leveloffset=+2]
 
-
+include::modules/machineconfig-garbage-collect.adoc[leveloffset=+1]
+include::modules/machineconfig-garbage-collect-viewing.adoc[leveloffset=+2]
+include::modules/machineconfig-garbage-collect-removing.adoc[leveloffset=+2]


### PR DESCRIPTION
New CLI command to delete unused rendered machine configs. 
https://issues.redhat.com/browse/OSDOCS-10093

Preview: [Managing unused rendered machine configs](https://74675--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#machineconfig-garbage-collect_post-install-machine-configuration-tasks)

Release note PR: https://github.com/openshift/openshift-docs/pull/76354
