### PR TITLE
TELCODOCS-1822: Use Cases - module.name not module-name

### DIFF
--- a/modules/kmm-customizing-upgrades-for-kernel-modules.adoc
+++ b/modules/kmm-customizing-upgrades-for-kernel-modules.adoc
@@ -8,11 +8,11 @@
 
 Use this procedure to upgrade the kernel module while running maintenance operations on the node, including rebooting the node, if needed. To minimize the impact on the workloads running in the cluster, run the kernel upgrade process sequentially, one node at a time.
 
+
 [NOTE]
 ====
 This procedure requires knowledge of the workload utilizing the kernel module and must be managed by the cluster administrator.
 ====
-
 
 .Prerequisites
 
@@ -46,7 +46,7 @@ $ oc label node/<node_name> kmm.node.kubernetes.io/version-module.<module_namesp
 
 . If required, as the cluster administrator, perform any additional maintenance required on the node for the kernel module upgrade.
 +
-If no additional upgrading is needed, you can skip Steps 3 through 6 by updating the `kmm.node.kubernetes.io/version-module.<module-namespace>.<module-name>` label value to the new `$moduleVersion` as set in the `Module`.
+If no additional upgrading is needed, you can skip Steps 3 through 6 by updating the `kmm.node.kubernetes.io/version-module.<module_namespace>.<module_name>` label value to the new `$moduleVersion` as set in the `Module`.
 
 . Run the following command to add the `kmm.node.kubernetes.io/version-module.<module_namespace>.<module_name>=$moduleVersion` label to the node. The `$moduleVersion` must be equal to the new value of the `version` field in the `Module` CR.
 +


### PR DESCRIPTION
D/S Docs: [MGMT-17316] Use Cases - module.name not module-name

Jira: https://issues.redhat.com/browse/TELCODOCS-1822

Version(s): openshift-4.16.0, openshift-4.15.0, openshift-4.14.0

Link to docs preview: https://75299--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html#kmm-customizing-upgrades-for-kernel-modules_kernel-module-management-operator

SME review: @qbarrand
QE review: @cdvultur

