### PR TITLE
Adds release note entry for OVNK migration support on Nutanix platforms

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -99,10 +99,10 @@ SHA1 certificates are no longer supported for use with HaProxy. Both existing an
 
 With this release, IP addresses and ranges are handled more efficiently in NSGs for {product-title} clusters hosted on Azure. As a result, the maximum limit of CIDRs for all Ingress Controllers in Azure clusters, using the `allowedSourceRanges` field, increases from approximately 1000 to 4000 CIDRs.
 
-[id="ocp-4-16-metallb-addresspool-removed"]
-==== MetalLB AddressPool custom resource definition (CRD) removed
+[id="ocp-4-16-sdn-ovnk-migration-nutanix-support"]
+==== Migration from OpenShift SDN to OVN-Kubernetes on Nutanix
 
-The MetalLB `AddressPool` custom resource definition (CRD) has been deprecated for several versions. However, in this release, the CRD is completely removed. The sole supported method of configuring MetalLB address pools is by using the `IPAddressPools` CRD.
+With this release, migration from the OpenShift SDN network plugin to OVN-Kubernetes is now supported on Nutanix platforms. For more information, see xref:../networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc#nw-ovn-kubernetes-migration-about_migrate-from-openshift-sdn[Migration to the OVN-Kubernetes network plugin].
 
 [id="ocp-4-16-registry"]
 === Registry
@@ -424,6 +424,12 @@ In the following tables, features are marked with the following statuses:
 //|`podTopologySpread`
 
 //|===
+
+[id="ocp-4-16-metallb-addresspool-removed"]
+==== MetalLB AddressPool custom resource definition (CRD) removed
+
+The MetalLB `AddressPool` custom resource definition (CRD) has been deprecated for several versions. However, in this release, the CRD is completely removed. The sole supported method of configuring MetalLB address pools is by using the `IPAddressPools` CRD.
+
 [id="ocp-4-16-future-deprecation"]
 === Notice of future deprecation
 


### PR DESCRIPTION
Version(s):
4.16 only

Issue:
No issue. RN follow up. 

Link to docs preview:
https://75035--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-sdn-ovnk-migration-nutanix-support

Follow up release note for https://github.com/openshift/openshift-docs/pull/74852
