### PR TITLE
[Internal fix] admonitions-tables-vsphere

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -2642,7 +2642,7 @@ ifdef::agent,vsphere[]
 Additional VMware vSphere configuration parameters are described in the following table:
 
 .Additional VMware vSphere cluster parameters
-[cols=".^2l,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
+[cols=".^2l,.^4a,.^2a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -2656,8 +2656,10 @@ ifdef::vsphere[]
   vsphere:
     apiVIPs:
 |Virtual IP (VIP) addresses that you configured for control plane API access.
-
-*Note:* This parameter applies only to installer-provisioned infrastructure.
+[NOTE]
+====
+This parameter applies only to installer-provisioned infrastructure.
+====
 |Multiple IP addresses
 
 |platform:
@@ -2734,12 +2736,14 @@ ifdef::agent[]
       topology:
         datastore:
 |The path to the vSphere datastore that holds virtual machine files, templates, and ISO images.
-
-*Important:* You can specify the path of any datastore that exists in a datastore cluster.
+[IMPORTANT]
+====
+You can specify the path of any datastore that exists in a datastore cluster.
 By default, Storage vMotion is automatically enabled for a datastore cluster.
 Red{nbsp}Hat does not support Storage vMotion, so you must disable Storage vMotion to avoid data loss issues for your {product-title} cluster.
 
 If you must specify VMs across multiple datastores, use a `datastore` object to specify a failure domain in your cluster's `install-config.yaml` configuration file. For more information, see "VMware vSphere region and zone enablement".
+====
 |String
 endif::agent[]
 
@@ -2787,8 +2791,10 @@ ifdef::vsphere[]
   vsphere:
     ingressVIPs:
 |Virtual IP (VIP) addresses that you configured for cluster Ingress.
-
-*Note:* This parameter applies only to installer-provisioned infrastructure.
+[NOTE]
+====
+This parameter applies only to installer-provisioned infrastructure.
+====
 |Multiple IP addresses
 endif::vsphere[]
 
@@ -2842,7 +2848,7 @@ In {product-title} 4.13, the following vSphere configuration parameters are depr
 The following table lists each deprecated vSphere configuration parameter:
 
 .Deprecated VMware vSphere cluster parameters
-[cols=".^2l,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
+[cols=".^2l,.^4a,.^2a",options="header"]
 |====
 |Parameter|Description|Values
 ifdef::vsphere[]
@@ -2852,8 +2858,11 @@ ifdef::vsphere[]
     apiVIP:
 |The virtual IP (VIP) address that you configured for control plane API access.
 
-*Note:* In {product-title} 4.12 and later, the `apiVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `apiVIPs` configuration setting.
-a|An IP address, for example `128.0.0.1`.
+[NOTE]
+====
+In {product-title} 4.12 and later, the `apiVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `apiVIPs` configuration setting.
+====
+|An IP address, for example `128.0.0.1`.
 endif::vsphere[]
 
 |platform:
@@ -2885,9 +2894,11 @@ ifdef::vsphere[]
   vsphere:
     ingressVIP:
 |Virtual IP (VIP) addresses that you configured for cluster Ingress.
-
-*Note:* In {product-title} 4.12 and later, the `ingressVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `ingressVIPs` configuration setting.
-a|An IP address, for example `128.0.0.1`.
+[NOTE]
+====
+In {product-title} 4.12 and later, the `ingressVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `ingressVIPs` configuration setting.
+====
+|An IP address, for example `128.0.0.1`.
 
 |platform:
   vsphere:
@@ -2906,7 +2917,7 @@ endif::vsphere[]
   vsphere:
     resourcePool:
 |Optional: The absolute path of an existing resource pool where the installation program creates the virtual machines. If you do not specify a value, the installation program installs the resources in the root of the cluster under `/<datacenter_name>/host/<cluster_name>/Resources`.
-a|String, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
+|String, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
 
 |platform:
   vsphere:
@@ -2932,7 +2943,7 @@ ifdef::vsphere[]
 Optional VMware vSphere machine pool configuration parameters are described in the following table:
 
 .Optional VMware vSphere machine pool parameters
-[cols=".^2l,.^3a,.^3a",options="header"]
+[cols=".^2l,.^4a,.^2a",options="header"]
 |====
 |Parameter|Description|Values
 


### PR DESCRIPTION
As per the weekly OCP team meeting. Reverting admonitions because of vote to format inline with Asciidoc admonition styling that renders OK on Customer Portal as against d.o.c.

Version(s):
4.15+

Link to docs preview:
* [Additional VMware vSphere configuration parameters-vSphere](https://75264--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere#installation-configuration-parameters-additional-vsphere_installation-config-parameters-vsphere)
* [Deprecated VMware vSphere configuration parameters-vSphere](https://75264--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere#deprecated-parameters-vsphere_installation-config-parameters-vsphere)
* [Additional VMware vSphere configuration parameters-ABI](https://75264--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installation-config-parameters-agent#installation-configuration-parameters-additional-vsphere_installation-config-parameters-agent)
* [Deprecated VMware vSphere configuration parameters-ABI](https://75264--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installation-config-parameters-agent#deprecated-parameters-vsphere_installation-config-parameters-agent)