### PR TITLE
Fix xrefs that are breaking pv1 builds of 4.13

### DIFF
--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -553,11 +553,11 @@ include::modules/installation-extend-edge-nodes-aws-local-zones.adoc[leveloffset
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../installing/installing_aws/installing-aws-localzone.adoc[Installing a cluster using AWS Local Zones]
+* xref:../installing/installing_aws/installing-aws-localzone.adoc#installing-aws-localzone[Installing a cluster using AWS Local Zones]
 
-* xref:../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc[Understanding taints and tolerations]
+* xref:../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations[Understanding taints and tolerations]
 
-* xref:../logging/scheduling_resources/logging-taints-tolerations.adoc[Using taints and tolerations to control logging pod placement]
+* xref:../observability/logging/scheduling_resources/logging-taints-tolerations.adoc#logging-taints-tolerations[Using taints and tolerations to control logging pod placement]
 
 [id="post-worker-latency-profiles"]
 == Improving cluster stability in high latency environments using worker latency profiles


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://75400--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#post-worker-latency-profiles (scroll up to the additional resources section right above the linked heading)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Fixes a broken pv1 build
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
