### PR TITLE
[enterprise-4.14] OCPBUGS#33114: Doc improvements related to metrics, must-gather, and updating LVM Storage

### DIFF
--- a/modules/lvms-monitoring-logical-volume-manager-operator.adoc
+++ b/modules/lvms-monitoring-logical-volume-manager-operator.adoc
@@ -54,7 +54,7 @@ When the thin pool and volume group reach maximum storage capacity, further oper
 |Alert| Description
 |`VolumeGroupUsageAtThresholdNearFull`|This alert is triggered when both the volume group and thin pool usage exceeds 75% on nodes. Data deletion or volume group expansion is required.
 |`VolumeGroupUsageAtThresholdCritical`|This alert is triggered when both the volume group and thin pool usage exceeds 85% on nodes. In this case, the volume group is critically full. Data deletion or volume group expansion is required.
-|`ThinPoolDataUsageAtThresholdNearFull`|This alert is triggered when the thin pool data uusage in the volume group exceeds 75% on nodes. Data deletion or thin pool expansion is required.
+|`ThinPoolDataUsageAtThresholdNearFull`|This alert is triggered when the thin pool data usage in the volume group exceeds 75% on nodes. Data deletion or thin pool expansion is required.
 |`ThinPoolDataUsageAtThresholdCritical`|This alert is triggered when the thin pool data usage in the volume group exceeds 85% on nodes. Data deletion or thin pool expansion is required.
 |`ThinPoolMetaDataUsageAtThresholdNearFull`|This alert is triggered when the thin pool metadata usage in the volume group exceeds 75% on nodes. Data deletion or thin pool expansion is required.
 |`ThinPoolMetaDataUsageAtThresholdCritical`|This alert is triggered when the thin pool metadata usage in the volume group exceeds 85% on nodes. Data deletion or thin pool expansion is required.

--- a/modules/lvms-updating-lvms-on-sno.adoc
+++ b/modules/lvms-updating-lvms-on-sno.adoc
@@ -3,32 +3,34 @@
 // storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="lvms-upgrading-lvms-on-sno_{context}"]
-= Upgrading {lvms} on {sno} clusters
+[id="lvms-updating-lvms_{context}"]
+= Updating {lvms} on a {sno} cluster
 
-You can upgrade the {lvms-first} Operator to ensure compatibility with your {sno} version.
+You can update {lvms} to ensure compatibility with the {sno} version.
 
 .Prerequisites
 
-* You have upgraded your {sno} cluster.
+* You have updated your {sno} cluster.
 
-* You have installed a previous version of the {lvms} Operator.
+* You have installed a previous version of {lvms}.
 
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
-* You have logged in as a user with `cluster-admin` privileges.
+* You have access to the cluster using an account with `cluster-admin` permissions.
 
 .Procedure
 
-. Update the `Subscription` resource for the {lvms} Operator by running the following command:
+. Log in to the {oc-first}.
+
+. Update the `Subscription` custom resource (CR) that you created while installing {lvms} by running the following command:
 +
 [source,terminal]
 ----
-$ oc patch subscription lvms-operator -n openshift-storage --type merge --patch '{"spec":{"channel":"<update-channel>"}}' <1>
+$ oc patch subscription lvms-operator -n openshift-storage --type merge --patch '{"spec":{"channel":"<update_channel>"}}' <1>
 ----
-<1> Replace `<update-channel>` with the version of the {lvms} Operator that you want to install, for example `stable-{product-version}`.
+<1> Replace `<update_channel>` with the version of {lvms} that you want to install. For example, `stable-{product-version}`.
 
-. View the upgrade events to check that the installation is complete by running the following command:
+. View the update events to check that the installation is complete by running the following command:
 +
 [source,terminal]
 ----
@@ -50,7 +52,7 @@ $ oc get events -n openshift-storage
 
 .Verification
 
-* Verify the version of the {lvms} Operator by running the following command:
+* Verify the {lvms} version by running the following command:
 +
 [source,terminal]
 ----
@@ -61,4 +63,4 @@ $ oc get subscription lvms-operator -n openshift-storage -o jsonpath='{.status.i
 [source,terminal, subs="attributes"]
 ----
 lvms-operator.v{product-version}
-----
+---- 

--- a/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
+++ b/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
@@ -151,9 +151,6 @@ include::modules/lvms-scaling-storage-expand-pvc.adoc[leveloffset=+1]
 //Deleting a PVC
 include::modules/lvms-deleting-pvc.adoc[leveloffset=+1]
 
-//Upgrading
-include::modules/lvms-upgrading-lvms-on-sno.adoc[leveloffset=+1]
-
 //Volume snapshots
 include::modules/lvms-about-volume-snapshots.adoc[leveloffset=+1]
 
@@ -171,6 +168,9 @@ include::modules/lvms-about-volume-clones.adoc[leveloffset=+1]
 
 include::modules/lvms-creating-volume-clones.adoc[leveloffset=+2]
 include::modules/lvms-deleting-volume-clones.adoc[leveloffset=+2]
+
+//Updating
+include::modules/lvms-updating-lvms-on-sno.adoc[leveloffset=+1]
 
 //Monitoring
 include::modules/lvms-monitoring-logical-volume-manager-operator.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OCPBUGS-33114](https://issues.redhat.com/browse/OCPBUGS-33114)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[Preview](https://75331--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html#lvms-updating-lvms_logical-volume-manager-storage)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
