### PR TITLE
OCPBUGS-32204: typo fix

### DIFF
--- a/modules/nw-ipfailover-cluster-ha-ingress.adoc
+++ b/modules/nw-ipfailover-cluster-ha-ingress.adoc
@@ -3,10 +3,10 @@
 // * networking/configuring-ipfailover.adoc
 
 [id="nw-ipfailover-cluster-ha-ingress_{context}"]
-= High availability For ingressIP
+= High availability for ingressIP
 
 In non-cloud clusters, IP failover and `ingressIP` to a service can be combined. The result is high availability services for users that create services using `ingressIP`.
 
-The approach is to specify an `ingressIPNetworkCIDR` range and then use the same range in creating the ipfailover configuration.
+The approach is to specify an `ingressIPNetworkCIDR` range and then use the same range in creating the IP failover configuration.
 
-Because IP failover can support up to a maximum of 255 VIPs for the entire cluster, the `ingressIPNetworkCIDR` needs to be `/24` or smaller.
+Because IP failover can support up to a maximum of 255 VIPs for the entire cluster, the `ingressIPNetworkCIDR` must be `/24` or smaller.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-32204](https://issues.redhat.com/browse/OCPBUGS-32204)

Link to docs preview:
https://75187--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring-ipfailover.html

No QE required