### PR TITLE
OCPBUGS#32582: Removes accidental addition of multicluster TP entry from 4.15 release notes

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2243,22 +2243,6 @@ In the following tables, features are marked with the following statuses:
 |====
 
 [discrete]
-=== Web console Technology Preview features
-
-.Web console Technology Preview tracker
-[cols="4,1,1,1",options="header"]
-|====
-|Feature |4.13 |4.14 |4.15
-
-|Multicluster console
-|Technology Preview
-|Technology Preview
-|Technology Preview
-
-|====
-
-
-[discrete]
 [id="ocp-413-scalability-tech-preview"]
 === Scalability and performance Technology Preview features
 


### PR DESCRIPTION
Removes accidental addition of multicluster TP entry from 4.15 release notes.

Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OCPBUGS-32582

Link to docs preview:
https://74999--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-technology-preview-tables

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
FYI @cbippley 
