### PR TITLE
OSDOCS-10456: Clarify CPMS AWS and Azure specs for ext LB

### DIFF
--- a/modules/cpmso-yaml-provider-spec-aws.adoc
+++ b/modules/cpmso-yaml-provider-spec-aws.adoc
@@ -76,6 +76,11 @@ spec:
 <5> Specifies the AWS instance type for the control plane.
 <6> Specifies the cloud provider platform type. Do not change this value.
 <7> Specifies the internal (`int`) and external (`ext`) load balancers for the cluster.
++
+[NOTE]
+====
+You can omit the external (`ext`) load balancer parameters on private {product-title} clusters.
+====
 <8> Specifies where to create the control plane instance in AWS.
 <9> Specifies the AWS region for the cluster.
 <10> This parameter is configured in the failure domain and is shown with an empty value here. If a value specified for this parameter differs from the value in the failure domain, the Control Plane Machine Set Operator overwrites it with the value in the failure domain.

--- a/modules/cpmso-yaml-provider-spec-azure.adoc
+++ b/modules/cpmso-yaml-provider-spec-azure.adoc
@@ -74,6 +74,11 @@ spec:
 <6> Specifies the region to place control plane machines on.
 <7> Specifies the disk configuration for the control plane.
 <8> Specifies the public load balancer for the control plane.
++
+[NOTE]
+====
+You can omit the `publicLoadBalancer` parameter on private {product-title} clusters that have user-defined outbound routing.
+====
 <9> Specifies the subnet for the control plane.
 <10> Specifies the control plane user data secret. Do not change this value.
 <11> Specifies the zone configuration for clusters that use a single zone for all failure domains.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-10456](https://issues.redhat.com//browse/OSDOCS-10456)

Link to docs preview:
- [Sample AWS provider specification](https://75491--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration#cpmso-yaml-provider-spec-aws_cpmso-configuration)
- [Sample Azure provider specification](https://75491--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration#cpmso-yaml-provider-spec-azure_cpmso-configuration)

QE review:
- [x] QE has approved this change.

Additional information: