### PR TITLE
OSDOCS#10356: Update: Hoted control planes on AWS is GA in OCP 4.16

### DIFF
--- a/hosted_control_planes/hcp-getting-started.adoc
+++ b/hosted_control_planes/hcp-getting-started.adoc
@@ -44,11 +44,8 @@ You can view the procedures by selecting from one of the following providers:
 [id="hcp-getting-started-aws"]
 == {aws-first}
 
-:FeatureName: {hcp-capital} on the {aws-short} platform
-include::snippets/technology-preview.adoc[]
-
 * link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#hosting-cluster-aws-infra-reqs[AWS infrastructure requirements]: Review the infrastructure requirements to create a hosted cluster on {aws-short}.
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#hosting-service-cluster-configure-aws[Configuring hosted control plane clusters on AWS (Technology Preview)]: The tasks to configure hosted control plane clusters on {aws-short} include creating the {aws-short} S3 OIDC secret, creating a routable public zone, enabling external DNS, enabling {aws-short} PrivateLink, and deploying a hosted cluster.
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#hosting-service-cluster-configure-aws[Configuring hosted control plane clusters on AWS]: The tasks to configure hosted control plane clusters on {aws-short} include creating the {aws-short} S3 OIDC secret, creating a routable public zone, enabling external DNS, enabling {aws-short} PrivateLink, and deploying a hosted cluster.
 * xref:../networking/hardware_networks/configuring-sriov-operator.adoc#sriov-operator-hosted-control-planes_configuring-sriov-operator[Deploying the SR-IOV Operator for {hcp}]: After you configure and deploy your hosting service cluster, you can create a subscription to the Single Root I/O Virtualization (SR-IOV) Operator on a hosted cluster. The SR-IOV pod runs on worker machines rather than the control plane.
 
 * To destroy a hosted cluster on AWS, follow the instructions in link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#hypershift-cluster-destroy-aws[Destroying a hosted cluster on AWS].


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> ---> Update docs to reflect that hoted control planes on AWS is GA in OCP 4.16

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-10356
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://75199--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-getting-started.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
