### PR TITLE
[enterprise-4.14] OCPBUGS-30076: Fixed minor bugs with OCI docs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -49,6 +49,7 @@ endif::openshift-origin[]
 :oadp-version: 1.3.1
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
 :product-registry: OpenShift image registry
+:product-mirror-registry: Mirror registry for Red Hat OpenShift
 :rh-storage-first: Red Hat OpenShift Data Foundation
 :rh-storage: OpenShift Data Foundation
 :rh-rhacm-first: Red Hat Advanced Cluster Management (RHACM)
@@ -267,6 +268,7 @@ endif::[]
 :vmw-short: vSphere
 //Oracle
 :oci-first: Oracle(R) Cloud Infrastructure (OCI)
+:oci-first-no-rt: Oracle Cloud Infrastructure (OCI)
 :oci: OCI
 :oci-ccm-full: Oracle Cloud Controller Manager (CCM)
 :oci-ccm: Oracle CCM

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -469,9 +469,9 @@ Topics:
   Dir: installing_oci
   Distros: openshift-origin,openshift-enterprise
   Topics:
-  - Name: Using the Assisted Installer to install a cluster on OCI
+  - Name: Installing a cluster on Oracle Cloud Infrastructure by using the Assisted Installer
     File: installing-oci-assisted-installer
-  - Name: Using the Agent-based Installer to install a cluster on OCI
+  - Name: Installing a cluster on Oracle Cloud Infrastructure by using the Agent-based Installer
     File: installing-oci-agent-based-installer
 - Name: Installing on vSphere
   Dir: installing_vsphere

--- a/installing/installing_oci/installing-oci-agent-based-installer.adoc
+++ b/installing/installing_oci/installing-oci-agent-based-installer.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-oci-agent-based-installer"]
-= Installing a cluster OCI by using the Agent-based Installer 
+= Installing a cluster on {oci-first-no-rt} by using the Agent-based Installer
 include::_attributes/common-attributes.adoc[]
 :context: installing-oci-agent-based-installer
 
@@ -14,11 +14,11 @@ include::modules/installing-oci-about-agent-based-installer.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../architecture/architecture-installation.html#installation-process_architecture-installation[Installation process]
-* xref:../../installing/installing_platform_agnostic/installing-platform-agnostic.html#cluster-entitlements_installing-platform-agnostic[Internet access for {product-title}]
-* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#understanding-agent-install_preparing-to-install-with-agent-based-installer[Understanding the Agent-based Installer]
-* See link:https://docs.oracle.com/en-us/iaas/Content/Compute/Concepts/computeoverview.htm[Overview of the Compute Service] in the Oracle documentation.
-* See link:https://docs.oracle.com/en-us/iaas/Content/Block/Concepts/blockvolumeperformance.htm#vpus[Volume Performance Units] in the Oracle documentation.
+* xref:../../architecture/architecture-installation.adoc#installation-process_architecture-installation[Installation process]
+* xref:../../installing/installing_platform_agnostic/installing-platform-agnostic.adoc#cluster-entitlements_installing-platform-agnostic[Internet access for {product-title}]
+* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#understanding-agent-install_preparing-to-install-with-agent-based-installer[Understanding the Agent-based Installer]
+* link:https://docs.oracle.com/en-us/iaas/Content/Compute/Concepts/computeoverview.htm[Overview of the Compute Service (Oracle documentation)]
+* link:https://docs.oracle.com/en-us/iaas/Content/Block/Concepts/blockvolumeperformance.htm#vpus[Volume Performance Units (Oracle documentation)]
 
 // Creating OCI infrastructure resources and services
 include::modules/creating-oci-infra-resources-services.adoc[leveloffset=+1]
@@ -26,15 +26,13 @@ include::modules/creating-oci-infra-resources-services.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-See the following Oracle documentation resources: 
-
-* link:https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingcompartments.htm#ariaid-title5[Creating compartments] 
-* link:https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/create_vcn.htm[Creating a VCN]
-* link:https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/create-nsg.htm[Creating an NSG]
-* link:https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengdynamicgrouppolicyforselfmanagednodes.htm[Creating a dynamic group and a policy for self-managed nodes]
-* link:https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingpolicies.htm[Managing policies]
-* link:https://docs.oracle.com/en-us/iaas/Content/Balance/Tasks/managingloadbalancer_topic-Creating_Load_Balancers.htm[Creating a load balancer]
-* link:https://docs.oracle.com/en-us/iaas/Content/DNS/Tasks/record-add.htm[Adding a record to a DNS zone]
+* link:https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingcompartments.htm#ariaid-title5[Creating compartments (Oracle documentation)]
+* link:https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/create_vcn.htm[Creating a VCN (Oracle documentation)]
+* link:https://docs.oracle.com/en-us/iaas/Content/Network/Concepts/create-nsg.htm[Creating an NSG (Oracle documentation)]
+* link:https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengdynamicgrouppolicyforselfmanagednodes.htm[Creating a dynamic group and a policy for self-managed nodes (Oracle documentation)]
+* link:https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingpolicies.htm[Managing policies (Oracle documentation)]
+* link:https://docs.oracle.com/en-us/iaas/Content/Balance/Tasks/managingloadbalancer_topic-Creating_Load_Balancers.htm[Creating a load balancer (Oracle documentation)]
+* link:https://docs.oracle.com/en-us/iaas/Content/DNS/Tasks/record-add.htm[Adding a record to a DNS zone (Oracle documentation)]
 
 // Creating configuration files for installing a cluster on OCI
 include::modules/creating-config-files-cluster-install-oci.adoc[leveloffset=+1]
@@ -42,10 +40,28 @@ include::modules/creating-config-files-cluster-install-oci.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html#installing-ocp-agent-ztp_installing-with-agent-based-installer[Optional: Using ZTP manifests]
+* xref:../../architecture/architecture-installation.adoc#installation-overview_architecture-installation[About {product-title} installation]
+
+* xref:../../installing/installing-preparing.adoc#installing-preparing-selecting-cluster-type[Selecting a cluster installation type]
+
+* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#about-the-agent-based-installer[Preparing to install with the Agent-based Installer]
+
+* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-ocp-agent-retrieve_installing-with-agent-based-installer[Downloading the Agent-based Installer]
+
+* xref:../../installing/disconnected_install/installing-mirroring-installation-images.adoc#installation-mirror-repository_installing-mirroring-installation-images[Mirroring the {product-title} image repository]
+
+* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-ocp-agent-ztp_installing-with-agent-based-installer[Optional: Using ZTP manifests]
+
+// Configuring your firewall
+include::modules/configuring-firewall.adoc[leveloffset=+1]
 
 // Running your cluster on OCI
 include::modules/running-cluster-oci-agent-based.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#recommended-resources-for-topologies[Recommended resources for topologies]
 
 // Verifying a succesful cluster installation on OCI
 include::modules/verifying-cluster-install-oci-agent-based.adoc[leveloffset=+1]
@@ -53,4 +69,4 @@ include::modules/verifying-cluster-install-oci-agent-based.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html#installing-ocp-agent-gather-log_installing-with-agent-based-installer[Gathering log data from a failed Agent-based installation]
+* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-ocp-agent-gather-log_installing-with-agent-based-installer[Gathering log data from a failed Agent-based installation]

--- a/installing/installing_oci/installing-oci-assisted-installer.adoc
+++ b/installing/installing_oci/installing-oci-assisted-installer.adoc
@@ -1,12 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-oci-assisted-installer"]
-= Using the Assisted Installer to install a cluster on OCI
+= Installing a cluster on {oci-first-no-rt} by using the Assisted Installer
 include::_attributes/common-attributes.adoc[]
 :context: installing-oci-assisted-installer
 
 toc::[]
 
-From {product-title} {product-version} and later versions, you can use the Assisted Installer to install a cluster on {oci-first} by using infrastructure that you provide.
+From {product-title} {product-version} and later versions, you can use the {ai-full} to install a cluster on {oci-first} by using infrastructure that you provide.
 
 // The Assisted Installer and OCI overview
 include::modules/installing-oci-about-assisted-installer.adoc[leveloffset=+1]
@@ -14,10 +14,9 @@ include::modules/installing-oci-about-assisted-installer.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2024[Assisted Installer for {product-title}]
+* link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2024[{ai-full} for {product-title}]
 * xref:../../installing/installing_platform_agnostic/installing-platform-agnostic.adoc#cluster-entitlements_installing-platform-agnostic[Internet access for {product-title}]
-* link:https://docs.oracle.com/en-us/iaas/Content/Block/Concepts/blockvolumeperformance.htm#vpus[Volume Performance Units]
- 
+* link:https://docs.oracle.com/en-us/iaas/Content/Block/Concepts/blockvolumeperformance.htm#vpus[Volume Performance Units (Oracle documentation)]
 
 // Creating OCI resources
 include::modules/creating-oci-resources-services.adoc[leveloffset=+1]
@@ -25,13 +24,17 @@ include::modules/creating-oci-resources-services.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-See the following Oracle web-based documents:
-
-* link:https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingcompartments.htm[Managing compartments]
-* link:https://docs.oracle.com/en-us/iaas/Content/Object/Concepts/objectstorageoverview.htm[Overview of Object Storage]
+* link:https://docs.oracle.com/en-us/iaas/Content/Identity/Tasks/managingcompartments.htm[Managing compartments (Oracle documentation)]
+* link:https://docs.oracle.com/en-us/iaas/Content/Object/Concepts/objectstorageoverview.htm[Overview of Object Storage (Oracle documentation)]
 
 // Using the Assisted Installer to generate an OCI-compatible Agent ISO image
 include::modules/using-assisted-installer-oci-agent-iso.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../architecture/architecture-installation.adoc#architecture-installation[Installation and update]
+* xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[Configuring your firewall]
 
 // Downloading manifest files and deployment resources
 include::modules/downloading-manifest-files-resources-oci.adoc[leveloffset=+1]
@@ -48,8 +51,7 @@ include::modules/installing-troubleshooting-assisted-installer-oci.adoc[leveloff
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../installing/installing_on_prem_assisted/installing-on-prem-assisted.adoc#using-the-assisted-installer_installing-on-prem-assisted[Installing an on-premise cluster using the Assisted Installer]
-* link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2022/html-single/assisted_installer_for_openshift_container_platform/index[Assisted Installer for {product-title}]
-//* link:https://access.redhat.com/node/7038262[Using the Agent-based Installer to install a cluster on OCI]
-* link:https://docs.oracle.com/en-us/iaas/Content/ResourceManager/Concepts/resourcemanager.htm#ways[Ways to access Resource Manager]
-* link:https://docs.oracle.com/en-us/iaas/Content/ResourceManager/Tasks/create-stack.htm#top[Creating a stack] in the Oracle documentation.
+* xref:../../installing/installing_on_prem_assisted/installing-on-prem-assisted.adoc#using-the-assisted-installer_installing-on-prem-assisted[Installing an on-premise cluster using the {ai-full}]
+* link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2022/html-single/assisted_installer_for_openshift_container_platform/index[{ai-full} for {product-title}]
+* link:https://docs.oracle.com/en-us/iaas/Content/ResourceManager/Concepts/resourcemanager.htm#ways[Ways to access Resource Manager (Oracle documentation)]
+* link:https://docs.oracle.com/en-us/iaas/Content/ResourceManager/Tasks/create-stack.htm#top[Creating a stack (Oracle documentation)]

--- a/modules/complete-assisted-installer-oci.adoc
+++ b/modules/complete-assisted-installer-oci.adoc
@@ -1,33 +1,37 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_oci/installing-oci-assisted-installer.adoc [Using the Assisted Installer to install a cluster on OCI]
+// * installing/installing_oci/installing-oci-assisted-installer.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="complete-assisted-installer-oci_{context}"]
 = Completing the remaining Assisted Installer steps
 
-After you provision {oci-first} resources and upload {product-title} custom manifest configuration files to {oci}, you must complete the remaining cluster installation steps on the Assisted Installer before you can create an instance {oci}.
+After you provision {oci-first} resources and upload {product-title} custom manifest configuration files to {oci}, you must complete the remaining cluster installation steps on the {ai-full} before you can create an instance {oci}.
 
 .Prerequisites
 
-* You created a resource stack on {oci}, and the stack includes the custom manifest configuration files and {oci} Resource Manager configuration resources.
+* You created a resource stack on {oci} that includes the custom manifest configuration files and {oci} Resource Manager configuration resources. See the "Downloading manifest files and deployment resources" section.
 
 .Procedure
 
-. From the link:https://console.redhat.com/[Red Hat Hybrid Cloud Console] web console, go to the **Host discovery** step. Under the **Role** column, assign a node role, `Control plane node` or `Worker`, for each targeted hostname.
+. From the link:https://console.redhat.com/[Red Hat Hybrid Cloud Console] web console, go to the *Host discovery* page.
+
+.Under the *Role* column, select either `Control plane node` or `Worker` for each targeted hostname.
 +
 [IMPORTANT]
 ====
 Before, you can continue to the next steps, wait for each node to reach the `Ready` status.
 ====
 
-. Accept the default settings for the **Storage** and **Networking** steps. Click the **Next** button to go to the **Custom manifests** step. 
+. Accept the default settings for the *Storage* and *Networking* steps, and then Click *Next*.
 
-. Select the value `manifests` in the **Folder** field and enter a value in the **File name** field, such as `oci-ccm.yml`. From the **Content** section, click **Browse** and select the CCM manifest from your drive located in `custom_ manifest/manifests/oci-ccm.yml`. 
+. On the *Custom manifests* page, in the *Folder* field, select `manifest`. This is the {ai-full} folder where you want to save the custom manifest file.
+.. In the *File name* field, enter a value such as `oci-ccm.yml`.
+.. From the *Content* section, click *Browse*, and select the CCM manifest from your drive located in `custom_manifest/manifests/oci-ccm.yml`.
 
-. Expand the next **Custom manifest** section and repeat the same steps for the following manifests:
-    - CSI driver manifest: `custom_ manifest/manifests/oci-csi.yml`
-    - CCM machine configuration: `custom_ manifest/openshift/machineconfig-ccm.yml`
-    - CSI driver machine configuration: `custom_ manifest/openshift/machineconfig-csi.yml`
+. Expand the next *Custom manifest* section and repeat the same steps for the following manifests:
+ - CSI driver manifest: `custom_manifest/manifests/oci-csi.yml`
+ - CCM machine configuration: `custom_manifest/openshift/machineconfig-ccm.yml`
+ - CSI driver machine configuration: `custom_manifest/openshift/machineconfig-csi.yml`
 
-. Complete the **Review and create** step to create your {product-title} cluster on {oci}. Click the **Install cluster** button to complete the cluster installation. 
+. From the *Review and create* page, click *Install cluster* to create your {product-title} cluster on {oci}.

--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -1,14 +1,25 @@
 // Module included in the following assemblies:
 //
 // * installing/install_config/configuring-firewall.adoc
+// * installing/installing-oci-agent-based-installer.adoc
+
+ifeval::["{context}" == "installing-oci-agent-based-installer"]
+:oci-agent:
+endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="configuring-firewall_{context}"]
 = Configuring your firewall for {product-title}
 
-Before you install {product-title}, you must configure your firewall to grant access to the sites that {product-title} requires.
+Before you install {product-title}, you must configure your firewall to grant access to the sites that {product-title} requires. When using a firewall, make additional configurations to the firewall so that {product-title} can access the sites that it requires to function.
 
+ifndef::oci-agent[]
 There are no special configuration considerations for services running on only controller nodes compared to worker nodes.
+endif::oci-agent[]
+
+ifdef::oci-agent[]
+For a disconnected environment, you must mirror content from both Red{nbsp}Hat and Oracle. This environment requires that you create firewall rules to expose your firewall to specific ports and registries.
+endif::oci-agent[]
 
 [NOTE]
 ====
@@ -17,7 +28,7 @@ If your environment has a dedicated load balancer in front of your {product-titl
 
 .Procedure
 
-. Allowlist the following registry URLs:
+. Set the following registry URLs for your firewall's allowlist:
 +
 [cols="3,2,4",options="header"]
 |===
@@ -56,14 +67,13 @@ If your environment has a dedicated load balancer in front of your {product-titl
 |The `https://console.redhat.com` site uses authentication from `sso.redhat.com`
 |===
 +
-[.small]
 --
 1. In a firewall environment, ensure that the `access.redhat.com` resource is on the allowlist. This resource hosts a signature store that a container client requires for verifying images when pulling them from `registry.access.redhat.com`.
 --
 +
 You can use the wildcards `\*.quay.io` and `*.openshiftapps.com` instead of `cdn.quay.io` and `cdn0[1-3].quay.io` in your allowlist. When you add a site, such as `quay.io`, to your allowlist, do not add a wildcard entry, such as `*.quay.io`, to your denylist. In most cases, image registries use a content delivery network (CDN) to serve images. If a firewall blocks access, image downloads are denied when the initial download request redirects to a hostname such as `cdn01.quay.io`.
 
-. Allowlist any site that provides resources for a language or framework that your builds require.
+. Set your firewall's allowlist to include any site that provides resources for a language or framework that your builds require.
 
 . If you do not disable Telemetry, you must grant access to the following URLs to access Red Hat Insights:
 +
@@ -88,7 +98,48 @@ You can use the wildcards `\*.quay.io` and `*.openshiftapps.com` instead of `cdn
 |Required for Telemetry and for `insights-operator`
 |===
 
-. If you use Alibaba Cloud, Amazon Web Services (AWS), Microsoft Azure, or Google Cloud Platform (GCP) to host your cluster, you must grant access to the URLs that provide the cloud provider API and DNS for that cloud:
+ifdef::oci-agent[]
+. Set your firewall's allowlist to include the following registry URLs:
++
+[cols="3,2,4",options="header"]
+|===
+|URL | Port | Function
+
+|`api.openshift.com`
+|443
+|Required both for your cluster token and to check if updates are available for the cluster.
+
+|`rhcos.mirror.openshift.com`
+|443
+|Required to download {op-system-first} images.
+|===
+
+. Set your firewall's allowlist to include the following external URLs. Each repository URL hosts {oci} containers. Consider mirroring images to as few repositories as possible to reduce any performance issues.
++
+[cols="3,2,4",options="header"]
+|===
+|URL | Port | Function
+
+|`k8s.gcr.io`
+|port
+|A Kubernetes registry that hosts container images for a community-based image registry. This image registry is hosted on a custom Google Container Registry (GCR) domain.
+
+|`ghcr.io`
+|port
+|A GitHub image registry where you can store and manage Open Container Initiative images. Requires an access token to publish, install, and delete private, internal, and public packages.
+
+|`storage.googleapis.com`
+|443
+|A source of release image signatures, although the Cluster Version Operator needs only a single functioning source.
+
+|`registry.k8s.io`
+|port
+|Replaces the `k8s.gcr.io` image registry because the `k8s.gcr.io` image registry does not support other platforms and vendors.
+|===
+endif::oci-agent[]
+
+ifndef::oci-agent[]
+. If you use {alibaba}, {aws-first}, {azure-first}, or {gcp-first} to host your cluster, you must grant access to the URLs that offer the cloud provider API and DNS for that cloud:
 +
 [cols="2a,8a,2a,8a",options="header"]
 |===
@@ -97,7 +148,7 @@ You can use the wildcards `\*.quay.io` and `*.openshiftapps.com` instead of `cdn
 |Alibaba
 |`*.aliyuncs.com`
 |443
-|Required to access Alibaba Cloud services and resources. Review the link:https://github.com/aliyun/alibaba-cloud-sdk-go/blob/master/sdk/endpoints/endpoints_config.go?spm=a2c4g.11186623.0.0.47875873ciGnC8&file=endpoints_config.go[Alibaba endpoints_config.go file] to determine the exact endpoints to allow for the regions that you use.
+|Required to access Alibaba Cloud services and resources. Review the link:https://github.com/aliyun/alibaba-cloud-sdk-go/blob/master/sdk/endpoints/endpoints_config.go?spm=a2c4g.11186623.0.0.47875873ciGnC8&file=endpoints_config.go[Alibaba endpoints_config.go file] to find the exact endpoints to allow for the regions that you use.
 
 .17+|AWS
 |`aws.amazon.com`
@@ -106,9 +157,9 @@ You can use the wildcards `\*.quay.io` and `*.openshiftapps.com` instead of `cdn
 
 |`*.amazonaws.com`
 
-Alternatively, if you choose to not use a wildcard for AWS APIs, you must allowlist the following URLs:
+Alternatively, if you choose to not use a wildcard for AWS APIs, you must include the following URLs in your allowlist:
 |443
-|Required to access AWS services and resources. Review the link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS Service Endpoints] in the AWS documentation to determine the exact endpoints to allow for the regions that you use.
+|Required to access AWS services and resources. Review the link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS Service Endpoints] in the AWS documentation to find the exact endpoints to allow for the regions that you use.
 
 |`ec2.amazonaws.com`
 |443
@@ -173,16 +224,16 @@ Alternatively, if you choose to not use a wildcard for AWS APIs, you must allowl
 .2+|GCP
 |`*.googleapis.com`
 |443
-|Required to access GCP services and resources. Review link:https://cloud.google.com/endpoints/[Cloud Endpoints] in the GCP documentation to determine the endpoints to allow for your APIs.
+|Required to access GCP services and resources. Review link:https://cloud.google.com/endpoints/[Cloud Endpoints] in the GCP documentation to find the endpoints to allow for your APIs.
 
 |`accounts.google.com`
 |443
 | Required to access your GCP account.
 
-.3+|Azure
+.3+|Microsoft Azure
 |`management.azure.com`
 |443
-|Required to access Azure services and resources. Review the link:https://docs.microsoft.com/en-us/rest/api/azure/[Azure REST API reference] in the Azure documentation to determine the endpoints to allow for your APIs.
+|Required to access Microsoft Azure services and resources. Review the link:https://docs.microsoft.com/en-us/rest/api/azure/[Microsoft Azure REST API reference] in the Microsoft Azure documentation to find the endpoints to allow for your APIs.
 
 |`*.blob.core.windows.net`
 |443
@@ -190,7 +241,7 @@ Alternatively, if you choose to not use a wildcard for AWS APIs, you must allowl
 
 |`login.microsoftonline.com`
 |443
-|Required to access Azure services and resources. Review the link:https://docs.microsoft.com/en-us/rest/api/azure/[Azure REST API reference] in the Azure documentation to determine the endpoints to allow for your APIs.
+|Required to access Microsoft Azure services and resources. Review the link:https://docs.microsoft.com/en-us/rest/api/azure/[Azure REST API reference] in the Microsoft Azure documentation to find the endpoints to allow for your APIs.
 
 |===
 
@@ -275,3 +326,9 @@ that is specified in the `spec.route.hostname` field of the
 ====
 If you do not use a default Red Hat NTP server, verify the NTP server for your platform and allow it in your firewall.
 ====
+endif::oci-agent[]
+
+
+ifeval::["{context}" == "installing-oci-agent-based-installer"]
+:!oci-agent:
+endif::[]

--- a/modules/creating-config-files-cluster-install-oci.adoc
+++ b/modules/creating-config-files-cluster-install-oci.adoc
@@ -1,28 +1,48 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_oci/installing-oci-agent-based-installer.adoc [Using the Agent-based Installer to install a cluster on OCI]
+// * installing/installing_oci/installing-oci-agent-based-installer.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="creating-config-files-cluster-install-oci_{context}"]
 = Creating configuration files for installing a cluster on OCI
 
-You need to create the `install-config.yaml` and the `agent-config.yaml` configuration files so that you can use the Agent-based Installer to generate a bootable ISO image. The Agent-based installation comprises a bootable ISO that contains the Assisted discovery agent and the Assisted Service. Both of these components are required to perform the cluster installation, but the latter component runs on only one of the hosts.
+You need to create the `install-config.yaml` and the `agent-config.yaml` configuration files so that you can use the Agent-based Installer to generate a bootable ISO image. The Agent-based installation comprises a bootable ISO that has the Assisted discovery agent and the Assisted Service. Both of these components are required to perform the cluster installation, but the latter component runs on only one of the hosts.
 
-In a subsequent procedure, you can upload your generated Agent ISO image to Oracle’s default Object Storage bucket, which is the initial step for integrating your {product-title} cluster on {oci-first}.
+In a later procedure, you can upload your generated agent ISO image to Oracle’s default Object Storage bucket, which is the initial step for integrating your {product-title} cluster on {oci-first}.
 
 You can also use the Agent-based Installer to generate or accept Zero Touch Provisioning (ZTP) custom resources.
 
 .Prerequisites
-* You reviewed details about the xref:../../architecture/architecture-installation.html#installation-overview_architecture-installation[{product-title} installation and update processes].
-* You read the documentation on xref:../../installing/installing-preparing.html#installing-preparing-selecting-cluster-type[Selecting a cluster installation method and preparing it for users].
-* You have read the xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#about-the-agent-based-installer[Preparing to install with the Agent-based Installer] documentation.
-* You downloaded the xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html#installing-ocp-agent-retrieve_installing-with-agent-based-installer[Agent-Based Installer] and the command-line interface (CLI) from Red Hat’s Hybrid Cloud Console.
-* For a disconnected environment, you created a container image registry, such as Red Hat Quay. See xref:../../installing/disconnected_install/installing-mirroring-creating-registry.html#mirror-registry-introduction_installing-mirroring-creating-registry[Mirror registry for Red Hat OpenShift introduction].
-* You have logged into the {product-title} with administrator privileges. 
+* You reviewed details about the {product-title} installation and update processes.
+* You read the documentation on selecting a cluster installation method and preparing it for users.
+* You have read the "Preparing to install with the Agent-based Installer" documentation.
+* You downloaded the Agent-Based Installer and the command-line interface (CLI) from the Red{nbsp}Hat Hybrid Cloud Console.
+* You have logged in to the {product-title} with administrator privileges.
 
 .Procedure
 
-. Configure the `install-config.yaml` configuration file to meet the needs of your organization. 
+. For a disconnected environment, mirror the {product-mirror-registry} to your local container image registry.
++
+[IMPORTANT]
+====
+Check that your `openshift-install` binary version relates to your local image container registry and not a shared registry, such as {quay}.
+
+[source,terminal]
+----
+$ ./openshift-install version
+----
+
+.Example output for a shared registry binary
+[source,terminal,subs="quotes"]
+----
+./openshift-install 4.15.0
+built from commit ae7977b7d1ca908674a0d45c5c243c766fa4b2ca
+release image registry.ci.openshift.org/origin/release:4.15ocp-release@sha256:0da6316466d60a3a4535d5fed3589feb0391989982fba59d47d4c729912d6363
+release architecture amd64
+----
+====
+
+. Configure the `install-config.yaml` configuration file to meet the needs of your organization.
 +
 .Example `install-config.yaml` configuration file that demonstrates setting an external platform
 +
@@ -38,7 +58,7 @@ networking:
   network type: OVNKubernetes
   machineNetwork:
   - cidr: <ip_address_from_cidr> <2>
-  serviceNetwork: 
+  serviceNetwork:
   - 172.30.0.0/16
 compute:
   - architecture: amd64 <3>
@@ -58,21 +78,21 @@ sshKey: <public_ssh_key> <5>
 pullSecret: '<pull_secret>' <6>
 # ...
 ----
-<1> The base domain of your cloud provider. 
-<2> The IP address from the VCN that the CIDR allocates to resources and components that operate on your network.
+<1> The base domain of your cloud provider.
+<2> The IP address from the  virtual cloud network (VCN) that the CIDR allocates to resources and components that operate on your network.
 <3> Depending on your infrastructure, you can select either `x86_64`, or `amd64`.
-<4> Set `OCI` as the external platform, so that {product-title} can integrate with {oci}. 
+<4> Set `OCI` as the external platform, so that {product-title} can integrate with {oci}.
 <5> Specify your SSH public key.
-<6> The pull secret that you need for authenticate purposes when downloading container images for {product-title} components and services, such as Quay.io. See link:https://console.redhat.com/openshift/install/pull-secret[Install {product-title} 4] from the Red Hat Hybrid Cloud Console. 
+<6> The pull secret that you need for authenticate purposes when downloading container images for {product-title} components and services, such as Quay.io. See link:https://console.redhat.com/openshift/install/pull-secret[Install {product-title} 4] from the Red{nbsp}Hat Hybrid Cloud Console.
 
-. Create a directory on your local system named `openshift`. 
+. Create a directory on your local system named `openshift`.
 +
 [IMPORTANT]
 ====
 Do not move the `install-config.yaml` and `agent-config.yaml` configuration files to the `openshift` directory.
 ====
 
-. From the link:https://github.com/oracle-quickstart/oci-openshift[`oracle-quickstart / oci-openshift`] GitHub web page, select the **<> Code** button and click **Download ZIP**. Save the archive file to your `openshift` directory,  so that all the {oci-ccm-full} and {oci-csi-full} manifests exist in the same directory. The downloaded archive file includes files for creating cluster resources and custom manifests. 
+. From the link:https://github.com/oracle-quickstart/oci-openshift[`oracle-quickstart / oci-openshift`] GitHub web page, select the *<> Code* button and click *Download ZIP*. Save the archive file to your `openshift` directory,  so that all the {oci-ccm-full} and {oci-csi-full} manifests exist in the same directory. The downloaded archive file includes files for creating cluster resources and custom manifests.
 
 . Go to the link:https://github.com/oracle-quickstart/oci-openshift/tree/main/custom_manifests[custom_manifests] web page on GitHub to access the custom manifest files.
 +
@@ -80,50 +100,50 @@ The {oci-ccm} manifest are required for deploying the {oci-ccm} during cluster i
 +
 [IMPORTANT]
 ====
-You must modify the secret `oci-cloud-controller-manager` defined in the link:https://github.com/oracle-quickstart/oci-openshift/blob/main/custom_manifests/manifests/oci-ccm.yml[`oci-ccm.yml`] configuration file to match your organization's region, compartment {ocid}, VCN {ocid}, and the subnet {ocid} from the load balancer.
+You must change the secret `oci-cloud-controller-manager` defined in the link:https://github.com/oracle-quickstart/oci-openshift/blob/main/custom_manifests/manifests/oci-ccm.yml[`oci-ccm.yml`] configuration file to match your organization's region, compartment {ocid}, VCN {ocid}, and the subnet {ocid} from the load balancer.
 ====
 
-. Use the Agent-based Installer to generate a minimal ISO image, which excludes the `rootfs` image, by entering the following command in your {product-title} CLI. You can use this image later in the process to boot all your cluster’s nodes. 
+. Use the Agent-based Installer to generate a minimal ISO image, which excludes the `rootfs` image, by entering the following command in your {product-title} CLI. You can use this image later in the process to boot all your cluster’s nodes.
 +
 [source,terminal]
 ----
 $ ./openshift-install agent create image --log-level debug
 ----
 +
-The previous command also completes the following actions:
+The command also completes the following actions:
 +
-* Creates a subdirectory, `./<installation_directory>/auth directory:`, and places `kubeadmin-password` and `kubeconfig` files in the subdirectory.  
-* Creates a `rendezvousIP` file based on the IP address that you specified in the `agent-config.yaml` configuration file. 
-* Optional: Any modifications you made to `agent-config.yaml` and `install-config.yaml` configuration files get imported to the Zero Touch Provisioning (ZTP) custom resources. 
+* Creates a subdirectory, `./<installation_directory>/auth directory:`, and places `kubeadmin-password` and `kubeconfig` files in the subdirectory.
+* Creates a `rendezvousIP` file based on the IP address that you specified in the `agent-config.yaml` configuration file.
+* Optional: Any modifications you made to `agent-config.yaml` and `install-config.yaml` configuration files get imported to the Zero Touch Provisioning (ZTP) custom resources.
 +
 [IMPORTANT]
 ====
-The Agent-based Installer uses {op-system-first}. The `rootfs` image, which is mentioned in a subsequent listed item,  is required for booting, recovering, and repairing your operating system. 
+The Agent-based Installer uses {op-system-first}. The `rootfs` image, which is mentioned in a later listed item,  is required for booting, recovering, and repairing your operating system.
 ====
 
-. Configure the `agent-config.yaml` configuration file to meet your organization’s requirements. 
+. Configure the `agent-config.yaml` configuration file to meet your organization’s requirements.
 +
 .Example `agent-config.yaml` configuration file that sets values for an IPv4 formatted network.
 [source,yaml]
 ----
 apiVersion: v1alpha1
 metadata:
-  name: <cluster_name> <1>
+  name: <cluster_name> // <1>
   namespace: <cluster_namespace> <2>
-rendezvousIP:<ip_address_from_CIDR> <3>
-bootArtifactsBaseURL:<server_URL> <4>
-# …
+rendezvousIP: <ip_address_from_CIDR> <3>
+bootArtifactsBaseURL: <server_URL> <4>
+# ...
 ----
-<1> The cluster name that you specified in your DNS record. 
-<2> The name of your cluster on {product-title}. 
-<3> If you are using IPv4 as the network IP address format, ensure that you set the `rendezvousIP` parameter to an IPv4 address that the VCN’s Classless Inter-Domain Routing (CIDR) method allocates on your network. Also ensure that at least one instance from the pool of instances that you booted with the ISO matches the IP address value you set for `rendezvousIP`.  
+<1> The cluster name that you specified in your DNS record.
+<2> The namespace of your cluster on {product-title}.
+<3> If you use IPv4 as the network IP address format, ensure that you set the `rendezvousIP` parameter to an IPv4 address that the VCN’s Classless Inter-Domain Routing (CIDR) method allocates on your network. Also ensure that at least one instance from the pool of instances that you booted with the ISO matches the IP address value you set for `rendezvousIP`.
 <4> The URL of the server where you want to upload the `rootfs` image.
 
 . Apply one of the following two updates to your `agent-config.yaml` configuration file:
 +
-* For a disconnected network:  After you run the command to generate a minimal ISO Image, the Agent-based installer saves the `rootfs` image into the `./<installation_directory>/boot-artifacts` directory on your local system. Upload `rootfs` to the location stated in the `bootArtifactsBaseURL` parameter in the `agent-config.yaml` configuration file. 
+* For a disconnected network:  After you run the command to generate a minimal ISO Image, the Agent-based installer saves the `rootfs` image into the `./<installation_directory>/boot-artifacts` directory on your local system. Use your preferred web server, such as any Hypertext Transfer Protocol daemon (`httpd`), to upload `rootfs` to the location stated in the `bootArtifactsBaseURL` parameter in the `agent-config.yaml` configuration file.
 +
-For example, if the URL states \http://192.168.122.20, you would upload the generated `rootfs` image to this location, so that the installer can access the image from \http://192.168.122.20/agent.x86_64-rootfs.img. After the installer boots the minimal ISO for the external platform, the Agent-based Installer downloads the `rootfs` image from the \http://192.168.122.20/agent.x86_64-rootfs.img location into the system memory. 
+For example, if the `bootArtifactsBaseURL` parameter states \http://192.168.122.20, you would upload the generated `rootfs` image to this location, so that the Agent-based installer can access the image from \http://192.168.122.20/agent.x86_64-rootfs.img. After the Agent-based installer boots the minimal ISO for the external platform, the Agent-based Installer downloads the `rootfs` image from the \http://192.168.122.20/agent.x86_64-rootfs.img location into the system memory.
 +
 [NOTE]
 ====

--- a/modules/creating-oci-infra-resources-services.adoc
+++ b/modules/creating-oci-infra-resources-services.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_oci/installing-oci-agent-based-installer.adoc [Using the Agent-based Installer to install a cluster on OCI]
+// * installing/installing_oci/installing-oci-agent-based-installer.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="creating-oci-infra-resources-services_{context}"]
@@ -10,25 +10,25 @@
 Before you install {product-title} on {oci-first}, you must create an {oci} environment on your virtual machine (VM) shape. By creating this environment, you can install {product-title} and deploy a cluster on infrastructure that supports a wide range of cloud options and strong security policies.
 
 .Prerequisites
-* You have prior knowledge of {oci} components. See link:https://docs.oracle.com/en-us/iaas/Content/GSG/Concepts/concepts.htm[Learn About Oracle Cloud Basics] in the Oracle documentation.  
+* You have prior knowledge of {oci} components. See link:https://docs.oracle.com/en-us/iaas/Content/GSG/Concepts/concepts.htm[Learn About Oracle Cloud Basics] in the Oracle documentation.
 * Your organization signed up for an Oracle account and Identity Domain. This step is required so that you can access an administrator account, which is the initial cloud-identity and access management (IAM) user for your organization. See link:https://docs.oracle.com/en-us/iaas/Content/Identity/Concepts/overview.htm#ariaid-title4[The administrators group and policy] section in the Oracle documentation.
-* You have logged into your organization’s {oci} account with administrator privileges.
+* You have logged in to your organization’s {oci} account with administrator privileges.
 
 .Procedure
 
 . Create a compartment and ensure you defined your {ocid-first} in the compartment. A compartment is a component where you can organize and isolate your cloud resources. After you create a compartment, Oracle automatically assigns an {ocid} to your organization’s account. An administrator can access all compartments tagged to your organization’s {oci} account.
 
 . Create a virtual cloud network (VCN). A compute instance, load balancer, and other resources need this network infrastructure to connect to each other over an internet connection. To establish an on-premise network you must manually create subnets, gateways, routing rules, and security policies. Ensure that you complete the following steps:
-.. In **Primary VNIC IP addresses > Primary network**, select a VCN, such as *oci-cluster-vcn*. 
-.. From the **Subnet** section, select your subnet, such as *ici-cluster-private-subnet*. 
-.. For public IPV4 subnets, ensure that you select the **Do not assign a public IPv4 address** checkbox.
+.. In *Primary VNIC IP addresses* -> *Primary network*, select a VCN, such as *oci-cluster-vcn*.
+.. From the *Subnet* section, select your subnet, such as *ici-cluster-private-subnet*.
+.. For public IPv4 subnets, ensure that you select the *Do not assign a public IPv4 address* checkbox.
 
 . Create a network security group (NSG) in your VCN. You can use the NSG to establish advanced security rules for your network. You must locate the NSG in your compartment, so that certain groups can access network resources. Ensure that you complete the following steps:
-.. Click **Show advanced options**. 
-.. Select the **Use network security groups** to control traffic checkbox.
+.. Click *Show advanced options*.
+.. Select the *Use network security groups* to control traffic checkbox.
 .. Set your NSG, such as *oci-cluster-controlplane-nsg*.
 
-. Create a dynamic group that hosts compute instances. After you create the dynamic group, you can then create a policy statement that defines rules for your cluster environment. This statement sets the precedent  for each compute instance to join your {product-title} cluster as a self-managed node. 
+. Create a dynamic group that hosts compute instances. After you create the dynamic group, you can then create a policy statement that defines rules for your cluster environment. This statement sets the precedent  for each compute instance to join your {product-title} cluster as a self-managed node.
 
 . Create a policy statement. You must create a policy so that your administrator can grant access to your groups, users, or resources that operate in your network.
 

--- a/modules/creating-oci-resources-services.adoc
+++ b/modules/creating-oci-resources-services.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_oci/installing-oci-assisted-installer.adoc [Using the Assisted Installer to install a cluster on OCI]
+// * installing/installing_oci/installing-oci-assisted-installer.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="creating-oci-resources-services_{context}"]
@@ -25,8 +25,8 @@ By creating a compartment, you can better organize, restrict access, and set usa
 When creating the child compartment, specify the default parent compartment or any other parent compartment from the list.
 ====
 
-. Record the name and the link:https://docs.oracle.com/en-us/iaas/Content/libraries/glossary/ocid.htm[{ocid-first}] of the compartment
+. Record the name and the link:https://docs.oracle.com/en-us/iaas/Content/libraries/glossary/ocid.htm[{ocid-first}] of the compartment.
 
-. Create a bucket resource for your child compartment. Ensure that you specify your child compartment in the **Create in compartment** field for the bucket resource. 
+. Create a bucket resource for your child compartment. Ensure that you specify your child compartment in the *Create in compartment* field for the bucket resource.
 
-. Go to **Object Storage & Archive Storage > Buckets** and create a bucket, where **Bucket name** refers to your cluster's name.
+. Go to *Object Storage & Archive Storage* -> *Buckets* and create a bucket, where *Bucket name* refers to your cluster's name.

--- a/modules/downloading-manifest-files-resources-oci.adoc
+++ b/modules/downloading-manifest-files-resources-oci.adoc
@@ -1,12 +1,12 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_oci/installing-oci-assisted-installer.adoc [Using the Assisted Installer to install a cluster on OCI]
+// * installing/installing_oci/installing-oci-assisted-installer.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="downloading-manifest-files-resources-oci_{context}"]
 = Downloading manifest files and deployment resources
 
-You must download the archive file that includes files for creating cluster resources and custom manifests. After you extract the contents of the archive file, you must upload the extracted files to an {oci-first} stack. The archive file contains a script that when run creates OCI resources, such as DNS records, an instance, and so on.
+You must download the archive file that includes files for creating cluster resources and custom manifests. After you extract the contents of the archive file, you must upload the extracted files to an {oci-first} stack. The archive file contains a script that when run creates {oci} resources, such as DNS records, an instance, and so on.
 
 A stack is an {oci} feature where you can automate the provisioning of all necessary {oci} infrastructure resources, such as the custom image, that are required for installing an {product-title} cluster on {oci}.
 
@@ -14,13 +14,13 @@ The script uses the {oci-first} Compute Service to create a virtual machine (VM)
 
 .Prerequisites
 
-* You uploaded a generated Agent ISO image to {oci}. See the "Using the Assisted Installer to generate an OCI-compatible Agent ISO image" section.
+* You uploaded a generated discovery ISO image to {oci}. For more information, see "Using the Assisted Installer to generate an OCI-compatible discovery ISO image".
 * You have permissions to access the `oracle-quickstart / oci-openshift` GitHub repository.
-* You logged in to your Oracle Cloud Infrastructure account with administrator privileges.
+* You logged in to your {oci-first} account with administrator privileges.
 
 .Procedure
 
-. From the link:https://github.com/oracle-quickstart/oci-openshift[`oracle-quickstart / oci-openshift`] GitHub web page, click the **<> Code** button and then click **Download ZIP**.  The following list details these resources:
+. From the link:https://github.com/oracle-quickstart/oci-openshift[`oracle-quickstart / oci-openshift`] GitHub web page, click the *Code* button and then click *Download ZIP*.  The following list details these resources:
 +
 ** link:https://github.com/oracle-quickstart/oci-openshift/tree/main/custom_manifests[CCM and CSI custom manifests].
 ** link:https://github.com/oracle-quickstart/oci-openshift/blob/main/README.md[Download the {oci} Resource Manager configuration to provision resources for deploying Openshift on {oci}].
@@ -32,31 +32,48 @@ Consider using the example configurations in link:https://github.com/oracle-quic
 
 . Create a stack by completing the link:https://docs.oracle.com/en-us/iaas/Content/ResourceManager/Tasks/create-stack-compartment.htm[Creating a Stack from an Existing Compartment] procedure in the Oracle documentation. Ensure that you also complete the following subtasks:
 +
-.. Upload the archive file, `.zip`, that you downloaded previously from the `oracle-quickstart / oci-openshift` repository. This file contains a script and after you upload the script to OCI, the script creates OCI resources within your child compartment.
-.. From the **Stack information** section, specify a name for your stack.
-.. From the **Configure variables** section, complete the following fields. Ensure you replace the examples with your actual values:
-... **cluster_name:**  `ocicluster`.
-... **compartment_ocid:** Specify the {ocid} from the parent compartment. For example, `ocid1.compartment.oc1..aaaaaaaa6r2iu3qndqgz5ogqkgnh2u2ajy5iou5ugkjr2ksmkrtdqrvxsvyq`.
-... **home_region:**  `us-sanjose-1`
-... **zone_dns:**  `openshift-demo.devcluster.openshift.com`.
-... **enable_private_dns:** Set the DNS zone to public or private. Specifying a value of `true`, creates a private DNS zone; specifying a value of `false` creates a public DNS zone. For a private DNS zone, you must configure your local `/etc/hosts` file to reach the cluster.
-... **openshift_image_source_url:** Specify the URL that you copied from a previous step of the quick-start procedure.
+.. Upload the archive file, `.zip`, that you downloaded previously from the `oracle-quickstart / oci-openshift` repository. This file contains a script and after you upload the script to {oci}, the script creates {oci} resources within your child compartment.
+.. From the *Stack information* section, specify a name for your stack.
+.. From the *Configure variables* section, complete the following fields. Ensure you replace the examples with your actual values.
++
+[cols="2,2",options="header",subs="quotes"]
+|===
+|Field |Value
 
-. Click the **Apply** button to start an apply job. Check the **Logs** section to confirm that your stack was successfully created. 
+| *cluster_name:*
+|Specify the name of your cluster, such as `ocicluster`.
 
-. Copy the `oci_ccm_config` cloud configuration from the **Outputs** section of the log. 
+|*compartment_ocid:*
+|Specify the {ocid} from the parent compartment. For example, `ocid1.compartment.oc1..aaaaaaaa6r2iu3qndqgz5ogqkgnh2u2ajy5iou5ugkjr2ksmkrtdqrvxsvyq`.
+
+|*home_region:*
+|Specify a region, such as `us-sanjose-1`.
+
+|*zone_dns:*
+|Specify the DNS name server that stores DNS records for a zone, such as `openshift-demo.devcluster.openshift.com`.
+
+|*enable_private_dns:*
+|Set the DNS zone to public or private. Specifying a value of `true`, creates a private DNS zone; specifying a value of `false` creates a public DNS zone. For a private DNS zone, you must configure your local `/etc/hosts` file to reach the cluster.
+
+|*openshift_image_source_url:*
+|Specify the URL that you copied from a previous step of the quick-start procedure.
+|===
+
+. Click the *Apply* button to start an apply job. Check the *Logs* section to confirm that your stack is successfully created.
+
+. Copy the `oci_ccm_config` cloud configuration from the *Outputs* section of the log.
 
 . Extract the archive file that you downloaded in a previous step from the link:https://github.com/oracle-quickstart/oci-openshift[`oracle-quickstart / oci-openshift`] repository. A new directory displays on your file explorer. Open the directory in your preferred code editor.
 
-. Open the custom manifest template, `oci-ccm.yml`, and replace the cloud configuration section of the template file with the configuration that you previously copied from the **Logs** section on {oci}. Perform the same steps to update the configuration of the CSI driver in the `oci-csi.yml` file.
+. Open the custom manifest template, `oci-ccm.yml`, and replace the cloud configuration section of the template file with the configuration that you previously copied from the *Logs* section on {oci}. Perform the same steps to update the configuration of the CSI driver in the `oci-csi.yml` file.
 +
-The following example replaced the `region:` to `rateLimitBucketWrite` parameters of the `oci-csi.yml` file with the configuration from the `oci_ccm_config` cloud configuration on {oci}: 
+The following example replaces the `region:` to `rateLimitBucketWrite` parameters of the `oci-csi.yml` file with the configuration from the `oci_ccm_config` cloud configuration on {oci}:
 +
 [source,yaml]
 ----
 # …
 config.yaml: |
-   auth: 
+   auth:
      region: <region_name>
      useInstancePrincipals: true
      compartment: <compartment_ocid>

--- a/modules/installing-oci-about-agent-based-installer.adoc
+++ b/modules/installing-oci-about-agent-based-installer.adoc
@@ -1,12 +1,12 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_oci/installing-oci-agent-based-installer.adoc [Using the Agent-based Installer to install a cluster on OCI]
+// * installing/installing_oci/installing-oci-agent-based-installer.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="installing-oci-about-agent-based-installer_{context}"]
 = The Agent-based Installer and OCI overview
 
-You can install an {product-title} cluster on {oci-first} by using the Agent-based Installer. Both Red Hat and Oracle test, validate, and support running {oci} and {ocvs-first} workloads in an {product-title} cluster on {oci}. 
+You can install an {product-title} cluster on {oci-first} by using the Agent-based Installer. Both Red Hat and Oracle test, validate, and support running {oci} and {ocvs-first} workloads in an {product-title} cluster on {oci}.
 
 :FeatureName: Using the Agent-based Installer to install an {product-title} cluster on OCI that is configured with a virtual machine (VM) compute instance
 include::snippets/technology-preview.adoc[]
@@ -17,7 +17,7 @@ The Agent-based installer provides the ease of use of the Assisted Installation 
 
 [NOTE]
 ====
-Consider selecting a nonvolatile memory express (NVMe) drive or a solid-state drive (SSD) for your boot disk, because these drives offer low latency and high throughput capabilities for your boot disk. 
+Consider selecting a nonvolatile memory express (NVMe) drive or a solid-state drive (SSD) for your boot disk, because these drives offer low latency and high throughput capabilities for your boot disk.
 ====
 
 By running your {product-title} cluster on {oci}, you can access the following capabilities:
@@ -32,9 +32,9 @@ By running your {product-title} cluster on {oci}, you can access the following c
 ====
 To ensure the best performance conditions for your cluster workloads that operate on {oci} and on the OCVS service, ensure volume performance units (VPUs) for your block volume is sized for your workloads. The following list provides some guidance in selecting the VPUs needed for specific performance needs:
 
-* Test or proof of concept environment: `100` GB, and `20` to `30` VPUs.
-* Basic environment: `500` GB, and `60` VPUs.
-* Heavy production environment: More than `500` GB,  and `100` or more VPUs.
+* Test or proof of concept environment: 100 GB, and 20 to 30 VPUs.
+* Basic environment: 500 GB, and 60 VPUs.
+* Heavy production environment: More than 500 GB, and 100 or more VPUs.
 
 Consider reserving additional VPUs to provide sufficient capacity for updates and scaling activities. For more information about VPUs, see Volume Performance Units in the Oracle documentation.
 ====

--- a/modules/installing-oci-about-assisted-installer.adoc
+++ b/modules/installing-oci-about-assisted-installer.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_oci/installing-oci-assisted-installer.adoc [Using the Assisted Installer to install a cluster on OCI]
+// * installing/installing_oci/installing-oci-assisted-installer.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="installing-oci-about-assisted-installer_{context}"]
@@ -8,9 +8,9 @@
 
 You can run cluster workloads on {oci-first} infrastructure that supports dedicated, hybrid, public, and multiple cloud environments. Both Red Hat and Oracle test, validate, and support running {oci} in an {product-title} cluster on {oci}.
 
-The Assisted Installer supports the {oci} platform, and you can use the Assisted Installer to access an intuitive interactive workflow for the purposes of automating cluster installation tasks on {oci}.
+The {ai-full} supports the {oci} platform, and you can use the {ai-full} to access an intuitive interactive workflow for the purposes of automating cluster installation tasks on {oci}.
 
-:FeatureName: Using the Assisted Installer to install an {product-title} cluster on OCI
+:FeatureName: Using the {ai-full} to install an {product-title} cluster on OCI
 include::snippets/technology-preview.adoc[]
 
 {oci} provides services that can meet your needs for regulatory compliance, performance, and cost-effectiveness. You can access {oci} Resource Manager configurations to provision and configure {oci} resources.
@@ -20,7 +20,7 @@ include::snippets/technology-preview.adoc[]
 The steps for provisioning {oci} resources are provided as an example only. You can also choose to create the required resources through other methods; the scripts are just an example. Installing a cluster with infrastructure that you provide requires knowledge of the cloud provider and the installation process on {product-title}. You can access {oci} Resource Manager configurations to complete these steps, or use the configurations to model your own custom script.
 ====
 
-Follow the steps in this document to understand how to use the Assisted Installer to install a {product-title} cluster on {oci}. The document demonstrates the use of the {oci} Manager (CCM) and Oracle’s Container Storage Interface (CSI) objects to link your {product-title} cluster with the {oci} API.
+Follow the steps in this document to understand how to use the {ai-full} to install a {product-title} cluster on {oci}. The document demonstrates the use of the {oci} Manager (CCM) and Oracle’s Container Storage Interface (CSI) objects to link your {product-title} cluster with the {oci} API.
 
 [IMPORTANT]
 ====
@@ -33,4 +33,4 @@ To ensure the best performance conditions for your cluster workloads that operat
 Consider reserving additional VPUs to provide sufficient capacity for updates and scaling activities. For more information about VPUs, see Volume Performance Units in the Oracle documentation.
 ====
 
-If you are unfamiliar with the {product-title} Assisted Installer, see "Using the Assisted Installer" in _Additional Resources_.
+If you are unfamiliar with the {product-title} {ai-full}, see "Assisted Installer for {product-title}".

--- a/modules/installing-troubleshooting-assisted-installer-oci.adoc
+++ b/modules/installing-troubleshooting-assisted-installer-oci.adoc
@@ -1,27 +1,27 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_oci/installing-oci-assisted-installer.adoc [Using the Assisted Installer to install a cluster on OCI]
+// * installing/installing_oci/installing-oci-assisted-installer.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="installing-troubleshooting-assisted-installer-oci_{context}"]
 = Troubleshooting installation of a cluster on OCI
 
-If you experience issues with using the Assisted Installer to install an {product-title} cluster on {oci-first}, read the following sections to troubleshoot common problems.
+If you experience issues with using the {ai-full} to install an {product-title} cluster on {oci-first}, read the following sections to troubleshoot common problems.
 
 [discrete]
 == The Ingress Load Balancer in OCI is not at a healthy status
 
-This issue is classed as a `Warning` because by using the Resource Manager to create a stack, you created a pool of compute nodes, 3 by default, that are automatically added as backend listeners for the Ingress Load Balancer. By default, the {product-title} deploys 2 router pods, which are based on the default values from the {product-title} manifest files. The `Warning` is expected because a mismatch exists with the number of router pods available, two, to run on the three compute nodes. 
+This issue is classed as a `Warning` because by using the Resource Manager to create a stack, you created a pool of compute nodes, 3 by default, that are automatically added as backend listeners for the Ingress Load Balancer. By default, the {product-title} deploys 2 router pods, which are based on the default values from the {product-title} manifest files. The `Warning` is expected because a mismatch exists with the number of router pods available, two, to run on the three compute nodes.
 
-.Example of a `Warning` message that is under the Backend set information tab on {oci}: 
+.Example of a `Warning` message that is under the Backend set information tab on {oci}:
 image::ingress_load_balancer_warning_message.png[Example of an warning message that is under the Backend set information tab on OCI]
 
-You do not need to modify the Ingress Load Balancer configuration. Instead, you can point the Ingress Load Balancer to specific compute nodes that operate in your cluster on {product-title}. To do this, you will need to use placement mechanisms, such as annotations, on {product-title} to ensure router pods only run on the compute nodes that you originally configured on the Ingress Load Balancer as backend listeners. 
+You do not need to modify the Ingress Load Balancer configuration. Instead, you can point the Ingress Load Balancer to specific compute nodes that operate in your cluster on {product-title}. To do this, use placement mechanisms, such as annotations, on {product-title} to ensure router pods only run on the compute nodes that you originally configured on the Ingress Load Balancer as backend listeners.
 
 [discrete]
 == OCI create stack operation fails with an Error: 400-InvalidParameter message
 
-On attempting to create a stack on {oci}, you identified that the **Logs** section of the job outputs an error message. For example:
+On attempting to create a stack on {oci}, you identified that the *Logs* section of the job outputs an error message. For example:
 
 [source,terminal]
 ----
@@ -30,4 +30,4 @@ Suggestion: Please update the parameter(s) in the Terraform config as per error 
 Documentation: https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_vcn
 ----
 
-Go to the https://console.redhat.com/openshift/assisted-installer/clusters/~new[**Install OpenShift with the Assisted Installer**] page on the Hybrid Cloud Console, and check the **Cluster name** field on the  **Cluster Details** step. Remove any special characters, such as a hyphen (`-`),  from the name, because these special characters are not compatible with the {oci} naming conventions.  For example, change `oci-demo` to `ocidemo`. 
+Go to the https://console.redhat.com/openshift/assisted-installer/clusters/~new[*Install OpenShift with the Assisted Installer*] page on the Hybrid Cloud Console, and check the *Cluster name* field on the *Cluster Details* step. Remove any special characters, such as a hyphen (`-`), from the name, because these special characters are not compatible with the {oci} naming conventions. For example, change `oci-demo` to `ocidemo`.

--- a/modules/running-cluster-oci-agent-based.adoc
+++ b/modules/running-cluster-oci-agent-based.adoc
@@ -1,39 +1,42 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_oci/installing-oci-agent-based-installer.adoc [Using the Agent-based Installer to install a cluster on OCI]
+// * installing/installing_oci/installing-oci-agent-based-installer.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="running-cluster-oci-agent-based_{context}"]
 = Running a cluster on OCI
 
-To run a cluster on {oci-first}, you must upload the generated Agent ISO image to the default Object Storage bucket on {oci}. Additionally, you must create a compute instance from the supplied base image, so that your {product-title} and {oci} can communicate with each other for the purposes of running the cluster on {oci}.
+To run a cluster on {oci-first}, you must upload the generated agent ISO image to the default Object Storage bucket on {oci}. Additionally, you must create a compute instance from the supplied base image, so that your {product-title} and {oci} can communicate with each other for the purposes of running the cluster on {oci}.
 
 .Prerequisites
 
-* You generated an Agent ISO image. See the "Creating configuration files for installing a cluster on OCI" section.
+* You generated an agent ISO image. See the "Creating configuration files for installing a cluster on OCI" section.
 
 .Procedure
 
-. Upload the Agent ISO image to Oracle’s default Object Storage bucket and then import the Agent ISO image as a custom image to this bucket. You must then configure the custom image to boot in Unified Extensible Firmware Interface (UEFI) mode. See link:https://docs.oracle.com/en-us/iaas/secure-desktops/create-custom-image.htm[Creating a custom image] and link:https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/configuringimagecapabilities.htm#ariaid-title5[Using the Console] in Oracle’s documentation.
+. Upload the agent ISO image to Oracle’s default Object Storage bucket and then import the agent ISO image as a custom image to this bucket. You must then configure the custom image to boot in Unified Extensible Firmware Interface (UEFI) mode. See link:https://docs.oracle.com/en-us/iaas/secure-desktops/create-custom-image.htm[Creating a custom image] and link:https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/configuringimagecapabilities.htm#ariaid-title5[Using the Console] in Oracle’s documentation.
 +
-For example, from **Compute > Custom images**, import the Agent ISO image to the bucket, and enter values in the following fields:
+For example, from *Compute* -> *Custom images*, import the agent ISO image to the bucket, and enter values in the following fields:
 +
 * Name: *oci-cluster*
-* Bucket: Select the bucket where you uploaded the discovery ISO image
-* Object name: Select the name of the discovery ISO
+* Bucket: Select the bucket that contains the agent ISO image
+* Object name: Select the name of the agent ISO
 * Image type: *QCOW2*
-+
-After the image imports, go to the **Edit image capabilities** setting and ensure  that `UEFI_64` is selected for the **Firmware** field. 
 
-. Create a compute instance from the supplied base image for your preferred cluster topology, such as a single-node OpenShift (SNO) cluster, a highly-availability cluster that contains a minimum of 3 control plane instances and two compute instances, or a compact three-node cluster that contains a minimum of three control plane instances. See link:https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/launchinginstance.htm#top[Creating an instance] (Oracle documentation).
+. After the image imports, go to the *Edit image capabilities* setting and ensure that only `UEFI_64` is selected for the *Firmware* field.
+
+. For instructions on creating a compute instance from the supplied base image for your cluster topology, see link:https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/launchinginstance.htm#top[Creating an instance] in the Oracle documentation. The following {product-title} cluster topologies are supported on {oci}:
+* Installing an {product-title} cluster on a single node.
+* A highly-availabile cluster that has a minimum of three control plane instances and two compute instances.
+* A compact three-node cluster that has a minimum of three control plane instances.
 +
 [IMPORTANT]
 ====
-Before you create the compute instance, check that you have enough memory and disk resources for your cluster. See xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#recommended-resources-for-topologies[Recommended resources for topologies].  Additionally, ensure that at least one compute instance has the same IP address as the address stated under `rendezvousIP` in the `agent-config.yaml` file.
+Before you create the compute instance, check that you have enough memory and disk resources for your cluster. Additionally, ensure that at least one compute instance has the same IP address as the address stated under `rendezvousIP` in the `agent-config.yaml` file.
 ====
 +
-The following example lists important settings for an instance named *oci-cluster-master*. 
+The following example lists important settings for an instance named *oci-cluster-master*.
 +
-* Go to **Image and shape section >  Image >  My images** and then select your custom image.  
-* Go to  **Image and shape section > Shape menu** and then select at least 4 CPUs and 16 GB of memory.
-* From the **Boot volume** section, select the **Specify a custom boot volume size** checkbox. Enter a value that is at least `100` GB for the boot volume size. Allocate the number of VPUs for your organization needs, such as a value in the range of `20` to `30` VPUs. 
+* Go to *Image and shape section* ->  *Image* ->  *My images* and then select your custom image.
+* Go to  *Image and shape section* -> *Shape menu* and then select at least 4 CPUs and 16 GB of memory.
+* From the *Boot volume* section, select the *Specify a custom boot volume size* checkbox. Enter a value that is at least `100` GB for the boot volume size. Assign the number of volume performance units (VPUs) for your organization needs, such as a value in the range of 20 to 30 VPUs.

--- a/modules/using-assisted-installer-oci-agent-iso.adoc
+++ b/modules/using-assisted-installer-oci-agent-iso.adoc
@@ -1,47 +1,67 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_oci/installing-oci-assisted-installer.adoc [Using the Assisted Installer to install a cluster on OCI]
+// * installing/installing_oci/installing-oci-assisted-installer.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="using-assisted-installer-oci-agent-iso_{context}"]
-= Using the Assisted Installer to generate an OCI-compatible Agent ISO image
+= Using the Assisted Installer to generate an OCI-compatible discovery ISO image
 
-Generate an agent ISO image and upload the ISO image to {oci-first}, so that the agent can perform hardware and network validation checks before you install an {product-title} cluster on {oci}.
+Generate a discovery ISO image and upload the image to {oci-first}, so that the agent can perform hardware and network validation checks before you install an {product-title} cluster on {oci}.
 
 .Prerequisites
 
 * You created a child compartment and an object storage bucket on {oci}. See the "Creating OCI resources and services" section.
-* You reviewed details about the {product-title} xref:../../architecture/architecture-installation.adoc#architecture-installation[installation and update] processes. 
-* You completed the link:https://docs.google.com/forms/d/e/1FAIpQLSdQHmw0BUWjQxPKC5_G7lk2_o9Pcnn2ON84Al6s2Ir254gv6Q/viewform[Request Access to Red Hat OpenShift on Oracle Cloud Infrastructure in Developer Preview] form.
-* If you use a firewall and you plan to use a Telemetry service, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured your firewall], so that {product-title} can access the sites required.
+* You reviewed details about the {product-title} installation and update processes.
+* If you use a firewall and you plan to use a Telemetry service, you configured your firewall to allow {product-title} to access the sites required.
 * Before you create a virtual machines (VM), refer to {op-system-base-full} certified shapes, instance types, to identify the supported {oci} VM shapes. See link:https://catalog.redhat.com/cloud/detail/216977[Cloud instance types] on Red Hat Ecosystem Catalog portal.
 
 .Procedure
 
-. From the link:https://console.redhat.com/openshift/assisted-installer/clusters/~new[**Install OpenShift with the Assisted Installer**] page on the Hybrid Cloud Console, generate the discovery ISO image by completing all the required Assisted Installer steps. 
+. From the link:https://console.redhat.com/openshift/assisted-installer/clusters/~new[*Install OpenShift with the Assisted Installer*] page on the Hybrid Cloud Console, generate the discovery ISO image by completing all the required {ai-full} steps.
 +
-.. For the **Cluster Details** step, you complete the following fields:
+.. In the *Cluster Details* step, complete the following fields:
 +
-... **Cluster name**: Specify the name of your cluster, such as `ocidemo`. 
-... **Base domain**: Specify the base domain of the cluster, such as `splat-oci.devcluster.openshift.com`. Provided you previously created a compartment on {oci}, you can get this information by going to **DNS management > Zones > List scope** and then selecting the parent compartment. Your base domain should show under the **Public zones** tab.
-... **OpenShift version**: Specify OpenShift 4.15 or a later version.
-... **CPU architecture**: Specify `x86_64` or `Arm64`.
-... **Integrate with external partner platforms**: Specify `Oracle Cloud Infrastructure`.
-+
-After you specify this value, the *Include custom manifests* checkbox is automatically selected. 
-+
-[IMPORTANT] 
-====
-You can keep the default settings for the **Operators** step.
-====
+[cols="2,2",options="header",subs="quotes"]
+|===
+|Field |Action required
 
-.. For the **Host Discovery** step, click the **Add hosts** button to display a dialog box. For the **SSH public key** field, add your SSH key from your local system. Click the **Generate Discovery ISO** button to generate the discovery image ISO file. Ensure that you download the file to your local system.
+|*Cluster name*
+|Specify the name of your cluster, such as `ocidemo`.
+
+|*Base domain*
+|Specify the base domain of the cluster, such as `splat-oci.devcluster.openshift.com`. Provided you previously created a compartment on {oci}, you can get this information by going to *DNS management* -> *Zones* -> *List scope* and then selecting the parent compartment. Your base domain should show under the *Public zones* tab.
+
+|*OpenShift version*
+| Specify `OpenShift 4.15` or a later version.
+
+|*CPU architecture*
+| Specify `x86_64` or `Arm64`.
+
+|*Integrate with external partner platforms*
+|Specify `Oracle Cloud Infrastructure`.
+
+After you specify this value, the *Include custom manifests* checkbox is selected by default.
+|===
+
+.. On the *Operators* page, click *Next*.
+
+.. On the *Host Discovery* page, click *Add hosts*.
+
+.. For the *SSH public key* field, add your SSH key from your local system.
 +
 [TIP]
 ====
-You can create an SSH authentication key pair by using the `ssh-keygen` tool. 
+You can create an SSH authentication key pair by using the `ssh-keygen` tool.
 ====
 
-. Upload the Agent ISO image to the bucket by completing the steps in the link:https://docs.public.oneportal.content.oci.oraclecloud.com/en-us/iaas/Content/Object/Tasks/managingobjects_topic-To_upload_objects_to_a_bucket.htm[Uploading an Object Storage Object to a Bucket] section of the Oracle documentation.
+.. Click *Generate Discovery ISO* to generate the discovery ISO image file.
 
-. From the **Objects** menu, locate your uploaded image, and then click the overflow menu. From the **Create Pre-Authenticated Request** window, select the **Object** tile. After you create the request, copy the URL from the **Pre-Authenticated Request URL** field. See link:https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/usingpreauthenticatedrequests_topic-To_create_a_preauthenticated_request_for_all_objects_in_a_bucket.htm[Creating a Pre-Authenticated Request] in the Oracle documentation. 
+.. Download the file to your local system.
+
+. Upload the discovery ISO image to the bucket by completing the steps in the link:https://docs.public.oneportal.content.oci.oraclecloud.com/en-us/iaas/Content/Object/Tasks/managingobjects_topic-To_upload_objects_to_a_bucket.htm[Uploading an Object Storage Object to a Bucket] section of the Oracle documentation.
+
+. From the *Objects* menu, locate your uploaded image, and then click the overflow menu.
+
+. From the *Create Pre-Authenticated Request* window, select the *Object* tile.
+
+. After you create the request, copy the URL from the *Pre-Authenticated Request URL* field. See link:https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/usingpreauthenticatedrequests_topic-To_create_a_preauthenticated_request_for_all_objects_in_a_bucket.htm[Creating a Pre-Authenticated Request] in the Oracle documentation.

--- a/modules/verifying-cluster-install-ai-oci.adoc
+++ b/modules/verifying-cluster-install-ai-oci.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_oci/installing-oci-assisted-installer.adoc [Using the Assisted Installer to install a cluster on OCI]
+// * installing/installing_oci/installing-oci-assisted-installer.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="verifying-cluster-install-ai-oci_{context}"]

--- a/modules/verifying-cluster-install-oci-agent-based.adoc
+++ b/modules/verifying-cluster-install-oci-agent-based.adoc
@@ -1,18 +1,18 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_oci/installing-oci-agent-based-installer.adoc [Using the Agent-based Installer to install a cluster on OCI]
+// * installing/installing_oci/installing-oci-agent-based-installer.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="verifying-cluster-install-oci-agent-based_{context}"]
 = Verifying that your Agent-based cluster installation runs on OCI
 
-Verify that your cluster was installed and is running effectively on {oci-first}. 
+Verify that your cluster was installed and is running effectively on {oci-first}.
 
 .Prerequisites
 
 * You created all the required {oci} resources and services. See the "Creating OCI infrastructure resources and services" section.
 * You created `install-config.yaml` and `agent-config.yaml` configuration files. See the "Creating configuration files for installing a cluster on OCI" section.
-* You uploaded the Agent ISO image to Oracle’s default Object Storage bucket, and you created a compute instance on {oci}. See the "running-cluster-oci-agent-based" section
+* You uploaded the agent ISO image to Oracle’s default Object Storage bucket, and you created a compute instance on {oci}. For more information, see "Running a cluster on OCI".
 
 .Procedure
 
@@ -34,7 +34,7 @@ Check the status of the `rendezvous` host node that runs the bootstrap node.  Af
 $  export KUBECONFIG=~/auth/kubeconfig
 ----
 +
-Check the status of each of the cluster’s self-managed nodes. CCM applies a label to each node to designate the node as running in a cluster on {oci}. 
+Check the status of each of the cluster’s self-managed nodes. CCM applies a label to each node to designate the node as running in a cluster on {oci}.
 +
 [source,terminal]
 ----
@@ -45,7 +45,7 @@ $ oc get nodes -A
 +
 [source,terminal]
 ----
-NAME                                   STATUS ROLES                 AGE VERSION 
+NAME                                   STATUS ROLES                 AGE VERSION
 main-0.private.agenttest.oraclevcn.com Ready  control-plane, master 7m  v1.27.4+6eeca63
 main-1.private.agenttest.oraclevcn.com Ready  control-plane, master 15m v1.27.4+d7fa83f
 main-2.private.agenttest.oraclevcn.com Ready  control-plane, master 15m v1.27.4+d7fa83f

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -94,8 +94,12 @@ ifndef::openshift-origin[]
 - **xref:../installing/installing_ibm_power/installing-ibm-power.adoc#installing-ibm-power[Install a cluster on {ibm-power-name}]**: You can install {product-title} on {ibm-power-name} on user-provisioned infrastructure.
 endif::openshift-origin[]
 
+<<<<<<< HEAD
 ifndef::openshift-origin[]
 - **xref:../installing/installing_ibm_z/installing-ibm-z.adoc#installing-ibm-z[Install a cluster with z/VM on {ibm-z-name} and {ibm-linuxone-name}]**: You can install {product-title} with z/VM on {ibm-z-name} and {ibm-linuxone-name} on user-provisioned infrastructure.
+=======
+- **Install a cluster on {oci-first}**: You can use the {ai-full} or the Agent-based Installer to install a cluster on {oci}. This means that you can run cluster workloads on infrastructure that supports dedicated, hybrid, public, and multiple cloud environments. See xref:../installing/installing_oci/installing-oci-assisted-installer.adoc#installing-oci-assisted-installer[Installing a cluster on {oci-first-no-rt} by using the {ai-full}] and xref:../installing/installing_oci/installing-oci-agent-based-installer.adoc#installing-oci-agent-based-installer[Installing a cluster on {oci-first-no-rt} by using the Agent-based Installer].
+>>>>>>> 169340faa6 (OCPBUGS-30076: Fixed minor bugs with OCI docs post 4.15)
 
 - **xref:../installing/installing_ibm_z/installing-ibm-z-kvm.adoc#installing-ibm-z-kvm[Install a cluster with RHEL KVM on {ibm-z-name} and {ibm-linuxone-name}]**: You can install {product-title} with RHEL KVM on {ibm-z-name} and {ibm-linuxone-name} on user-provisioned infrastructure.
 endif::openshift-origin[]


### PR DESCRIPTION
Cherry picked #72364 with commit 169340faa658abe26da3ffc048b371290b60fded

Version(s):
4.14

Issue:
[OCPBUGS-30076](https://issues.redhat.com/browse/OCPBUGS-30076)
[OCPBUGS-30322](https://issues.redhat.com/browse/OCPBUGS-30322)

Link to docs preview:
* [Agent-based Installer on OCI](https://74760--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci/installing-oci-agent-based-installer)
* [Assisted Installer on OCI](https://74760--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci/installing-oci-assisted-installer)
* [Welcome page](https://72364--ocpdocs-pr.netlify.app/openshift-enterprise/latest/welcome/#:~:text=Installer%20to%20install%20a%20cluster%20on%20OCI.%20This%20means%20that%20you%20can)