### PR TITLE
OBSDOCS-1011: Fix information about the user-workload-monitoring-conf…

### DIFF
--- a/modules/monitoring-adding-a-secret-to-the-alertmanager-configuration.adoc
+++ b/modules/monitoring-adding-a-secret-to-the-alertmanager-configuration.adoc
@@ -23,9 +23,9 @@ ifndef::openshift-dedicated,openshift-rosa[]
 ** You have created the `cluster-monitoring-config` config map.
 ** You have created the secret to be configured in Alertmanager in the `openshift-monitoring` project.
 * *If you are configuring components that monitor user-defined projects*:
-** A cluster administrator has enabled monitoring for user-defined projects.
 ** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 ** You have created the secret to be configured in Alertmanager in the `openshift-user-workload-monitoring` project.
+** A cluster administrator has enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
@@ -128,13 +128,6 @@ data:
       - test-secret
       - test-api-receiver-token
 ----
-ifndef::openshift-dedicated,openshift-rosa[]
-+
-[NOTE]
-====
-Configurations applied to the `user-workload-monitoring-config` `ConfigMap` object are not activated unless a cluster administrator has enabled monitoring for user-defined projects.
-====
-endif::openshift-dedicated,openshift-rosa[]
 
 . Save the file to apply the changes to the `ConfigMap` object. The new configuration is applied automatically.
 

--- a/modules/monitoring-assigning-tolerations-to-monitoring-components.adoc
+++ b/modules/monitoring-assigning-tolerations-to-monitoring-components.adoc
@@ -22,7 +22,7 @@ ifndef::openshift-dedicated,openshift-rosa[]
 ** You have created the `cluster-monitoring-config` `ConfigMap` object.
 * *If you are configuring components that monitor user-defined projects*:
 ** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
-** You have created the `user-workload-monitoring-config` `ConfigMap` object.
+** A cluster administrator has enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
@@ -126,13 +126,6 @@ data:
 ----
 
 . Save the file to apply the changes. The new component placement configuration is applied automatically.
-ifndef::openshift-dedicated,openshift-rosa[]
-+
-[NOTE]
-====
-Configurations applied to the `user-workload-monitoring-config` `ConfigMap` object are not activated unless a cluster administrator has enabled monitoring for user-defined projects.
-====
-endif::openshift-dedicated,openshift-rosa[]
 +
 [WARNING]
 ====

--- a/modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc
+++ b/modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc
@@ -16,7 +16,7 @@ ifndef::openshift-dedicated,openshift-rosa[]
 ** You have created the `cluster-monitoring-config` `ConfigMap` object.
 * *If you are configuring components that monitor user-defined projects*:
 ** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
-** You have created the `user-workload-monitoring-config` `ConfigMap` object.
+** A cluster administrator has enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
@@ -135,13 +135,6 @@ data:
 ----
 
 . Save the file to apply the changes. The new configuration is applied automatically.
-ifndef::openshift-dedicated,openshift-rosa[]
-+
-[NOTE]
-====
-Configurations applied to the `user-workload-monitoring-config` `ConfigMap` object are not activated unless a cluster administrator has enabled monitoring for user-defined projects.
-====
-endif::openshift-dedicated,openshift-rosa[]
 +
 [WARNING]
 ====

--- a/modules/monitoring-configuring-a-local-persistent-volume-claim.adoc
+++ b/modules/monitoring-configuring-a-local-persistent-volume-claim.adoc
@@ -21,7 +21,7 @@ ifndef::openshift-dedicated,openshift-rosa[]
 ** You have created the `cluster-monitoring-config` `ConfigMap` object.
 * *If you are configuring components that monitor user-defined projects*:
 ** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
-** You have created the `user-workload-monitoring-config` `ConfigMap` object.
+** A cluster administrator has enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
@@ -207,13 +207,6 @@ Storage requirements for the `thanosRuler` component depend on the number of rul
 ====
 
 . Save the file to apply the changes. The pods affected by the new configuration are restarted automatically and the new storage configuration is applied.
-ifndef::openshift-dedicated,openshift-rosa[]
-+
-[NOTE]
-====
-Configurations applied to the `user-workload-monitoring-config` `ConfigMap` object are not activated unless a cluster administrator has enabled monitoring for user-defined projects.
-====
-endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 +
 [WARNING]

--- a/modules/monitoring-configuring-external-alertmanagers.adoc
+++ b/modules/monitoring-configuring-external-alertmanagers.adoc
@@ -24,7 +24,7 @@ ifndef::openshift-dedicated,openshift-rosa[]
 ** You have created the `cluster-monitoring-config` config map.
 * *If you are configuring components that monitor user-defined projects*:
 ** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
-** You have created the `user-workload-monitoring-config` config map.
+** A cluster administrator has enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
@@ -165,14 +165,5 @@ data:
 ----
 
 . Save the file to apply the changes to the `ConfigMap` object. The new component placement configuration is applied automatically.
-ifndef::openshift-dedicated,openshift-rosa[]
-+
-[NOTE]
-====
-Configurations applied to the `user-workload-monitoring-config` `ConfigMap` object are not activated unless a cluster administrator has enabled monitoring for user-defined projects.
-====
-endif::openshift-dedicated,openshift-rosa[]
 
 . Save the file to apply the changes to the `ConfigMap` object. The new component placement configuration is applied automatically.
-
-

--- a/modules/monitoring-configuring-pod-topology-spread-constraints.adoc
+++ b/modules/monitoring-configuring-pod-topology-spread-constraints.adoc
@@ -29,8 +29,8 @@ ifndef::openshift-dedicated,openshift-rosa[]
 ** You have access to the cluster as a user with the `cluster-admin` cluster role.
 ** You have created the `cluster-monitoring-config` `ConfigMap` object.
 * *If you are configuring pods for user-defined monitoring:*
-** A cluster administrator has enabled monitoring for user-defined projects.
 ** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+** A cluster administrator has enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.

--- a/modules/monitoring-configuring-remote-write-storage.adoc
+++ b/modules/monitoring-configuring-remote-write-storage.adoc
@@ -17,7 +17,7 @@ ifndef::openshift-dedicated,openshift-rosa[]
 ** You have created the `cluster-monitoring-config` `ConfigMap` object.
 * *If you are configuring components that monitor user-defined projects:*
 ** You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
-** You have created the `user-workload-monitoring-config` `ConfigMap` object.
+** A cluster administrator has enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
@@ -202,13 +202,6 @@ data:
 See the link:https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config[Prometheus relabel_config documentation] for information about write relabel configuration options.
 
 . Save the file to apply the changes. The pods affected by the new configuration restart automatically.
-ifndef::openshift-dedicated,openshift-rosa[]
-+
-[NOTE]
-====
-Configurations applied to the `user-workload-monitoring-config` `ConfigMap` object are not activated unless a cluster administrator has enabled monitoring for user-defined projects.
-====
-endif::openshift-dedicated,openshift-rosa[]
 +
 [WARNING]
 ====

--- a/modules/monitoring-configuring-the-monitoring-stack.adoc
+++ b/modules/monitoring-configuring-the-monitoring-stack.adoc
@@ -21,7 +21,7 @@ ifndef::openshift-dedicated,openshift-rosa[]
 ** You have created the `cluster-monitoring-config` `ConfigMap` object.
 * *If you are configuring components that monitor user-defined projects*:
 ** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
-** You have created the `user-workload-monitoring-config` `ConfigMap` object.
+** A cluster administrator has enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
@@ -137,13 +137,6 @@ The Prometheus config map component is called `prometheusK8s` in the `cluster-mo
 endif::openshift-dedicated,openshift-rosa[]
 
 . Save the file to apply the changes to the `ConfigMap` object. The pods affected by the new configuration are restarted automatically.
-ifndef::openshift-dedicated,openshift-rosa[]
-+
-[NOTE]
-====
-Configurations applied to the `user-workload-monitoring-config` `ConfigMap` object are not activated unless a cluster administrator has enabled monitoring for user-defined projects.
-====
-endif::openshift-dedicated,openshift-rosa[]
 +
 [WARNING]
 ====

--- a/modules/monitoring-creating-cluster-id-labels-for-metrics.adoc
+++ b/modules/monitoring-creating-cluster-id-labels-for-metrics.adoc
@@ -34,7 +34,7 @@ ifndef::openshift-dedicated,openshift-rosa[]
 ** You have created the `cluster-monitoring-config` `ConfigMap` object.
 * *If you are configuring components that monitor user-defined projects:*
 ** You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
-** You have created the `user-workload-monitoring-config` `ConfigMap` object.
+** A cluster administrator has enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.

--- a/modules/monitoring-creating-scrape-sample-alerts.adoc
+++ b/modules/monitoring-creating-scrape-sample-alerts.adoc
@@ -14,8 +14,7 @@ You can create alerts that notify you when:
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
-* You have enabled monitoring for user-defined projects.
-* You have created the `user-workload-monitoring-config` `ConfigMap` object.
+* A cluster administrator has enabled monitoring for user-defined projects.
 * You have limited the number of samples that can be accepted per target scrape in user-defined projects, by using `enforcedSampleLimit`.
 * You have installed the OpenShift CLI (`oc`).
 

--- a/modules/monitoring-creating-user-defined-workload-monitoring-configmap.adoc
+++ b/modules/monitoring-creating-user-defined-workload-monitoring-configmap.adoc
@@ -6,11 +6,13 @@
 [id="creating-user-defined-workload-monitoring-configmap_{context}"]
 = Creating a user-defined workload monitoring config map
 
-You can configure the user workload monitoring components by creating the `user-workload-monitoring-config` `ConfigMap` object in the `openshift-user-workload-monitoring` project. The Cluster Monitoring Operator (CMO) then configures the components that monitor user-defined projects.
+You can configure the user workload monitoring components with the `user-workload-monitoring-config` `ConfigMap` object in the `openshift-user-workload-monitoring` project. The Cluster Monitoring Operator (CMO) then configures the components that monitor user-defined projects.
 
 [NOTE]
 ====
-When you save your changes to the `user-workload-monitoring-config` `ConfigMap` object, some or all of the pods in the `openshift-user-workload-monitoring` project might be redeployed. It can sometimes take a while for these components to redeploy. You can create and configure the config map before you first enable monitoring for user-defined projects, to prevent having to redeploy the pods often.
+* If you enable monitoring for user-defined projects, the `user-workload-monitoring-config` `ConfigMap` object is created by default.
+
+* When you save your changes to the `user-workload-monitoring-config` `ConfigMap` object, some or all of the pods in the `openshift-user-workload-monitoring` project might be redeployed. It can sometimes take a while for these components to redeploy.
 ====
 
 .Prerequisites
@@ -47,8 +49,10 @@ data:
 ----
 $ oc apply -f user-workload-monitoring-config.yaml
 ----
+ifndef::openshift-dedicated,openshift-rosa[]
 +
 [NOTE]
 ====
 Configurations applied to the `user-workload-monitoring-config` `ConfigMap` object are not activated unless a cluster administrator has enabled monitoring for user-defined projects.
 ====
+endif::openshift-dedicated,openshift-rosa[]

--- a/modules/monitoring-enabling-a-separate-alertmanager-instance-for-user-defined-alert-routing.adoc
+++ b/modules/monitoring-enabling-a-separate-alertmanager-instance-for-user-defined-alert-routing.adoc
@@ -22,7 +22,7 @@ ifdef::openshift-rosa,openshift-dedicated[]
 endif::[]
 ifndef::openshift-rosa,openshift-dedicated[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
-* You have enabled monitoring for user-defined projects in the `cluster-monitoring-config` config map for the `openshift-monitoring` namespace.
+* You have enabled monitoring for user-defined projects.
 endif::[]
 * You have installed the OpenShift CLI (`oc`).
 

--- a/modules/monitoring-enabling-monitoring-for-user-defined-projects.adoc
+++ b/modules/monitoring-enabling-monitoring-for-user-defined-projects.adoc
@@ -27,7 +27,7 @@ You must have access to the cluster as a user with the `cluster-admin` cluster r
 +
 [NOTE]
 ====
-Every time you save configuration changes to the `user-workload-monitoring-config` `ConfigMap` object, the pods in the `openshift-user-workload-monitoring` project are redeployed. It can sometimes take a while for these components to redeploy. You can create and configure the `ConfigMap` object before you first enable monitoring for user-defined projects, to prevent having to redeploy the pods often.
+Every time you save configuration changes to the `user-workload-monitoring-config` `ConfigMap` object, the pods in the `openshift-user-workload-monitoring` project are redeployed. It might sometimes take a while for these components to redeploy.
 ====
 
 .Procedure
@@ -56,12 +56,17 @@ data:
 
 . Save the file to apply the changes. Monitoring for user-defined projects is then enabled automatically.
 +
+[NOTE]
+====
+If you enable monitoring for user-defined projects, the `user-workload-monitoring-config` `ConfigMap` object is created by default.
+====
++
 [WARNING]
 ====
 When changes are saved to the `cluster-monitoring-config` `ConfigMap` object, the pods and other resources in the `openshift-monitoring` project might be redeployed. The running monitoring processes in that project might also be restarted.
 ====
 
-. Check that the `prometheus-operator`, `prometheus-user-workload` and `thanos-ruler-user-workload` pods are running in the `openshift-user-workload-monitoring` project. It might take a short while for the pods to start:
+. Verify that the `prometheus-operator`, `prometheus-user-workload`, and `thanos-ruler-user-workload` pods are running in the `openshift-user-workload-monitoring` project. It might take a short while for the pods to start:
 +
 [source,terminal]
 ----

--- a/modules/monitoring-granting-users-permission-to-configure-alert-routing-for-user-defined-projects.adoc
+++ b/modules/monitoring-granting-users-permission-to-configure-alert-routing-for-user-defined-projects.adoc
@@ -17,7 +17,7 @@ ifdef::openshift-rosa,openshift-dedicated[]
 endif::[]
 ifndef::openshift-rosa,openshift-dedicated[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
-* You have enabled monitoring for user-defined projects in the `cluster-monitoring-config` config map for the `openshift-monitoring` namespace.
+* You have enabled monitoring for user-defined projects.
 endif::[]
 * The user account that you are assigning the role to already exists.
 * You have installed the OpenShift CLI (`oc`).

--- a/modules/monitoring-investigating-why-user-defined-metrics-are-unavailable.adoc
+++ b/modules/monitoring-investigating-why-user-defined-metrics-are-unavailable.adoc
@@ -18,8 +18,7 @@ ifdef::openshift-rosa,openshift-dedicated[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 endif::openshift-rosa,openshift-dedicated[]
 * You have installed the OpenShift CLI (`oc`).
-* You have enabled and configured monitoring for user-defined workloads.
-* You have created the `user-workload-monitoring-config` `ConfigMap` object.
+* You have enabled and configured monitoring for user-defined projects.
 * You have created a `ServiceMonitor` resource.
 
 .Procedure

--- a/modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc
+++ b/modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc
@@ -45,9 +45,8 @@ ifndef::openshift-dedicated,openshift-rosa[]
 ** You have access to the cluster as a user with the `cluster-admin` cluster role.
 ** You have created the `cluster-monitoring-config` `ConfigMap` object.
 * *If you are configuring components that monitor user-defined projects*:
-** A cluster administrator has enabled monitoring for user-defined projects.
 ** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
-** You have created the `user-workload-monitoring-config` `ConfigMap` object.
+** A cluster administrator has enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.

--- a/modules/monitoring-modifying-the-retention-time-for-thanos-ruler-metrics-data.adoc
+++ b/modules/monitoring-modifying-the-retention-time-for-thanos-ruler-metrics-data.adoc
@@ -13,7 +13,6 @@ By default, for user-defined projects, Thanos Ruler automatically retains metric
 ifndef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 * A cluster administrator has enabled monitoring for user-defined projects.
-* You have created the `user-workload-monitoring-config` `ConfigMap` object.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.

--- a/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
+++ b/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
@@ -26,7 +26,7 @@ ifndef::openshift-dedicated,openshift-rosa[]
 ** You have created the `cluster-monitoring-config` `ConfigMap` object.
 * *If you are configuring components that monitor user-defined projects*:
 ** You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
-** You have created the `user-workload-monitoring-config` `ConfigMap` object.
+** A cluster administrator has enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
@@ -119,13 +119,6 @@ If monitoring components remain in a `Pending` state after configuring the `node
 
 . Save the file to apply the changes.
 The components specified in the new configuration are moved to the new nodes automatically.
-ifndef::openshift-dedicated,openshift-rosa[]
-+
-[NOTE]
-====
-Configurations applied to the `user-workload-monitoring-config` `ConfigMap` object are not activated unless a cluster administrator has enabled monitoring for user-defined projects.
-====
-endif::openshift-dedicated,openshift-rosa[]
 +
 [WARNING]
 ====

--- a/modules/monitoring-resizing-a-persistent-storage-volume.adoc
+++ b/modules/monitoring-resizing-a-persistent-storage-volume.adoc
@@ -22,7 +22,7 @@ No service disruption occurs during this process.
 ** You have configured at least one PVC for core {product-title} monitoring components.
 * *If you are configuring components that monitor user-defined projects*:
 ** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
-** You have created the `user-workload-monitoring-config` `ConfigMap` object.
+** A cluster administrator has enabled monitoring for user-defined projects.
 ** You have configured at least one PVC for components that monitor user-defined projects.
 
 .Procedure

--- a/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
+++ b/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
@@ -35,7 +35,7 @@ ifndef::openshift-dedicated,openshift-rosa[]
 ** You have created the `cluster-monitoring-config` `ConfigMap` object.
 * *If you are setting a log level for Prometheus Operator, Prometheus, or Thanos Ruler in the `openshift-user-workload-monitoring` project*:
 ** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
-** You have created the `user-workload-monitoring-config` `ConfigMap` object.
+** A cluster administrator has enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
@@ -104,13 +104,6 @@ For user workload monitoring, available component values are `alertmanager`, `pr
 <2> The log level to apply to the component. The available values are `error`, `warn`, `info`, and `debug`. The default value is `info`.
 
 . Save the file to apply the changes. The pods for the component restart automatically when you apply the log-level change.
-ifndef::openshift-dedicated,openshift-rosa[]
-+
-[NOTE]
-====
-Configurations applied to the `user-workload-monitoring-config` `ConfigMap` object are not activated unless a cluster administrator has enabled monitoring for user-defined projects.
-====
-endif::openshift-dedicated,openshift-rosa[]
 +
 [WARNING]
 ====

--- a/modules/monitoring-setting-query-log-file-for-prometheus.adoc
+++ b/modules/monitoring-setting-query-log-file-for-prometheus.adoc
@@ -25,11 +25,11 @@ ifndef::openshift-dedicated,openshift-rosa[]
 ** You have created the `cluster-monitoring-config` `ConfigMap` object.
 * *If you are enabling the query log file feature for Prometheus in the `openshift-user-workload-monitoring` project*:
 ** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
-** You have created the `user-workload-monitoring-config` `ConfigMap` object.
+** A cluster administrator has enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
-* The `user-workload-monitoring-config` ConfigMap object exists. This object is created by default when the cluster is created.
+* The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
 endif::openshift-dedicated,openshift-rosa[]
 * You have installed the OpenShift CLI (`oc`).
 
@@ -112,13 +112,6 @@ data:
 <1> The full path to the file in which queries will be logged.
 +
 . Save the file to apply the changes.
-ifndef::openshift-dedicated,openshift-rosa[]
-+
-[NOTE]
-====
-Configurations applied to the `user-workload-monitoring-config` `ConfigMap` object are not activated unless a cluster administrator has enabled monitoring for user-defined projects.
-====
-endif::openshift-dedicated,openshift-rosa[]
 +
 [WARNING]
 ====

--- a/modules/monitoring-setting-scrape-sample-and-label-limits-for-user-defined-projects.adoc
+++ b/modules/monitoring-setting-scrape-sample-and-label-limits-for-user-defined-projects.adoc
@@ -17,7 +17,7 @@ If you set sample or label limits, no further sample data is ingested for that t
 
 ifndef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
-* You have enabled monitoring for user-defined projects.
+* A cluster administrator has enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
@@ -74,13 +74,6 @@ The default value is `0`, which specifies no limit.
 The default value is `0`, which specifies no limit.
 
 . Save the file to apply the changes. The limits are applied automatically.
-ifndef::openshift-dedicated,openshift-rosa[]
-+
-[NOTE]
-====
-Configurations applied to the `user-workload-monitoring-config` `ConfigMap` object are not activated unless a cluster administrator has enabled monitoring for user-defined projects.
-====
-endif::openshift-dedicated,openshift-rosa[]
 +
 [WARNING]
 ====


### PR DESCRIPTION
Version(s): `enterprise-4.12` and later

Issue: [OBSDOCS-1011](https://issues.redhat.com/browse/OBSDOCS-1011)

Links to docs preview: 

* [Configuring the monitoring stack
](https://75201--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack)
* [Enabling monitoring for user-defined projects](https://75201--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/enabling-monitoring-for-user-defined-projects#enabling-monitoring-for-user-defined-projects_enabling-monitoring-for-user-defined-projects)
* [Investigating why user-defined project metrics are unavailable](https://75201--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/troubleshooting/investigating-monitoring-issues.html#investigating-why-user-defined-metrics-are-unavailable_investigating-monitoring-issues)

QE review:
- [x] QE has approved this change.

**Additional information:**