### PR TITLE
OCPBUGS32411: Updated prerequisites for oc-mirror plugin

### DIFF
--- a/modules/oc-mirror-installing-plugin.adoc
+++ b/modules/oc-mirror-installing-plugin.adoc
@@ -12,6 +12,8 @@ To use the oc-mirror OpenShift CLI plugin to mirror registry images, you must in
 .Prerequisites
 
 * You have installed the OpenShift CLI (`oc`).
+* You have set the `umask` parameter to `0022` on the operating system that uses oc-mirror.
+* You have installed the correct binary for the {op-system-base} version that you are using. 
 
 .Procedure
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUG32411](https://issues.redhat.com/browse/OCPBUGS-32411)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Preview](https://75071--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.html)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
