### PR TITLE
TELCODOCS-1823:

### DIFF
--- a/hardware_enablement/kmm-kernel-module-management.adoc
+++ b/hardware_enablement/kmm-kernel-module-management.adoc
@@ -16,6 +16,20 @@ include::modules/kmm-installing-using-web-console.adoc[leveloffset=+2]
 include::modules/kmm-installing-using-cli.adoc[leveloffset=+2]
 include::modules/kmm-installing-older-versions.adoc[leveloffset=+2]
 
+// Added for TELCODOCS-1823
+include::modules/kmm-configuring-kmmo.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+
+* For more information, see xref:../hardware_enablement/kmm-kernel-module-management.adoc#kmm-install_kernel-module-management-operator[Installing the Kernel Module Management Operator].
+
+include::modules/kmm-unloading-kernel-module.adoc[leveloffset=+2]
+include::modules/kmm-setting-kernel-firmware-search-path.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about the `worker.setFirmwareClassPath` path, see xref:../hardware_enablement/kmm-kernel-module-management.adoc#kmm-configuring-kmmo_kernel-module-management-operator[Configuring the Kernel Module Management Operator].
+
 // Added for TELCODOCS-1309
 include::modules/kmm-uninstalling-kmm.adoc[leveloffset=+1]
 include::modules/kmm-uninstalling-kmmo-red-hat-catalog.adoc[leveloffset=+2]
@@ -26,7 +40,7 @@ include::modules/kmm-creating-module-cr.adoc[leveloffset=+2]
 
 // Added for TELCODOCS-1280
 include::modules/kmm-setting-soft-dependencies-between-kernel-modules.adoc[leveloffset=+2]
-include::modules/kmm-security.adoc[leveloffset=+2]
+include::modules/kmm-security.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/kmm-configuring-kmmo.adoc
+++ b/modules/kmm-configuring-kmmo.adoc
@@ -1,0 +1,108 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="kmm-configuring-kmmo_{context}"]
+= Configuring the Kernel Module Management Operator
+
+In most cases, the default configuration for the Kernel Module Management (KMM) Operator does not need to be modified. However, you can modify the Operator settings to suit your environment using the following procedure.
+
+The Operator configuration is set in the `kmm-operator-manager-config` `ConfigMap` in the Operator namespace.
+
+.Procedure
+
+. To modify the settings, edit the `ConfigMap` data by entering the following command:
++
+[source,terminal]
+----
+$ oc edit configmap -n "$namespace" kmm-operator-manager-config
+----
++
+.Example output
++
+[source,yaml]
+----
+healthProbeBindAddress: :8081
+leaderElection:
+  enabled: true
+  resourceID: kmm.sigs.x-k8s.io
+webhook:
+  disableHTTP2: true  # CVE-2023-44487
+  port: 9443
+metrics:
+  enableAuthnAuthz: true
+  disableHTTP2: true  # CVE-2023-44487
+  bindAddress: 0.0.0.0:8443
+  secureServing: true
+worker:
+  runAsUser: 0
+  seLinuxType: spc_t
+  setFirmwareClassPath: /var/lib/firmware
+----
++
+.Operator configuration parameters
+[cols="2,8",options="header"]
+|===
+|Parameter |Description
+
+| `healthProbeBindAddress`
+| Defines the address on which the Operator monitors for kubelet health probes. The recommended value is `:8081`.
+
+|`leaderElection.enabled`
+|Determines whether leader election is used to ensure that only one replica of the KMM Operator is running at any time. For more information, see https://kubernetes.io/docs/concepts/architecture/leases/[Leases]. The recommended value is `true`.
+
+|`leaderElection.resourceID`
+|Determines the name of the resource that leader election uses for holding the leader lock. The recommended value is `kmm.sigs.x-k8s.io`.
+
+|`webhook.disableHTTP2`
+|If `true`, disables HTTP/2 for the webhook server, as a mitigation for link:https://access.redhat.com/security/cve/cve-2023-44487[cve-2023-44487]. The recommended value is `true`.
+
+|`webhook.port`
+|Defines the port on which the Operator monitors webhook requests. The recommended value is `9443`.
+
+|`metrics.enableAuthnAuthz`
+a|Determines if metrics are authenticated using `TokenReviews` and authorized using `SubjectAccessReviews` with the kube-apiserver.
+
+For authentication and authorization, the controller needs a `ClusterRole` with the following rules:
+
+* `apiGroups: authentication.k8s.io, resources: tokenreviews, verbs: create`
+
+* `apiGroups: authorization.k8s.io, resources: subjectaccessreviews, verbs: create`
+
+To scrape metrics, for example, using Prometheus, the client needs a `ClusterRole` with the following rule:
+
+* `nonResourceURLs: "/metrics", verbs: get`
+
+The recommended value is `true`.
+
+|`metrics.disableHTTP2`
+|If `true`, disables HTTP/2 for the metrics server as a mitigation for https://access.redhat.com/security/cve/cve-2023-44487[CVE-2023-44487]. The recommended value is `true`.
+
+|`metrics.bindAddress`
+|Determines the bind address for the metrics server. If unspecified, the default is `:8080`. To disable the metrics server, set to `0`. The recommended value is `0.0.0.0:8443`.
+
+|`metrics.secureServing`
+|Determines whether the metrics are served over HTTPS instead of HTTP. The recommended value is `true`.
+
+|`worker.runAsUser`
+|Determines the value of the `runAsUser` field of the worker container's security context. For more information, see link:https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[SecurityContext]. The recommended value is `9443`.
+
+|`worker.seLinuxType`
+|Determines the value of the `seLinuxOptions.type` field of the worker container's security context. For more information, see link:https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[SecurityContext]. The recommended value is `spc_t`.
+
+|`worker.setFirmwareClassPath`
+|Sets the kernel's firmware search path into the `/sys/module/firmware_class/parameters/path` file on the node. The recommended value is `/var/lib/firmware` if you need to set that value through the worker app. Otherwise, unset.
+|===
+
+. After modifying the settings, restart the controller with the following command:
++
+[source,terminal]
+----
+$ oc delete pod -n "<namespace>" -l app.kubernetes.io/component=kmm
+----
++
+[NOTE]
+====
+The value of <namespace> depends on your original installation method.
+====

--- a/modules/kmm-setting-kernel-firmware-search-path.adoc
+++ b/modules/kmm-setting-kernel-firmware-search-path.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="kmm-setting-kernel-firmware-search-path_{context}"]
+= Setting the kernel firmware search path
+
+The Linux kernel accepts the `firmware_class.path` parameter as a search path for firmware, as explained in link:https://www.kernel.org/doc/html/latest/driver-api/firmware/fw_search_path.html[Firmware search paths].
+
+KMM worker pods can set this value on nodes by writing to sysfs before attempting to load kmods.
+
+.Procedure
+
+* To define a firmware search path, set `worker.setFirmwareClassPath` to `/var/lib/firmware` in the Operator configuration.

--- a/modules/kmm-unloading-kernel-module.adoc
+++ b/modules/kmm-unloading-kernel-module.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="kmm-unloading-kernel-module_{context}"]
+= Unloading the kernel module
+
+You must unload the kernel modules when moving to a newer version or if they introduce some undesirable side effect on the node.
+
+.Procedure
+
+* To unload a module loaded with KMM from nodes, delete the corresponding `Module` resource. KMM then creates worker pods, where required, to run `modprobe -r` and unload the kernel module from the nodes.
++
+[WARNING]
+====
+When unloading worker pods, KMM needs all the resources it uses when loading the kernel module. This includes the `ServiceAccount` referenced in the `Module` as well as any RBAC defined to allow privileged KMM worker Pods to run. It also includes any pull secret referenced in `.spec.imageRepoSecret`.
+
+To avoid situations where KMM is unable to unload the kernel module from nodes:
+
+* Do not delete those resources while the `Module` resource is still present in the cluster in any state, including `Terminating`.
+* Do not delete any namespace containing at least a `Module` resource.
+====


### PR DESCRIPTION
D/S Docs: [MGMT-17316] Reference page for the KMM Operator configuration.

Jira: https://issues.redhat.com/browse/TELCODOCS-1823

Version(s):  openshift-4.16.0, openshift-4.15.0, openshift-4.14.0 

Link to docs preview: https://75038--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html#kmm-configuring-kmmo_kernel-module-management-operator

SME review: @qbarrand
QE review: @cdvultur

