### PR TITLE
OBSDOCS-1029

### DIFF
--- a/modules/cluster-logging-collector-limits.adoc
+++ b/modules/cluster-logging-collector-limits.adoc
@@ -30,9 +30,9 @@ spec:
     resources:
       limits: <1>
         memory: 736Mi
-        requests:
-          cpu: 100m
-          memory: 736Mi
+      requests:
+        cpu: 100m
+        memory: 736Mi
 # ...
 ----
 <1> Specify the CPU and memory limits and requests as needed. The values shown are the default values.


### PR DESCRIPTION
[OBSDOCS-1029](https://issues.redhat.com/browse/OBSDOCS-1029): Incorrect indentation in "spec.collection.resources.requests" within ClusterLogging CR in "Configure log collector CPU and memory limits" doc
Aligned team: Observability
OCP version for cherry-picking: 4.12+
JIRA issues: [OBSDOCS-1029](https://issues.redhat.com/browse/OBSDOCS-1029)
Preview pages: https://75488--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/log_collection_forwarding/cluster-logging-collector#cluster-logging-collector-limits_cluster-logging-collector
SME review **completed**: @yuokada126
QE review **completed**: @QiaolingTang
Peer review **completed**: @xenolinux
