### PR TITLE
[OSDOCS-10362]: Fix bug in gcp-compute-types_osd-service-definition

### DIFF
--- a/modules/sdpolicy-am-gcp-compute-types.adoc
+++ b/modules/sdpolicy-am-gcp-compute-types.adoc
@@ -8,7 +8,7 @@
 {product-title} offers the following worker node types and sizes on Google Cloud that are chosen to have a common CPU and memory capacity that are the same as other cloud instance types:
 [NOTE]
 ====
-`e2`, `ns` and `c2` compute types are available for CCS only.
+`e2`, `n2` and `c2` compute types are available for CCS only.
 ====
 
 .General purpose


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.15+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-10362
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://75172--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-service-definition.html#gcp-compute-types_osd-service-definition
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
NO QE needed. They already approved https://github.com/openshift/openshift-docs/pull/74436. This was typo that was noticed after initial release. 
Additional information:
<!--- Optional: Include additional context or expand the description here.--->
![image](https://github.com/openshift/openshift-docs/assets/122639474/ffdd0be0-d143-4d0d-a425-037d0171cfc9)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
