### PR TITLE
[enterprise-4.14] OCPBUGS#32509: Doc improvements related to installation and uninstallation modules

### DIFF
--- a/modules/lvms-about-lvm-storage-installation.adoc
+++ b/modules/lvms-about-lvm-storage-installation.adoc
@@ -6,7 +6,7 @@
 [id="lvms-about-lvm-storage-installation_{context}"]
 = Logical Volume Manager Storage installation
 
-You can install Logical Volume Manager (LVM) Storage on a {sno} cluster and configure it to dynamically provision storage for your workloads.
+You can install {lvms-first} on a {sno} cluster and configure it to dynamically provision storage for your workloads.
 
 You can deploy {lvms} on {sno} clusters by using the {product-title} CLI (`oc`), {product-title} web console, or {rh-rhacm-first}.
 

--- a/modules/lvms-installing-logical-volume-manager-operator-disconnected-environment.adoc
+++ b/modules/lvms-installing-logical-volume-manager-operator-disconnected-environment.adoc
@@ -6,20 +6,20 @@
 [id="lvms-installing-lvms-disconnected-env_{context}"]
 = Installing {lvms} in a disconnected environment
 
-You can install {lvms} on {product-title} {product-version} in a disconnected environment. All sections referenced in this procedure are linked in _Additional resources_.
+You can install {lvms-first} on {product-title} {product-version} in a disconnected environment. All sections referenced in this procedure are linked in the "Additional resources" section.
 
 .Prerequisites
 
-* You read the _About disconnected installation mirroring_ section.
+* You read the "About disconnected installation mirroring" section.
 * You have access to the {product-title} image repository.
 * You created a mirror registry.
 
 .Procedure
 
-. Follow the steps in the _Creating the image set configuration_ procedure. To create an `ImageSetConfiguration` resource for {lvms}, you can use the following example YAML file:
+. Follow the steps in the "Creating the image set configuration" procedure. To create an image set configuration for {lvms}, you can use the following example `ImageSetConfiguration` object configuration:
 +
 include::snippets/lvms-disconnected-ImageSetConfig.adoc[]
 
-. Follow the procedure in the _Mirroring an image set to a mirror registry_ section.
+. Follow the procedure in the "Mirroring an image set to a mirror registry" section.
 
-. Follow the procedure in the _Configuring image registry repository mirroring_ section.
+. Follow the procedure in the "Configuring image registry repository mirroring" section.

--- a/modules/lvms-installing-logical-volume-manager-operator-using-cli.adoc
+++ b/modules/lvms-installing-logical-volume-manager-operator-using-cli.adoc
@@ -4,22 +4,21 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="install-lvms-operator-cli_{context}"]
-= Installing {lvms} with the CLI
+= Installing {lvms} by using the CLI
 
-As a cluster administrator, you can install {lvms-first} by using the CLI.
+As a cluster administrator, you can install {lvms-first} by using the OpenShift CLI (`oc`).
 
 .Prerequisites
 
 * You have installed the OpenShift CLI (`oc`).
 
-* You have logged in as a user with `cluster-admin` privileges.
+* You have logged in to {product-title} as a user with `cluster-admin` and Operator installation permissions.
 
 .Procedure
 
-. Create a namespace for the {lvms} Operator.
-
-.. Save the following YAML in the `lvms-namespace.yaml` file:
+. Create a YAML file and add the configuration for creating a namespace.
 +
+.Example YAML configuration for creating a namespace
 [source,yaml]
 ----
 apiVersion: v1
@@ -33,17 +32,16 @@ metadata:
   name: openshift-storage
 ----
 
-.. Create the `Namespace` CR:
+. Create the namespace by running the following command:
 +
 [source,terminal]
 ----
-$ oc create -f lvms-namespace.yaml
+$ oc create -f <file_name>
 ----
 
-. Create an Operator group for the {lvms} Operator.
-
-.. Save the following YAML in the `lvms-operatorgroup.yaml` file:
+. Create an `OperatorGroup` custom resource (CR) YAML file.
 +
+.Example `OperatorGroup` CR
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1
@@ -56,17 +54,16 @@ spec:
   - openshift-storage
 ----
 
-.. Create the `OperatorGroup` CR:
+. Create the `OperatorGroup` CR by running the following command:
 +
 [source,terminal]
 ----
-$ oc create -f lvms-operatorgroup.yaml
+$ oc create -f <file_name>
 ----
 
-. Subscribe to the {lvms} Operator.
-
-.. Save the following YAML in the `lvms-sub.yaml` file:
+. Create a `Subscription` CR YAML file.
 +
+.Example `Subscription` CR
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -81,14 +78,16 @@ spec:
   sourceNamespace: openshift-marketplace
 ----
 
-.. Create the `Subscription` CR:
+. Create the `Subscription` CR by running the following command:
 +
 [source,terminal]
 ----
-$ oc create -f lvms-sub.yaml
+$ oc create -f <file_name>
 ----
 
-. To verify that the Operator is installed, enter the following command:
+.Verification
+
+. To verify that {lvms} is installed, run the following command:
 +
 [source,terminal]
 ----

--- a/modules/lvms-installing-logical-volume-manager-operator-using-openshift-web-console.adoc
+++ b/modules/lvms-installing-logical-volume-manager-operator-using-openshift-web-console.adoc
@@ -4,33 +4,35 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="lvms-installing-lvms-with-web-console_{context}"]
-= Installing {lvms} with the web console
+= Installing {lvms} by using the web console
 
-You can install {lvms-first} by using the Red Hat {product-title} OperatorHub.
+You can install {lvms-first} by using the {product-title} web console.
 
 .Prerequisites
 
 * You have access to the {sno} cluster.
-* You are using an account with the `cluster-admin` and Operator installation permissions.
+* You have access to {product-title} with `cluster-admin` and Operator installation permissions.
 
 .Procedure
 
-. Log in to the {product-title} Web Console.
+. Log in to the {product-title} web console.
 . Click *Operators -> OperatorHub*.
-. Scroll or type `LVM Storage` into the *Filter by keyword* box to find {lvms}.
-. Click *Install*.
-. Set the following options on the *Install Operator* page:
+. Click *LVM Storage* on the *OperatorHub* page.
+. Set the following options on the *Operator Installation* page:
 .. *Update Channel* as *stable-{product-version}*.
 .. *Installation Mode* as *A specific namespace on the cluster*.
 .. *Installed Namespace* as *Operator recommended namespace openshift-storage*.
    If the `openshift-storage` namespace does not exist, it is created during the operator installation.
-.. *Approval Strategy* as *Automatic* or *Manual*.
+.. *Update approval* as *Automatic* or *Manual*.
 +
-If you select *Automatic* updates, then the Operator Lifecycle Manager (OLM) automatically upgrades the running instance of your Operator without any intervention.
-+
-If you select *Manual* updates, then the OLM creates an update request.
-As a cluster administrator, you must then manually approve that update request to update the Operator to a newer version.
+[NOTE]
+====
+If you select *Automatic* updates, the Operator Lifecycle Manager (OLM) automatically updates the running instance of {lvms} without any intervention.
 
+If you select *Manual* updates, the OLM creates an update request.
+As a cluster administrator, you must manually approve the update request to update {lvms} to a newer version.
+====
+. Optional: Select the *Enable Operator recommended cluster monitoring on this Namespace* checkbox.
 . Click *Install*.
 
 .Verification steps

--- a/modules/lvms-uninstalling-logical-volume-manager-operator-using-openshift-web-console.adoc
+++ b/modules/lvms-uninstalling-logical-volume-manager-operator-using-openshift-web-console.adoc
@@ -6,21 +6,20 @@
 [id="lvms-unstalling-lvms-with-web-console_{context}"]
 = Uninstalling {lvms} using the web console
 
-You can uninstall {lvms} using the {product-title} web console.
+You can uninstall {lvms-first} using the {product-title} web console.
 
 .Prerequisites
 
-* You deleted all the applications on the clusters that are using the storage provisioned by {lvms}.
-* You deleted the persistent volume claims (PVCs) and persistent volumes (PVs) provisioned using {lvms}.
-* You deleted all volume snapshots provisioned by {lvms}.
-* You verified that no logical volume resources exist by using the `oc get logicalvolume` command.
-* You have access to the {sno} cluster using an account with `cluster-admin` permissions.
+* You have access to the {sno} cluster as a user with `cluster-admin` permissions.
+* You have deleted the persistent volume claims (PVCs), volume snapshots, and volume clones provisioned by {lvms}. You have also deleted the applications that are using these resources.
+* You have deleted the `LVMCluster` custom resource (CR).
 
 .Procedure
 
-. From the *Operators* → *Installed Operators* page, scroll to *LVM Storage* or type `LVM Storage` into the *Filter by name* to find and click on it.
-. Click on the *LVMCluster* tab.
-. On the right-hand side of the *LVMCluster* page, select *Delete LVMCluster* from the *Actions* drop-down menu.
-. Click on the *Details* tab.
-. On the right-hand side of the *Operator Details* page, select *Uninstall Operator* from the *Actions* drop-down menu.
-. Select *Remove*. {lvms} stops running and is completely removed.
+. Log in to the {product-title} web console.
+. Click *Operators* -> *Installed Operators*.
+. Click *LVM Storage* in the `openshift-storage` namespace.
+. Click the *Details* tab. 
+. From the *Actions* menu, click *Uninstall Operator*.
+. Optional: When prompted, select the *Delete all operand instances for this operator* checkbox to delete the operand instances for {lvms}. 
+. Click *Uninstall*.

--- a/snippets/lvms-disconnected-ImageSetConfig.adoc
+++ b/snippets/lvms-disconnected-ImageSetConfig.adoc
@@ -25,12 +25,12 @@ mirror:
   - name: registry.redhat.io/ubi9/ubi:latest <9>
   helm: {}
 ----
-<1> Add `archiveSize` to set the maximum size, in GiB, of each file within the image set.
-<2> Set the back-end location to save the image set metadata to. This location can be a registry or local directory. It is required to specify `storageConfig` values, unless you are using the Technology Preview OCI feature.
-<3> Set the registry URL for the storage backend.
-<4> Set the channel to retrieve the {product-title} images from.
-<5> Add `graph: true` to generate the OpenShift Update Service (OSUS) graph image to allow for an improved cluster update experience when using the web console. For more information, see _About the OpenShift Update Service_.
-<6> Set the Operator catalog to retrieve the {product-title} images from.
-<7> Specify only certain Operator packages to include in the image set. Remove this field to retrieve all packages in the catalog.
-<8> Specify only certain channels of the Operator packages to include in the image set. You must always include the default channel for the Operator package even if you do not use the bundles in that channel. You can find the default channel by running the following command: `oc mirror list operators --catalog=<catalog_name> --package=<package_name>`.
-<9> Specify any additional images to include in image set.
+<1> Set the the maximum size (in gibibytes) of each file within the image set.
+<2> Specify the location in which you want to save the image set. This location can be a registry or a local directory.
+<3> Specify the storage URL for the image stream when using a registry. For more information, see "Why use imagestreams".
+<4> Specify the channel from which you want to retrieve the {product-title} images.
+<5> Set this field to `true` to generate the OpenShift Update Service (OSUS) graph image. For more information, see "About the OpenShift Update Service".
+<6> Specify the Operator catalog from which you want to retrieve the {product-title} images.
+<7> Specify the Operator packages to include in the image set. If this field is empty, all packages in the catalog are retrieved.
+<8> Specify the channels of the Operator packages to include in the image set. You must include the default channel for the Operator package even if you do not use the bundles in that channel. You can find the default channel by running the following command: `$ oc mirror list operators --catalog=<catalog_name> --package=<package_name>`.
+<9> Specify any additional images to include in the image set.

--- a/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
+++ b/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
@@ -6,9 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{lvms-first} uses the TopoLVM CSI driver to dynamically provision local storage on {sno} clusters.
-
-{lvms} creates thin-provisioned volumes using Logical Volume Manager and provides dynamic provisioning of block storage on a limited resources {sno} cluster.
+{lvms-first} uses Logical Volume Manager (LVM2) through the TopoLVM Container Storage Interface (CSI) driver to dynamically provision local storage on a cluster with limited resources.
 
 You can create volume groups, persistent volume claims (PVCs), volume snapshots, and volume clones by using {lvms}.
 
@@ -23,8 +21,6 @@ include::modules/lvms-about-lvm-storage-installation.adoc[leveloffset=+1]
 include::modules/lvms-installing-logical-volume-manager-operator-using-cli.adoc[leveloffset=+2]
 
 include::modules/lvms-installing-logical-volume-manager-operator-using-openshift-web-console.adoc[leveloffset=+2]
-
-include::modules/lvms-uninstalling-logical-volume-manager-operator-using-openshift-web-console.adoc[leveloffset=+2]
 
 include::modules/lvms-installing-logical-volume-manager-operator-disconnected-environment.adoc[leveloffset=+2]
 
@@ -41,8 +37,13 @@ include::modules/lvms-installing-logical-volume-manager-operator-disconnected-en
 
 * xref:../../../installing/disconnected_install/installing-mirroring-disconnected.adoc#mirroring-image-set[Mirroring an image set to a mirror registry]
 
-* xref:../../../openshift_images/image-configuration.adoc#images-configuration-registry-mirror_image-configuration[Configuring image registry repository mirroring]
+* xref:../../../openshift_images/image-configuration.adoc#images-configuration-registry-mirror-configuring_image-configuration[Configuring image registry repository mirroring]
 
+* xref:../../../installing/disconnected_install/installing-mirroring-disconnected.adoc#oc-mirror-imageset-config-params_installing-mirroring-disconnected[Image set configuration parameters]
+
+* xref:../../../openshift_images/image-streams-manage.adoc#images-imagestream-use_image-configuration[Why use imagestreams]
+
+* xref:../../../updating/understanding_updates/intro-to-updates.adoc#update-service-about_understanding-openshift-updates[About the OpenShift Update Service]
 
 include::modules/lvms-installing-logical-volume-manager-operator-using-rhacm.adoc[leveloffset=+2]
 
@@ -50,14 +51,6 @@ include::modules/lvms-installing-logical-volume-manager-operator-using-rhacm.ado
 .Additional resources
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.6/html/install/installing#installing-while-connected-online[Red Hat Advanced Cluster Management for Kubernetes: Installing while connected online]
-
-* xref:../../../storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc#lvms-reference-file_logical-volume-manager-storage[{lvms} reference YAML file]
-
-
-include::modules/lvms-uninstalling-logical-volume-manager-operator-using-rhacm.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
 
 * xref:../../../storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc#lvms-reference-file_logical-volume-manager-storage[{lvms} reference YAML file]
 
@@ -136,6 +129,12 @@ include::modules/lvms-deleting-cloned-volumes-in-single-node-openshift.adoc[leve
 
 //Monitoring
 include::modules/lvms-monitoring-logical-volume-manager-operator.adoc[leveloffset=+1]
+
+//Uninstalling LVMS
+
+include::modules/lvms-uninstalling-logical-volume-manager-operator-using-openshift-web-console.adoc[leveloffset=+1]
+
+include::modules/lvms-uninstalling-logical-volume-manager-operator-using-rhacm.adoc[leveloffset=+1]
 
 //Must-gather
 include::modules/lvms-download-log-files-and-diagnostics.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OCPBUGS-32509](https://issues.redhat.com/browse/OCPBUGS-32509)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[Preview](https://74931--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms#install-lvms-operator-cli_logical-volume-manager-storage)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->