### PR TITLE
OBSDOCS-1008 - 5.9.1 Release Notes

### DIFF
--- a/modules/logging-release-notes-5-9-1.adoc
+++ b/modules/logging-release-notes-5-9-1.adoc
@@ -1,0 +1,36 @@
+//module included in logging-5-9-release-notes.adoc
+:content-type: REFERENCE
+[id="logging-release-notes-5-9-1_{context}"]
+= Logging 5.9.1
+This release includes link:https://access.redhat.com/errata/RHSA-2024:2096[OpenShift Logging Bug Fix Release 5.9.1]
+
+[id="logging-release-notes-5-9-1-enhancements"]
+== Enhancements
+
+* Before this update, the {loki-op} configured Loki to use path-based style access for the Amazon Simple Storage Service (S3), which has been deprecated. With this update, the {loki-op} defaults to virtual-host style without users needing to change their configuration. (link:https://issues.redhat.com/browse/LOG-5401[LOG-5401])
+
+* Before this update, the {loki-op} did not validate the Amazon Simple Storage Service (S3) endpoint used in the storage secret. With this update, the validation process ensures the S3 endpoint is a valid S3 URL, and the `LokiStack` status updates to indicate any invalid URLs. (link:https://issues.redhat.com/browse/LOG-5395[LOG-5395])
+
+[id="logging-release-notes-5-9-1-bug-fixes"]
+== Bug Fixes
+
+* Before this update, a bug in LogQL parsing left out some line filters from the query. With this update, the parsing now includes all the line filters while keeping the original query unchanged. (link:https://issues.redhat.com/browse/LOG-5268[LOG-5268])
+
+* Before this update, a prune filter without a defined `pruneFilterSpec` would cause a segfault. With this update, there is a validation error if a prune filter is without a defined `puneFilterSpec`. (link:https://issues.redhat.com/browse/LOG-5322[LOG-5322])
+
+* Before this update, a drop filter without a defined `dropTestsSpec` would cause a segfault. With this update, there is a validation error if a prune filter is without a defined `puneFilterSpec`. (link:https://issues.redhat.com/browse/LOG-5323[LOG-5323])
+
+* Before this update, the {loki-op} did not validate the Amazon Simple Storage Service (S3) endpoint URL format used in the storage secret. With this update, the S3 endpoint URL goes through a validation step that reflects on the status of the `LokiStack`. (link:https://issues.redhat.com/browse/LOG-5397[LOG-5397])
+
+* Before this update, poorly formatted timestamp fields in audit log records led to `WARN` messages in {clo} logs. With this update, a remap transformation ensures that the timestamp field is properly formatted. (link:https://issues.redhat.com/browse/LOG-4672[LOG-4672])
+
+* Before this update, the error message thrown while validating a `ClusterLogForwarder` resource name and namespace did not correspond to the correct error. With this update, the system checks if a `ClusterLogForwarder` resource with the same name exists in the same namespace. If not, it corresponds to the correct error. (link:https://issues.redhat.com/browse/LOG-5062[LOG-5062])
+
+* Before this update, the validation feature for output config required a TLS URL, even for services such as Amazon CloudWatch or Google Cloud Logging where a URL is not needed by design. With this update, the validation logic for services without URLs are improved, and the error message are more informative. (link:https://issues.redhat.com/browse/LOG-5307[LOG-5307])
+
+* Before this update, defining an infrastructure input type did not exclude {logging} workloads from the collection. With this update, the collection excludes {logging} services to avoid feedback loops. (link:https://issues.redhat.com/browse/LOG-5309[LOG-5309])
+
+
+[id="logging-release-notes-5-9-1-CVEs"]
+== CVEs
+No CVEs.

--- a/observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
@@ -10,4 +10,6 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-9-1.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-9-0.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Logging Z-Stream Release Notes - 5.9.1
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1008

Fix Version: 4.13+

Doc Preview: https://75242--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/logging_release_notes/logging-5-9-release-notes.html#logging-release-notes-5-9-1_logging-5-9-release-notes 

SME Review: @periklis 
QE Review: @kabirbhartiRH 
Peer Review: @mburke5678 