### PR TITLE
OSDOCS-10343: CAPI TP table in 4.15

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2457,7 +2457,12 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.13 |4.14 |4.15
 
-|Managing machines with the Cluster API
+|Managing machines with the Cluster API for {aws-full}
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|Managing machines with the Cluster API for {gcp-full}
 |Technology Preview
 |Technology Preview
 |Technology Preview


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-10343](https://issues.redhat.com//browse/OSDOCS-10343)

Link to docs preview:
[Machine management Technology Preview features](https://75113--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#machine-management-technology-preview-features)

QE review:
- [x] QE has approved this change.

Additional information: