### PR TITLE
OSDOCS#10345: Restructured the Firewall Prereq modules

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -3,18 +3,29 @@
 // * osd_planning/aws-ccs.adoc
 // * rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc
 // * rosa_planning/rosa-sts-aws-prereqs.adoc
-// * rosa_planning/rosa-hcp-prereqs.adoc
 
 ifeval::["{context}" == "rosa-sts-aws-prereqs"]
 :fedramp:
+:rosa-classic-sts:
 endif::[]
-ifeval::["{context}" == "rosa-hcp-aws-prereqs"]
-:fedramp:
+ifeval::["{context}" == "aws-ccs"]
+:osd:
+endif::[]
+ifeval::["{context}" == "prerequisites"]
+:rosa-classic:
 endif::[]
 
 :_mod-docs-content-type: PROCEDURE
+ifdef::rosa-classic-sts[]
+[id="rosa-classic-firewall-prerequisites_{context}"]
+= ROSA Classic
+endif::rosa-classic-sts[]
+ifndef::rosa-classic-sts[]
 [id="osd-aws-privatelink-firewall-prerequisites_{context}"]
 = AWS firewall prerequisites
+
+If you are using a firewall to control egress traffic from {product-title}, you must configure your firewall to grant access to the certain domain and port combinations below. {product-title} requires this access to provide a fully managed OpenShift service.
+endif::rosa-classic-sts[]
 
 ifdef::openshift-rosa[]
 [IMPORTANT]
@@ -23,7 +34,9 @@ Only ROSA clusters deployed with PrivateLink can use a firewall to control egres
 ====
 endif::[]
 
-This section provides the necessary details that enable you to control egress traffic from your {product-title} cluster. If you are using a firewall to control egress traffic, you must configure your firewall to grant access to the domain and port combinations below. {product-title} requires this access to provide a fully managed OpenShift service.
+.Prerequisites
+
+* You have configured an Amazon S3 gateway endpoint in your AWS Virtual Private Cloud (VPC). This endpoint is required to complete requests from the cluster to the Amazon S3 service.
 
 .Procedure
 
@@ -40,7 +53,15 @@ This section provides the necessary details that enable you to control egress tr
 |443
 |Provides core container images.
 
-|`.quay.io`
+|`cdn01.quay.io`
+|443
+|Provides core container images.
+
+|`cdn02.quay.io`
+|443
+|Provides core container images.
+
+|`cdn03.quay.io`
 |443
 |Provides core container images.
 
@@ -68,9 +89,13 @@ This section provides the necessary details that enable you to control egress tr
 |443
 |Provides {op-system-first} images.
 
-|`registry.access.redhat.com` ^[1]^
+|`registry.access.redhat.com`
 |443
 |Hosts all the container images that are stored on the Red Hat Ecosytem Catalog. Additionally, the registry provides access to the `odo` CLI tool that helps developers build on OpenShift and Kubernetes.
+
+|`access.redhat.com`
+|443
+|Required. Hosts a signature store that a container client requires for verifying images when pulling them from `registry.access.redhat.com`. 
 
 |`registry.connect.redhat.com`
 |443
@@ -108,39 +133,33 @@ This section provides the necessary details that enable you to control egress tr
 |443
 |The `registry.access.redhat.com` and `https://registry.redhat.io` sites redirect through `catalog.redhat.com`.
 
-|`dvbwgdztaeq9o.cloudfront.net` ^[2]^
+|`dvbwgdztaeq9o.cloudfront.net` ^[1]^
 |443
 |Used by ROSA for STS implementation with managed OIDC configuration.
 
 ifdef::fedramp[]
 |`time-a-g.nist.gov`
-|123 ^[3]^
+|123 ^[2]^
 |Allows NTP traffic for FedRAMP.
 
 |`time-a-wwv.nist.gov`
-|123 ^[3]^
+|123 ^[2]^
 |Allows NTP traffic for FedRAMP.
 
 |`time-a-b.nist.gov`
-|123 ^[3]^
+|123 ^[2]^
 |Allows NTP traffic for FedRAMP.
 endif::fedramp[]
 |===
 +
 [.small]
 --
-1. In a firewall environment, ensure that the `access.redhat.com` resource is on the allowlist. This resource hosts a signature store that a container client requires for verifying images when pulling them from `registry.access.redhat.com`.
-2. The string of alphanumeric characters before `cloudfront.net` could change if there is a major cloudfront outage that requires redirecting the resource.
+1. The string of alphanumeric characters before `cloudfront.net` could change if there is a major cloudfront outage that requires redirecting the resource.
 ifdef::fedramp[]
-3. Both TCP and UDP ports.
+2. Both TCP and UDP ports.
 endif::fedramp[]
-
 --
 +
-When you add a site such as `quay.io` to your allowlist, do not add a wildcard entry such as `.quay.io` to your denylist. In most cases, image registries use a content delivery network (CDN) to serve images. If a firewall blocks access, then image downloads are denied when the initial download request is redirected to a host name such as `cdn01.quay.io`.
-+
-CDN host names, such as `cdn01.quay.io`, are covered when you add a wildcard entry, such as `.quay.io`, in your allowlist.
-
 . Allowlist the following telemetry URLs:
 +
 [cols="6,1,6",options="header"]
@@ -327,26 +346,16 @@ OR
 | Required for Sonatype Nexus, F5 Big IP operators.
 |===
 
-. If you did not allow a wildcard for Amazon Web Services (AWS) APIs, you must also allow the S3 bucket used for the internal OpenShift registry. To retrieve that endpoint, run the following command after the cluster is successfully provisioned:
-+
-[source,terminal]
-----
-$ oc -n openshift-image-registry get pod -l docker-registry=default -o json | jq '.items[].spec.containers[].env[] | select(.name=="REGISTRY_STORAGE_S3_BUCKET")'
-----
-+
-The S3 endpoint should be in the following format:
-+
-[source,terminal]
-----
-'<cluster-name>-<random-string>-image-registry-<cluster-region>-<random-string>.s3.dualstack.<cluster-region>.amazonaws.com'.
-----
-
 . Allowlist any site that provides resources for a language or framework that your builds require.
 . Allowlist any outbound URLs that depend on the languages and frameworks used in OpenShift. See link:https://access.redhat.com/solutions/2998411[OpenShift Outbound URLs to Allow] for a list of recommended URLs to be allowed on the firewall or proxy.
 
 ifeval::["{context}" == "rosa-sts-aws-prereqs"]
 :!fedramp:
+:!rosa-classic-sts:
 endif::[]
-ifeval::["{context}" == "rosa-hcp-aws-prereqs"]
-:!fedramp:
+ifeval::["{context}" == "aws-ccs"]
+:!osd:
+endif::[]
+ifeval::["{context}" == "prerequisites"]
+:!rosa-classic:
 endif::[]

--- a/modules/rosa-hcp-firewall-prerequisites.adoc
+++ b/modules/rosa-hcp-firewall-prerequisites.adoc
@@ -1,0 +1,141 @@
+// Module included in the following assemblies:
+//
+// * rosa_planning/rosa-sts-aws-prereqs.adoc
+// * rosa_planning/rosa-hcp-prereqs.adoc
+
+ifeval::["{context}" == "rosa-sts-aws-prereqs"]
+:rosa-classic-sts:
+endif::[]
+ifeval::["{context}" == "rosa-hcp-aws-prereqs"]
+:hcp:
+endif::[]
+
+[id="rosa-hcp-firewall-prerequisites_{context}"]
+// Conditionals are to change the title when displayed on the rosa-sts-aws-prereqs page
+ifdef::rosa-classic-sts[]
+= {hcp-title}
+endif::rosa-classic-sts[]
+ifndef::rosa-classic-sts[]
+= AWS firewall prerequisites
+
+If you are using a firewall to control egress traffic from {product-title}, you must configure your firewall to grant access to the certain domain and port combinations below. {product-title} requires this access to provide a fully managed OpenShift service.
+endif::rosa-classic-sts[]
+
+.Prerequisites
+
+* You have configured an Amazon S3 gateway endpoint in your AWS Virtual Private Cloud (VPC). This endpoint is required to complete requests from the cluster to the Amazon S3 service. 
+
+.Procedure
+
+. Allowlist the following URLs that are used to download and install packages and tools:
++
+[cols="6,1,6",options="header"]
+|===
+|Domain | Port | Function
+|`quay.io`
+|443
+|Provides core container images.
+
+|`cdn01.quay.io`
+|443
+|Provides core container images.
+
+|`cdn02.quay.io`
+|443
+|Provides core container images.
+
+|`cdn03.quay.io`
+|443
+|Provides core container images.
+
+|`quayio-production-s3.s3.amazonaws.com`
+|443
+|Provides core container images.
+
+|`registry.redhat.io`
+|443
+|Provides core container images.
+
+|`registry.access.redhat.com`
+|443
+|Required. Hosts all the container images that are stored on the Red Hat Ecosytem Catalog. Additionally, the registry provides access to the `odo` CLI tool that helps developers build on OpenShift and Kubernetes.
+
+|`access.redhat.com`
+|443
+|Required. Hosts a signature store that a container client requires for verifying images when pulling them from `registry.access.redhat.com`. 
+
+|`mirror.openshift.com`
+|443
+|Required. Used to access mirrored installation content and images. This site is also a source of release image signatures, although the Cluster Version Operator (CVO) needs only a single functioning source.
+|===
++
+. Allowlist the following telemetry URLs:
++
+[cols="6,1,6",options="header"]
+|===
+|Domain | Port | Function
+|`infogw.api.openshift.com`
+|443
+|Required for telemetry.
+
+|`console.redhat.com`
+|443
+|Required. Allows interactions between the cluster and OpenShift Console Manager to enable functionality, such as scheduling upgrades.
+
+|`sso.redhat.com`
+|443
+|Required. The `https://console.redhat.com/openshift` site uses authentication from `sso.redhat.com` to download the pull secret and use Red Hat SaaS solutions to facilitate monitoring of your subscriptions, cluster inventory, chargeback reporting, etc.
+|===
++
+Managed clusters require enabling telemetry to allow Red Hat to react more quickly to problems, better support the customers, and better understand how product upgrades impact clusters.
+For more information about how remote health monitoring data is used by Red Hat, see _About remote health monitoring_ in the _Additional resources_ section.
+
+. Allowlist the following Amazon Web Services (AWS) API URls:
++
+[cols="6,1,6",options="header"]
+|===
+|Domain | Port | Function
+
+|`sts.<aws_region>.amazonaws.com` ^[1]^
+|443
+|Required. Used to access the AWS Secure Token Service (STS) regional endpoint. Ensure that you replace `<aws-region>` with the region that your cluster is deployed in.
+
+|`sts.amazonaws.com` ^[2]^
+|443
+|See footnote. Used to access the AWS Secure Token Service (STS) global endpoint.
+|===
++
+[.small]
+--
+1. This can also be accomplished by configuring a private interface endpoint in your AWS Virtual Private Cloud (VPC) to the regional AWS STS endpoint.
+2. The AWS STS global endpoint is only required to be allowed if you are running a version of OpenShift before 4.14.18 or 4.15.4. ROSA HCP version 4.14.18+, 4.15.4+, and 4.16.0+ use the AWS STS regional endpoint.
+--
++
+
+. Allowlist the following URLs for optional third-party content:
++
+[cols="6,1,6",options="header"]
+|===
+|Domain | Port | Function
+|`registry.connect.redhat.com`
+| 443
+| Optional. Required for all third-party-images and certified operators.
+
+|`rhc4tp-prod-z8cxf-image-registry-us-east-1-evenkyleffocxqvofrk.s3.dualstack.us-east-1.amazonaws.com`
+| 443
+| Optional. Provides access to container images hosted on `registry.connect.redhat.com`.
+
+|`oso-rhc4tp-docker-registry.s3-us-west-2.amazonaws.com`
+| 443
+| Optional. Required for Sonatype Nexus, F5 Big IP operators.
+|===
+
+. Allowlist any site that provides resources for a language or framework that your builds require.
+. Allowlist any outbound URLs that depend on the languages and frameworks used in OpenShift. See link:https://access.redhat.com/solutions/2998411[OpenShift Outbound URLs to Allow] for a list of recommended URLs to be allowed on the firewall or proxy.
+
+ifeval::["{context}" == "rosa-sts-aws-prereqs"]
+:!rosa-classic-sts:
+endif::[]
+ifeval::["{context}" == "rosa-hcp-aws-prereqs"]
+:!hcp:
+endif::[]

--- a/osd_planning/aws-ccs.adoc
+++ b/osd_planning/aws-ccs.adoc
@@ -15,7 +15,7 @@ include::modules/ccs-aws-customer-procedure.adoc[leveloffset=+1]
 include::modules/ccs-aws-scp.adoc[leveloffset=+1]
 include::modules/ccs-aws-iam.adoc[leveloffset=+1]
 include::modules/ccs-aws-provisioned.adoc[leveloffset=+1]
-include::modules/osd-aws-privatelink-firewall-prerequisites.adoc[leveloffset=+2]
+include::modules/osd-aws-privatelink-firewall-prerequisites.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources

--- a/rosa_planning/rosa-hcp-prereqs.adoc
+++ b/rosa_planning/rosa-hcp-prereqs.adoc
@@ -73,7 +73,7 @@ With the STS deployment model, Red Hat is no longer responsible for creating and
 * For every cluster, you must have the necessary operator roles. See xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-operator-roles_rosa-sts-about-iam-resources[Cluster-specific Operator IAM role reference].
 
 include::modules/rosa-aws-provisioned.adoc[leveloffset=+1]
-include::modules/osd-aws-privatelink-firewall-prerequisites.adoc[leveloffset=+1]
+include::modules/rosa-hcp-firewall-prerequisites.adoc[leveloffset=+1]
 
 == Next steps
 * xref:../rosa_planning/rosa-sts-required-aws-service-quotas.adoc#rosa-sts-required-aws-service-quotas[Review the required AWS service quotas]

--- a/rosa_planning/rosa-sts-aws-prereqs.adoc
+++ b/rosa_planning/rosa-sts-aws-prereqs.adoc
@@ -70,7 +70,14 @@ With the STS deployment model, Red Hat is no longer responsible for creating and
 * For every cluster, you must have the necessary operator roles. See xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-operator-roles_rosa-sts-about-iam-resources[Cluster-specific Operator IAM role reference].
 
 include::modules/rosa-aws-provisioned.adoc[leveloffset=+1]
-include::modules/osd-aws-privatelink-firewall-prerequisites.adoc[leveloffset=+1]
+// Keeping existing ID to prevent link breakage
+[id="osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs"]
+== AWS firewall prerequisites
+
+If you are using a firewall to control egress traffic from your {product-title}, you must configure your firewall to grant access to the certain domain and port combinations below. {product-title} requires this access to provide a fully managed OpenShift service.
+
+include::modules/osd-aws-privatelink-firewall-prerequisites.adoc[leveloffset=+2]
+include::modules/rosa-hcp-firewall-prerequisites.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
Version(s):
`enterprise-4.15+`

Issue:
**[OSDOCS-10345](https://issues.redhat.com/browse/OSDOCS-9614)**

Link to docs preview:

- [Customer Cloud Subscriptions on AWS
](https://75197--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/aws-ccs.html#osd-aws-privatelink-firewall-prerequisites_aws-ccs)
- [AWS prerequisites for ROSA
](https://75197--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_prerequisites)
- [Detailed requirements for deploying ROSA using STS
](https://75197--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Restructured the conditions in the Firewall modules.