### PR TITLE
OBSDOCS-961: Update docs to explain persistence of silences when mult…

### DIFF
--- a/modules/monitoring-configuring-persistent-storage.adoc
+++ b/modules/monitoring-configuring-persistent-storage.adoc
@@ -3,10 +3,15 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="configuring_persistent_storage_{context}"]
+[id="configuring-persistent-storage_{context}"]
 = Configuring persistent storage
 
-Running cluster monitoring with persistent storage means that your metrics are stored to a persistent volume (PV) and can survive a pod being restarted or recreated. This is ideal if you require your metrics or alerting data to be guarded from data loss. For production environments, it is highly recommended to configure persistent storage. Because of the high IO demands, it is advantageous to use local storage.
+Run cluster monitoring with persistent storage to gain the following benefits:
+
+* Protect your metrics and alerting data from data loss by storing them in a persistent volume (PV). As a result, they can survive pods being restarted or recreated.
+* Avoid getting duplicate notifications and losing silences for alerts when the Alertmanager pods are restarted.
+
+For production environments, it is highly recommended to configure persistent storage. Because of the high IO demands, it is advantageous to use local storage.
 
 [id="persistent-storage-prerequisites"]
 == Persistent storage prerequisites

--- a/modules/monitoring-managing-silences.adoc
+++ b/modules/monitoring-managing-silences.adoc
@@ -14,3 +14,8 @@ Creating silences is useful in scenarios where you have received an initial aler
 When creating a silence, you must specify whether it becomes active immediately or at a later time. You must also set a duration period after which the silence expires.
 
 After you create silences, you can view, edit, and expire them.
+
+[NOTE]
+====
+When you create silences, they are replicated across Alertmanager pods. However, if you do not configure persistent storage for Alertmanager, silences might be lost. This can happen, for example, if all Alertmanager pods restart at the same time.
+====

--- a/observability/monitoring/managing-alerts.adoc
+++ b/observability/monitoring/managing-alerts.adoc
@@ -38,6 +38,10 @@ include::modules/monitoring-getting-information-about-alerts-silences-and-alerti
 
 // Managing silences
 include::modules/monitoring-managing-silences.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#configuring-persistent-storage_configuring-the-monitoring-stack[Configuring persistent storage]
+
 include::modules/monitoring-silencing-alerts.adoc[leveloffset=+2]
 include::modules/monitoring-editing-silences.adoc[leveloffset=+2]
 include::modules/monitoring-expiring-silences.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s): `enterprise-4.12` and later

Issue: [OBSDOCS-961](https://issues.redhat.com/browse/OBSDOCS-961)

Links to docs preview: 
* [Managing silences](https://75013--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/managing-alerts#managing-silences_managing-alerts)
* [Configuring persistent storage](https://75013--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack#configuring-persistent-storage_configuring-the-monitoring-stack)

QE review:
- [x] QE has approved this change.

**Additional information:**