### PR TITLE
MIG-1539: incorrect command in modules/migration-migrating-applications-api.adoc

### DIFF
--- a/modules/migration-migrating-applications-api.adoc
+++ b/modules/migration-migrating-applications-api.adoc
@@ -78,7 +78,7 @@ EOF
 +
 [source,terminal]
 ----
-$ oc describe cluster <cluster>
+$ oc describe MigCluster <cluster>
 ----
 
 . Create a `Secret` object manifest for the replication repository:


### PR DESCRIPTION
### JIRA

* [MIG-1539](https://issues.redhat.com/browse/MIG-1539)

### VERSION

*  OCP 4.12 → branch/enterprise-4.12
*  OCP 4.13 → branch/enterprise-4.13
*  OCP 4.14 → branch/enterprise-4.14
*  OCP 4.15 → branch/enterprise-4.15
*  OCP 4.16 → branch/enterprise-4.16

### Link to docs preview:

* [Migrating an application by using the MTC API 3->4](https://75472--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/advanced-migration-options-3-4.html#migration-migrating-applications-api_advanced-migration-options-3-4)

* [Migrating an application by using the MTC API](https://75472--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/advanced-migration-options-mtc.html#migration-migrating-applications-api_advanced-migration-options-mtc)

### QE review:
- [X ] [QE has approved this change](https://github.com/openshift/openshift-docs/pull/75472#issuecomment-2091297666).
