### PR TITLE
OSDOCS-10445: 4.15.12 RN

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2718,6 +2718,78 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+[id="ocp-4-15-12"]
+=== RHSA-2024:2664 - {product-title} 4.15.12 bug fix and security update
+
+Issued: 2024-05-09
+
+{product-title} release 4.15.12, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:2664[RHSA-2024:2664] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:2669[RHSA-2024:2669] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.12 --pullspecs
+----
+
+[id="ocp-4-15-12-enhancements"]
+==== Enhancements
+
+The following enhancements are included in this z-stream release:
+
+[id="ocp-4-15-12-apiversion-upgrade-v1beta1"]
+===== API version for the ClusterTriggerBinding, TriggerTemplate, and EventListener CRDs upgraded from v1alpha1 to v1beta1
+
+* Previously, the API version for the `ClusterTriggerBinding`, `TriggerTemplate`, and `EventListener` CRDs was `v1alpha1`. With this release, the API version is upgraded to `v1beta1` so that the pipelines plugin supports the latest Pipeline Trigger API version for the `ClusterTriggerBinding`, `TriggerTemplate`, and `EventListener` CRDs. (link:https://issues.redhat.com/browse/OCPBUGS-31445[*OCPBUGS-31445*])
+
+[id="ocp-4-15-12-pipeline-list-page-improvement"]
+===== PipelineRun list view performance improvement
+
+* Previously, in the `PipelineRun` list page, all of the `TaskRun` objects were fetched and separated based on their `PipelineRun` name. With this release, `TaskRun` objects are only fetched for failed and cancelled `PipelineRun` objects, and a caching mechanism is added to fetch the `PipelineRun` and `TaskRun` objects that are associated with the failed and cancelled `PipelineRun` objects. (link:https://issues.redhat.com/browse/OCPBUGS-31799[*OCPBUGS-31799*])
+
+[id="ocp-4-15-12-installer-handling-new-character"]
+===== Installer handles the escaping of the % character
+
+* Previously, if a cluster was installed using a proxy, and the proxy information contained escaped characters in the format `%XX`, the installation failed. With this release, the installer now handles the escaping of the `%` character. (link:https://issues.redhat.com/browse/OCPBUGS-32259[*OCPBUGS-32259*])
+
+[id="ocp-4-15-12-cfe-evaluation-status"]
+===== Cluster Fleet Evaluation status information added to the Machine Config Operator
+
+* Previously, the Machine Config Operator (MCO) did not include the Cluster Fleet Evaluation (CFE) status. With this release, the CFE status information is added to the MCO and available to customers. (link:https://issues.redhat.com/browse/OCPBUGS-32922[*OCPBUGS-32922*])
+
+[id="ocp-4-15-12-operatorhub-filter-rename-FIPS"]
+===== OperatorHub filter renamed from FIPS Mode to Designed for FIPS
+
+* Previously, OperatorHub included a filter named *FIPS Mode*. With this release, that filter is named *Designed for FIPS*. (link:https://issues.redhat.com/browse/OCPBUGS-32933[*OCPBUGS-32933*])
+
+[id="ocp-4-15-12-bug-fixes"]
+==== Bug fixes
+
+* Previously, containers had an incorrect view of the pids limit in their `cgroup` hierarchy and reported as a random number instead of `max`. The containers do not have max PIDs and are limited by the pod PID limit, which is set outside of the container's `cgroup` hierarchy and not visible from within the container. With this release, the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-28926[*OCPBUGS-28926*])
+
+* Previously, for {product-title} deployments on {rh-openstack-first}, the `MachineSet` object did not correctly apply the value for the `Port Security` parameter. With this release, the `MachineSet` object applies the `port_security_enabled` flag as expected. (link:https://issues.redhat.com/browse/OCPBUGS-30857[*OCPBUGS-30857*])
+
+* Previously, the installation program erroneously attempted to verify the libvirt network interfaces when an agent-based installation was configured with the `openshift-baremetal-install` binary. With this release, the agent installation method does not require libvirt and this validation is disabled. (link:https://issues.redhat.com/browse/OCPBUGS-30944[*OCPBUGS-30944*])
+
+* Previously, the `cpuset-configure.sh` script could run before all of the system processes were created. With this release, the script is only triggered to run when CRI-O is initialized and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-31692[*OCPBUGS-31692*])
+
+* Previously, an incorrect `dnsPolicy` was used for the `konnectivity-agent` daemon set in the data plane. As a result, when CoreDNS was down, `konnectivity-agent` pods on the data plane could not resolve the `proxy-server-address` and could fail the `konnectivity-server` in the control plane. With this release, `konnectivity-agent` uses the host system DNS service to lookup the `proxy-server-address` and no longer depends on CoreDNS. (link:https://issues.redhat.com/browse/OCPBUGS-31826[*OCPBUGS-31826*])
+
+* Previously, if gathering logs from the bootstrap node failed during the `gather bootstrap` execution, the virtual machine (VM) serial console logs were not included in the gather output even if they were collected. With this release, serial logs are always included if they are collected. (link:https://issues.redhat.com/browse/OCPBUGS-32264[*OCPBUGS-32264*])
+
+* Previously, port 22 was missing from the compute node's security group in AWS SDK installations, therefore connecting to the compute nodes with SSH failed when users used AWS SDK provisioning. With this release, port 22 is added to the compute node's security group and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-32383[*OCPBUGS-32383*])
+
+* Previously, the installation program required the `s3:HeadBucket` permission for AWS, even though it does not exist. The correct permission for the `HeadBucket` action is `s3:ListBucket`. With this release, `s3:HeadBucket` is removed from the list of required permissions and only `s3:ListBucket` is required, as expected. (link:https://issues.redhat.com/browse/OCPBUGS-32690[*OCPBUGS-32690*])
+
+* Previously, there was an issue with {product-title} Ansible upgrades because the IPsec configuration was not idempotent. With this release, changes are made to the {product-title} Ansible playbooks, ensuring that all IPsec configurations are idempotent. (link:https://issues.redhat.com/browse/OCPBUGS-33102[*OCPBUGS-33102*])
+
+[id="ocp-4-15-12-updating"]
+==== Updating
+To update an existing {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+
 [id="ocp-4-15-11"]
 === RHSA-2024:2068 - {product-title} 4.15.11 bug fix and security update
 


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-10445](https://issues.redhat.com/browse/OSDOCS-10445)

Link to docs preview:
https://75528--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-12

QE review:
N/A

Additional information:
 Errrata links will return 404 until go-live (5/9/24)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
