### PR TITLE
OCPBUGS#33258: Adding back in support for the descheduler in OKE

### DIFF
--- a/nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
+++ b/nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
@@ -25,7 +25,6 @@ The following advisory is available for the {descheduler-operator} 5.0.0:
 === Notable changes
 
 * With this release, the {descheduler-operator} delivers updates independent of the {product-title} minor version release stream.
-* With this release, the {descheduler-operator} is no longer supported on {oke}.
 
 [id="descheduler-operator-5.0.0-bug-fixes"]
 === Bug fixes

--- a/welcome/oke_about.adoc
+++ b/welcome/oke_about.adoc
@@ -256,7 +256,7 @@ The following table is a summary of the feature availability in {oke} and {produ
 | File Integrity Operator | Included | Included | File Integrity Operator
 | Gatekeeper Operator | Not Included - Requires separate subscription | Not Included - Requires separate subscription | Gatekeeper Operator
 | Klusterlet | Not Included - Requires separate subscription | Not Included - Requires separate subscription | N/A
-| {descheduler-operator} provided by Red Hat | Not Included | Included | {descheduler-operator}
+| {descheduler-operator} provided by Red Hat | Included | Included | {descheduler-operator}
 | Local Storage provided by Red Hat | Included | Included | Local Storage Operator
 | Node Feature Discovery provided by Red Hat | Included | Included | Node Feature Discovery Operator
 | Performance Profile controller | Included | Included | N/A


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OCPBUGS-33258

Link to docs preview:
* https://75498--ocpdocs-pr.netlify.app/openshift-enterprise/latest/welcome/oke_about.html#feature-summary (changed "Not included" to "Included")
* https://75498--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/descheduler/nodes-descheduler-release-notes.html#descheduler-operator-5.0.0-notable-changes (removed note about no longer being supported)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

This change requires change mangement. Will get acks, etc. before merging
