### PR TITLE
[enterprise-4.12] OCPBUGS#16643: Updated storage class name in YAML configurations

### DIFF
--- a/modules/persistent-storage-local-create-cr-manual.adoc
+++ b/modules/persistent-storage-local-create-cr-manual.adoc
@@ -41,7 +41,7 @@ spec:
   accessModes:
   - ReadWriteOnce
   persistentVolumeReclaimPolicy: Delete
-  storageClassName: local-storage <2>
+  storageClassName: local-sc <2>
   local:
     path: /dev/xvdf <3>
   nodeAffinity:
@@ -76,7 +76,7 @@ spec:
   accessModes:
   - ReadWriteOnce
   persistentVolumeReclaimPolicy: Delete
-  storageClassName: local-storage <2>
+  storageClassName: local-sc <2>
   local:
     path: /dev/xvdf <3>
   nodeAffinity:
@@ -110,8 +110,8 @@ $ oc get pv
 [source,terminal]
 ----
 NAME                    CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM                STORAGECLASS    REASON   AGE
-example-pv-filesystem   100Gi      RWO            Delete           Available                        local-storage            3m47s
-example-pv1             1Gi        RWO            Delete           Bound       local-storage/pvc1   local-storage            12h
-example-pv2             1Gi        RWO            Delete           Bound       local-storage/pvc2   local-storage            12h
-example-pv3             1Gi        RWO            Delete           Bound       local-storage/pvc3   local-storage            12h
+example-pv-filesystem   100Gi      RWO            Delete           Available                        local-sc            3m47s
+example-pv1             1Gi        RWO            Delete           Bound       local-storage/pvc1   local-sc            12h
+example-pv2             1Gi        RWO            Delete           Bound       local-storage/pvc2   local-sc            12h
+example-pv3             1Gi        RWO            Delete           Bound       local-storage/pvc3   local-sc            12h
 ----

--- a/modules/persistent-storage-local-create-cr.adoc
+++ b/modules/persistent-storage-local-create-cr.adoc
@@ -89,7 +89,7 @@ spec:
           - ip-10-0-140-255
           - ip-10-0-144-180
   storageClassDevices:
-    - storageClassName: "localblock-sc" <3>
+    - storageClassName: "local-sc" <3>
       volumeMode: Block <4>
       devicePaths: <5>
         - /path/to/device <6>

--- a/modules/persistent-storage-local-discovery.adoc
+++ b/modules/persistent-storage-local-discovery.adoc
@@ -100,7 +100,7 @@ spec:
             values:
               - worker-0
               - worker-1
-  storageClassName: example-storageclass <1>
+  storageClassName: local-sc <1>
   volumeMode: Filesystem
   fsType: ext4
   maxDeviceCount: 10
@@ -141,10 +141,10 @@ $ oc get pv
 .Example output
 [source,terminal]
 ----
-NAME                CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM   STORAGECLASS           REASON   AGE
-local-pv-1cec77cf   100Gi      RWO            Delete           Available           example-storageclass            88m
-local-pv-2ef7cd2a   100Gi      RWO            Delete           Available           example-storageclass            82m
-local-pv-3fa1c73    100Gi      RWO            Delete           Available           example-storageclass            48m
+NAME                CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM   STORAGECLASS   REASON   AGE
+local-pv-1cec77cf   100Gi      RWO            Delete           Available           local-sc                88m
+local-pv-2ef7cd2a   100Gi      RWO            Delete           Available           local-sc                82m
+local-pv-3fa1c73    100Gi      RWO            Delete           Available           local-sc                48m
 ----
 
 [NOTE]

--- a/modules/persistent-storage-local-tolerations.adoc
+++ b/modules/persistent-storage-local-tolerations.adoc
@@ -42,7 +42,7 @@ To configure local volumes for scheduling on tainted nodes:
         operator: Equal <2>
         value: "localstorage" <3>
     storageClassDevices:
-        - storageClassName: "localblock-sc"
+        - storageClassName: "local-sc"
           volumeMode: Block <4>
           devicePaths: <5>
             - /dev/xvdg


### PR DESCRIPTION
Version:
4.12

Cherry-picked from:
af0e275601a45a6c4c6707a67807bbb5898a4d75


xref: https://github.com/openshift/openshift-docs/pull/75123
