### PR TITLE
RHDEVDOCS-5954: Fixing typos in pre-reqs

### DIFF
--- a/accesscontrol_usermanagement/configuring-argo-cd-rbac.adoc
+++ b/accesscontrol_usermanagement/configuring-argo-cd-rbac.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-By default, if you are logged into Argo CD using Red Hat SSO (RH SSO), you are a read-only user. You can change and manage the user level access.
+By default, if you are logged in to Argo CD using Red Hat SSO (RH SSO), you are a read-only user. You can change and manage the user level access.
 
 // Configuring user level access
 include::modules/gitops-configuring-user-level-access.adoc[leveloffset=+1]

--- a/accesscontrol_usermanagement/configuring-sso-for-argo-cd-using-keycloak.adoc
+++ b/accesscontrol_usermanagement/configuring-sso-for-argo-cd-using-keycloak.adoc
@@ -11,7 +11,7 @@ After the {gitops-title} Operator is installed, Argo CD automatically creates a 
 [id="prerequisites_configuring-sso-for-argo-cd-using-keycloak"]
 == Prerequisites
 * Red Hat SSO is installed on the cluster.
-* {gitops-title} Operator is installed on the cluster.
+* The {gitops-title} Operator is installed on your {OCP} cluster.
 * Argo CD is installed on the cluster.
 
 // Configuring a new client in Keycloak

--- a/argo_rollouts/using-argo-rollouts-for-progressive-deployment-delivery.adoc
+++ b/argo_rollouts/using-argo-rollouts-for-progressive-deployment-delivery.adoc
@@ -22,7 +22,7 @@ You can use Argo Rollouts to manage multiple replica sets that represent differe
 == Prerequisites
 * You have access to the cluster with `cluster-admin` privileges.
 * You have access to the {OCP} web console.
-* {gitops-title} 1.9.0 or a newer version is installed in your cluster.
+* {gitops-title} 1.9.0 or a newer version is installed on your cluster.
 
 // Benefits of Argo Rollouts
 include::modules/gitops-benefits-of-argo-rollouts.adoc[leveloffset=+1]

--- a/modules/gitops-additional-permissions-for-cluster-config.adoc
+++ b/modules/gitops-additional-permissions-for-cluster-config.adoc
@@ -9,8 +9,8 @@
 You can grant permissions for an Argo CD instance to manage cluster configuration. Create a cluster role with additional permissions and then create a new cluster role binding to associate the cluster role with a service account. 
 
 .Prerequisites
-* You have access to an {OCP} cluster with `cluster-admin` privileges and are logged into the web console.
-* You have installed the {gitops-title} Operator on your cluster.
+* You have access to an {OCP} cluster with `cluster-admin` privileges and are logged in to the web console.
+* You have installed the {gitops-title} Operator on your {OCP} cluster.
 
 .Procedure
 

--- a/modules/gitops-argo-cd-dynamic-scaling-by-using-cli.adoc
+++ b/modules/gitops-argo-cd-dynamic-scaling-by-using-cli.adoc
@@ -12,7 +12,7 @@
 You can enable dynamic scaling of shards by using the {oc-first}.
 
 .Prerequisites
-* You have installed the {gitops-title} Operator in your cluster.
+* You have installed the {gitops-title} Operator on your {OCP} cluster.
 * You have access to the cluster with `cluster-admin` privileges.
 
 .Procedure

--- a/modules/gitops-argo-cd-dynamic-scaling-in-web-console.adoc
+++ b/modules/gitops-argo-cd-dynamic-scaling-in-web-console.adoc
@@ -12,7 +12,7 @@ You can enable dynamic scaling of shards by using the {OCP} web console.
 .Prerequisites
 * You have access to the cluster with `cluster-admin` privileges.
 * You have access to the {OCP} web console.
-* You have installed the {gitops-title} Operator in your cluster.
+* You have installed the {gitops-title} Operator on your {OCP} cluster.
 
 .Procedure
 

--- a/modules/gitops-argo-cd-installation.adoc
+++ b/modules/gitops-argo-cd-installation.adoc
@@ -12,7 +12,7 @@ To manage cluster configurations or deploy applications, you can install and dep
 
 * You have access to the cluster with `cluster-admin` privileges.
 
-* You have installed the {gitops-title} Operator in your cluster.
+* You have installed the {gitops-title} Operator on your {OCP} cluster.
 
 .Procedure
 . Log in to the {OCP} web console. 

--- a/modules/gitops-argo-cd-notification.adoc
+++ b/modules/gitops-argo-cd-notification.adoc
@@ -9,7 +9,7 @@
 Argo CD notifications allow you to send notifications to external services when events occur in your Argo CD instance. For example, you can send notifications to Slack or email when a sync operation fails. By default, notifications are disabled in Argo CD instances.
 
 .Prerequisites
-* You have access to an {OCP} cluster with `cluster-admin` privileges and are logged into the web console.
+* You have access to an {OCP} cluster with `cluster-admin` privileges and are logged in to the web console.
 * You have installed the {gitops-title} Operator on your cluster.
 
 .Procedure

--- a/modules/gitops-configuring-user-level-access.adoc
+++ b/modules/gitops-configuring-user-level-access.adoc
@@ -28,7 +28,7 @@ metadata
     scopes: '[groups]'
 ----
 +
-. Add the `policy` configuration to the `rbac` section and add the `name`, `email` and the `role` of the user: 
+. Add the `policy` configuration to the `rbac` section and add the `name` and the desired `role` to be applied to the user:
 +
 [source,yaml]
 ----
@@ -36,7 +36,7 @@ metadata
 ...
 ...
 rbac:
-    policy: <name>, <email>, role:<admin>
+    policy: g, <name>, role:<admin>
     scopes: '[groups]'
 ----
 

--- a/modules/gitops-creating-rolloutmanager-custom-resource.adoc
+++ b/modules/gitops-creating-rolloutmanager-custom-resource.adoc
@@ -10,7 +10,7 @@ To manage progressive delivery of deployments by using Argo Rollouts in {gitops-
 
 .Prerequisites
 
-* {gitops-title} 1.9.0 or a newer version is installed in your cluster.
+* {gitops-title} 1.9.0 or a newer version is installed on your cluster.
 
 .Procedure 
 

--- a/modules/gitops-deleting-rolloutmanager-custom-resource.adoc
+++ b/modules/gitops-deleting-rolloutmanager-custom-resource.adoc
@@ -10,7 +10,7 @@ Uninstalling the {gitops-title} Operator does not remove the resources that were
 
 .Prerequisites
 
-* {gitops-title} 1.9.0 or a newer version is installed in your cluster.
+* {gitops-title} 1.9.0 or a newer version is installed on your cluster.
 * A `RolloutManager` CR exists in your namespace.
 
 .Procedure 

--- a/modules/gitops-enabling-the-round-robin-sharding-algorithm-in-web-console.adoc
+++ b/modules/gitops-enabling-the-round-robin-sharding-algorithm-in-web-console.adoc
@@ -9,7 +9,7 @@
 You can enable the `round-robin` sharding algorithm by using the {OCP} web console.
 
 .Prerequisites
-* You have installed the {gitops-title} Operator in your cluster.
+* You have installed the {gitops-title} Operator on your {OCP} cluster.
 * You have access to the {OCP} web console.
 * You have access to the cluster with `cluster-admin` privileges.
 

--- a/modules/gitops-enabling-the-round-robin-sharding-algorithm-using-cli.adoc
+++ b/modules/gitops-enabling-the-round-robin-sharding-algorithm-using-cli.adoc
@@ -9,7 +9,7 @@
 You can enable the `round-robin` sharding algorithm by using the command-line interface.
 
 .Prerequisites
-* You have installed the {gitops-title} Operator in your cluster.
+* You have installed the {gitops-title} Operator on your {OCP} cluster.
 * You have access to the cluster with `cluster-admin` privileges.
 
 .Procedure

--- a/modules/gitops-release-notes-1-12-0.adoc
+++ b/modules/gitops-release-notes-1-12-0.adoc
@@ -137,7 +137,7 @@ Workaround: No workaround currently exists for this issue, so you must wait for 
 +
 Workaround: Perform the following steps:
 +
-. Install the {gitops-title} Operator in your cluster.
+. Install the {gitops-title} Operator on your cluster.
 . In the *Administrator* perspective of the web console, navigate to *Home* -> *Overview*.
 . On the *Overview* tab, click the *Dynamic plugins* link in the *Status* section. 
 . To enable the {gitops-title} Dynamic Plugin, click *gitops-plugin* and then click *Enabled*. 

--- a/modules/gitops-storing-and-retrieving-argo-cd-logs.adoc
+++ b/modules/gitops-storing-and-retrieving-argo-cd-logs.adoc
@@ -10,8 +10,8 @@ You can use the Kibana dashboard to store and retrieve Argo CD logs.
 
 .Prerequisites
 
-* The {gitops-title} Operator is installed in your cluster.
-* The {logging-title} is installed with default configuration in your cluster.
+* The {gitops-title} Operator is installed on your {OCP} cluster.
+* The {logging-title} is installed with default configuration on your {OCP} cluster.
 
 .Procedure
 

--- a/modules/logging-in-to-the-argo-cd-instance-by-using-the-argo-cd-admin-account.adoc
+++ b/modules/logging-in-to-the-argo-cd-instance-by-using-the-argo-cd-admin-account.adoc
@@ -12,7 +12,7 @@ Use the Argo CD admin account to log in to the default ready-to-use Argo CD inst
 
 .Prerequisites
 
-* You have installed the {gitops-title} Operator in your cluster.
+* You have installed the {gitops-title} Operator on your {OCP} cluster.
 
 .Procedure
 

--- a/modules/moving-the-gitops-operator-pod-to-infrastructure-nodes.adoc
+++ b/modules/moving-the-gitops-operator-pod-to-infrastructure-nodes.adoc
@@ -9,7 +9,7 @@
 You can move the {gitops-shortname} Operator pod to the infrastructure nodes.
 
 .Prerequisites
-* You have installed the {gitops-title} Operator in your cluster.
+* You have installed the {gitops-title} Operator on your {OCP} cluster.
 * You have access to the cluster with `cluster-admin` privileges.
 
 .Procedure

--- a/modules/proc_configuring-by-using-the-ocp-web-console.adoc
+++ b/modules/proc_configuring-by-using-the-ocp-web-console.adoc
@@ -10,7 +10,7 @@ You can configure the `NotificationsConfiguration` custom resource (CR) by using
 
 .Prerequisites
 
-* You have access to an {OCP} cluster with `cluster-admin` privileges and are logged into the web console.
+* You have access to an {OCP} cluster with `cluster-admin` privileges and are logged in to the web console.
 * You have installed the {gitops-title} Operator on your cluster.
 * You have enabled notifications for the Argo CD instance. For more information, see "Enabling notifications with an Argo CD instance".
 

--- a/observability/monitoring/monitoring-argo-cd-custom-resource-workloads.adoc
+++ b/observability/monitoring/monitoring-argo-cd-custom-resource-workloads.adoc
@@ -15,9 +15,9 @@ You can enable and disable the setting for monitoring Argo CD custom resource wo
 == Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role. 
-* {gitops-title} is installed in your cluster.
+* You have installed the {gitops-title} Operator on your {OCP} cluster.
 * The monitoring stack is configured in your cluster in the `openshift-monitoring` project. In addition, the Argo CD instance is in a namespace that you can monitor through Prometheus.
-* The `kube-state-metrics` service is running in your cluster.
+* The `kube-state-metrics` service is running on your cluster.
 * Optional: If you are enabling monitoring for an Argo CD instance already present in a user-defined project, ensure that the monitoring is link:https://docs.openshift.com/container-platform/latest/monitoring/enabling-monitoring-for-user-defined-projects.html#enabling-monitoring-for-user-defined-projects_enabling-monitoring-for-user-defined-projects[enabled for user-defined projects] in your cluster.
 +
 [NOTE]

--- a/observability/monitoring/monitoring-argo-cd-instances.adoc
+++ b/observability/monitoring/monitoring-argo-cd-instances.adoc
@@ -12,7 +12,7 @@ By default, the {gitops-title} Operator automatically detects an installed Argo 
 == Prerequisites
 * You have access to the cluster with `cluster-admin` privileges.
 * You have access to the {OCP} web console.
-* You have installed the {gitops-title} Operator in your cluster.
+* You have installed the {gitops-title} Operator on your {OCP} cluster.
 * You have installed an Argo CD application in your defined namespace, for example, `openshift-gitops`.
 
 // Monitoring Argo CD health using Prometheus metrics


### PR DESCRIPTION
**Version(s):** GitOps 1.9, GitOps 1.10, GitOps 1.11, GitOps 1.12

**Issue:** https://issues.redhat.com/browse/RHDEVDOCS-5954

**Link to docs preview:** I have made the changes in a lot of places in the content. So, I am just adding a sample link for the changes at one instance: https://74766--ocpdocs-pr.netlify.app/openshift-gitops/latest/observability/monitoring/monitoring-argo-cd-instances.html

SME review: @reginapizza 
QE review: @varshab1210 
Internal Peer review: @eromanova97 
Peer review:

**QE review:**
- [ ] QE has approved this change.


**Additional information:** This PR also includes the changes in content for correct policy for user level permissions from the following [PR](https://github.com/openshift/openshift-docs/pull/69135/files). Further details for this issue are available in the following: https://github.com/openshift/openshift-docs/issues/69134
