### PR TITLE
OBSDOCS-975 - Logging 5.8.6 Release Notes

### DIFF
--- a/modules/logging-release-notes-5-8-6.adoc
+++ b/modules/logging-release-notes-5-8-6.adoc
@@ -1,0 +1,38 @@
+// module included in /logging/logging-5-8-release-notes
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-5-8-6_{context}"]
+= Logging 5.8.6
+This release includes link:https://access.redhat.com/errata/RHSA-2024:2094[OpenShift Logging Bug Fix Release 5.8.6 Security Update] and link:https://access.redhat.com/errata/RHBA-2024:2095[OpenShift Logging Bug Fix Release 5.8.6].
+
+[id="logging-release-notes-5-8-6-enhancements"]
+== Enhancements
+
+* Before this update, the {loki-op} did not validate the Amazon Simple Storage Service (S3) endpoint used in the storage secret. With this update, the validation process ensures the S3 endpoint is a valid S3 URL, and the `LokiStack` status updates to indicate any invalid URLs. (link:https://issues.redhat.com/browse/LOG-5392[LOG-5392])
+
+* Before this update, the {loki-op} configured Loki to use path-based style access for the Amazon Simple Storage Service (S3), which has been deprecated. With this update, the {loki-op} defaults to virtual-host style without users needing to change their configuration. (link:https://issues.redhat.com/browse/LOG-5402[LOG-5402])
+
+[id="logging-release-notes-5-8-6-bug-fixes"]
+== Bug fixes
+
+* Before this update, the Elastisearch Operator `ServiceMonitor` in the `openshift-operators-redhat` namespace used static token and certificate authority (CA) files for authentication, causing errors in the Prometheus Operator in the User Workload Monitoring specification on the `ServiceMonitor` configuration. With this update, the Elastisearch Operator `ServiceMonitor` in the `openshift-operators-redhat` namespace now references a service account token secret by a `LocalReference` object. This approach allows the User Workload Monitoring specifications in the Prometheus Operator to handle the Elastisearch Operator `ServiceMonitor` successfully. This enables Prometheus to scrape the Elastisearch Operator metrics. (link:https://issues.redhat.com/browse/LOG-5164[LOG-5164])
+
+* Before this update, the {loki-op} did not validate the Amazon Simple Storage Service (S3) endpoint URL format used in the storage secret. With this update, the S3 endpoint URL goes through a validation step that reflects on the status of the `LokiStack`. (link:https://issues.redhat.com/browse/LOG-5398[LOG-5398])
+
+[id="logging-release-notes-5-8-6-CVEs"]
+== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2023-4244[CVE-2023-4244]
+* link:https://access.redhat.com/security/cve/CVE-2023-5363[CVE-2023-5363]
+* link:https://access.redhat.com/security/cve/CVE-2023-5717[CVE-2023-5717]
+* link:https://access.redhat.com/security/cve/CVE-2023-5981[CVE-2023-5981]
+* link:https://access.redhat.com/security/cve/CVE-2023-6356[CVE-2023-6356]
+* link:https://access.redhat.com/security/cve/CVE-2023-6535[CVE-2023-6535]
+* link:https://access.redhat.com/security/cve/CVE-2023-6536[CVE-2023-6536]
+* link:https://access.redhat.com/security/cve/CVE-2023-6606[CVE-2023-6606]
+* link:https://access.redhat.com/security/cve/CVE-2023-6610[CVE-2023-6610]
+* link:https://access.redhat.com/security/cve/CVE-2023-6817[CVE-2023-6817]
+* link:https://access.redhat.com/security/cve/CVE-2023-46218[CVE-2023-46218]
+* link:https://access.redhat.com/security/cve/CVE-2023-51042[CVE-2023-51042]
+* link:https://access.redhat.com/security/cve/CVE-2024-0193[CVE-2024-0193]
+* link:https://access.redhat.com/security/cve/CVE-2024-0553[CVE-2024-0553]
+* link:https://access.redhat.com/security/cve/CVE-2024-0567[CVE-2024-0567]
+* link:https://access.redhat.com/security/cve/CVE-2024-0646[CVE-2024-0646]

--- a/observability/logging/logging_release_notes/logging-5-8-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-8-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-8-6.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-8-5.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-8-4.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Logging Z-Stream Release Notes - 5.8.6
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-975

Fix Version: 4.12, 4.13, 4.14, 4.15

Doc Preview: https://75243--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging_release_notes/logging-5-8-release-notes#logging-release-notes-5-8-6_logging-5-8-release-notes

SME Review: @periklis 
QE Review: @anpingli 
Peer Review: @mburke5678 