### PR TITLE
OSDOCS-9449: adds RHEL 9.4 to Microshift 4.16 relnotes

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -30,7 +30,7 @@ This release adds improvements related to the following components and concepts.
 //L3 major categories with features in each as L4s
 [id="microshift-4-16-rhel"]
 === {op-system-base-full}
-//* {microshift-short} now runs on {op-system-base-full} 9.4
+* {microshift-short} now runs on {op-system-base-full} 9.4.
 
 // Some details of the next note are adapted from https://kubernetes.io/blog/2022/08/31/cgroupv2-ga-1-25/
 * {microshift-short} uses crun and Control Group v2 (cgroup v2). If workloads rely on the cgroup file system layout, they might need to be updated to be compatible with cgroup v2.


### PR DESCRIPTION
Version(s):
4.16 only

Issue:
[OSDOCS-9449](https://issues.redhat.com/browse/OSDOCS-9449)

Link to docs preview:
[Release notes RHEL](https://75540--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-rhel)

SME review:
- [x] SME has approved this change.

QE review:
- [x] QE has approved this change.
