### PR TITLE
OSDOCS-10105: adds 4.14.22 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -495,3 +495,12 @@ Issued: 2024-04-18
 {product-title} release 4.14.21 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1767[RHBA-2024:1767] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1765[RHSA-2024:1765] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-14-22-dp"]
+=== RHBA-2024:1895 - {microshift-short} 4.14.22 bug fix and enhancement advisory
+
+Issued: 2024-04-25
+
+{product-title} release 4.14.22 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1895[RHBA-2024:1895] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1891[RHSA-2024:1891] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-10105](https://issues.redhat.com/browse/OSDOCS-10105)

Link to docs preview:
[4.14.22 async release note](https://74968--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes.html#microshift-4-14-22-dp)

QE review:
- N/A release notes stock text