### PR TITLE
Moves a networking entry to notable technical change and adds a heading

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -92,8 +92,6 @@ This release introduces the following updates to the *Developer* perspective of 
 [id="ocp-4-16-networking"]
 === Networking
 
-SHA1 certificates are no longer supported for use with HaProxy. Both existing and new routes using SHA1 certificates in {product-version} are rejected and no longer function.
-
 [id="ocp-4-16-networking-multiple-cidr"]
 ==== Define multiple CIDR blocks for one network security group (NSG) rule
 
@@ -164,6 +162,12 @@ The Network Observability Operator releases updates independently from the {prod
 ===  HAProxy version 2.8
 
 {product-title} {product-version} uses HAProxy 2.8.
+
+[discrete]
+[id="ocp-4-16-sha-haproxy-support-removed"]
+=== SHA1 certificates no longer supported for use with HAProxy
+
+SHA1 certificates are no longer supported for use with HaProxy. Both existing and new routes using SHA1 certificates in {product-version} are rejected and no longer function.
 
 [id="ocp-4-16-deprecated-removed-features"]
 == Deprecated and removed features


### PR DESCRIPTION
Version(s):
4.16 only

Issue:
No issue raised

Link to docs preview:
https://75040--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-notable-technical-changes

QE not needed. Migration only
