### PR TITLE
OSDOCS-10107: adds 4.14.24 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -495,3 +495,12 @@ Issued: 2024-04-18
 {product-title} release 4.14.21 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1767[RHBA-2024:1767] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1765[RHSA-2024:1765] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-14-24-dp"]
+=== RHSA-2024:2671 - {microshift-short} 4.14.24 bug fix update and security update advisory
+
+Issued: 2024-05-09
+
+{product-title} release 4.14.24, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:2671[RHSA-2024:2671] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:2668[RHSA-2024:2668] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-10107](https://issues.redhat.com/browse/OSDOCS-10107)

Link to docs preview:
[4.14.24 async release note](https://75538--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes.html#microshift-4-14-24-dp)

QE review:
- N/A stock text, no other release notes