### PR TITLE
MIG-1551: formatting error in MTC 1.8.3 release notes

### DIFF
--- a/modules/migration-mtc-release-notes-1-8-3.adoc
+++ b/modules/migration-mtc-release-notes-1-8-3.adoc
@@ -12,7 +12,7 @@
 
 .{oadp-short} 1.3 is now supported
 
-{mtc-short} 1.8.3 adds support to {oadp-first} as a dependency of {mtc-short} 1.8.z. 
+{mtc-short} 1.8.3 adds support to {oadp-first} as a dependency of {mtc-short} 1.8.z.
 
 [id="resolved-issues-1-8-3_{context}"]
 == Resolved issues
@@ -52,7 +52,7 @@ For a complete list of all resolved issues, see the list of link:https://issues.
 [id="known-issues-1-8-3_{context}"]
 == Known issues
 
-mtc-short has the following known issues:
+{mtc-short} has the following known issues:
 
 .The associated SCC for service account cannot be migrated in {OCP} 4.12
 


### PR DESCRIPTION
### JIRA

* [MIG-1551](https://issues.redhat.com/browse/MIG-1551)

* Single formatting error fixed in MTC 1.8.3 release notes

### Version(s):

* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16


### Link to docs preview:

* [Known issues - MTC 1.8.3](https://74935--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/mtc-release-notes.html#known-issues-1-8-3_mtc-release-notes)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

### QE review:
- [ ] QE has approved this change. *No substantive change to docs, only a single formatting error that has been corrected*

<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
