### PR TITLE
OSDOCS-9553: Netobserv Lokiless enhancements

### DIFF
--- a/modules/network-observability-RTT-overview.adoc
+++ b/modules/network-observability-RTT-overview.adoc
@@ -5,24 +5,24 @@
 :_mod-docs-content-type: CONCEPT
 [id="network-observability-RTT-overview_{context}"]
 = Round-Trip Time
-You can use TCP handshake Round-Trip Time (RTT) to analyze network flows. You can use RTT captured from the `fentry/tcp_rcv_established` eBPF hookpoint to read SRTT from the TCP socket to help with the following:
+You can use TCP smoothed Round-Trip Time (sRTT) to analyze network flow latencies. You can use RTT captured from the `fentry/tcp_rcv_established` eBPF hookpoint to read sRTT from the TCP socket to help with the following:
 
 
-* Network Monitoring: Gain insights into TCP handshakes, helping
+* Network Monitoring: Gain insights into TCP latencies, helping
   network administrators identify unusual patterns, potential bottlenecks, or
   performance issues.
 * Troubleshooting: Debug TCP-related issues by tracking latency and identifying
   misconfigurations.
 
-By default, when RTT is enabled, you can see the following TCP handshake RTT metrics represented in the *Overview*:
+By default, when RTT is enabled, you can see the following TCP RTT metrics represented in the *Overview*:
 
-* Top X 90th percentile TCP handshake Round Trip Time with overall
-* Top X average TCP handshake Round Trip Time with overall
-* Bottom X minimum TCP handshake Round Trip Time with overall
+* Top X 90th percentile TCP Round Trip Time with overall
+* Top X average TCP Round Trip Time with overall
+* Bottom X minimum TCP Round Trip Time with overall
 
 Other RTT panels can be added in *Manage panels*:
 
-* Top X maximum TCP handshake Round Trip Time with overall
-* Top X 99th percentile TCP handshake Round Trip Time with overall
+* Top X maximum TCP Round Trip Time with overall
+* Top X 99th percentile TCP Round Trip Time with overall
 
 See the _Additional Resources_ in this section for more information about enabling and working with this view.

--- a/modules/network-observability-RTT.adoc
+++ b/modules/network-observability-RTT.adoc
@@ -23,7 +23,6 @@ metadata:
   name: cluster
 spec:
   namespace: netobserv
-  deploymentModel: Direct
   agent:
     type: eBPF
     ebpf:

--- a/modules/network-observability-dns-tracking.adoc
+++ b/modules/network-observability-dns-tracking.adoc
@@ -27,7 +27,6 @@ metadata:
   name: cluster
 spec:
   namespace: netobserv
-  deploymentModel: Direct
   agent:
     type: eBPF
     ebpf:

--- a/modules/network-observability-packet-drops.adoc
+++ b/modules/network-observability-packet-drops.adoc
@@ -28,7 +28,6 @@ metadata:
   name: cluster
 spec:
   namespace: netobserv
-  deploymentModel: Direct
   agent:
     type: eBPF
     ebpf:

--- a/modules/network-observability-quickfilter.adoc
+++ b/modules/network-observability-quickfilter.adoc
@@ -12,6 +12,7 @@ You can use *Query Options* to optimize the search results, as listed below:
 
 ** *Log Type*: The available options *Conversation* and *Flows* provide the ability to query flows by log type, such as flow log, new conversation, completed conversation, and a heartbeat, which is a periodic record with updates for long conversations. A conversation is an aggregation of flows between the same peers.
 ** *Match filters*: You can determine the relation between different filter parameters selected in the advanced filter. The available options are *Match all* and *Match any*. *Match all*  provides results that match all the values, and *Match any* provides results that match any of the values entered. The default value is *Match all*.
+** *Datasource*: You can choose the datasource to use for queries: *Loki*, *Prometheus*, or *Auto*. Notable performance improvements can be realized when using Prometheus as a datasource rather than Loki, but Prometheus supports a limited set of filters and aggregations. The default datasource is *Auto*, which uses Prometheus on supported queries or uses Loki if the query does not support Prometheus.
 ** *Drops filter*: You can view different levels of dropped packets with the following query options:
 *** *Fully dropped* shows flow records with fully dropped packets.
 *** *Containing drops* shows flow records that contain drops but can be sent.

--- a/modules/network-observability-without-loki.adoc
+++ b/modules/network-observability-without-loki.adoc
@@ -4,16 +4,25 @@
 :_mod-docs-content-type: REFERENCE
 [id="network-observability-without-loki_{context}"]
 = Network Observability without Loki
-You can use Network Observability without Loki by not performing the Loki installation steps and skipping directly to "Installing the Network Observability Operator". If you only want to export flows to a Kafka consumer or IPFIX collector, or you only need dashboard metrics, then you do not need to install Loki or provide storage for Loki.  Without Loki, there is no *Network Traffic* panel under *Observe*, which means there is no overview charts, flow table, or topology. The following table compares available features with and without Loki:
+You can use Network Observability without Loki by not performing the Loki installation steps and skipping directly to "Installing the Network Observability Operator". If you only want to export flows to a Kafka consumer or IPFIX collector, or you only need dashboard metrics, then you do not need to install Loki or provide storage for Loki. The following table compares available features with and without Loki.
 
 .Comparison of feature availability with and without Loki
 [options="header"]
 |===
 |                                     | *With Loki* | *Without Loki*
-| *Exporters*                         | image:check-solid.png[,10]  | image:check-solid.png[,10]
-| *Flow-based metrics and dashboards*             | image:check-solid.png[,10] | image:check-solid.png[,10]
-| *Traffic Flow Overview, Table and Topology views* | image:check-solid.png[,10] | image:x-solid.png[,10]
-| *Quick Filters*                     | image:check-solid.png[,10] | image:x-solid.png[,10]
-| *{product-title} console Network Traffic tab integration* | image:check-solid.png[,10] | image:x-solid.png[,10]
+| *Exporters*                         | image:check-solid.png[,10] | image:check-solid.png[,10]
+| *Multi-tenancy*                     | image:check-solid.png[,10] | image:x-solid.png[,10]
+| *Complete filtering and aggregations capabilities* ^[1]^| image:check-solid.png[,10] | image:x-solid.png[,10]
+| *Partial filtering and aggregations capabilities* ^[2]^ | image:check-solid.png[,10] | image:check-solid.png[,10]
+| *Flow-based metrics and dashboards* | image:check-solid.png[,10] | image:check-solid.png[,10]
+| *Traffic flows view overview* ^[3]^  | image:check-solid.png[,10] | image:check-solid.png[,10]
+| *Traffic flows view table*       | image:check-solid.png[,10] | image:x-solid.png[,10]
+| *Topology view*                | image:check-solid.png[,10] | image:check-solid.png[,10]
+| *{product-title} console Network Traffic tab integration* | image:check-solid.png[,10] | image:check-solid.png[,10]
 |===
-
+[.small]
+--
+1. Such as per pod.
+2. Such as per workload or namespace.
+3. Statistics on packet drops are only available with Loki.
+--

--- a/modules/network-observability-working-with-zones.adoc
+++ b/modules/network-observability-working-with-zones.adoc
@@ -23,7 +23,7 @@ metadata:
 spec:
 # ...
  processor:
-  addZone: true
+   addZone: true
 # ...
 ----
 

--- a/observability/network_observability/network-observability-overview.adoc
+++ b/observability/network_observability/network-observability-overview.adoc
@@ -6,19 +6,18 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Red Hat offers cluster administrators the Network Observability Operator to observe the network traffic for {product-title} clusters. The Network Observability Operator uses the eBPF technology to create network flows. The network flows are then enriched with {product-title} information and stored in Loki. You can view and analyze the stored network flows information in the {product-title} console for further insight and troubleshooting.
+Red Hat offers cluster administrators the Network Observability Operator to observe the network traffic for {product-title} clusters. The Network Observability Operator uses the eBPF technology to create network flows. The network flows are then enriched with {product-title} information. They are available as Prometheus metrics or as logs in Loki. You can view and analyze the stored network flows information in the {product-title} console for further insight and troubleshooting.
 
 [id="dependency-network-observability"]
 == Optional dependencies of the Network Observability Operator
 
-* {loki-op}: Loki is the backend that is used to store all collected flows. It is recommended to install Loki to use with the Network Observability Operator. You can choose to use xref:../network_observability/installing-operators.adoc#network-observability-without-loki_network_observability[Network Observability without Loki], but there are some considerations for doing this, as described in the linked section. If you choose to install Loki, it is recommended to use the {loki-op}, as it is supported by Red Hat.
-* Grafana Operator: You can install Grafana for creating custom dashboards and querying capabilities, by using an open source product, such as the Grafana Operator. Red Hat does not support the Grafana Operator.
+* {loki-op}: Loki is the backend that can be used to store all collected flows with a maximal level of details. You can choose to use xref:../network_observability/installing-operators.adoc#network-observability-without-loki_network_observability[Network Observability without Loki], but there are some considerations for doing this, as described in the linked section. If you choose to install Loki, it is recommended to use the {loki-op}, which is supported by Red Hat.
 * AMQ Streams Operator: Kafka provides scalability, resiliency and high availability in the {product-title} cluster for large scale deployments. If you choose to use Kafka, it is recommended to use the AMQ Streams Operator, because it is supported by Red Hat.
 
 [id="network-observability-operator"]
 == Network Observability Operator
 
-The Network Observability Operator provides the Flow Collector API custom resource definition. A Flow Collector instance is created during installation and enables configuration of network flow collection. The Flow Collector instance deploys pods and services that form a monitoring pipeline where network flows are then collected and enriched with the Kubernetes metadata before storing in Loki. The eBPF agent, which is deployed as a `daemonset` object, creates the network flows.
+The Network Observability Operator provides the Flow Collector API custom resource definition. A Flow Collector instance is a cluster-scoped resource that enables configuration of network flow collection. The Flow Collector instance deploys pods and services that form a monitoring pipeline where network flows are then collected and enriched with the Kubernetes metadata before storing in Loki or generating Prometheus metrics. The eBPF agent, which is deployed as a `daemonset` object, creates the network flows.
 
 [id="no-console-integration"]
 == {product-title} console integration
@@ -28,17 +27,21 @@ The Network Observability Operator provides the Flow Collector API custom resour
 [id="network-observability-dashboards"]
 === Network Observability metrics dashboards
 
-On the *Overview* tab in the {product-title} console, you can view the overall aggregated metrics of the network traffic flow on the cluster. You can choose to display the information by node, namespace, owner, pod, zone, and service. Filters and display options can further refine the metrics. For more information, see xref:../network_observability/observing-network-traffic.adoc#network-observability-overview_nw-observe-network-traffic[Observing the network traffic from the Overview view].
+On the *Overview* tab in the {product-title} console, you can view the overall aggregated metrics of the network traffic flow on the cluster. You can choose to display the information by zone, node, namespace, owner, pod, and service. Filters and display options can further refine the metrics. For more information, see xref:../network_observability/observing-network-traffic.adoc#network-observability-overview_nw-observe-network-traffic[Observing the network traffic from the Overview view].
 
-In *Observe* -> *Dashboards*, the *Netobserv* dashboard provides a quick overview of the network flows in your {product-title} cluster. The *Netobserv/Health* dashboard provides metrics about the health of the Operator. For more information, see xref:../network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network Observability Metrics] and xref:../network_observability/network-observability-operator-monitoring.adoc#network-observability-health-dashboard-overview_network_observability[Viewing health information].
+In *Observe* -> *Dashboards*, the *Netobserv* dashboards provide a quick overview of the network flows in your {product-title} cluster. The *Netobserv/Health* dashboard provides metrics about the health of the Operator. For more information, see xref:../network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network Observability Metrics] and xref:../network_observability/network-observability-operator-monitoring.adoc#network-observability-health-dashboard-overview_network_observability[Viewing health information].
 
 
 [id="network-observability-topology-views"]
 === Network Observability topology views
 
-The {product-title} console offers the *Topology* tab which displays a graphical representation of the network flows and the amount of traffic. The topology view represents traffic between the {product-title} components as a network graph. You can refine the graph by using the filters and display options. You can access the information for node, namespace, owner, pod, and service.
+The {product-title} console offers the *Topology* tab which displays a graphical representation of the network flows and the amount of traffic. The topology view represents traffic between the {product-title} components as a network graph. You can refine the graph by using the filters and display options. You can access the information for zone, node, namespace, owner, pod, and service.
 
 [id="traffic-flow-tables"]
 === Traffic flow tables
 
 The traffic flow table view provides a view for raw flows, non aggregated filtering options, and configurable columns. The {product-title} console offers the *Traffic flows* tab which displays the data of the network flows and the amount of traffic.
+
+[id="network-observability-cli"]
+== Network Observability CLI
+You can quickly debug and troubleshoot networking issues with Network Observability by using the Network Observability CLI (`oc netobserv`). The Network Observability CLI is a flow and packet visualization tool that relies on eBPF agents to stream collected data to an ephemeral collector pod. It requires no persistent storage during the capture. After the run, the output is transferred to your local machine. This enables quick, live insight into packets and flow data without installing the Network Observability Operator.  


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
Merge to only the no-1.6 branch - no cherrypicks are required.
This PR is part of an experiment for simplifying merges for asynchronous content, and I will open one PR against main to incorporate all of the Network Observability 1.6 content just before its GA
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-9553
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
Network Observability Overview: https://75530--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-overview.html

Network Observability without Loki: https://75530--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/installing-operators.html#network-observability-without-loki_network_observability

## Observing Network Traffic
Round-trip time overview: https://75530--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/observing-network-traffic#network-observability-RTT-overview_nw-observe-network-traffic

Working with packet drops: https://75530--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/observing-network-traffic#network-observability-packet-drops_nw-observe-network-traffic

Working with DNS tracking: https://75530--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/observing-network-traffic#network-observability-dns-tracking_nw-observe-network-traffic

Working with RTT: https://75530--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/observing-network-traffic#network-observability-RTT_nw-observe-network-traffic

Working with zones: https://75530--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/observing-network-traffic#network-observability-zonesnw-observe-network-traffic

Query Options (new datasource options): https://75530--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/observing-network-traffic#network-observability-quickfilternw-observe-network-traffic

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
Merge to only the `no-1.6` branch - no cherrypicks are required.
This PR is part of an experiment for simplifying merges for asynchronous content, and I will open one PR against main to incorporate all of the Network Observability 1.6 content just before its GA
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
