### PR TITLE
OSDOCS-10110: adds 4.15.12 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -279,3 +279,12 @@ Issued: 2024-04-16
 {product-title} release 4.15.9 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:1772[RHBA-2024:1772] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1770[RHSA-2024:1770] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-15-12-dp"]
+=== RHSA-2024:2667 - {microshift-short} 4.15.12 bug fix and security update advisory
+
+Issued: 2024-05-09
+
+{product-title} release 4.15.12 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:2667[RHSA-2024:2667] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:2664[RHSA-2024:2664] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-10110](https://issues.redhat.com/browse/OSDOCS-10110)

Link to docs preview:
[4.15.12 async release note](https://75539--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-12-dp)

QE review:
- N/A, no technical relnote; stock doc advisory text

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
