### PR TITLE
Contribution Guidelines - Add distro info to assembly metadata requirements. 

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -9,7 +9,7 @@ link:https://redhat-documentation.github.io/modular-docs/[_Red Hat modular docs 
 
 [NOTE]
 ====
-These _Documentation guidelines_ are primarily concerned with the modular structure and AsciiDoc / AsciiBinder requirements for building OpenShift documention. For general style guidelines in OpenShift docs, see the following:
+These _Documentation guidelines_ are primarily concerned with the modular structure and AsciiDoc / AsciiBinder requirements for building OpenShift documentation. For general style guidelines in OpenShift docs, see the following:
 
 * Primary source: link:https://www.ibm.com/docs/en/ibm-style[_IBM Style_]
 * Supplementary source: link:https://redhat-documentation.github.io/supplementary-style-guide/[_Red Hat supplementary style guide for product documentation_]
@@ -36,18 +36,22 @@ In the Pulsar editor, you can use `Ctrl`+`J` to undo hard wrapping on a paragrap
 Every assembly file should contain the following metadata at the top, with no line spacing in between, except where noted:
 
 ----
-:_mod-docs-content-type: ASSEMBLY                                        <1>
-[id="<unique-heading-for-assembly>"]                            <2>
-= Assembly title                                                <3>
-include::_attributes/common-attributes.adoc[]                   <4>
-:context: <unique-context-for-assembly>                         <5>
-                                                                <6>
-toc::[]                                                         <7>
+// Assembly included in the following distros:
+//
+// * list of distros containing this assembly           <1>
+:_mod-docs-content-type: ASSEMBLY                       <2>
+[id="<unique-heading-for-assembly>"]                    <3>
+= Assembly title                                        <4>
+include::_attributes/common-attributes.adoc[]           <5>
+:context: <unique-context-for-assembly>                 <6>
+                                                        <7>
+toc::[]                                                 <8>
 ----
-<1> The content type for the file. For assemblies, always use `:_mod-docs-content-type: ASSEMBLY`. Place this attribute before the anchor ID or, if present, the conditional that contains the anchor ID.
-<2> A unique (within OpenShift docs) anchor ID for this assembly. Use lowercase. Example: cli-developer-commands
-<3> Human readable title (notice the `=` top-level header)
-<4> Includes attributes common to OpenShift docs.
+<1> List of distro topic maps containing this assembly.
+<2> The content type for the file. For assemblies, always use `:_mod-docs-content-type: ASSEMBLY`. Place this attribute before the anchor ID or, if present, the conditional that contains the anchor ID.
+<3> A unique (within OpenShift docs) anchor ID for this assembly. Use lowercase. Example: cli-developer-commands
+<4> Human readable title (notice the `=` top-level header)
+<5> Includes attributes common to OpenShift docs.
 +
 [NOTE]
 ====
@@ -55,9 +59,9 @@ toc::[]                                                         <7>
 * If you use a variable in the title of the first assembly in a section, move the include attributes directive above the title in this assembly. Otherwise, the variable will not render correctly on access.redhat.com.
 ====
 +
-<5> Context used for identifying headers in modules that is the same as the anchor ID. Example: cli-developer-commands.
-<6> A blank line. You *must* have a blank line here before the toc.
-<7> The table of contents for the current assembly.
+<6> Context used for identifying headers in modules that is the same as the anchor ID. Example: cli-developer-commands.
+<7> A blank line. You *must* have a blank line here before the toc.
+<8> The table of contents for the current assembly.
 
 [NOTE]
 ====


### PR DESCRIPTION
Adds distro info to assembly metadata requirements.

Initial commit tested building with this modified assembly metadata, and passed. 