### PR TITLE
OSDOCS#10460: Document configuring OAuth for the hosted cluster by using the web console

### DIFF
--- a/hosted_control_planes/hcp-authentication-authorization.adoc
+++ b/hosted_control_planes/hcp-authentication-authorization.adoc
@@ -9,6 +9,7 @@ toc::[]
 The {product-title} control plane includes a built-in OAuth server. You can obtain OAuth access tokens to authenticate to the {product-title} API. After you create your hosted cluster, you can configure OAuth by specifying an identity provider.
 
 include::modules/hcp-configuring-oauth.adoc[leveloffset=+1]
+include::modules/hcp-configuring-oauth-console.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/hcp-configuring-oauth-console.adoc
+++ b/modules/hcp-configuring-oauth-console.adoc
@@ -1,0 +1,75 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-authentication-authorization.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-configuring-oauth-console_{context}"]
+= Configuring the OAuth server for a hosted cluster by using the web console
+
+You can configure the internal OAuth server for your hosted cluster by using the {product-title} web console.
+
+You can configure OAuth for the following supported identity providers:
+
+* `oidc`
+* `htpasswd`
+* `keystone`
+* `ldap`
+* `basic-authentication`
+* `request-header`
+* `github`
+* `gitlab`
+* `google`
+
+Adding any identity provider in the OAuth configuration removes the default `kubeadmin` user provider.
+
+.Prerequisites
+
+* You logged in as a user with `cluster-admin` privileges.
+* You created your hosted cluster.
+
+.Procedure
+
+. Navigate to *Home* -> *API Explorer*.
+
+. Use the *Filter by kind* box to search for your `HostedCluster` resource.
+
+. Click the `HostedCluster` resource that you want to edit.
+
+. Click the *Instances* tab.
+
+. Click the Options menu {kebab} next to your hosted cluster name entry and click *Edit HostedCluster*.
+
+. Add the OAuth configuration in the YAML file:
++
+[source,yaml]
+----
+spec:
+  configuration:
+    oauth:
+      identityProviders:
+      - openID: <1>
+          claims:
+            email: <2>
+              - <email_address>
+            name: <3>
+              - <display_name>
+            preferredUsername:
+              - <preferred_username> <4>
+          clientID: <client_id> <5>
+          clientSecret:
+            name: <client_id_secret_name> <6>
+          issuer: https://example.com/identity <7>
+        mappingMethod: lookup <8>
+        name: IAM
+        type: OpenID
+----
+<1> This provider name is prefixed to the value of the identity claim to form an identity name. The provider name is also used to build the redirect URL.
+<2> Defines a list of attributes to use as the email address.
+<3> Defines a list of attributes to use as a display name.
+<4> Defines a list of attributes to use as a preferred user name.
+<5> Defines the ID of a client registered with the OpenID provider. You must allow the client to redirect to the `\https://oauth-openshift.apps.<cluster_name>.<cluster_domain>/oauth2callback/<idp_provider_name>` URL.
+<6> Defines a secret of a client registered with the OpenID provider.
+<7> The link:https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier[Issuer Identifier] described in the OpenID spec. You must use `https` without query or fragment component.
+<8> Defines a mapping method that controls how mappings are established between identities of this provider and `User` objects.
+
+. Click *Save*.

--- a/modules/hcp-configuring-oauth.adoc
+++ b/modules/hcp-configuring-oauth.adoc
@@ -4,9 +4,23 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="hcp-configuring-oauth_{context}"]
-= Configuring the internal OAuth server for a hosted cluster
+= Configuring the OAuth server for a hosted cluster by using the CLI
 
-You can configure the internal OAuth server for your hosted cluster by using an OpenID Connect identity provider (`oidc`). You can also configure OAuth for the other supported identity providers such as `htpasswd`, `keystone`, `ldap`, `basic-authentication`, `request-header`, `github`, `gitlab`, and `google`. Adding any identity provider in the OAuth configuration removes the default `kubeadmin` user provider.
+You can configure the internal OAuth server for your hosted cluster by using an OpenID Connect identity provider (`oidc`).
+
+You can configure OAuth for the following supported identity providers:
+
+* `oidc`
+* `htpasswd`
+* `keystone`
+* `ldap`
+* `basic-authentication`
+* `request-header`
+* `github`
+* `gitlab`
+* `google`
+
+Adding any identity provider in the OAuth configuration removes the default `kubeadmin` user provider.
 
 .Prerequisites
 


### PR DESCRIPTION
Configuring OAuth for the hosted cluster by using the CLI is already covered. This PR adds the web console method.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-10460
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://75514--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-authentication-authorization.html#hcp-configuring-oauth-console_hcp-authentication-authorization
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
