### PR TITLE
OBSDOCS-912: Document how to configure audit logging for Metrics Server

### DIFF
--- a/modules/monitoring-configuring-audit-logs-for-metrics-server.adoc
+++ b/modules/monitoring-configuring-audit-logs-for-metrics-server.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * observability/monitoring/configuring-the-monitoring-stack.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="configuring-audit-logs-for-metrics-server_{context}"]
+= Configuring audit logs for Metrics Server
+
+You can configure audit logs for Metrics Server to help you troubleshoot issues with the server. 
+Audit logs record the sequence of actions in a cluster. It can record user, application, or control plane activities.
+
+You can set audit log rules, which determine what events are recorded and what data they should include. This can be achieved with the following audit profiles:
+
+* *Metadata (default)*: This profile enables the logging of event metadata including user, timestamps, resource, and verb. It does not record request and response bodies.
+* *Request*: This enables the logging of event metadata and request body, but it does not record response body. This configuration does not apply for non-resource requests.
+* *RequestResponse*: This enables the logging of event metadata, and request and response bodies. This configuration does not apply for non-resource requests.
+* *None*: None of the previously described events are recorded.
+
+You can configure the audit profiles by modifying the `cluster-monitoring-config` config map.
+The following example sets the profile to `Request`, allowing the logging of event metadata and request body for Metrics Server:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    metricsServer:
+      audit:
+        profile: Request
+----

--- a/observability/monitoring/configuring-the-monitoring-stack.adoc
+++ b/observability/monitoring/configuring-the-monitoring-stack.adoc
@@ -211,6 +211,11 @@ ifndef::openshift-dedicated,openshift-rosa[]
 * For information about how to get your cluster ID, see xref:../../support/gathering-cluster-data.adoc#support-get-cluster-id_gathering-cluster-data[Obtaining your cluster ID].
 endif::openshift-dedicated,openshift-rosa[]
 
+ifndef::openshift-dedicated,openshift-rosa[]
+// Configuring audit logs for Metrics Server
+include::modules/monitoring-configuring-audit-logs-for-metrics-server.adoc[leveloffset=+1]
+endif::openshift-dedicated,openshift-rosa[]
+
 // Configuring metrics collection profiles
 // TP features are excluded from OSD and ROSA. When this feature is GA, it can be included in the OSD/ROSA docs.
 ifndef::openshift-dedicated,openshift-rosa[]


### PR DESCRIPTION
Version(s): `enterprise-4.16`

Issue: [OBSDOCS-912](https://issues.redhat.com/browse/OBSDOCS-912)

Link to docs preview: [Configuring audit logs for Metrics Server](https://74681--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#configuring-audit-logs-for-metrics-server_configuring-the-monitoring-stack)

QE review:
- [x] QE has approved this change.

**Additional information:**