### PR TITLE
OSDOCS-9425: add Multus to new MicroShift install

### DIFF
--- a/microshift_install/microshift-install-rpm.adoc
+++ b/microshift_install/microshift-install-rpm.adoc
@@ -48,6 +48,8 @@ include::modules/microshift-install-rpms-olm.adoc[leveloffset=+1]
 
 include::modules/microshift-install-rpms-gitops.adoc[leveloffset=+1]
 
+include::modules/microshift-install-multus-rpm.adoc[leveloffset=+1]
+
 include::modules/microshift-service-starting.adoc[leveloffset=+1]
 
 include::modules/microshift-service-stopping.adoc[leveloffset=+1]

--- a/modules/microshift-install-multus-rpm.adoc
+++ b/modules/microshift-install-multus-rpm.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// microshift/microshift-install-rpm.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-installing-multus_{context}"]
+== Installing the multiple networks plugin
+
+Use this procedure to install the {microshift-short} Multus CNI plugin alongside a new {microshift-short} installation. The {microshift-short} Multus Container Network Interface (CNI) plugin is not installed by default. If you want to attach additional networks to a pod for high-performance network configurations, install the `microshift-multus` RPM package.
+
+[IMPORTANT]
+====
+Uninstalling the {microshift-short} Multus CNI is not supported.
+====
+
+.Procedure
+
+* Install the Multus RPM package by running the following command:
++
+[source,terminal]
+----
+$ sudo dnf install microshift-multus
+----
++
+[TIP]
+====
+If you create your custom resources (CRs) while you are completing your installation of {microshift-short}, you can avoid restarting the service to apply them.
+====
+
+.Next steps
+. Continue with your new {microshift-short} installation, including any add-ons.
+
+. Create the custom resources (CRs) needed for your {microshift-short} Multus CNI plugin.
+
+. Configure other networking CNIs as needed.
+
+. After you have finished installing all of the RPMs that you want to include, start the {microshift-short} service. The {microshift-short} Multus CNI plugin is automatically deployed.

--- a/modules/microshift-install-rpms-olm.adoc
+++ b/modules/microshift-install-rpms-olm.adoc
@@ -6,18 +6,18 @@
 [id="microshift-installing-with-olm-from-rpm-package_{context}"]
 == Installing the Operator Lifecycle Manager (OLM) from an RPM package
 
-When you install {microshift-short}, the Operator Lifecycle Manager (OLM) package is not installed by default. You can install the OLM on your {microshift-short} instance using a RPM package. 
+When you install {microshift-short}, the Operator Lifecycle Manager (OLM) package is not installed by default. You can install the OLM on your {microshift-short} instance using an RPM package.
 
-.Procedure 
+.Procedure
 
-. Install the OLM package by running the following command: 
+. Install the OLM package by running the following command:
 +
 [source,terminal]
 ----
 $ sudo dnf install microshift-olm
 ----
 
-. To apply the manifest from the package to an active cluster, run the following command: 
+. To apply the manifest from the package to an active cluster, run the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-9425](https://issues.redhat.com/browse/OSDOCS-9425)

Link to docs preview:
[Multus install](https://74734--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-install-rpm.html#microshift-installing-multus_microshift-install-rpm)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[Day 2 install multus](https://github.com/openshift/openshift-docs/pull/74739)
[Multus release note](https://github.com/openshift/openshift-docs/pull/74735)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
