### PR TITLE
[enterprise-4.12] Manual cherry-pick OSSM-6170 OSSM 2.5.1, 2.4.7, and 2.3.11 [DOC] Release Notes, Known Is…

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -148,7 +148,7 @@ endif::[]
 :product-rosa: Red Hat OpenShift Service on AWS
 :SMProductName: Red Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 2.5
+:SMProductVersion: 2.5.1
 :MaistraVersion: 2.5
 :KialiProduct: Kiali Operator provided by Red Hat
 :SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin

--- a/modules/ossm-rn-deprecated-features.adoc
+++ b/modules/ossm-rn-deprecated-features.adoc
@@ -20,11 +20,11 @@ Removed functionality no longer exists in the product.
 
 The v2.2 `ServiceMeshControlPlane` resource is no longer supported. Customers should update their mesh deployments to use a later version of the `ServiceMeshControlPlane` resource.
 
-Support for the Jaeger Operator is deprecated. To collect trace spans, use the {DTProductName} (Tempo) Stack.
+Support for the {JaegerName} Operator is deprecated. To collect trace spans, use the {DTProductName} (Tempo) Stack.
 
-Support for the Elastic Search Operator is deprecated. 
+Support for the {es-op} is deprecated.
 
-Istio will remove support for first-party JSON Web Tokens (JWTs). Istio will still support third-Party JWTs. 
+Istio will remove support for first-party JSON Web Tokens (JWTs). Istio will still support third-Party JWTs.
 
 == Deprecated and removed features in {SMProductName} 2.4
 
@@ -32,7 +32,7 @@ The v2.1 `ServiceMeshControlPlane` resource is no longer supported. Customers sh
 
 Support for Istio OpenShift Routing (IOR) is deprecated and will be removed in a future release.
 
-Support for Grafana is deprecated and will be removed in a future release. 
+Support for Grafana is deprecated and will be removed in a future release.
 
 Support for the following cipher suites, which were deprecated in {SMProductName} 2.3, has been removed from the default list of ciphers used in TLS negotiations on both the client and server sides. Applications that require access to services requiring one of these cipher suites will fail to connect when a TLS connection is initiated from the proxy.
 

--- a/modules/ossm-rn-fixed-issues.adoc
+++ b/modules/ossm-rn-fixed-issues.adoc
@@ -14,7 +14,33 @@ Provide the following info for each issue if possible:
 *Result* - How has the behavior changed as a result? Try to avoid “It is fixed” or “The issue is resolved” or “The error no longer presents”.
 ////
 
-The following issue has been resolved in the current release:
+The following issues have been resolved in the current release:
+//current release is 2.5.1/2.4.7/2.3.11 scheduled for April 18, 2024
+
+* https://issues.redhat.com/browse/OSSM-6177[OSSM-6177] Previously, when validation messages were enabled in the `ServiceMeshControlPlane` (SMCP), the `istiod` crashed continuously unless `GatewayAPI` support was enabled. Now, when validation messages are enabled but `GatewayAPI` support is not, the `istiod` does not continuously crash.
+
+* https://issues.redhat.com/browse/OSSM-6163[OSSM-6163] Resolves the following issues:
++
+** Previously, an unstable Prometheus image was included in the {SMProductShortName} control plane (SMCP) v2.5, and users were not able to access the Prometheus dashboard. Now, in the {SMProductShortName} operator 2.5.1, the Prometheus image has been updated.
++
+** Previously, in the {SMProductShortName} control plane (SMCP), a Grafana data source was not able to set Basic authentication password automatically and users were not able to view metrics from Prometheus in Grafana mesh dashboards. Now, a Grafana data source password is configured under the `secureJsonData` field. Metrics are displayed correctly in dashboards.
+
+* https://issues.redhat.com/browse/OSSM-6148[OSSM-6148] Previously, the {SMPlugin} did not respond when the user clicked any option in the menu of any node on the **Traffic Graph** page. Now, the plugin responds to the selected option in the menu by redirecting to the corresponding details page.
+
+* https://issues.redhat.com/browse/OSSM-6099[OSSM-6099] Previously, the {SMPlugin} failed to load correctly in an IPv6 cluster. Now, the OSSMC plugin configuration has been modified to ensure proper loading in an IPv6 cluster.
+
+* https://issues.redhat.com/browse/OSSM-5960[OSSM-5960] Previously, the {SMPlugin} did not display notification messages such as backend errors or Istio validations. Now, these notifications are displayed correctly at the top of the plugin page.
+
+* https://issues.redhat.com/browse/OSSM-5959[OSSM-5959] Previously, the {SMPlugin} did not display TLS and Istio certification information in the **Overview** page. Now, this information is displayed correctly.
+
+* https://issues.redhat.com/browse/OSSM-5902[OSSM-5902] Previously, the {SMPlugin} redirected to a "Not Found Page" error when the user clicked the **Istio config** health symbol on the **Overview** page. Now, the plugin redirects to the correct **Istio config** details page.
+
+* https://issues.redhat.com/browse/OSSM-5541[OSSM-5541] Previously, an Istio operator pod might keep waiting for the leader lease in some restart conditions. Now, the leader election implementation has been enhanced to avoid this issue.
+
+The following issues have been resolved in previous releases:
+
+[id="ossm-rn-fixed-issues-ossm_{context}"]
+== {SMProductShortName} fixed issues
 
 * https://issues.redhat.com/browse/OSSM-1397[OSSM-1397] Previously, if you removed the `maistra.io/member-of` label from a namespace, the {SMProductShortName} Operator did not automatically reapply the label to the namespace. As a result, sidecar injection did not work in the namespace.
 +
@@ -22,12 +48,7 @@ The Operator would reapply the label to the namespace when you made changes to t
 +
 Now, any change to the namespace also triggers the member object reconciliation.
 
-The following issues have been resolved in previous releases:
-
-[id="ossm-rn-fixed-issues-ossm_{context}"]
-== {SMProductShortName} fixed issues
-
-* https://issues.redhat.com/browse/OSSM-3647[OSSM-3647] Previously, in the {SMProductShortName} control plane (SMCP) v2.2 (Istio 1.12), WasmPlugins were applied only to inbound listeners. Since SMCP v2.3 (Istio 1.14), WasmPlugins have been applied to inbound and outbound listeners by default, which introduced regression for users of the 3scale WasmPlugin. Now, the environment variable `APPLY_WASM_PLUGINS_TO_INBOUND_ONLY` is added, which allows safe migration from SMCP v2.2 to v2.3 and v2.4. 
+* https://issues.redhat.com/browse/OSSM-3647[OSSM-3647] Previously, in the {SMProductShortName} control plane (SMCP) v2.2 (Istio 1.12), WasmPlugins were applied only to inbound listeners. Since SMCP v2.3 (Istio 1.14), WasmPlugins have been applied to inbound and outbound listeners by default, which introduced regression for users of the 3scale WasmPlugin. Now, the environment variable `APPLY_WASM_PLUGINS_TO_INBOUND_ONLY` is added, which allows safe migration from SMCP v2.2 to v2.3 and v2.4.
 +
 The following setting should be added to the SMCP config:
 +

--- a/modules/ossm-rn-known-issues.adoc
+++ b/modules/ossm-rn-known-issues.adoc
@@ -36,11 +36,14 @@ endif::openshift-rosa[]
 
 These are the known issues in {SMProductName}:
 
-* https://issues.redhat.com/browse/OSSM-6099[OSSM-6099] Installing the OpenShift {SMProductShortName} Console (OSSMC) plugin fails on an IPv6 cluster. 
-+
-Workaround: Install the OSSMC plugin on an IPv4 cluster.
+* https://issues.redhat.com/browse/OSSM-6267[OSSM-6267] After a data source is configured correctly in the Grafana, a data query returns authentication error. Users are not able to view data in the **Istio service** and **Istio workload** dashboards. Currently, no workaround exists for this issue.
 
-* https://issues.redhat.com/browse/OSSM-5556[OSSM-5556] Gateways are skipped when istio-system labels do not match discovery selectors. 
+//To be removed pending confirmation from dev/QE. They are still testing to make sure OSSMC works on IPv6 for 2.5.1. If not removed, then comment out [OSSM-6099] in "Fixed issues." Comment it out as it may be added to the 2.5.2 or 2.6, whichever is next.
+//* https://issues.redhat.com/browse/OSSM-6099[OSSM-6099] Installing the OpenShift {SMProductShortName} Console (OSSMC) plugin fails on an IPv6 cluster.
+//+
+//Workaround: Install the OSSMC plugin on an IPv4 cluster.
+
+* https://issues.redhat.com/browse/OSSM-5556[OSSM-5556] Gateways are skipped when istio-system labels do not match discovery selectors.
 +
 Workaround: Label the control plane namespace to match discovery selectors to avoid skipping the Gateway configurations.
 +
@@ -49,14 +52,14 @@ Workaround: Label the control plane namespace to match discovery selectors to av
 ----
 apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
-metadata: 
+metadata:
   name: basic
   namespace: istio-system
-spec: 
+spec:
   mode: ClusterWide
-  meshConfig: 
-    discoverySelectors: 
-    - matchLabels: 
+  meshConfig:
+    discoverySelectors:
+    - matchLabels:
         istio-discovery: enabled
   gateways:
     ingress:
@@ -197,6 +200,14 @@ New issues for Kiali should be created in the link:https://issues.redhat.com/pro
 ====
 
 These are the known issues in Kiali:
+
+// Separate PR since only applies to 4.15 * https://issues.redhat.com/browse/OSSM-6299[OSSM-6299] In {product-title} 4.15, when you click the **Node graph** menu option of any node menu within the traffic graph, the node graph is not displayed. Instead, the page is refreshed with the same traffic graph. Currently, no workaround exists for this issue.
+
+* https://issues.redhat.com/browse/OSSM-6298[OSSM-6298] When you click an item reference within the {SMPlugin}, such as a workload link related to a specific service, the console sometimes performs multiple redirections before opening the desired page. If you click *Back* in a web browser, a different page of the console opens instead of the previous page.
++
+Workaround: In the web browser, click *Back* twice to navigate to the previous page.
+
+// Separate PR since only applies to 4.15 * https://issues.redhat.com/browse/OSSM-6290[OSSM-6290] For {product-title} 4.15, the **Project** filter of the **Istio Config** list page does not work correctly. All `istio` items are displayed even if you select a specific project from the dropdown. Currently, no workaround exists for this issue.
 
 //Keep KIALI-2206 in RN as this is for information purposes.
 * link:https://issues.jboss.org/browse/KIALI-2206[KIALI-2206] When you are accessing the Kiali console for the first time, and there is no cached browser data for Kiali, the “View in Grafana” link on the Metrics tab of the Kiali Service Details page redirects to the wrong location. The only way you would encounter this issue is if you are accessing Kiali for the first time.

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -15,6 +15,35 @@ Module included in the following assemblies:
 
 This release adds improvements related to the following components and concepts.
 
+[id="new-features-ossm-2-5-1"]
+== New features {SMProductName} version 2.5.1
+
+//As of March 28, 2024, there are no new features so the phrase "new features" has been removed. This release is to address container grades and Bug fixes.
+//Includes 2.5.1, 2.4.7, 2.3.11
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.12 and later.
+
+=== Component versions for {SMProductName} version 2.5.1
+
+//Release is scheduled for April 18, 2024. Code Freeze is scheduled for April 4, 2024. Component versions should be available after April 4.
+//Kiali updated to 1.73.5 on April 4, 2024
+//Kiali updated to 1.73.7 04/11/2024
+//Istio stays the same 04/15/2024
+//Envoy stays the same 04/15/2024
+
+|===
+|Component |Version
+
+|Istio
+|1.18.5
+
+|Envoy Proxy
+|1.26.8
+
+|Kiali
+|1.73.7
+|===
+
 [id="new-features-ossm-2-5"]
 == New features {SMProductName} version 2.5
 
@@ -121,10 +150,38 @@ A new version of the Gateway API custom resource definition (CRD) is now availab
 |For multitenant mesh deployment, all Gateway API CRDs must be present. Use the experimental branch.
 |===
 
+[id="new-features-ossm-2-4-7"]
+== New features {SMProductName} version 2.4.7
+
+//2.5.1, 2.4.7, 2.3.11
+//As of March 28, 2024, there are no new features so the phrase "new features" has been removed. This release is to address container grades, and at bug fixes.
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.12 and later.
+
+=== Component versions for {SMProductName} version 2.4.7
+
+//Release is scheduled for April 18, 2024. Code Freeze is scheduled for April 4, 2024. Component versions should be available after April 4.
+//Envoy stays the same 04/15/2024
+//Istio stays the same 04/15/2024
+//Kiali stays the same 04/11/2024
+
+|===
+|Component |Version
+
+|Istio
+|1.16.7
+
+|Envoy Proxy
+|1.24.12
+
+|Kiali
+|1.65.11
+|===
+
 [id="new-features-ossm-2-4-6"]
 == New features {SMProductName} version 2.4.6
 
-This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.13 and later.
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.12 and later.
 
 === Component versions for {SMProductName} version 2.4.6
 |===
@@ -404,6 +461,35 @@ spec:
 * {SMProductShortName} on ARM64 architecture is not supported.
 * OpenTelemetry API remains a Technology Preview feature.
 
+[id="new-features-ossm-2-3-11"]
+== New features {SMProductName} version 2.3.11
+
+//2.5.1, 2.4.7, 2.3.11
+//As of March 28, 2024, there are no new features so the phrase "new features" has been removed.
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.12 and later.
+
+=== Component versions for {SMProductName} version 2.3.11
+
+//Release is scheduled for April 18, 2024. Code Freeze is scheduled for April 4, 2024. Component versions should be available after April 4.
+//Envoy stays the same 04/15/2024
+//Istio stays the same 04/15/2024
+//Kiali stays the same 04/11/2024
+
+|===
+|Component |Version
+
+|Istio
+|1.14.5
+
+|Envoy Proxy
+|1.22.11
+
+|Kiali
+|1.57.14
+|===
+
+[id="new-features-ossm-2-3-10"]
 == New features {SMProductName} version 2.3.10
 
 This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.12 and later versions.


### PR DESCRIPTION
[enterprise-4.12] Manual cherry-pick [OSSM-6170](https://issues.redhat.com//browse/OSSM-6170) OSSM 2.5.1, 2.4.7, and 2.3.11 [DOC] Release Notes, Known Issues and Bug Fixes

Cherry Picked from #73889  

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSSM-6170

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
