### PR TITLE
OSDOCS-10346: Update link to latest version of the ROSA CLI in the "What's New" page

### DIFF
--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -16,7 +16,7 @@ toc::[]
 [id="rosa-q2-2024_{context}"]
 === Q2 2024
 
-* **ROSA CLI update.** The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/tag/v1.2.37[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-about_rosa-getting-started-cli[About the ROSA CLI].
+* **ROSA CLI update.** The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-about_rosa-getting-started-cli[About the ROSA CLI].
 
 * **Longer cluster names enhancement.** You can now specify a cluster name that is longer than 15 characters. For cluster names that are longer than 15 characters, you can customize the domain prefix for the cluster URL by using the `domain-prefix` flag in the ROSA CLI (`rosa`) or by selecting the **Create custom domain prefix** checkbox in the {hybrid-console}. For more information, see xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-cluster-command_rosa-managing-objects-cli[create cluster in Managing objects with the ROSA CLI].
 


### PR DESCRIPTION
[OSDOCS-10346](https://issues.redhat.com//browse/OSDOCS-10346): Update link to latest version of the ROSA CLI in the "What's New" page

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-10346

Link to docs preview:
https://75121--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html

QE review:
- [ ] QE has approved this change.
No QE review needed

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
