### PR TITLE
RHDEVDOCS-5955: Replacing the {product-title} attribute with the {OCP} attribute

### DIFF
--- a/modules/gitops-configuring-sscsi-driver-to-mount-secrets-from-aws-secrets-manager.adoc
+++ b/modules/gitops-configuring-sscsi-driver-to-mount-secrets-from-aws-secrets-manager.adoc
@@ -6,7 +6,7 @@
 [id="gitops-configuring-sscsi-driver-to-mount-secrets-from-aws-secrets-manager_{context}"]
 = Configuring SSCSI driver to mount secrets from AWS Secrets Manager
 
-To store and manage your secrets securely, use {gitops-shortname} workflows and configure the Secrets Store Container Storage Interface (SSCSI) Driver Operator to mount secrets from AWS Secrets Manager to a CSI volume in OpenShift Container Platform. For example, consider that you want to mount a secret to a deployment pod under the `dev` namespace which is in the `/environments/dev/` directory.
+To store and manage your secrets securely, use {gitops-shortname} workflows and configure the Secrets Store Container Storage Interface (SSCSI) Driver Operator to mount secrets from AWS Secrets Manager to a CSI volume in {OCP}. For example, consider that you want to mount a secret to a deployment pod under the `dev` namespace which is in the `/environments/dev/` directory.
 
 .Prerequisites
 

--- a/modules/gitops-enabling-dex.adoc
+++ b/modules/gitops-enabling-dex.adoc
@@ -22,7 +22,7 @@ spec:
 +
 This update causes the `argocd-cluster-dex-server` instance to run.
 
-. To enable login with {product-title}, update the `argo-cd` custom resource by adding the following field: 
+. To enable login with {OCP}, update the `argo-cd` custom resource by adding the following field: 
 +
 [source,yaml]
 ----

--- a/modules/gitops-keycloak-identity-brokering-with-openshift-oauthclient.adoc
+++ b/modules/gitops-keycloak-identity-brokering-with-openshift-oauthclient.adoc
@@ -3,9 +3,9 @@
 // *
 
 [id="keycloak-identity-brokering-with-openshift-oauthclient_{context}"]
-= Keycloak Identity Brokering with {product-title}
+= Keycloak Identity Brokering with {OCP}
 
-You can configure a Keycloak instance to use {product-title} for authentication through Identity Brokering. This allows for Single Sign-On (SSO) between the {product-title} cluster and the Keycloak instance.
+You can configure a Keycloak instance to use {OCP} for authentication through Identity Brokering. This allows for Single Sign-On (SSO) between the {OCP} cluster and the Keycloak instance.
 
 .Prerequisites
 
@@ -14,7 +14,7 @@ You can configure a Keycloak instance to use {product-title} for authentication 
 
 .Procedure
 
-. Obtain the {product-title} API URL:
+. Obtain the {OCP} API URL:
 +
 [source,terminal]
 ----
@@ -23,12 +23,12 @@ $ curl -s -k -H "Authorization: Bearer $(oc whoami -t)" https://<openshift-user-
 +
 [NOTE]
 ====
-The address of the {product-title} API is often protected by HTTPS. Therefore, you must configure X509_CA_BUNDLE in the container and set it to `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`. Otherwise, Keycloak cannot communicate with the API Server.
+The address of the {OCP} API is often protected by HTTPS. Therefore, you must configure X509_CA_BUNDLE in the container and set it to `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`. Otherwise, Keycloak cannot communicate with the API Server.
 ====
 
 . In the Keycloak server dashboard, navigate to *Identity Providers* and select *Openshift v4*. Specify the following values:
-*Base Url*:: {product-title} 4 API URL
+*Base Url*:: {OCP} 4 API URL
 *Client ID*:: `keycloak-broker`
 *Client Secret*:: A secret that you want define
 +
-Now you can log in to Argo CD with your {product-title} credentials through Keycloak as an Identity Broker.
+Now you can log in to Argo CD with your {OCP} credentials through Keycloak as an Identity Broker.

--- a/modules/gitops-registering-an-additional-oauth-client.adoc
+++ b/modules/gitops-registering-an-additional-oauth-client.adoc
@@ -5,7 +5,7 @@
 [id="registering-an-additional-oauth-client_{context}"]
 = Registering an additional an OAuth client
 
-If you need an additional OAuth client to manage authentication for your {product-title} cluster, you can register one.
+If you need an additional OAuth client to manage authentication for your {OCP} cluster, you can register one.
 
 .Procedure
 

--- a/modules/gitops-registering-an-oauth-client.adoc
+++ b/modules/gitops-registering-an-oauth-client.adoc
@@ -5,7 +5,7 @@
 [id="registering-an-additional-oauth-client_{context}"]
 = Registering an additional an OAuth client
 
-If you need an additional OAuth client to manage authentication for your {product-title} cluster, you can register one.
+If you need an additional OAuth client to manage authentication for your {OCP} cluster, you can register one.
 
 .Procedure
 

--- a/modules/gitops-storing-aws-secret-manager-resources-in-gitops-repository.adoc
+++ b/modules/gitops-storing-aws-secret-manager-resources-in-gitops-repository.adoc
@@ -6,7 +6,7 @@
 [id="gitops-storing-aws-secret-manager-resources-in-gitops-repository_{context}"]
 = Storing AWS Secrets Manager resources in {gitops-shortname} repository
 
-This guide provides instructions with examples to help you use {gitops-shortname} workflows with the Secrets Store Container Storage Interface (SSCSI) Driver Operator to mount secrets from AWS Secrets Manager to a CSI volume in OpenShift Container Platform.
+This guide provides instructions with examples to help you use {gitops-shortname} workflows with the Secrets Store Container Storage Interface (SSCSI) Driver Operator to mount secrets from AWS Secrets Manager to a CSI volume in {OCP}.
 
 [IMPORTANT]
 ====

--- a/modules/go-settings-for-environment-labels-and-annotations.adoc
+++ b/modules/go-settings-for-environment-labels-and-annotations.adoc
@@ -6,7 +6,7 @@
 [id="go-settings-for-environment-labels-and-annotations_{context}"]
 = Settings for environment labels and annotations
 
-This section provides reference settings for environment labels and annotations required to display an environment application in the *Environments* page, in the *Developer* perspective of the {product-title} web console.
+This section provides reference settings for environment labels and annotations required to display an environment application in the *Environments* page, in the *Developer* perspective of the {OCP} web console.
 
 [discrete]
 == Environment labels

--- a/release_notes/gitops-release-notes.adoc
+++ b/release_notes/gitops-release-notes.adoc
@@ -76,5 +76,3 @@ include::modules/gitops-release-notes-1-9-0.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 * link:https://docs.openshift.com/container-platform/latest/operators/admin/olm-configuring-proxy-support.html#olm-inject-custom-ca_olm-configuring-proxy-support[Injecting a custom CA certificate]
-
-

--- a/troubleshooting_gitops_issues/auto-reboot-during-argo-cd-sync-with-machine-configurations.adoc
+++ b/troubleshooting_gitops_issues/auto-reboot-during-argo-cd-sync-with-machine-configurations.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In the Red Hat OpenShift Container Platform, nodes are updated automatically through the Red Hat OpenShift Machine Config Operator (MCO). A Machine Config Operator (MCO) is a custom resource that is used by the cluster to manage the complete life cycle of its nodes.
+In the Red Hat {OCP}, nodes are updated automatically through the Red Hat OpenShift Machine Config Operator (MCO). A Machine Config Operator (MCO) is a custom resource that is used by the cluster to manage the complete life cycle of its nodes.
 
 When an MCO resource is created or updated in a cluster, the MCO picks up the update, performs the necessary changes to the selected nodes, and restarts the nodes gracefully by cordoning, draining, and rebooting those nodes. It handles everything from the kernel to the kubelet.
 


### PR DESCRIPTION
**Version(s):** GitOps 1.9, GitOps 1.10, GitOps 1.11, GitOps 1.12

**Issue:** https://issues.redhat.com/browse/RHDEVDOCS-5955

**Link to docs preview:**: 
https://74871--ocpdocs-pr.netlify.app/openshift-gitops/latest/troubleshooting_gitops_issues/auto-reboot-during-argo-cd-sync-with-machine-configurations.html

https://74871--ocpdocs-pr.netlify.app/openshift-gitops/latest/securing_openshift_gitops/managing-secrets-securely-using-sscsid-with-gitops#gitops-configuring-sscsi-driver-to-mount-secrets-from-aws-secrets-manager_managing-secrets-securely-using-sscsid-with-gitops

https://74871--ocpdocs-pr.netlify.app/openshift-gitops/latest/troubleshooting_gitops_issues/auto-reboot-during-argo-cd-sync-with-machine-configurations

https://74871--ocpdocs-pr.netlify.app/openshift-gitops/latest/observability/monitoring/health-information-for-resources-deployment#go-settings-for-environment-labels-and-annotations_health-information-for-resources-deployment

https://74871--ocpdocs-pr.netlify.app/openshift-gitops/latest/securing_openshift_gitops/managing-secrets-securely-using-sscsid-with-gitops#gitops-storing-aws-secret-manager-resources-in-gitops-repository_managing-secrets-securely-using-sscsid-with-gitops

SME review: @reginapizza 
QE review: @varshab1210 
Internal Peer review: @eromanova97
Peer review:

**QE review:**
- [ ] QE has approved this change.
