### PR TITLE
OCPBUGS#30087: Support for other identity providers

### DIFF
--- a/modules/hcp-configuring-oauth.adoc
+++ b/modules/hcp-configuring-oauth.adoc
@@ -6,7 +6,7 @@
 [id="hcp-configuring-oauth_{context}"]
 = Configuring the internal OAuth server for a hosted cluster
 
-You can configure the internal OAuth server for your hosted cluster by using an OpenID Connect identity provider. Adding any identity provider in the OAuth configuration removes the default `kubeadmin` user provider.
+You can configure the internal OAuth server for your hosted cluster by using an OpenID Connect identity provider (`oidc`). You can also configure OAuth for the other supported identity providers such as `htpasswd`, `keystone`, `ldap`, `basic-authentication`, `request-header`, `github`, `gitlab`, and `google`. Adding any identity provider in the OAuth configuration removes the default `kubeadmin` user provider.
 
 .Prerequisites
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> ---> This PR addresses the support for identity providers on Hosted control planes other than `oidc`. 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-30087
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
 
Link to docs preview: https://74789--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-authentication-authorization.html#hcp-configuring-oauth_hcp-authentication-authorization
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
