### PR TITLE
RHDEVDOCS-6045: Content creation for GitOps 1.11.4 RN

### DIFF
--- a/modules/gitops-release-notes-1-11-4.adoc
+++ b/modules/gitops-release-notes-1-11-4.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assembly:
+//
+// * release_notes/gitops-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="release-notes-for-gitops-1-11-4_{context}"]
+= Release Notes for {gitops-title} 1.11.4
+
+{gitops-title} 1.11.4 is now available on {OCP} 4.12, 4.13, and 4.14.
+
+[id="errata-updates-1-11-4_{context}"]
+== Errata updates
+
+[id="rhsa-2024-2815-gitops-1-11-4-security-update-advisory_{context}"]
+=== RHSA-2024:2815 - {gitops-title} 1.11.4 security update advisory
+
+Issued: 2024-05-10
+
+The list of security fixes that are included in this release is documented in the following advisory:
+
+* link:https://access.redhat.com/errata/RHSA-2024:2815[RHSA-2024:2815]
+
+If you have installed the {gitops-title} Operator, run the following command to view the container images in this release:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-operators
+----
+
+[id="fixed-issues-1-11-4_{context}"]
+== Fixed issues
+
+* Before this update, users could not use the `argocd-k8s-auth` binary to add Google Kubernetes Engine (GKE) and Amazon Elastic Kubernetes Service (EKS) clusters because this binary was not available in the {gitops-shortname} container. This update fixes the issue by adding the `argocd-k8s-auth` binary in the {gitops-shortname} container. link:https://issues.redhat.com/browse/GITOPS-4226[GITOPS-4226]
+
+* Before this update, attempts to connect to Azure DevOps with Argo CD would result in an error due to the deprecation of the `rsa-ssh` host key algorithm by the Azure DevOps Repository service. This update fixes the issue by providing support for the `rsa-ssh` host key algorithms during the communication process between Argo CD and Azure DevOps Repository service. link:https://issues.redhat.com/browse/GITOPS-4543[GITOPS-4543]
+
+* Before this update, the `ignoreDifferences` sync option in Argo CD did not work for array fields. This update fixes the issue by modifying the merge strategy of the `ignoreDifferences` sync option used in the upstream project to handle array fields. As a result, the sync option now functions correctly by allowing users to ignore specific elements in the array during sync. link:https://issues.redhat.com/browse/GITOPS-2962[GITOPS-2962]
+
+* Before this update, users accessing a Red Hat OpenShift on AWS (ROSA) cluster after hibernation were unable to log in to the Argo CD web console due to an error indicating an invalid redirect URI in the Dex configuration. With this update, users can now log in to the Argo CD web console without facing any errors when the ROSA cluster is operational post-hibernation. link:https://issues.redhat.com/browse/GITOPS-4358[GITOPS-4358]
+
+* Before this update, users were unable to log in to the Argo CD web console if the availability of the `openshift-gitops` route was delayed while the {gitops-title} Operator processed an Argo CD custom resource instance. An error message was displayed indicating an invalid redirect URI in the Dex configuration. With this update, users can now log in to the Argo CD web console without facing any errors. link:https://issues.redhat.com/browse/GITOPS-3736[GITOPS-3736]
+
+* Before this update, users could not create custom resources for Argo CD from the *Add* page on the *Developer* perspective of the {gitops-title} web console. This issue has been observed from {gitops-title} 1.10 and later releases. This update fixes the issue because Operator-backed resources with the correct versions are included in the `ClusterServiceVersion` manifest file.
+link:https://issues.redhat.com/browse/GITOPS-4513[GITOPS-4513]

--- a/release_notes/gitops-release-notes.adoc
+++ b/release_notes/gitops-release-notes.adoc
@@ -34,6 +34,9 @@ include::modules/gitops-release-notes-1-12-1.adoc[leveloffset=+1]
 // Release notes for Red Hat OpenShift GitOps 1.12.0
 include::modules/gitops-release-notes-1-12-0.adoc[leveloffset=+1]
 
+// Release notes for Red Hat OpenShift GitOps 1.11.4
+include::modules/gitops-release-notes-1-11-4.adoc[leveloffset=+1]
+
 // Release notes for Red Hat OpenShift GitOps 1.11.3
 include::modules/gitops-release-notes-1-11-3.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):

gitops-docs-1.11 , and gitops-docs-1.12

Issue:

https://issues.redhat.com/browse/RHDEVDOCS-6045

Link to docs preview:

https://75485--ocpdocs-pr.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes.html#release-notes-for-gitops-1-11-4_gitops-release-notes

SME review: completed by @jgwest [ansingh@redhat.com] [anjoseph@redhat.com]
QE review: completed by [skatyal@redhat.com)
Internal Peer review: completed by @eromanova97
Peer review: completed by @skopacz1 