### PR TITLE
OSDOCS 10426 fix exit code in case of an ERROR message in build_for_portal.py

### DIFF
--- a/build_for_portal.py
+++ b/build_for_portal.py
@@ -23,7 +23,7 @@ from aura import cli
 
 cli.init_logging(False, True)
 
-has_errors = False
+list_of_errors = []
 CLONE_DIR = "."
 BASE_PORTAL_URL = "https://access.redhat.com/documentation/en-us/"
 # ID_RE = re.compile("^\[(?:\[|id=\'|#)(.*?)(\'?,.*?)?(?:\]|\')?\]", re.M | re.DOTALL)
@@ -442,6 +442,7 @@ def reformat_for_drupal(info):
 
     # Reformat the data
     for book in books:
+
         log.info("Processing %s", book["Dir"])
         book_src_dir = os.path.join(src_dir, book["Dir"])
 
@@ -458,6 +459,7 @@ def reformat_for_drupal(info):
 
         log.debug("Copying images for " + book["Name"])
         copy_images(book, src_dir, images_dir, distro)
+
 
 
 def copy_images(node, src_path, dest_dir, distro):
@@ -630,7 +632,7 @@ def scrub_file(info, book_src_dir, src_file, tag=None, cwd=None):
                 raise ConnectionError("Malformed URL")
         except Exception as exception:
             log.error("An include file wasn't found: %s", base_src_file)
-            has_errors = True
+            list_of_errors.append(f"An include file wasn't found: {base_src_file}")
             sys.exit(-1)
 
     # Get a list of predefined custom title ids for the file
@@ -732,7 +734,6 @@ def fix_links(content, info, book_src_dir, src_file, tag=None, cwd=None):
             content = _fix_links(
                 content, book_src_dir, src_file, info, tag=tag, cwd=cwd
             )
-
     return content
 
 def dir_to_book_name(dir,src_file,info):
@@ -742,11 +743,11 @@ def dir_to_book_name(dir,src_file,info):
             return(book["Name"])
             break
 
-    has_errors = True
     log.error(
         'ERROR (%s): book not found for the directory %s',
         src_file,
         dir)
+    list_of_errors.append(f"ERROR ({src_file}): book not found for the directory {dir}")
     return(dir)
 
 
@@ -791,6 +792,7 @@ def _fix_links(content, book_dir, src_file, info, tag=None, cwd=None):
                         'ERROR (%s): link pointing outside source directory? %s',
                         src_file,
                         link_file)
+                    list_of_errors.append(f'ERROR ({src_file}): link pointing outside source directory? {link_file}')
                     continue
                 split_relative_path = full_relative_path.split("/")
                 book_dir_name = split_relative_path[0]
@@ -823,13 +825,14 @@ def _fix_links(content, book_dir, src_file, info, tag=None, cwd=None):
                 fixed_link = link_text
                 if EXTERNAL_LINK_RE.search(link_file) is not None:
                     rel_src_file = src_file.replace(os.path.dirname(book_dir) + "/", "")
-                    has_errors = True
+                    link_text_message = link_text.replace("\n", "")
                     log.error(
                         'ERROR (%s): "%s" appears to try to reference a file not included in the "%s" distro',
                         rel_src_file,
-                        link_text.replace("\n", ""),
+                        link_text_message,
                         info["distro"],
                     )
+                    list_of_errors.append(f'ERROR ({rel_src_file})): {link_text_message} appears to try to reference a file not included in the {info["distro"]} distro')
         else:
             fixed_link = "xref:" + link_anchor.replace("#", "") + link_title
 
@@ -1177,7 +1180,7 @@ def main():
     # Copy the original data and reformat for drupal
     reformat_for_drupal(info)
 
-    if has_errors:
+    if list_of_errors:
         sys.exit(1)
 
     if args.push:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12, 4.13, 4.14, 4.15, 4.16
also please cp to:
gitops-docs-main
pipelines-docs-main
serverless-docs-main
build-docs-main
service-mesh-docs-main

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
OSDOCS 10426

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Build fix only, no doc change

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
