### PR TITLE
[internal-fix] fix-vsphere-datastore-ifdef

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -2718,15 +2718,21 @@ endif::vsphere[]
 The list of datacenters must match the list of datacenters specified in the `vcenters` field.
 |String
 
+ifdef::vsphere[]
 |platform:
   vsphere:
     failureDomains:
       topology:
         datastore:
-ifdef::vsphere[]
 |Specifies the path to a vSphere datastore that stores virtual machines files for a failure domain. You must apply the `datastore` role to the vSphere vCenter datastore location.
+|String
 endif::vsphere[]
 ifdef::agent[]
+|platform:
+  vsphere:
+    failureDomains:
+      topology:
+        datastore:
 |The path to the vSphere datastore that holds virtual machine files, templates, and ISO images.
 
 *Important:* You can specify the path of any datastore that exists in a datastore cluster.
@@ -2734,8 +2740,8 @@ By default, Storage vMotion is automatically enabled for a datastore cluster.
 Red{nbsp}Hat does not support Storage vMotion, so you must disable Storage vMotion to avoid data loss issues for your {product-title} cluster.
 
 If you must specify VMs across multiple datastores, use a `datastore` object to specify a failure domain in your cluster's `install-config.yaml` configuration file. For more information, see "VMware vSphere region and zone enablement".
-endif::agent[]
 |String
+endif::agent[]
 
 |platform:
   vsphere:


### PR DESCRIPTION
Purpose:
An ifdef statement has broken the table at the `datastore` parameter entry in the vSphere docs. See [CP link](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/installing/installing-on-vsphere#installation-configuration-parameters-additional-vsphere_installation-config-parameters-vsphere). The issue does not impact [docs.openshift.com](https://docs.openshift.com/container-platform/4.15/installing/installing_vsphere/installation-config-parameters-vsphere.html#installation-configuration-parameters-additional-vsphere_installation-config-parameters-vsphere) nor the on-premise Agent-based Installer docs. Suggestion: do not let two ifdef statements shared the same table entry.

Version(s):
4.16 and 4.15 as the vSphere parameters were added to the on-premise Agent-based docs at 4.15. See [link](https://docs.openshift.com/container-platform/4.15/installing/installing_with_agent_based_installer/installation-config-parameters-agent.html#installation-configuration-parameters-additional-vsphere_installation-config-parameters-agent).

Issue:
[OCPBUGS-29262](https://issues.redhat.com/browse/OCPBUGS-29262)

Link to docs preview:
* [Additional VMware vSphere configuration parameters - vSphere](https://75240--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere#installation-configuration-parameters-additional-vsphere_installation-config-parameters-vsphere)
* [Additional VMware vSphere configuration parameters - Agent-based Installer](https://75240--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installation-config-parameters-agent#installation-configuration-parameters-additional-vsphere_installation-config-parameters-agent)
