### PR TITLE
CNV-27866: [Doc] expose the downwardMetrics through a virtio-serial channel

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -4185,6 +4185,8 @@ Topics:
     File: virt-prometheus-queries
   - Name: Virtual machine custom metrics
     File: virt-exposing-custom-metrics-for-vms
+  - Name: Virtual machine downward metrics
+    File: virt-exposing-downward-metrics
   - Name: Virtual machine health checks
     File: virt-monitoring-vm-health
   - Name: Runbooks

--- a/modules/virt-configuring-downward-metrics.adoc
+++ b/modules/virt-configuring-downward-metrics.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// * virt/monitoring/virt-exposing-downward-metrics.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-configuring-downward-metrics_virt-using-downward-metrics_{context}"]
+= Configuring a downward metrics device
+
+You enable the capturing of downward metrics for a host VM by creating a configuration file that includes a `downwardMetrics` device. Adding this device establishes that the metrics are exposed through a `virtio-serial` port.
+
+.Prerequisites
+
+* You must first enable the `downwardMetrics` feature gate.
+
+.Procedure
+
+* Edit or create a YAML file that includes a `downwardMetrics` device, as shown in the following example:
++
+.Example downwardMetrics configuration file
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: fedora
+  namespace: default
+spec:
+  dataVolumeTemplates:
+    - metadata:
+        name: fedora-volume
+      spec:
+        sourceRef:
+          kind: DataSource
+          name: fedora
+          namespace: openshift-virtualization-os-images
+        storage:
+          resources: {}
+          storageClassName: hostpath-csi-basic
+  instancetype:
+    name: u1.medium
+  preference:
+    name: fedora
+  running: true
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: headless
+    spec:
+      domain:
+        devices:
+          downwardMetrics: {} <1>
+      subdomain: headless
+      volumes:
+        - dataVolume:
+            name: fedora-volume
+          name: rootdisk
+        - cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              chpasswd:
+                expire: false
+              password: '<password>' <2>
+              user: fedora
+          name: cloudinitdisk
+----
+<1> The `downwardMetrics` device.
+<2> The password for the `fedora` user.

--- a/modules/virt-enabling-disabling-downward-metrics-feature-gate-cli.adoc
+++ b/modules/virt-enabling-disabling-downward-metrics-feature-gate-cli.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * virt/monitoring/virt-exposing-downward-metrics.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-enabling-disabling-downward-metrics-feature-gate-cli_{context}"]
+= Enabling or disabling the downward metrics feature gate from the command line
+
+To expose downward metrics for a host virtual machine, you can enable the `downwardMetrics` feature gate by using the command line.
+
+.Prerequisites
+
+* You must have administrator privileges to enable the feature gate.
+
+.Procedure
+
+* Choose to enable or disable the `downwardMetrics` feature gate as follows:
+
+** Enable the `downwardMetrics` feature gate by running the command shown in the following example:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc patch hco kubevirt-hyperconverged -n openshift-cnv \
+  --type json -p '[{"op": "replace", "path": \
+  "/spec/featureGates/downwardMetrics" \
+  "value": true}]'
+----
+
+** Disable the `downwardMetrics` feature gate by running the command shown in the following example:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc patch hco kubevirt-hyperconverged -n openshift-cnv \
+  --type json -p '[{"op": "replace", "path": \
+  "/spec/featureGates/downwardMetrics" \
+  "value": false}]'
+----

--- a/modules/virt-enabling-disabling-downward-metrics-feature-gate-yaml.adoc
+++ b/modules/virt-enabling-disabling-downward-metrics-feature-gate-yaml.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// * virt/monitoring/virt-exposing-downward-metrics.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-enabling-disabling-downward-metrics-feature-gate-yaml_{context}"]
+= Enabling or disabling the downward metrics feature gate in a YAML file
+
+To expose downward metrics for a host virtual machine, you can enable the `downwardMetrics` feature gate by editing a YAML file.
+
+.Prerequisites
+
+* You must have administrator privileges to enable the feature gate.
+
+.Procedure
+
+. Open the HyperConverged custom resource (CR) in your default editor by running the following command:
++
+[source,terminal]
+----
+$ oc edit hyperconverged kubevirt-hyperconverged -n openshift-cnv
+----
+
+. Choose to enable or disable the downwardMetrics feature gate as follows:
+
+* To enable the `downwardMetrics` feature gate, add and then set `spec.featureGates.downwardMetrics` to `true`. For example:
++
+[source,yaml]
+----
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: openshift-cnv
+spec:
+    featureGates:
+      downwardMetrics: true
+# ...
+----
+
+
+* To disable the `downwardMetrics` feature gate, set `spec.featureGates.downwardMetrics` to `false`. For example:
++
+[source,yaml]
+----
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: openshift-cnv
+spec:
+    featureGates:
+      downwardMetrics: false
+# ...
+----

--- a/modules/virt-viewing-downward-metrics-cli.adoc
+++ b/modules/virt-viewing-downward-metrics-cli.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * virt/monitoring/virt-exposing-downward-metrics.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-viewing-downward-metrics-cli_{context}"]
+= Viewing downward metrics by using the command line
+
+You can view downward metrics by entering a command from inside a guest virtual machine (VM).
+
+.Procedure
+
+* Run the following commands:
++
+[source,terminal]
+----
+$ sudo sh -c 'printf "GET /metrics/XML\n\n" > /dev/virtio-ports/org.github.vhostmd.1'
+----
++
+[source,terminal]
+----
+$ sudo cat /dev/virtio-ports/org.github.vhostmd.1
+----

--- a/modules/virt-viewing-downward-metrics-tool.adoc
+++ b/modules/virt-viewing-downward-metrics-tool.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * virt/monitoring/virt-exposing-downward-metrics.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-viewing-downward-metrics-tool_{context}"]
+= Viewing downward metrics by using the vm-dump-metrics tool
+
+To view downward metrics, install the `vm-dump-metrics` tool and then use the tool to expose the metrics results.
+
+.Procedure
+
+. Install the `vm-dump-metrics` tool by running the following command:
++
+[source,terminal]
+----
+$ sudo dnf install -y vm-dump-metrics
+----
+
+. Retrieve the metrics results by running the following command:
++
+[source,terminal]
+----
+$ sudo vm-dump-metrics
+----
++
+.Example output
+[source,xml]
+----
+<metrics>
+  <metric type="string" context="host">
+    <name>HostName</name>
+    <value>node01</value>
+[...]
+  <metric type="int64" context="host" unit="s">
+    <name>Time</name>
+    <value>1619008605</value>
+  </metric>
+  <metric type="string" context="host">
+    <name>VirtualizationVendor</name>
+    <value>kubevirt.io</value>
+  </metric>
+</metrics>
+----

--- a/modules/virt-viewing-downward-metrics.adoc
+++ b/modules/virt-viewing-downward-metrics.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * virt/monitoring/virt-using-downward-metrics.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-viewing-downward-metrics_{context}"]
+= Viewing downward metrics
+
+You can view downward metrics by using either of the following options:
+
+* The command line interface (CLI)
+* The `vm-dump-metrics` tool
+

--- a/virt/monitoring/virt-exposing-downward-metrics.adoc
+++ b/virt/monitoring/virt-exposing-downward-metrics.adoc
@@ -1,0 +1,32 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="virt-exposing-downward-metrics"]
+= Exposing downward metrics for virtual machines
+include::_attributes/common-attributes.adoc[]
+:context: virt-exposing-downward-metrics
+
+toc::[]
+
+As an administrator, you can expose a limited set of host and virtual machine (VM) metrics to a guest VM by first enabling a `downwardMetrics` feature gate and then configuring a `downwardMetrics` device.
+
+Users can view the metrics results by using the command line or the `vm-dump-metrics tool`.
+
+[id="virt-enabling-disabling-feature-gate"]
+== Enabling or disabling the downwardMetrics feature gate
+
+You can enable or disable the `downwardMetrics` feature gate by performing either of the following actions:
+
+* Editing the HyperConverged custom resource (CR) in your default editor
+* Using the command line
+
+include::modules/virt-enabling-disabling-downward-metrics-feature-gate-yaml.adoc[leveloffset=+2]
+
+include::modules/virt-enabling-disabling-downward-metrics-feature-gate-cli.adoc[leveloffset=+2]
+
+include::modules/virt-configuring-downward-metrics.adoc[leveloffset=+1]
+
+include::modules/virt-viewing-downward-metrics.adoc[leveloffset=+1]
+
+include::modules/virt-viewing-downward-metrics-cli.adoc[leveloffset=+2]
+
+include::modules/virt-viewing-downward-metrics-tool.adoc[leveloffset=+2]
+


### PR DESCRIPTION
Version(s): 4.16

Issue: [CNV-27866](https://issues.redhat.com/browse/CNV-27866)

Links to docs previews: 

[Exposing downward metrics for virtual machines](https://74920--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-exposing-downward-metrics.html)

[Enabling or disabling the downwardMetrics feature gate](https://74920--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-exposing-downward-metrics.html#virt-enabling-disabling-feature-gate)

- [Enabling or disabling the downward metrics feature gate in a YAML file](https://74920--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-exposing-downward-metrics.html#virt-enabling-disabling-downward-metrics-feature-gate-yaml_virt-exposing-downward-metrics)

- [Enabling or disabling the downward metrics feature gate from the command line](https://74920--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-exposing-downward-metrics.html#virt-enabling-disabling-downward-metrics-feature-gate-yaml_virt-exposing-downward-metrics)

 [Configuring a downward metrics device](https://74920--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-exposing-downward-metrics.html#virt-configuring-downward-metrics_virt-using-downward-metrics)

[Viewing downward metrics](https://74920--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-exposing-downward-metrics.html#virt-viewing-downward-metrics_virt-exposing-downward-metrics)

-  [ Viewing downward metrics by using the command line](https://74920--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-exposing-downward-metrics.html#virt-viewing-downward-metrics-cli_virt-exposing-downward-metrics)

-  [Viewing downward metrics by using the vm-metrics-tool](https://74920--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-exposing-downward-metrics.html#virt-viewing-downward-metrics-tool_virt-exposing-downward-metrics)

QE review:
- [x] QE has approved this change.




<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
