### PR TITLE
OBSDOCS-865/TRACING-3962: Documentation for hostmetrics receiver

### DIFF
--- a/modules/otel-collector-components.adoc
+++ b/modules/otel-collector-components.adoc
@@ -82,6 +82,91 @@ The Jaeger receiver ingests traces in the Jaeger formats.
 <4> The Jaeger Thrift Binary endpoint. If omitted, the default `+0.0.0.0:6832+` is used.
 <5> The  server-side TLS configuration. See the OTLP receiver configuration section for more details.
 
+[id="hostmetrics-receiver_{context}"]
+=== Host Metrics Receiver
+
+:FeatureName: The Host Metrics Receiver
+include::snippets/technology-preview.adoc[]
+
+The Host Metrics Receiver ingests metrics in the OTLP format.
+
+.OpenTelemetry Collector custom resource with an enabled Host Metrics Receiver
+[source,yaml]
+----
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-hostfs-daemonset
+  namespace: <namespace>
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: true
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities: null
+defaultAddCapabilities:
+- SYS_ADMIN
+fsGroup:
+  type: RunAsAny
+groups: []
+metadata:
+  name: otel-hostmetrics
+readOnlyRootFilesystem: true
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:<namespace>:otel-hostfs-daemonset
+volumes:
+- configMap
+- emptyDir
+- hostPath
+- projected
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel
+  namespace: <namespace>
+spec:
+  serviceAccount: otel-hostfs-daemonset
+  mode: daemonset
+  volumeMounts:
+    - mountPath: /hostfs
+      name: host
+      readOnly: true
+  volumes:
+    - hostPath:
+        path: /
+      name: host
+  config: |
+    receivers:
+      hostmetrics:
+        collection_interval: 10s # <1>
+        initial_delay: 1s # <2>
+        root_path: / # <3>
+        scrapers: # <4>
+          cpu:
+          memory:
+          disk:
+    service:
+      pipelines:
+        metrics:
+          receivers: [hostmetrics]
+----
+<1> Sets the time interval for host metrics collection. If omitted, the default value is `+1m+`.
+<2> Sets the initial time delay for host metrics collection. If omitted, the default value is `+1s+`.
+<3> Configures the `root_path` so that the Host Metrics Receiver knows where the root filesystem is. If running multiple instances of the Host Metrics Receiver, set the same `root_path` value for each instance.
+<4> Lists the enabled host metrics scrapers. Available scrapers are `cpu`, `disk`, `load`, `filesystem`, `memory`, `network`, `paging`, `processes`, and `process`.
+
 [id="k8sobjectsreceiver-receiver_{context}"]
 === Kubernetes Objects Receiver
 


### PR DESCRIPTION
:warning: This PR is tied to a product release date, which is currently set to **June 5** (Wednesday).

- If the merge review gets delayed, you're welcome to ping `mleonov` on Slack.
- If you have any questions, ping `mleonov` on Slack.

Signed-off-by: Benedikt Bongartz <bongartz@klimlive.de>

Edit of https://github.com/openshift/openshift-docs/pull/74966

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12, 4.13, 4.14, 4.15, 4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OBSDOCS-865
https://issues.redhat.com/browse/TRACING-3962

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://75426--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-configuration-of-otel-collector.html#hostmetrics-receiver_otel-configuration-of-otel-collector

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
