### PR TITLE
CMA 2.12.1-384 RN

### DIFF
--- a/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.adoc
+++ b/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.adoc
@@ -10,6 +10,23 @@ The following release notes are for previous versions of the Custom Metrics Auto
 
 For the current version, see xref:../../../nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc#nodes-cma-autoscaling-custom-rn[Custom Metrics Autoscaler Operator release notes].
 
+[id="nodes-pods-autoscaling-custom-rn-2121-376_{context}"]
+== Custom Metrics Autoscaler Operator 2.12.1-376 release notes
+
+This release of the Custom Metrics Autoscaler Operator 2.12.1-376 provides security updates and bug fixes for running the Operator in an {product-title} cluster. The following advisory is available for the link:https://access.redhat.com/errata/RHSA-2024:1812[RHSA-2024:1812].
+
+[IMPORTANT]
+====
+Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of KEDA.
+====
+
+[id="nodes-pods-autoscaling-custom-rn-2121-376-bugs_{context}"]
+=== Bug fixes
+
+* Previously, if invalid values such as nonexistent namespaces were specified in scaled object metadata, the underlying scaler clients would not free, or close, their client descriptors, resulting in a slow memory leak. This fix properly closes the underlying client descriptors when there are errors, preventing memory from leaking. (link:https://issues.redhat.com/browse/OCPBUGS-30145[*OCPBUGS-30145*])
+
+* Previously the `ServiceMonitor` custom resource (CR) for the `keda-metrics-apiserver` pod was not functioning, because the CR referenced an incorrect metrics port name of `http`. This fix corrects the `ServiceMonitor` CR to reference the proper port name of `metrics`. As a result, the Service Monitor functions properly. (link:https://issues.redhat.com/browse/OCPBUGS-25806[*OCPBUGS-25806*])
+
 [id="nodes-pods-autoscaling-custom-rn-2112-322_{context}"]
 == Custom Metrics Autoscaler Operator 2.11.2-322 release notes
 

--- a/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
+++ b/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
@@ -43,19 +43,17 @@ The following table defines the Custom Metrics Autoscaler Operator versions for 
 |General availability
 |===
 
-[id="nodes-pods-autoscaling-custom-rn-2121-376_{context}"]
-== Custom Metrics Autoscaler Operator 2.12.1-376 release notes
+[id="nodes-pods-autoscaling-custom-rn-2121-384_{context}"]
+== Custom Metrics Autoscaler Operator 2.12.1-384 release notes
 
-This release of the Custom Metrics Autoscaler Operator 2.12.1-376 provides security updates and bug fixes for running the Operator in an {product-title} cluster. The following advisory is available for the link:https://access.redhat.com/errata/RHSA-2024:1812[RHSA-2024:1812].
+This release of the Custom Metrics Autoscaler Operator 2.12.1-384 provides a bug fix for running the Operator in an {product-title} cluster. The following advisory is available for the link:https://access.redhat.com/errata/RHSA-TDB[RHSA-TDB].
 
 [IMPORTANT]
 ====
 Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of KEDA.
 ====
 
-[id="nodes-pods-autoscaling-custom-rn-2121-376-bugs_{context}"]
+[id="nodes-pods-autoscaling-custom-rn-2121-384-bugs_{context}"]
 === Bug fixes
 
-* Previously, if invalid values, such as nonexistent namespaces, were specified in scaled object metadata, the underlying scaler clients would not free, or close, their client descriptors, resulting in a slow memory leak. This fix properly closes the underlying client descriptors when there are errors, preventing memory from leaking. (link:https://issues.redhat.com/browse/OCPBUGS-30145[*OCPBUGS-30145*])
-
-* Previously the `ServiceMonitor` custom resource (CR) for the `keda-metrics-apiserver` pod was not functioning, because the CR referenced an incorrect metrics port name of `http`. This fix corrects the `ServiceMonitor` CR to reference the proper port name of `metrics`. As a result, the Service Monitor functions properly. (link:https://issues.redhat.com/browse/OCPBUGS-25806[*OCPBUGS-25806*])
+* Previously, the `custom-metrics-autoscaler` and `custom-metrics-autoscaler-adapter` images were missing time zone information. As a consequence, scaled objects with `cron` triggers failed to work because the controllers were unable to find time zone information. With this fix, the image builds are updated to include time zone information. As a result, scaled objects containing `cron` triggers now function properly. (link:https://issues.redhat.com/browse/OCPBUGS-32395[*OCPBUGS-32395*]) 


### PR DESCRIPTION
For planned 4/25 release.
Errata: https://errata.devel.redhat.com/docs/show/130592

Previews:
[Custom Metrics Autoscaler Operator 2.12.1-384 release notes](https://74864--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.html#nodes-pods-autoscaling-custom-rn-2121-384_nodes-cma-autoscaling-custom-rn) -- This is new text for peer review; link to errata will be updated when the errata is published.
[Custom Metrics Autoscaler Operator 2.12.1-376 release notes](https://74864--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past#nodes-pods-autoscaling-custom-rn-2121-376_nodes-cma-autoscaling-custom-rn-past) -- This text is unchanged, just moved from the current CMA release notes to the past CMA release notes. See [this section in the current CMA release notes](https://docs.openshift.com/container-platform/4.15/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.html#nodes-pods-autoscaling-custom-rn-2121-376_nodes-cma-autoscaling-custom-rn). 

Accidentally merged without updating errata link. See follow up: https://github.com/openshift/openshift-docs/pull/75141
