### PR TITLE
OCPBUGS#19874: Agent host config docs

### DIFF
--- a/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
@@ -67,6 +67,15 @@ include::modules/agent-installer-configuring-fips-compliance.adoc[leveloffset=+1
 
 * xref:../../installing/installing-fips.adoc#installing-fips[Support for FIPS cryptography]
 
+// Host configuration
+include::modules/agent-host-config.adoc[leveloffset=+1]
+
+// Host roles
+include::modules/agent-host-roles.adoc[leveloffset=+2]
+
+// About root device hints
+include::modules/agent-install-ipi-install-root-device-hints.adoc[leveloffset=+2]
+
 //About networking
 include::modules/agent-install-networking.adoc[leveloffset=+1]
 
@@ -102,9 +111,6 @@ include::modules/installation-bare-metal-agent-installer-config-yaml.adoc[levelo
 
 //Validation checks before agent ISO creation
 include::modules/validations-before-agent-iso-creation.adoc[leveloffset=+1]
-
-//About root device hints
-include::modules/agent-install-ipi-install-root-device-hints.adoc[leveloffset=+1]
 
 [id="agent-based-installation-next-steps"]
 == Next steps

--- a/modules/agent-configuration-parameters.adoc
+++ b/modules/agent-configuration-parameters.adoc
@@ -99,7 +99,13 @@ If a `NetworkConfig` section is provided in the `agent-config.yaml` file, this t
   interfaces:
     macAddress:
 |The MAC address of an interface on the host.
-|A MAC address such as the following example: `00-B0-D0-63-C2-26`
+|A MAC address such as the following example: `00-B0-D0-63-C2-26`.
+
+|hosts:
+  role:
+|Defines whether the host is a `master` or `worker` node.
+If no role is defined in the `agent-config.yaml` file, roles will be assigned at random during cluster installation.
+|`master` or `worker`.
 
 |hosts:
   rootDeviceHints:

--- a/modules/agent-host-config.adoc
+++ b/modules/agent-host-config.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * installing/installing-with-agent-based-installer/preparing-to-install-with-agent-based-installer.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="agent-host-config_{context}"]
+= Host configuration
+
+// Starting with whatever content I could find just to have something for feedback, but any additions or replacements are welcome.
+
+You can make additional configurations for each host on the cluster in the `agent-config.yaml` file, such as network configurations and root device hints.
+
+[IMPORTANT]
+====
+For each host you configure, you must provide the MAC address of an interface on the host to specify which host you are configuring.
+====

--- a/modules/agent-host-roles.adoc
+++ b/modules/agent-host-roles.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * installing/installing-with-agent-based-installer/preparing-to-install-with-agent-based-installer.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="agent-host-roles_{context}"]
+= Host roles
+
+Each host in the cluster is assigned a role of either `master` or `worker`.
+You can define the role for each host in the `agent-config.yaml` file by using the `role` parameter.
+If you do not assign a role to the hosts, the roles will be assigned at random during installation.
+
+It is recommended to explicitly define roles for your hosts.
+
+The `rendezvousIP` must be assigned to a host with the `master` role. This can be done manually or by allowing the Agent-based Installer to assign the role.
+
+[IMPORTANT]
+====
+You do not need to explicitly define the `master` role for the rendezvous host, however you cannot create configurations that conflict with this assignment.
+
+For example, if you have 4 hosts with 3 of the hosts explicitly defined to have the `master` role, the last host that is automatically assigned the `worker` role during installation cannot be configured as the rendezvous host.
+====
+
+.Sample agent-config.yaml file
+[source,yaml]
+----
+apiVersion: v1beta1
+kind: AgentConfig
+metadata:
+  name: example-cluster
+rendezvousIP: 192.168.111.80
+hosts:
+  - hostname: master-1
+    role: master
+    interfaces:
+      - name: eno1
+        macAddress: 00:ef:44:21:e6:a5
+  - hostname: master-2
+    role: master
+    interfaces:
+      - name: eno1
+        macAddress: 00:ef:44:21:e6:a6
+  - hostname: master-3
+    role: master
+    interfaces:
+      - name: eno1
+        macAddress: 00:ef:44:21:e6:a7
+  - hostname: worker-1
+    role: worker
+    interfaces:
+      - name: eno1
+        macAddress: 00:ef:44:21:e6:a8
+----


### PR DESCRIPTION
[OCPBUGS-19874](https://issues.redhat.com/browse/OCPBUGS-19874)

Versions: 4.14+

This PR adds documentation about host configuration, specifically roles, to the Agent docs

QE review:
- [x] QE has approved this change.

Previews:

- [Host configuration](https://75490--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#agent-host-config_preparing-to-install-with-agent-based-installer)
- [Optional configuration parameters](https://75490--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installation-config-parameters-agent.html#agent-configuration-parameters-optional_installation-config-parameters-agent)