### PR TITLE
OSDOCS#10302: Added the eu-central-2 region to the ROSA with HCP docs.

### DIFF
--- a/modules/rosa-sdpolicy-am-regions-az.adoc
+++ b/modules/rosa-sdpolicy-am-regions-az.adoc
@@ -60,6 +60,7 @@ endif::rosa-with-hcp[]
 ifndef::rosa-with-hcp[]
 * eu-west-3 (Paris)
 endif::rosa-with-hcp[]
+* eu-central-2 (Zurich, AWS opt-in required)
 * me-south-1 (Bahrain, AWS opt-in required)
 ifndef::rosa-with-hcp[]
 * me-central-1 (UAE, AWS opt-in required)

--- a/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc
@@ -31,6 +31,12 @@ include::modules/rosa-sdpolicy-am-aws-compute-types.adoc[leveloffset=+2]
 * link:https://aws.amazon.com/ec2/instance-types[AWS Instance Types]
 
 include::modules/rosa-sdpolicy-am-regions-az.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional Resources
+
+* link:https://docs.aws.amazon.com/general/latest/gr/rosa.html[Red Hat OpenShift Service on AWS endpoints and quotas]
+
 include::modules/rosa-sdpolicy-am-local-zones.adoc[leveloffset=+2]
 include::modules/rosa-sdpolicy-am-sla.adoc[leveloffset=+2]
 include::modules/rosa-sdpolicy-am-limited-support.adoc[leveloffset=+2]

--- a/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
@@ -32,6 +32,12 @@ include::modules/rosa-sdpolicy-am-aws-compute-types.adoc[leveloffset=+2]
 * link:https://aws.amazon.com/ec2/instance-types[AWS Instance Types]
 
 include::modules/rosa-sdpolicy-am-regions-az.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional Resources
+
+* link:https://docs.aws.amazon.com/general/latest/gr/rosa.html[Red Hat OpenShift Service on AWS endpoints and quotas]
+
 include::modules/rosa-sdpolicy-am-local-zones.adoc[leveloffset=+2]
 include::modules/rosa-sdpolicy-am-sla.adoc[leveloffset=+2]
 include::modules/rosa-sdpolicy-am-limited-support.adoc[leveloffset=+2]

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -17,6 +17,11 @@ toc::[]
 === Q2 2024
 
 * **ROSA CLI update.** The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-about_rosa-getting-started-cli[About the ROSA CLI].
+* **{hcp-title} regional availability update.** {hcp-title-first} is now available in the following regions:
++
+** Zurich (`eu-central-2`)
++
+For more information on region availabilities, see xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc#rosa-sdpolicy-regions-az_rosa-hcp-service-definition[Regions and availability zones].
 
 * **Longer cluster names enhancement.** You can now specify a cluster name that is longer than 15 characters. For cluster names that are longer than 15 characters, you can customize the domain prefix for the cluster URL by using the `domain-prefix` flag in the ROSA CLI (`rosa`) or by selecting the **Create custom domain prefix** checkbox in the {hybrid-console}. For more information, see xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-cluster-command_rosa-managing-objects-cli[create cluster in Managing objects with the ROSA CLI].
 


### PR DESCRIPTION
Version(s):
`enterprise-4.15+`

Issue:
**[OSDOCS-10302](https://issues.redhat.com/browse/OSDOCS-10302)**

Link to docs preview:
- [ROSA with HCP regions](https://file.rdu.redhat.com/eponvell/OSDOCS-10302_eu-central-2-zone/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-regions-az_rosa-hcp-service-definition)
- Added a link to ROSA Classic and ROSA with HCP that points to the AWS regions: 
![image](https://github.com/openshift/openshift-docs/assets/16167833/cdf89e45-5f63-41a4-8e01-4cd2be9a6f5f)
- [Release note](https://file.rdu.redhat.com/eponvell/OSDOCS-10302_eu-central-2-zone/rosa_release_notes/rosa-release-notes.html#rosa-q2-2024_rosa-whats-new)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added the `eu-central-2` region to ROSA with HCP docs.