### PR TITLE
OSDOCS-10286: Documented the 4.14.22 z-stream notes

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3313,6 +3313,43 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.14.22
+[id="ocp-4-14-22"]
+=== RHSA-2024:1891 - {product-title} 4.14.22 bug fix update and security update
+
+Issued: 2024-04-25
+
+{product-title} release 4.14.22, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:1891[RHSA-2024:1891] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1897[RHSA-2024:1897] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.22 --pullspecs
+----
+
+[id="ocp-4-14-22-enhancements"]
+==== Enhancements
+
+[id="ocp-4-14-22-validate-control-plane-replicas"]
+===== Number of configured control plane replicas validated
+
+* Previously, you could set the number of control plane replicas to an invalid value, such as `2`. With this release, a validation is added to prevent any misconfiguration of the control plane replicas at the ISO generation time. (link:https://issues.redhat.com/browse/OCPBUGS-31885[*OCPBUGS-31885*])
+
+[id="ocp-4-14-22-bug-fixes"]
+==== Bug fixes
+
+* Previously, the `network-tools` image, which is a debugging tool, included the Wireshark network protocol analyzer. Wireshark had a dependency on the `gstreamer1` package, and this package has specific licensing requirements. With this release, the `gstreamer1` package is removed from the `network-tools` image and the image now includes the `wireshark-cli` package. (link:https://issues.redhat.com/browse/OCPBUGS-31862[*OCPBUGS-31862*])
+
+* Previously, an external neighbor could change its Media Access Control (MAC) address while the cluster was shutting down or hibernating. Although a Gratuitous Address Resolution Protocol (GARP) was supposed to inform the other neighbors about this change, the cluster did not process the GARP. After restarting the cluster, the neighbor might no longer be available from the OVN-Kubernetes cluster network because the outdated MAC address was being used. With this release, an update enables an aging mechanism so that a neighbor's MAC address is updated regularly every 300 seconds. (link:https://issues.redhat.com/browse/OCPBUGS-11710[*OCPBUGS-11710*])
+
+[id="ocp-4-14-22-updating"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 [id="ocp-4-14-21"]
 === RHSA-2024:1765 - {product-title} 4.14.21 bug fix update and security update
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-10286

Link to docs preview:
[4.14.22](https://75014--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-22)

- [x] QE not required. See the peer-review checklist.

