### PR TITLE
TELCODOCS-1485: release note

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -188,6 +188,16 @@ It is expected that if the values for CPU limits are different from the value fo
 
 For more information, see xref:../scalability_and_performance/enabling-workload-partitioning.adoc#enabling-workload-partitioning[Workload partitioning].
 
+[id="ocp-4-16-edge-computing"]
+=== Edge computing
+
+[id="ocp-4-16-edge-computing-talm-enfore-policies"]
+==== {cgu-operator} policy remediation
+
+With this release, {cgu-operator-first} uses a {rh-rhacm-first} feature to remediate `inform` policies on managed clusters. This enhancement removes the need for the Operator to create `enforce` copies of `inform` policies during policy remediation. This enhancement also reduces the workload on the hub cluster due to copied policies, and can reduce the overall time required to remediate policies on managed clusters.
+
+For more information, see xref:../edge_computing/cnf-talm-for-cluster-upgrades.adoc#talo-policies-concept_cnf-topology-aware-lifecycle-manager[Update policies on managed clusters].
+
 [id="ocp-4-16-hcp"]
 === Hosted control planes
 


### PR DESCRIPTION
[TELCODOCS-1485](https://issues.redhat.com//browse/TELCODOCS-1485): Backend updates for TALM policy remediation on managed clusters. 

FAO reviewer - this PR create a new section in the RNs. I raised that here and no objections so far! https://redhat-internal.slack.com/archives/C04DLQNN7B9/p1715765353794219

Version(s):
4.16

Issue:
https://issues.redhat.com/browse/TELCODOCS-1485

Link to docs preview: https://75495--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-edge-computing-talm-enfore-policies


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

