### PR TITLE
TELCDOCS-1771-RN-416 Adding RN for 4.16

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -166,6 +166,17 @@ The Network Observability Operator releases updates independently from the {prod
 [id="ocp-4-16-scalability-and-performance"]
 === Scalability and performance
 
+[id="workload-partitioning-enhancement"]
+==== Workload partitioning enhancement
+With this release, platform pods deployed with a workload annotation that includes both CPU limits and CPU requests will have the CPU limits accurately calculated and applied as a CPU quota for the specific pod. In prior releases, if a workload partitioned pod had both CPU limits and requests set, they were ignored by the webhook. The pod did not benefit from workload partitioning and was not locked down to specific cores. This update ensures the requests and limits are now interpreted correctly by the webhook. 
+
+[NOTE]
+====
+It is expected that if the values for CPU limits are different from the value for requests in the annotation, the CPU limits are taken as being the same as the requests. 
+====
+
+For more information, see xref:../scalability_and_performance/enabling-workload-partitioning.adoc#enabling-workload-partitioning[Workload partitioning].
+
 [id="ocp-4-16-hcp"]
 === Hosted control planes
 


### PR DESCRIPTION
[Telcodocs 1771]: Extend workload partitioning to support cpu limits RN 

Version(s): 4.16 RN

Issue:https://issues.redhat.com/browse/TELCODOCS-1771

Link to docs preview: https://75127--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#workload-partitioning-enhancement

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
