### PR TITLE
TELCODOCS-1837: Fix erroneous example in day 1 bare metal networking config

### DIFF
--- a/modules/ipi-install-configuring-host-network-interfaces-for-subnets.adoc
+++ b/modules/ipi-install-configuring-host-network-interfaces-for-subnets.adoc
@@ -35,22 +35,21 @@ networking:
 [source,yaml]
 ----
 networkConfig:
-  nmstate:
-    interfaces:
-    - name: <interface_name> <1>
-      type: ethernet
-      state: up
-      ipv4:
-        enabled: true
-        dhcp: false
-        address:
-        - ip: <node_ip> <2>
-          prefix-length: 24
-        gateway: <gateway_ip> <3>
-        dns-resolver:
-          config:
-            server:
-            - <dns_ip> <4>
+  interfaces:
+  - name: <interface_name> <1>
+    type: ethernet
+    state: up
+    ipv4:
+      enabled: true
+      dhcp: false
+      address:
+      - ip: <node_ip> <2>
+        prefix-length: 24
+      gateway: <gateway_ip> <3>
+      dns-resolver:
+        config:
+          server:
+          - <dns_ip> <4>
 ----
 +
 <1> Replace `<interface_name>` with the interface name.


### PR DESCRIPTION
There is no "nmstate" key under "networkConfig" inside the install-config, as can be observed from all of the other examples. (The "nmstate" key is where the NMState data lives in the Secret generated from the install-config to associate with the BareMetalHost, or by the user when adding nodes on Day 2.)

Version(s):
4.12-4.16

(also affects 4.10-4.11)

Issue:
https://issues.redhat.com/browse/TELCODOCS-1837

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
