### PR TITLE
OSDOCS-10271: VMware CPMS TP to GA

### DIFF
--- a/machine_management/control_plane_machine_management/cpmso-getting-started.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-getting-started.adoc
@@ -28,17 +28,17 @@ The status of the control plane machine set after installation depends on your c
 |====
 |Cloud provider |Active by default |Generated CR |Manual CR required
 
-|Amazon Web Services (AWS)
+|{aws-first}
 |X ^[1]^
 |X
 |
 
-|Google Cloud Platform (GCP)
+|{gcp-first}
 |X ^[2]^
 |X
 |
 
-|Microsoft Azure
+|{azure-first}
 |X ^[2]^
 |X
 |
@@ -48,22 +48,22 @@ The status of the control plane machine set after installation depends on your c
 |X
 |
 
-|VMware vSphere
-|X ^[4]^
-|X ^[4]^
-|X
-
 |{rh-openstack-first}
 |X ^[3]^
+|X
+|
+
+|{vmw-full}
+|X ^[4]^
 |X
 |
 |====
 [.small]
 --
-1. AWS clusters that are upgraded from version 4.11 or earlier require xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-activating_cpmso-getting-started[CR activation].
-2. GCP and Azure clusters that are upgraded from version 4.12 or earlier require xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-activating_cpmso-getting-started[CR activation].
+1. {aws-short} clusters that are upgraded from version 4.11 or earlier require xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-activating_cpmso-getting-started[CR activation].
+2. {gcp-short} and {azure-short} clusters that are upgraded from version 4.12 or earlier require xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-activating_cpmso-getting-started[CR activation].
 3. Nutanix and {rh-openstack} clusters that are upgraded from version 4.13 or earlier require xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-activating_cpmso-getting-started[CR activation].
-4. In {product-title} {product-version}, installing a cluster with an active generated CR on VWware vSphere is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] feature. To enable the feature, set the `featureSet` parameter to `TechPreviewNoUpgrade` in the `install-config.yaml file`.
+4. {vmw-short} clusters that are upgraded from version 4.15 or earlier require xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-activating_cpmso-getting-started[CR activation].
 --
 
 //Checking the control plane machine set custom resource state

--- a/modules/cpmso-yaml-failure-domain-vsphere.adoc
+++ b/modules/cpmso-yaml-failure-domain-vsphere.adoc
@@ -4,21 +4,21 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="cpmso-yaml-failure-domain-vsphere_{context}"]
-= Sample VMware vSphere failure domain configuration
+= Sample {vmw-full} failure domain configuration
 
-On VMware vSphere infrastructure, the cluster-wide infrastructure Custom Resource Definition (CRD), `infrastructures.config.openshift.io`, defines failure domains for your cluster. The `providerSpec` in the `ControlPlaneMachineSet` custom resource (CR) specifies names for failure domains. A failure domain is an infrastructure resource that comprises a control plane machine set, a vCenter datacenter, vCenter datastore, and a network.
+On {vmw-full} infrastructure, the cluster-wide infrastructure Custom Resource Definition (CRD), `infrastructures.config.openshift.io`, defines failure domains for your cluster.
+The `providerSpec` in the `ControlPlaneMachineSet` custom resource (CR) specifies names for failure domains that the control plane machine set uses to ensure control plane nodes are deployed to the appropriate failure domain.
+A failure domain is an infrastructure resource made up of a control plane machine set, a vCenter datacenter, vCenter datastore, and a network.
 
-By using a failure domain resource, you can use a control plane machine set to deploy control plane machines on hardware that is separate from the primary VMware vSphere infrastructure. A control plane machine set also balances control plane machines across defined failure domains to provide fault tolerance capabilities to your infrastructure.
+By using a failure domain resource, you can use a control plane machine set to deploy control plane machines on  separate clusters or datacenters.
+A control plane machine set also balances control plane machines across defined failure domains to provide fault tolerance capabilities to your infrastructure.
 
 [NOTE]
 ====
 If you modify the `ProviderSpec` configuration in the `ControlPlaneMachineSet` CR, the control plane machine set updates all control plane machines deployed on the primary infrastructure and each failure domain infrastructure.
 ====
 
-:FeatureName: Defining a failure domain for a control plane machine set
-include::snippets/technology-preview.adoc[]
-
-.Sample vSphere failure domain values
+.Sample {vmw-full} failure domain values
 [source,yaml]
 ----
 apiVersion: machine.openshift.io/v1
@@ -31,9 +31,9 @@ spec:
   template:
 # ...
     machines_v1beta1_machine_openshift_io:
-      failureDomains: <1>
+      failureDomains: # <1>
         platform: VSphere
-        vsphere: <2>
+        vsphere: # <2>
         - name: <failure_domain_name1>
         - name: <failure_domain_name2>
 # ...
@@ -43,5 +43,13 @@ spec:
 
 [IMPORTANT]
 ====
-Each `failureDomains.platform.vsphere.name` field value in the `ControlPlaneMachineSet` CR must match the corresponding value defined in the `failureDomains.name` field of the cluster-wide infrastructure CRD. Currently, the `vsphere.name` field is the only supported failure domain field that you can specify in the `ControlPlaneMachineSet` CR.
+Currently, the `vsphere.name` field is the only supported failure domain field that you can specify in the `ControlPlaneMachineSet` CR.
+Each `failureDomains.platform.vsphere.name` field value in the `ControlPlaneMachineSet` CR must match the corresponding value defined in the `failureDomains.name` field of the cluster-wide infrastructure CRD.
+
+You can find the value of the `failureDomains.name` field by running the following command:
+
+[source,terminal]
+----
+$ oc get infrastructure cluster -o=jsonpath={.spec.platformSpec.vsphere.failureDomains[0].name
+----
 ====


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-10271](https://issues.redhat.com//browse/OSDOCS-10271)

Link to docs preview:
- [Supported cloud providers](https://75106--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-getting-started.html#cpmso-platform-matrix_cpmso-getting-started)
- [Sample VMware vSphere failure domain configuration](https://75106--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration.html#cpmso-yaml-failure-domain-vsphere_cpmso-configuration)

QE review:
- [x] QE has approved this change.

Additional information:
There is install impact too, this is just for the machine mgmt book
RN update: #75109