### PR TITLE
OBSDOCS-1034/TRACING-4069: Write docs for the filelog receiver component

### DIFF
--- a/modules/otel-collector-components.adoc
+++ b/modules/otel-collector-components.adoc
@@ -199,6 +199,32 @@ The OpenCensus receiver provides backwards compatibility with the OpenCensus pro
 Wildcards with `+*+` are accepted under the `cors_allowed_origins`.
 To match any origin, enter only `+*+`.
 
+[id="filelog-receiver_{context}"]
+=== Filelog Receiver
+
+:FeatureName: The Filelog Receiver
+include::snippets/technology-preview.adoc[]
+
+The Filelog Receiver tails and parses logs from files.
+
+.OpenTelemetry Collector custom resource with the enabled Filelog Receiver that tails a text file
+[source,yaml]
+----
+receivers:
+  filelog:
+    include: [ /simple.log ] # <1>
+    operators: # <2>
+      - type: regex_parser
+        regex: '^(?P<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) (?P<sev>[A-Z]*) (?P<msg>.*)$'
+        timestamp:
+          parse_from: attributes.time
+          layout: '%Y-%m-%d %H:%M:%S'
+        severity:
+          parse_from: attributes.sev
+----
+<1> A list of file glob patterns that match the file paths to be read.
+<2> An array of Operators. Each Operator performs a simple task such as parsing a timestamp or JSON. To process logs into a desired format, chain the Operators together.
+
 [id="processors_{context}"]
 == Processors
 


### PR DESCRIPTION
:warning: This PR is tied to a product release date, which is currently set to **June 5** (Wednesday).

- If the merge review gets delayed, you're welcome to ping `mleonov` on Slack.
- If you have any questions, ping `mleonov` on Slack.

Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>

My edit of https://github.com/openshift/openshift-docs/pull/73770
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12, 4.13, 4.14, 4.15, 4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OBSDOCS-1034
https://issues.redhat.com/browse/TRACING-4069

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://75550--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-configuration-of-otel-collector.html#filelog-receiver_otel-configuration-of-otel-collector

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
