### PR TITLE
Reorders sdn to ovnk rollback procedure

### DIFF
--- a/modules/nw-ovn-kubernetes-rollback.adoc
+++ b/modules/nw-ovn-kubernetes-rollback.adoc
@@ -139,25 +139,7 @@ $ oc patch Network.operator.openshift.io cluster --type=merge \
     }}}}'
 ----
 
-. Wait until the Multus daemon set rollout completes.
-+
-[source,terminal]
-----
-$ oc -n openshift-multus rollout status daemonset/multus
-----
-+
-The name of the Multus pods is in form of `multus-<xxxxx>` where `<xxxxx>` is a random sequence of letters. It might take several moments for the pods to restart.
-+
-.Example output
-[source,text]
-----
-Waiting for daemon set "multus" rollout to finish: 1 out of 6 new pods have been updated...
-...
-Waiting for daemon set "multus" rollout to finish: 5 of 6 updated pods are available...
-daemon set "multus" successfully rolled out
-----
-
-. To complete changing the network plugin, reboot each node in your cluster. You can reboot the nodes in your cluster with either of the following approaches:
+. Reboot each node in your cluster. You can reboot the nodes in your cluster with either of the following approaches:
 
 ** With the `oc rsh` command, you can use a bash script similar to the following:
 +
@@ -189,7 +171,26 @@ do
 done
 ----
 
-. After the nodes in your cluster have rebooted, start all of the machine configuration pools:
+
+. Wait until the Multus daemon set rollout completes. Run the following command to see your rollout status:
++
+[source,terminal]
+----
+$ oc -n openshift-multus rollout status daemonset/multus
+----
++
+The name of the Multus pods is in the form of `multus-<xxxxx>` where `<xxxxx>` is a random sequence of letters. It might take several moments for the pods to restart.
++
+.Example output
+[source,text]
+----
+Waiting for daemon set "multus" rollout to finish: 1 out of 6 new pods have been updated...
+...
+Waiting for daemon set "multus" rollout to finish: 5 of 6 updated pods are available...
+daemon set "multus" successfully rolled out
+----
+
+. After the nodes in your cluster have rebooted and the multus pods are rolled out, start all of the machine configuration pools by running the following commands::
 +
 --
 * Start the master configuration pool:


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-32528

Link to docs preview:
https://75039--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/rollback-to-openshift-sdn.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
