### PR TITLE
Fix typo in CAS docs

### DIFF
--- a/modules/cluster-autoscaler-cr.adoc
+++ b/modules/cluster-autoscaler-cr.adoc
@@ -66,7 +66,7 @@ If you do not specify a value, the default value of `1` is used.
 <14> Optional: Specify the period to wait before deleting a node after a node has recently been _deleted_. If you do not specify a value, the default value of `0s` is used.
 <15> Optional: Specify the period to wait before deleting a node after a scale down failure occurred. If you do not specify a value, the default value of `3m` is used.
 <16> Optional: Specify a period of time before an unnecessary node is eligible for deletion. If you do not specify a value, the default value of `10m` is used.
-<17> Optional:  Specify the _node utilization level_. Nodes below this utilization level are eligible for deletion. If you do not specify a value, the default value of `10m` is used.
+<17> Optional:  Specify the _node utilization level_. Nodes below this utilization level are eligible for deletion.
 +
 The node utilization level is the sum of the requested resources divided by the allocated resources for the node, and must be a value greater than `"0"` but less than `"1"`. If you do not specify a value, the cluster autoscaler uses a default value of `"0.5"`, which corresponds to 50% utilization. You must express this value as a string.
 <18> Optional: Specify any expanders that you want the cluster autoscaler to use.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
Reported via [Slack](https://redhat-internal.slack.com/archives/CBZHF4DHC/p1714994639165639)

Link to docs preview:
[Cluster autoscaler resource definition](https://75542--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/applying-autoscaling.html#cluster-autoscaler-cr_applying-autoscaling)

QE review:
N/A

Additional information: