### PR TITLE
OSDOCS-9800: CAS expanders (RNs)

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -128,6 +128,13 @@ The MetalLB `AddressPool` custom resource definition (CRD) has been deprecated f
 [id="ocp-4-16-machine-api"]
 === Machine API
 
+[id="ocp-4-16-cluster-autoscaler-expanders"]
+==== Configuring expanders for the cluster autoscaler
+
+With this release, the cluster autoscaler can use the `LeastWaste`, `Priority`, and `Random` expanders.
+You can configure these expanders to influence the selection of machine sets when scaling the cluster.
+For more information, see xref:../machine_management/applying-autoscaling.adoc#configuring-clusterautoscaler_applying-autoscaling[Configuring the cluster autoscaler].
+
 [id="ocp-4-16-nodes"]
 === Nodes
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-9800](https://issues.redhat.com//browse/OSDOCS-9800) > [OSDOCS-10332](https://issues.redhat.com//browse/OSDOCS-10332)

Link to docs preview:
[Configuring expanders for the cluster autoscaler](https://75036--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-cluster-autoscaler-expanders)

QE review:
- [x] QE has approved this change.

Additional information: