### PR TITLE
OSDOCS-10266: Add links to Red Hat OpenShift Network Calculator

### DIFF
--- a/installing/index.adoc
+++ b/installing/index.adoc
@@ -13,6 +13,11 @@ include::modules/install-openshift-common-terms.adoc[leveloffset=+2]
 
 include::modules/installation-process.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://access.redhat.com/labs/ocpnc/[Red Hat OpenShift Network Calculator]
+
 include::modules/ipi-verifying-nodes-after-installation.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -48,3 +53,5 @@ include::modules/supported-platforms-for-openshift-clusters.adoc[leveloffset=+1]
 * See xref:../installing/installing-preparing.adoc#supported-installation-methods-for-different-platforms[Supported installation methods for different platforms] for more information about the types of installations that are available for each supported platform.
 
 * See xref:../installing/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users] for information about choosing an installation method and preparing the required resources.
+
+* link:https://access.redhat.com/labs/ocpnc/[Red Hat OpenShift Network Calculator] can help you design your cluster network during both the deployment and expansion phases. It addresses common questions related to the cluster network and provides output in a convenient JSON format.

--- a/networking/configuring-cluster-network-range.adoc
+++ b/networking/configuring-cluster-network-range.adoc
@@ -24,4 +24,5 @@ include::modules/nw-cluster-network-range-edit.adoc[leveloffset=+1]
 [id="configuring-cluster-network-range-additional-resources"]
 == Additional resources
 
+* link:https://access.redhat.com/labs/ocpnc/[Red Hat OpenShift Network Calculator]
 * xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[About the OVN-Kubernetes network plugin]

--- a/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
@@ -19,6 +19,7 @@ include::modules/nw-ovn-kubernetes-migration.adoc[leveloffset=+1]
 [id="migrate-from-openshift-sdn-additional-resources"]
 == Additional resources
 
+* link:https://access.redhat.com/labs/ocpnc/[Red Hat OpenShift Network Calculator]
 * xref:../../networking/cluster-network-operator.adoc#nw-operator-configuration-parameters-for-ovn-sdn_cluster-network-operator[Configuration parameters for the OVN-Kubernetes network plugin]
 * xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[Backing up etcd]
 * xref:../../networking/network_policy/about-network-policy.adoc#about-network-policy[About network policy]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-10266

Link to docs preview:

https://74741--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring-cluster-network-range#configuring-cluster-network-range-additional-resources

https://74741--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#migrate-from-openshift-sdn-additional-resources

https://74741--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/#supported-platforms-for-openshift-clusters_ocp-installation-overview

https://74741--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/#installation-process_ocp-installation-overview

No QE review required.

