### PR TITLE
OSDOCS-10398: updating docs to reflect the use of oc adm node-logs is allowed

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -367,7 +367,7 @@ Name: Security and compliance
 Dir: security
 Distros: openshift-dedicated
 Topics:
-- Name: Audit logs
+- Name: Viewing audit logs
   File: audit-log-view
 ---
 Name: Authentication and authorization

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -590,7 +590,7 @@ Name: Security and compliance
 Dir: security
 Distros: openshift-rosa
 Topics:
-- Name: Audit logs
+- Name: Viewing audit logs
   File: audit-log-view
 - Name: Adding additional constraints for IP-based AWS role assumption
   File: rosa-adding-additional-constraints-for-ip-based-aws-role-assumption

--- a/modules/gathering-data-audit-logs.adoc
+++ b/modules/gathering-data-audit-logs.adoc
@@ -24,7 +24,15 @@ You can gather audit logs, which are a security-relevant chronological set of re
 
 endif::support[]
 ifdef::viewing[]
+
 You can use the must-gather tool to collect the audit logs for debugging your cluster, which you can review or send to Red Hat Support.
+
+ifdef::openshift-dedicated[]
+[NOTE]
+====
+In {product-title} deployments, customers who are not using the Customer Cloud Subscription (CCS) model must request a copy of your cluster's audit logs by contacting Red Hat Support. This is because using the must-gather tool requires `cluster-admin` privileges.
+====
+endif::openshift-dedicated[]
 endif::viewing[]
 
 .Procedure

--- a/modules/nodes-nodes-audit-log-basic-viewing.adoc
+++ b/modules/nodes-nodes-audit-log-basic-viewing.adoc
@@ -8,6 +8,13 @@
 
 You can view the logs for the OpenShift API server, Kubernetes API server, OpenShift OAuth API server, and OpenShift OAuth server for each control plane node.
 
+ifdef::openshift-dedicated[]
+[NOTE]
+====
+In {product-title} deployments, customers who are not using the Customer Cloud Subscription (CCS) model must request a copy of your cluster's audit logs by contacting Red Hat Support. This is because viewing API server audit logs requires `cluster-admin` privileges.
+====
+endif::openshift-dedicated[]
+
 .Procedure
 
 To view the audit logs:

--- a/security/audit-log-view.adoc
+++ b/security/audit-log-view.adoc
@@ -1,15 +1,11 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
-ifndef::openshift-rosa,openshift-dedicated[]
-[id="audit-log-view"]
-= Viewing audit logs
-endif::openshift-rosa,openshift-dedicated[]
-
 ifdef::openshift-rosa,openshift-dedicated[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
-[id="audit-log-view"]
-= Audit logs
 endif::openshift-rosa,openshift-dedicated[]
+
+[id="audit-log-view"]
+= Viewing audit logs
 :context: audit-log-view
 
 toc::[]
@@ -18,23 +14,23 @@ toc::[]
 
 include::modules/nodes-nodes-audit-log-basic.adoc[leveloffset=+1]
 
-ifndef::openshift-rosa,openshift-dedicated[]
 // Viewing the audit log
 include::modules/nodes-nodes-audit-log-basic-viewing.adoc[leveloffset=+1]
 
 // Filtering audit logs
 include::modules/security-audit-log-filtering.adoc[leveloffset=+1]
-endif::openshift-rosa,openshift-dedicated[]
+
 // Gathering audit logs
 include::modules/gathering-data-audit-logs.adoc[leveloffset=+1]
 
-ifndef::openshift-rosa,openshift-dedicated[]
 [id="viewing-audit-logs-additional-resources"]
 [role="_additional-resources"]
 == Additional resources
 
+ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../support/gathering-cluster-data.adoc#about-must-gather_gathering-cluster-data[Must-gather tool]
 * link:https://github.com/kubernetes/apiserver/blob/master/pkg/apis/audit/v1/types.go#L72[API audit log event structure]
 * xref:../security/audit-log-policy-config.adoc#audit-log-policy-config[Configuring the audit log policy]
-* xref:../observability/logging/log_collection_forwarding/log-forwarding.adoc#log-forwarding[About log forwarding]
 endif::[]
+* xref:../observability/logging/log_collection_forwarding/log-forwarding.adoc#log-forwarding[About log forwarding]
+


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): `enterprise-4.15+`
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-10398
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
_Primary changes:_
- https://75292--ocpdocs-pr.netlify.app/openshift-dedicated/latest/security/audit-log-view.html
- https://75292--ocpdocs-pr.netlify.app/openshift-rosa/latest/security/audit-log-view.html

_Secondary changes:_ (no change in appearance to OCP docs, added conditionals for ROSA/OSD only)
- https://75292--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/audit-log-view.html 
- https://75292--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data.html

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Made additional changes to include notes for non-CCS OSD customers and added additional resources applicable to ROSA/OSD. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
