### PR TITLE
OSDOCS-9535: RN update for microarchitecture requirement change

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -20,6 +20,8 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 
 {product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 has not yet been submitted for FIPS validation. Red Hat expects, though cannot commit to a specific timeframe, to obtain FIPS validation for {op-system-base} 9.0 and {op-system-base} 9.2 modules, and later even minor releases of {op-system-base} 9.x. Updates will be available in link:https://access.redhat.com/articles/2918071[Compliance Activities and Government Standards].
 
+Because {product-title} 4.13 is based on the {op-system-base} 9.2 host operating system, the micro-architecture requirements are now increased to x86_64-v2, Power9, and Z14. See the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/9.0_release_notes/index#architectures[RHEL micro-architecture requirements documentation]. You can verify compatibility before updating by following the procedures outlined in this link:https://access.redhat.com/solutions/7052996[KCS article].
+
 // Double check OP system versions
 {product-title} {product-version} is supported on {op-system-base-full} 8.6, 8.7, and 8.8 as well as on {op-system-first} 4.13.
 


### PR DESCRIPTION
Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-9535

Link to docs preview:
https://75457--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
No change management required - confirmed 
