### PR TITLE
OADP-3179: Release Notes for OADP 1.2.4

### DIFF
--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-2.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-2.adoc
@@ -9,6 +9,8 @@ toc::[]
 
 The release notes for OpenShift API for Data Protection (OADP) 1.2 describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
 
+include::modules/oadp-release-notes-1-2-4.adoc[leveloffset=+1]
+
 include::modules/oadp-release-notes-1-2-3.adoc[leveloffset=+1]
 
 include::modules/oadp-release-notes-1-2-2.adoc[leveloffset=+1]

--- a/modules/oadp-release-notes-1-2-4.adoc
+++ b/modules/oadp-release-notes-1-2-4.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-release-notes-1-2.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="migration-oadp-release-notes-1-2-4_{context}"]
+= OADP 1.2.4 release notes
+
+{oadp-first} 1.2.4 is a Container Grade Only (CGO) release, released to refresh the health grades of the containers, with no changes to any code in the product itself compared to that of {oadp-short} 1.2.3.
+
+
+[id="resolved-issues-1-2-4_{context}"]
+== Resolved issues
+
+There are no resolved issues in {oadp-short} 1.2.4.
+
+
+[id="known-issues-1-2-4_{context}"]
+== Known issues
+
+The {oadp-short} 1.2.4 has the following known issue:
+
+.Data Protection Application (DPA) does not reconcile when the credentials secret is updated
+
+Currently, the {oadp-short} Operator does not reconcile when you update the `cloud-credentials` secret. This occurs because there are no {oadp-short} specific labels or owner references on the `cloud-credentials` secret. If you create a `cloud-credentials` secret with incorrect credentials, such as empty data, the Operator reconciles and creates a Backup Storage Location (BSL) and registry deployment with the empty data. As a result, when you update the `cloud-credentials` secret with the correct credentials, the Operator does not immediately reconcile to catch the new credentials.
+
+Workaround: Update to {oadp-short} 1.3.
+
+link:https://issues.redhat.com/browse/OADP-3327[(OADP-3327)]
+


### PR DESCRIPTION
### Jira

* [OADP-3179](https://issues.redhat.com/browse/OADP-3179)

    Release notes for OADP 1.2.4 Container Grade Only
 
    GA - 7th May

### Version(s):

* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16

### Link to docs preview:

* [OADP 1.2.4 release notes](https://75258--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-2.html#migration-oadp-release-notes-1-2-4_oadp-release-notes)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
