### PR TITLE
[virt] DPDK Checkup: Update upstream image tags

### DIFF
--- a/modules/virt-checking-cluster-dpdk-readiness.adoc
+++ b/modules/virt-checking-cluster-dpdk-readiness.adoc
@@ -108,8 +108,8 @@ metadata:
 data:
   spec.timeout: 10m
   spec.param.networkAttachmentDefinitionName: <network_name> <1>
-  spec.param.trafficGenContainerDiskImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:v0.3.1 <2>
-  spec.param.vmUnderTestContainerDiskImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-vm:v0.3.1" <3>
+  spec.param.trafficGenContainerDiskImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:v0.4.0 <2>
+  spec.param.vmUnderTestContainerDiskImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-vm:v0.4.0" <3>
 ----
 <1> The name of the `NetworkAttachmentDefinition` object.
 <2> The container disk image for the traffic generator. In this example, the image is pulled from the upstream Project Quay Container Registry.
@@ -194,8 +194,8 @@ metadata:
 data:
   spec.timeout: 10m
   spec.param.NetworkAttachmentDefinitionName: "dpdk-network-1"
-  spec.param.trafficGenContainerDiskImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:v0.2.0"
-  spec.param.vmUnderTestContainerDiskImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-vm:v0.2.0"
+  spec.param.trafficGenContainerDiskImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:v0.4.0"
+  spec.param.vmUnderTestContainerDiskImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-vm:v0.4.0"
   status.succeeded: "true" <1>
   status.failureReason: "" <2>
   status.startTimestamp: "2023-07-31T13:14:38Z" <3>

--- a/modules/virt-dpdk-config-map-parameters.adoc
+++ b/modules/virt-dpdk-config-map-parameters.adoc
@@ -24,8 +24,8 @@ The following table shows the mandatory and optional parameters that you can set
 |True
 
 |`spec.param.trafficGenContainerDiskImage`
-|The container disk image for the traffic generator. The default value is `quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:main`.
-|False
+|The container disk image for the traffic generator.
+|True
 
 |`spec.param.trafficGenTargetNodeName`
 |The node on which the traffic generator VM is to be scheduled. The node should be configured to allow DPDK traffic.
@@ -36,8 +36,8 @@ The following table shows the mandatory and optional parameters that you can set
 |False
 
 |`spec.param.vmUnderTestContainerDiskImage`
-|The container disk image for the VM under test. The default value is `quay.io/kiagnose/kubevirt-dpdk-checkup-vm:main`.
-|False
+|The container disk image for the VM under test.
+|True
 
 |`spec.param.vmUnderTestTargetNodeName`
 |The node on which the VM under test is to be scheduled. The node should be configured to allow DPDK traffic.


### PR DESCRIPTION
Update traffic-gen and VM-under-test container disk
image versions.

Also remove their default values and mark them as mandatory.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.16+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://75380--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-running-cluster-checkups.html#virt-checking-cluster-dpdk-readiness_virt-running-cluster-checkups

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
