### PR TITLE
OSDOCS-9803:updates CIDR ranges that are internal to OVN-K

### DIFF
--- a/networking/cidr-range-definitions.adoc
+++ b/networking/cidr-range-definitions.adoc
@@ -22,14 +22,14 @@ endif::[]
 
 [IMPORTANT]
 ====
-OVN-Kubernetes, the default network provider in {product-title} 4.11 and later, uses the `100.64.0.0/16` IP address range internally. If your cluster uses OVN-Kubernetes, do not include the `100.64.0.0/16` IP address range in any other CIDR definitions in your cluster.
+OVN-Kubernetes, the default network provider in {product-title} 4.14 and later versions, uses the following IP address ranges internally: `100.64.0.0/16`, `169.254.169.0/29`, `100.88.0.0/16`, `fd98::/64`, `fd69::/125`, and the `fd97::/64`. If your cluster uses OVN-Kubernetes, do not include any IP address ranges in any other CIDR definitions in your cluster.
 ====
 
 [id="machine-cidr-description"]
 == Machine CIDR
-In the Machine CIDR field, you must specify the IP address range for machines or cluster nodes. 
+In the Machine classless inter-domain routing (CIDR) field, you must specify the IP address range for machines or cluster nodes.
 ifdef::openshift-rosa,openshift-dedicated[]
-This range must encompass all CIDR address ranges for your virtual private cloud (VPC) subnets. Subnets must be contiguous.  A minimum IP address range of 128 addresses, using the subnet prefix `/25`, is supported for single availability zone deployments. A minimum address range of 256 addresses, using the subnet prefix `/24`, is supported for deployments that use multiple availability zones. 
+This range must encompass all CIDR address ranges for your virtual private cloud (VPC) subnets. Subnets must be contiguous. A minimum IP address range of 128 addresses, using the subnet prefix `/25`, is supported for single availability zone deployments. A minimum address range of 256 addresses, using the subnet prefix `/24`, is supported for deployments that use multiple availability zones.
 endif::openshift-rosa,openshift-dedicated[]
 
 The default is `10.0.0.0/16`. This range must not conflict with any connected networks.
@@ -43,29 +43,29 @@ endif::[]
 
 [id="service-cidr-description"]
 == Service CIDR
-In the Service CIDR field, you must specify the IP address range for services. 
+In the Service CIDR field, you must specify the IP address range for services.
 ifdef::openshift-rosa,openshift-dedicated[]
-It is recommended, but not required, that the address block is the same between clusters. This will not create IP address conflicts. 
+It is recommended, but not required, that the address block is the same between clusters. This will not create IP address conflicts.
 endif::openshift-rosa,openshift-dedicated[]
 The range must be large enough to accommodate your workload. The address block must not overlap with any external service accessed from within the cluster. The default is `172.30.0.0/16`.
 
 [id="pod-cidr-description"]
 == Pod CIDR
-In the pod CIDR field, you must specify the IP address range for pods. 
+In the pod CIDR field, you must specify the IP address range for pods.
 
 ifdef::openshift-enterprise[]
-The pod CIDR is the same as the `clusterNetwork` CIDR and the cluster CIDR. 
+The pod CIDR is the same as the `clusterNetwork` CIDR and the cluster CIDR.
 endif::openshift-enterprise[]
 ifdef::openshift-rosa,openshift-dedicated[]
-It is recommended, but not required, that the address block is the same between clusters. This will not create IP address conflicts. 
+It is recommended, but not required, that the address block is the same between clusters. This will not create IP address conflicts.
 endif::openshift-rosa,openshift-dedicated[]
-The range must be large enough to accommodate your workload. The address block must not overlap with any external service accessed from within the cluster. The default is `10.128.0.0/14`. 
+The range must be large enough to accommodate your workload. The address block must not overlap with any external service accessed from within the cluster. The default is `10.128.0.0/14`.
 ifdef::openshift-enterprise[]
 You can expand the range after cluster installation.
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../networking/cluster-network-operator.adoc#nw-operator-cr-cno-object_cluster-network-operator[Cluster Network Operator Configuration] 
+* xref:../networking/cluster-network-operator.adoc#nw-operator-cr-cno-object_cluster-network-operator[Cluster Network Operator configuration]
 * xref:../networking/configuring-cluster-network-range.adoc#configuring-cluster-network-range[Configuring the cluster network range]
 endif::openshift-enterprise[]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-9803
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://75273--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/cidr-range-definitions.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
PTAL: 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
