### PR TITLE
OBSDOCS-991: Add information to the Support monitoring section about …

### DIFF
--- a/modules/monitoring-support-considerations.adoc
+++ b/modules/monitoring-support-considerations.adoc
@@ -28,6 +28,8 @@ This procedure is a supported exception to the preceding statement.
 * *Modifying resources of the stack.* The {product-title} monitoring stack ensures its resources are always in the state it expects them to be. If they are modified, the stack will reset them.
 * *Deploying user-defined workloads to `openshift-&#42;`, and `kube-&#42;` projects.* These projects are reserved for Red Hat provided components and they should not be used for user-defined workloads.
 * *Enabling symptom based monitoring by using the `Probe` custom resource definition (CRD) in Prometheus Operator.*
+* *Manually deploying monitoring resources into namespaces that have the `openshift.io/cluster-monitoring: "true"` label.* 
+* *Adding the `openshift.io/cluster-monitoring: "true"` label to namespaces.* This label is reserved only for the namespaces with core {product-title} components and Red{nbsp}Hat certified components.
 endif::openshift-dedicated,openshift-rosa[]
 
 * *Installing custom Prometheus instances on {product-title}.* A custom instance is a Prometheus custom resource (CR) managed by the Prometheus Operator.


### PR DESCRIPTION
Version(s): `enterprise-4.12` and later

Issue: [OBSDOCS-991](https://issues.redhat.com/browse/OBSDOCS-991)

Link to docs preview: [Support considerations for monitoring](https://74818--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#support-considerations_configuring-the-monitoring-stack)

QE review:
- [x] QE has approved this change.

**Additional information:**