### PR TITLE
TELCODOCS-1825: Add a webhook for namespace deletion

### DIFF
--- a/modules/kmm-unloading-kernel-module.adoc
+++ b/modules/kmm-unloading-kernel-module.adoc
@@ -16,8 +16,5 @@ You must unload the kernel modules when moving to a newer version or if they int
 ====
 When unloading worker pods, KMM needs all the resources it uses when loading the kernel module. This includes the `ServiceAccount` referenced in the `Module` as well as any RBAC defined to allow privileged KMM worker Pods to run. It also includes any pull secret referenced in `.spec.imageRepoSecret`.
 
-To avoid situations where KMM is unable to unload the kernel module from nodes:
-
-* Do not delete those resources while the `Module` resource is still present in the cluster in any state, including `Terminating`.
-* Do not delete any namespace containing at least a `Module` resource.
+To avoid situations where KMM is unable to unload the kernel module from nodes, make sure those resources are not deleted while the `Module` resource is still present in the cluster in any state, including `Terminating`. KMM includes a validating admission webhook that rejects the deletion of namespaces that contain at least one `Module` resource.
 ====


### PR DESCRIPTION
D/S Docs: [MGMT-17316] Add a webhook for namespace deletion

Jira: https://issues.redhat.com/browse/TELCODOCS-1825

Version(s): openshift-4.16.0, openshift-4.15.0, openshift-4.14.0

Link to docs preview: https://75412--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html#kmm-unloading-kernel-module_kernel-module-management-operator

SME review: @qbarrand
QE review: @cdvultur
