### PR TITLE
OSSM-6396 Move Upgrading Service Mesh beneath Service Mesh 2.x Release Notes

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3841,6 +3841,8 @@ Topics:
     File: ossm-about
   - Name: Service Mesh 2.x release notes
     File: servicemesh-release-notes
+  - Name: Upgrading Service Mesh
+    File: upgrading-ossm
   - Name: Understanding Service Mesh
     File: ossm-architecture
   - Name: Service Mesh deployment models
@@ -3857,8 +3859,6 @@ Topics:
     File: ossm-create-mesh
   - Name: Enabling sidecar injection
     File: prepare-to-deploy-applications-ossm
-  - Name: Upgrading Service Mesh
-    File: upgrading-ossm
   - Name: Managing users and profiles
     File: ossm-profiles-users
   - Name: Security


### PR DESCRIPTION
[OSSM-6396](https://issues.redhat.com//browse/OSSM-6396) Move Upgrading Service Mesh beneath Service Mesh 2.x Release Notes

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSSM-6396

Link to docs preview:
https://75374--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/upgrading-ossm

QE review:

QE review is not needed for this PR.

Additional information:

"Upgrading Service Mesh" is currently 8 topics below "Service Mesh Release Notes 2.x," making it difficult for users to understand things like OSSM Operator vs Service Mesh Control Plane upgrades, and hard for users to find information they need when upgrading from say, OSSM 2.4 to OSSM 2.5.

Moving "Upgrading Service Mesh" so that it is underneath "Service Mesh Release Notes 2.x" increases its visibility, and most closely ties its relevance to release notes, hopefully helping users get the information they need easier and faster since they don't have to scroll or scan or remember to check "Upgrading Service Mesh."

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
