### PR TITLE
Update installation-mirror-repository.adoc

### DIFF
--- a/modules/installation-mirror-repository.adoc
+++ b/modules/installation-mirror-repository.adoc
@@ -176,7 +176,7 @@ endif::[]
 +
 [source,terminal]
 ----
-$ oc image mirror -a ${LOCAL_SECRET_JSON} --from-dir=${REMOVABLE_MEDIA_PATH}/mirror "file://openshift/release:${OCP_RELEASE}*" ${LOCAL_REGISTRY}/${LOCAL_REPOSITORY} <1>
+$ oc image mirror -a ${LOCAL_SECRET_JSON} --from-dir=${REMOVABLE_MEDIA_PATH}/mirror "file://openshift/release:${OCP_RELEASE}*" ${LOCAL_REGISTRY}/${LOCAL_REPOSITORY} --insecure=true <1>
 ----
 +
 <1> For `REMOVABLE_MEDIA_PATH`, you must use the same path that you specified when you mirrored the images.
@@ -195,7 +195,7 @@ ifdef::openshift-origin[]
 $ oc adm release mirror -a ${LOCAL_SECRET_JSON}  \
      --from=quay.io/${PRODUCT_REPO}/${RELEASE_NAME}:${OCP_RELEASE} \
      --to=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY} \
-     --to-release-image=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}
+     --to-release-image=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE} --insecure=true
 ----
 endif::[]
 ifndef::openshift-origin[]
@@ -204,7 +204,7 @@ ifndef::openshift-origin[]
 $ oc adm release mirror -a ${LOCAL_SECRET_JSON}  \
      --from=quay.io/${PRODUCT_REPO}/${RELEASE_NAME}:${OCP_RELEASE}-${ARCHITECTURE} \
      --to=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY} \
-     --to-release-image=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE}
+     --to-release-image=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE} --insecure=true
 ----
 endif::[]
 +
@@ -225,20 +225,20 @@ mirrored, extract it and pin it to the release:
 +
 [source,terminal]
 ----
-$ oc adm release extract -a ${LOCAL_SECRET_JSON} --icsp-file=<file> \ --command=openshift-install "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}"
+$ oc adm release extract -a ${LOCAL_SECRET_JSON} --icsp-file=<file> \ --command=openshift-install "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE}" --insecure=true
 ----
 ** If the local container registry is connected to the mirror host, run the following command:
 +
 ifdef::openshift-origin[]
 [source,terminal]
 ----
-$ oc adm release extract -a ${LOCAL_SECRET_JSON} --command=openshift-install "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}"
+$ oc adm release extract -a ${LOCAL_SECRET_JSON} --command=openshift-install "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE}" --insecure=true
 ----
 endif::[]
 ifndef::openshift-origin[]
 [source,terminal]
 ----
-$ oc adm release extract -a ${LOCAL_SECRET_JSON} --command=openshift-install "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE}"
+$ oc adm release extract -a ${LOCAL_SECRET_JSON} --command=openshift-install "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE}" --insecure=true
 ----
 endif::[]
 +
@@ -270,7 +270,7 @@ ifdef::openshift-rosa,openshift-dedicated[]
 $ oc adm release mirror -a ${LOCAL_SECRET_JSON}  \
      --from=quay.io/${PRODUCT_REPO}/${RELEASE_NAME}:${OCP_RELEASE}-${ARCHITECTURE} \
      --to=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY} \
-     --to-release-image=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE}
+     --to-release-image=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE} --insecure=true
 ----
 +
 This command pulls the release information as a digest, and its output includes
@@ -289,7 +289,7 @@ mirrored, extract it and pin it to the release by running the following command:
 +
 [source,terminal]
 ----
-$ oc adm release extract -a ${LOCAL_SECRET_JSON} --command=openshift-install "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE}"
+$ oc adm release extract -a ${LOCAL_SECRET_JSON} --command=openshift-install "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE}" --insecure=true
 ----
 +
 [IMPORTANT]


### PR DESCRIPTION
We need to add --insecure=true

If we will not pass this argument then we will get the below error:

```
mirror -a ps.json --from-dir=/home/remveabel/images/mirror file://openshift/release:4.15.10* registry.babbar.ocp.com:8443/ocp4/openshift4  --dir /home/registry-user/images/ 2>&1 | tail -n 5 
error: unable to upload blob sha256:3dbd6d14ab672581a0c504cb478bbdd9cfb59f134661b121af44a0383141ecd0 to registry.babbar.ocp.com:8443/ocp4/openshift4: Get "https://registry.babbar.ocp.com:8443/v2/": tls: failed to verify certificate: x509: certificate signed by unknown authority
error: unable to upload blob sha256:0404bbe384152d3d167082f8a1869226a1119b7ea4faeda24d6586372b08e45b to registry.babbar.ocp.com:8443/ocp4/openshift4: Get "https://registry.babbar.ocp.com:8443/v2/": tls: failed to verify certificate: x509: certificate signed by unknown authority
error: unable to upload blob sha256:172b222acc964dc43a669d25ac3f841afb592da5c6fcff0cad45f64b13b2ce1c to registry.babbar.ocp.com:8443/ocp4/openshift4: Get "https://registry.babbar.ocp.com:8443/v2/": tls: failed to verify certificate: x509: certificate signed by unknown authority
info: Mirroring completed in 0s (0B/s)
error: one or more errors occurred while uploading images
```
```
# oc adm release mirror -a ps.json       --from=quay.io/openshift-release-dev/ocp-release:4.15.10-x86_64      --to=registry.babbar.ocp.com:8443/ocp4/openshift4      --to-release-image=registry.babbar.ocp.com:8443/ocp4/openshift4:4.15.10-x86_64 --insecure=false  2>&1 | tail -n 5
error: unable to push quay.io/openshift-release-dev/ocp-v4.0-art-dev: failed to upload blob sha256:8ff3ea26f54cce2f59355b8acb6f363f6365fcac091b4d8d91863bdf636ef256: Get "https://registry.babbar.ocp.com:8443/v2/": tls: failed to verify certificate: x509: certificate signed by unknown authority
error: unable to push quay.io/openshift-release-dev/ocp-v4.0-art-dev: failed to upload blob sha256:6c0475e1fedc59031be585151ea0f86363f4315c3339fecca5e0ccf4a7be2109: Get "https://registry.babbar.ocp.com:8443/v2/": tls: failed to verify certificate: x509: certificate signed by unknown authority
error: unable to push quay.io/openshift-release-dev/ocp-v4.0-art-dev: failed to upload blob sha256:287f6442155530d9cb8c823e5746c6b2b6db1ecd3b88c0921ad34019188db5b0: Get "https://registry.babbar.ocp.com:8443/v2/": tls: failed to verify certificate: x509: certificate signed by unknown authority
info: Mirroring completed in 1.65s (0B/s)
error: one or more errors occurred while uploading images
```
this the way to avoid error and accomplish the task, but if you don't want to use this then provide the CA to be passed in this command

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

given command: 

`$ oc adm release extract -a ${LOCAL_SECRET_JSON} --icsp-file=<file> \ --command=openshift-install "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}"`

Fixed command: 
`$ oc adm release extract -a ${LOCAL_SECRET_JSON} --icsp-file=<file> \ --command=openshift-install "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE}" --insecure=true`




Issue:
https://issues.redhat.com/browse/OCPBUGS-32929

Link to docs preview:
https://docs.openshift.com/container-platform/4.15/installing/disconnected_install/installing-mirroring-installation-images.html#installation-mirror-repository_installing-mirroring-installation-images

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


