### PR TITLE
MIG-1542: Document skipping SELinux relabelling

### DIFF
--- a/migration_toolkit_for_containers/mtc-direct-migration-requirements.adoc
+++ b/migration_toolkit_for_containers/mtc-direct-migration-requirements.adoc
@@ -56,4 +56,11 @@ include::modules/migration-rsync-mig-migration-root-non-root.adoc[leveloffset=+3
 
 include::modules/mtc-mig-cluster-configuration.adoc[leveloffset=+2]
 
+
+[id="mtc-direct-migration-known-issues_{context}"]
+== Direct migration known issues
+
+include::modules/relabeling-selinux-workaround.adoc[leveloffset=+2]
+
+
 :!mtc-direct-migration-requirements:

--- a/migration_toolkit_for_containers/troubleshooting-mtc.adoc
+++ b/migration_toolkit_for_containers/troubleshooting-mtc.adoc
@@ -2,6 +2,7 @@
 [id="troubleshooting-mtc"]
 = Troubleshooting
 include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: troubleshooting-mtc
 :troubleshooting-mtc:
 :namespace: openshift-migration
@@ -43,6 +44,7 @@ This section describes common issues and concerns that can cause issues during m
 
 include::modules/migration-dvm-error-node-selectors.adoc[leveloffset=+2]
 include::modules/migration-error-messages.adoc[leveloffset=+2]
+include::modules/relabeling-selinux-workaround.adoc[leveloffset=+2]
 
 [id="rolling-back-migration_{context}"]
 == Rolling back a migration

--- a/modules/relabeling-selinux-workaround.adoc
+++ b/modules/relabeling-selinux-workaround.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assemblies:
+//
+// migration_toolkit_for_containers/troubleshooting-mtc.adoc
+// migration_toolkit_for_containers/mtc-direct-migration-requirements.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="relabeling-selinux-workaround_{context}"]
+= Applying the Skip SELinux relabel workaround with `spc_t` automatically on workloads running on {OCP}
+
+When attempting to migrate a namespace with {mtc-full} ({mtc-short}) and a substantial volume associated with it, the `rsync-server` may become frozen without any further information to troubleshoot the issue.
+
+[id="diagnosis-selinux-workaround_{context}"]
+== Diagnosing the need for the Skip SELinux relabel workaround
+
+Search for an error of `Unable to attach or mount volumes for pod...timed out waiting for the condition` in the kubelet logs from the node where the `rsync-server` for the Direct Volume Migration (DVM) runs.
+
+.Example kubelet log
+[source,yaml]
+----
+kubenswrapper[3879]: W0326 16:30:36.749224    3879 volume_linux.go:49] Setting volume ownership for /var/lib/kubelet/pods/8905d88e-6531-4d65-9c2a-eff11dc7eb29/volumes/kubernetes.io~csi/pvc-287d1988-3fd9-4517-a0c7-22539acd31e6/mount and fsGroup set. If the volume has a lot of files then setting volume ownership could be slow, see https://github.com/kubernetes/kubernetes/issues/69699
+
+kubenswrapper[3879]: E0326 16:32:02.706363    3879 kubelet.go:1841] "Unable to attach or mount volumes for pod; skipping pod" err="unmounted volumes=[8db9d5b032dab17d4ea9495af12e085a], unattached volumes=[crane2-rsync-server-secret 8db9d5b032dab17d4ea9495af12e085a kube-api-access-dlbd2 crane2-stunnel-server-config crane2-stunnel-server-secret crane2-rsync-server-config]: timed out waiting for the condition" pod="caboodle-preprod/rsync-server"
+
+kubenswrapper[3879]: E0326 16:32:02.706496    3879 pod_workers.go:965] "Error syncing pod, skipping" err="unmounted volumes=[8db9d5b032dab17d4ea9495af12e085a], unattached volumes=[crane2-rsync-server-secret 8db9d5b032dab17d4ea9495af12e085a kube-api-access-dlbd2 crane2-stunnel-server-config crane2-stunnel-server-secret crane2-rsync-server-config]: timed out waiting for the condition" pod="caboodle-preprod/rsync-server" podUID=8905d88e-6531-4d65-9c2a-eff11dc7eb29
+----
+
+[id="resolving-selinux-workaround_{context}"]
+== Resolving using the Skip SELinux relabel workaround
+
+To resolve this issue, set the `migration_rsync_super_privileged` parameter to `true` in both the source and destination `MigClusters` using the `MigrationController` custom resource (CR).
+
+.Example MigrationController CR
+
+[source,yaml]
+----
+apiVersion: migration.openshift.io/v1alpha1
+kind: MigrationController
+metadata:
+  name: migration-controller
+  namespace: openshift-migration
+spec:
+  migration_rsync_super_privileged: true # <1>
+  azure_resource_group: ""
+  cluster_name: host
+  mig_namespace_limit: "10"
+  mig_pod_limit: "100"
+  mig_pv_limit: "100"
+  migration_controller: true
+  migration_log_reader: true
+  migration_ui: true
+  migration_velero: true
+  olm_managed: true
+  restic_timeout: 1h
+  version: 1.8.3
+----
+
+<1> The value of the `migration_rsync_super_privileged` parameter indicates whether or not to run Rsync Pods as _super privileged_ containers (`spc_t selinux context`). Valid settings are `true` or `false`.


### PR DESCRIPTION
### JIRA

* [MIG-1542](https://issues.redhat.com/browse/MIG-1542)


### Version(s):

* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16

### Link to docs preview:

* [Direct migration known issues - Applying Skip SELinux relabel workaround with spc_t automatically on workloads running on OpenShift Container Platform](https://74895--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/mtc-direct-migration-requirements.html#relabeling-selinux-workaround_mtc-direct-migration-requirements)
* [Troubleshooting - Applying Skip SELinux relabel workaround with spc_t automatically on workloads running on OpenShift Container Platform](https://74895--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/troubleshooting-mtc#relabeling-selinux-workaround_troubleshooting-mtc)


### QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
