### PR TITLE
[internal fix] missing-agent-eval-table

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -3566,4 +3566,7 @@ endif::[]
 ifeval::["{context}" == "installation-config-parameters-aws"]
 :!aws:
 endif::[]
+ifeval::["{context}" == "installation-config-parameters-agent"]
+:!agent:
+endif::[]
 :!platform:


### PR DESCRIPTION
Version(s):
4.14+ 

The [Additional bare metal configuration parameters for the Agent-based Installer](https://docs.redhat.com/en/documentation/openshift_container_platform/4.15/html/installing/installing-on-vsphere#installation-configuration-parameters-additional-bare_installation-config-parameters-vsphere) does not belong in vSphere docs. A closing ifeval statement has caused this issue. "agent" Ifdef statements in the installation-configuration-parameters.adoc are broken.

Preview links:

* [Additional VMware vSphere configuration parameters -vSphere](https://75451--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere#installation-configuration-parameters-additional-vsphere_installation-config-parameters-vsphere)
* [Additional VMware vSphere configuration parameters -ABI](https://75451--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installation-config-parameters-agent#installation-configuration-parameters-additional-vsphere_installation-config-parameters-agent)