### PR TITLE
WMCO 10.15.2 RN Fix Link

### DIFF
--- a/windows_containers/windows-containers-release-notes-10-15-x.adoc
+++ b/windows_containers/windows-containers-release-notes-10-15-x.adoc
@@ -36,7 +36,7 @@ Starting with this release, y-stream releases of the WMCO will be in step with {
 [id="wmco-10-15-2"]
 == Release notes for Red{nbsp}Hat Windows Machine Config Operator 10.15.2
 
-This release of the WMCO provides new features and bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.15.2 were released in link:https://access.redhat.com/errata/RHBA-2024:TBD[RHBA-2024:TBD].
+This release of the WMCO provides new features and bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.15.2 were released in link:https://access.redhat.com/errata/RHBA-2024:2704[RHBA-2024:2704].
 
 [id="wmco-10-15-2-bug-fixes"]
 === Bug fixes


### PR DESCRIPTION
Fix bad link in 10.15.2 release notes

Preview: [Link to errata in first paragraph](https://75577--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-10-15-x.html#wmco-10-15-2).

No QE