### PR TITLE
Update cloud-experts-using-alb-and-waf.adoc

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-using-alb-and-waf.adoc
+++ b/cloud_experts_tutorials/cloud-experts-using-alb-and-waf.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-using-alb-and-waf"]
-= Tutorial: Using AWS WAF and AWS ALBs to protect ROSA workloads
+= Tutorial: Using AWS WAF and AWS ALBs to protect ROSA Classic workloads
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-using-alb-and-waf
 
@@ -50,13 +50,14 @@ AWS ALBs require a multi-AZ cluster, as well as three public subnets split acros
 [source,terminal]
 ----
 $ export AWS_PAGER=""
+$ export CLUSTER_ID=$(oc get infrastructure cluster -o=jsonpath="{.status.infrastructureName}")
 $ export CLUSTER_NAME=$(oc get infrastructure cluster -o=jsonpath="{.status.infrastructureName}"  | sed 's/-[a-z0-9]\{5\}$//')
 $ export REGION=$(oc get infrastructure cluster -o=jsonpath="{.status.platformStatus.aws.region}")
 $ export OIDC_ENDPOINT=$(oc get authentication.config.openshift.io cluster -o jsonpath='{.spec.serviceAccountIssuer}' | sed  's|^https://||')
 $ export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 $ export SCRATCH="/tmp/${CLUSTER_NAME}/alb-waf"
 $ mkdir -p ${SCRATCH}
-$ echo "Cluster: ${CLUSTER_NAME}, Region: ${REGION}, OIDC Endpoint: ${OIDC_ENDPOINT}, AWS Account ID: ${AWS_ACCOUNT_ID}"
+$ echo "Cluster ID: ${CLUSTER_ID}, Cluster: ${CLUSTER_NAME}, Region: ${REGION}, OIDC Endpoint: ${OIDC_ENDPOINT}, AWS Account ID: ${AWS_ACCOUNT_ID}"
 ----
 
 [id="aws-vpc-and-subnets_{context}"]
@@ -80,7 +81,7 @@ $ export PRIVATE_SUBNET_IDS=<private-subnets>
 +
 [source,terminal]
 ----
-$ aws ec2 create-tags --resources ${VPC_ID} --tags Key=kubernetes.io/cluster/${CLUSTER_NAME},Value=owned --region ${REGION}
+$ aws ec2 create-tags --resources ${VPC_ID} --tags Key=kubernetes.io/cluster/${CLUSTER_ID},Value=owned --region ${REGION}
 ----
 +
 . Add a tag to your public subnets:
@@ -439,5 +440,5 @@ The expected result is a `403 Forbidden` error, which means the AWS WAF is prote
 [id="additional-resources_{context}"]
 == Additional resources
 
-* link:https://docs.openshift.com/rosa/applications/deployments/osd-config-custom-domains-applications.html[Custom domains for applications] in the Red Hat documentation
+* link:https://docs.openshift.com/rosa/applications/deployments/rosa-config-custom-domains-applications.html[Custom domains for applications] in the Red Hat documentation
 * link:https://youtu.be/-HorEsl2ho4[Adding Extra Security with AWS WAF, CloudFront and ROSA | Amazon Web Services] on YouTube


### PR DESCRIPTION
should be using the cluster id for the VPC tag.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
