### PR TITLE
OADP 3355 - 1.3.1 Release Notes

### DIFF
--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
@@ -7,8 +7,9 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-The release notes for OpenShift API for Data Protection (OADP) 1.3 describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
+The release notes for OpenShift API for Data Protection (OADP) describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
 
+include::modules/oadp-release-notes-1-3-1.adoc[leveloffset=+1]
 include::modules/oadp-release-notes-1-3-0.adoc[leveloffset=+1]
 include::modules/oadp-upgrade-from-oadp-data-mover-1-2-0.adoc[leveloffset=+3]
 include::modules/oadp-backing-up-dpa-configuration-1-3-0.adoc[leveloffset=+3]

--- a/modules/oadp-release-notes-1-3-0.adoc
+++ b/modules/oadp-release-notes-1-3-0.adoc
@@ -16,8 +16,8 @@ The {oadp-first} 1.3.0 release notes lists new features, resolved issues and bug
 OADP 1.3 includes a built-in Data Mover that you can use to move Container Storage Interface (CSI) volume snapshots to a remote object store. The built-in Data Mover allows you to restore stateful applications from the remote object store if a failure, accidental deletion, or corruption of the cluster occurs. It uses Kopia as the uploader mechanism to read the snapshot data and to write to the Unified Repository.
 
 
-:FeatureName: Velero built-in DataMover
-include::snippets/technology-preview.adoc[]
+//:FeatureName: Velero built-in DataMover
+Velero built-in DataMover is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
 
 .Backing up applications with File System Backup: Kopia or Restic
 

--- a/modules/oadp-release-notes-1-3-1.adoc
+++ b/modules/oadp-release-notes-1-3-1.adoc
@@ -1,0 +1,86 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-release-notes-1-3.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="oadp-release-notes-1-3-1_{context}"]
+= OADP 1.3.1 release notes
+
+The {oadp-first} 1.3.1 release notes lists new features and resolved issues.
+
+[id="new-features-1-3-1_{context}"]
+== New features
+
+.OADP 1.3.0 Data Mover is now fully supported
+
+The OADP built-in Data Mover, introduced in OADP 1.3.0 as a Technology Preview, is now fully supported for both containerized and virtual machine workloads.
+
+[id="resolved-issues-1-3-1_{context}"]
+== Resolved issues
+
+.{ibm-cloud-name} Object Storage is now supported as a backup storage provider
+
+{ibm-cloud-name} Object Storage is one of the AWS S3 compatible backup storage providers, which was unsupported previously.  
+With this update, {ibm-cloud-name} Object Storage is now supported as an AWS S3 compatible backup storage provider.
+
+link:https://issues.redhat.com/browse/OADP-3788[OADP-3788]
+
+.OADP operator now correctly reports the missing region error
+
+Previously, when you specified `profile:default` without specifying the `region` in the AWS Backup Storage Location (BSL) configuration, the OADP operator failed to report the `missing region` error on the Data Protection Application (DPA) custom resource (CR). This update corrects validation of DPA BSL specification for AWS. As a result, the OADP Operator reports the `missing region` error.
+
+link:https://issues.redhat.com/browse/OADP-3044[OADP-3044]
+
+.Custom labels are not removed from the openshift-adp namespace
+
+Previously, the `openshift-adp-controller-manager` pod would reset the labels attached to the `openshift-adp` namespace. This caused synchronization issues for applications requiring custom labels such as Argo CD, leading to improper functionality. With this update, this issue is fixed and custom labels are not removed from the `openshift-adp` namespace.
+
+link:https://issues.redhat.com/browse/OADP-3189[OADP-3189]
+
+.OADP must-gather image collects CRDs
+
+Previously, the OADP `must-gather` image did not collect the custom resource definitions (CRDs) shipped by OADP. Consequently, you could not use the `omg` tool to extract data in the support shell. 
+With this fix, the `must-gather` image now collects CRDs shipped by OADP and can use the `omg` tool to extract data.
+
+link:https://issues.redhat.com/browse/OADP-3229[OADP-3229]
+
+.Garbage collection has the correct description for the default frequency value
+
+Previously, the `garbage-collection-frequency` field had a wrong description for the default frequency value. With this update, `garbage-collection-frequency` has a correct value of one hour for the `gc-controller` reconciliation default frequency.
+
+link:https://issues.redhat.com/browse/OADP-3486[OADP-3486]
+
+.FIPS Mode flag is available in OperatorHub
+
+By setting the `fips-compliant` flag to `true`, the FIPS mode flag is now added to the OADP Operator listing in OperatorHub. This feature was enabled in OADP 1.3.0 but did not show up in the Red Hat Container catalog as being FIPS enabled.
+
+link:https://issues.redhat.com/browse/OADP-3495[OADP-3495]
+
+.CSI plugin does not panic with a nil pointer when csiSnapshotTimeout is set to a short duration
+
+Previously, when the `csiSnapshotTimeout` parameter was set to a short duration, the CSI plugin encountered the following error: `plugin panicked: runtime error: invalid memory address or nil pointer dereference`.
+
+With this fix, the backup fails with the following error: `Timed out awaiting reconciliation of volumesnapshot`.
+
+link:https://issues.redhat.com/browse/OADP-3069[OADP-3069]
+
+
+For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12432794[OADP 1.3.1 resolved issues] in Jira.
+
+[id="known-issues-1-3-1_{context}"]
+== Known issues
+
+.Backup and storage restrictions for {sno-caps} clusters deployed on {ibm-power-name} and {ibm-z-name} platforms
+
+Review the following backup and storage related restrictions for {sno-caps} clusters that are deployed on {ibm-power-name} and {ibm-z-name} platforms:
+ 
+Storage:: Only NFS storage is currently compatible with {sno} clusters deployed on {ibm-power-name} and {ibm-z-name} platforms.
+Backup:: Only the backing up applications with File System Backup such as `kopia` and `restic` are supported for backup and restore operations.
+
+link:https://issues.redhat.com/browse/OADP-3787[OADP-3787]
+
+.Cassandra application pods enter in the CrashLoopBackoff status after restoring OADP
+
+After OADP restores, the Cassandra application pods might enter in the `CrashLoopBackoff` status. To work around this problem, delete the `StatefulSet` pods with any error or the `CrashLoopBackoff` state after restoring OADP. The `StatefulSet` controller recreates these pods and it runs normally. 
+
+link:https://issues.redhat.com/browse/OADP-3767[OADP-3767]


### PR DESCRIPTION
### Jira

[OADP-3355](https://issues.redhat.com/browse/OADP-3355)

### Version(s)

OADP 1.3.1
OCP 4.12 → OCP 4.16
Link to docs preview:

[OADP 1.3.1 release notes preview](https://74026--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3)

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
