### PR TITLE
OCPBUGS#32312: Adds missing mentions of service proxy in dynamic plugin docs

### DIFF
--- a/modules/dynamic-plugin-api.adoc
+++ b/modules/dynamic-plugin-api.adoc
@@ -7,7 +7,7 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="dynamic-plugin-api_{context}"]
-= {product-title} console API
+= Dynamic plugin API
 
 [discrete]
 == `useActivePerspective`

--- a/modules/dynamic-plugin-proxy-service.adoc
+++ b/modules/dynamic-plugin-proxy-service.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * web_console/dynamic-plugin/deploy-plugin-cluster.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="dynamic-plugin-proxy-service_{context}"]
+= Plugin service proxy
+
+If you need to make HTTP requests to an in-cluster service from your plugin, you can declare a service proxy in its `ConsolePlugin` resource by using the `spec.proxy` array field. The console backend exposes the `/api/proxy/plugin/<plugin-name>/<proxy-alias>/<request-path>++?++<optional-query-parameters>` endpoint to proxy the communication between the plugin and the service. A proxied request uses a _service CA bundle_ by default. The service must use HTTPS.
+
+[NOTE]
+====
+The plugin must use the `consolefetch` API to make requests from its JavaScript code or some requests might fail. For more information, see "Dynamic plugin API".
+====
+
+For each entry, you must specify an endpoint and alias of the proxy under the `endpoint` and `alias` fields. For the Service proxy type, you must set the endpoint `type` field to `Service` and the `service` must include values for the `name`, `namespace`, and `port` fields. For example, `/api/proxy/plugin/helm/helm-charts/releases++?++limit++=++10` is a proxy request path from the `helm` plugin with a `helm-charts` service that lists ten helm releases.
+
+.Example service proxy
+[source,YAML,subs="+quotes,+macros"]
+----
+apiVersion: console.openshift.io/v1
+kind: ConsolePlugin
+metadata:
+  name:<plugin-name>
+spec:
+  proxy:
+  - alias: helm-charts <1>
+    authorization: UserToken <2>
+    caCertificate: +'-----BEGIN CERTIFICATE-----\nMIID....'en+ <3>
+    endpoint: <4>
+      service:
+        name: <service-name>
+        namespace: <service-namespace>
+        port: <service-port>
+      type: Service
+----
+<1> Alias of the proxy.
+<2> If the service proxy request must contain the logged-in user's {product-title} access token, you must set the authorization field to `UserToken`.
++
+[NOTE]
+====
+If the service proxy request does not contain the logged-in user's {product-title} access token, set the authorization field to `None`.
+====
+<3> If the service uses a custom service CA, the `caCertificate` field must contain the certificate bundle.
+<4> Endpoint of the proxy.

--- a/web_console/dynamic-plugin/deploy-plugin-cluster.adoc
+++ b/web_console/dynamic-plugin/deploy-plugin-cluster.adoc
@@ -12,11 +12,23 @@ include::modules/build-image-docker.adoc[leveloffset=+1]
 
 include::modules/deployment-plug-in-cluster.adoc[leveloffset=+1]
 
+include::modules/dynamic-plugin-proxy-service.adoc[leveloffset=+1]
+
+ifndef::openshift-rosa,openshift-dedicated[]
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../security/certificate_types_descriptions/service-ca-certificates.adoc#service-ca-certificates[Service CA certificates]
+* xref:../../security/certificates/service-serving-certificate.adoc#service-serving-certificate[Securing service traffic using service serving certificate secrets]
+* xref:../../web_console/dynamic-plugin/dynamic-plugins-reference.adoc#dynamic-plugin-api_dynamic-plugins-reference[Dynamic plugin API]
+endif::openshift-rosa,openshift-dedicated[]
+
 include::modules/disabling-plug-in-browser.adoc[leveloffset=+1]
 
 ifndef::openshift-rosa,openshift-dedicated[]
 [role="_additional-resources"]
 [id="dynamic-plugins_additional-resources"]
 == Additional resources
+
 * xref:../../applications/working_with_helm_charts/understanding-helm.adoc#understaning-helm[Understanding Helm]
 endif::openshift-rosa,openshift-dedicated[]


### PR DESCRIPTION
Adds missing mentions of service proxy in dynamic plugin docs

Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OCPBUGS-32312

Link to docs preview:
https://74800--ocpdocs-pr.netlify.app/openshift-enterprise/latest/web_console/dynamic-plugin/deploy-plugin-cluster#dynamic-plugin-proxy-service_deploy-plugin-cluster

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Pulled from https://github.com/openshift/console/tree/master/dynamic-demo-plugin#proxy-service and convo in slack.
