### PR TITLE
OSDOCS#10324: Removed Tech Preview snippet and reference for Static IP assignment feature

### DIFF
--- a/modules/installation-vsphere-installer-infra-static-ip-nodes.adoc
+++ b/modules/installation-vsphere-installer-infra-static-ip-nodes.adoc
@@ -9,9 +9,6 @@
 
 You can provision bootstrap, control plane, and compute nodes to be configured with static IP addresses in environments where Dynamic Host Configuration Protocol (DHCP) does not exist. To configure this environment, you must provide values to the `platform.vsphere.hosts.role` parameter in the `install-config.yaml` file.
 
-:FeatureName: Static IP addresses for vSphere nodes
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 By default, the installation program is configured to use the DHCP for the network, but this network has limited configurable capabilities.
 
 After you define one or more machine pools in your `install-config.yaml` file, you can define network definitions for nodes on your network. Ensure that the number of network definitions matches the number of machine pools that you configured for your cluster.
@@ -37,10 +34,5 @@ platform:
 <2> Lists IPv4, IPv6, or both IP addresses that the installation program passes to the network interface. The machine API controller assigns all configured IP addresses to the default network interface.
 <3> The default gateway for the network interface.
 <4> Lists up to 3 DNS nameservers.
-+
-[IMPORTANT]
-====
-To enable the Technology Preview feature of static IP addresses for vSphere nodes for your cluster, you must include `featureSet:TechPreviewNoUpgrade` as the initial entry in the `install-config.yaml` file.
-====
 
 After you deployed your cluster to run nodes with static IP addresses, you can scale a machine to use one of these static IP addresses. Additionally, you can use a machine set to configure a machine to use one of the configured static IP addresses.

--- a/modules/nodes-vsphere-machine-set-concept-static-ip.adoc
+++ b/modules/nodes-vsphere-machine-set-concept-static-ip.adoc
@@ -8,9 +8,6 @@
 
 You can use a machine set to scale machines with configured static IP addresses.
 
-:FeatureName: Static IP addresses for vSphere nodes
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 After you configure a machine set to request a static IP address for a machine, the machine controller creates an `IPAddressClaim` resource in the `openshift-machine-api` namespace. The external controller then creates an `IPAddress` resource and binds any static IP addresses to the `IPAddressClaim` resource.
 
 [IMPORTANT]

--- a/modules/nodes-vsphere-machine-set-scaling-static-ip.adoc
+++ b/modules/nodes-vsphere-machine-set-scaling-static-ip.adoc
@@ -8,14 +8,10 @@
 
 You can use a machine set to scale machines with configured static IP addresses.
 
-:FeatureName: Static IP addresses for vSphere nodes
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 The example in the procedure demonstrates the use of controllers for scaling machines in a machine set.
 
 .Prerequisites
 
-* You included `featureSet:TechPreviewNoUpgrade` as the initial entry in the `install-config.yaml` file.
 * You deployed a cluster that runs at least one node with a configured static IP address.
 
 .Procedure

--- a/modules/nodes-vsphere-scaling-machines-static-ip.adoc
+++ b/modules/nodes-vsphere-scaling-machines-static-ip.adoc
@@ -8,12 +8,8 @@
 
 You can scale additional machine sets to use pre-defined static IP addresses on your cluster. For this configuration, you need to create a machine resource YAML file and then define static IP addresses in this file.
 
-:FeatureName: Static IP addresses for vSphere nodes
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 .Prerequisites
 
-* You included `featureSet:TechPreviewNoUpgrade` as the initial entry in the `install-config.yaml` file.
 * You deployed a cluster that runs at least one node with a configured static IP address.
 
 .Procedure


### PR DESCRIPTION
Version(s): 4.16

Issue: https://issues.redhat.com/browse/OSDOCS-10324

Link to docs preview: 
https://75068--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.html
https://75068--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html

QE review:
- [x] QE has approved this change. @sgaoshang 