### PR TITLE
Removing restore cluster content from troubleshooting

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -723,8 +723,8 @@ Topics:
    # File: recovering-update-before-applied
   - Name: Gathering data about your cluster update
     File: gathering-data-cluster-update
-  - Name: Restoring your cluster to a previous state
-    File: restoring-cluster-previous-state
+  #- Name: Restoring your cluster to a previous state
+    #File: restoring-cluster-previous-state
 ---
 Name: Support
 Dir: support


### PR DESCRIPTION
Version(s):
4.14+

Issue:
N/A

Link to docs preview:
https://75401--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/troubleshooting_updates/gathering-data-cluster-update

Current docs are: https://docs.openshift.com/container-platform/4.14/updating/troubleshooting_updates/gathering-data-cluster-update.html

QE review:
N/A

Additional information:
PM asked to remove content for now - commented it out in the topic map 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
