### PR TITLE
CNV-31882: Move common instance types to virt operator

### DIFF
--- a/modules/virt-about-ssp-operator.adoc
+++ b/modules/virt-about-ssp-operator.adoc
@@ -6,7 +6,7 @@
 [id="virt-about-ssp-operator_{context}"]
 = About the Scheduling, Scale, and Performance (SSP) Operator
 
-The SSP Operator, `ssp-operator`, deploys the common templates, the related default boot sources, the pipeline tasks, and the template validator.
+The SSP Operator, `ssp-operator`, deploys the common templates, the related default boot sources, and the template validator.
 
 image::cnv_components_ssp-operator.png[ssp-operator components]
 

--- a/modules/virt-about-virt-operator.adoc
+++ b/modules/virt-about-virt-operator.adoc
@@ -6,7 +6,7 @@
 [id="virt-about-virt-operator_{context}"]
 = About the {VirtProductName} Operator
 
-The {VirtProductName} Operator, `virt-operator` deploys, upgrades, and manages {VirtProductName} without disrupting current virtual machine (VM) workloads.
+The {VirtProductName} Operator, `virt-operator`, deploys, upgrades, and manages {VirtProductName} without disrupting current virtual machine (VM) workloads. In addition, the {VirtProductName} Operator deploys the common instance types and common preferences.
 
 image::cnv_components_virt-operator.png[virt-operator components]
 


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/CNV-31882

CNV 4.16+

Preview:
https://75343--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/about_virt/virt-architecture.html#virt-about-virt-operator_virt-architecture
https://75343--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/about_virt/virt-architecture.html#virt-about-ssp-operator_virt-architecture