### PR TITLE
OBSDOCS-1009 List MS Teams as a supported receiver for monitoring alerts

### DIFF
--- a/modules/monitoring-sending-notifications-to-external-systems.adoc
+++ b/modules/monitoring-sending-notifications-to-external-systems.adoc
@@ -13,6 +13,7 @@ In {product-title} {product-version}, firing alerts can be viewed in the Alertin
 * Webhook
 * Email
 * Slack
+* Microsoft Teams
 
 Routing alerts to receivers enables you to send timely notifications to the appropriate teams when failures occur. For example, critical alerts require immediate attention and are typically paged to an individual or a critical response team. Alerts that provide non-critical warning notifications might instead be routed to a ticketing system for non-immediate review.
 

--- a/post_installation_configuration/configuring-alert-notifications.adoc
+++ b/post_installation_configuration/configuring-alert-notifications.adoc
@@ -9,11 +9,10 @@ toc::[]
 In {product-title}, an alert is fired when the conditions defined in an alerting rule are true. An alert provides a notification that a set of circumstances are apparent within a cluster. Firing alerts can be viewed in the Alerting UI in the {product-title} web console by default. After an installation, you can configure {product-title} to send alert notifications to external systems.
 
 include::modules/monitoring-sending-notifications-to-external-systems.adoc[leveloffset=+1]
-include::modules/monitoring-configuring-alert-receivers.adoc[leveloffset=+2]
 
 [id="configuring-alert-notifications-additional-resources"]
 [role="_additional-resources"]
 == Additional resources
 
 * xref:../observability/monitoring/monitoring-overview.adoc#monitoring-overview[Monitoring overview]
-* xref:../observability/monitoring/managing-alerts.adoc#managing-alerts[Managing alerts]
+* xref:../observability/monitoring/managing-alerts.adoc#configuring-alert-receivers_managing-alerts[Configuring alert receivers]


### PR DESCRIPTION
Version(s): `enterprise-4.15` and later

Issue: [OBSDOCS-1009](https://issues.redhat.com/browse/OBSDOCS-1009)

Links to docs preview: 
* [Sending notifications to external systems](https://75483--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/managing-alerts.html#sending-notifications-to-external-systems_managing-alerts)
* [Configuring alert notifications](https://75483--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-alert-notifications)

QE review:
- [x] QE has approved this change.

**Additional information:**