### PR TITLE
OCP RHEL nodes goes to NotReady state post resuming MCP pool from pau…

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -54,16 +54,6 @@ openshift-origin:
     enterprise-3.11:
       name: '3.11'
       dir: '3.11'
-openshift-online:
-  name: OpenShift Online
-  author: OpenShift Documentation Project <openshift-docs@redhat.com>
-  site: commercial
-  site_name: Documentation
-  site_url: https://docs.openshift.com/
-  branches:
-    enterprise-3.11:
-      name: 'Pro'
-      dir: online/pro
 openshift-enterprise:
   name: OpenShift Container Platform
   author: OpenShift Documentation Project <openshift-docs@redhat.com>

--- a/index-commercial.html
+++ b/index-commercial.html
@@ -164,9 +164,9 @@
 <div class="landing">
   <div class="container">
     <div class="row">
-      <div class="col-md-10 col-centered">
+      <div class="col-md-12 col-centered">
         <div class="row">
-          <div class="col-sm-3 text-center">
+          <div class="col-sm-4 text-center">
             <h2>OpenShift Container Platform</h2>
             <div class="list-group">
               <p class="list-group-item-text">Red Hat's private, on-premise cloud application deployment and hosting platform.</p>
@@ -203,7 +203,7 @@
               </div>
             </div>
           </div>
-          <div class="col-sm-3 text-center">
+          <div class="col-sm-4 text-center">
             <h2>OpenShift Dedicated</h2>
             <div class="list-group">
               <p class="list-group-item-text">Red Hat's managed public cloud application deployment and hosting service.</p>
@@ -213,7 +213,7 @@
 
             </div>
           </div>
-          <div class="col-sm-3 text-center">
+          <div class="col-sm-4 text-center">
             <h2>Red Hat OpenShift Service on AWS</h2>
             <div class="list-group">
               <p class="list-group-item-text">Red Hat OpenShift Service on AWS (ROSA) is a fully-managed OpenShift service, jointly managed and supported by Red Hat and Amazon Web Services (AWS).</p>
@@ -222,7 +222,7 @@
           </div>
         </div>
         <div class="row">
-          <div class="col-sm-3 text-center">
+          <div class="col-sm-4 text-center">
 
             <h2>Azure Red Hat OpenShift</h2>
             <div class="list-group">
@@ -235,7 +235,7 @@
 
           </div>
 
-          <div class="col-sm-3 text-center">
+          <div class="col-sm-4 text-center">
 
             <h2>Red Hat Advanced Cluster Security for Kubernetes</h2>
             <div class="list-group">
@@ -261,41 +261,18 @@
                 </ul>
               </div>
             </div>
-
-
-
           </div>
-
-
-
-
-          <div class="col-sm-3 text-center">
-
-            <h2>OpenShift Online</h2>
-            <div class="list-group">
-              <p class="list-group-item-text">Red Hat's public cloud application deployment and hosting platform.</p>
-                <p><a role="button" class="btn btn-primary" href="online/pro/welcome/index.html"><i class="fa fa-arrow-circle-o-right"></i> Pro</a></p>
-
-
-          </div>
-
-        </div>
-        <div class="col-sm-3 text-center">
-
-            <div class="list-group">
-
-          <h2>OpenShift Kubernetes Engine</h2>
+          <div class="col-sm-4 text-center">
+            <h2>OpenShift Kubernetes Engine</h2>
           <div class="list-group">
             <p class="list-group-item-text">The OpenShift Kubernetes Engine is the core of the OpenShift Container Platform. Use OpenShift Container Platform docs links for OpenShift Kubernetes Engine documentation.</p>
             Read more about <a href="/container-platform/4.15/welcome/oke_about.html">OKE</a>.
           </div>
-
-        </div>
-
+          </div>
         </div>
       </div>
       <div class="row">
-        <div class="col-sm-3 text-center">
+        <div class="col-sm-4 text-center">
             <h2>OpenShift Container Platform <font size="-1">(日本語翻訳)</font></h2>
           <div class="list-group">
             <p class="list-group-item-text">Red Hat のプライベート、オンプレミスクラウドアプリケーションのデプロイメントおよびホスティングプラットフォーム。</p>
@@ -318,7 +295,7 @@
             </div>
           </div>
         </div>
-        <div class="col-sm-3 text-center">
+        <div class="col-sm-4 text-center">
           <h2>OpenShift Container Platform <font size="-1">(中文文档)</font></h2>
           <div class="list-group">
             <p class="list-group-item-text">红帽的私有内部云应用程序部署和托管平台。</p>
@@ -341,7 +318,7 @@
           </div>
         </div>
 
-        <div class="col-sm-3 text-center">
+        <div class="col-sm-4 text-center">
           <h2>OpenShift Container Platform <font size="-1">(한국어 문서)</font></h2>
           <div class="list-group">
             <p class="list-group-item-text">Red Hat의 프라이빗 온프레미스 클라우드 애플리케이션 배포 및 호스팅 플랫폼입니다.</p>

--- a/modules/updating-eus-to-eus-upgrade-console.adoc
+++ b/modules/updating-eus-to-eus-upgrade-console.adoc
@@ -51,4 +51,8 @@ If pools are paused, the cluster is not permitted to upgrade to any future minor
 +
 You can verify that your pools have updated on the *MachineConfigPools* tab under the *Compute* page by confirming that the *Update status* has a value of *Up to date*.
 +
+[IMPORTANT]
+====
+When you update a cluster that contains {op-system-base-full} compute machines, those machines temporarily become unavailable during the update process. You must run the upgrade playbook against each {op-system-base} machine as it enters the `NotReady` state for the cluster to finish updating.
+====
 You can verify that your cluster has completed the update by viewing the *Last completed version* of your cluster. You can find this information on the *Cluster Settings* page under the *Details* tab.


### PR DESCRIPTION
…sed state

A note something like this to be added in docs[1] at point 11:  ~~~
When you update a cluster that contains Red Hat Enterprise Linux (RHEL) worker machines, those workers temporarily become unavailable during the update process. You must run the upgrade playbook against each RHEL machine as it enters the NotReady state for the cluster to finish updating. ~~~

OCP v 4.12 EUS to EUS channel.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
OCP 4.12 EUS to EUS

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-32944

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
