### PR TITLE
OBSDOCS-937/TRACING-4071: Write documentation for oidcauthextension component

### DIFF
--- a/modules/otel-collector-components.adoc
+++ b/modules/otel-collector-components.adoc
@@ -1190,6 +1190,48 @@ The File Storage Extension supports traces, metrics, and logs. This extension ca
 <5> Defines the maximum size of the compaction transaction. To ignore the transaction size, set to zero. If omitted, the default is `+65536+` bytes.
 <6> When set, forces the database to perform an `fsync` call after each write operation. This helps to ensure database integrity if there is an interruption to the database process, but at the cost of performance.
 
+[id="oidcauth-extension_{context}"]
+=== OIDC Auth Extension
+
+:FeatureName: The OIDC Auth Extension
+include::snippets/technology-preview.adoc[]
+
+The OIDC Auth Extension authenticates incoming requests to receivers by using the OpenID Connect (OIDC) protocol.
+It validates the ID token in the authorization header against the issuer and updates the authentication context of the incoming request.
+
+.OpenTelemetry Collector custom resource with the configured OIDC Auth Extension
+[source,yaml]
+----
+  config: |
+    extensions:
+      oidc:
+        attribute: authorization # <1>
+        issuer_url: https://example.com/auth/realms/opentelemetry # <2>
+        issuer_ca_path: /var/run/tls/issuer.pem # <3>
+        audience: otel-collector # <4>
+        username_claim: email # <5>
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            auth:
+              authenticator: oidc
+    exporters:
+      otlp:
+        endpoint: <endpoint>
+    service:
+      extensions: [oidc]
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [otlp]
+----
+<1> The name of the header that contains the ID token. The default name is `authorization`.
+<2> The base URL of the OIDC provider.
+<3> Optional: The path to the issuer's CA certificate.
+<4> The audience for the token.
+<5> The name of the claim that contains the username. The default name is `sub`.
+
 [id="jaegerremotesampling-extension_{context}"]
 === Jaeger Remote Sampling extension
 


### PR DESCRIPTION
:warning: This PR is tied to a product release date, which is currently set to **June 5** (Wednesday).

- If the merge review gets delayed, you're welcome to ping `mleonov` on Slack.
- If you have any questions, ping `mleonov` on Slack.

Signed-off-by: Andreas Gerstmayr <agerstmayr@redhat.com>

Edit of https://github.com/openshift/openshift-docs/pull/73780

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12, 4.13, 4.14, 4.15, 4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OBSDOCS-937
https://issues.redhat.com/browse/TRACING-4071

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://75487--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-configuration-of-otel-collector.html#oidcauth-extension_otel-configuration-of-otel-collector

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
