### PR TITLE
OSDOCS#10331: Agent note about NMSate versions

### DIFF
--- a/modules/installing-ocp-agent-inputs.adoc
+++ b/modules/installing-ocp-agent-inputs.adoc
@@ -26,6 +26,12 @@ endif::pxe-boot[]
 ----
 $ sudo dnf install /usr/bin/nmstatectl -y
 ----
++
+[IMPORTANT]
+====
+The version of `nmstatectl` that is included with the Agent-based Installer varies between different versions of {product-title} (OCP).
+If you are installing an older version of OCP, it might contain a version of NMState that does not support the latest features or properties.
+====
 
 . Place the `openshift-install` binary in a directory that is on your PATH.
 


### PR DESCRIPTION
[OSDOCS-10331](https://issues.redhat.com/browse/OSDOCS-10331)

Versions: 4.12+

This PR adds a note in the Agent install docs clarifying that different versions of OCP/ABI come with different versions of `nmstatectl`.

QE review:
- [ ] QE has approved this change.

Preview: [Creating the preferred configuration inputs](https://75034--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html#installing-ocp-agent-inputs_installing-with-agent-based-installer)
