### PR TITLE
OBSDOCS-973 - Logging 5.6.18 Release Notes

### DIFF
--- a/modules/logging-release-notes-5-6-18.adoc
+++ b/modules/logging-release-notes-5-6-18.adoc
@@ -1,0 +1,35 @@
+// module included in /logging/logging-5-6-release-notes
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-5-6-18_{context}"]
+= Logging 5.6.18
+This release includes link:https://access.redhat.com/errata/RHSA-2024:2092[OpenShift Logging Bug Fix 5.6.18]
+
+[id="logging-release-notes-5-6-18-enhancements"]
+== Enhancements
+
+* Before this update, {loki-op} set up Loki to use path-based style access for the Amazon Simple Storage Service (S3), which has been deprecated. With this update, the {loki-op} defaults to virtual-host style without users needing to change their configuration. (link:https://issues.redhat.com/browse/LOG-5404[LOG-5404])
+
+* Before this update, the {loki-op} did not validate the Amazon Simple Storage Service (S3) endpoint used in the storage secret. With this update, the validation process ensures the S3 endpoint is a valid S3 URL, and the `LokiStack` status updates to indicate any invalid URLs. (link:https://issues.redhat.com/browse/LOG-5396[LOG-5396])
+
+[id="logging-release-notes-5-6-18-bug-fixes"]
+== Bug fixes
+
+* Before this update, the Elastisearch Operator `ServiceMonitor` in the `openshift-operators-redhat` namespace used static token and certificate authority (CA) files for authentication, causing errors in the Prometheus Operator in the User Workload Monitoring specification on the `ServiceMonitor` configuration. With this update, the Elastisearch Operator `ServiceMonitor` in the `openshift-operators-redhat` namespace now references a service account token secret by a `LocalReference` object. This approach allows the User Workload Monitoring specifications in the Prometheus Operator to handle the Elastisearch Operator `ServiceMonitor` successfully. This enables Prometheus to scrape the Elastisearch Operator metrics. (link:https://issues.redhat.com/browse/LOG-5244[LOG-5244])
+
+* Before this update, the {loki-op} did not validate the Amazon Simple Storage Service (S3) endpoint URL format used in the storage secret. With this update, the S3 endpoint URL goes through a validation step that reflects on the status of the `LokiStack`. (link:https://issues.redhat.com/browse/LOG-5400[LOG-5400])
+
+
+[id="logging-release-notes-5-6-18-CVEs"]
+== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2021-33631[CVE-2021-33631]
+* link:https://access.redhat.com/security/cve/CVE-2021-43618[CVE-2021-43618]
+* link:https://access.redhat.com/security/cve/CVE-2022-38096[CVE-2022-38096]
+* link:https://access.redhat.com/security/cve/CVE-2022-48624[CVE-2022-48624]
+* link:https://access.redhat.com/security/cve/CVE-2023-6546[CVE-2023-6546]
+* link:https://access.redhat.com/security/cve/CVE-2023-6931[CVE-2023-6931]
+* link:https://access.redhat.com/security/cve/CVE-2023-28322[CVE-2023-28322]
+* link:https://access.redhat.com/security/cve/CVE-2023-38546[CVE-2023-38546]
+* link:https://access.redhat.com/security/cve/CVE-2023-46218[CVE-2023-46218]
+* link:https://access.redhat.com/security/cve/CVE-2023-51042[CVE-2023-51042]
+* link:https://access.redhat.com/security/cve/CVE-2024-0565[CVE-2024-0565]
+* link:https://access.redhat.com/security/cve/CVE-2024-1086[CVE-2024-1086]

--- a/observability/logging/logging_release_notes/logging-5-6-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-6-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-6-18.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-6-17.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-6-16.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Logging Z-Stream Release Notes - 5.6.18
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-973

Fix Version: 4.12, 4.13

Doc Preview: https://75245--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging_release_notes/logging-5-6-release-notes#logging-release-notes-5-6-18_logging-5-6-release-notes

SME Review: @periklis 
QE Review: @kabirbhartiRH 
Peer Review: @cbippley 