### PR TITLE
OSDOCS-5778: CAPI vSphere TP (rel notes)

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -123,8 +123,8 @@ With this release, migration from the OpenShift SDN network plugin to OVN-Kubern
 [id="ocp-4-16-machine-config-operator"]
 === Machine Config Operator
 
-[id="ocp-4-16-machine-api"]
-=== Machine API
+[id="ocp-4-16-machine-management"]
+=== Machine management
 
 [id="ocp-4-16-cluster-autoscaler-expanders"]
 ==== Configuring expanders for the cluster autoscaler
@@ -132,6 +132,15 @@ With this release, migration from the OpenShift SDN network plugin to OVN-Kubern
 With this release, the cluster autoscaler can use the `LeastWaste`, `Priority`, and `Random` expanders.
 You can configure these expanders to influence the selection of machine sets when scaling the cluster.
 For more information, see xref:../machine_management/applying-autoscaling.adoc#configuring-clusterautoscaler_applying-autoscaling[Configuring the cluster autoscaler].
+
+[id="ocp-4-16-capi-tp-vmw"]
+==== Managing machines with the Cluster API for {vmw-full} (Technology Preview)
+
+This release introduces the ability to manage machines by using the upstream Cluster API, integrated into {product-title}, as a Technology Preview for {vmw-full} clusters.
+This capability is in addition or an alternative to managing machines with the Machine API.
+For more information, see _Managing machines with the Cluster API_.
+//xref blocked by #72885
+//For more information, see xr3f:../machine_management/cluster_api_machine_management/cluster-api-about.adoc#cluster-api-about[Managing machines with the Cluster API].
 
 [id="ocp-4-16-nodes"]
 === Nodes
@@ -996,6 +1005,11 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
+|Managing machines with the Cluster API for {vmw-full}
+|Not Available
+|Not Available
+|Technology Preview
+
 |Defining a vSphere failure domain for a control plane machine set
 |Not Available
 |Technology Preview
@@ -1011,7 +1025,7 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |General Availability
 
-|Cloud controller manager for {ibm-power-name} VS
+|Cloud controller manager for {ibm-power-server-name}
 |Technology Preview
 |Technology Preview
 |Technology Preview


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-5778](https://issues.redhat.com//browse/OSDOCS-5778)

Link to docs preview:
- [Managing machines with the Cluster API for VMware vSphere (Technology Preview)](https://75178--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-capi-tp-vmw)
- [Machine management Technology Preview features](https://75178--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#machine-management-technology-preview-features)

QE review:
- [x] QE has approved this change.

Additional information:
Can add xref when #72885 merges