### PR TITLE
OSDOCS-10444: updated the offline deployments links in relnotes Micros…

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -199,7 +199,7 @@ Issued: 2024-02-27
 
 {product-title} release 4.15.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:7200[RHSA-2023:7200] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7198[RHSA-2023:7198] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-15-2-dp"]
 === RHBA-2024:1212 - {microshift-short} 4.15.2 bug fix and enhancement update advisory
@@ -208,7 +208,7 @@ Issued: 2024-03-13
 
 {product-title} release 4.15.2 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1212[RHBA-2024:1212] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1210[RHSA-2024:1210] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [discrete]
 [id="microshift-4-15-2-bug-fixes"]
@@ -235,7 +235,7 @@ Issued: 2024-03-20
 
 {product-title} release 4.15.3 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1257[RHBA-2024:1257] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1255[RHSA-2024:1255] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-15-5-dp"]
 === RHBA-2024:1451 - {microshift-short} 4.15.5 bug fix and enhancement update advisory
@@ -244,7 +244,7 @@ Issued: 2024-03-27
 
 {product-title} release 4.15.5 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1451[RHBA-2024:1451] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1449[RHSA-2024:1449] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [discrete]
 [id="microshift-4-15-5-enhancements"]
@@ -260,7 +260,7 @@ Issued: 2024-04-02
 
 {product-title} release 4.15.6 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:1561[RHSA-2024:1561] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1559[RHSA-2024:1559] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-15-8-dp"]
 === RHBA-2024:1670 - {microshift-short} 4.15.8 bug fix and security update advisory
@@ -269,7 +269,7 @@ Issued: 2024-04-08
 
 {product-title} release 4.15.8 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1670[RHBA-2024:1670] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1668[RHSA-2024:1668] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-15-9-dp"]
 === RHBA-2024:1772 - {microshift-short} 4.15.9 bug fix and security update advisory
@@ -278,7 +278,7 @@ Issued: 2024-04-16
 
 {product-title} release 4.15.9 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1772[RHBA-2024:1772] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1770[RHSA-2024:1770] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-15-12-dp"]
 === RHSA-2024:2667 - {microshift-short} 4.15.12 bug fix and security update advisory
@@ -287,4 +287,4 @@ Issued: 2024-05-09
 
 {product-title} release 4.15.12 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:2667[RHSA-2024:2667] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:2664[RHSA-2024:2664] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-10444](https://issues.redhat.com/browse/OSDOCS-10444)

Link to docs preview:
[Embedding MicroShift containers for offline deployments](https://75464--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-0-dp)

QE review:
- [x] QE has approved this change.
