### PR TITLE
OSDOCS#7763: Updating OSD documentation to be cloud agnostic or have GCP references included

### DIFF
--- a/authentication/bound-service-account-tokens.adoc
+++ b/authentication/bound-service-account-tokens.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can use bound service account tokens, which improves the ability to integrate with cloud provider identity access management (IAM) services, such as AWS IAM.
+You can use bound service account tokens, which improves the ability to integrate with cloud provider identity access management (IAM) services, such as {product-title} on AWS IAM or Google Cloud Platform IAM.
 
 // About bound service account tokens
 include::modules/bound-sa-tokens-about.adoc[leveloffset=+1]

--- a/modules/cluster-logging-cloudwatch.adoc
+++ b/modules/cluster-logging-cloudwatch.adoc
@@ -6,12 +6,9 @@
 // can be re-used in associated products.
 
 :_mod-docs-content-type: CONCEPT
-[id="cluster-logging-cloudwatch_{context}"]
-= CloudWatch recommendation for {product-title}
-
-Red Hat recommends that you use the AWS CloudWatch solution for your logging needs.
 
 [id="cluster-logging-requirements-explained_{context}"]
 == Logging requirements
 
 Hosting your own logging stack requires a large amount of compute resources and storage, which might be dependent on your cloud service quota. The compute resource requirements can start at 48 GB or more, while the storage requirement can be as large as 1600 GB or more. The logging stack runs on your worker nodes, which reduces your available workload resource. With these considerations, hosting your own logging stack increases your cluster operating costs.
+

--- a/modules/insights-operator-what-information-is-collected.adoc
+++ b/modules/insights-operator-what-information-is-collected.adoc
@@ -11,8 +11,8 @@ The following information is collected by the Insights Operator:
 * Configuration files, such as the image registry configuration, of your cluster to determine incorrect settings and issues that are specific to parameters you set
 * Errors that occur in the cluster components
 * Progress information of running updates, and the status of any component upgrades
-* Details of the platform that {product-title} is deployed on, such as Amazon Web Services, and the region that the cluster is located in
+* Details of the platform that {product-title} is deployed on and the region that the cluster is located in
 ifndef::openshift-dedicated[]
 * Cluster workload information transformed into discreet Secure Hash Algorithm (SHA) values, which allows Red Hat to assess workloads for security and version vulnerabilities without disclosing sensitive details
 endif::openshift-dedicated[]
-* If an Operator reports an issue, information is collected about core {product-title} pods in the `openshift-&#42;` and `kube-&#42;` projects. This includes state, resource, security context, volume information, and more.
+* If an Operator reports an issue, information is collected about core {product-title} pods in the `openshift-&#42;` and `kube-&#42;` projects. This includes state, resource, security context, volume information, and more

--- a/modules/logging-create-loki-cr-cli.adoc
+++ b/modules/logging-create-loki-cr-cli.adoc
@@ -54,7 +54,7 @@ It is not possible to change the number `1x` for the deployment size.
 // end::pre-5.9[]
 
 // tag::5.9[]
-+
+
 .Example `LokiStack` CR
 [source,yaml]
 ----

--- a/modules/logging-loki-retention.adoc
+++ b/modules/logging-loki-retention.adoc
@@ -8,9 +8,14 @@
 
 With Logging version 5.6 and higher, you can configure retention policies based on log streams. Rules for these may be set globally, per tenant, or both. If you configure both, tenant rules apply before global rules.
 
+[NOTE]
+====
+Although logging version 5.9 and higher supports schema v12, v13 is recommended.
+====
+
 . To enable stream-based retention, create a `LokiStack` custom resource (CR):
 +
-.Example global stream-based retention
+.Example global stream-based retention for AWS
 [source,yaml]
 ----
 apiVersion: loki.grafana.com/v1
@@ -19,8 +24,8 @@ metadata:
   name: logging-loki
   namespace: openshift-logging
 spec:
-  limits:
-    global: <1>
+  limits: 
+   global: <1>
       retention: <2>
         days: 20
         streams:
@@ -40,15 +45,16 @@ spec:
     secret:
       name: logging-loki-s3
       type: aws
-  storageClassName: standard
+  storageClassName: gp3-csi
   tenants:
     mode: openshift-logging
 ----
 <1> Sets retention policy for all log streams. *Note: This field does not impact the retention period for stored logs in object storage.*
 <2> Retention is enabled in the cluster when this block is added to the CR.
-<3> Contains the link:https://grafana.com/docs/loki/latest/logql/query_examples/#query-examples[LogQL query] used to define the log stream.
-+
-.Example per-tenant stream-based retention
+<3> Contains the link:https://grafana.com/docs/loki/latest/logql/query_examples/#query-examples[LogQL query] used to define the log stream.spec:
+  limits:
+
+.Example per-tenant stream-based retention for AWS
 [source,yaml]
 ----
 apiVersion: loki.grafana.com/v1
@@ -84,15 +90,15 @@ spec:
     secret:
       name: logging-loki-s3
       type: aws
-  storageClassName: standard
+  storageClassName: gp3-csi
   tenants:
     mode: openshift-logging
 ----
 <1> Sets retention policy by tenant. Valid tenant types are `application`, `audit`, and `infrastructure`.
 <2> Contains the link:https://grafana.com/docs/loki/latest/logql/query_examples/#query-examples[LogQL query] used to define the log stream.
 
-. Apply the `LokiStack` CR:
-+
+2 Apply the `LokiStack` CR:
+
 [source,terminal]
 ----
 $ oc apply -f <filename>.yaml

--- a/modules/nodes-nodes-viewing-listing.adoc
+++ b/modules/nodes-nodes-viewing-listing.adoc
@@ -101,6 +101,9 @@ For example:
 $ oc describe node node1.example.com
 ----
 +
+
+include::snippets/osd-aws-example-only.adoc[]
+
 .Example output
 [source,text]
 ----

--- a/modules/nodes-pods-pod-disruption-about.adoc
+++ b/modules/nodes-pods-pod-disruption-about.adoc
@@ -45,6 +45,8 @@ You can check for pod disruption budgets across all projects with the following:
 $ oc get poddisruptionbudget --all-namespaces
 ----
 
+include::snippets/osd-aws-example-only.adoc[]
+
 .Example output
 [source,terminal]
 ----

--- a/modules/oc-adm-by-example-content.adoc
+++ b/modules/oc-adm-by-example-content.adoc
@@ -634,6 +634,8 @@ Initiate reboot of the specified MachineConfigPool.
 == oc adm release extract
 Extract the contents of an update payload to disk
 
+include::snippets/osd-aws-example-only.adoc[]
+
 .Example usage
 [source,bash,options="nowrap"]
 ----

--- a/modules/oc-by-example-content.adoc
+++ b/modules/oc-by-example-content.adoc
@@ -1702,6 +1702,8 @@ Display information about an image
 == oc image mirror
 Mirror images from one repository to another
 
+include::snippets/osd-aws-example-only.adoc[]
+
 .Example usage
 [source,bash,options="nowrap"]
 ----

--- a/modules/rosa-cluster-autoscaler-ui-settings.adoc
+++ b/modules/rosa-cluster-autoscaler-ui-settings.adoc
@@ -56,7 +56,7 @@ The tables explain all the configurable UI settings when using cluster autoscali
 |false
 
 |`balancing-ignored-labels`
-|This option specifies labels that the cluster autoscaler should ignore when considering node group similarity. For example, if you have nodes with a "topology.ebs.csi.aws.com/zone" label, you can add the name of this label to prevent the cluster autoscaler from splitting nodes into different node groups based on its value. This option cannot contain spaces.
+|This option specifies labels that the cluster autoscaler should ignore when considering node group similarity. This option cannot contain spaces.
 |`array (string)`
 |Format should be a comma-separated list of labels.
 |===

--- a/modules/telemetry-showing-data-collected-from-the-cluster.adoc
+++ b/modules/telemetry-showing-data-collected-from-the-cluster.adoc
@@ -30,7 +30,9 @@ endif::openshift-rosa,openshift-dedicated[]
 . Log in to a cluster.
 
 . Run the following command, which queries a cluster's Prometheus service and returns the full set of time series data captured by Telemetry:
-+
+
+include::snippets/osd-aws-example-only.adoc[]
+
 [source,terminal]
 ----
 $ curl -G -k -H "Authorization: Bearer $(oc whoami -t)" \

--- a/networking/cidr-range-definitions.adoc
+++ b/networking/cidr-range-definitions.adoc
@@ -17,7 +17,7 @@ Machine CIDR ranges cannot be changed after creating your cluster.
 ====
 
 ifdef::openshift-rosa,openshift-dedicated[]
-When specifying subnet CIDR ranges, ensure that the subnet CIDR range is within the defined Machine CIDR. You must verify that the subnet CIDR ranges allow for enough IP addresses for all intended workloads, including at least eight IP addresses for possible AWS Load Balancers.
+When specifying subnet CIDR ranges, ensure that the subnet CIDR range is within the defined Machine CIDR. You must verify that the subnet CIDR ranges allow for enough IP addresses for all intended workloads depending on which platform the cluster is hosted.
 endif::[]
 
 [IMPORTANT]

--- a/networking/network-verification.adoc
+++ b/networking/network-verification.adoc
@@ -38,7 +38,7 @@ The network verification includes checks for each of the following requirements:
 * The VPC has `enableDnsSupport` enabled.
 * The VPC has `enableDnsHostnames` enabled.
 ifdef::openshift-dedicated[]
-* Egress is available to the required domain and port combinations that are specified in the xref:../osd_planning/aws-ccs.adoc#osd-aws-privatelink-firewall-prerequisites_aws-ccs[AWS firewall prerequisites] section.
+* Egress is available to the required domain and port combinations for {product-title} (ROSA). For ROSA the required domain and port combinations are specified in the xref:../osd_planning/aws-ccs.adoc#osd-aws-privatelink-firewall-prerequisites_aws-ccs[AWS firewall prerequisites] section.
 endif::openshift-dedicated[]
 ifdef::openshift-rosa[]
 * Egress is available to the required domain and port combinations that are specified in the xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs[AWS firewall prerequisites] section.

--- a/nodes/cma/nodes-cma-autoscaling-custom-trigger-auth.adoc
+++ b/nodes/cma/nodes-cma-autoscaling-custom-trigger-auth.adoc
@@ -117,7 +117,7 @@ spec:
 ----
 <1> Specifies the namespace of the object you want to scale.
 <2> Specifies that this trigger authentication uses a platform-native pod authentication method for authorization.
-<3> Specifies a pod identity. Supported values are `none`, `azure`, `aws-eks`, or `aws-kiam`. The default is `none`.
+<3> Specifies a pod identity. Supported values are `none`, `azure`, `gcp`, `aws-eks`, or `aws-kiam`. The default is `none`.
 
 // Remove ifdef after https://github.com/openshift/openshift-docs/pull/62147 merges
 ifndef::openshift-rosa,openshift-dedicated[]

--- a/observability/logging/cluster-logging.adoc
+++ b/observability/logging/cluster-logging.adoc
@@ -30,8 +30,7 @@ include::modules/cluster-logging-about.adoc[leveloffset=+1]
 
 ifdef::openshift-rosa,openshift-dedicated[]
 include::modules/cluster-logging-cloudwatch.adoc[leveloffset=+1]
-.Next steps
-* See xref:../../observability/logging/log_collection_forwarding/configuring-log-forwarding.adoc#cluster-logging-collector-log-forward-cloudwatch_configuring-log-forwarding[Forwarding logs to Amazon CloudWatch] for instructions.
+For information, see xref:../../observability/logging/log_collection_forwarding/log-forwarding.adoc#about-log-collection_log-forwarding[About log collection and forwarding].
 endif::[]
 
 include::modules/cluster-logging-json-logging-about.adoc[leveloffset=+2]

--- a/observability/logging/log_collection_forwarding/logging-output-types.adoc
+++ b/observability/logging/log_collection_forwarding/logging-output-types.adoc
@@ -30,3 +30,4 @@ The `fluentdForward` output is only supported if you are using the Fluentd colle
 ====
 `syslog`:: An external log aggregation solution that supports the syslog link:https://tools.ietf.org/html/rfc3164[RFC3164] or link:https://tools.ietf.org/html/rfc5424[RFC5424] protocols. The `syslog` output can use a UDP, TCP, or TLS connection.
 `cloudwatch`:: Amazon CloudWatch, a monitoring and log storage service hosted by Amazon Web Services (AWS).
+`cloudlogging`:: Google Cloud Logging, a monitoring and log storage service hosted by Google Cloud Platform (GCP).

--- a/snippets/osd-aws-example-only.adoc
+++ b/snippets/osd-aws-example-only.adoc
@@ -1,0 +1,13 @@
+//Text snippet appears in the following modules:
+//
+// * ../modules/telemetry-showing-data-collected-from-the-cluster.adoc
+// * ../modules/oc-adm-by-example-content.adoc
+// * ../modules/nodes-pods-pod-disruption-about.adoc
+// * ../modules/oc-by-example-content.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+[NOTE]
+====
+The following example contains some values that are specific to {product-title} on AWS.
+====


### PR DESCRIPTION
Issue:
[OSDOCS-7763](https://issues.redhat.com/browse/OSDOCS-7763)

Version:
4.15+

Link to docs preview:

1. [General settings table: Balancing-ignored-labels setting uses row](https://75001--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_cluster_admin/osd-cluster-autoscaling.html#general-settings) - This no longer references AWS.
2. [Information collected by the Insights Operator](https://75001--ocpdocs-pr.netlify.app/openshift-dedicated/latest/support/remote_health_monitoring/about-remote-health-monitoring#insights-operator-what-information-is-collected_about-remote-health-monitoring) - The fifth bullet point no longer mentions AWS. Additionally, removed a period from another bullet point so they're all consistent.
3. [Using bound service account tokens](https://75001--ocpdocs-pr.netlify.app/openshift-dedicated/latest/authentication/bound-service-account-tokens) - Added GCP IAM to first paragraph.
4. [Example trigger authentication with pod authentication providers](https://75001--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/cma/nodes-cma-autoscaling-custom-trigger-auth) - Added 'gcp-gke' value to 3 Specifies a pod identity.
5. [Log output types](https://75001--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/log_collection_forwarding/logging-output-types#logging-output-types-descriptions) - added cloudlogging into the Output type descriptions section.
6. [Enabling stream-based retention for Loki](https://75001--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/log_storage/cluster-logging-loki#logging-loki-retention_cluster-logging-loki) - Added two examples - Example global stream-based retention for GCP and Example per-tenant stream-based retention for GCP.
7. [Cloudwatch recommendation for OpenShift Dedicated](https://75001--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/cluster-logging#cluster-logging-about-custom-resources_cluster-logging) - Removed "Cloudwatch recommendation for OpenShift Dedicated section.


The following have a note added above the example:

1. [oc adm release extract](https://75001--ocpdocs-pr.netlify.app/openshift-dedicated/latest/cli_reference/openshift_cli/administrator-cli-commands#oc-adm-release-extract) - Added note before the example.
2. [oc image mirror](https://75001--ocpdocs-pr.netlify.app/openshift-dedicated/latest/cli_reference/openshift_cli/developer-cli-commands#oc-image-mirror) - Added note before the example.
3. [Showing data collected by Telemetry](https://75001--ocpdocs-pr.netlify.app/openshift-dedicated/latest/support/remote_health_monitoring/showing-data-collected-by-remote-health-monitoring#showing-data-collected-from-the-cluster_showing-data-collected-by-remote-health-monitoring) - Added note before the example.
4. [Understanding how to use pod disruption budgets to specify the number of pods that must be up](https://75001--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/pods/nodes-pods-configuring#nodes-pods-pod-distruption-about_nodes-pods-configuring) - Added note before the example.

Note: Before and after images are attached to [OSDOCS-7763](https://issues.redhat.com/browse/OSDOCS-7763) for ease of viewing.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
