### PR TITLE
[Internal fix] glossary-terms-banner-main

### DIFF
--- a/contributing_to_docs/term_glossary.adoc
+++ b/contributing_to_docs/term_glossary.adoc
@@ -18,13 +18,16 @@ goal is to standardize terminology across OpenShift content and be consistent in
 the usage of our terminology when referring to OpenShift components or
 architecture.
 
-For terms that are also API objects, there is different guidance for general usage of the term versus referencing the actual API object. This glossary mainly defines the general usage guideline (lowercase, separating words), but be sure to use the object formatting (PascalCase, in monospace) when referring to the actual object. See link:doc_guidelines.adoc#api-object-formatting[API object formatting] for more information.
+[IMPORTANT]
+====
+Do not backport `term_glossary.adoc` file updates to enterprise branches. An enterprise branch is created from the latest enterprise branch and not the `main` branch. Asynchronous behavior can occur between `main` and an enterprise branch if you complete a backport operation.
+====
+
+For terms that are also API objects, there is different guidance for general usage of the term compared to referencing the actual API object. This glossary mainly defines the general usage guideline (lowercase, separating words), but be sure to use the object formatting (PascalCase, in monospace) when referring to the actual object. See link:doc_guidelines.adoc#api-object-formatting[API object formatting] for more information.
 
 [NOTE]
 ====
-If you want to add terms or other content to this document, or if anything must
-be fixed, send an email to openshift-docs@redhat.com or submit a PR
-on GitHub.
+If you want to add terms or other content to this document, or if anything must be fixed, send an email to openshift-docs@redhat.com or submit a PR on GitHub. Do not bundle the glossary term update in a regular writing assignment PR.
 ====
 
 == A


### PR DESCRIPTION
I experienced merge conflicts on #72364 that was caused by making changes to the glossary_terms.adoc file and backporting these to enterprise brances. On speaking with Andrea, changes to this file should stay on `main`. Questionable whether to delete the file that was backported on some occasion to the enterprise branches, but that is outside the scope of this PR.

Version(s):
main
