### PR TITLE
Fix links to rh-mobb content

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-aws-load-balancer-operator.adoc
+++ b/cloud_experts_tutorials/cloud-experts-aws-load-balancer-operator.adoc
@@ -129,7 +129,7 @@ $ POLICY_ARN=$(aws iam list-policies --query \
      --output text)
 $ if [[ -z "${POLICY_ARN}" ]]; then
     wget -O "${SCRATCH}/load-balancer-operator-policy.json" \
-       https://raw.githubusercontent.com/rh-mobb/documentation/main/content/docs/rosa/aws-load-balancer-operator/load-balancer-operator-policy.json
+       https://raw.githubusercontent.com/rh-mobb/documentation/main/content/rosa/aws-load-balancer-operator/load-balancer-operator-policy.json
      POLICY_ARN=$(aws --region "$REGION" --query Policy.Arn \
      --output text iam create-policy \
      --policy-name aws-load-balancer-operator-policy \

--- a/cloud_experts_tutorials/cloud-experts-using-alb-and-waf.adoc
+++ b/cloud_experts_tutorials/cloud-experts-using-alb-and-waf.adoc
@@ -123,7 +123,7 @@ $ POLICY_ARN=$(aws iam list-policies --query \
      --output text)
 $ if [[ -z "${POLICY_ARN}" ]]; then
     wget -O "${SCRATCH}/load-balancer-operator-policy.json" \
-       https://raw.githubusercontent.com/rh-mobb/documentation/main/content/docs/rosa/aws-load-balancer-operator/load-balancer-operator-policy.json
+       https://raw.githubusercontent.com/rh-mobb/documentation/main/content/rosa/aws-load-balancer-operator/load-balancer-operator-policy.json
      POLICY_ARN=$(aws --region "$REGION" --query Policy.Arn \
      --output text iam create-policy \
      --policy-name aws-load-balancer-operator-policy \


### PR DESCRIPTION
Points to the updated location of content in the rh-mobb repository; it was [moved](https://github.com/rh-mobb/documentation/commit/9e3d3b9c21) from `content/docs` to `content/` a while back.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
