### PR TITLE
MIG-1509: MTC 1.7.15 Release Notes

### DIFF
--- a/migration_toolkit_for_containers/mtc-release-notes.adoc
+++ b/migration_toolkit_for_containers/mtc-release-notes.adoc
@@ -20,6 +20,7 @@ For information on the support policy for {mtc-short}, see link:https://access.r
 include::modules/migration-mtc-release-notes-1-8-2.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-8-1.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-8.adoc[leveloffset=+1]
+include::modules/migration-mtc-release-notes-1-7-15.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-7-14.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-7-13.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-7-12.adoc[leveloffset=+1]

--- a/modules/migration-mtc-release-notes-1-7-15.adoc
+++ b/modules/migration-mtc-release-notes-1-7-15.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="migration-mtc-release-notes-1-7-15_{context}"]
+= {mtc-full} 1.7.15 release notes
+
+[id="resolved-issues-1-7-15_{context}"]
+== Resolved issues
+
+This release has the following resolved issues:
+
+.CVE-2024-24786: A flaw was found in Golang's protobuf module, where the unmarshal function can enter an infinite loop
+
+A flaw was found in the `protojson.Unmarshal` function that could cause the function to enter an infinite loop when unmarshaling certain forms of invalid JSON messages. This condition could occur when unmarshaling into a message that contained a `google.protobuf.Any` value or when the `UnmarshalOptions.DiscardUnknown` option was set in a JSON-formatted message.
+
+To resolve this issue, upgrade to {mtc-short} 1.7.15.
+
+For more details, see link:https://access.redhat.com/security/cve/CVE-2024-24786[(CVE-2024-24786)].
+
+.CVE-2024-28180: `jose-go` improper handling of highly compressed data
+
+A vulnerability was found in Jose due to improper handling of highly compressed data. An attacker could send a JSON Web Encryption (JWE) encrypted message that contained compressed data that used large amounts of memory and CPU when decompressed by the `Decrypt` or `DecryptMulti` functions. 
+
+To resolve this issue, upgrade to {mtc-short} 1.7.15.
+
+For more details, see link:https://access.redhat.com/security/cve/CVE-2024-28180[(CVE-2024-28180)].
+
+
+[id="known-issues-1-7-15_{context}"]
+== Known issues
+
+This release has the following known issues:
+
+.Direct Volume Migration is failing as the Rsync pod on the source cluster goes into an `Error` state
+
+On migrating any application with Persistent Volume Claim (PVC), the `Stage` migration operation succeeds with warnings, and Direct Volume Migration (DVM) fails with the `rsync` pod on the source namespace going into an `error` state. link:https://bugzilla.redhat.com/show_bug.cgi?id=2256141[(BZ#2256141)]
+
+.The conflict condition is briefly cleared after it is created
+
+When creating a new state migration plan that results in a conflict error message, the error message is cleared shortly after it is displayed. link:https://bugzilla.redhat.com/show_bug.cgi?id=2144299[(BZ#2144299)]
+
+.Migration fails when there are multiple Volume Snapshot Locations (VSLs) of different provider types configured in a cluster with no specified default VSL.
+
+When there are multiple VSLs in a cluster with different provider types, and you set none of them as the default VSL, Velero results in a validation error that causes migration operations to fail. link:https://bugzilla.redhat.com/show_bug.cgi?id=2180565[(BZ#2180565)]


### PR DESCRIPTION
### JIRA

* [MIG-1509](https://issues.redhat.com/browse/MIG-1509)

* GA 30th April

### Version(s):

* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16

### Link to docs preview:

* [MTC 1.7.15 release notes](https://75137--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/mtc-release-notes.html#migration-mtc-release-notes-1-7-15_mtc-release-notes)

QE review:
- [X ] [QE has approved this change.](https://github.com/openshift/openshift-docs/pull/75137#pullrequestreview-2027504824)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
