### PR TITLE
RHDEVDOCS-5912 - Updates to the argo cd CLI installation and reference sections

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -14,7 +14,8 @@
 //gitops
 :gitops-title: Red Hat OpenShift GitOps
 :gitops-shortname: GitOps
-:gitops-ver: 1.1
+:gitops-ver: 1.12
+:upstream-ver: 2.10
 :rh-app-icon: image:red-hat-applications-menu-icon.jpg[title="Red Hat applications"]
 
 // IBM Power

--- a/gitops_cli_argocd/argocd-gitops-cli-reference.adoc
+++ b/gitops_cli_argocd/argocd-gitops-cli-reference.adoc
@@ -29,5 +29,5 @@ include::modules/gitops-argocd-cli-utility-commands.adoc[leveloffset=+1]
 * xref:../gitops_cli_argocd/configuring-argocd-gitops-cli.adoc#configuring-argocd-gitops-cli[Configuring the {gitops-shortname} CLI]
 * xref:../gitops_cli_argocd/logging-in-to-argocd-server-in-default-mode.adoc#logging-in-to-argocd-server-in-default-mode[Logging in to the Argo CD server in the default mode]
 * link:https://github.com/redhat-developer/gitops-operator/blob/7ac4b2ce179c167b39be259b8d9be37dc280f689/docs/OpenShift%20GitOps%20CLI%20User%20Guide.md#login-related-commands[OpenShift {gitops-shortname} CLI User Guide]
-* link:https://argo-cd.readthedocs.io/en/release-2.10/user-guide/commands/argocd/[`argocd` command reference]
-//delete the link to `argocd` command reference after you document all the argocd reference commmands
+* link:https://argo-cd.readthedocs.io/en/release-{upstream-ver}/user-guide/commands/argocd/[`argocd` command reference]
+//update the upstream version attribute value for every release

--- a/installing_gitops/installing-argocd-gitops-cli.adoc
+++ b/installing_gitops/installing-argocd-gitops-cli.adoc
@@ -17,16 +17,16 @@ Both the compressed archives and the RPMs contain the `argocd` executable binary
 ====
 
 // Install GitOps argocd CLI on Linux
-// include::modules/gitops-installing-argocd-cli-on-linux.adoc[leveloffset=+1]
+include::modules/gitops-installing-argocd-cli-on-linux.adoc[leveloffset=+1]
 
 // Install GitOps argocd CLI on Linux using RPM
 include::modules/gitops-installing-argocd-cli-on-linux-using-rpm.adoc[leveloffset=+1]
 
 //Install GitOps argocd CLI on Windows
-// include::modules/gitops-installing-argocd-cli-on-windows.adoc[leveloffset=+1]
+include::modules/gitops-installing-argocd-cli-on-windows.adoc[leveloffset=+1]
 
 //Install GitOps argocd CLI on macOS
-// include::modules/gitops-installing-argocd-cli-on-macos.adoc[leveloffset=+1]
+include::modules/gitops-installing-argocd-cli-on-macos.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources_installing-argocd-gitops-cli"]

--- a/modules/gitops-installing-argocd-cli-on-linux-using-rpm.adoc
+++ b/modules/gitops-installing-argocd-cli-on-linux-using-rpm.adoc
@@ -15,95 +15,93 @@ For {op-system-base-full} version 8 or later, you can install the {gitops-shortn
 
 .Procedure
 
-. Register with Red Hat Subscription Manager:
+. Register with Red Hat Subscription Manager by running the following command:
 +
 [source,terminal]
 ----
 # subscription-manager register
 ----
 
-. Pull the latest subscription data:
+. Pull the latest subscription data by running the following command:
 +
 [source,terminal]
 ----
 # subscription-manager refresh
 ----
 
-. List the available subscriptions:
+. List the available subscriptions by running the following command:
 +
 [source,terminal]
 ----
 # subscription-manager list --available --matches '*gitops*'
 ----
 
-. In the output for the previous command, find the pool ID for your {OCP} subscription and attach the subscription to the registered system:
+. In the output for the previous command, find the pool ID for your {OCP} subscription, and attach the subscription to the registered system by running the following command:
 +
 [source,terminal]
 ----
 # subscription-manager attach --pool=<pool_id>
 ----
 
-. Enable the repositories required by {gitops-title}:
+. Enable the repositories required by {gitops-title} for {op-system-base} version 8 or later by running the following command: 
 +
-* For RHEL 8
-** Linux (x86_64, amd64)
-+
-[source,terminal]
-----
-# subscription-manager repos --enable="gitops-1.12-for-rhel-8-x86_64-rpms"
-----
-+
-** Linux on {ibmzProductName} and {linuxoneProductName} (s390x)
+* Linux (x86_64, amd64)
 +
 [source,terminal]
 ----
-# subscription-manager repos --enable="gitops-1.12-for-rhel-8-s390x-rpms"
+# subscription-manager repos --enable="gitops-<gitops_version>-for-rhel-<rhel_version>-x86_64-rpms"
 ----
 +
-** Linux on {ibmpowerProductName} (ppc64le)
-+
-[source,terminal]
+.Example command
+[source,terminal,subs="attributes+"]
 ----
-# subscription-manager repos --enable="gitops-1.12-for-rhel-8-ppc64le-rpms"
+# subscription-manager repos --enable="gitops-{gitops-ver}-for-rhel-8-x86_64-rpms"
 ----
+// Update the gitops version attribute value for every release
 +
-** Linux on ARM (aarch64, arm64)
-+
-[source,terminal]
-----
-# subscription-manager repos --enable="gitops-1.12-for-rhel-8-aarch64-rpms"
-----
-+
-* For RHEL 9
-** Linux (x86_64, amd64)
+* Linux on {ibmzProductName} and {linuxoneProductName} (s390x)
 +
 [source,terminal]
 ----
-# subscription-manager repos --enable="gitops-1.12-for-rhel-9-x86_64-rpms"
+# subscription-manager repos --enable="gitops-<gitops_version>-for-rhel-<rhel_version>-s390x-rpms"
 ----
 +
-** Linux on {ibmzProductName} and {linuxoneProductName} (s390x)
-+
-[source,terminal]
+.Example command
+[source,terminal,subs="attributes+"]
 ----
-# subscription-manager repos --enable="gitops-1.12-for-rhel-9-s390x-rpms"
+# subscription-manager repos --enable="gitops-{gitops-ver}-for-rhel-8-s390x-rpms"
 ----
+// Update the gitops version attribute value for every release
 +
-** Linux on {ibmpowerProductName} (ppc64le)
-+
-[source,terminal]
-----
-# subscription-manager repos --enable="gitops-1.12-for-rhel-9-ppc64le-rpms"
-----
-+
-** Linux on ARM (aarch64, arm64)
+* Linux on {ibmpowerProductName} (ppc64le)
 +
 [source,terminal]
 ----
-# subscription-manager repos --enable="gitops-1.12-for-rhel-9-aarch64-rpms"
+# subscription-manager repos --enable="gitops-<gitops_version>-for-rhel-<rhel_version>-ppc64le-rpms"
 ----
++
+.Example command
+[source,terminal,subs="attributes+"]
+----
+# subscription-manager repos --enable="gitops-{gitops-ver}-for-rhel-8-ppc64le-rpms"
+----
+// Update the gitops version attribute value for every release
++
+* Linux on ARM (aarch64, arm64)
++
+[source,terminal]
+----
+# subscription-manager repos --enable="gitops-<gitops_version>-for-rhel-<rhel_version>-aarch64-rpms"
+----
++
+.Example command
+[source,terminal,subs="attributes+"]
+----
+# subscription-manager repos --enable="gitops-{gitops-ver}-for-rhel-8-aarch64-rpms"
+----
+// Update the gitops version attribute value for every release
 
-. Install the `openshift-gitops-argocd-cli` package:
+. Install the `openshift-gitops-argocd-cli` package by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/gitops-installing-argocd-cli-on-linux.adoc
+++ b/modules/gitops-installing-argocd-cli-on-linux.adoc
@@ -10,35 +10,42 @@ For Linux distributions, you can download the {gitops-shortname} `argocd` CLI as
 
 .Procedure
 
-. Download the relevant CLI tool.
-
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/v1.12.0/argocd-linux-amd64.tar.gz[Linux (x86_64, amd64)]
-
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/v1.12.0/argocd-linux-s390x.tar.gz[Linux on {ibmzProductName} and {linuxoneProductName} (s390x)]
-
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/v1.12.0/argocd-linux-ppc64le.tar.gz[Linux on {ibmpowerProductName} (ppc64le)]
-
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/v1.12.0/argocd-linux-arm64.tar.gz[Linux on ARM (aarch64, arm64)]
-
+. Download the latest version of the CLI tool from the link:https://developers.redhat.com/content-gateway/rest/browse/pub/openshift-v4/clients/openshift-gitops/latest/[content gateway] for your operating system and architecture.
 +
-You can also download any version of the {gitops-shortname} `argocd` CLI by navigating to the corresponding directory for the version that you want in the link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/[`argocd` CLI client download mirror].
-// Binaries also need to be updated in the following modules:
-// gitops-installing-argocd-cli-on-windows.adoc
-// gitops-installing-argocd-cli-on-macos.adoc
-// gitops-installing-argocd-cli-on-linux-using-rpm.adoc
+[options="header"]
+|===
+|Operating system |Architecture |Tarball
 
-. Extract the archive:
+|Linux |x86_64, amd64 |`argocd-linux-amd64.tar.gz`
+|Linux on {ibmzProductName} and {linuxoneProductName} |s390x |`argocd-linux-s390x.tar.gz`
+|Linux on {ibmpowerProductName} |ppc64le |`argocd-linux-ppc64le.tar.gz`
+|Linux on ARM |aarch64, arm64 |`argocd-linux-arm64.tar.gz`
+|===
++
+[NOTE]
+====
+Newer versions of the CLI tool are compatible with the older versions of {gitops-title} server, but not vice versa.
+====
+
+. Extract the archive by running the following command:
 +
 [source,terminal]
 ----
 $ tar xvzf <file>
 ----
 
-. Move the binary to a directory on your `PATH` environment variable:
+. Move the binary to a directory on your `PATH` environment variable by running the following command:
 +
 [source,terminal]
 ----
-$ sudo mv argocd-darwin-amd64 /usr/local/bin/argocd
+$ sudo mv argocd /usr/local/bin/argocd
+----
+
+. Make the file executable by running the following command:
++
+[source,terminal]
+----
+$ sudo chmod +x /usr/local/bin/argocd
 ----
 
 . After you install the {gitops-shortname} `argocd` CLI, verify that it is available by running the following command:

--- a/modules/gitops-installing-argocd-cli-on-macos.adoc
+++ b/modules/gitops-installing-argocd-cli-on-macos.adoc
@@ -10,29 +10,42 @@ For macOS, you can download the {gitops-shortname} `argocd` CLI as a `tar.gz` ar
 
 .Procedure
 
-. Download the relevant CLI tool.
-
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/v1.12.0/argocd-darwin-amd64.tar.gz[macOS on Intel]
-
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/v1.12.0/argocd-darwin-arm64.tar.gz[macOS on ARM]
-
+. Download the latest version of the CLI tool from the link:https://developers.redhat.com/content-gateway/rest/browse/pub/openshift-v4/clients/openshift-gitops/latest/[content gateway] for your operating system and architecture.
 +
-You can also download any version of the {gitops-shortname} `argocd` CLI by navigating to the corresponding directory for the version that you want in the link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/[`argocd` CLI client download mirror].
+[options="header"]
+|===
+|Operating system |Architecture |Tarball
 
-. Extract the archive:
+|macOS on Intel |x86_64 |`argocd-macos-amd64.tar.gz`
+|macOS on ARM |arm64 |`argocd-macos-arm64.tar.gz`
+|===
++
+[NOTE]
+====
+Newer versions of the CLI tool are compatible with the older versions of {gitops-title} server, but not vice versa.
+====
+
+. Extract the archive by running the following command:
 +
 [source,terminal]
 ----
 $ tar xvzf <file>
 ----
 
-. Move the binary to a directory on your `PATH` environment variable:
+. Move the binary to a directory on your `PATH` environment variable by running the following command:
 +
 [source,terminal]
 ----
-$ sudo mv argocd-darwin-amd64 /usr/local/bin/argocd
+$ sudo mv argocd /usr/local/bin/argocd
 ----
+
+. Make the file executable by running the following command:
 +
+[source,terminal]
+----
+$ sudo chmod +x /usr/local/bin/argocd
+----
+
 . After you install the {gitops-shortname} `argocd` CLI, verify that it is available by running the following command:
 +
 [source,terminal]

--- a/modules/gitops-installing-argocd-cli-on-windows.adoc
+++ b/modules/gitops-installing-argocd-cli-on-windows.adoc
@@ -10,14 +10,23 @@ For Windows, you can download the {gitops-shortname} `argocd` CLI as a compresse
 
 .Procedure
 
-. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/v1.12.0/argocd-windows-amd64.zip[CLI tool].
-
+. Download the latest version of the CLI tool from the link:https://developers.redhat.com/content-gateway/rest/browse/pub/openshift-v4/clients/openshift-gitops/latest/[content gateway] for your operating system and architecture.
 +
-You can also download any version of the {gitops-shortname} `argocd` CLI by navigating to the corresponding directory for the version that you want in the link:https://mirror.openshift.com/pub/openshift-v4/clients/argocd-cli/[`argocd` CLI client download mirror].
+[options="header"]
+|===
+|Operating system |Architecture |Tarball
+
+|Windows |x86_64 |`argocd-windows-amd64.zip`
+|===
++
+[NOTE]
+====
+Newer versions of the CLI tool are compatible with the older versions of {gitops-title} server, but not vice versa.
+====
 
 . Extract the archive with a ZIP program.
 
-. Move the binary to a directory on your `PATH` environment variable:
+. Move the binary to a directory on your `PATH` environment variable by running the following command:
 +
 [source,terminal]
 ----

--- a/release_notes/gitops-release-notes.adoc
+++ b/release_notes/gitops-release-notes.adoc
@@ -57,22 +57,3 @@ include::modules/gitops-release-notes-1-10-1.adoc[leveloffset=+1]
 
 // Release notes for Red Hat OpenShift GitOps 1.10.0
 include::modules/gitops-release-notes-1-10-0.adoc[leveloffset=+1]
-
-// Release notes for Red Hat OpenShift GitOps 1.9.4
-include::modules/gitops-release-notes-1-9-4.adoc[leveloffset=+1]
-
-// Release notes for Red Hat OpenShift GitOps 1.9.3
-include::modules/gitops-release-notes-1-9-3.adoc[leveloffset=+1]
-
-// Release notes for Red Hat OpenShift GitOps 1.9.2
-include::modules/gitops-release-notes-1-9-2.adoc[leveloffset=+1]
-
-// Release notes for Red Hat OpenShift GitOps 1.9.1
-include::modules/gitops-release-notes-1-9-1.adoc[leveloffset=+1]
-
-// Release notes for Red Hat OpenShift GitOps 1.9.0
-include::modules/gitops-release-notes-1-9-0.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-* link:https://docs.openshift.com/container-platform/latest/operators/admin/olm-configuring-proxy-support.html#olm-inject-custom-ca_olm-configuring-proxy-support[Injecting a custom CA certificate]


### PR DESCRIPTION
**Jira issue:** [RHDEVDOCS-5912](https://issues.redhat.com/browse/RHDEVDOCS-5912)

**Aligned team:** DevTools 
**Cherry-pick to versions:** `gitops-docs-1.12`

**Docs preview:**

- [Installing the GitOps CLI](https://75177--ocpdocs-pr.netlify.app/openshift-gitops/latest/installing_gitops/installing-argocd-gitops-cli)
- [GitOps argocd CLI reference](https://75177--ocpdocs-pr.netlify.app/openshift-gitops/latest/gitops_cli_argocd/argocd-gitops-cli-reference#additional-resources_argocd-gitops-cli-reference)
- [Red Hat OpenShift GitOps release notes](https://75177--ocpdocs-pr.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes)

SME review: Completed by @anandf

QE review: Completed by @varshab1210 

Peer review: 

**Additional information:** This PR is related to https://github.com/openshift/openshift-docs/pull/72634. The content was already reviewed and approved. Due to the content gateway link issue from the Engineering side, certain installation procedures were commented out during the GitOps 1.12 GA. This PR comments-in back those procedures while adding admonition and updates to the content gateway links and their steps. TY!
