### PR TITLE
[enterprise-4.14] OCPBUGS-29262-redo: Updated the vSphere add parameters to include mis…

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -58,7 +58,7 @@ ifeval::["{context}" == "installation-config-parameters-agent"]
 :agent:
 endif::[]
 
-// You can issue a command such as `openshift-install explain installconfig.platform.vsphere.failureDomains` to see information about a parameter. You must store the `openshift-install` binary in your bin directory.
+// You can issue a command such as `openshift-install explain installconfig.platform.vsphere.failureDomains` to see information about a parameter. You must store the `openshift-install` binary in your bin directory. Also, consider viewing the installer/pkg/types/vsphere/platform.go for information about supported parameters.
 
 :_mod-docs-content-type: CONCEPT
 [id="installation-configuration-parameters_{context}"]
@@ -2392,16 +2392,20 @@ In either case, this resource group must only be used for a single cluster insta
 endif::ibm-cloud[]
 
 ifdef::vsphere[]
-
 [id="installation-configuration-parameters-additional-vsphere_{context}"]
 == Additional VMware vSphere configuration parameters
 
 Additional VMware vSphere configuration parameters are described in the following table:
 
 .Additional VMware vSphere cluster parameters
-[cols=".^2l,.^3a,.^3",options="header,word-wrap",subs="+quotes,+attributes"]
+[cols=".^2l,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
 |====
 |Parameter|Description|Values
+
+|platform:
+  vsphere:
+|Describes your account on the cloud platform that hosts your cluster. You can use the parameter to customize the platform. If you provide additional configuration settings for compute and control plane machines in the machine pool, the parameter is not required. You can only specify one vCenter server for your {product-title} cluster.
+|A dictionary of vSphere configuration objects
 
 |platform:
   vsphere:
@@ -2414,13 +2418,58 @@ Additional VMware vSphere configuration parameters are described in the followin
 |platform:
   vsphere:
     diskType:
-|Optional. The disk provisioning method. This value defaults to the vSphere default storage policy if not set.
+|Optional: The disk provisioning method. This value defaults to the vSphere default storage policy if not set.
 |Valid values are `thin`, `thick`, or `eagerZeroedThick`.
 
 |platform:
   vsphere:
     failureDomains:
 |Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
+|An array of failure domain configuration objects.
+
+|platform:
+  vsphere:
+    failureDomains:
+      name:
+|The name of the failure domain.
+|String
+
+|platform:
+  vsphere:
+    failureDomains:
+      region:
+|If you define multiple failure domains for your cluster, you must attach the tag to each vCenter datacenter. To define a region, use a tag from the `openshift-region` tag category. For a single vSphere datacenter environment, you do not need to attach a tag, but you must enter an alphanumeric value, such as `datacenter`, for the parameter.
+|String
+
+|platform:
+  vsphere:
+    failureDomains:
+      server:
+|Specifies the fully-qualified hostname or IP address of the VMware vCenter server, so that a client can access failure domain resources. You must apply the `server` role to the vSphere vCenter server location.
+|String
+
+|platform:
+  vsphere:
+    failureDomains:
+      zone:
+|If you define multiple failure domains for your cluster, you must attach a tag to each vCenter cluster. To define a zone, use a tag from the `openshift-zone` tag category. For a single vSphere datacenter environment, you do not need to attach a tag, but you must enter an alphanumeric value, such as `cluster`, for the parameter.
+|String
+
+|platform:
+  vsphere:
+    failureDomains:
+      topology:
+        computeCluster:
+|The path to the vSphere compute cluster.
+|String
+
+|platform:
+  vsphere:
+    failureDomains:
+      topology:
+        datacenter:
+|Lists and defines the datacenters where {product-title} virtual machines (VMs) operate.
+The list of datacenters must match the list of datacenters specified in the `vcenters` field.
 |String
 
 |platform:
@@ -2435,6 +2484,15 @@ Additional VMware vSphere configuration parameters are described in the followin
   vsphere:
     failureDomains:
       topology:
+        folder:
+|Optional: The absolute path of an existing folder where the user creates the virtual machines, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
+If you do not provide this value, the installation program creates a top-level folder in the datacenter virtual machine folder that is named with the infrastructure ID. If you are providing the infrastructure for the cluster and you do not want to use the default `StorageClass` object, named `thin`, you can omit the `folder` parameter from the `install-config.yaml` file.
+|String
+
+|platform:
+  vsphere:
+    failureDomains:
+      topology:
         networks:
 |Lists any network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured.
 |String
@@ -2442,29 +2500,19 @@ Additional VMware vSphere configuration parameters are described in the followin
 |platform:
   vsphere:
     failureDomains:
-      server:
-|Specifies the fully-qualified hostname or IP address of the VMware vCenter server, so that a client can access failure domain resources. You must apply the `server` role to the vSphere vCenter server location.
+      topology:
+        resourcePool:
+
+|Optional: The absolute path of an existing resource pool where the installation program creates the virtual machines, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
+If you do not specify a value, the installation program installs the resources in the root of the cluster under `/<datacenter_name>/host/<cluster_name>/Resources`.
 |String
 
 |platform:
   vsphere:
     failureDomains:
-      region:
-|If you define multiple failure domains for your cluster, you must attach the tag to each vCenter datacenter. To define a region, use a tag from the `openshift-region` tag category. For a single vSphere datacenter environment, you do not need to attach a tag, but you must enter an alphanumeric value, such as `datacenter`, for the parameter.
-|String
-
-|platform:
-  vsphere:
-    failureDomains:
-      zone:
-|If you define multiple failure domains for your cluster, you must attach the tag to each vCenter cluster. To define a zone, use a tag from the `openshift-zone` tag category. For a single vSphere datacenter environment, you do not need to attach a tag, but you must enter an alphanumeric value, such as `cluster`, for the parameter.
-|String
-
-|platform:
-  vsphere:
-    failureDomains:
-      template:
-|Specify the absolute path to a pre-existing {op-system-first} image template or virtual machine. The installation program can use the image template or virtual machine to quickly install {op-system} on vSphere hosts. Consider using this parameter as an alternative to uploading an {op-system} image on vSphere hosts. The parameter is available for use only on installer-provisioned infrastructure.
+      topology
+        template:
+|Specifies the absolute path to a pre-existing {op-system-first} image template or virtual machine. The installation program can use the image template or virtual machine to quickly install {op-system} on vSphere hosts. Consider using this parameter as an alternative to uploading an {op-system} image on vSphere hosts. This parameter is available for use only on installer-provisioned infrastructure.
 |String
 
 |platform:
@@ -2477,20 +2525,43 @@ Additional VMware vSphere configuration parameters are described in the followin
 
 |platform:
   vsphere:
-| Describes your account on the cloud platform that hosts your cluster. You can use the parameter to customize the platform. When providing additional configuration settings for compute and control plane machines in the machine pool, the parameter is optional. You can only specify one vCenter server for your {product-title} cluster.
-|String
-
-|platform:
-  vsphere:
     vcenters:
-|Lists any fully-qualified hostname or IP address of a vCenter server.
-|String
+|Configures the connection details so that services can communicate with a vCenter server. Currently, only a single vCenter server is supported.
+|An array of vCenter configuration objects.
 
 |platform:
   vsphere:
     vcenters:
       datacenters:
 |Lists and defines the datacenters where {product-title} virtual machines (VMs) operate. The list of datacenters must match the list of datacenters specified in the `failureDomains` field.
+|String
+
+|platform:
+  vsphere:
+    vcenters:
+      password:
+|The password associated with the vSphere user.
+|String
+
+|platform:
+  vsphere:
+    vcenters:
+      port:
+|The port number used to communicate with the vCenter server.
+|Integer
+
+|platform:
+  vsphere:
+    vcenters:
+      server:
+|The fully qualified host name (FQHN) or IP address of the vCenter server.
+|String
+
+|platform:
+  vsphere:
+    vcenters:
+      user:
+|The username associated with the vSphere user.
 |String
 |====
 
@@ -2535,7 +2606,7 @@ a|An IP address, for example `128.0.0.1`.
 |platform:
   vsphere:
     folder:
-|Optional. The absolute path of an existing folder where the installation program creates the virtual machines. If you do not provide this value, the installation program creates a folder that is named with the infrastructure ID in the data center virtual machine folder.
+|Optional: The absolute path of an existing folder where the installation program creates the virtual machines. If you do not provide this value, the installation program creates a folder that is named with the infrastructure ID in the data center virtual machine folder.
 |String, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
 
 |platform:
@@ -2561,7 +2632,7 @@ a|An IP address, for example `128.0.0.1`.
 |platform:
   vsphere:
     resourcePool:
-|Optional. The absolute path of an existing resource pool where the installation program creates the virtual machines. If you do not specify a value, the installation program installs the resources in the root of the cluster under `/<datacenter_name>/host/<cluster_name>/Resources`.
+|Optional: The absolute path of an existing resource pool where the installation program creates the virtual machines. If you do not specify a value, the installation program installs the resources in the root of the cluster under `/<datacenter_name>/host/<cluster_name>/Resources`.
 a|String, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
 
 |platform:
@@ -2916,7 +2987,7 @@ If defined, the parameters `compute.platform.alibabacloud` and `controlPlane.pla
 endif::alibaba-cloud[]
 
 ifdef::nutanix[]
-[id="installation-configuration-parameters-additional-vsphere_{context}"]
+[id="installation-configuration-parameters-additional-nutanix_{context}"]
 == Additional Nutanix configuration parameters
 
 Additional Nutanix configuration parameters are described in the following table:


### PR DESCRIPTION
Cherry pick from #74339 with commit ID cbb655c5f3951964d78635096d1585baa5957293

Issue:
[OCPBUGS-29262](https://issues.redhat.com/browse/OCPBUGS-29262)

Link to docs preview:
* [Additional VMware vSphere configuration parameters](https://75140--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere#installation-configuration-parameters-additional-vsphere_installation-config-parameters-vsphere)
* [Additional Nutanix configuration parameters](https://75140--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installation-config-parameters-nutanix#installation-configuration-parameters-additional-nutanix_installation-config-parameters-nutanix)
* [Agent-based installer additional parameters](https://75140--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installation-config-parameters-agent#installation-configuration-parameters-additional-vsphere_installation-config-parameters-agent)

**NOTE:** As per https://github.com/openshift/openshift-docs/pull/70551, the Agent-based installer only apply to 4.15+.