### PR TITLE
OSDOCS#10322: HCP Workshop cleanup

### DIFF
--- a/modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc
+++ b/modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc
@@ -20,13 +20,14 @@ Before using the {product-title} (ROSA) CLI (`rosa`) to create {hcp-title-first}
 
 .Procedure
 
-* If they do not exist in your AWS account, create the required account-wide STS roles and attach the policies by running the following command:
+. If they do not exist in your AWS account, create the required account-wide STS roles and attach the policies by running the following command:
 +
 [source,terminal]
 ----
-$ rosa create account-roles --hosted-cp --mode auto --yes
+$ rosa create account-roles --hosted-cp
 ----
-** Optional: Set your prefix as an environmental variable by running the following command:
+
+. Optional: Set your prefix as an environmental variable by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/rosa-hcp-sts-creating-a-cluster-cli.adoc
+++ b/modules/rosa-hcp-sts-creating-a-cluster-cli.adoc
@@ -67,7 +67,7 @@ $ rosa create cluster --private --cluster-name=<cluster_name> \
 +
 [source,terminal]
 ----
-$ rosa create cluster --cluster-name=<cluster_name> --mode=auto --hosted-cp --operator-roles-prefix=$OPERATOR_ROLES_PREFIX --oidc-config-id=$ODIC_CONFIG --subnet-ids=$SUBNET_IDS
+$ rosa create cluster --cluster-name=<cluster_name> --mode=auto --hosted-cp --operator-roles-prefix=$OPERATOR_ROLES_PREFIX --oidc-config-id=$OIDC_CONFIG --subnet-ids=$SUBNET_IDS
 ----
 +
 . Check the status of your cluster by running the following command:

--- a/modules/rosa-hcp-vpc-subnet-tagging.adoc
+++ b/modules/rosa-hcp-vpc-subnet-tagging.adoc
@@ -35,20 +35,6 @@ You must tag at least one private subnet and, if applicable, and one public subn
 
 .Procedure
 
-. Verify the tags currently on your subnet by running the following command:
-+
-[source,terminal]
-----
-$ aws ec2 describe-tags --filters "Name=resource-id,Values=<subnet-id>"
-----
-+
-.Example output
-+
-[source,text]
-----
-TAGS    Name    <subnet-id>    subnet  <prefix>-subnet-public1-us-east-1a
-----
-
 . Tag your resources in your terminal by running the following commands:
 .. For public subnets, run:
 +
@@ -65,7 +51,7 @@ $ aws ec2 create-tags --resources <private-subnet-id> --tags Key=kubernetes.io/r
 
 .Verification
 
-. Verify that the tag is correctly applied by running the following command:
+* Verify that the tag is correctly applied by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/rosa-hcp-vpc-terraform.adoc
+++ b/modules/rosa-hcp-vpc-terraform.adoc
@@ -42,7 +42,7 @@ A message confirming the initialization appears when this process completes.
 +
 [source,terminal]
 ----
-$ terraform plan -out rosa.tfplan -var region=<region> [-var cluster_name=<cluster_name>]
+$ terraform plan -out rosa.tfplan -var region=<region>
 ----
 
 . Apply this plan file to build your VPC by running the following command:
@@ -51,17 +51,15 @@ $ terraform plan -out rosa.tfplan -var region=<region> [-var cluster_name=<clust
 ----
 $ terraform apply rosa.tfplan
 ----
-
-. Optional: You can capture the values of the Terraform-provisioned private, public, and machinepool subnet IDs as environment variables to use when creating your {hcp-title} cluster by running the following commands:
++
+.. Optional: You can capture the values of the Terraform-provisioned private, public, and machinepool subnet IDs as environment variables to use when creating your {hcp-title} cluster by running the following commands:
 +
 [source,terminal]
 ----
 $ export SUBNET_IDS=$(terraform output -raw cluster-subnets-string)
 ----
-
-.Verification
-
-* You can verify that the variables were correctly set with the following command:
++
+.. Verify that the variables were correctly set with the following command:
 +
 [source,terminal]
 ----

--- a/modules/rosa-sts-byo-oidc.adoc
+++ b/modules/rosa-sts-byo-oidc.adoc
@@ -35,11 +35,11 @@ endif::rosa-hcp[]
 
 .Procedure
 
-* To create your OIDC configuration alongside the AWS resources, run the following command:
+. To create your OIDC configuration alongside the AWS resources, run the following command:
 +
 [source,terminal]
 ----
-$ rosa create oidc-config --mode=auto  --yes
+$ rosa create oidc-config --mode=auto --yes
 ----
 +
 This command returns the following information.
@@ -60,13 +60,15 @@ I: Created OIDC provider with ARN 'arn:aws:iam::4540112244:oidc-provider/dvbwgdz
 +
 When creating your cluster, you must supply the OIDC config ID. The CLI output provides this value for `--mode auto`, otherwise you must determine these values based on `aws` CLI output for `--mode manual`.
 
-** Optional: you can save the OIDC configuration ID as a variable to use later. Run the following command to save the variable:
+. Optional: you can save the OIDC configuration ID as a variable to use later. Run the following command to save the variable:
 +
+--
 [source,terminal]
 ----
 $ export OIDC_ID=<oidc_config_id><1>
 ----
 <1> In the example output above, the OIDC configuration ID is 13cdr6b.
+--
 
 ** View the value of the variable by running the following command:
 +

--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
@@ -94,7 +94,7 @@ include::modules/rosa-hcp-vpc-terraform.adoc[leveloffset=+3]
 [discrete]
 include::modules/rosa-hcp-vpc-manual.adoc[leveloffset=+2]
 [discrete]
-include::modules/rosa-hcp-vpc-subnet-tagging.adoc[leveloffset=+2]
+include::modules/rosa-hcp-vpc-subnet-tagging.adoc[leveloffset=+3]
 
 [role="_additional-resources"]
 [id="additional-resources_rosa-hcp-vpc-aws"]


### PR DESCRIPTION
Version(s):
`enterprise-4.15+`

Issue:
[OSDOCS-10322](https://issues.redhat.com/browse/OSDOCS-10322)

Link to docs preview:
- [Creating ROSA with HCP clusters using the default options](https://file.rdu.redhat.com/eponvell/HCP-Workshop-Cleanup/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html)

Additional information:
I removed some arguments in the various commands that were making the process less consistent. Then, I fixed a typo in another command.