### PR TITLE
OSDOCS-10106: adds 4.14.25 release note MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -504,3 +504,12 @@ Issued: 2024-05-09
 {product-title} release 4.14.24, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:2671[RHSA-2024:2671] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:2668[RHSA-2024:2668] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-14-25-dp"]
+=== RHSA-2024:2791 - {microshift-short} 4.14.25 bug fix update and enhancements advisory
+
+Issued: 2024-05-15
+
+{product-title} release 4.14.25, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:2791[RHBA-2024:2791] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:2789[RHBA-2024:2789] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-10280](https://issues.redhat.com/browse/OSDOCS-10280)

Link to docs preview:
[4.14.25 release note MicroShift](https://75247--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes.html#microshift-4-14-23-dp)

QE review:
- N/A standard advisory text

Additional info: Reuses 4.14.23 canceled release PR

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
