### PR TITLE
OSDOCS-10364: Documented the 4.15.11 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2720,6 +2720,80 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+[id="ocp-4-15-11"]
+=== RHSA-2024:2068 - {product-title} 4.15.11 bug fix and security update
+
+Issued: 2024-05-02
+
+{product-title} release 4.15.11, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:2068[RHSA-2024:2068] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:2071[RHSA-2024:2071] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.11 --pullspecs
+----
+
+[id="ocp-4-15-11-enhancements"]
+==== Enhancements
+
+The following enhancements are included in this z-stream release:
+
+[id="ocp-4-15-11-topology-page-node-limit-increase"]
+===== Increased the number of supported nodes on the *Topology* view
+
+* Previously, the {product-title} web console *Topology* view could only display a maximum of 100 nodes. If you attempted to view more than 100 nodes, the web console would output a `Loading is taking longer than expected.` error message. With this release, the `MAX_NODES_LIMIT` parameter for the web console is set to `200`, so that the web console can display a maximum of 200 nodes. (link:https://issues.redhat.com/browse/OCPBUGS-32340[*OCPBUGS-32340*])
+
+[id="ocp-4-15-11-grc-acr-rhel-providers"]
+===== Added `gcr` and `acr` {op-system-base} credential providers
+
+* {product-title} {product-version} includes `gcr` and `acr` {op-system-base-full} credential providers so that future upgrades to later versions of {product-title} that require {op-system-base} compute nodes deployed on a cluster do not result in a failed installation. (link:https://issues.redhat.com/browse/OCPBUGS-30970[*OCPBUGS-30970*])
+
+[id="ocp-4-15-11-featuregates-rbac-dns-operator"]
+===== Added permission for reading the `featureGates` resource to RBAC rule
+
+* {product-title} {product-version} adds a permission to the role-based access control (RBAC) rule so that the DNS Operator can read the `featureGates` resource. Without this permission, an upgrade operation to a later version of {product-title} could fail. (link:https://issues.redhat.com/browse/OCPBUGS-32093[*OCPBUGS-32093*])
+
+[id="ocp-4-15-11-bug-fixes"]
+==== Bug fixes
+
+* The installation of {product-title} failed when a performance profile was located in the extra manifests folder and targeted *master* or *worker* node roles. This was caused by the internal installation that processes the performance profile before the default *master* or *worker* node roles were created. With this release, the internal installation processes the performance profile after the node roles are created so that this issue no longer exists. (link:https://issues.redhat.com/browse/OCPBUGS-27948[*OCPBUGS-27948*])
+
+* Previously, the image registry did not support {aws-first} region `ca-west-1`. With this release, the image registry can now be deployed in this region. (link:https://issues.redhat.com/browse/OCPBUGS-31641[*OCPBUGS-31641*])
+
+* Previously, a cluster upgraded to {product-title} 4.14 or later experienced router pods unexpectedly closing `keep-alive` connections that caused traffic degradation issues for Apache HTTP clients. This issue was caused by router pods using a version of an HAProxy router that closed idle connections after the HAProxy router was restarted. With this release, the pods use a version of an HAProxy router that includes an `idle-close-on-response` option. The HAProxy router now waits for the last request and response transaction before the idle connection is closed. (link:https://issues.redhat.com/browse/OCPBUGS-32435[*OCPBUGS-32435*])
+
+* Previously, a Redfish virtual media Hewlett Packard Enterprise (HPE) integrated Lights Out (iLO) 5 bare-metal machine's compression was forcibly disabled to workaround other unrelated issues in different hardware models. This caused the `FirmwareSchema` resource to be missing from each iLO 5 bare-metal machine. Each machine needs compression to fetch message registries from their Redfish Baseboard Management Controller (BMC) endpoints. With this release, each iLO 5 bare-metal machine that needs the `FirmwareSchema` resource does not have compression forcibly disabled. (link:https://issues.redhat.com/browse/OCPBUGS-31686[*OCPBUGS-31686*])
+
+* Previously, nodes of paused `MachineConfigPools` might have their pause status dropped when performing a cluster update. With this release, nodes of paused `MachineConfigPools` correctly stay paused when performing a cluster update. (link:https://issues.redhat.com/browse/OCPBUGS-31839[*OCPBUGS-31839*])
+
+* Previously, newer versions of Redfish used Manager resources to deprecate the Uniform Resource Identifier (URI) for the RedFish Virtual Media API. This caused any hardware that used the newer Redfish URI for Virtual Media to not be provisioned. With this release, the Ironic API identifies the correct Redfish URI to deploy for the RedFish Virtual Media API so that hardware relying on either the deprecated or the newer URI could be provisioned.  (link:https://issues.redhat.com/browse/OCPBUGS-31830[*OCPBUGS-31830*])
+
+* Previously, the Cloud Credential Operator (CCO) checked for a non-existent `s3:HeadBucket` permission during the validation checks in mint mode that resulted in a failed cluster installation. With this release, CCO removes the validation check for this non-existing permission so that validation checks pass in mint mode and the cluster installation does not fail. (link:https://issues.redhat.com/browse/OCPBUGS-31924[*OCPBUGS-31924*])
+
+* Previously, a new Operator Lifecycle Manager (OLM) Operator that upgraded to {product-title} 4.15.3 resulted in failure because important resources were not injected into the upgrade operation. With this release, these resources are now cached so that newer OLM Operator upgrades can succeed. (link:https://issues.redhat.com/browse/OCPBUGS-32311[*OCPBUGS-32311*])
+
+* Previously, the Red{nbsp} {product-title} web console did not require the `Creator` field as a mandatory field. API changes specified an empty value for this field, but a user profile could still create silent alerts. With this release, the API marks the `Creator` field as a mandatory field for a user profile that needs to create silent alerts. (link:https://issues.redhat.com/browse/OCPBUGS-32097[*OCPBUGS-32097*])
+
+* Previously, in hosted control planes for {product-title}, when you created the custom resource definition (CRD) for `ImageDigestMirrorSet` and `ImageContentSourcePolicy` objects at the same time in a disconnected environment, the HyperShift Operator created the object only for the `ImageDigestMirrorSet` CRD, ignoring the `ImageContentSourcePolicy` CRD. With this release, the HyperShift Operator can create objects at the same time for the `ImageDigestMirrorSet` and `ImageContentSourcePolicy` CRDs. (link:https://issues.redhat.com/browse/OCPBUGS-32164[*OCPBUGS-32164*])
+
+* Previously, IPv6 networking services that operated in {rh-openstack-first} environments could not share an IPv6 load balancer that was configured with multiple services because of an issue that mistakenly marks an IPv6 load balancer as `Internal` to the cluster. With this release, IPv6 load balancers are no longer marked as `Internal` so that an IPv6 load balancer with multiple services can be shared among IPv6 networking services. (link:https://issues.redhat.com/browse/OCPBUGS-32246[*OCPBUGS-32246*])
+
+* Previously, the control plane machine sets (CPMS) did not allow template names for vSphere in a CPMS definition. With this release, a CPMS Operator fix allows template names for vSphere in the CPMS definition so that this issue no longer persists. (link:https://issues.redhat.com/browse/OCPBUGS-32357[*OCPBUGS-32357*])
+
+* Previously, the control plane machine sets (CPMS) Operator was not correctly handling older {product-title} version configurations that had a vSphere definition in the infrastructure custom resource. This would cause cluster upgrade operations to fail and the CPMS Operator to remain in a `crashloopback` state. With this release, the cluster upgrade operations do not fail because of this issue. (link:https://issues.redhat.com/browse/OCPBUGS-32414[*OCPBUGS-32414*])
+
+* Previously, the image registry's Azure path fix job incorrectly required the presence of `AZURE_CLIENT_ID` and `TENANT_CLIENT_ID` parameters to function. This caused a valid configuration to throw an error message. With this release, adds a check to the Identity and Access Management (IAM) service account key to validate if these parameters are needed, so that a cluster upgrade operation no longer fails. (link:https://issues.redhat.com/browse/OCPBUGS-32396[*OCPBUGS-32396*])
+
+* Previously, a build pod that failed because of a memory limitation would have its pod status changed to `Error` instead of `OOMKilled`. This caused these pods to not be reported correctly. The issue would only occur on cgroup v2 nodes. With this release, a pod with a status of `OOMKilled` is correctly detected and reported. (link:https://issues.redhat.com/browse/OCPBUGS-32498[*OCPBUGS-32498*])
+
+[id="ocp-4-15-11-updating"]
+==== Updating
+To update an existing {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+
 [id="ocp-4-15-10"]
 === RHSA-2024:1887 - {product-title} 4.15.10 bug fix and security update
 


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-10364](https://issues.redhat.com/browse/OSDOCS-10364)

Link to docs preview:
[4.15.11](https://75336--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-11)


