### PR TITLE
OBSDOCS-1020/TRACING-4075: Write documentation for the k8sobjectsreceiver component

### DIFF
--- a/modules/otel-collector-components.adoc
+++ b/modules/otel-collector-components.adoc
@@ -82,6 +82,98 @@ The Jaeger receiver ingests traces in the Jaeger formats.
 <4> The Jaeger Thrift Binary endpoint. If omitted, the default `+0.0.0.0:6832+` is used.
 <5> The  server-side TLS configuration. See the OTLP receiver configuration section for more details.
 
+[id="k8sobjectsreceiver-receiver_{context}"]
+=== Kubernetes Objects Receiver
+
+:FeatureName: The Kubernetes Objects Receiver
+include::snippets/technology-preview.adoc[]
+
+The Kubernetes Objects Receiver pulls or watches objects to be collected from the Kubernetes API server.
+This receiver watches primarily Kubernetes events, but it can collect any type of Kubernetes objects.
+This receiver gathers telemetry for the cluster as a whole, so only one instance of this receiver suffices for collecting all the data.
+
+.OpenTelemetry Collector custom resource with an enabled Kubernetes Objects Receiver
+[source,yaml]
+----
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-k8sobj
+  namespace: <namespace>
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otel-k8sobj
+  namespace: <namespace>
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "events.k8s.io"
+  resources:
+  - events
+  verbs:
+  - watch
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otel-k8sobj
+subjects:
+  - kind: ServiceAccount
+    name: otel-k8sobj
+    namespace: <namespace>
+roleRef:
+  kind: ClusterRole
+  name: otel-k8sobj
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel-k8s-obj
+  namespace: <namespace>
+spec:
+  serviceAccount: otel-k8sobj
+  image: ghcr.io/os-observability/redhat-opentelemetry-collector/redhat-opentelemetry-collector:main
+  mode: deployment
+  config: |
+    receivers:
+      k8sobjects:
+        auth_type: serviceAccount
+        objects:
+          - name: pods # <1>
+            mode: pull # <2>
+            interval: 30s # <3>
+            label_selector: # <4>
+            field_selector: # <5>
+            namespaces: [<namespace>,...] # <6>
+          - name: events
+            mode: watch
+    exporters:
+      debug:
+    service:
+      pipelines:
+        logs:
+          receivers: [k8sobjects]
+          exporters: [debug]
+----
+<1> The Resource name that this receiver observes: for example, `pods`, `deployments`, or `events`.
+<2> The observation mode that this receiver uses: `pull` or `watch`.
+<3> Only applicable to the pull mode. The request interval for pulling an object. If omitted, the default value is `+1h+`.
+<4> The label selector to define targets.
+<5> The field selector to filter targets.
+<6> The list of namespaces to collect events from. If omitted, the default value is `+all+`.
+
 [id="prometheus-receiver_{context}"]
 === Prometheus Receiver
 


### PR DESCRIPTION
:warning: This PR is tied to a product release date, which is currently set to **June 5** (Wednesday).

- If the merge review gets delayed, you're welcome to ping `mleonov` on Slack.
- If you have any questions, ping `mleonov` on Slack.

Signed-off-by: Benedikt Bongartz <bongartz@klimlive.de>

Edit of https://github.com/openshift/openshift-docs/pull/74966

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12, 4.13, 4.14, 4.15, 4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OBSDOCS-1020
https://issues.redhat.com/browse/TRACING-4076

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://75335--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-configuration-of-otel-collector.html#k8sobjectsreceiver-receiver_otel-configuration-of-otel-collector

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
