### PR TITLE
ocpbugs32742: removing redundant sentence

### DIFF
--- a/modules/nw-networkpolicy-multitenant-isolation.adoc
+++ b/modules/nw-networkpolicy-multitenant-isolation.adoc
@@ -13,7 +13,6 @@ project namespaces.
 .Prerequisites
 
 * Your cluster uses a network plugin that supports `NetworkPolicy` objects, such as the OVN-Kubernetes network plugin or the OpenShift SDN network plugin with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
-This mode is the default for OpenShift SDN.
 * You installed the OpenShift CLI (`oc`).
 * You are logged in to the cluster with a user with `admin` privileges.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OCPBUGS-32742
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://75372--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/openshift_network_security/network_policy/multitenant-network-policy.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.---> Removing the redundant sentence "his mode is the default for OpenShift SDN." from the prerequisites section

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
