### PR TITLE
[internal fix] admonitions-tables-vsphere-12

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1688,7 +1688,7 @@ The `platform.vsphere` parameter prefixes each parameter listed in the table.
 ====
 
 .Additional VMware vSphere cluster parameters
-[cols=".^2,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
+[cols=".^2,.^4a,.^2a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -1733,15 +1733,19 @@ in vSphere.
 
 |`apiVIPs`
 |The virtual IP (VIP) address that you configured for control plane API access.
-
-*Note:* In {product-title} 4.12 and later, the `apiVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `apiVIPs` configuration setting.
+[NOTE]
+====
+In {product-title} 4.12 and later, the `apiVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `apiVIPs` configuration setting.
+====
 |An IP address, for example `128.0.0.1`.
 
 |`ingressVIPs`
 |The virtual IP (VIP) address that you configured for cluster ingress.
-
-*Note:* In {product-title} 4.12 and later, the `ingressVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `ingressVIPs` configuration setting.
-a|An IP address, for example `128.0.0.1`.
+[NOTE]
+====
+In {product-title} 4.12 and later, the `ingressVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `ingressVIPs` configuration setting.
+====
+|An IP address, for example `128.0.0.1`.
 
 |`diskType`
 |Optional. The disk provisioning method. This value defaults to the vSphere default storage policy if not set.
@@ -1759,7 +1763,7 @@ The `platform.vsphere` parameter prefixes each parameter listed in the table.
 ====
 
 .Optional VMware vSphere machine pool parameters
-[cols=".^2,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
+[cols=".^2,.^4a,.^2a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -1800,7 +1804,7 @@ The `platform.vsphere` parameter prefixes each parameter listed in the table.
 ====
 
 .Region and zone enablement parameters
-[cols=".^2,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
+[cols=".^2,.^4a,.^2a",options="header"]
 |====
 |Parameter|Description|Values
 


### PR DESCRIPTION
As per the weekly OCP team meeting. Reverting admonitions because of vote to format inline with Asciidoc admonition styling that renders OK on Customer Portal as against d.o.c.

Version(s):
4.12

Link to docs preview:
* [Additional VMware vSphere configuration parameters-vSphere](https://75284--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations#installation-configuration-parameters-additional-vsphere_installing-vsphere-installer-provisioned-network-customizations)
* [Region and zone enablement configuration parameters-vSphere](https://75284--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations#installation-parameters-region-zone-technology-preview-vsphere_installing-vsphere-installer-provisioned-network-customizations)
