### PR TITLE
Manual CP of OSSM-4104: Service Mesh 2.5 Release Notes to Enterprise OCP 4.13

### DIFF
--- a/modules/ossm-rn-deprecated-features.adoc
+++ b/modules/ossm-rn-deprecated-features.adoc
@@ -15,6 +15,17 @@ Deprecated functionality is still included in {product-title} and continues to b
 
 Removed functionality no longer exists in the product.
 
+[id="deprecated-removed-features-ossm-2-5"]
+== Deprecated and removed features in {SMProductName} 2.5
+
+The v2.2 `ServiceMeshControlPlane` resource is no longer supported. Customers should update their mesh deployments to use a later version of the `ServiceMeshControlPlane` resource.
+
+Support for the Jaeger Operator is deprecated. To collect trace spans, use the {DTProductName} (Tempo) Stack.
+
+Support for the Elastic Search Operator is deprecated. 
+
+Istio will remove support for first-party JSON Web Tokens (JWTs). Istio will still support third-Party JWTs. 
+
 == Deprecated and removed features in {SMProductName} 2.4
 
 The v2.1 `ServiceMeshControlPlane` resource is no longer supported. Customers should upgrade their mesh deployments to use a later version of the `ServiceMeshControlPlane` resource.

--- a/modules/ossm-rn-fixed-issues.adoc
+++ b/modules/ossm-rn-fixed-issues.adoc
@@ -16,6 +16,17 @@ Provide the following info for each issue if possible:
 
 The following issue has been resolved in the current release:
 
+* https://issues.redhat.com/browse/OSSM-1397[OSSM-1397] Previously, if you removed the `maistra.io/member-of` label from a namespace, the {SMProductShortName} Operator did not automatically reapply the label to the namespace. As a result, sidecar injection did not work in the namespace.
++
+The Operator would reapply the label to the namespace when you made changes to the `ServiceMeshMember` object, which triggered the reconciliation of this member object.
++
+Now, any change to the namespace also triggers the member object reconciliation.
+
+The following issues have been resolved in previous releases:
+
+[id="ossm-rn-fixed-issues-ossm_{context}"]
+== {SMProductShortName} fixed issues
+
 * https://issues.redhat.com/browse/OSSM-3647[OSSM-3647] Previously, in the {SMProductShortName} control plane (SMCP) v2.2 (Istio 1.12), WasmPlugins were applied only to inbound listeners. Since SMCP v2.3 (Istio 1.14), WasmPlugins have been applied to inbound and outbound listeners by default, which introduced regression for users of the 3scale WasmPlugin. Now, the environment variable `APPLY_WASM_PLUGINS_TO_INBOUND_ONLY` is added, which allows safe migration from SMCP v2.2 to v2.3 and v2.4. 
 +
 The following setting should be added to the SMCP config:
@@ -40,11 +51,6 @@ To ensure safe migration, perform the following steps:
 . Set `spec.match[].mode: SERVER` in WasmPlugins.
 . Remove the previously-added environment variable.
 --
-
-The following issues have been resolved in previous releases:
-
-[id="ossm-rn-fixed-issues-ossm_{context}"]
-== {SMProductShortName} fixed issues
 
 * https://issues.redhat.com/browse/OSSM-4851[OSSM-4851] Previously, an error occurred in the operator deploying new pods in a namespace scoped inside the mesh when `runAsGroup`, `runAsUser`, or `fsGroup` parameters were `nil`. Now, a yaml validation has been added to avoid the `nil` value.
 

--- a/modules/ossm-rn-known-issues.adoc
+++ b/modules/ossm-rn-known-issues.adoc
@@ -36,6 +36,40 @@ endif::openshift-rosa[]
 
 These are the known issues in {SMProductName}:
 
+* https://issues.redhat.com/browse/OSSM-6099[OSSM-6099] Installing the OpenShift {SMProductShortName} Console (OSSMC) plugin fails on an IPv6 cluster. 
++
+Workaround: Install the OSSMC plugin on an IPv4 cluster.
+
+* https://issues.redhat.com/browse/OSSM-5556[OSSM-5556] Gateways are skipped when istio-system labels do not match discovery selectors. 
++
+Workaround: Label the control plane namespace to match discovery selectors to avoid skipping the Gateway configurations.
++
+.Example `ServiceMeshControlPlane` resource
+[source,YAML]
+----
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata: 
+  name: basic
+  namespace: istio-system
+spec: 
+  mode: ClusterWide
+  meshConfig: 
+    discoverySelectors: 
+    - matchLabels: 
+        istio-discovery: enabled
+  gateways:
+    ingress:
+      enabled: true
+----
++
+Then, run the following command at the command line:
++
+[source,terminal]
+----
+oc label namespace istio-system istio-discovery=enabled
+----
+
 * https://issues.redhat.com/browse/OSSM-3890[OSSM-3890] Attempting to use the Gateway API in a multitenant mesh deployment generates an error message similar to the following:
 +
 [source,text]

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -159,9 +159,6 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 |Envoy Proxy
 |1.24.12
 
-|Jaeger
-|1.47.0
-
 |Kiali
 |1.65.11
 |===
@@ -409,7 +406,7 @@ spec:
 
 == New features {SMProductName} version 2.3.10
 
-This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.11 and later versions.
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.12 and later versions.
 
 === Component versions for {SMProductName} version 2.3.10
 |===


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Manual cherry pick of Service Mesh 2.5 release notes to Enterprise OCP 4.12 branch.

Manual CP for #68434

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSSM-4104](https://issues.redhat.com//browse/OSSM-4104)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
