### PR TITLE
TELCODOCS-1688:Adding Telco Core RDS resource in a container image

### DIFF
--- a/modules/telco-core-rds-container.adoc
+++ b/modules/telco-core-rds-container.adoc
@@ -1,0 +1,59 @@
+// Module included in the following assemblies:
+//
+// * telco_ref_design_specs/core/telco-core-ref-crs.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="telco-core-rds-container_{context}"]
+= Extracting the telco core reference design configuration CRs
+
+You can extract the complete set of custom resources (CRs) for the telco core profile from the `telco-core-rds-rhel9` container image. 
+The container image has both the required CRs, and the optional CRs, for the telco core profile.
+
+.Prerequisites
+
+* You have installed `podman`.
+
+.Procedure
+
+* Extract the content from the `telco-core-rds-rhel9` container image by running the following commands:
++
+[source,terminal]
+----
+$ mkdir -p ./out
+----
++
+[source,terminal]
+----
+$ podman run -it registry.redhat.io/openshift4/telco-core-rds-rhel9:v4.16 | base64 -d | tar xv -C out
+----
+
+.Verification
+
+* The `out` directory has the following folder structure. You can view the telco core CRs in the `out/telco-core-rds/` directory.
++
+.Example output
+[source,text]
+----
+out/
+└── telco-core-rds
+    ├── configuration
+    │   └── reference-crs
+    │       ├── optional
+    │       │   ├── logging
+    │       │   ├── networking
+    │       │   │   └── multus
+    │       │   │       └── tap_cni
+    │       │   ├── other
+    │       │   └── tuning
+    │       └── required
+    │           ├── networking
+    │           │   ├── metallb
+    │           │   ├── multinetworkpolicy
+    │           │   └── sriov
+    │           ├── other
+    │           ├── performance
+    │           ├── scheduling
+    │           └── storage
+    │               └── odf-external
+    └── install
+----

--- a/telco_ref_design_specs/core/telco-core-ref-crs.adoc
+++ b/telco_ref_design_specs/core/telco-core-ref-crs.adoc
@@ -10,10 +10,7 @@ toc::[]
 Use the following custom resources (CRs) to configure and deploy {product-title} clusters with the {rds} profile.
 Use the CRs to form the common baseline used in all the specific use models unless otherwise indicated.
 
-[NOTE]
-====
-The {rds} CRs are available in link:https://github.com/openshift-kni/telco-reference/tree/release-4.15[GitHub].
-====
+include::modules/telco-core-rds-container.adoc[leveloffset=+1]
 
 include::modules/telco-core-crs-resource-tuning.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[TELCODOCS-1688](https://issues.redhat.com//browse/TELCODOCS-1688): New telco core RDS container image contained tried and tested core-related CRs.

Version(s):
4.16

Issue:
https://issues.redhat.com/browse/TELCODOCS-1688

Link to docs preview:
https://file.emea.redhat.com/rohennes/TELCODOCS-1688/telco_ref_design_specs/core/telco-core-ref-crs.html#telco-core-rds-container_ran-core-ref-design-crs

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
