### PR TITLE
[internal-fix] admonitions-tables-vsphere-13

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1940,7 +1940,7 @@ The `platform.vsphere` parameter prefixes each parameter listed in the table.
 ====
 
 .Additional VMware vSphere cluster parameters
-[cols=".^2l,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
+[cols=".^2l,.^4a,.^2a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -1953,8 +1953,10 @@ The `platform.vsphere` parameter prefixes each parameter listed in the table.
   vsphere:
     apiVIPs:
 |Virtual IP (VIP) addresses that you configured for control plane API access.
-
-*Note:* This parameter applies only to installer-provisioned infrastructure.
+[NOTE]
+====
+This parameter applies only to installer-provisioned infrastructure.
+====
 |Multiple IP addresses
 
 |platform:
@@ -2033,8 +2035,10 @@ If you do not specify a value, the installation program installs the resources i
   vsphere:
     ingressVIPs:
 |Virtual IP (VIP) addresses that you configured for cluster Ingress.
-
-*Note:* This parameter applies only to installer-provisioned infrastructure.
+[NOTE]
+====
+This parameter applies only to installer-provisioned infrastructure.
+====
 |Multiple IP addresses
 
 |platform:
@@ -2092,7 +2096,7 @@ The `platform.vsphere` parameter prefixes each parameter listed in the table.
 ====
 
 .Deprecated VMware vSphere cluster parameters
-[cols=".^2l,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
+[cols=".^2l,.^4a,.^2a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -2100,9 +2104,11 @@ The `platform.vsphere` parameter prefixes each parameter listed in the table.
   vsphere:
     apiVIP:
 |The virtual IP (VIP) address that you configured for control plane API access.
-
-*Note:* In {product-title} 4.12 and later, the `apiVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `apiVIPs` configuration setting.
-a|An IP address, for example `128.0.0.1`.
+[NOTE]
+====
+In {product-title} 4.12 and later, the `apiVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `apiVIPs` configuration setting.
+====
+|An IP address, for example `128.0.0.1`.
 
 |platform:
   vsphere:
@@ -2132,9 +2138,11 @@ a|An IP address, for example `128.0.0.1`.
   vsphere:
     ingressVIP:
 |Virtual IP (VIP) addresses that you configured for cluster Ingress.
-
-*Note:* In {product-title} 4.12 and later, the `ingressVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `ingressVIPs` configuration setting.
-a|An IP address, for example `128.0.0.1`.
+[NOTE]
+====
+In {product-title} 4.12 and later, the `ingressVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `ingressVIPs` configuration setting.
+====
+|An IP address, for example `128.0.0.1`.
 
 |platform:
   vsphere:
@@ -2152,7 +2160,7 @@ a|An IP address, for example `128.0.0.1`.
   vsphere:
     resourcePool:
 |Optional: The absolute path of an existing resource pool where the installation program creates the virtual machines. If you do not specify a value, the installation program installs the resources in the root of the cluster under `/<datacenter_name>/host/<cluster_name>/Resources`.
-a|String, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
+|String, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
 
 |platform:
   vsphere:
@@ -2181,7 +2189,7 @@ The `platform.vsphere` parameter prefixes each parameter listed in the table.
 ====
 
 .Optional VMware vSphere machine pool parameters
-[cols=".^2a,.^3a,.^3a",options="header"]
+[cols=".^2a,.^4a,.^2a",options="header"]
 |====
 |Parameter|Description|Values
 


### PR DESCRIPTION
As per the weekly OCP team meeting. Reverting admonitions because of vote to format inline with Asciidoc admonition styling that renders OK on Customer Portal as against d.o.c.

Version(s):
4.13

Link to docs preview:
* [Additional VMware vSphere configuration parameters-vSphere](https://75282--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations#installation-configuration-parameters-additional-vsphere_installing-vsphere-installer-provisioned-network-customizations)
* [Deprecated VMware vSphere configuration parameters-vSphere](https://75282--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations#deprecated-parameters-vsphere_installing-vsphere-installer-provisioned-network-customizations)
