### PR TITLE
cGroup v1 is deprecated in 4.16

### DIFF
--- a/installing/install_config/enabling-cgroup-v1.adoc
+++ b/installing/install_config/enabling-cgroup-v1.adoc
@@ -9,6 +9,9 @@ toc::[]
 
 As of {product-title} 4.14, {product-title} uses link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[Linux control group version 2] (cgroup v2) in your cluster. If you are using cgroup v1 on {product-title} 4.13 or earlier, migrating to {product-title} 4.15 will not automatically update your cgroup configuration to version 2. A fresh installation of {product-title} 4.14 or later will use cgroup v2 by default. However, you can enable link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1/index.html[Linux control group version 1] (cgroup v1) upon installation. Enabling cgroup v1 in {product-title} disables all cgroup v2 controllers and hierarchies in your cluster.
 
+:FeatureName: cgroup v1
+include::snippets/deprecated-feature.adoc[]
+
 include::snippets/cgroupv2-vs-cgroupv1.adoc[]
 
 ifndef::openshift-origin[]

--- a/installing/installing_openstack/installing-openstack-nfv-preparing.adoc
+++ b/installing/installing_openstack/installing-openstack-nfv-preparing.adoc
@@ -19,6 +19,9 @@ You must configure {rh-openstack} before you install a cluster that uses SR-IOV 
 
 When installing a cluster using SR-IOV, you must deploy clusters using cgroup v1. For more information, xref:../../installing/install_config/enabling-cgroup-v1.adoc#enabling-cgroup-v1[Enabling Linux control group version 1 (cgroup v1)].
 
+:FeatureName: cgroup v1
+include::snippets/deprecated-feature.adoc[]
+
 include::modules/installation-osp-configuring-sr-iov.adoc[leveloffset=+2]
 
 [id="installing-openstack-nfv-preparing-tasks-ovs-dpdk"]

--- a/modules/cnf-tuning-nodes-for-low-latency-via-performanceprofile.adoc
+++ b/modules/cnf-tuning-nodes-for-low-latency-via-performanceprofile.adoc
@@ -14,6 +14,9 @@ The performance profile lets you control latency tuning aspects of nodes that be
 
 You can use a performance profile to specify whether to update the kernel to kernel-rt, to allocate huge pages, and to partition the CPUs for performing housekeeping duties or running workloads.
 
+:FeatureName: cgroup v1
+include::snippets/deprecated-feature.adoc[]
+
 [NOTE]
 ====
 You can manually create the `PerformanceProfile` object or use the Performance Profile Creator (PPC) to generate a performance profile. See the additional resources below for more information on the PPC.

--- a/modules/nodes-clusters-cgroups-2-install.adoc
+++ b/modules/nodes-clusters-cgroups-2-install.adoc
@@ -8,6 +8,9 @@
 
 You can enable Linux control group version 1 (cgroup v1) when you install a cluster by creating installation manifests.
 
+:FeatureName: cgroup v1
+include::snippets/deprecated-feature.adoc[]
+
 .Procedure
 
 . Create or edit the `node.config` object to specify the `v1` cgroup:
@@ -23,4 +26,3 @@ spec:
 ----
 
 . Proceed with the installation as usual.
-

--- a/modules/nodes-clusters-cgroups-2.adoc
+++ b/modules/nodes-clusters-cgroups-2.adoc
@@ -16,7 +16,7 @@ endif::[]
 
 ifndef::openshift-origin[]
 ifdef::post[]
-As of {product-title} 4.14, {product-title} uses link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[Linux control group version 2] (cgroup v2) in your cluster. If you are using cgroup v1 on {product-title} 4.13 or earlier, migrating to {product-title} 4.14 or later will not automatically update your cgroup configuration to version 2. A fresh installation of {product-title} 4.14 or later will use cgroup v2 by default. However, you can enable link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1/index.html[Linux control group version 1] (cgroup v1) upon installation. 
+As of {product-title} 4.14, {product-title} uses link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[Linux control group version 2] (cgroup v2) in your cluster. If you are using cgroup v1 on {product-title} 4.13 or earlier, migrating to {product-title} 4.14 or later will not automatically update your cgroup configuration to version 2. A fresh installation of {product-title} 4.14 or later will use cgroup v2 by default. However, you can enable link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1/index.html[Linux control group version 1] (cgroup v1) upon installation.
 endif::post[]
 endif::openshift-origin[]
 ifdef::openshift-origin[]
@@ -28,12 +28,15 @@ endif::openshift-origin[]
 ifdef::post[]
 cgroup v2 is the current version of the Linux cgroup API. cgroup v2 offers several improvements over cgroup v1, including a unified hierarchy, safer sub-tree delegation, new features such as link:https://www.kernel.org/doc/html/latest/accounting/psi.html[Pressure Stall Information], and enhanced resource management and isolation. However, cgroup v2 has different CPU, memory, and I/O management characteristics than cgroup v1. Therefore, some workloads might experience slight differences in memory or CPU usage on clusters that run cgroup v2.
 
-You can change between cgroup v1 and cgroup v2, as needed. Enabling cgroup v1 in {product-title} disables all cgroup v2 controllers and hierarchies in your cluster. 
+You can change between cgroup v1 and cgroup v2, as needed. Enabling cgroup v1 in {product-title} disables all cgroup v2 controllers and hierarchies in your cluster.
 endif::post[]
 
 ifdef::nodes[]
 You can enable link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1/index.html[Linux control group version 1] (cgroup v1) or link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[Linux control group version 2] (cgroup v2)  by editing the `node.config` object. The default is cgroup v2.
 endif::nodes[]
+
+:FeatureName: cgroup v1
+include::snippets/deprecated-feature.adoc[]
 
 [NOTE]
 ====

--- a/modules/nodes-nodes-kernel-arguments.adoc
+++ b/modules/nodes-nodes-kernel-arguments.adoc
@@ -20,6 +20,11 @@ Examples of kernel arguments you could set include:
 
 ifndef::openshift-origin[]
 * **systemd.unified_cgroup_hierarchy**: Enables link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[Linux control group version 2] (cgroup v2). cgroup v2 is the next version of the kernel link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/resource_management_guide/ch01[control group] and offers multiple improvements.
++
+--
+:FeatureName: cgroup v1
+include::snippets/deprecated-feature.adoc[]
+--
 endif::openshift-origin[]
 
 ifdef::openshift-origin[]
@@ -29,6 +34,11 @@ ifdef::openshift-origin[]
 ====
 cgroup v2 is enabled by default. To disable cgroup v2, use the `systemd.unified_cgroup_hierarchy=0` kernel argument, as shown in the following procedure.
 ====
++
+--
+:FeatureName: cgroup v1
+include::snippets/deprecated-feature.adoc[]
+--
 endif::openshift-origin[]
 
 * **enforcing=0**: Configures Security Enhanced Linux (SELinux) to run in permissive mode. In permissive mode, the system acts as if SELinux is enforcing the loaded security policy, including labeling objects and emitting access denial entries in the logs, but it does not actually deny any operations. While not supported for production systems, permissive mode can be helpful for debugging.

--- a/modules/telco-ran-crs-machine-configuration.adoc
+++ b/modules/telco-ran-crs-machine-configuration.adoc
@@ -29,3 +29,6 @@ Set RCU normal,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#z
 Set RCU normal,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-08-set-rcu-normal-worker-yaml[08-set-rcu-normal-worker.yaml],No,No
 SR-IOV related kernel arguments,xref:../../telco_ref_design_specs/ran/telco-ran-ref-du-crs.adoc#ztp-07-sriov-related-kernel-args-master-yaml[07-sriov-related-kernel-args-master.yaml],No,Yes
 |====
+
+:FeatureName: cgroup v1
+include::snippets/deprecated-feature.adoc[]

--- a/modules/telco-ran-node-tuning-operator.adoc
+++ b/modules/telco-ran-node-tuning-operator.adoc
@@ -72,3 +72,6 @@ In {product-title} {product-version}, any `PerformanceProfile` CR configured on 
 
 For more information about cgroups, see link:https://docs.openshift.com/container-platform/4.15/nodes/clusters/nodes-cluster-cgroups-2.html#nodes-clusters-cgroups-2_nodes-cluster-cgroups-2[Configuring Linux cgroup].
 ====
+
+:FeatureName: cgroup v1
+include::snippets/deprecated-feature.adoc[]

--- a/nodes/clusters/nodes-cluster-cgroups-2.adoc
+++ b/nodes/clusters/nodes-cluster-cgroups-2.adoc
@@ -7,15 +7,18 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 ifndef::openshift-origin[]
-As of {product-title} 4.14, {product-title} uses link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[Linux control group version 2] (cgroup v2) in your cluster. If you are using cgroup v1 on {product-title} 4.13 or earlier, migrating to {product-title} 4.14 or later will not automatically update your cgroup configuration to version 2. A fresh installation of {product-title} 4.14 or later will use cgroup v2 by default. However, you can enable link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1/index.html[Linux control group version 1] (cgroup v1) upon installation. 
+As of {product-title} 4.14, {product-title} uses link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[Linux control group version 2] (cgroup v2) in your cluster. If you are using cgroup v1 on {product-title} 4.13 or earlier, migrating to {product-title} 4.14 or later will not automatically update your cgroup configuration to version 2. A fresh installation of {product-title} 4.14 or later will use cgroup v2 by default. However, you can enable link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1/index.html[Linux control group version 1] (cgroup v1) upon installation.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
 {product-title} uses link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[Linux control group version 2] (cgroup v2) in your cluster.
 endif::openshift-origin[]
 
+:FeatureName: cgroup v1
+include::snippets/deprecated-feature.adoc[]
+
 include::snippets/cgroupv2-vs-cgroupv1.adoc[]
 
-You can change between cgroup v1 and cgroup v2, as needed. Enabling cgroup v1 in {product-title} disables all cgroup v2 controllers and hierarchies in your cluster. 
+You can change between cgroup v1 and cgroup v2, as needed. Enabling cgroup v1 in {product-title} disables all cgroup v2 controllers and hierarchies in your cluster.
 
 [NOTE]
 ====


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-10339

Add deprecation snippet to various docs.

[Enabling Linux control group version 1 (cgroup v1) ](https://75120--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/enabling-cgroup-v1.html) -- Important note after first paragraph.
[Preparing to install a cluster that uses SR-IOV](https://75120--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-nfv-preparing.html#installing-openstack-nfv-preparing-tasks-sr-iov) -- Important note after second paragraph.
[Tuning nodes for low latency with the performance profile](https://github.com/openshift/openshift-docs/pull/75120/files#diff-341b0f3904dea2a70fa6bab52e1b1d416ac420b26f337c033c8b237bb07c02cd) -- Not sure this module  is being used.
[Enabling Linux control group version 1 (cgroup v1) ](https://75120--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/enabling-cgroup-v1) -- Important note after second bullet
[Configuring the Linux cgroup version on your nodes](https://75120--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-cgroups-2.html) -- Important note after first paragraph 
Nodes -> Working with nodes -> Managing nodes -> [Adding kernel arguments to nodes](https://75120--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-managing.html#nodes-nodes-kernel-arguments_nodes-nodes-managing) -- Important note after second bullet 
OCP: [Adding kernel arguments to nodes](https://75120--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks#nodes-nodes-kernel-arguments_post-install-machine-configuration-tasks) -- Important note after second bullet 
OKD: [Adding kernel arguments to nodes](https://file.rdu.redhat.com/mburke/node-cgroup-v1-deprecation/nodes/nodes/nodes-nodes-managing.html) -- Important note after second bullet 
Telco: Reference design specifications -> Telco reference design specifications -> [RAN DU reference design configuration CRs](https://file.rdu.redhat.com/mburke/node-cgroup-v1-deprecation/telco_ref_design_specs/ran/telco-ran-ref-du-crs.html#machine-configuration-crs_ran-ref-design-crs) --  Important Note after table.
Telco -> RAN DU ref design components -> [Node Tuning Operator](https://file.rdu.redhat.com/mburke/node-cgroup-v1-deprecation/telco_ref_design_specs/ran/telco-ran-ref-du-components.html#telco-ran-node-tuning-operator_ran-ref-design-components) -- Important note after _Engineering consideratiuons_ list
OCP: [Configuring Linux cgroup](https://75120--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks#nodes-clusters-cgroups-2_post-install-cluster-tasks) -- Important note after third paragraph  
OKD: [Configuring Linux cgroup](https://file.rdu.redhat.com/mburke/node-cgroup-v1-deprecation/post_installation_configuration/cluster-tasks.html#nodes-clusters-cgroups-2_post-install-cluster-tasks) -- Important note after third paragraph 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->