### PR TITLE
[OCM-6607] Enable Osaka and HK regions for HCP

### DIFF
--- a/modules/rosa-sdpolicy-am-regions-az.adoc
+++ b/modules/rosa-sdpolicy-am-regions-az.adoc
@@ -42,16 +42,12 @@ ifndef::rosa-with-hcp[]
 endif::rosa-with-hcp[]
 * us-west-2 (Oregon)
 * af-south-1 (Cape Town, AWS opt-in required)
-ifndef::rosa-with-hcp[]
 * ap-east-1 (Hong Kong, AWS opt-in required)
-endif::rosa-with-hcp[]
 * ap-south-2 (Hyderabad, AWS opt-in required)
 * ap-southeast-3 (Jakarta, AWS opt-in required)
 * ap-southeast-4 (Melbourne, AWS opt-in required)
 * ap-south-1 (Mumbai)
-ifndef::rosa-with-hcp[]
 * ap-northeast-3 (Osaka)
-endif::rosa-with-hcp[]
 * ap-northeast-2 (Seoul)
 * ap-southeast-1 (Singapore)
 * ap-southeast-2 (Sydney)


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCM-6607

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
