### PR TITLE
OSCDOCS-6023#adding new step

### DIFF
--- a/modules/core-user-password.adoc
+++ b/modules/core-user-password.adoc
@@ -19,12 +19,19 @@ You can create a password for the `core` user by using a machine config. The Mac
 
 You can change the password, if needed, by editing the machine config you used to create the password. Also, you can remove the password by deleting the machine config. Deleting the machine config does not remove the user account.
 
-.Prerequisites
-
-* Create a hashed password by using a tool that is supported by your operating system.
-
 .Procedure
-
+. Using a tool that is supported by your operating system, create a hashed password. For example, create a hashed password using `mkpasswd` by running the following command:
++
+[source,terminal]
+----
+$ mkpasswd -m SHA-512 testpass
+----
++
+.Example output
+[source,terminal]
+----
+$ $6$CBZwA6s6AVFOtiZe$aUKDWpthhJEyR3nnhM02NM1sKCpHn9XN.NPrJNQ3HYewioaorpwL3mKGLxvW0AOb4pJxqoqP4nFX77y0p00.8.
+----
 . Create a machine config file that contains the `core` username and the hashed password:
 +
 [source,terminal]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Versions:
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-6023

Link to docs preview:
https://74874--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#core-user-password_post-install-machine-configuration-tasks (removed the 'Prerequisites' and added the text from this section into step 1 with new command and example output)

QE review:
- [x] QE has approved this change - see comment in https://issues.redhat.com/browse/OSDOCS-6023
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
