### PR TITLE
RHDEVDOCS-5958: Table header correction for tables using the ** style in it's headers

### DIFF
--- a/modules/gitops-argo-cd-properties.adoc
+++ b/modules/gitops-argo-cd-properties.adoc
@@ -8,8 +8,9 @@
 
 The Argo CD Custom Resource consists of the following properties:
 
+[options="header"]
 |===
-|**Name** |**Description** |**Default** | **Properties**
+|Name |Description |Default |Properties
 |`applicationInstanceLabelKey` |The `metadata.label` key name where Argo CD injects the app name as a tracking label.|`app.kubernetes.io/instance` |
 
 |`applicationSet`

--- a/modules/gitops-inbuilt-permissions-for-cluster-config.adoc
+++ b/modules/gitops-inbuilt-permissions-for-cluster-config.adoc
@@ -14,8 +14,9 @@ Argo CD does not have cluster-admin permissions.
 ====
 
 Permissions for the Argo CD instance:
+[options="header"]
 |===
-|*Resources* |*Descriptions*
+|Resources |Descriptions
 |Resource Groups | Configure the user or administrator
 |`operators.coreos.com` | Optional Operators managed by OLM
 |`user.openshift.io` , `rbac.authorization.k8s.io`    | Groups, Users and their permissions

--- a/modules/gitops-modifying-rhsso-requests-limits.adoc
+++ b/modules/gitops-modifying-rhsso-requests-limits.adoc
@@ -8,8 +8,9 @@
 
 By default, the RHSSO container is created with resource requests and limitations. You can change and manage the resource requests.
 
+[options="header"]
 |===
-|*Resource* |*Requests* |*Limits*
+|Resource |Requests |Limits
 
 |CPU|500|1000m
 |Memory|512 Mi|1024 Mi

--- a/modules/gitops-repo-server-properties.adoc
+++ b/modules/gitops-repo-server-properties.adoc
@@ -8,8 +8,9 @@
 
 The following properties are available for configuring the Repo server component:
 
+[options="header"]
 |===
-|**Name** |**Default** | **Description**
+|Name |Default | Description
 |`resources` |`__<empty>__` |The container compute resources.
 |`mountsatoken` |`false` |Defines whether the `serviceaccount` token should be mounted to the repo-server pod.
 |`serviceaccount` |`""` |The name of the `serviceaccount` to use with the repo-server pod.

--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -19,10 +19,11 @@ In the table, features are marked with the following statuses:
 In {OCP} 4.13, the `stable` channel has been removed. Before upgrading to {OCP} 4.13, if you are already on the `stable` channel, choose the appropriate channel and switch to it.
 ====
 
+[options="header"]
 |===
-|*OpenShift GitOps* 7+|*Component Versions*|*OpenShift Versions*
+|OpenShift GitOps 7+|Component Versions|OpenShift Versions
 
-|*Version* |*`kam`*    |*Helm*  |*Kustomize* |*Argo CD*|*Argo Rollouts*|*Dex*     |*RH SSO* |
+s|Version s|`kam`    s|Helm  s|Kustomize s|Argo CD s|Argo Rollouts s|Dex     s|RH SSO |
 
 |1.12.0 |0.0.51 TP |3.14.0 GA |5.2.1 GA |2.10.3 GA |1.6.0 TP |2.36.0 GA |7.6.0 GA |4.12-4.15
 

--- a/observability/monitoring/monitoring-the-gitops-operator-performance.adoc
+++ b/observability/monitoring/monitoring-the-gitops-operator-performance.adoc
@@ -9,8 +9,9 @@ toc::[]
 The {gitops-title} Operator emits metrics about its performance. With the OpenShift monitoring stack that picks up these metrics, you can monitor and analyze the Operator’s performance. The Operator exposes the following metrics, which you can view by using the {OCP} web console:
 
 .{gitops-shortname} Operator performance metrics
+[options="header"]
 |===
-|*Metric name* |*Type* |*Description*
+|Metric name |Type |Description
 
 |`active_argocd_instances_total` |Gauge |The total number of active Argo CD instances currently managed by the Operator across the cluster at a given time.
 


### PR DESCRIPTION
**Version(s):** GitOps 1.10, GitOps 1.11, GitOps 1.12, and GitOps 1.13
**Issue:** https://issues.redhat.com/browse/RHDEVDOCS-5958

**Link to docs preview:** The following tables include the table header change:

- Argo CD custom resource properties - https://74878--ocpdocs-pr.netlify.app/openshift-gitops/latest/argocd_instance/argo-cd-cr-component-properties#argo-cd-properties_argo-cd-cr-component-properties
- In-built permissions for cluster configuration - https://74878--ocpdocs-pr.netlify.app/openshift-gitops/latest/declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations#gitops-inbuilt-permissions-for-cluster-config_configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations
- Modifying RHSSO resource requests/limits - https://74878--ocpdocs-pr.netlify.app/openshift-gitops/latest/accesscontrol_usermanagement/configuring-argo-cd-rbac#modifying-rhsso-resource-requests-limits_configuring-argo-cd-rbac
- Repo server properties - https://74878--ocpdocs-pr.netlify.app/openshift-gitops/latest/argocd_instance/argo-cd-cr-component-properties#argo-repo-server-properties_argo-cd-cr-component-properties
- Compatibility and support matrix - https://74878--ocpdocs-pr.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes#GitOps-compatibility-support-matrix_gitops-release-notes
- Monitoring the GitOps Operator performance - https://74878--ocpdocs-pr.netlify.app/openshift-gitops/latest/observability/monitoring/monitoring-the-gitops-operator-performance


SME review: @reginapizza 
QE review: @varshab1210 
Internal Peer review: @eromanova97
Peer review:

**QE review:**
- [ ] QE has approved this change.
