### PR TITLE
Don't use [enterprise-4.12] Manual CP OSSM-4104: Service Mesh 2.5 Release Notes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -150,9 +150,6 @@ endif::[]
 :SMProductShortName: Service Mesh
 :SMProductVersion: 2.5
 :MaistraVersion: 2.5
-:KialiProduct: Kiali Operator provided by Red Hat
-:SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin
-:SMPluginShort: OSSMC plugin
 //Service Mesh v1
 :SMProductVersion1x: 1.1.18.2
 //Windows containers

--- a/modules/ossm-rn-deprecated-features.adoc
+++ b/modules/ossm-rn-deprecated-features.adoc
@@ -15,13 +15,23 @@ Deprecated functionality is still included in {product-title} and continues to b
 
 Removed functionality no longer exists in the product.
 
+== Deprecated and removed features in Red Hat OpenShift Service Mesh 2.5
+
+The v2.2 ServiceMeshControlPlane resource is no longer supported. Customers should update their mesh deployments to use a later version of the ServiceMeshControlPlane resource.
+
+Support for the {JaegerName} Operator is deprecated. To collect trace spans, use the {DTProductName} (Tempo) Stack. Operator is deprecated. To collect trace spans, use the Red Hat OpenShift distributed tracing platform (Tempo) Stack.
+
+Support for the {es-op} is deprecated. Operator is deprecated.
+
+Istio will remove support for first-party JSON Web Tokens (JWTs). Istio will still support third-Party JWTs.
+
 == Deprecated and removed features in {SMProductName} 2.4
 
 The v2.1 `ServiceMeshControlPlane` resource is no longer supported. Customers should upgrade their mesh deployments to use a later version of the `ServiceMeshControlPlane` resource.
 
 Support for Istio OpenShift Routing (IOR) is deprecated and will be removed in a future release.
 
-Support for Grafana is deprecated and will be removed in a future release. 
+Support for Grafana is deprecated and will be removed in a future release.
 
 Support for the following cipher suites, which were deprecated in {SMProductName} 2.3, has been removed from the default list of ciphers used in TLS negotiations on both the client and server sides. Applications that require access to services requiring one of these cipher suites will fail to connect when a TLS connection is initiated from the proxy.
 

--- a/modules/ossm-rn-fixed-issues.adoc
+++ b/modules/ossm-rn-fixed-issues.adoc
@@ -16,6 +16,17 @@ Provide the following info for each issue if possible:
 
 The following issue has been resolved in the current release:
 
+* https://issues.redhat.com/browse/OSSM-1397[OSSM-1397] Previously, if you removed the `maistra.io/member-of` label from a namespace, the {SMProductShortName} Operator did not automatically reapply the label to the namespace. As a result, sidecar injection did not work in the namespace.
++
+The Operator would reapply the label to the namespace when you made changes to the `ServiceMeshMember` object, which triggered the reconciliation of this member object.
++
+Now, any change to the namespace also triggers the member object reconciliation.
+
+The following issues have been resolved in previous releases:
+
+[id="ossm-rn-fixed-issues-ossm_{context}"]
+== {SMProductShortName} fixed issues
+
 * https://issues.redhat.com/browse/OSSM-3647[OSSM-3647] Previously, in the {SMProductShortName} control plane (SMCP) v2.2 (Istio 1.12), WasmPlugins were applied only to inbound listeners. Since SMCP v2.3 (Istio 1.14), WasmPlugins have been applied to inbound and outbound listeners by default, which introduced regression for users of the 3scale WasmPlugin. Now, the environment variable `APPLY_WASM_PLUGINS_TO_INBOUND_ONLY` is added, which allows safe migration from SMCP v2.2 to v2.3 and v2.4. 
 +
 The following setting should be added to the SMCP config:
@@ -40,11 +51,6 @@ To ensure safe migration, perform the following steps:
 . Set `spec.match[].mode: SERVER` in WasmPlugins.
 . Remove the previously-added environment variable.
 --
-
-The following issues have been resolved in previous releases:
-
-[id="ossm-rn-fixed-issues-ossm_{context}"]
-== {SMProductShortName} fixed issues
 
 * https://issues.redhat.com/browse/OSSM-4851[OSSM-4851] Previously, an error occurred in the operator deploying new pods in a namespace scoped inside the mesh when `runAsGroup`, `runAsUser`, or `fsGroup` parameters were `nil`. Now, a yaml validation has been added to avoid the `nil` value.
 

--- a/modules/ossm-rn-known-issues.adoc
+++ b/modules/ossm-rn-known-issues.adoc
@@ -36,6 +36,40 @@ endif::openshift-rosa[]
 
 These are the known issues in {SMProductName}:
 
+* https://issues.redhat.com/browse/OSSM-6099[OSSM-6099] Installing the OpenShift {SMProductShortName} Console (OSSMC) plugin fails on an IPv6 cluster. 
++
+Workaround: Install the OSSMC plugin on an IPv4 cluster.
+
+* https://issues.redhat.com/browse/OSSM-5556[OSSM-5556] Gateways are skipped when istio-system labels do not match discovery selectors. 
++
+Workaround: Label the control plane namespace to match discovery selectors to avoid skipping the Gateway configurations.
++
+.Example `ServiceMeshControlPlane` resource
+[source,YAML]
+----
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata: 
+  name: basic
+  namespace: istio-system
+spec: 
+  mode: ClusterWide
+  meshConfig: 
+    discoverySelectors: 
+    - matchLabels: 
+        istio-discovery: enabled
+  gateways:
+    ingress:
+      enabled: true
+----
++
+Then, run the following command at the command line:
++
+[source,terminal]
+----
+oc label namespace istio-system istio-discovery=enabled
+----
+
 * https://issues.redhat.com/browse/OSSM-3890[OSSM-3890] Attempting to use the Gateway API in a multitenant mesh deployment generates an error message similar to the following:
 +
 [source,text]

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -18,7 +18,7 @@ This release adds improvements related to the following components and concepts.
 [id="new-features-ossm-2-5"]
 == New features {SMProductName} version 2.5
 
-This release of {SMProductName} adds new features, addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.12 and later.
+This release of {SMProductName} adds new features, addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.13 and later.
 
 This release ends maintenance support for OpenShift {SMProductShortName} version 2.2. If you are using OpenShift {SMProductShortName} version 2.2, you should update to a supported version.
 
@@ -70,7 +70,7 @@ This release introduces a generally available integration of the tracing extensi
 
 This release introduces a generally available version of the OpenShift {SMProductShortName} Console (OSSMC) plugin.
 
-The OSSMC plugin is an extension to the OpenShift Console that provides visibility into your Service Mesh. With the OSSMC plugin installed, a new Service Mesh menu option is available on the navigation pane of the web console, as well as new Service Mesh tabs that enhance existing Workloads and Service console pages.
+The OSSMC plugin is an extension to the OpenShift Console that provides visibility into your Service Mesh. With the OSSMC plugin installed, a new Service Mesh menu option is available in the left-hand navigation of the web console, as well as new Service Mesh tabs that enhance existing Workloads and Service console pages.
 
 The features of the OSSMC plugin are very similar to those of the standalone Kiali Console. The OSSMC plugin does not replace the Kiali Console, and after installing the OSSMC plugin, you can still access the standalone Kiali Console.
 
@@ -158,9 +158,6 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 
 |Envoy Proxy
 |1.24.12
-
-|Jaeger
-|1.47.0
 
 |Kiali
 |1.65.11
@@ -407,9 +404,11 @@ spec:
 * {SMProductShortName} on ARM64 architecture is not supported.
 * OpenTelemetry API remains a Technology Preview feature.
 
+[id="new-features-ossm-2-3-10"]
 == New features {SMProductName} version 2.3.10
+//Update with 2.5
 
-This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.11 and later versions.
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.13 and later.
 
 === Component versions for {SMProductName} version 2.3.10
 |===


### PR DESCRIPTION
Manual CP of [OSSM-4104](https://issues.redhat.com//browse/OSSM-4104) to 4.12

Cherry Picked from 5a473014adbb5c2ff2aedf161b3d94de41cc51e2 xref: https://github.com/openshift/openshift-docs/pull/68434


Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSSM-4104

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

For whatever reason, despite all but the 2.5 Deprecate Features being accounted for, this CP required adding the existing 2.5 release notes content again. When asked whether to "accept incoming changes"

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
