### PR TITLE
OSDOCS#10440: Added eu-west-3 region to ROSA with HCP docs

### DIFF
--- a/modules/rosa-sdpolicy-am-regions-az.adoc
+++ b/modules/rosa-sdpolicy-am-regions-az.adoc
@@ -57,9 +57,7 @@ endif::rosa-with-hcp[]
 * eu-west-1 (Ireland)
 * eu-west-2 (London)
 * eu-south-1 (Milan, AWS opt-in required)
-ifndef::rosa-with-hcp[]
 * eu-west-3 (Paris)
-endif::rosa-with-hcp[]
 * eu-south-2 (Spain)
 * eu-central-2 (Zurich, AWS opt-in required)
 * me-south-1 (Bahrain, AWS opt-in required)


### PR DESCRIPTION
Version(s):
`enterprise-4.15+`

Issue:
**[OSDOCS-10440](https://issues.redhat.com/browse/OSDOCS-10440)**

Link to docs preview:
- [ROSA AWS regions](https://75440--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-regions-az_rosa-service-definition) (unchanged)
- [ROSA with HCP AWS regions](https://75440--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-regions-az_rosa-hcp-service-definition)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added the `eu-west-3` region to the ROSA with HCP docs