### PR TITLE
updates typo on rosa HCP creation steps

### DIFF
--- a/modules/rosa-hcp-sts-creating-a-cluster-cli.adoc
+++ b/modules/rosa-hcp-sts-creating-a-cluster-cli.adoc
@@ -60,7 +60,7 @@ If you specified custom ARN paths when you created the associated account-wide r
 ----
 $ rosa create cluster --private --cluster-name=<cluster_name> \ 
   --mode=auto --hosted-cp --operator-roles-prefix=$OPERATOR_ROLES_PREFIX \ 
-  --oidc-config-id=$ODIC_CONFIG --subnet-ids=$SUBNET_IDS
+  --oidc-config-id=$OIDC_ID --subnet-ids=$SUBNET_IDS
 ----
 +
 * If you set the environmental variables, create a cluster with a single, initial machine pool, a publicly available API, and a publicly available Ingress by running the following command:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Quick typo fix for ROSA HCP Docs as I was going through the steps: 
* [Earlier steps](https://docs.openshift.com/rosa/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html#rosa-sts-byo-oidc_rosa-hcp-sts-creating-a-cluster-quickly) in the process use the variable `OIDC_ID` for the oidc config ID value
* [Later on](https://docs.openshift.com/rosa/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html#rosa-hcp-sts-creating-a-cluster-cli_rosa-hcp-sts-creating-a-cluster-quickly) its referenced as `ODIC_CONFIG` which is both inaccurate and also misspelled
* This change updates the reference in the create command to make use of the variable set earlier on in the process

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Latest ROSA

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
N/A -- I can open a GH issue if one is needed.

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
