### PR TITLE
OBSDOCS-118

### DIFF
--- a/modules/cluster-logging-configuration-of-json-log-data-for-default-elasticsearch.adoc
+++ b/modules/cluster-logging-configuration-of-json-log-data-for-default-elasticsearch.adoc
@@ -51,7 +51,7 @@ spec:
     parse: json <2>
 ----
 <1> Uses the value of the key-value pair that is formed by the Kubernetes `logFormat` label.
-<2> Enables parsing JSON logs.
+<2> Enables parsing JSON logs. 
 
 In that case, the following structured log record goes to the `app-apache-write` index:
 
@@ -79,32 +79,38 @@ Suppose that you use the following snippet in your `ClusterLogForwarder` CR YAML
 
 [source,yaml]
 ----
-outputDefaults:
- elasticsearch:
-    structuredTypeKey: openshift.labels.myLabel <1>
+outputDefaults: <1>
+  elasticsearch:
+    structuredTypeKey: kubernetes.labels.managed <2>
     structuredTypeName: nologformat
+outputs:
+  - name: elasticsearch-secure
+    elasticsearch:
+      structuredTypeKey: openshift.labels.unmanaged <3>
+      structuredTypeName: nologformat
 pipelines:
- - name: application-logs
-   inputRefs:
-   - application
-   - audit
-   outputRefs:
-   - elasticsearch-secure
-   - default
-   parse: json
-   labels:
-     myLabel: myValue <2>
+  - name: application-logs
+    inputRefs:
+    - application
+    - audit
+    outputRefs:
+    - elasticsearch-secure
+    - default
+    parse: json
+    labels:
+      unmanaged: myvalue
 ----
-<1> Uses the value of the key-value pair that is formed by the OpenShift `myLabel` label.
-<2> The `myLabel` element gives its string value, `myValue`, to the structured log record.
+<1> `outputDefaults` applies only to the default Elasticsearch logstore and not to the other defined Elasticsearch outputs.
+<2> Use the value found at this path in the record to format the index name for the default output.
+<3> Use the value defined in pipeline to format the index name for the elasticsearch output named `elasticsearch-secure`.
 
-In that case, the following structured log record goes to the `app-myValue-write` index:
+In that case, the following structured log record goes to the `app-myvalue-write` index:
 
 [source]
 ----
 {
   "structured":{"name":"fred","home":"bedrock"},
-  "openshift":{"labels":{"myLabel": "myValue", ...}}
+  "openshift":{"labels":{"unmanaged": "myvalue", ...}}
 }
 ----
 


### PR DESCRIPTION
[OBSDOCS-118](https://issues.redhat.com/browse/OBSDOCS-118): Configuring JSON log data for Elasticsearch is defined incorrectly
Aligned team: Observability
OCP version for cherry-picking: 
JIRA issues: [OBSDOCS-118](https://issues.redhat.com/browse/OBSDOCS-118)
Preview pages: https://75444--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/log_collection_forwarding/cluster-logging-enabling-json-logging.html#cluster-logging-configuration-of-json-log-data-for-default-elasticsearch_cluster-logging-enabling-json-logging
SME review **completed**: @jcantrill
QE review **completed**: @anpingli 
Peer review **requested**: 
