### PR TITLE
OSDOCS-10343: CAPI TP table in 4.12

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -2921,7 +2921,12 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.10 |4.11 | 4.12
 
-|Managing machines with the Cluster API
+|Managing machines with the Cluster API for {aws-full}
+|Not Available
+|Technology Preview
+|Technology Preview
+
+|Managing machines with the Cluster API for {gcp-full}
 |Not Available
 |Technology Preview
 |Technology Preview


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-10343](https://issues.redhat.com//browse/OSDOCS-10343)

Link to docs preview:
[Machine management Technology Preview features](https://75116--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#machine-management-technology-preview-features)

QE review:
- [x] QE has approved this change.

Additional information: