### PR TITLE
[enterprise-4.12]OCPBUGS-29262-redo: Updated the vSphere add parameters to include mis…

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -226,7 +226,7 @@ ifeval::["{context}" == "installing-restricted-networks-nutanix-installer-provis
 :nutanix:
 endif::[]
 
-// You can issue a command such as `openshift-install explain installconfig.platform.vsphere.failureDomains` to see information about a parameter. You must store the `openshift-install` binary in your bin directory.
+// You can issue a command such as `openshift-install explain installconfig.platform.vsphere.failureDomains` to see information about a parameter. You must store the `openshift-install` binary in your bin directory. Also, consider viewing the installer/pkg/types/vsphere/platform.go for information about supported parameters.
 
 :_mod-docs-content-type: CONCEPT
 [id="installation-configuration-parameters_{context}"]
@@ -1845,7 +1845,7 @@ The `platform.vsphere` parameter prefixes each parameter listed in the table.
 |String
 
 |`failureDomains.topology.resourcePool`
-|The absolute path of an existing resource pool where the installation program creates the virtual machines. If you do not define this parameter in your configuration, the resource pool takes the value of `platform.vsphere.failureDomains.topology.computeCluster`.
+|Optional: The absolute path of an existing resource pool where the installation program creates the virtual machines, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`. If you do not specify a value, the installation program installs the resources in the root of the cluster under `/<datacenter_name>/host/<cluster_name>/Resources`.
 |====
 endif::vsphere,vmc[]
 
@@ -2040,7 +2040,7 @@ If defined, the parameters `compute.platform.alibabacloud` and `controlPlane.pla
 endif::alibabacloud[]
 
 ifdef::nutanix[]
-[id="installation-configuration-parameters-additional-vsphere_{context}"]
+[id="installation-configuration-parameters-additional-nutanix_{context}"]
 == Additional Nutanix configuration parameters
 
 Additional Nutanix configuration parameters are described in the following table:


### PR DESCRIPTION
Cherry pick from #74339 with commit ID cbb655c5f3951964d78635096d1585baa5957293

Issue:
[OCPBUGS-29262](https://issues.redhat.com/browse/OCPBUGS-29262)

Link to docs preview:
* [Additional VMware vSphere configuration parameters - vSphere](https://75165--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations#installation-configuration-parameters-additional-vsphere_installing-vsphere-installer-provisioned-network-customizations)
* [Additional VMware vSphere configuration parameters - VMC](https://75165--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vmc/installing-vmc-customizations#installation-configuration-parameters-additional-vsphere_installing-vmc-customizations)
* [Additional Nutanix configuration parameters](https://75165--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned#installation-configuration-parameters-additional-nutanix_installing-nutanix-installer-provisioned)

**NOTE:** As per https://github.com/openshift/openshift-docs/pull/70551, the Agent-based installer only apply to 4.15+.

One parameter missing:

![image](https://github.com/openshift/openshift-docs/assets/57954076/4f534550-9b3d-4fba-8b74-ac6d104979e1)


vCentre parameters were not live until 4.13. So vCenter is OK for [4.12](https://docs.openshift.com/container-platform/4.12/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.html#installation-configuration-parameters-additional-vsphere_installing-vsphere-installer-provisioned-network-customizations) , so the following parameters are not applicable to 4.12:

- platform.vsphere.vcenters.password
- platform.vsphere.vcenters.port
- platform.vsphere.vcenters.server
- platform.vsphere.vcenters.user

See https://issues.redhat.com/browse/OCPBUGS-29262