### PR TITLE
OSDOCS-9448: modified the updating section for Microshift 4.16

### DIFF
--- a/microshift_updating/microshift-about-updates.adoc
+++ b/microshift_updating/microshift-about-updates.adoc
@@ -10,7 +10,7 @@ Updates are supported on {product-title} beginning with the General Availability
 
 * A maximum of two minor versions to the next in sequence, for example, from 4.14 to 4.16.
 * One minor version to the next in sequence, for example, from 4.15 to 4.16.
-* Patch updates are also supported from z-stream to z-stream, for example 4.14.1 to 4.14.2.
+* Patch updates are also supported from z-stream to z-stream, for example 4.16.1 to 4.16.2.
 
 [id="microshift-about-updates-understanding-microshift-updates_{context}"]
 == Understanding {microshift-short} updates

--- a/microshift_updating/microshift-update-rpms-manually.adoc
+++ b/microshift_updating/microshift-update-rpms-manually.adoc
@@ -6,7 +6,7 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-Updating {product-title} for non-OSTree systems such as {op-system-base-full} requires downloading then updating the RPMs. For patch releases, such as 4.15.1 to 4.15.2, download and update the RPMs. For minor-version release updates, add the step of enabling the update repository using your subscription manager.
+Updating {product-title} for non-OSTree systems such as {op-system-base-full} requires downloading then updating the RPMs. For patch releases, such as 4.16.1 to 4.16.2, download and update the RPMs. For minor-version release updates, add the step of enabling the update repository using your subscription manager.
 
 [IMPORTANT]
 ====

--- a/microshift_updating/microshift-update-rpms-ostree.adoc
+++ b/microshift_updating/microshift-update-rpms-ostree.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 Updating {product-title} on an `rpm-ostree` system such as {op-system-ostree-first} requires building a new operating system image containing the new version of {product-title}. After you have the `rpm-ostree` image with {product-title} embedded, direct your system to boot into that operating system image.
 
-The procedures are the same for minor-version and patch updates. For example, use the same steps to upgrade from 4.14 to 4.16 or from 4.15.0 to 4.15.1.
+The procedures are the same for minor-version and patch updates. For example, use the same steps to upgrade from 4.14 to 4.16 or from 4.16.0 to 4.16.1.
 
 include::snippets/microshift-rhde-compatibility-table-snip.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-9448](https://issues.redhat.com/browse/OSDOCS-9448)

Link to docs preview:
[About updates](https://75493--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-about-updates.html)
[Manual updates with RPM](https://75493--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-rpms-manually.html)
[Updates with RPM ostree](https://75493--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-rpms-ostree.html)

SME review:
- [x] SME has approved this change.

QE review:
- [x] QE has approved this change.
