### PR TITLE
OBSDOCS-574: Add duration to YAML alert examples

### DIFF
--- a/modules/monitoring-creating-alerting-rules-for-user-defined-projects.adoc
+++ b/modules/monitoring-creating-alerting-rules-for-user-defined-projects.adoc
@@ -40,16 +40,18 @@ spec:
   - name: example
     rules:
     - alert: VersionAlert # <1>
-      expr: version{job="prometheus-example-app"} == 0 # <2>
+      for: 1m # <2>
+      expr: version{job="prometheus-example-app"} == 0 # <3>
       labels:
-        severity: warning # <3>
+        severity: warning # <4>
       annotations:
-        message: This is an example alert. # <4>
+        message: This is an example alert. # <5>
 ----
 <1> The name of the alerting rule you want to create.
-<2> The PromQL query expression that defines the new rule.
-<3> The severity assigned to the alert.
-<4> The message associated with the alert.
+<2> The duration for which the condition should be true before an alert is fired.
+<3> The PromQL query expression that defines the new rule.
+<4> The severity that alerting rule assigns to the alert.
+<5> The message associated with the alert.
 
 . Apply the configuration file to the cluster:
 +

--- a/modules/monitoring-creating-new-alerting-rules.adoc
+++ b/modules/monitoring-creating-new-alerting-rules.adoc
@@ -40,16 +40,18 @@ spec:
   - name: example-rules
     rules:
     - alert: ExampleAlert # <1>
-      expr: vector(1) # <2>
+      for: 1m # <2>
+      expr: vector(1) # <3>
       labels:
-        severity: warning # <3>
+        severity: warning # <4>
       annotations:
-        message: This is an example alert. # <4>
+        message: This is an example alert. # <5>
 ----
 <1> The name of the alerting rule you want to create.
-<2> The PromQL query expression that defines the new rule.
-<3> The severity assigned to the alert.
-<4> The message associated with the alert.
+<2> The duration for which the condition should be true before an alert is fired.
+<3> The PromQL query expression that defines the new rule.
+<4> The severity that alerting rule assigns to the alert.
+<5> The message associated with the alert.
 
 . Apply the configuration file to the cluster:
 +


### PR DESCRIPTION
Version(s): `enterprise-4.12` and later

Issue: [OBSDOCS-574](https://issues.redhat.com/browse/OBSDOCS-574)

Links to docs preview: 
* [Creating new alerting rules](https://74762--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/managing-alerts.html#creating-new-alerting-rules_managing-alerts)
* [Creating alerting rules for user-defined projects](https://74762--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/managing-alerts.html#creating-alerting-rules-for-user-defined-projects_managing-alerts)

QE review:
- [x] QE has approved this change.

**Additional information:**