### PR TITLE
OSDOCS-9428: install multus running cluster MicroShift

### DIFF
--- a/microshift_networking/microshift_multiple_networks/microshift-cni-multus.adoc
+++ b/microshift_networking/microshift_multiple_networks/microshift-cni-multus.adoc
@@ -9,3 +9,7 @@ toc::[]
 In addition to the default OVN-Kubernetes Container Network Interface (CNI) plugin, {microshift-short} uses the Multus CNI to chain other CNI plugins.
 
 include::modules/microshift-multus-intro.adoc[leveloffset=+1]
+
+//TODO: add more detail on supported plugins
+
+include::modules/microshift-install-multus-running-cluster.adoc[leveloffset=+1]

--- a/modules/microshift-install-multus-running-cluster.adoc
+++ b/modules/microshift-install-multus-running-cluster.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies:
+//
+// * microshift_networking/microshift-cni-multus.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-multus-installing-on-running-cluster_{context}"]
+= Installing the Multus CNI plugin on a running cluster
+
+If you want to attach additional networks to a pod for high-performance network configurations, you can install the {microshift-short} Multus RPM package. After installation, a host restart is required to recreate all the pods with the Multus annotation.
+
+[IMPORTANT]
+====
+Uninstalling the Multus CNI plugin is not supported.
+====
+
+.Prerequisites
+
+. You have root access to the host.
+
+.Procedure
+
+. Install the Multus RPM package by running the following command:
++
+[source,terminal]
+----
+$ sudo dnf install microshift-multus
+----
++
+[TIP]
+====
+If you create your custom resources (CRs) for additional networks now, you can complete your installation and apply configurations with one restart.
+====
+
+. To apply the package manifest to an active cluster, restart the host by running the following command:
++
+[source,terminal]
+----
+$ sudo systemctl restart
+----
+
+.Verification
+
+. After restarting, ensure that the Multus CNI plugin components are created by running the following command:
++
+[source,terminal]
+----
+$ oc get pod -A | grep multus
+----
++
+.Example output
+[source,terminal]
+----
+openshift-multus      dhcp-daemon-ktzqf     1/1   Running   0     45h
+openshift-multus      multus-4frf4          1/1   Running   0     45h
+----
+
+.Next steps
+
+. If you have not done so, configure and apply the additional networks you want to use.
+
+. Deploy your applications that use the created CRs.


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-9428](https://issues.redhat.com/browse/OSDOCS-9428)

Link to docs preview:
[Install Multus on running cluster](https://74739--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift_multiple_networks/microshift-cni-multus.html#microshift-multus-installing-on-running-cluster_microshift-cni-multus)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[Day 0 install](https://github.com/openshift/openshift-docs/pull/74734)
[Release Note](https://github.com/openshift/openshift-docs/pull/74735)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
