### PR TITLE
WMCO applies image mirroring settings to Windows instances and disconnected support

### DIFF
--- a/modules/images-configuration-registry-mirror-configuring.adoc
+++ b/modules/images-configuration-registry-mirror-configuring.adoc
@@ -3,12 +3,24 @@
 // * openshift_images/image-configuration.adoc
 // * post_installation_configuration/preparing-for-users.adoc
 // * updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update.adoc
+// * windows_containers/enabling-windows-container-workloads.adoc
+
+ifeval::["{context}" == "enabling-windows-container-workloads"]
+:winc:
+endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="images-configuration-registry-mirror-configuring_{context}"]
 = Configuring image registry repository mirroring
 
 You can create postinstallation mirror configuration custom resources (CR) to redirect image pull requests from a source image registry to a mirrored image registry.
+
+ifdef::winc[]
+[IMPORTANT]
+====
+Windows images mirrored through `ImageDigestMirrorSet` and `ImageTagMirrorSet` objects have specific naming requirements. The final portion of the namespace and the image name of the mirror image must match the image being mirrored. For example, when mirroring the `mcr.microsoft.com/oss/kubernetes/pause:3.9` image, the mirror image must have the `<mirror_registry>/<optional_namespaces>/oss/kubernetes/pause:3.9` format. The `optional_namespaces` can be any number of leading repository namespaces.
+====
+endif::winc[]
 
 .Prerequisites
 ifndef::openshift-rosa,openshift-dedicated[]
@@ -22,6 +34,7 @@ endif::openshift-rosa,openshift-dedicated[]
 
 . Configure mirrored repositories, by either:
 +
+--
 * Setting up a mirrored repository with Red Hat Quay, as described in link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/manage_red_hat_quay/repo-mirroring-in-red-hat-quay[Red Hat Quay Repository Mirroring]. Using Red Hat Quay allows you to copy images from one repository to another and also automatically sync those repositories repeatedly over time.
 
 * Using a tool such as `skopeo` to copy images manually from the source repository to the mirrored repository.
@@ -30,15 +43,30 @@ For example, after installing the skopeo RPM package on a Red Hat Enterprise Lin
 +
 [source,terminal]
 ----
-$ skopeo copy \
+$ skopeo copy --all \
 docker://registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:5cf... \
 docker://example.io/example/ubi-minimal
 ----
 +
 In this example, you have a container image registry that is named `example.io` with an image repository named `example` to which you want to copy the `ubi9/ubi-minimal` image from `registry.access.redhat.com`. After you create the mirrored registry, you can configure your {product-title} cluster to redirect requests made of the source repository to the mirrored repository.
+--
++
+ifdef::winc[]
+[IMPORTANT]
+====
+You must mirror the `mcr.microsoft.com/oss/kubernetes/pause:3.9` image. For example, you could use the following `skopeo` command to mirror the image:
+
+[source,terminal]
+----
+$ skopeo copy \
+docker://mcr.microsoft.com/oss/kubernetes/pause:3.9\
+docker://example.io/oss/kubernetes/pause:3.9
+----
+====
 
 . Log in to your {product-title} cluster.
-
+endif::winc[]
+ifndef::winc[]
 . Create a postinstallation mirror configuration CR, by using one of the following examples:
 
 * Create an `ImageDigestMirrorSet` or `ImageTagMirrorSet` CR, as needed, replacing the source and mirrors with your own registry and repository pairs and images:
@@ -85,8 +113,8 @@ spec:
 ** `imageDigestMirrors`: Use for an `ImageDigestMirrorSet` CR.
 ** `imageTagMirrors`: Use for an `ImageTagMirrorSet` CR.
 <4> Indicates the name of the mirrored image registry and repository.
-<5> Optional: Indicates a secondary mirror repository for each target repository. If one mirror is down, the target repository can use another mirror.
-<6> Indicates the registry and repository source, which is the repository that is referred to in image pull specifications.
+<5> Optional: Indicates a secondary mirror repository for each target repository. If one mirror is down, the target repository can use the secondary mirror.
+<6> Indicates the registry and repository source, which is the repository that is referred to in an image pull specification.
 <7> Optional: Indicates the fallback policy if the image pull fails:
 ** `AllowContactingSource`: Allows continued attempts to pull the image from the source repository. This is the default.
 ** `NeverContactSource`: Prevents continued attempts to pull the image from the source repository.
@@ -115,6 +143,46 @@ spec:
 ----
 <1> Specifies the name of the mirror image registry and repository.
 <2> Specifies the online registry and repository containing the content that is mirrored.
+endif::winc[]
+ifdef::winc[]
+. Create an `ImageDigestMirrorSet` or `ImageTagMirrorSet` CR, as needed, replacing the source and mirrors with your own registry and repository pairs and images:
++
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1 <1>
+kind: ImageDigestMirrorSet <2>
+metadata:
+  name: ubi9repo
+spec:
+  imageDigestMirrors: <3>
+  - mirrors:
+    - example.io/example/ubi-minimal <4>
+    - example.com/example2/ubi-minimal <5>
+    source: registry.access.redhat.com/ubi9/ubi-minimal <6>
+    mirrorSourcePolicy: AllowContactingSource <7>
+  - mirrors:
+    - mirror.example.com
+    source: registry.redhat.io
+    mirrorSourcePolicy: NeverContactSource
+  - mirrors:
+    - docker.io
+    source: docker-mirror.internal
+    mirrorSourcePolicy: AllowContactingSource
+----
+<1> Indicates the API to use with this CR. This must be `config.openshift.io/v1`.
+<2> Indicates the kind of object according to the pull type:
+** `ImageDigestMirrorSet`: Pulls a digest reference image.
+** `ImageTagMirrorSet`: Pulls a tag reference image.
+<3> Indicates the type of image pull method, either:
+** `imageDigestMirrors`: Use for an `ImageDigestMirrorSet` CR.
+** `imageTagMirrors`: Use for an `ImageTagMirrorSet` CR.
+<4> Indicates the name of the mirrored image registry and repository. 
+<5> Optional: Indicates a secondary mirror repository for each target repository. If one mirror is down, the target repository can use another mirror.
+<6> Indicates the registry and repository source, which is the repository that is referred to in image pull specifications.
+<7> Optional: Indicates the fallback policy if the image pull fails:
+** `AllowContactingSource`: Allows continued attempts to pull the image from the source repository. This is the default.
+** `NeverContactSource`: Prevents continued attempts to pull the image from the source repository.
+endif::winc[]
 
 . Create the new object:
 +
@@ -123,7 +191,9 @@ spec:
 $ oc create -f registryrepomirror.yaml
 ----
 +
+ifndef::winc[]
 After the object is created, the Machine Config Operator (MCO) drains the nodes for `ImageTagMirrorSet` objects only. The MCO does not drain the nodes for `ImageDigestMirrorSet` and `ImageContentSourcePolicy` objects.
+endif::winc[]
 
 . To check that the mirrored configuration settings are applied, do the following on one of the nodes.
 
@@ -167,6 +237,7 @@ To use host binaries, run `chroot /host`
 sh-4.2# chroot /host
 ----
 
+ifndef::winc[]
 .. Check the `/etc/containers/registries.conf` file to make sure the changes were made:
 +
 [source,terminal]
@@ -247,6 +318,56 @@ short-name-mode = ""
 <3> Indicates that the image pull from the mirror is a digest reference image.
 <4> Indicates that the `NeverContactSource` parameter is set for this repository.
 <5> Indicates that the image pull from the mirror is a tag reference image.
+endif::winc[]
+ifdef::winc[]
+.. Check that the WMCO generated a `hosts.toml` file for each registry on each Windows instance. For the previous example IDMS object, there should be three files in the following file structure:
++
+[source,terminal]
+----
+$ tree $config_path
+----
++
+[source,terminal]
+.Example output
+----
+C:/k/containerd/registries/
+|── registry.access.redhat.com
+|   └── hosts.toml
+|── mirror.example.com
+|   └── hosts.toml
+└── docker.io
+    └── hosts.toml:
+----
++
+The following output represents a `hosts.toml` containerd configuration file where the previous example IDMS object was applied.
++
+[source,terminal]
+.Example host.toml files
+----
+$ cat "$config_path"/registry.access.redhat.com/host.toml
+server = "https://registry.access.redhat.com" # default fallback server since "AllowContactingSource" mirrorSourcePolicy is set
+
+[host."https://example.io/example/ubi-minimal"]
+ capabilities = ["pull"]
+
+[host."https://example.com/example2/ubi-minimal"] # secondary mirror
+ capabilities = ["pull"]
+
+
+$ cat "$config_path"/registry.redhat.io/host.toml
+# "server" omitted since "NeverContactSource" mirrorSourcePolicy is set
+
+[host."https://mirror.example.com"]
+ capabilities = ["pull"]
+
+
+$ cat "$config_path"/docker.io/host.toml
+server = "https://docker.io"
+
+[host."https://docker-mirror.internal"]
+ capabilities = ["pull", "resolve"] # resolve tags
+----
+endif::winc[]
 
 .. Pull an image to the node from the source and check if it is resolved by the mirror.
 +
@@ -262,4 +383,10 @@ If the repository mirroring procedure does not work as described, use the follow
 * The first working mirror is used to supply the pulled image.
 * The main registry is only used if no other mirror works.
 * From the system context, the `Insecure` flags are used as fallback.
+ifndef::winc[]
 * The format of the `/etc/containers/registries.conf` file has changed recently. It is now version 2 and in TOML format.
+endif::winc[]
+
+ifeval::["{context}" == "enabling-windows-container-workloads"]
+:!winc:
+endif::[]

--- a/modules/images-configuration-registry-mirror.adoc
+++ b/modules/images-configuration-registry-mirror.adoc
@@ -3,6 +3,11 @@
 // * openshift_images/image-configuration.adoc
 // * post_installation_configuration/preparing-for-users.adoc
 // * updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update.adoc
+// * windows_containers/enabling-windows-container-workloads.adoc
+
+ifeval::["{context}" == "enabling-windows-container-workloads"]
+:winc:
+endif::[]
 
 :_mod-docs-content-type: CONCEPT
 [id="images-configuration-registry-mirror_{context}"]
@@ -18,7 +23,12 @@ Repository mirroring in {product-title} includes the following attributes:
 * Image pulls are resilient to registry downtimes.
 * Clusters in disconnected environments can pull images from critical locations, such as quay.io, and have registries behind a company firewall provide the requested images.
 * A particular order of registries is tried when an image pull request is made, with the permanent registry typically being the last one tried.
+ifndef::winc[]
 * The mirror information you enter is added to the `/etc/containers/registries.conf` file on every node in the {product-title} cluster.
+endif::winc[]
+ifdef::winc[]
+* The mirror information you enter is added to the appropriate `hosts.toml` containerd configuration file(s) on every Windows node in the {product-title} cluster.
+endif::winc[]
 * When a node makes a request for an image from the source repository, it tries each mirrored repository in turn until it finds the requested content. If all mirrors fail, the cluster tries the source repository. If successful, the image is pulled to the node.
 
 Setting up repository mirroring can be done in the following ways:
@@ -35,14 +45,19 @@ If you did not configure mirroring during {product-title} installation, you can 
 ** `ImageDigestMirrorSet` (IDMS). This object allows you to pull images from a mirrored registry by using digest specifications. The IDMS CR enables you to set a fall back policy that allows or stops continued attempts to pull from the source registry if the image pull fails.
 +
 ** `ImageTagMirrorSet` (ITMS). This object allows you to pull images from a mirrored registry by using image tags. The ITMS CR enables you to set a fall back policy that allows or stops continued attempts to pull from the source registry if the image pull fails.
+// Hiding ICSP as it is not supported in WINC
+ifndef::winc[]
 +
 ** `ImageContentSourcePolicy` (ICSP). This object allows you to pull images from a mirrored registry by using digest specifications. The ICSP CR always falls back to the source registry if the mirrors do not work.
+endif::winc[]
 --
+ifndef::winc[]
 +
 [IMPORTANT]
 ====
 Using an `ImageContentSourcePolicy` (ICSP) object to configure repository mirroring is a deprecated feature. Deprecated functionality is still included in {product-title} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments. If you have existing YAML files that you used to create `ImageContentSourcePolicy` objects, you can use the `oc adm migrate icsp` command to convert those files to an `ImageDigestMirrorSet` YAML file. For more information, see "Converting ImageContentSourcePolicy (ICSP) files for image registry repository mirroring" in the following section.
 ====
+endif::winc[]
 
 Each of these custom resource objects identify the following information:
 --
@@ -51,8 +66,22 @@ Each of these custom resource objects identify the following information:
 requested from the source repository.
 --
 
+ifndef::winc[]
 For new clusters, you can use IDMS, ITMS, and ICSP CRs objects as desired. However, using IDMS and ITMS is recommended.
 
 If you upgraded a cluster, any existing ICSP objects remain stable, and both IDMS and ICSP objects are supported. Workloads using ICSP objects continue to function as expected. However, if you want to take advantage of the fallback policies introduced in the IDMS CRs, you can migrate current workloads to IDMS objects by using the `oc adm migrate icsp` command as shown in the *Converting ImageContentSourcePolicy (ICSP) files for image registry repository mirroring* section that follows. Migrating to IDMS objects does not require a cluster reboot.
 
-include::snippets/idms-global-pull-secret.adoc[]
+include::snippets/idms-global-pull-secret.adoc[]endif::winc[]
+endif::winc[]
+ifdef::winc[]
+The Windows Machine Config Operator (WMCO) watches for changes to the IDMS and ITMS resources and generates a set of `hosts.toml` containerd configuration files, one file for each source registry, with those changes. The WMCO then updates any existing Windows nodes to use the new registry configuration.
+
+[NOTE]
+====
+The IDMS and ITMS objects must be created before you can add Windows nodes using a mirrored registry.
+====
+endif::winc[]
+
+ifeval::["{context}" == "enabling-windows-container-workloads"]
+:!winc:
+endif::[]

--- a/modules/machineset-creating.adoc
+++ b/modules/machineset-creating.adoc
@@ -59,6 +59,9 @@ endif::vsphere[]
 ifdef::ash[]
 * Create an availability set in which to deploy Azure Stack Hub compute machines.
 endif::ash[]
+ifdef::win[]
+* In disconnected environments, the image specified in the `MachineSet` custom resource (CR) must have the link:https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse?tabs=powershell#install-openssh-for-windows[OpenSSH server v0.0.1.0 installed].
+endif::win[]
 
 .Procedure
 

--- a/modules/wmco-disconnected-cluster.adoc
+++ b/modules/wmco-disconnected-cluster.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// windows_containers/enabling-windows-container-workloads.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="wmco-disconnected-cluster_{context}"]
+= Using Windows containers with a mirror registry
+
+The Windows Machine Config Operator (WMCO) can pull images from a registry mirror rather than from a public registry by using an `ImageDigestMirrorSet` (IDMS) or `ImageTagMirrorSet` (ITMS) object to configure your cluster to pull images from the mirror registry.
+
+A mirror registry has the following benefits: 
+
+* Avoids public registry outages 
+* Speeds up node and pod creation
+* Pulls images from behind your organization's firewall
+
+A mirror registry can also be used with a {product-title} cluster in a disconnected, or air-gapped, network. A _disconnected network_ is a restricted network without direct internet connectivity. Because the cluster does not have access to the internet, any external container images cannot be referenced.
+
+Using a mirror registry requires the following general steps:
+
+* Create the mirror registry, using a tool such as Red Hat Quay.
+* Create a container image registry credentials file.
+* Copy the images from your online image repository to your mirror registry.
+
+For information about these steps, see "About disconnected installation mirroring."
+
+After creating the mirror registry and mirroring the images, you can use an `ImageDigestMirrorSet` (IDMS) or `ImageTagMirrorSet` (ITMS) object to configure your cluster to pull images from the mirror registry without needing to update each of your pod specs. The IDMS and ITMS objects redirect requests to pull images from a repository on a source image registry and have it resolved by the mirror repository instead. 
+
+If changes are made to the IDMS or ITMS object, the WMCO automatically updates the appropriate `hosts.toml` file on your Windows nodes with the new information. Note that the WMCO sequentially updates each Windows node when mirror settings are changed. As such, the time required for these updates increases with the number of Windows nodes in the cluster.
+
+Also, because Windows nodes configured by the WMCO rely on containerd container runtime, the WMCO ensures that the containerd config files are up-to-date with the registry settings. For new nodes, these files are copied to the instances upon creation. For existing nodes, after activating the mirror registry, the registry controller uses SSH to access each node and copy the generated config files, replacing any existing files.
+
+You can use a mirror registry with machine set or Bring-Your-Own-Host (BYOH) Windows nodes.
+

--- a/snippets/idms-global-pull-secret.adoc
+++ b/snippets/idms-global-pull-secret.adoc
@@ -3,8 +3,11 @@
 // * modules/builds-image-source
 // * modules/images-configuration-registry-mirror
 
-:_mod-docs-content-type: SNIPPET
+ifeval::["{context}" == "enabling-windows-container-workloads"]
+:winc:
+endif::[]
 
+:_mod-docs-content-type: SNIPPET
 
 [NOTE]
 ====

--- a/windows_containers/enabling-windows-container-workloads.adoc
+++ b/windows_containers/enabling-windows-container-workloads.adoc
@@ -28,7 +28,7 @@ Dual NIC is not supported on WMCO-managed Windows instances.
 
 [NOTE]
 ====
-Windows instances deployed by the WMCO are configured with the containerd container runtime. Because WMCO installs and manages the runtime, it is recommanded that you do not manually install containerd on nodes.
+Windows instances deployed by the WMCO are configured with the containerd container runtime. Because WMCO installs and manages the runtime, it is recommended that you do not manually install containerd on nodes.
 ====
 
 [role="_additional-resources"]
@@ -52,6 +52,15 @@ include::modules/wmco-cluster-wide-proxy.adoc[leveloffset=+1]
 
 * xref:../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[Configuring the cluster-wide proxy].
 
+include::modules/wmco-disconnected-cluster.adoc[leveloffset=+1]
+
+.Additional references
+
+* xref:../installing/disconnected_install/index.adoc#installing-mirroring-disconnected-about[About disconnected installation mirroring]
+
+include::modules/images-configuration-registry-mirror.adoc[leveloffset=+2]
+
+include::modules/images-configuration-registry-mirror-configuring.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 == Additional resources


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-10100

https://issues.redhat.com/browse/WINC-936
https://issues.redhat.com/browse/WINC-1221 hosts.toml
https://issues.redhat.com/browse/WINC-1222 mirroring
https://issues.redhat.com/browse/WINC-1294  token added to hosts.toml
https://github.com/openshift/enhancements/pull/1531 enhancement doc
https://github.com/openshift/windows-machine-config-operator/pull/2238/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R228 -- Internal doc


Previews

* Windows Container Support for OpenShift -> Enabling Windows container workloads -> [Using Windows containers with a mirror registry](https://74918--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/enabling-windows-container-workloads.html#wmco-disconnected-cluster_enabling-windows-container-workloads) -- New module.

* Windows Container Support for OpenShift -> Enabling Windows container workloads -> [Understanding image registry repository mirroring](https://74918--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/enabling-windows-container-workloads.html#images-configuration-registry-mirror_enabling-windows-container-workloads) -- [Various changes for WMCO-specific environments](https://github.com/openshift/openshift-docs/pull/74918/files#diff-5fa1176e0fd07350c91b903bf4d7eb0f9fa8eaa37343148a503fcb82823b6da6).
[Example of a non-Windows use of the module](https://74918--ocpdocs-pr.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration#images-configuration-registry-mirror_image-configuration)

* Windows Container Support for OpenShift -> Enabling Windows container workloads -> [Configuring image registry repository mirroring](https://74918--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/enabling-windows-container-workloads.html#images-configuration-registry-mirror-configuring_enabling-windows-container-workloads) -- [Various changes for WMCO-specific environments](https://github.com/openshift/openshift-docs/pull/74918/files#diff-27a101211672fed423ee44a9a33b205e3f03d0c45f9e6522c230de0a83cb70ed), including [updated snippet](https://github.com/openshift/openshift-docs/pull/74918/files#diff-f6adbadac7d50b41c9000f5f079469f8e25918c47f4c977274b167df2a831345). 
[Example of a non-Windows use of the module](https://74918--ocpdocs-pr.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration#images-configuration-registry-mirror-configuring_image-configuration)
*  Windows Container Support for OpenShift -> Creating Windows machine sets -> Creating a Windows machine set on AWS -> [Creating a compute machine set](https://74918--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws#machineset-creating_creating-windows-machineset-aws) -- Added 4th prereq bullet

- [x] SME has approved this change.
- [x] QE has approved this change.
