### PR TITLE
OSDOCS-7880: Defining paths for configuring DNS inteface NMSTATE

### DIFF
--- a/modules/virt-example-nmstate-IP-management.adoc
+++ b/modules/virt-example-nmstate-IP-management.adoc
@@ -91,32 +91,110 @@ The following snippet configures an Ethernet interface that uses a dynamic IP ad
 [id="virt-example-nmstate-IP-management-dns_{context}"]
 == DNS
 
-Setting the DNS configuration is analagous to modifying the `/etc/resolv.conf` file. The following snippet sets the DNS configuration on the host.
+By default, the `nmstate` API stores DNS values globally as against storing them in a network interface. For certain situations, you must configure a network interface to store DNS values. To define a DNS configuration for a network interface, you must initially specify the `dns-resolver` section in the network interface's YAML configuration file.
 
-[source,yaml]
-----
-# ...
-    interfaces: <1>
-       ...
-       ipv4:
-         ...
-         auto-dns: false
-         ...
-    dns-resolver:
-      config:
-        search:
-        - example.com
-        - example.org
-        server:
-        - 8.8.8.8
-# ...
-----
-<1> You must configure an interface with `auto-dns: false` or you must use static IP configuration on an interface in order for Kubernetes NMState to store custom DNS settings.
+[TIP]
+====
+Setting a DNS configuration is comparable to modifying the `/etc/resolv.conf` file.
+====
+
+The following examples show situations that require configuring a network interface to store DNS values:
 
 [IMPORTANT]
 ====
-You cannot use `br-ex`, an OVNKubernetes-managed Open vSwitch bridge, as the interface when configuring DNS resolvers.
+You cannot use `br-ex` bridge, an OVNKubernetes-managed Open vSwitch bridge, as the interface when configuring DNS resolvers.
 ====
+
+* Configure a static DNS for a network interface with an automatic IP configuration. Note that for this configuration, you must set the `auto-dns` parameter to `false`, so that the Kubernetes NMState Operator can store custom DNS settings for the network interface.
++
+[source,yaml]
+----
+dns-resolver:
+  config:
+    search:
+    - example.com
+    - example.org
+    server:
+    - 2001:db8:f::1
+    - 192.0.2.251
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      enabled: true
+      dhcp: true
+      auto-dns: false
+    ipv6:
+      enabled: true
+      dhcp: true
+      autoconf: true
+      auto-dns: false
+# ...
+----
+
+* Configure a static DNS for a network interface with a static IP configuration. Note that for this configuration, you must set the `dhcp` parameter to `false` and the `autoconf` parameter to `false`.
++
+[source,yaml]
+----
+dns-resolver:
+  config:
+# ...
+    server:
+    - 2001:4860:4860::8844
+    - 192.0.2.251
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      enabled: true
+      dhcp: false
+      address:
+      - ip: 192.0.2.251
+        prefix-length: 24
+    ipv6:
+      enabled: true
+      dhcp: false
+      autoconf: false
+      address:
+      - ip: 2001:db8:1::1
+        prefix-length: 64
+routes:
+  config:
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.0.2.1
+    next-hop-interface: eth1
+  - destination: ::/0
+    next-hop-address: 2001:db8:1::3
+    next-hop-interface: eth1
+# ...
+----
+
+* Configure a static DNS name server to append to Dynamic Host Configuration Protocol (DHCP) and IPv6 Stateless Address AutoConfiguration (SLAAC) servers:
++
+[source,yaml]
+----
+dns-resolver:
+  config:
+# ...
+    server:
+    - 192.0.2.251
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      enabled: true
+      dhcp: true
+      auto-dns: true
+    ipv6:
+      enabled: true
+      dhcp: true
+      autoconf: true
+      auto-dns: true
+# ...
+----
 
 [id="virt-example-nmstate-IP-management-static-routing_{context}"]
 == Static routing
@@ -125,25 +203,27 @@ The following snippet configures a static route and a static IP on interface `et
 
 [source,yaml]
 ----
+dns-resolver:
+  config:
 # ...
-    interfaces:
-    - name: eth1
-      description: Static routing on eth1
-      type: ethernet
-      state: up
-      ipv4:
-        dhcp: false
-        address:
-        - ip: 192.0.2.251 <1>
-          prefix-length: 24
-        enabled: true
-    routes:
-      config:
-      - destination: 198.51.100.0/24
-        metric: 150
-        next-hop-address: 192.0.2.1 <2>
-        next-hop-interface: eth1
-        table-id: 254
+interfaces:
+  - name: eth1
+    description: Static routing on eth1
+    type: ethernet
+    state: up
+    ipv4:
+      dhcp: false
+      enabled: true
+      address:
+      - ip: 192.0.2.251 <1>
+        prefix-length: 24
+routes:
+  config:
+  - destination: 198.51.100.0/24
+    metric: 150
+    next-hop-address: 192.0.2.1 <2>
+    next-hop-interface: eth1
+    table-id: 254
 # ...
 ----
 <1> The static IP address for the Ethernet interface.

--- a/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
@@ -42,13 +42,13 @@ The following examples show different `NodeNetworkConfigurationPolicy` manifest 
 
 For best performance, consider the following factors when applying a policy:
 
-* When you need to apply a policy to more than one node, create a `NodeNetworkConfigurationPolicy` manifest for each target node. Scoping a policy to a single node reduces the overall length of time for the Kubernetes NMState Operator to apply the policies. 
+* When you need to apply a policy to more than one node, create a `NodeNetworkConfigurationPolicy` manifest for each target node. Scoping a policy to a single node reduces the overall length of time for the Kubernetes NMState Operator to apply the policies.
 +
-In contrast, if a single policy includes configurations for several nodes, the Kubernetes NMState Operator applies the policy to each node in sequence, which increases the overall length of time for policy application. 
+In contrast, if a single policy includes configurations for several nodes, the Kubernetes NMState Operator applies the policy to each node in sequence, which increases the overall length of time for policy application.
 
-* All related network configurations should be specified in a single policy. 
+* All related network configurations should be specified in a single policy.
 +
-When a node restarts, the Kubernetes NMState Operator cannot control the order in which policies are applied. Therefore, the Kubernetes NMState Operator might apply interdependent policies in a sequence that results in a degraded network object. 
+When a node restarts, the Kubernetes NMState Operator cannot control the order in which policies are applied. Therefore, the Kubernetes NMState Operator might apply interdependent policies in a sequence that results in a degraded network object.
 
 include::modules/virt-example-bridge-nncp.adoc[leveloffset=+2]
 
@@ -88,5 +88,5 @@ include::modules/virt-example-inherit-static-ip-from-nic.adoc[leveloffset=+2]
 .Additional resources
 * link:https://nmstate.io/nmpolicy/user-guide/102-policy-syntax.html[The NMPolicy project - Policy syntax]
 
-// Dropping offset by one again
+// Examples: IP management
 include::modules/virt-example-nmstate-IP-management.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.13+

Issue:
(https://issues.redhat.com/browse/OSDOCS-7880)

Link to docs preview:
* [DNS](https://74767--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#virt-example-nmstate-IP-management-dns_k8s_nmstate-updating-node-network-config)
* [Example policy configurations for different interfaces](https://74767--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#virt-nmstate-example-policy-configurations)

- [x] SME has approved this change.
- [x] QE has approved this change.

Additional information:
* https://nmstate.io/features/dns.html)
* https://datatracker.ietf.org/doc/html/rfc8106
