### PR TITLE
OADP-3937: Mistake in DPA for Virt docs

### DIFF
--- a/modules/oadp-installing-dpa-1-3.adoc
+++ b/modules/oadp-installing-dpa-1-3.adoc
@@ -363,8 +363,8 @@ spec:
 <6> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.
 <7> The administrative agent that routes the administrative requests to servers.
 <8> Set this value to `true` if you want to enable `nodeAgent` and perform File System Backup.
-<9> Enter `kopia` or `restic` as your uploader. You cannot change the selection after the installation. For the Built-in DataMover you must use Kopia. The `nodeAgent` deploys a daemon set, which means that the `nodeAgent` pods run on each working node. You can configure File System Backup by adding `spec.defaultVolumesToFsBackup: true` to the `Backup` CR.
-<10> Specify the nodes on which Kopia or Restic are available. By default, Kopia or Restic run on all nodes.
+<9> Enter `kopia` as your uploader to use the Built-in DataMover. The `nodeAgent` deploys a daemon set, which means that the `nodeAgent` pods run on each working node. You can configure File System Backup by adding `spec.defaultVolumesToFsBackup: true` to the `Backup` CR.
+<10> Specify the nodes on which Kopia are available. By default, Kopia runs on all nodes.
 <11> Specify the backup provider.
 <12> Specify the correct default name for the `Secret`, for example, `cloud-credentials-gcp`, if you use a default plugin for the backup provider. If specifying a custom name, then the custom name is used for the backup location. If you do not specify a `Secret` name, the default name is used.
 <13> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.


### PR DESCRIPTION
### Jira

* [OADP-3937](https://issues.redhat.com/browse/OADP-3937)

I made a mistake in the DPA for 1.3 and left in references to `restic`, which I have now changed to `kopia`

### Versions

* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16


### Link to docs preview:

* [OADP docs - Installing the Data Protection Application 1.3](https://75002--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.html#oadp-installing-dpa-1-3_installing-oadp-kubevirt)

### QE review:

* [X ] [QE has approved this change.](https://github.com/openshift/openshift-docs/pull/75002#pullrequestreview-2017319292)

