### PR TITLE
OSDOCS-9799: adds relnote Multus MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -61,8 +61,13 @@ See the following list for details:
 //[id="microshift-4-16-configuring"]
 //===Configuring
 
-//[id="microshift-4-16-networking"]
-//=== Networking
+[id="microshift-4-16-networking"]
+=== Networking
+
+[id="microshift-4-16-multus"]
+==== Multiple networks capability now available
+
+With this release, using multiple networks is supported with the {microshift-short} Multus plugin. If you have advanced networking requirements, you can attach additional networks to a pod for high-performance network configurations. After installing the {microshift-short} Multus RPM package, you can use the Bridge, MACVLAN, or IPVLAN plugins to create additional networks. See xref:../microshift_networking/microshift_multiple_networks/microshift-cni-multus.adoc#microshift-multus-intro_microshift-cni-multus[Additional networks in {microshift-short}].
 
 //[id="microshift-4-16-storage"]
 //=== Storage


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-9799](https://issues.redhat.com/browse/OSDOCS-9799)

Link to docs preview:
[Multus release note](https://74735--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-networking)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[Multus day0 install](https://github.com/openshift/openshift-docs/pull/74734)
[Multus day2 install](https://github.com/openshift/openshift-docs/pull/74739)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
