### PR TITLE
[enterprise-4.14] Removes third ovnkube-control-plane pod in ovnk netowkring documentation

### DIFF
--- a/modules/nw-ovn-kubernetes-change-log-levels.adoc
+++ b/modules/nw-ovn-kubernetes-change-log-levels.adoc
@@ -29,7 +29,6 @@ $ oc get po -o wide -n openshift-ovn-kubernetes
 NAME                                     READY   STATUS    RESTARTS       AGE    IP           NODE                                       NOMINATED NODE   READINESS GATES
 ovnkube-control-plane-65497d4548-9ptdr   2/2     Running   2 (128m ago)   147m   10.0.0.3     ci-ln-3njdr9b-72292-5nwkp-master-0         <none>           <none>
 ovnkube-control-plane-65497d4548-j6zfk   2/2     Running   0              147m   10.0.0.5     ci-ln-3njdr9b-72292-5nwkp-master-2         <none>           <none>
-ovnkube-control-plane-65497d4548-k7xqt   2/2     Running   0              147m   10.0.0.4     ci-ln-3njdr9b-72292-5nwkp-master-1         <none>           <none>
 ovnkube-node-5dx44                       8/8     Running   0              146m   10.0.0.3     ci-ln-3njdr9b-72292-5nwkp-master-0         <none>           <none>
 ovnkube-node-dpfn4                       8/8     Running   0              146m   10.0.0.4     ci-ln-3njdr9b-72292-5nwkp-master-1         <none>           <none>
 ovnkube-node-kwc9l                       8/8     Running   0              134m   10.0.128.2   ci-ln-3njdr9b-72292-5nwkp-worker-a-2fjcj   <none>           <none>

--- a/modules/nw-ovn-kubernetes-list-database-contents.adoc
+++ b/modules/nw-ovn-kubernetes-list-database-contents.adoc
@@ -33,7 +33,6 @@ $ oc get po -n openshift-ovn-kubernetes
 NAME                                     READY   STATUS    RESTARTS      AGE
 ovnkube-control-plane-8444dff7f9-4lh9k   2/2     Running   0             27m
 ovnkube-control-plane-8444dff7f9-5rjh9   2/2     Running   0             27m
-ovnkube-control-plane-8444dff7f9-k64b7   2/2     Running   2 (11m ago)   27m
 ovnkube-node-55xs2                       8/8     Running   0             26m
 ovnkube-node-7r84r                       8/8     Running   0             16m
 ovnkube-node-bqq8p                       8/8     Running   0             17m
@@ -55,7 +54,6 @@ $ oc get pods -n openshift-ovn-kubernetes -owide
 NAME                                     READY   STATUS    RESTARTS      AGE   IP           NODE                                       NOMINATED NODE   READINESS GATES
 ovnkube-control-plane-8444dff7f9-4lh9k   2/2     Running   0             27m   10.0.0.3     ci-ln-t487nnb-72292-mdcnq-master-1         <none>           <none>
 ovnkube-control-plane-8444dff7f9-5rjh9   2/2     Running   0             27m   10.0.0.4     ci-ln-t487nnb-72292-mdcnq-master-2         <none>           <none>
-ovnkube-control-plane-8444dff7f9-k64b7   2/2     Running   2 (12m ago)   27m   10.0.0.5     ci-ln-t487nnb-72292-mdcnq-master-0         <none>           <none>
 ovnkube-node-55xs2                       8/8     Running   0             26m   10.0.0.4     ci-ln-t487nnb-72292-mdcnq-master-2         <none>           <none>
 ovnkube-node-7r84r                       8/8     Running   0             17m   10.0.128.3   ci-ln-t487nnb-72292-mdcnq-worker-b-wbz7z   <none>           <none>
 ovnkube-node-bqq8p                       8/8     Running   0             17m   10.0.128.2   ci-ln-t487nnb-72292-mdcnq-worker-a-lh7ms   <none>           <none>

--- a/modules/nw-ovn-kubernetes-list-resources.adoc
+++ b/modules/nw-ovn-kubernetes-list-resources.adoc
@@ -29,7 +29,6 @@ Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavaila
 NAME                                         READY   STATUS    RESTARTS       AGE
 pod/ovnkube-control-plane-65c6f55656-6d55h   2/2     Running   0              114m
 pod/ovnkube-control-plane-65c6f55656-fd7vw   2/2     Running   2 (104m ago)   114m
-pod/ovnkube-control-plane-65c6f55656-vtqtm   2/2     Running   0              114m
 pod/ovnkube-node-bcvts                       8/8     Running   0              113m
 pod/ovnkube-node-drgvv                       8/8     Running   0              113m
 pod/ovnkube-node-f2pxt                       8/8     Running   0              113m

--- a/modules/nw-ovn-kubernetes-list-southbound-database-contents.adoc
+++ b/modules/nw-ovn-kubernetes-list-southbound-database-contents.adoc
@@ -33,7 +33,6 @@ $ oc get po -n openshift-ovn-kubernetes
 NAME                                     READY   STATUS    RESTARTS      AGE
 ovnkube-control-plane-8444dff7f9-4lh9k   2/2     Running   0             27m
 ovnkube-control-plane-8444dff7f9-5rjh9   2/2     Running   0             27m
-ovnkube-control-plane-8444dff7f9-k64b7   2/2     Running   2 (11m ago)   27m
 ovnkube-node-55xs2                       8/8     Running   0             26m
 ovnkube-node-7r84r                       8/8     Running   0             16m
 ovnkube-node-bqq8p                       8/8     Running   0             17m
@@ -55,7 +54,6 @@ $ oc get pods -n openshift-ovn-kubernetes -owide
 NAME                                     READY   STATUS    RESTARTS      AGE   IP           NODE                                       NOMINATED NODE   READINESS GATES
 ovnkube-control-plane-8444dff7f9-4lh9k   2/2     Running   0             27m   10.0.0.3     ci-ln-t487nnb-72292-mdcnq-master-1         <none>           <none>
 ovnkube-control-plane-8444dff7f9-5rjh9   2/2     Running   0             27m   10.0.0.4     ci-ln-t487nnb-72292-mdcnq-master-2         <none>           <none>
-ovnkube-control-plane-8444dff7f9-k64b7   2/2     Running   2 (12m ago)   27m   10.0.0.5     ci-ln-t487nnb-72292-mdcnq-master-0         <none>           <none>
 ovnkube-node-55xs2                       8/8     Running   0             26m   10.0.0.4     ci-ln-t487nnb-72292-mdcnq-master-2         <none>           <none>
 ovnkube-node-7r84r                       8/8     Running   0             17m   10.0.128.3   ci-ln-t487nnb-72292-mdcnq-worker-b-wbz7z   <none>           <none>
 ovnkube-node-bqq8p                       8/8     Running   0             17m   10.0.128.2   ci-ln-t487nnb-72292-mdcnq-worker-a-lh7ms   <none>           <none>

--- a/modules/ovn-kubernetes-architecture-con.adoc
+++ b/modules/ovn-kubernetes-architecture-con.adoc
@@ -24,4 +24,4 @@ It translates the logical network configuration in terms of conventional network
 
 The OVN southbound database has physical and logical representations of the network and binding tables that link them together. It contains the chassis information of the node and other constructs like remote transit switch ports that are required to connect to the other nodes in the cluster. The OVN southbound database also contains all the logic flows. The logic flows are shared with the `ovn-controller` process that runs on each node and the `ovn-controller` turns those into `OpenFlow` rules to program `Open vSwitch`(OVS).
 
-The Kubernetes control plane nodes each contain an `ovnkube-control-plane` pod which does the central IP address management (IPAM) allocation for each node in the cluster. At any given time a single `ovnkube-control-plane` pod is the leader.
+The Kubernetes control plane nodes contain two `ovnkube-control-plane` pods on separate nodes, which perform the central IP address management (IPAM) allocation for each node in the cluster. At any given time, a single `ovnkube-control-plane` pod is the leader.


### PR DESCRIPTION
xref: https://github.com/openshift/openshift-docs/pull/71697
Cherry picked from d995d70208bb5bbc3d3bc450e999bf8cc0dcfae9

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OCPBUGS-29480

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
