### PR TITLE
TRACING-4106: add note that tempo gateway service only supports OTLP/gRPC

### DIFF
--- a/modules/distr-tracing-tempo-config-multitenancy.adoc
+++ b/modules/distr-tracing-tempo-config-multitenancy.adoc
@@ -9,6 +9,11 @@
 Multitenancy with authentication and authorization is provided in the Tempo Gateway service.
 The authentication uses OpenShift OAuth and the Kubernetes `TokenReview` API. The authorization uses the Kubernetes `SubjectAccessReview` API.
 
+[NOTE]
+====
+The Tempo Gateway service supports ingestion of traces via OTLP over gRPC only (OTLP over HTTP is not supported).
+====
+
 .Sample Tempo CR with two tenants, `dev` and `prod`
 [source,yaml]
 ----


### PR DESCRIPTION
Version(s): all

Issue:
https://issues.redhat.com/browse/TRACING-4106

Link to docs preview:
https://74946--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-configuring.html#distr-tracing-tempo-config-multitenancy_distr-tracing-tempo-configuring

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
@max-cx 
