### PR TITLE
Ability to schedule Vertical pod autoscaler pods on Infra/worker nodes

### DIFF
--- a/machine_management/creating-infrastructure-machinesets.adoc
+++ b/machine_management/creating-infrastructure-machinesets.adoc
@@ -128,6 +128,8 @@ include::modules/infrastructure-moving-registry.adoc[leveloffset=+2]
 
 include::modules/infrastructure-moving-monitoring.adoc[leveloffset=+2]
 
+include::modules/nodes-pods-vertical-autoscaler-moving-vpa.adoc[leveloffset=+2]
+
 [role="_additional-resources"]
 .Additional resources
 * xref:../observability/monitoring/configuring-the-monitoring-stack.adoc#moving-monitoring-components-to-different-nodes_configuring-the-monitoring-stack[Moving monitoring components to different nodes]

--- a/modules/nodes-pods-vertical-autoscaler-install.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-install.adoc
@@ -36,7 +36,7 @@ is automatically created if it does not exist.
 
 .. Navigate to *Workloads* -> *Deployments* to verify that there are four deployments running.
 
-. Optional. Verify the installation in the {product-title} CLI using the following command:
+. Verify the installation in the {product-title} CLI using the following command:
 +
 [source,terminal]
 ----

--- a/modules/nodes-pods-vertical-autoscaler-moving-vpa.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-moving-vpa.adoc
@@ -1,0 +1,360 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating-infrastructure-machinesets.adoc
+// * nodes/pods/nodes-pods-vertical-autoscaler
+
+ifeval::["{context}" == "nodes-pods-vertical-autoscaler"]
+:vpa:
+endif::[]
+ifeval::["{context}" == "creating-infrastructure-machinesets"]
+:machinemgmt:
+endif::[]
+
+:_mod-docs-content-type: PROCEDURE
+[id="infrastructure-moving-vpa_{context}"]
+= Moving the Vertical Pod Autoscaler Operator components
+
+ifdef::machinemgmt[]
+The Vertical Pod Autoscaler Operator (VPA) consists of three components: the recommender, updater, and admission controller. The Operator and each component has its own pod in the VPA namespace on the control plane nodes. You can move the VPA Operator and component pods to infrastructure nodes by adding a node selector to the VPA subscription and the `VerticalPodAutoscalerController` CR.
+endif::machinemgmt[]
+ifdef::vpa[]
+The Vertical Pod Autoscaler Operator (VPA) and each component has its own pod in the VPA namespace on the control plane nodes. You can move the VPA Operator and component pods to infrastructure or worker nodes by adding a node selector to the VPA subscription and the `VerticalPodAutoscalerController` CR.
+
+You can create and use infrastructure nodes to host only infrastructure components, such as the default router, the integrated container image registry, and the components for cluster metrics and monitoring. These infrastructure nodes are not counted toward the total number of subscriptions that are required to run the environment. For more information, see _Creating infrastructure machine sets_.
+
+You can move the components to the same node or separate nodes as appropriate for your organization.
+endif::vpa[]
+
+The following example shows the default deployment of the VPA pods to the control plane nodes.
+
+.Example output
+[source,terminal]
+----
+NAME                                                READY   STATUS    RESTARTS   AGE     IP            NODE                  NOMINATED NODE   READINESS GATES
+vertical-pod-autoscaler-operator-6c75fcc9cd-5pb6z   1/1     Running   0          7m59s   10.128.2.24   c416-tfsbj-master-1   <none>           <none>
+vpa-admission-plugin-default-6cb78d6f8b-rpcrj       1/1     Running   0          5m37s   10.129.2.22   c416-tfsbj-master-1   <none>           <none>
+vpa-recommender-default-66846bd94c-dsmpp            1/1     Running   0          5m37s   10.129.2.20   c416-tfsbj-master-0   <none>           <none>
+vpa-updater-default-db8b58df-2nkvf                  1/1     Running   0          5m37s   10.129.2.21   c416-tfsbj-master-1   <none>           <none> 
+----
+
+.Procedure
+
+ifdef::machinemgmt[]
+. Move the VPA Operator pod by adding a node selector to the `Subscription` custom resource (CR) for the VPA Operator:
+
+.. Edit the CR:
++
+[source,terminal]
+----
+$ oc edit Subscription vertical-pod-autoscaler -n openshift-vertical-pod-autoscaler
+----
+
+.. Add a node selector to match the node role label on the infra node:
++
+[source,terminal]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/vertical-pod-autoscaler.openshift-vertical-pod-autoscaler: ""
+  name: vertical-pod-autoscaler
+# ...
+spec:
+  config:
+    nodeSelector:
+      node-role.kubernetes.io/infra: "" <1>
+----
+<1> Specifies the node role of an infra node.
++
+[NOTE]
+====
+If the infra node uses taints, you need to add a toleration to the `Subscription` CR.
+
+For example:
+
+[source,terminal]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/vertical-pod-autoscaler.openshift-vertical-pod-autoscaler: ""
+  name: vertical-pod-autoscaler
+# ...
+spec:
+  config:
+    nodeSelector:
+      node-role.kubernetes.io/infra: ""
+    tolerations: <1>
+    - key: "node-role.kubernetes.io/infra"
+      operator: "Exists"
+      effect: "NoSchedule"
+----
+====
+<1> Specifies a toleration for a taint on the infra node.
+
+. Move each VPA component by adding node selectors to the `VerticalPodAutoscaler` custom resource (CR):
+
+.. Edit the CR:
++
+[source,terminal]
+----
+$ oc edit VerticalPodAutoscalerController default -n openshift-vertical-pod-autoscaler
+----
+
+.. Add node selectors to match the node role label on the infra node:
++
+[source,terminal]
+----
+apiVersion: autoscaling.openshift.io/v1
+kind: VerticalPodAutoscalerController
+metadata:
+ name: default
+  namespace: openshift-vertical-pod-autoscaler
+# ...
+spec:
+  deploymentOverrides:
+    admission:
+      container:
+        resources: {}
+      nodeSelector:
+        node-role.kubernetes.io/infra: "" <1>
+    recommender:
+      container:
+        resources: {}
+      nodeSelector:
+        node-role.kubernetes.io/infra: "" <2>
+    updater:
+      container:
+        resources: {}
+      nodeSelector:
+        node-role.kubernetes.io/infra: "" <3>
+----
+<1> Optional: Specifies the node role for the VPA admission pod.
+<2> Optional: Specifies the node role for the VPA recommender pod.
+<3> Optional: Specifies the node role for the VPA updater pod.
++
+[NOTE]
+====
+If a target node uses taints, you need to add a toleration to the `VerticalPodAutoscalerController` CR.
+
+For example:
+
+[source,terminal]
+----
+apiVersion: autoscaling.openshift.io/v1
+kind: VerticalPodAutoscalerController
+metadata:
+ name: default
+  namespace: openshift-vertical-pod-autoscaler
+# ...
+spec:
+  deploymentOverrides:
+    admission:
+      container:
+        resources: {}
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations: <1>
+      - key: "my-example-node-taint-key"
+        operator: "Exists"
+        effect: "NoSchedule"
+    recommender:
+      container:
+        resources: {}
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations: <2>
+      - key: "my-example-node-taint-key"
+        operator: "Exists"
+        effect: "NoSchedule"
+    updater:
+      container:
+        resources: {}
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations: <3>
+      - key: "my-example-node-taint-key"
+        operator: "Exists"
+        effect: "NoSchedule"
+----
+====
+<1> Specifies a toleration for the admission controller pod for a taint on the infra node.
+<2> Specifies a toleration for the recommender pod for a taint on the infra node.
+<3> Specifies a toleration for the updater pod for a taint on the infra node.
+endif::machinemgmt[]
+
+ifdef::vpa[]
+. Move the VPA Operator pod by adding a node selector to the `Subscription` custom resource (CR) for the VPA Operator:
+
+.. Edit the CR:
++
+[source,terminal]
+----
+$ oc edit Subscription vertical-pod-autoscaler -n openshift-vertical-pod-autoscaler
+----
+
+.. Add a node selector to match the node role label on the node where you want to install the VPA Operator pod:
++
+[source,terminal]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/vertical-pod-autoscaler.openshift-vertical-pod-autoscaler: ""
+  name: vertical-pod-autoscaler
+# ...
+spec:
+  config:
+    nodeSelector:
+      node-role.kubernetes.io/<node_role>: "" <1>
+----
+<1> Specifies the node role of the node where you want to move the VPA Operator pod.
++
+[NOTE]
+====
+If the infra node uses taints, you need to add a toleration to the `Subscription` CR.
+
+For example:
+
+[source,terminal]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/vertical-pod-autoscaler.openshift-vertical-pod-autoscaler: ""
+  name: vertical-pod-autoscaler
+# ...
+spec:
+  config:
+    nodeSelector:
+      node-role.kubernetes.io/infra: ""
+    tolerations: <1>
+    - key: "node-role.kubernetes.io/infra"
+      operator: "Exists"
+      effect: "NoSchedule"
+----
+====
+<1> Specifies a toleration for a taint on the node where you want to move the VPA Operator pod.
+
+. Move each VPA component by adding node selectors to the `VerticalPodAutoscaler` custom resource (CR):
+
+.. Edit the CR:
++
+[source,terminal]
+----
+$ oc edit VerticalPodAutoscalerController default -n openshift-vertical-pod-autoscaler
+----
+
+.. Add node selectors to match the node role label on the node where you want to install the VPA components:
++
+[source,terminal]
+----
+apiVersion: autoscaling.openshift.io/v1
+kind: VerticalPodAutoscalerController
+metadata:
+ name: default
+  namespace: openshift-vertical-pod-autoscaler
+# ...
+spec:
+  deploymentOverrides:
+    admission:
+      container:
+        resources: {}
+      nodeSelector:
+        node-role.kubernetes.io/<node_role>: "" <1>
+    recommender:
+      container:
+        resources: {}
+      nodeSelector:
+        node-role.kubernetes.io/<node_role>: "" <2>
+    updater:
+      container:
+        resources: {}
+      nodeSelector:
+        node-role.kubernetes.io/<node_role>: "" <3>
+----
+<1> Optional: Specifies the node role for the VPA admission pod.
+<2> Optional: Specifies the node role for the VPA recommender pod.
+<3> Optional: Specifies the node role for the VPA updater pod.
++
+[NOTE]
+====
+If a target node uses taints, you need to add a toleration to the `VerticalPodAutoscalerController` CR.
+
+For example:
+
+[source,terminal]
+----
+apiVersion: autoscaling.openshift.io/v1
+kind: VerticalPodAutoscalerController
+metadata:
+ name: default
+  namespace: openshift-vertical-pod-autoscaler
+# ...
+spec:
+  deploymentOverrides:
+    admission:
+      container:
+        resources: {}
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+      tolerations: <1>
+      - key: "my-example-node-taint-key"
+        operator: "Exists"
+        effect: "NoSchedule"
+    recommender:
+      container:
+        resources: {}
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+      tolerations: <2>
+      - key: "my-example-node-taint-key"
+        operator: "Exists"
+        effect: "NoSchedule"
+    updater:
+      container:
+        resources: {}
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+      tolerations: <3>
+      - key: "my-example-node-taint-key"
+        operator: "Exists"
+        effect: "NoSchedule"
+----
+====
+<1> Specifies a toleration for the admission controller pod for a taint on the node where you want to install the pod.
+<2> Specifies a toleration for the recommender pod for a taint on the node where you want to install the pod.
+<3> Specifies a toleration for the updater pod for a taint on the node where you want to install the pod.
+endif::vpa[]
+
+.Verification
+
+* You can verify the pods have moved by using the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-vertical-pod-autoscaler -o wide
+----
++
+The pods are no longer deployed to the control plane nodes.
++
+.Example output
+[source,terminal]
+----
+NAME                                                READY   STATUS    RESTARTS   AGE     IP            NODE                              NOMINATED NODE   READINESS GATES
+vertical-pod-autoscaler-operator-6c75fcc9cd-5pb6z   1/1     Running   0          7m59s   10.128.2.24   c416-tfsbj-infra-eastus3-2bndt   <none>           <none>
+vpa-admission-plugin-default-6cb78d6f8b-rpcrj       1/1     Running   0          5m37s   10.129.2.22   c416-tfsbj-infra-eastus1-lrgj8   <none>           <none>
+vpa-recommender-default-66846bd94c-dsmpp            1/1     Running   0          5m37s   10.129.2.20   c416-tfsbj-infra-eastus1-lrgj8   <none>           <none>
+vpa-updater-default-db8b58df-2nkvf                  1/1     Running   0          5m37s   10.129.2.21   c416-tfsbj-infra-eastus1-lrgj8   <none>           <none> 
+----
+
+ifeval::["{context}" == "nodes-pods-vertical-autoscaler"]
+:!vpa:
+endif::[]
+ifeval::["{context}" == "creating-infrastructure-machinesets"]
+:!machinemgmt:
+endif::[]

--- a/nodes/pods/nodes-pods-vertical-autoscaler.adoc
+++ b/nodes/pods/nodes-pods-vertical-autoscaler.adoc
@@ -22,6 +22,12 @@ include::modules/nodes-pods-vertical-autoscaler-about.adoc[leveloffset=+1]
 
 include::modules/nodes-pods-vertical-autoscaler-install.adoc[leveloffset=+1]
 
+include::modules/nodes-pods-vertical-autoscaler-moving-vpa.adoc[leveloffset=+1]
+
+.Additional resources
+
+* xref:../../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets-production[Creating infrastructure machine sets] 
+
 include::modules/nodes-pods-vertical-autoscaler-using-about.adoc[leveloffset=+1]
 
 include::modules/nodes-pods-vertical-autoscaler-tuning.adoc[leveloffset=+2]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-9016

Previews:

* Node -> Working with pods -> Automatically adjust pod resource levels with the vertical pod autoscaler -> [Moving the Vertical Pod Autoscaler Operator components](https://75005--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler#infrastructure-moving-vpa_nodes-pods-vertical-autoscaler) -- This is more generic, instructing users they can put the VPA pods on worker and/or infra nodes.
* Nodes -> Working with pods -> Automatically adjust pod resource levels with the vertical pod autoscaler -> [Installing the Vertical Pod Autoscaler Operator](https://75005--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler#nodes-pods-vertical-autoscaler-install_nodes-pods-vertical-autoscaler) -- Added step 5 to move the VPA pods upon installation.
* Machine Management -> Creating infrastructure machine sets -> [Moving the Vertical Pod Autoscaler Operator components](https://75005--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#infrastructure-moving-vpa_creating-infrastructure-machinesets) -- This specifically shows how to put the VPA pods on only infra nodes.

@bergerhoffer FYI, I added ^^ to the machine management docs.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

