### PR TITLE
ROSA: fix operator policy link, subnet tagging to use cluster id

### DIFF
--- a/modules/aws-installing-an-aws-load-balancer-operator.adoc
+++ b/modules/aws-installing-an-aws-load-balancer-operator.adoc
@@ -154,8 +154,8 @@ For more information on creating AWS IAM roles, see link:https://docs.aws.amazon
 +
 [source, terminal]
 ----
-$ curl -o albo-operator-permission-policy.json https://raw.githubusercontent.com/alebedev87/aws-load-balancer-operator/aws-cli-commands-for-sts/hack/operator-permission-policy.json
-aws iam put-role-policy --role-name albo-operator --policy-name perms-policy-albo-operator --policy-document file://albo-operator-permission-policy.json
+$ curl -o albo-operator-permission-policy.json https://raw.githubusercontent.com/openshift/aws-load-balancer-operator/release-1.1/hack/operator-permission-policy.json
+$ aws iam put-role-policy --role-name albo-operator --policy-name perms-policy-albo-operator --policy-document file://albo-operator-permission-policy.json
 ----
 +
 For more information on adding AWS IAM permissions to AWS IAM roles, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_manage-attach-detach.html[Adding and removing IAM identity permissions].
@@ -223,7 +223,7 @@ $ echo $CONTROLLER_ROLE_ARN
 [source,terminal]
 ----
 $ curl -o albo-controller-permission-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.4.7/docs/install/iam_policy.json
-aws iam put-role-policy --role-name albo-controller --policy-name perms-policy-albo-controller --policy-document file://albo-controller-permission-policy.json
+$ aws iam put-role-policy --role-name albo-controller --policy-name perms-policy-albo-controller --policy-document file://albo-controller-permission-policy.json
 ----
 +
 .. Generate the controller's AWS credentials:
@@ -253,7 +253,7 @@ endif::openshift-rosa[]
 ifdef::openshift-rosa[]
 ROSA
 endif::openshift-rosa[]
-cluster. Replace `{Cluster Infra ID}` with the Infra ID specified previously:
+cluster and to all its subnets. Replace `{Cluster Infra ID}` with the Infra ID specified previously:
 +
 [source, terminal]
 ----


### PR DESCRIPTION
- The link to download the operator permission policy used my personal repository.
- The doc misses a note about tagging the cluster subnets with the cluster id.

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
