### PR TITLE
OSDOCS#10085 reorganizing AWS installation requirements (IPI)

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -155,7 +155,7 @@ Topics:
   Dir: installing_aws
   Distros: openshift-origin,openshift-enterprise
   Topics:
-  - Name: Preparing to install
+  - Name: Installation methods
     File: preparing-to-install-on-aws
   - Name: Configuring an AWS account
     File: installing-aws-account
@@ -163,6 +163,8 @@ Topics:
     Dir: ipi
     Distros: openshift-origin,openshift-enterprise
     Topics:
+    - Name: Preparing to install a cluster
+      File: ipi-aws-preparing-to-install
     - Name: Installing a cluster
       File: installing-aws-default
     - Name: Installing a cluster with customizations

--- a/installing/installing_aws/ipi/installing-aws-china.adoc
+++ b/installing/installing_aws/ipi/installing-aws-china.adoc
@@ -26,19 +26,13 @@ If you have an AWS profile stored on your computer, it must not use a temporary 
 
 include::modules/installation-aws-regions-with-no-ami.adoc[leveloffset=+1]
 
-include::modules/cluster-entitlements.adoc[leveloffset=+1]
-
 include::modules/private-clusters-default.adoc[leveloffset=+1]
 include::modules/private-clusters-about-aws.adoc[leveloffset=+2]
 
 include::modules/installation-custom-aws-vpc.adoc[leveloffset=+1]
 include::modules/installation-aws-security-groups.adoc[leveloffset=+2]
 
-include::modules/ssh-agent-using.adoc[leveloffset=+1]
-
 include::modules/installation-aws-upload-custom-rhcos-ami.adoc[leveloffset=+1]
-
-include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 
@@ -60,9 +54,6 @@ include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 include::modules/installation-applying-aws-security-groups.adoc[leveloffset=+2]
-
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 [id="installing-aws-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project
@@ -110,13 +101,10 @@ include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
 include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 
-include::modules/cluster-telemetry.adoc[leveloffset=+1]
-
 [role="_additional-resources"]
 .Additional resources
 
 * See xref:../../../web_console/web-console.adoc#web-console[Accessing the web console] for more details about accessing and understanding the {product-title} web console.
-* See xref:../../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service.
 
 == Next steps
 

--- a/installing/installing_aws/ipi/installing-aws-customizations.adoc
+++ b/installing/installing_aws/ipi/installing-aws-customizations.adoc
@@ -29,13 +29,7 @@ If you have an AWS profile stored on your computer, it must not use a temporary 
 ====
 * If you use a firewall, you xref:../../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 
-include::modules/cluster-entitlements.adoc[leveloffset=+1]
-
-include::modules/ssh-agent-using.adoc[leveloffset=+1]
-
 include::modules/installation-aws-marketplace-subscribe.adoc[leveloffset=+1]
-
-include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
@@ -57,9 +51,6 @@ include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
 include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
-
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 [id="installing-aws-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project
@@ -111,13 +102,6 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 .Additional resources
 
 * See xref:../../../web_console/web-console.adoc#web-console[Accessing the web console] for more details about accessing and understanding the {product-title} web console.
-
-include::modules/cluster-telemetry.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* See xref:../../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service.
 
 == Next steps
 

--- a/installing/installing_aws/ipi/installing-aws-default.adoc
+++ b/installing/installing_aws/ipi/installing-aws-default.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-aws-default"]
-= Installing a cluster quickly on AWS
+= Installing a cluster on AWS
 include::_attributes/common-attributes.adoc[]
 :context: installing-aws-default
 
@@ -21,20 +21,12 @@ If you have an AWS profile stored on your computer, it must not use a temporary 
 ====
 * If you use a firewall, you xref:../../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 
-include::modules/cluster-entitlements.adoc[leveloffset=+1]
-
-include::modules/ssh-agent-using.adoc[leveloffset=+1]
-
-include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
-
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
 * See link:https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html[Configuration and credential file settings] in the AWS documentation for more information about AWS profile and credential configuration.
-
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
@@ -44,13 +36,6 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 .Additional resources
 
 * See xref:../../../web_console/web-console.adoc#web-console[Accessing the web console] for more details about accessing and understanding the {product-title} web console.
-
-include::modules/cluster-telemetry.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* See xref:../../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
 
 == Next steps
 

--- a/installing/installing_aws/ipi/installing-aws-government-region.adoc
+++ b/installing/installing_aws/ipi/installing-aws-government-region.adoc
@@ -33,13 +33,7 @@ include::modules/private-clusters-about-aws.adoc[leveloffset=+2]
 include::modules/installation-custom-aws-vpc.adoc[leveloffset=+1]
 include::modules/installation-aws-security-groups.adoc[leveloffset=+2]
 
-include::modules/cluster-entitlements.adoc[leveloffset=+1]
-
-include::modules/ssh-agent-using.adoc[leveloffset=+1]
-
 include::modules/installation-aws-marketplace-subscribe.adoc[leveloffset=+1]
-
-include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 
@@ -61,9 +55,6 @@ include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 include::modules/installation-applying-aws-security-groups.adoc[leveloffset=+2]
-
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 [id="installing-aws-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project
@@ -115,13 +106,6 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 .Additional resources
 
 * See xref:../../../web_console/web-console.adoc#web-console[Accessing the web console] for more details about accessing and understanding the {product-title} web console.
-
-include::modules/cluster-telemetry.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* See xref:../../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service.
 
 == Next steps
 

--- a/installing/installing_aws/ipi/installing-aws-localzone.adoc
+++ b/installing/installing_aws/ipi/installing-aws-localzone.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-aws-localzone"]
-= Installing a cluster on AWS with compute nodes on AWS Local Zones
+= Installing a cluster with compute nodes on AWS Local Zones
 include::_attributes/common-attributes.adoc[]
 :context: installing-aws-localzone
 :zone-type: Local Zones
@@ -75,20 +75,8 @@ Before you install a cluster in an AWS {zone-type} environment, you must configu
 // Opting in to AWS Local Zones
 include::modules/installation-aws-add-zone-locations.adoc[leveloffset=+2]
 
-// Internet access for OpenShift Container Platform
-include::modules/cluster-entitlements.adoc[leveloffset=+2]
-
 // Obtaining an AWS Marketplace image
 include::modules/installation-aws-marketplace-subscribe.adoc[leveloffset=+2]
-
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+2]
-
-// Obtaining the installation program
-include::modules/installation-obtaining-installer.adoc[leveloffset=+2]
-
-// Generating a key pair for cluster node SSH access
-include::modules/ssh-agent-using.adoc[leveloffset=+2]
 
 [id="prep-installation-aws-local-zone_{context}"]
 == Preparing for the installation
@@ -223,14 +211,6 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+2]
 
 // Verifying nodes that were created with edge compute pool
 include::modules/machine-edge-pool-review-nodes.adoc[leveloffset=+2]
-
-// Telemetry access for OpenShift Container Platform
-include::modules/cluster-telemetry.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
 
 .Next steps
 

--- a/installing/installing_aws/ipi/installing-aws-network-customizations.adoc
+++ b/installing/installing_aws/ipi/installing-aws-network-customizations.adoc
@@ -27,14 +27,6 @@ cluster.
 If you have an AWS profile stored on your computer, it must not use a temporary session token that you generated while using a multi-factor authentication device. The cluster continues to use your current AWS credentials to create AWS resources for the entire life of the cluster, so you must use key-based, long-term credentials. To generate appropriate keys, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users] in the AWS documentation. You can supply the keys when you run the installation program.
 ====
 * If you use a firewall, you xref:../../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
-// TODO
-// Concept that describes networking
-
-include::modules/cluster-entitlements.adoc[leveloffset=+1]
-
-include::modules/ssh-agent-using.adoc[leveloffset=+1]
-
-include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/nw-network-config.adoc[leveloffset=+1]
 
@@ -57,9 +49,6 @@ include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
 include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
-
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 [id="installing-aws-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project
@@ -131,13 +120,6 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 .Additional resources
 
 * See xref:../../../web_console/web-console.adoc#web-console[Accessing the web console] for more details about accessing and understanding the {product-title} web console.
-
-include::modules/cluster-telemetry.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* See xref:../../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service.
 
 == Next steps
 

--- a/installing/installing_aws/ipi/installing-aws-outposts.adoc
+++ b/installing/installing_aws/ipi/installing-aws-outposts.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-aws-outposts"]
-= Installing a cluster on AWS with compute nodes on AWS Outposts
+= Installing a cluster with compute nodes on AWS Outposts
 include::_attributes/common-attributes.adoc[]
 :context: installing-aws-outposts
 

--- a/installing/installing_aws/ipi/installing-aws-private.adoc
+++ b/installing/installing_aws/ipi/installing-aws-private.adoc
@@ -28,12 +28,6 @@ include::modules/private-clusters-about-aws.adoc[leveloffset=+2]
 include::modules/installation-custom-aws-vpc.adoc[leveloffset=+1]
 include::modules/installation-aws-security-groups.adoc[leveloffset=+2]
 
-include::modules/cluster-entitlements.adoc[leveloffset=+1]
-
-include::modules/ssh-agent-using.adoc[leveloffset=+1]
-
-include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
-
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -55,9 +49,6 @@ include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 include::modules/installation-applying-aws-security-groups.adoc[leveloffset=+2]
-
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 [id="installing-aws-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project
@@ -109,13 +100,6 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 .Additional resources
 
 * See xref:../../../web_console/web-console.adoc#web-console[Accessing the web console] for more details about accessing and understanding the {product-title} web console.
-
-include::modules/cluster-telemetry.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* See xref:../../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service.
 
 == Next steps
 

--- a/installing/installing_aws/ipi/installing-aws-secret-region.adoc
+++ b/installing/installing_aws/ipi/installing-aws-secret-region.adoc
@@ -36,13 +36,7 @@ include::modules/private-clusters-about-aws.adoc[leveloffset=+2]
 include::modules/installation-custom-aws-vpc.adoc[leveloffset=+1]
 include::modules/installation-aws-security-groups.adoc[leveloffset=+2]
 
-include::modules/cluster-entitlements.adoc[leveloffset=+1]
-
 include::modules/installation-aws-upload-custom-rhcos-ami.adoc[leveloffset=+1]
-
-include::modules/ssh-agent-using.adoc[leveloffset=+1]
-
-include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 
@@ -54,9 +48,6 @@ include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
 include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 include::modules/installation-applying-aws-security-groups.adoc[leveloffset=+2]
-
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 [id="installing-aws-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project
@@ -108,13 +99,6 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 [id="additional-resources_installing-aws-secret-region_console"]
 .Additional resources
 * xref:../../../web_console/web-console.adoc#web-console[Accessing the web console]
-
-include::modules/cluster-telemetry.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-[id="additional-resources_installing-aws-secret-region_telemetry"]
-.Additional resources
-* xref:../../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
 
 [id="next-steps_installing-aws-secret-region"]
 == Next steps

--- a/installing/installing_aws/ipi/installing-aws-vpc.adoc
+++ b/installing/installing_aws/ipi/installing-aws-vpc.adoc
@@ -26,12 +26,6 @@ include::modules/installation-custom-aws-vpc.adoc[leveloffset=+1]
 include::modules/installation-aws-security-groups.adoc[leveloffset=+2]
 include::modules/installation-aws-permissions-iam-shared-vpc.adoc[leveloffset=+2]
 
-include::modules/cluster-entitlements.adoc[leveloffset=+1]
-
-include::modules/ssh-agent-using.adoc[leveloffset=+1]
-
-include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
-
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -53,9 +47,6 @@ include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 include::modules/installation-applying-aws-security-groups.adoc[leveloffset=+2]
-
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 [id="installing-aws-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project
@@ -107,13 +98,6 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 .Additional resources
 
 * See xref:../../../web_console/web-console.adoc#web-console[Accessing the web console] for more details about accessing and understanding the {product-title} web console.
-
-include::modules/cluster-telemetry.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* See xref:../../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service.
 
 == Next steps
 

--- a/installing/installing_aws/ipi/installing-aws-wavelength-zone.adoc
+++ b/installing/installing_aws/ipi/installing-aws-wavelength-zone.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-aws-wavelength-zone"]
-= Installing a cluster on AWS with compute nodes on AWS Wavelength Zones
+= Installing a cluster with compute nodes on AWS Wavelength Zones
 include::_attributes/common-attributes.adoc[]
 :context: installing-aws-wavelength-zone
 :zone-type: Wavelength Zones
@@ -91,20 +91,8 @@ Before you install a cluster in an AWS {zone-type} environment, you must configu
 // Opting in to AWS Zones
 include::modules/installation-aws-add-zone-locations.adoc[leveloffset=+2]
 
-// Internet access for OpenShift Container Platform
-include::modules/cluster-entitlements.adoc[leveloffset=+2]
-
 // Obtaining an AWS Marketplace image
 include::modules/installation-aws-marketplace-subscribe.adoc[leveloffset=+2]
-
-//Installing the OpenShift CLI by downloading the binary
-include::modules/cli-installing-cli.adoc[leveloffset=+2]
-
-// Obtaining the installation program
-include::modules/installation-obtaining-installer.adoc[leveloffset=+2]
-
-// Generating a key pair for cluster node SSH access
-include::modules/ssh-agent-using.adoc[leveloffset=+2]
 
 [id="prep-installation-aws-wavelength-zone_{context}"]
 == Preparing for the installation
@@ -236,14 +224,6 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+2]
 
 // Verifying nodes that were created with edge compute pool
 include::modules/machine-edge-pool-review-nodes.adoc[leveloffset=+2]
-
-// Telemetry access for OpenShift Container Platform
-include::modules/cluster-telemetry.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
 
 .Next steps
 

--- a/installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.adoc
+++ b/installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.adoc
@@ -40,10 +40,6 @@ include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 
 include::modules/installation-custom-aws-vpc.adoc[leveloffset=+1]
 
-include::modules/cluster-entitlements.adoc[leveloffset=+1]
-
-include::modules/ssh-agent-using.adoc[leveloffset=+1]
-
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -60,9 +56,6 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
-
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 [id="installing-aws-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project
@@ -109,13 +102,6 @@ include::modules/installation-launching-installer.adoc[leveloffset=+1]
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
 include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+1]
-
-include::modules/cluster-telemetry.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* See xref:../../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
 
 [id="next-steps_installing-restricted-networks-aws-installer-provisioned"]
 == Next steps

--- a/installing/installing_aws/ipi/ipi-aws-preparing-to-install.adoc
+++ b/installing/installing_aws/ipi/ipi-aws-preparing-to-install.adoc
@@ -1,0 +1,44 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="ipi-aws-preparing-to-install"]
+= Preparing to install a cluster on AWS
+include::_attributes/common-attributes.adoc[]
+:context: ipi-aws-preparing-to-install
+
+toc::[]
+
+You prepare to install an {product-title} cluster on AWS by completing the following steps:
+
+* Verifying internet connectivity for your cluster.
+
+* xref:../../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configuring an AWS account].
+
+* Downloading the installation program.
++
+[NOTE]
+====
+If you are installing in a disconnected environment, you extract the installation program from the mirrored content. For more information, see xref:../../../installing/disconnected_install/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Mirroring images for a disconnected installation].
+====
+* Installing the {oc-first}.
++
+[NOTE]
+====
+If you are installing in a disconnected environment, install `oc` to the mirror host.
+====
+* Generating an SSH key pair. You can use this key pair to authenticate into the {product-title} cluster's nodes after it is deployed.
+
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, xref:../../../installing/installing_aws/ipi/installing-aws-customizations.adoc#manually-create-iam_installing-aws-customizations[manually creating long-term credentials for AWS] or xref:../../../installing/installing_aws/ipi/installing-aws-customizations.adoc#installing-aws-with-short-term-creds_installing-aws-customizations[configuring an AWS cluster to use short-term credentials] with Amazon Web Services Security Token Service (AWS STS).
+
+include::modules/cluster-entitlements.adoc[leveloffset=+1]
+
+include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
+
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
+include::modules/ssh-agent-using.adoc[leveloffset=+1]
+
+include::modules/cluster-telemetry.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* See xref:../../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service

--- a/installing/installing_aws/preparing-to-install-on-aws.adoc
+++ b/installing/installing_aws/preparing-to-install-on-aws.adoc
@@ -1,38 +1,15 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="preparing-to-install-on-aws"]
-= Preparing to install on AWS
+= Installation methods
 include::_attributes/common-attributes.adoc[]
 :context: preparing-to-install-on-aws
 
 toc::[]
 
-[id="preparing-to-install-on-aws-prerequisites"]
-== Prerequisites
-
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-
-[id="requirements-for-installing-ocp-on-aws"]
-== Requirements for installing {product-title} on AWS
-
-Before installing {product-title} on Amazon Web Services (AWS), you must create an AWS account. See xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configuring an AWS account] for details about configuring an account, account limits, account permissions, IAM user setup, and supported AWS regions.
-
-If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, see xref:../../installing/installing_aws/ipi/installing-aws-customizations.adoc#manually-create-iam_installing-aws-customizations[Manually creating long-term credentials for AWS] or xref:../../installing/installing_aws/ipi/installing-aws-customizations.adoc#installing-aws-with-short-term-creds_installing-aws-customizations[configuring an AWS cluster to use short-term credentials] with Amazon Web Services Security Token Service (AWS STS).
-
-[id="choosing-an-method-to-install-ocp-on-aws"]
-== Choosing a method to install {product-title} on AWS
-
-You can install {product-title} on installer-provisioned or user-provisioned infrastructure. The default installation type uses installer-provisioned infrastructure, where the installation program provisions the underlying infrastructure for the cluster. You can also install {product-title} on infrastructure that you provision. If you do not use infrastructure that the installation program provisions, you must manage and maintain the cluster resources yourself.
-
-See xref:../../architecture/architecture-installation.adoc#installation-process_architecture-installation[Installation process] for more information about installer-provisioned and user-provisioned installation processes.
-
-[id="choosing-an-method-to-install-ocp-on-aws-single-node"]
-=== Installing a cluster on a single node
-
-Installing {product-title} on a single node alleviates some of the requirements for high availability and large scale clusters. However, you must address the xref:../../installing/installing_sno/install-sno-preparing-to-install-sno.adoc#install-sno-requirements-for-installing-on-a-single-node_install-sno-preparing[requirements for installing on a single node], and the xref:../../installing/installing_sno/install-sno-installing-sno.adoc#additional-requirements-for-installing-sno-on-a-cloud-provider_install-sno-installing-sno-with-the-assisted-installer[additional requirements for installing {sno} on a cloud provider]. After addressing the requirements for single node installation, use the xref:../../installing/installing_aws/ipi/installing-aws-customizations.adoc#installing-aws-customizations[Installing a customized cluster on AWS] procedure to install the cluster. The xref:../../installing/installing_sno/install-sno-installing-sno.adoc#install-sno-installing-sno-manually[installing single-node OpenShift manually] section contains an exemplary `install-config.yaml` file when installing an {product-title} cluster on a single node.
+You can install {product-title} on Amazon Web Services (AWS) using installer-provisioned or user-provisioned infrastructure. The default installation type uses installer-provisioned infrastructure, where the installation program provisions the underlying infrastructure for the cluster. You can also install {product-title} on infrastructure that you provision. If you do not use infrastructure that the installation program provisions, you must manage and maintain the cluster resources yourself. You can also install {product-title} on a single node, which is a specialized installation method that is ideal for edge computing environments.
 
 [id="choosing-an-method-to-install-ocp-on-aws-installer-provisioned"]
-=== Installing a cluster on installer-provisioned infrastructure
+== Installing a cluster on installer-provisioned infrastructure
 
 You can install a cluster on AWS infrastructure that is provisioned by the {product-title} installation program, by using one of the following methods:
 
@@ -51,7 +28,7 @@ You can install a cluster on AWS infrastructure that is provisioned by the {prod
 * **xref:../../installing/installing_aws/ipi/installing-aws-government-region.adoc#installing-aws-government-region[Installing a cluster on AWS into a government or secret region]**: {product-title} can be deployed into AWS regions that are specifically designed for US government agencies at the federal, state, and local level, as well as contractors, educational institutions, and other US customers that must run sensitive workloads in the cloud.
 
 [id="choosing-an-method-to-install-ocp-on-aws-user-provisioned"]
-=== Installing a cluster on user-provisioned infrastructure
+== Installing a cluster on user-provisioned infrastructure
 
 You can install a cluster on AWS infrastructure that you provision, by using one of the following methods:
 
@@ -59,7 +36,12 @@ You can install a cluster on AWS infrastructure that you provision, by using one
 
 * **xref:../../installing/installing_aws/upi/installing-restricted-networks-aws.adoc#installing-restricted-networks-aws[Installing a cluster on AWS in a restricted network with user-provisioned infrastructure]**: You can install {product-title} on AWS infrastructure that you provide by using an internal mirror of the installation release content. You can use this method to install a cluster that does not require an active internet connection to obtain the software components. You can also use this installation method to ensure that your clusters only use container images that satisfy your organizational controls on external content. While you can install {product-title} by using the mirrored content, your cluster still requires internet access to use the AWS APIs.
 
-[id="preparing-to-install-on-aws-next-steps"]
-== Next steps
+[id="choosing-an-method-to-install-ocp-on-aws-single-node"]
+== Installing a cluster on a single node
 
-* xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configuring an AWS account]
+Installing {product-title} on a single node alleviates some of the requirements for high availability and large scale clusters. However, you must address the xref:../../installing/installing_sno/install-sno-preparing-to-install-sno.adoc#install-sno-requirements-for-installing-on-a-single-node_install-sno-preparing[requirements for installing on a single node], and the xref:../../installing/installing_sno/install-sno-installing-sno.adoc#additional-requirements-for-installing-sno-on-a-cloud-provider_install-sno-installing-sno-with-the-assisted-installer[additional requirements for installing {sno} on a cloud provider]. After addressing the requirements for single node installation, use the xref:../../installing/installing_aws/ipi/installing-aws-customizations.adoc#installing-aws-customizations[Installing a customized cluster on AWS] procedure to install the cluster. The xref:../../installing/installing_sno/install-sno-installing-sno.adoc#install-sno-installing-sno-manually[installing single-node OpenShift manually] section contains an exemplary `install-config.yaml` file when installing an {product-title} cluster on a single node.
+
+[role="_additional-resources"]
+[id="preparing-to-install-on-aws-additional-resources"]
+== Additional resources
+* xref:../../architecture/architecture-installation.adoc#installation-process_architecture-installation[Installation process]

--- a/modules/cli-installing-cli.adoc
+++ b/modules/cli-installing-cli.adoc
@@ -59,7 +59,7 @@ endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="cli-installing-cli_{context}"]
-= Installing the OpenShift CLI by downloading the binary
+= Installing the OpenShift CLI
 
 You can install the {oc-first} to interact with
 ifndef::openshift-rosa[]


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-10085

Link to docs preview:
[Installation methods](https://75476--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/preparing-to-install-on-aws)

[Preparing to install a cluster (IPI)](https://75476--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/ipi-aws-preparing-to-install)

[Installing a cluster](https://75476--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-default)
[Installing a cluster in China](https://75476--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-china.html)
[Installing a cluster with customizations](https://75476--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-customizations.html)
[Installing a cluster in a government region](https://75476--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-government-region.html)
[Installing a cluster on AWS Local Zones](https://75476--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-localzone.html)
[Installing a cluster with network customizations](https://75476--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-network-customizations.html)
[Installing a private cluster](https://75476--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-private.html)
[Installing a cluster into a secret region](https://75476--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-secret-region.html)
[Installing a cluster on an existing VPC](https://75476--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-vpc.html)
[Installing a cluster on AWS Wavelengths](https://75476--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-wavelength-zone.html)
[Installing a cluster on a restricted network](https://75476--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.html)

No QE required as these changes are only structural.

- Move "prerequisites" from global [preparing-to-install-on-aws.adoc](https://github.com/openshift/openshift-docs/pull/75476/files#diff-c1d5a01bc33e8d8e3a8f79665b3ce47987156900bf6c703b4e536d9b4407f510) file into IPI-specific [installing/installing_aws/ipi/ipi-aws-preparing-to-install.adoc](https://github.com/openshift/openshift-docs/pull/75476/files#diff-40ed035cae926c45bcf01eb94367ca8b6e4d4c673bb72b83fc14beeb4d6fd250) file
- Change heading of [preparing-to-install-on-aws.adoc](https://github.com/openshift/openshift-docs/pull/75476/files#diff-c1d5a01bc33e8d8e3a8f79665b3ce47987156900bf6c703b4e536d9b4407f510) to "Installation methods" (keeping filename the same to avoid any 404/redirect issues)
- Move SSH, entitlements, CLI, OC and telemetry modules out of installation assemblies and into [installing/installing_aws/ipi/ipi-aws-preparing-to-install.adoc](https://github.com/openshift/openshift-docs/pull/75476/files#diff-40ed035cae926c45bcf01eb94367ca8b6e4d4c673bb72b83fc14beeb4d6fd250) file