### PR TITLE
[OSDOCS-10307]:Remove obsolete information from OSD docs about upgrading cluster sections

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -453,12 +453,8 @@ Name: Upgrading
 Dir: upgrading
 Distros: openshift-dedicated
 Topics:
-- Name: Preparing to upgrade OpenShift Dedicated to 4.9
-  File: osd-upgrading-cluster-prepare
-  Distros: openshift-dedicated
 - Name: Upgrading OpenShift Dedicated
   File: osd-upgrades
-  Distros: openshift-dedicated
 ---
 Name: CI/CD
 Dir: cicd

--- a/modules/osd-create-cluster-ccs.adoc
+++ b/modules/osd-create-cluster-ccs.adoc
@@ -344,7 +344,7 @@ You can review the end-of-life dates in the update lifecycle documentation for {
 ** Individual updates: If you select an update version that requires approval, provide an administrator’s acknowledgment and click *Approve and continue*.
 ** Recurring updates: If you selected recurring updates for your cluster, provide an administrator’s acknowledgment and click *Approve and continue*. {cluster-manager} does not start scheduled y-stream updates for minor versions without receiving an administrator’s acknowledgment.
 +
-For information about administrator acknowledgment, see xref:./../upgrading/osd-upgrading-cluster-prepare.adoc#upgrade-49-acknowledgement_osd-updating-cluster-prepare[Administrator acknowledgment when upgrading to OpenShift 4.9].
+
 .. If you opted for recurring updates, select a preferred day of the week and upgrade start time in UTC from the drop-down menus.
 .. Optional: You can set a grace period for *Node draining* during cluster upgrades. A *1 hour* grace period is set by default.
 .. Click *Next*.

--- a/modules/osd-create-cluster-gcp-account.adoc
+++ b/modules/osd-create-cluster-gcp-account.adoc
@@ -165,7 +165,6 @@ You can review the end-of-life dates in the update lifecycle documentation for {
 ** Individual updates: If you select an update version that requires approval, provide an administrator’s acknowledgment and click *Approve and continue*.
 ** Recurring updates: If you selected recurring updates for your cluster, provide an administrator’s acknowledgment and click *Approve and continue*. {cluster-manager} does not start scheduled y-stream updates for minor versions without receiving an administrator’s acknowledgment.
 +
-For information about administrator acknowledgment, see xref:./../upgrading/osd-upgrading-cluster-prepare.adoc#upgrade-49-acknowledgement_osd-updating-cluster-prepare[Administrator acknowledgment when upgrading to OpenShift 4.9].
 .. If you opted for recurring updates, select a preferred day of the week and upgrade start time in UTC from the drop-down menus.
 .. Optional: You can set a grace period for *Node draining* during cluster upgrades. A *1 hour* grace period is set by default.
 .. Click *Next*.

--- a/modules/osd-create-cluster-red-hat-account.adoc
+++ b/modules/osd-create-cluster-red-hat-account.adoc
@@ -118,7 +118,6 @@ You can review the end-of-life dates in the update lifecycle documentation for {
 ** Individual updates: If you select an update version that requires approval, provide an administrator’s acknowledgment and click *Approve and continue*.
 ** Recurring updates: If you selected recurring updates for your cluster, provide an administrator’s acknowledgment and click *Approve and continue*. {cluster-manager} does not start scheduled y-stream updates for minor versions without receiving an administrator’s acknowledgment.
 +
-For information about administrator acknowledgment, see xref:./../upgrading/osd-upgrading-cluster-prepare.adoc#upgrade-49-acknowledgement_osd-updating-cluster-prepare[Administrator acknowledgment when upgrading to OpenShift 4.9].
 .. If you opted for recurring updates, select a preferred day of the week and upgrade start time in UTC from the drop-down menus.
 .. Optional: You can set a grace period for *Node draining* during cluster upgrades. A *1 hour* grace period is set by default.
 .. Click *Next*.

--- a/modules/osd-create-cluster-rhm-gcp-account.adoc
+++ b/modules/osd-create-cluster-rhm-gcp-account.adoc
@@ -164,7 +164,6 @@ You can review the end-of-life dates in the update lifecycle documentation for {
 ** Individual updates: If you select an update version that requires approval, provide an administrator’s acknowledgment and click *Approve and continue*.
 ** Recurring updates: If you selected recurring updates for your cluster, provide an administrator’s acknowledgment and click *Approve and continue*. {cluster-manager} does not start scheduled y-stream updates for minor versions without receiving an administrator’s acknowledgment.
 +
-For information about administrator acknowledgment, see xref:./../upgrading/osd-upgrading-cluster-prepare.adoc#upgrade-49-acknowledgement_osd-updating-cluster-prepare[Administrator acknowledgment when upgrading to OpenShift 4.9].
 .. If you opted for recurring updates, select a preferred day of the week and upgrade start time in UTC from the drop-down menus.
 .. Optional: You can set a grace period for *Node draining* during cluster upgrades. A *1 hour* grace period is set by default.
 .. Click *Next*.

--- a/modules/upgrade.adoc
+++ b/modules/upgrade.adoc
@@ -7,7 +7,6 @@
 [id="upgrade_{context}"]
 = Understanding {product-title} cluster upgrades
 
-
 When upgrades are made available for your {product-title} cluster, you can upgrade to the newest version through {cluster-manager-first} or {cluster-manager} CLI. You can set your upgrade policies on existing clusters or during cluster creation, and upgrades can be scheduled to occur automatically or manually.
 
 Red Hat Site Reliability Engineers (SRE) will provide a curated list of available versions for your {product-title} clusters. For each cluster you will be able to review the full list of available releases, as well as the corresponding release notes. {cluster-manager} will enable installation of clusters at the latest supported versions, and upgrades can be canceled at any time.
@@ -29,7 +28,7 @@ When following a scheduled upgrade policy, there might be a delay of an hour or 
 
 Upgrades can be scheduled to occur automatically on a day and time specified by the cluster owner or administrator. Upgrades occur on a weekly basis, unless an upgrade is unavailable for that week.
 
-If you select recurring updates for your cluster, you must provide an administrator’s acknowledgment. {cluster-manager} does not start scheduled y-stream updates for minor versions without receiving an administrator’s acknowledgment. For information about administrator acknowledgment, see link:https://docs.openshift.com/dedicated/upgrading/osd-upgrading-cluster-prepare.html#upgrade-49-acknowledgement_osd-updating-cluster-prepare[Administrator acknowledgment when upgrading to OpenShift 4.9].
+If you select recurring updates for your cluster, you must provide an administrator’s acknowledgment. {cluster-manager} does not start scheduled y-stream updates for minor versions without receiving an administrator’s acknowledgment.
 
 [NOTE]
 ====
@@ -39,7 +38,7 @@ Recurring upgrade policies are optional and if they are not set, the upgrade pol
 [id="upgrade-manual_upgrades_{context}"]
 == Individual upgrades
 
-If you opt for individual upgrades, you are responsible for updating your cluster. If you select an update version that requires approval, you must provide an administrator’s acknowledgment. For information about administrator acknowledgment, see xref:./../upgrading/osd-upgrading-cluster-prepare.adoc#upgrade-49-acknowledgement_osd-updating-cluster-prepare[Administrator acknowledgment when upgrading to OpenShift 4.9].
+If you opt for individual upgrades, you are responsible for updating your cluster. If you select an update version that requires approval, you must provide an administrator’s acknowledgment.
 
 If your cluster version becomes outdated, it will transition to a limited support status. For more information on OpenShift life cycle policies, see xref:../osd_architecture/osd_policy/osd-life-cycle.adoc#osd-life-cycle[{product-title} update life cycle].
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.15+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-10307
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://74960--ocpdocs-pr.netlify.app/openshift-dedicated/latest/welcome/
https://74960--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-a-gcp-cluster.html
https://74960--ocpdocs-pr.netlify.app/openshift-dedicated/latest/upgrading/osd-upgrades.html
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
**Reviewers: The same information that was removed from the ROSA docs regarding upgrading clusters to version 4.9 needed to be removed from OSD docs. This PR addresses that issue.** 
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
