### PR TITLE
TELCODOCS#1842: Minimum provisioning size for PVCs

### DIFF
--- a/modules/lvms-provisioning-storage-using-logical-volume-manager-operator.adoc
+++ b/modules/lvms-provisioning-storage-using-logical-volume-manager-operator.adoc
@@ -8,6 +8,12 @@
 
 After you have created the LVM volume groups using the `LVMCluster` custom resource (CR), you can provision the storage by creating persistent volume claims (PVCs).
 
+The following are the minimum storage sizes that you can request for each file system type:
+
+* `block`: 8 MiB
+* `xfs`: 300 MiB
+* `ext4`: 32 MiB
+
 To create a PVC, you must create a `PersistentVolumeClaim` object.
 
 .Prerequisites
@@ -35,12 +41,15 @@ spec:
   resources:
     requests:
       storage: 10Gi <3>
-  storageClassName: lvms-vg1 <4>
+    limits:
+      storage: 20Gi <4>
+  storageClassName: lvms-vg1 <5>
 ----
 <1> Specify a name for the PVC.
 <2> To create a block PVC, set this field to `Block`. To create a file PVC, set this field to `Filesystem`.
-<3> Specify the storage size. The total storage size that you can provision is limited by the size of the Logical Volume Manager (LVM) thin pool and the overprovisioning factor.
-<4> The value of the `storageClassName` field must be in the format `lvms-<device_class_name>`, where, `<device_class_name>` is the value of the `deviceClasses.name` field in the `LVMCluster` CR.
+<3> Specify the storage size. If the value is less than the minimum storage size, the requested storage size is rounded to the minimum storage size. The total storage size you can provision is limited by the size of the Logical Volume Manager (LVM) thin pool and the over-provisioning factor.
+<4> Optional: Specify the storage limit. Set this field to a value that is greater than or equal to the minimum storage size. Otherwise, PVC creation fails with an error. 
+<5> The value of the `storageClassName` field must be in the format `lvms-<device_class_name>` where `<device_class_name>` is the value of the `deviceClasses.name` field in the `LVMCluster` CR.
 For example, if the `deviceClasses.name` field is set to `vg1`, you must set the `storageClassName` field to `lvms-vg1`.
 +
 [NOTE]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[TELCODOCS-1842](https://issues.redhat.com/browse/TELCODOCS-1842)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[Preview](https://75016--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html#lvms-provisioning-storage-using-lvms_logical-volume-manager-storage)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->