### PR TITLE
MIG-1552: Fix must-gather image in MTC 1.7 docs

### DIFF
--- a/modules/migration-using-must-gather.adoc
+++ b/modules/migration-using-must-gather.adoc
@@ -39,23 +39,41 @@ endif::[]
 . Navigate to the directory where you want to store the `must-gather` data.
 . Run the `oc adm must-gather` command for one of the following data collection options:
 
-ifdef::troubleshooting-3-4,troubleshooting-mtc[]
-* To collect data for the past hour:
+ifdef::troubleshooting-3-4[]
+* To collect data for the past hour, use the following command:
++
+[source,terminal]
+----
+$ oc adm must-gather --image=registry.redhat.io/rhmtc/openshift-migration-must-gather-rhel8:v1.7
+----
++
+This command saves the data as the `must-gather/must-gather.tar.gz` file. You can upload this file to a support case on the link:https://access.redhat.com/[Red Hat Customer Portal].
+* To collect data for the past 24 hours, use the following command:
++
+[source,terminal]
+----
+$ oc adm must-gather --image=registry.redhat.io/rhmtc/openshift-migration-must-gather-rhel8:v1.7 -- /usr/bin/gather_metrics_dump
+----
++
+This operation can take a long time. This command saves the data as the `must-gather/metrics/prom_data.tar.gz` file.
+endif::[]
+ifdef::troubleshooting-mtc[]
+* To collect data for the past 24 hours, use the following command:
 +
 [source,terminal]
 ----
 $ oc adm must-gather --image=registry.redhat.io/rhmtc/openshift-migration-must-gather-rhel8:v1.8
 ----
 +
-The data is saved as `must-gather/must-gather.tar.gz`. You can upload this file to a support case on the link:https://access.redhat.com/[Red Hat Customer Portal].
-* To collect data for the past 24 hours:
+This command saves the data as the `must-gather/must-gather.tar.gz` file. You can upload this file to a support case on the link:https://access.redhat.com/[Red Hat Customer Portal].
+* To collect data for the past 24 hours, use the following command:
 +
 [source,terminal]
 ----
 $ oc adm must-gather --image=registry.redhat.io/rhmtc/openshift-migration-must-gather-rhel8:v1.8 -- /usr/bin/gather_metrics_dump
 ----
 +
-This operation can take a long time. The data is saved as `must-gather/metrics/prom_data.tar.gz`.
+This operation can take a long time. This command saves the data as the `must-gather/metrics/prom_data.tar.gz` file.
 endif::[]
 ifdef::oadp-troubleshooting[]
 * Full `must-gather` data collection, including Prometheus metrics:


### PR DESCRIPTION
### JIRA

* [MIG-1552](https://issues.redhat.com/browse/MIG-1552)

### Version(s):

* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16

### Link to docs preview:

* [Migration from OpenShift Container Platform 3 to 4 -  Using the must-gather tool](https://75087--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/troubleshooting-3-4.html)

* [REMOVED  - MTC application troubleshooting](https://75087--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting.html)

* [REMOVED - MTC troubleshooting](https://75087--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/troubleshooting-mtc.html)

### QE review:

- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
