### PR TITLE
OBSDOCS-992: Fix ClusterRole for Kubernetes attributes processor

### DIFF
--- a/modules/otel-collector-components.adoc
+++ b/modules/otel-collector-components.adoc
@@ -1084,13 +1084,17 @@ This processor automatically identifies the Kubernetes resources, extracts the m
 .Minimum {product-title} permissions required for the Kubernetes Attributes Processor
 [source,yaml]
 ----
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: otel-collector
 rules:
-  - apiGroups: ['']
-    resources: ['pods', 'namespaces']
-    verbs: ['get', 'watch', 'list']
+- apiGroups: [""]
+  resources: ["pods", "namespaces", "nodes"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["apps"]
+  resources: ["replicasets"]
+  verbs: ["get", "list", "watch"]
 ----
 
 .OpenTelemetry Collector using the Kubernetes Attributes Processor


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12, 4.13, 4.14, 4.15, 4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OBSDOCS-992

Link to docs preview: https://74820--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-configuration-of-otel-collector.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
