### PR TITLE
OBSDOCS-1036/TRACING-4106: mention that tempo gateway only supports gRPC for ingesting traces

### DIFF
--- a/modules/distr-tracing-tempo-config-multitenancy.adoc
+++ b/modules/distr-tracing-tempo-config-multitenancy.adoc
@@ -9,6 +9,11 @@
 Multitenancy with authentication and authorization is provided in the Tempo Gateway service.
 The authentication uses OpenShift OAuth and the Kubernetes `TokenReview` API. The authorization uses the Kubernetes `SubjectAccessReview` API.
 
+[NOTE]
+====
+The Tempo Gateway service supports ingestion of traces only via the OTLP/gRPC. The OTLP/HTTP is not supported.
+====
+
 .Sample Tempo CR with two tenants, `dev` and `prod`
 [source,yaml]
 ----


### PR DESCRIPTION
:warning: This PR is tied to a product release date, which is currently set to **June 5** (Wednesday).

- If the merge review gets delayed, you're welcome to ping `mleonov` on Slack.
- If you have any questions, ping `mleonov` on Slack.

Signed-off-by: Andreas Gerstmayr <agerstmayr@redhat.com>

Edit of https://github.com/openshift/openshift-docs/pull/74946

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12, 4.13, 4.14, 4.15, 4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OBSDOCS-1036
https://issues.redhat.com/browse/TRACING-4106

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://75557--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-configuring.html#distr-tracing-tempo-config-multitenancy_distr-tracing-tempo-configuring

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
