### PR TITLE
OSSM-6304 [DOC] Reorg and Deprecation Notice for Jaeger and Elasticsearch

### DIFF
--- a/modules/ossm-accessing-jaeger.adoc
+++ b/modules/ossm-accessing-jaeger.adoc
@@ -13,6 +13,11 @@ Kiali Console > Distributed Tracing tab
 
 The deployment process creates a route to access the Jaeger console.
 
+[IMPORTANT]
+====
+Starting with {SMProductName} 2.5, {JaegerName} and {es-op} have been deprecated and will be removed in a future release. Red{nbsp}Hat will provide bug fixes and support for this feature during the current release lifecycle, but this feature will no longer receive enhancements and will be removed. As an alternative to {JaegerName}, you can use {TempoName} instead.
+====
+
 .Procedure
 . Log in to the {Product-title} console.
 

--- a/modules/ossm-config-external-jaeger.adoc
+++ b/modules/ossm-config-external-jaeger.adoc
@@ -9,6 +9,11 @@ This module is included in the following assemblies:
 
 If you already have an existing {JaegerName} instance in {product-title}, you can configure your `ServiceMeshControlPlane` resource to use that instance for {DTShortName}.
 
+[IMPORTANT]
+====
+Starting with {SMProductName} 2.5, {JaegerName} and {es-op} are deprecated and will be removed in a future release. Red{nbsp}Hat will provide bug fixes and support for these features during the current release lifecycle, but these features will no longer receive enhancements and will be removed. As an alternative to {JaegerName}, you can use {TempoName} instead.
+====
+
 .Prerequisites
 
 * {DTProductName} instance installed and configured.

--- a/modules/ossm-install-ossm-operator.adoc
+++ b/modules/ossm-install-ossm-operator.adoc
@@ -7,16 +7,26 @@
 [id="ossm-install-ossm-operator_{context}"]
 = Installing the Operators
 
-To install {SMProductName}, install the following Operators in this order. Repeat the procedure for each Operator.
+To install {SMProductName}, you must install the {SMProductName} Operator. Repeat the procedure for each additional Operator you want to install.
 
-* OpenShift Elasticsearch
+Additional Operators include:
+
+* {KialiProduct}
+* {TempoOperator}
+
+Deprecated additional Operators include:
+
+[IMPORTANT]
+====
+Starting with {SMProductName} 2.5, {JaegerName} and {es-op} are deprecated and will be removed in a future release. Red{nbsp}Hat will provide bug fixes and support for these features during the current release lifecycle, but this feature will no longer receive enhancements and will be removed. As an alternative to {JaegerName}, you can use {TempoName} instead.
+====
+
 * {JaegerName}
-* Kiali Operator provided by Red Hat
-* {SMProductName}
+* {es-op}
 
 [NOTE]
 ====
-If you have already installed the OpenShift Elasticsearch Operator as part of OpenShift Logging, you do not need to install the OpenShift Elasticsearch Operator again. The {JaegerName} Operator will create the Elasticsearch instance using the installed OpenShift Elasticsearch Operator.
+If you have already installed the {es-op} as part of OpenShift {logging-uc}, you do not need to install the {es-op} again. The {JaegerName} Operator creates the Elasticsearch instance using the installed {es-op}.
 ====
 
 .Procedure
@@ -36,12 +46,24 @@ endif::openshift-rosa,openshift-dedicated[]
 
 . On the *Install Operator* page for each Operator, accept  the default settings.
 
-. Click *Install*. Wait until the Operator has installed before repeating the steps for the next Operator in the list.
+. Click *Install*. Wait until the Operator installs before repeating the steps for the next Operator you want to install.
 +
-* The OpenShift Elasticsearch Operator is installed in the `openshift-operators-redhat` namespace and is available for all namespaces in the cluster.
-* The {JaegerName} is installed in the `openshift-distributed-tracing` namespace and is available for all namespaces in the cluster.
-* The Kiali Operator provided by Red Hat is installed in the `openshift-operators` namespace and is available for all namespaces in the cluster.
-* The {SMProductName} Operator is installed in the `openshift-operators` namespace and is available for all namespaces in the cluster.
+* The {SMProductName} Operator installs in the `openshift-operators` namespace and is available for all namespaces in the cluster.
+* The {KialiProduct} installs in the `openshift-operators` namespace and is available for all namespaces in the cluster.
+* The {TempoOperator} installs in the `openshift-tempo-operator` namespace and is available for all namespaces in the cluster.
+* The {JaegerName} installs in the `openshift-distributed-tracing` namespace and is available for all namespaces in the cluster.
++
+[IMPORTANT]
+====
+Starting with {SMProductName} 2.5, {JaegerName} is deprecated and will be removed in a future release. Red{nbsp}Hat will provide bug fixes and support for this feature during the current release lifecycle, but this feature will no longer receive enhancements and will be removed. As an alternative to {JaegerName}, you can use {TempoName} instead.
+====
++
+* The {es-op} installs in the `openshift-operators-redhat` namespace and is available for all namespaces in the cluster.
++
+[IMPORTANT]
+====
+Starting with {SMProductName} 2.5, {es-op} is deprecated and will be removed in a future release. Red{nbsp}Hat will provide bug fixes and support for this feature during the current release lifecycle, but this feature will no longer receive enhancements and will be removed.
+====
 
 .Verification
 

--- a/modules/ossm-installation-activities.adoc
+++ b/modules/ossm-installation-activities.adoc
@@ -2,15 +2,33 @@
 //
 // * service_mesh/v1x/preparing-ossm-installation.adoc
 // * service_mesh/v2x/preparing-ossm-installation.adoc
-// * post_installation_configuration/network-configuration.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="ossm-installation-activities_{context}"]
-= Operator overview
+= Service Mesh Operators overview
 
-{SMProductName} requires the following Operators:
+{SMProductName} requires the use of the {SMProductName} Operator which allows you to connect, secure, control, and observe the microservices that comprise your applications. You can also install other Operators to enhance your service mesh experience.
 
-* *OpenShift Elasticsearch* - (Optional) Provides database storage for tracing and logging with the {JaegerShortName}. It is based on the open source link:https://www.elastic.co/[Elasticsearch] project.
-* *{JaegerName}* - Provides distributed tracing to monitor and troubleshoot transactions in complex distributed systems. It is based on the open source link:https://www.jaegertracing.io/[Jaeger] project.
-* *Kiali Operator (provided by Red Hat)* - Provides observability for your service mesh. You can view configurations, monitor traffic, and analyze traces in a single console. It is based on the open source link:https://www.kiali.io/[Kiali] project.
-* *{SMProductName}* - Allows you to connect, secure, control, and observe the microservices that comprise your applications. The {SMProductShortName} Operator defines and monitors the `ServiceMeshControlPlane` resources that manage the deployment, updating, and deletion of the {SMProductShortName} components. It is based on the open source link:https://istio.io/[Istio] project.
+[WARNING]
+====
+Do not install Community versions of the Operators. Community Operators are not supported.
+====
+
+The following Operator is required:
+
+{SMProductName} Operator:: Allows you to connect, secure, control, and observe the microservices that comprise your applications. It also defines and monitors the `ServiceMeshControlPlane` resources that manage the deployment, updating, and deletion of the {SMProductShortName} components. It is based on the open source link:https://istio.io/[Istio] project.
+
+The following Operators are optional:
+
+{KialiProduct}:: Provides observability for your service mesh. You can view configurations, monitor traffic, and analyze traces in a single console. It is based on the open source link:https://www.kiali.io/[Kiali] project.
+{TempoName}:: Provides distributed tracing to monitor and troubleshoot transactions in complex distributed systems. It is based on the open source link:https://grafana.com/oss/tempo/[Grafana Tempo] project.
+
+The following optional Operators are deprecated:
+
+[IMPORTANT]
+====
+Starting with {SMProductName} 2.5, {JaegerName} and {es-op} are deprecated and will be removed in a future release. Red{nbsp}Hat will provide bug fixes and support for these features during the current release lifecycle, but these features will no longer receive enhancements and will be removed. As an alternative to {JaegerName}, you can use {TempoName} instead.
+====
+
+{JaegerName}:: Provides distributed tracing to monitor and troubleshoot transactions in complex distributed systems. It is based on the open source link:https://www.jaegertracing.io/[Jaeger] project.
+{es-op}:: Provides database storage for tracing and logging with the {JaegerShortName}. It is based on the open source link:https://www.elastic.co/[Elasticsearch] project.

--- a/modules/ossm-jaeger-accessing-console.adoc
+++ b/modules/ossm-jaeger-accessing-console.adoc
@@ -14,6 +14,11 @@ The installation process creates a route to access the Jaeger console.
 
 If you know the URL for the Jaeger console, you can access it directly.  If you do not know the URL, use the following directions.
 
+[IMPORTANT]
+====
+Starting with {SMProductName} 2.5, {JaegerName} and {es-op} have been deprecated and will be removed in a future release. Red{nbsp}Hat will provide bug fixes and support for this feature during the current release lifecycle, but this feature will no longer receive enhancements and will be removed. As an alternative to {JaegerName}, you can use {TempoName} instead.
+====
+
 .Procedure from OpenShift console
 . Log in to the {product-title} web console as a user with cluster-admin rights. If you use {product-dedicated}, you must have an account with the `dedicated-admin` role.
 

--- a/post_installation_configuration/network-configuration.adoc
+++ b/post_installation_configuration/network-configuration.adoc
@@ -94,16 +94,6 @@ include::modules/modifying-template-for-new-projects.adoc[leveloffset=+2]
 include::modules/nw-networkpolicy-project-defaults.adoc[leveloffset=+3]
 endif::[]
 
-ifndef::openshift-origin[]
-include::modules/ossm-supported-configurations.adoc[leveloffset=+1]
-
-include::modules/ossm-installation-activities.adoc[leveloffset=+2]
-
-.Next steps
-
-* xref:../service_mesh/v2x/installing-ossm.adoc#installing-ossm[Install {SMProductName}] in your {product-title} environment.
-endif::openshift-origin[]
-
 [id="post-installationrouting-optimization"]
 == Optimizing routing
 

--- a/service_mesh/v2x/installing-ossm.adoc
+++ b/service_mesh/v2x/installing-ossm.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-To install {SMProductName}, first install the required Operators on {product-title} and then create a `ServiceMeshControlPlane` resource to deploy the control plane.
+To install {SMProductName}, first install the {SMProductName} Operator and any optional Operators on {product-title}. Then create a `ServiceMeshControlPlane` resource to deploy the control plane.
 
 [NOTE]
 ====
@@ -24,12 +24,12 @@ endif::openshift-rosa[]
 
 The following steps show how to install a basic instance of {SMProductName} on {product-title}.
 
-include::modules/ossm-installation-activities.adoc[leveloffset=+1]
+[IMPORTANT]
+====
+Starting with {SMProductName} 2.5, {JaegerName} and {es-op} are deprecated and will be removed in a future release. Red{nbsp}Hat will provide bug fixes and support for these features during the current release lifecycle, but this feature will no longer receive enhancements and will be removed. As an alternative to {JaegerName}, you can use {TempoName} instead.
+====
 
-[WARNING]
-====
-Do not install Community versions of the Operators. Community Operators are not supported.
-====
+include::modules/ossm-installation-activities.adoc[leveloffset=+1]
 
 include::modules/ossm-install-ossm-operator.adoc[leveloffset=+1]
 

--- a/service_mesh/v2x/ossm-reference-jaeger.adoc
+++ b/service_mesh/v2x/ossm-reference-jaeger.adoc
@@ -10,7 +10,9 @@ When the {SMProductShortName} Operator deploys the `ServiceMeshControlPlane` res
 
 [IMPORTANT]
 ====
-Jaeger does not use FIPS validated cryptographic modules.
+* Jaeger does not use FIPS validated cryptographic modules.
+
+* Starting with {SMProductName} 2.5, {JaegerName} is deprecated and will be removed in a future release. Red{nbsp}Hat will provide bug fixes and support for this feature during the current release lifecycle, but this feature will no longer receive enhancements and will be removed. As an alternative to {JaegerName}, you can use {TempoName} instead.
 ====
 
 include::modules/ossm-enabling-jaeger.adoc[leveloffset=+1]
@@ -39,7 +41,7 @@ include::modules/distr-tracing-config-jaeger-collector.adoc[leveloffset=+2]
 
 include::modules/distr-tracing-config-sampling.adoc[leveloffset=+2]
 
-include::modules/distr-tracing-config-storage.adoc[leveloffset=+2] 
+include::modules/distr-tracing-config-storage.adoc[leveloffset=+2]
 
 ifdef::openshift-enterprise[]
 For more information about configuring Elasticsearch with {product-title}, see xref:../../observability/logging/log_storage/logging-config-es-store.adoc#logging-config-es-store[Configuring the Elasticsearch log store] or xref:../../observability/distr_tracing/distr_tracing_jaeger/distr-tracing-jaeger-configuring.adoc#distr-tracing-jaeger-configuring[Configuring and deploying distributed tracing].


### PR DESCRIPTION
[OSSM-6304](https://issues.redhat.com//browse/OSSM-6304) [DOC] Reorg and Deprecation Notice for Jaeger and Elasitcsearch

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSSM-6304

Link to docs preview:

Installing Operators: https://75458--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/installing-ossm.html 

Jaeger configuration reference: https://75458--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-reference-jaeger 

Troubleshooting > Accessing Jaeger console: https://75458--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-troubleshooting-istio#ossm-accessing-jaeger-console_troubleshooting-ossm 

Connecting an existing Jaeger instance: https://75458--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-observability#ossm-config-external-jaeger_observability

Accessing Jaeger console: https://75458--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-observability#ossm-accessing-jaeger-console_observability 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Most of this is adding deprecation notices for Jaeger and Elasticsearch that also directs users to use Tempo instead of Jaeger. 

However, in the process of clarifying it was discovered that the installation instructions have been incorrect for quite some time, stating that all 4 Operators are required when they are not. Only the Service Mesh Operator is required. The rest are optional. So there was some restructuring/reorganizing and some rewriting in order to update the installation instructions, and also bring the file in line with current style practices but doing such things as replacing product names with the corresponding attribute.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
