### PR TITLE
[enterprise-4.13] OCPBUGS-29262-redo: Updated the vSphere add parameters to include mis…

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -254,7 +254,7 @@ ifeval::["{context}" == "installing-restricted-networks-nutanix-installer-provis
 :nutanix:
 endif::[]
 
-// You can issue a command such as `openshift-install explain installconfig.platform.vsphere.failureDomains` to see information about a parameter. You must store the `openshift-install` binary in your bin directory.
+// You can issue a command such as `openshift-install explain installconfig.platform.vsphere.failureDomains` to see information about a parameter. You must store the `openshift-install` binary in your bin directory. Also, consider viewing the installer/pkg/types/vsphere/platform.go for information about supported parameters.
 
 :_mod-docs-content-type: CONCEPT
 [id="installation-configuration-parameters_{context}"]
@@ -1940,60 +1940,142 @@ The `platform.vsphere` parameter prefixes each parameter listed in the table.
 ====
 
 .Additional VMware vSphere cluster parameters
-[cols=".^2,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
+[cols=".^2l,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
 |====
 |Parameter|Description|Values
 
-|`apiVIPs`
+|platform:
+  vsphere:
+|Describes your account on the cloud platform that hosts your cluster. You can use the parameter to customize the platform. If you provide additional configuration settings for compute and control plane machines in the machine pool, the parameter is not required. You can only specify one vCenter server for your {product-title} cluster.
+|A dictionary of vSphere configuration objects
+
+|platform:
+  vsphere:
+    apiVIPs:
 |Virtual IP (VIP) addresses that you configured for control plane API access.
 
 *Note:* This parameter applies only to installer-provisioned infrastructure.
 |Multiple IP addresses
 
-|`diskType`
-|Optional. The disk provisioning method. This value defaults to the vSphere default storage policy if not set.
+|platform:
+  vsphere:
+    diskType:
+|Optional: The disk provisioning method. This value defaults to the vSphere default storage policy if not set.
 |Valid values are `thin`, `thick`, or `eagerZeroedThick`.
 
-|`failureDomains`
-|Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
-|String
-
-|`failureDomains.topology.datastore`
-|Specifies the path to a vSphere datastore that stores virtual machines files for a failure domain. You must apply the datastore role to the vSphere vCenter datastore location.
-|String
-
-|`failureDomains.topology.networks`
-|Lists any network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured.
-|String
-
-|`failureDomains.server`
-|Specifies the fully-qualified hostname or IP address of the VMware vCenter server, so that a client can access failure domain resources. You must apply the server role to the vSphere vCenter server location.
-|String
-
-|`failureDomains.region`
+|platform:
+  vsphere:
+    failureDomains:
+      region:
 |If you define multiple failure domains for your cluster, you must attach the tag to each vCenter datacenter. To define a region, use a tag from the `openshift-region` tag category. For a single vSphere datacenter environment, you do not need to attach a tag, but you must enter an alphanumeric value, such as `datacenter`, for the parameter.
 |String
 
-|`failureDomains.zone`
-|If you define multiple failure domains for your cluster, you must attach the tag to each vCenter cluster. To define a zone, use a tag from the `openshift-zone` tag category. For a single vSphere datacenter environment, you do not need to attach a tag, but you must enter an alphanumeric value, such as `cluster`, for the parameter.
-|`String`
+|platform:
+  vsphere:
+    failureDomains:
+      server:
+|Specifies the fully-qualified hostname or IP address of the VMware vCenter server, so that a client can access failure domain resources. You must apply the `server` role to the vSphere vCenter server location.
+|String
 
-|`ingressVIPs`
+|platform:
+  vsphere:
+    failureDomains:
+      zone:
+|If you define multiple failure domains for your cluster, you must attach a tag to each vCenter cluster. To define a zone, use a tag from the `openshift-zone` tag category. For a single vSphere datacenter environment, you do not need to attach a tag, but you must enter an alphanumeric value, such as `cluster`, for the parameter.
+|String
+
+|platform:
+  vsphere:
+    failureDomains:
+      topology:
+        datacenter:
+|Lists and defines the datacenters where {product-title} virtual machines (VMs) operate.
+The list of datacenters must match the list of datacenters specified in the `vcenters` field.
+|String
+
+
+|platform:
+  vsphere:
+    failureDomains:
+      topology:
+        datastore:
+|Specifies the path to a vSphere datastore that stores virtual machines files for a failure domain. You must apply the `datastore` role to the vSphere vCenter datastore location.
+|String
+
+|platform:
+  vsphere:
+    failureDomains:
+      topology:
+        folder:
+|Optional: The absolute path of an existing folder where the user creates the virtual machines, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
+If you do not provide this value, the installation program creates a top-level folder in the datacenter virtual machine folder that is named with the infrastructure ID. If you are providing the infrastructure for the cluster and you do not want to use the default `StorageClass` object, named `thin`, you can omit the `folder` parameter from the `install-config.yaml` file.
+|String
+
+|platform:
+  vsphere:
+    failureDomains:
+      topology:
+        networks:
+|Lists any network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured.
+|String
+
+|platform:
+  vsphere:
+    failureDomains:
+      topology:
+        resourcePool:
+
+|Optional: The absolute path of an existing resource pool where the installation program creates the virtual machines, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
+If you do not specify a value, the installation program installs the resources in the root of the cluster under `/<datacenter_name>/host/<cluster_name>/Resources`.
+|String
+
+|platform:
+  vsphere:
+    ingressVIPs:
 |Virtual IP (VIP) addresses that you configured for cluster Ingress.
 
 *Note:* This parameter applies only to installer-provisioned infrastructure.
 |Multiple IP addresses
 
-|`vsphere`
-| Describes your account on the cloud platform that hosts your cluster. You can use the parameter to customize the platform. When providing additional configuration settings for compute and control plane machines in the machine pool, the parameter is optional. You can only specify one vCenter server for your {product-title} cluster.
-|String
+|platform:
+  vsphere:
+    vcenters:
+|Configures the connection details so that services can communicate with a vCenter server. Currently, only a single vCenter server is supported.
+|An array of vCenter configuration objects.
 
-|`vcenters`
-|Lists any fully-qualified hostname or IP address of a vCenter server.
-|String
-
-|`vcenters.datacenters`
+|platform:
+  vsphere:
+    vcenters:
+      datacenters:
 |Lists and defines the datacenters where {product-title} virtual machines (VMs) operate. The list of datacenters must match the list of datacenters specified in the `failureDomains` field.
+|String
+
+|platform:
+  vsphere:
+    vcenters:
+      password:
+|The password associated with the vSphere user.
+|String
+
+|platform:
+  vsphere:
+    vcenters:
+      port:
+|The port number used to communicate with the vCenter server.
+|Integer
+
+|platform:
+  vsphere:
+    vcenters:
+      server:
+|The fully qualified host name (FQHN) or IP address of the vCenter server.
+|String
+
+|platform:
+  vsphere:
+    vcenters:
+      user:
+|The username associated with the vSphere user.
 |String
 |====
 
@@ -2010,58 +2092,80 @@ The `platform.vsphere` parameter prefixes each parameter listed in the table.
 ====
 
 .Deprecated VMware vSphere cluster parameters
-[cols=".^2,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
+[cols=".^2l,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
 |====
 |Parameter|Description|Values
 
-|`apiVIP`
+|platform:
+  vsphere:
+    apiVIP:
 |The virtual IP (VIP) address that you configured for control plane API access.
 
 *Note:* In {product-title} 4.12 and later, the `apiVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `apiVIPs` configuration setting.
 a|An IP address, for example `128.0.0.1`.
 
-|`cluster`
+|platform:
+  vsphere:
+    cluster:
 |The vCenter cluster to install the {product-title} cluster in.
 |String
 
-|`datacenter`
+|platform:
+  vsphere:
+    datacenter:
 |Defines the datacenter where {product-title} virtual machines (VMs) operate.
 |String
 
-|`defaultDatastore`
+|platform:
+  vsphere:
+    defaultDatastore:
 |The name of the default datastore to use for provisioning volumes.
 |String
 
-|`folder`
-|Optional. The absolute path of an existing folder where the installation program creates the virtual machines. If you do not provide this value, the installation program creates a folder that is named with the infrastructure ID in the data center virtual machine folder.
+|platform:
+  vsphere:
+    folder:
+|Optional: The absolute path of an existing folder where the installation program creates the virtual machines. If you do not provide this value, the installation program creates a folder that is named with the infrastructure ID in the data center virtual machine folder.
 |String, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
 
-|`ingressVIP`
+|platform:
+  vsphere:
+    ingressVIP:
 |Virtual IP (VIP) addresses that you configured for cluster Ingress.
 
 *Note:* In {product-title} 4.12 and later, the `ingressVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `ingressVIPs` configuration setting.
 a|An IP address, for example `128.0.0.1`.
 
-|`network`
+|platform:
+  vsphere:
+    network:
 |The network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured.
 |String
 
-|`password`
+|platform:
+  vsphere:
+    password:
 |The password for the vCenter user name.
 |String
 
-|`resourcePool`
-|Optional. The absolute path of an existing resource pool where the installation program creates the virtual machines. If you do not specify a value, the installation program installs the resources in the root of the cluster under `/<datacenter_name>/host/<cluster_name>/Resources`.
+|platform:
+  vsphere:
+    resourcePool:
+|Optional: The absolute path of an existing resource pool where the installation program creates the virtual machines. If you do not specify a value, the installation program installs the resources in the root of the cluster under `/<datacenter_name>/host/<cluster_name>/Resources`.
 a|String, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
 
-|`username`
+|platform:
+  vsphere:
+    username:
 |The user name to use to connect to the vCenter instance with. This user must have at least
 the roles and privileges that are required for
 link:https://github.com/vmware-archive/vsphere-storage-for-kubernetes/blob/master/documentation/vcp-roles.md[static or dynamic persistent volume provisioning]
 in vSphere.
 |String
 
-|`vCenter`
+|platform:
+  vsphere:
+    vCenter:
 |The fully-qualified hostname or IP address of a vCenter server.
 |String
 |====
@@ -2294,7 +2398,7 @@ If defined, the parameters `compute.platform.alibabacloud` and `controlPlane.pla
 endif::alibabacloud[]
 
 ifdef::nutanix[]
-[id="installation-configuration-parameters-additional-vsphere_{context}"]
+[id="installation-configuration-parameters-additional-nutanix_{context}"]
 == Additional Nutanix configuration parameters
 
 Additional Nutanix configuration parameters are described in the following table:


### PR DESCRIPTION
Cherry pick from #74339 with commit ID cbb655c5f3951964d78635096d1585baa5957293

Issue:
[OCPBUGS-29262](https://issues.redhat.com/browse/OCPBUGS-29262)

Link to docs preview:
* [Additional VMware vSphere configuration parameters - vSphere](https://75159--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-network-customizations#installation-configuration-parameters-additional-vsphere_installing-vsphere-network-customizations)
* [Additional VMware vSphere configuration parameters - VMC](https://75159--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vmc/installing-vmc-customizations#installation-configuration-parameters-additional-vsphere_installing-vmc-customizations)
* [Additional Nutanix configuration parameters](https://75159--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned#installation-configuration-parameters-additional-nutanix_installing-nutanix-installer-provisioned)

**NOTE:** As per https://github.com/openshift/openshift-docs/pull/70551, the Agent-based installer only apply to 4.15+.