### PR TITLE
Adds OMR 1.3.11 release notes

### DIFF
--- a/modules/mirror-registry-release-notes.adoc
+++ b/modules/mirror-registry-release-notes.adoc
@@ -11,6 +11,17 @@ These release notes track the development of the _mirror registry for Red Hat Op
 
 For an overview of the _mirror registry for Red Hat OpenShift_, see xref:../../installing/disconnected_install/installing-mirroring-creating-registry.adoc#mirror-registry-flags_installing-mirroring-creating-registry[Creating a mirror registry with mirror registry for Red Hat OpenShift].
 
+[id="mirror-registry-for-openshift-1-3-11"]
+== Mirror registry for Red Hat OpenShift 1.3.11
+
+Issued: 2024-04-23
+
+_Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.8.15.
+
+The following advisory is available for the _mirror registry for Red Hat OpenShift_:
+
+* link:https://access.redhat.com/errata/RHBA-2024:1758[RHBA-2024:1758 - mirror registry for Red Hat OpenShift 1.3.11]
+
 [id="mirror-registry-for-openshift-1-3-10"]
 == Mirror registry for Red Hat OpenShift 1.3.10
 


### PR DESCRIPTION
Released on 4.23

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-10350

Link to docs preview:
https://75136--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-creating-registry.html#mirror-registry-for-openshift-1-3-11

Not needed