### PR TITLE
OSDOCS-9813: adds custom CA relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -58,15 +58,19 @@ See the following list for details:
 //[id="microshift-4-16-installation"]
 //=== Installation
 
-//[id="microshift-4-16-configuring"]
-//===Configuring
+[id="microshift-4-16-configuring"]
+=== Configuring
+
+[id="microshift-4-16-custom-cert-auths"]
+==== Customizable certificate authorities for the API server are supported
+With this release, you can configure a custom server certificate that has been issued by an external certificate authority (CA). The default API server certificate is issued by an internal {microshift-short} cluster CA. You can now replace this certificate with one that is issued by a CA that clients trust.
+//TODO add xref after section merges
 
 [id="microshift-4-16-networking"]
 === Networking
 
 [id="microshift-4-16-multus"]
 ==== Multiple networks capability now available
-
 With this release, using multiple networks is supported with the {microshift-short} Multus plugin. If you have advanced networking requirements, you can attach additional networks to a pod for high-performance network configurations. After installing the {microshift-short} Multus RPM package, you can use the Bridge, MACVLAN, or IPVLAN plugins to create additional networks. See xref:../microshift_networking/microshift_multiple_networks/microshift-cni-multus.adoc#microshift-multus-intro_microshift-cni-multus[Additional networks in {microshift-short}].
 
 //[id="microshift-4-16-storage"]


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-9813](https://issues.redhat.com/browse/OSDOCS-9813)

Link to docs preview:
[Custom CAs release note](https://75373--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-custom-cert-auths)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[Feature work docs](https://github.com/openshift/openshift-docs/pull/74615)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
