### PR TITLE
Fixing weird behaviour with mbps when specified twice in the list with different capitalization

### DIFF
--- a/.vale/styles/config/vocabularies/OpenShiftDocs/accept.txt
+++ b/.vale/styles/config/vocabularies/OpenShiftDocs/accept.txt
@@ -17,8 +17,7 @@ gpspipe
 hyperthreads?
 KPIs?
 linuxptp
-Mbps
-MBps
+[Mm][Bb]ps
 Mellanox
 MetalLB
 NICs?


### PR DESCRIPTION
Previously the two entries were causing some sort of conflict I think so the rule wasn't working as expected.