### PR TITLE
aws-load-balancer-operator: fix mistakes in STS installation using AWS CLI

### DIFF
--- a/modules/using-aws-cli-create-iam-role-alb-controller.adoc
+++ b/modules/using-aws-cli-create-iam-role-alb-controller.adoc
@@ -45,7 +45,7 @@ EOF
 +
 [source,terminal]
 ----
-$ aws iam create-role --role-name albo-controller --assume-role-policy-document file://albo-controller-trusted-policy.json
+$ aws iam create-role --role-name albo-controller --assume-role-policy-document file://albo-controller-trust-policy.json
 ----
 +
 .Example output

--- a/modules/using-aws-cli-create-iam-role-alb-operator.adoc
+++ b/modules/using-aws-cli-create-iam-role-alb-operator.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="using-aws-cli-create-iam-role-alb-operator_{context}"]
-= Creating an AWS IAM role by using the Cloud Credential Operator utility
+= Creating an AWS IAM role by using the AWS CLI
 
 You can use the AWS Command Line Interface to create an IAM role for the AWS Load Balancer Operator. The IAM role is used to interact with subnets and Virtual Private Clouds (VPCs).
 
@@ -45,7 +45,7 @@ EOF
 +
 [source,terminal]
 ----
-$ aws iam create-role --role-name albo-operator --assume-role-policy-document file://albo-operator-trusted-policy.json
+$ aws iam create-role --role-name albo-operator --assume-role-policy-document file://albo-operator-trust-policy.json
 ----
 +
 .Example output
@@ -63,12 +63,12 @@ PRINCIPAL	arn:aws:iam:777777777777:oidc-provider/<oidc-provider-id>
 +
 [source,terminal]
 ----
-$ curl -o albo-controller-permission-policy.json https://raw.githubusercontent.com/openshift/aws-load-balancer-operator/main/assets/iam-policy.json
+$ curl -o albo-operator-permission-policy.json https://raw.githubusercontent.com/openshift/aws-load-balancer-operator/main/hack/operator-permission-policy.json
 ----
 
 . Attach the permission policy for the AWS Load Balancer Controller to the IAM role by running the following command:
 +
 [source,terminal]
 ----
-$ aws iam put-role-policy --role-name albo-controller --policy-name perms-policy-albo-controller --policy-document file://albo-controller-permission-policy.json
+$ aws iam put-role-policy --role-name albo-operator --policy-name perms-policy-albo-operator --policy-document file://albo-operator-permission-policy.json
 ----


### PR DESCRIPTION
I found a drift from [the developer documentation](https://github.com/openshift/aws-load-balancer-operator/blob/main/docs/prerequisites.md#option-2-using-the-aws-cli) for the ALBO installation instructions on STS cluster using AWS CLI.

Version(s): 4.15, 4.14

Issue: N/A

Link to docs preview: https://75219--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/aws_load_balancer_operator/installing-albo-sts-cluster.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
