### PR TITLE
OSDOCS-9431: update RHDE page for Microshift 4.16

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -15,6 +15,6 @@
 :microshift-first: Red Hat build of MicroShift
 :microshift: MicroShift
 //removing short form of MicroShift pending approval of use
-:microshift-version: 4.15
+:microshift-version: 4.16
 :ansible: Red Hat Ansible Automation Platform
 :ansible-version: 2.4

--- a/modules/about-rhde.adoc
+++ b/modules/about-rhde.adoc
@@ -27,6 +27,8 @@ The latest release notes for each product that is part of {product-title} are av
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/{op-system-version-major}/html/9.3_release_notes/index[{op-system-ostree-first}] 9.3 release notes contain details about {op-system-ostree}
 
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/{op-system-version-major}/html/9.4_release_notes/index[{op-system-ostree-first}] 9.4 release notes contain details about {op-system-ostree}
+
 * link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{ansible-version}/html/red_hat_ansible_automation_platform_release_notes/index[{ansible} Release Notes]
 
 [id="device-edge-compatibility_{context}"]
@@ -41,10 +43,15 @@ The latest release notes for each product that is part of {product-title} are av
 ^|*{microshift} release status*
 ^|*{microshift} supported updates*
 
+^|9.4
+^|4.16
+^|Generally Available
+^|4.16.0&#8594;4.16.z and 4.16&#8594;maximum two minor versions
+
 ^|9.2, 9.3
 ^|4.15
 ^|Generally Available
-^|4.15.0&#8594;4.15.z and 4.14&#8594;future minor version
+^|4.15.0&#8594;4.15.z and 4.15&#8594;future minor version
 
 ^|9.2, 9.3
 ^|4.14


### PR DESCRIPTION
Version(s):
N/A (no CPs, version "4" is for Pantheon only; versionless branch in the repo)
Can be merged, but Pantheon sync is EMBARGOED for after OCP 4.16 GA when the rest of the docs are published.

Issue:
[OSDOCS-9431](https://issues.redhat.com/browse/OSDOCS-9431)

Link to docs preview:
[Red Hat Device Edge release notes and compatibility](https://75484--ocpdocs-pr.netlify.app/openshift-rhde/latest/overview/rhde-overview.html)

SME review:
 - [x] SME has approved this change.

QE review:
- [x] QE has approved this change.
