### PR TITLE
OCPBUGS#32769: Adding dockercfg to list of types of secrets

### DIFF
--- a/modules/nodes-pods-secrets-about.adoc
+++ b/modules/nodes-pods-secrets-about.adoc
@@ -64,10 +64,12 @@ which is the default.
 
 Specify one of the following types to trigger minimal server-side validation to ensure the presence of specific key names in the secret data:
 
-* `kubernetes.io/service-account-token`. Uses a service account token.
-* `kubernetes.io/basic-auth`. Use with Basic Authentication.
-* `kubernetes.io/ssh-auth`. Use with SSH Key Authentication.
-* `kubernetes.io/tls`. Use with TLS certificate authorities.
+* `kubernetes.io/basic-auth`: Use with Basic authentication
+* `kubernetes.io/dockercfg`: Use as an image pull secret
+* `kubernetes.io/dockerconfigjson`: Use as an image pull secret
+* `kubernetes.io/service-account-token`: Use to obtain a legacy service account API token
+* `kubernetes.io/ssh-auth`: Use with SSH key authentication
+* `kubernetes.io/tls`: Use with TLS certificate authorities
 
 Specify `type: Opaque` if you do not want validation, which means the secret does not claim to conform to any convention for key names or values.
 An _opaque_ secret, allows for unstructured `key:value` pairs that can contain arbitrary values.
@@ -78,7 +80,7 @@ You can specify other arbitrary types, such as `example.com/my-secret-type`. The
 but indicate that the creator of the secret intended to conform to the key/value requirements of that type.
 ====
 
-For examples of different secret types, see the code samples in _Using Secrets_.
+For examples of creating different types of secrets, see _Understanding how to create secrets_.
 
 [id="nodes-pods-secrets-about-keys_{context}"]
 == Secret data keys


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-32769

Link to docs preview:
https://75082--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets.html#nodes-pods-secrets-about-types_nodes-pods-secrets

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
