### PR TITLE
fix terms in CAPI for OpenStack RNs

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -75,12 +75,14 @@ For more information, see the link:https://access.redhat.com/documentation/en-us
 
 You can now encrypt Azure storage accounts during installation by providing the installation program with a customer managed encryption key. See xref:../installing/installing_azure/installation-config-parameters-azure.adoc#installation-configuration-parameters-additional-azure_installation-config-parameters-azure[Installation configuration parameters] for descriptions of the parameters required to encrypt Azure storage accounts.
 
-[id="ocp-4-15-CAPO-tech-preview-no-upgrade"]
-==== CAPO integration into the cluster CAPI Operator (Tech Preview)
+[id="ocp-4-15-capi-openstack-tech-preview-no-upgrade"]
+==== {rh-openstack} integration into the Cluster CAPI Operator (Tech Preview)
 
-If you enable the `TechPreviewNoUpgrade` feature flag, the Cluster API (CAPI) Operator deploys the Cluster API Provider for OpenStack (CAPO) and manages its lifecycle. The CAPI Operator automatically creates `Cluster` and `OpenStackCluster` resources for the current {product-title} cluster.
+If you enable the `TechPreviewNoUpgrade` feature flag, the Cluster CAPI Operator deploys the Cluster API Provider OpenStack and manages its lifecycle.
+The Cluster CAPI Operator automatically creates `Cluster` and `OpenStackCluster` resources for the current {product-title} cluster.
 
-It is now possible to configure the CAPI `Machine` and CAPO `OpenStackMachine` resources in similar fashion to how Machine API (MAPI) resources are configured. It is important to note that the CAPI resources are equivalent to MAPI resources but not identical.
+It is now possible to configure the Cluster API `Machine` and `OpenStackMachine` resources similarly to how Machine API resources are configured.
+It is important to note that while Cluster API resources are functionally equivalent to Machine API resources, structurally they are not identical.
 
 [id="ocp-4-15-installation-and-update-ibm-cloud-user-managed-encryption"]
 ==== IBM Cloud and user-managed encryption
@@ -2404,7 +2406,7 @@ In the following tables, features are marked with the following statuses:
 |Not Available
 |General Availability
 
-|CAPO integration into the cluster CAPI Operator ^[1]^
+|OpenStack integration into the Cluster CAPI Operator ^[1]^
 |Not Available
 |Not Available
 |Technology Preview
@@ -2416,7 +2418,7 @@ In the following tables, features are marked with the following statuses:
 |====
 [.small]
 --
-1. For more information, see xref:../release_notes/ocp-4-15-release-notes.adoc#ocp-4-15-CAPO-tech-preview-no-upgrade[CAPO integration into the cluster CAPI Operator].
+1. For more information, see xref:../release_notes/ocp-4-15-release-notes.adoc#ocp-4-15-capi-openstack-tech-preview-no-upgrade[OpenStack integration into the Cluster CAPI Operator].
 --
 
 [discrete]


### PR DESCRIPTION
Version(s):
4.15

Issue:
Follows up on #70182 and #70813 for [OSDOCS-9302](https://issues.redhat.com//browse/OSDOCS-9302)

Link to docs preview:
- [OpenStack integration into the Cluster CAPI Operator (Tech Preview)](https://75024--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-capi-openstack-tech-preview-no-upgrade)
- [Red Hat OpenStack Platform (RHOSP) Technology Preview features](https://75024--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#red-hat-openstack-platform-rhosp-technology-preview-features)

QE review:
N/A

Additional information: