### PR TITLE
CMP-2247: Implement Openshift CIS 1.5.0

### DIFF
--- a/modules/compliance-supported-profiles.adoc
+++ b/modules/compliance-supported-profiles.adoc
@@ -40,7 +40,7 @@ The Compliance Operator provides the following compliance profiles:
 |link:https://public.cyber.mil/stigs/downloads/[DISA-STIG] ^[1]^
 |`x86_64`
 
-|ocp4-cis
+|ocp4-cis-1-4
 |CIS Red Hat OpenShift Container Platform 4 Benchmark v1.4.0
 |Platform
 |1.2.0+
@@ -49,10 +49,28 @@ The Compliance Operator provides the following compliance profiles:
  `ppc64le`
  `s390x`
 
-|ocp4-cis-node
+|ocp4-cis-node-1-4
 |CIS Red Hat OpenShift Container Platform 4 Benchmark v1.4.0
 |Node ^[2]^
 |1.2.0+
+|link:https://www.cisecurity.org/cis-benchmarks/[CIS Benchmarks &#8482;] ^[1]^
+|`x86_64`
+ `ppc64le`
+ `s390x`
+
+|ocp4-cis
+|CIS Red Hat OpenShift Container Platform 4 Benchmark v1.5.0
+|Platform
+|1.4.1+
+|link:https://www.cisecurity.org/cis-benchmarks/[CIS Benchmarks &#8482;] ^[1]^
+|`x86_64`
+ `ppc64le`
+ `s390x`
+
+|ocp4-cis-node
+|CIS Red Hat OpenShift Container Platform 4 Benchmark v1.5.0
+|Node ^[2]^
+|1.4.1+
 |link:https://www.cisecurity.org/cis-benchmarks/[CIS Benchmarks &#8482;] ^[1]^
 |`x86_64`
  `ppc64le`


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/CMP-2247
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://75117--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/co-scans/compliance-operator-supported-profiles.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This is an update to a table in the Compliance Operator documentation specifying support for the new CIS OpenShift 1.5.0 certification ruleset. It adds two new entries and does not delete anything currently existing.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
