### PR TITLE
OSDOCS-10439 PID limit config support for ROSA with HCP

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -588,6 +588,7 @@ Topics:
     File: nodes-cluster-resource-configure
 - Name: Configuring PID limits
   File: rosa-configuring-pid-limits
+  Distros: openshift-rosa
 ---
 Name: Security and compliance
 Dir: security

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -552,9 +552,9 @@ Topics:
 #    File: rosa-cluster-auth
 #  - Name: Authorization and RBAC
 #    File: rosa-auth-rbac
-  - Name: Cluster notifications
-    File: rosa-cluster-notifications
-    Distros: openshift-rosa-hcp
+- Name: Cluster notifications
+  File: rosa-cluster-notifications
+  Distros: openshift-rosa-hcp
 # - Name: Configuring private connections
 #   Dir: cloud_infrastructure_access
 #   Distros: openshift-rosa-hcp
@@ -584,8 +584,9 @@ Topics:
 #     File: rosa-nodes-about-autoscaling-nodes
 #   - Name: Configuring cluster memory to meet container memory and risk requirements
 #     File: nodes-cluster-resource-configure
-# - Name: Configuring PID limits
-#   File: rosa-configuring-pid-limits
+- Name: Configuring PID limits
+  File: rosa-configuring-pid-limits
+  Distros: openshift-rosa
 # ---
 # Name: Security and compliance
 # Dir: security

--- a/modules/removing-custom-config-from-cluster.adoc
+++ b/modules/removing-custom-config-from-cluster.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa-configuring-pid-limits.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="removing-custom-config-from-cluster_{context}"]
+= Removing custom configuration from a cluster
+
+You can remove custom configuration from your cluster by removing the `KubeletConfig` object that contains the configuration details.
+
+.Prerequisites
+* You have an existing {product-title} cluster.
+* You have installed the ROSA CLI (rosa).
+* You have logged in to your Red Hat account by using the ROSA CLI.
+
+.Procedure
+
+* Remove custom configuration from the cluster by deleting the relevant custom `KubeletConfig` object:
++
+[source,terminal]
+----
+$ rosa delete kubeletconfig --cluster <cluster_name> --name <kubeletconfig_name>
+----
+
+.Verification steps
+* Confirm that the custom `KubeletConfig` object is not listed for the cluster:
++
+[source,terminal]
+----
+$ rosa describe kubeletconfig --name <cluster_name>
+----

--- a/modules/removing-custom-config-from-machinepool.adoc
+++ b/modules/removing-custom-config-from-machinepool.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa-configuring-pid-limits.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="removing-custom-config-from-machinepool_{context}"]
+= Removing custom configuration from a machine pool
+
+You can remove custom configuration on your machine pools by removing the `KubeletConfig` object that contains the configuration details.
+
+.Prerequisites
+* You have an existing {product-title} cluster.
+* You have installed the ROSA CLI (rosa).
+* You have logged in to your Red Hat account by using the ROSA CLI.
+
+.Procedure
+
+* Edit the machine pool and set the `--kubeletconfigs` parameter so that the `KubeletConfig` object you want to remove is omitted.
++
+To remove all `KubeletConfig` objects from the machine pool, set an empty value for the `--kubeletconfigs` parameter, for example:
++
+[source,terminal]
+----
+$ rosa edit machinepool -c <cluster_name> --kubeletconfigs="" --name <machinepool_name>
+----
+
+.Verification steps
+* Confirm that the `KubeletConfig` object you removed is not visible in the machine pool description:
++
+[source,terminal]
+----
+$ rosa describe machinepool --cluster <cluster_name> --name <machinepool_name>
+----

--- a/modules/rosa-create-objects.adoc
+++ b/modules/rosa-create-objects.adoc
@@ -645,12 +645,19 @@ $ rosa create ingress --cluster=mycluster --label-match=foo=bar,bar=baz
 [id="rosa-create-kubeletconfig_{context}"]
 == create kubeletconfig
 
-Create a custom `KubeletConfig` object for the cluster.
+Create a custom `KubeletConfig` object to allow custom configuration of nodes in a machine pool. For {product-title} clusters, these settings are cluster-wide. For {hcp-title-first} clusters, each machine pool can be configured differently.
+//TODO OSDOCS-10439: Add conditions back when HCP and Classic are published separately
+// ifdef::openshift-rosa-classic[]
+// cluster.
+// endif::openshift-rosa-classic[]
+// ifdef::openshift-rosa-hcp[]
+// machine pool.
+// endif::openshift-rosa-hcp[]
 
 .Syntax
 [source,terminal]
 ----
-$ rosa create kubeletconfig --cluster=<cluster_name|cluster_id> --pod-pids-limit=<number> [flags]
+$ rosa create kubeletconfig --cluster=<cluster_name|cluster_id> --name=<kubeletconfig_name> --pod-pids-limit=<number> [flags]
 ----
 
 .Flags
@@ -659,10 +666,27 @@ $ rosa create kubeletconfig --cluster=<cluster_name|cluster_id> --pod-pids-limit
 |Option |Definition
 
 |--pod-pids-limit <number>
-|Required. The maximum number of PIDs for the cluster.
+a|Required. The maximum number of PIDs for each node in the machine pool associated with the `KubeletConfig` object.
+//TODO OSDOCS-10439: Add conditions back when HCP and Classic are published separately
+// ifdef::openshift-rosa-classic[]
+// cluster.
+// endif::openshift-rosa-classic[]
+// ifdef::openshift-rosa-hcp[]
+// machine pool associated with the `KubeletConfig` object.
+// endif::openshift-rosa-hcp[]
 
 a|-c, --cluster <cluster_name>\|<cluster_id>
-|Required. The name or ID of the cluster for which the `KubeletConfig` object will be created.
+|Required. The name or ID of the cluster in which to create the `KubeletConfig` object.
+
+|--name
+a| Required for {hcp-title-first} clusters. Optional for {product-title}, as there is only one `KubeletConfig` for the cluster. Specifies a name for the `KubeletConfig` object.
+//TODO OSDOCS-10439: Add conditions back when HCP and Classic are published separately
+// ifdef::openshift-rosa-classic[]
+// Optional.
+// endif::openshift-rosa-classic[]
+// ifdef::openshift-rosa-hcp[]
+// Required.
+// endif::openshift-rosa-hcp[]
 
 |-i, --interactive
 |Enable interactive mode.
@@ -701,6 +725,12 @@ a|--cluster <cluster_name>\|<cluster_id>
 
 |--instance-type
 |The instance type (string) that should be used. Default: `m5.xlarge`
+
+//TODO OSDOCS-10439: Add conditions back when HCP and Classic are published separately
+//ifdef::openshift-rosa-hcp[]
+a|--kubelet-configs <kubeletconfig_name>
+| For {hcp-title-first} clusters, the names of any `KubeletConfig` objects to apply to nodes in a machine pool.
+//endif::openshift-rosa-hcp[]
 
 |--labels
 |The labels (string) for the machine pool. The format must be a comma-delimited list of key=value pairs. This list overwrites any modifications made to node labels on an ongoing basis.

--- a/modules/rosa-delete-objects.adoc
+++ b/modules/rosa-delete-objects.adoc
@@ -285,6 +285,16 @@ a|-c, --cluster <cluster_name>\|<cluster_id>
 |-h, --help
 |Shows help for this command.
 
+|--name
+a| Required for {hcp-title-first} clusters. Optional for {product-title}, as there is only one `KubeletConfig` for the cluster. Specifies a name for the `KubeletConfig` object.
+//TODO OSDOCS-10439: Add conditions back when HCP and Classic are published separately
+// ifdef::openshift-rosa-classic[]
+// Optional.
+// endif::openshift-rosa-classic[]
+// ifdef::openshift-rosa-hcp[]
+// Required.
+// endif::openshift-rosa-hcp[]
+
 |-y, --yes
 |Automatically answers `yes` to confirm the operation.
 

--- a/modules/rosa-edit-objects.adoc
+++ b/modules/rosa-edit-objects.adoc
@@ -171,12 +171,19 @@ $ rosa edit ingress --lb-type=nlb --cluster=mycluster apps2
 [id="rosa-edit-kubeletconfig_{context}"]
 == edit kubeletconfig
 
-Edit a custom `KubeletConfig` object in a cluster.
+Edit a custom `KubeletConfig` object in a machine pool.
+//TODO OSDOCS-10439: Add conditions back when HCP and Classic are published separately
+// ifdef::openshift-rosa-classic[]
+// cluster.
+// endif::openshift-rosa-classic[]
+// ifdef::openshift-rosa-hcp[]
+// machine pool.
+// endif::openshift-rosa-hcp[]
 
 .Syntax
 [source,terminal]
 ----
-$ rosa edit kubeletconfig --cluster=<cluster_name|cluster_id> --pod-pids-limit=<number> [flags]
+$ rosa edit kubeletconfig --cluster=<cluster_name|cluster_id> --name=<kubeletconfig_name> --pod-pids-limit=<number> [flags]
 ----
 
 .Flags
@@ -191,7 +198,24 @@ a|-c, --cluster <cluster_name>\|<cluster_id>
 |Enable interactive mode.
 
 |--pod-pids-limit <number>
-|Required. The maximum number of PIDs for the cluster.
+a|Required. The maximum number of PIDs for each node in the machine pool associated with the `KubeletConfig` object.
+//TODO OSDOCS-10439: Add conditions back when HCP and Classic are published separately
+// ifdef::openshift-rosa-classic[]
+// cluster.
+// endif::openshift-rosa-classic[]
+// ifdef::openshift-rosa-hcp[]
+// machine pool associated with the `KubeletConfig` object.
+// endif::openshift-rosa-hcp[]
+
+|--name
+a| Required for {hcp-title-first} clusters. Optional for {product-title}, as there is only one `KubeletConfig` for the cluster. Specifies a name for the `KubeletConfig` object.
+//TODO OSDOCS-10439: Add conditions back when HCP and Classic are published separately
+// ifdef::openshift-rosa-classic[]
+// Optional.
+// endif::openshift-rosa-classic[]
+// ifdef::openshift-rosa-hcp[]
+// Required.
+// endif::openshift-rosa-hcp[]
 
 |-h, --help
 |Shows help for this command.
@@ -223,6 +247,12 @@ $ rosa edit machinepool --cluster=<cluster_name> | <cluster_id> <machinepool_ID>
 
 |--labels
 |The labels (string) for the machine pool. The format must be a comma-delimited list of key=value pairs. Editing this value only affects newly created nodes of the machine pool, which are created by increasing the node number, and does not affect the existing nodes. This list overwrites any modifications made to node labels on an ongoing basis.
+
+//TODO OSDOCS-10439: Add conditions back when HCP and Classic are published separately
+//ifdef::openshift-rosa-hcp[]
+a|--kubelet-configs <kubeletconfig_name>
+| For {hcp-title-first} clusters, the names of any `KubeletConfig` objects to apply to nodes in a machine pool.
+//endif::openshift-rosa-hcp[]
 
 |--max-replicas
 |Specifies the maximum number of compute nodes when enabling autoscaling.
@@ -286,4 +316,11 @@ Modify the autoscaling range on a machine pool named `mp1` on a cluster named `m
 [source,terminal]
 ----
 $ rosa edit machinepool --max-replicas=9 --cluster=mycluster --name=mp1
+----
+
+Associate a `KubeletConfig` object with an existing machine pool on a {hcp-title-first} cluster.
+
+[source,terminal]
+----
+$ rosa edit machinepool -c mycluster --kubelet-configs=set-high-pids --name high-pid-pool
 ----

--- a/modules/rosa-list-objects.adoc
+++ b/modules/rosa-list-objects.adoc
@@ -287,6 +287,49 @@ List all instance types.
 $ rosa list instance-types
 ----
 
+[id="rosa-list-kubeletconfigs_{context}"]
+== list kubeletconfigs
+
+List the `KubeletConfig` objects configured on a cluster.
+
+.Syntax
+[source,terminal]
+----
+$ rosa list kubeletconfigs --cluster=<cluster_name> | <cluster_id> [arguments]
+----
+
+.Arguments
+[cols="30,70"]
+|===
+|Option |Definition
+
+|--cluster
+|Required: The name or ID (string) of the cluster that the machine pools will be listed for.
+|===
+
+.Optional arguments inherited from parent commands
+[cols="30,70"]
+|===
+|Option |Definition
+
+|--help
+|Shows help for this command.
+
+|--debug
+|Enables debug mode.
+
+// |--profile
+// |Specifies an AWS profile (string) from your credentials file.
+|===
+
+.Example
+List all of the `KubeletConfig` objects on a cluster named `mycluster`.
+
+[source,terminal]
+----
+$ rosa list kubeletconfigs --cluster=mycluster
+----
+
 [id="rosa-list-machinepools_{context}"]
 == list machinepools
 
@@ -670,6 +713,16 @@ a|-c, --cluster <cluster_name>\|<cluster_id>
 
 |-h, --help
 |Shows help for this command.
+
+|--name
+a| Optional. Specifies the name of the `KubeletConfig` object to describe.
+//TODO OSDOCS-10439: Add conditions back when HCP and Classic are published separately
+// ifdef::openshift-rosa-classic[]
+// Optional.
+// endif::openshift-rosa-classic[]
+// ifdef::openshift-rosa-hcp[]
+// Required.
+// endif::openshift-rosa-hcp[]
 
 |-o, --output string    
 |The output format. You can specify either `json` or `yaml`.

--- a/modules/setting-higher-pid-limit-on-existing-cluster.adoc
+++ b/modules/setting-higher-pid-limit-on-existing-cluster.adoc
@@ -4,9 +4,9 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="setting-higher-pid-limit-on-existing-cluster_{context}"]
-= Setting a higher PID limit on an existing {product-title} cluster
+= Setting a higher process ID limit on an existing {product-title} cluster
 
-You can set a higher `podPidsLimit` on an existing {product-title} cluster by creating or editing a `KubeletConfig` object that changes the `--pod-pids-limit` parameter.
+You can set a higher `podPidsLimit` on an existing {product-title} (ROSA) cluster by creating or editing a `KubeletConfig` object that changes the `--pod-pids-limit` parameter.
 
 [IMPORTANT]
 ====
@@ -15,17 +15,12 @@ Changing the `podPidsLimit` on an existing cluster will trigger non-control plan
 
 .Prerequisites
 
-* You have a ROSA Classic cluster.
-+
---
-:FeatureName: Configuring the maximum number of PIDs
-include::snippets/rosa-classic-support.adoc[]
---
+* You have a {product-title} cluster.
+* You have installed the ROSA CLI (`rosa`).
 * You have installed the OpenShift CLI (`oc`).
 * You have logged in to your Red Hat account by using the ROSA CLI.
 
 .Procedure
-
 . Create or edit the `KubeletConfig` object to change the PID limit.
 +
 --
@@ -33,21 +28,22 @@ include::snippets/rosa-classic-support.adoc[]
 +
 [source,terminal]
 ----
-$ rosa create kubeletconfig -c <cluster_name> --pod-pids-limit=<value>
+$ rosa create kubeletconfig -c <cluster_name> --name <kubeletconfig_name> --pod-pids-limit=<value>
 ----
++
+NOTE: The `--name` parameter is optional on ROSA Classic clusters, because only one `KubeletConfig` object is supported per ROSA Classic cluster.
 +
 For example, the following command sets a maximum of 16,384 PIDs per pod for cluster `my-cluster`:
 +
 [source,terminal]
 ----
-$ rosa create kubeletconfig -c my-cluster --pod-pids-limit=16384
+$ rosa create kubeletconfig -c my-cluster --name set-high-pids --pod-pids-limit=16384
 ----
-
 ** If you previously created a `KubeletConfig` object, edit the existing `KubeletConfig` object and set the `--pod-pids-limit` value by running the following command:
 +
 [source,terminal]
 ----
-$ rosa edit kubeletconfig -c <cluster_name> --pod-pids-limit=<value>
+$ rosa edit kubeletconfig -c <cluster_name> --name <kubeletconfig_name> --pod-pids-limit=<value>
 ----
 --
 +

--- a/modules/setting-higher-pid-limit-on-machinepool.adoc
+++ b/modules/setting-higher-pid-limit-on-machinepool.adoc
@@ -1,0 +1,84 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa-configuring-pid-limits.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="setting-higher-pid-limit-on-machine-pool_{context}"]
+= Setting a higher process ID limit on a machine pool in a {product-title} cluster
+
+You can set a higher `podPidsLimit` for machine pools in an existing {product-title} (ROSA) cluster by creating or editing a `KubeletConfig` object that changes the `--pod-pids-limit` parameter.
+
+[IMPORTANT]
+====
+Changing the `podPidsLimit` on an existing machine pool triggers nodes in the machine pool to reboot one at a time. Make this change outside of peak usage hours for workloads in your machine pool and avoid upgrading or hibernating your cluster until all nodes have rebooted.
+====
+
+.Prerequisites
+
+* You have a {product-title} cluster.
+* You have installed the ROSA CLI (`rosa`).
+* You have logged in to your Red Hat account by using the ROSA CLI.
+
+.Procedure
+
+. Create a new `KubeletConfig` object for your cluster that specifies a new `--pod-pids-limit`:
++
+[source,terminal]
+----
+$ rosa create kubeletconfig -c <cluster_name> --name=<kubeletconfig_name>  --pod-pids-limit=<value>
+----
++
+For example, the following command creates a `set-high-pids` `KubeletConfig` object for the `my-cluster` cluster that sets a maximum of 16,384 PIDs per pod:
++
+[source,terminal]
+----
+$ rosa create kubeletconfig -c my-cluster --name=set-high-pids --pod-pids-limit=16384
+----
+
+. Associate the new `KubeletConfig` object with a new or existing machine pool.
++
+--
+** For a new machine pool:
++
+[source,terminal]
+----
+$ rosa create machinepool -c <cluster_name> --kubelet-configs=<kubeletconfig_name> --name <machinepool_name>
+----
+** For an existing machine pool:
++
+[source,terminal]
+----
+$ rosa edit machinepool -c <cluster_name> --kubelet-configs=<kubeletconfig_name> --name <machinepool_name>
+----
+--
++
+For example, the following command associates the `set-high-pids` `KubeletConfig` object with the `high-pid-pool` machine pool in the `my-cluster` cluster:
++
+[source,terminal]
+----
+$ rosa edit machinepool -c my-cluster --kubelet-configs=set-high-pids --name=high-pid-pool
+----
++
+A rolling reboot of worker nodes is triggered when a new `KubeletConfig` object is attached to an existing machine pool. You can check the progress of the rollout in the machine pool description:
++
+[source,terminal]
+----
+$ rosa describe machinepool --cluster <cluster_name> --name <machinepool_name>
+----
+
+.Verification
+
+* Confirm that the new setting is in place on nodes in the machine pool:
++
+[source,terminal]
+----
+$ rosa describe kubeletconfig --cluster=<cluster_name> --name <kubeletconfig_name>
+----
++
+The new PIDs limit appears in the output, as shown in the following example:
++
+.Example output
+[source,terminal]
+----
+Pod Pids Limit:                       16384
+----

--- a/rosa_cluster_admin/rosa-configuring-pid-limits.adoc
+++ b/rosa_cluster_admin/rosa-configuring-pid-limits.adoc
@@ -23,8 +23,8 @@ In {product-title} 4.11 and later, by default, a pod can have a maximum of 4,096
 
 {product-title} clusters running versions earlier than 4.11 use a default PID limit of `1024`.
 
-:FeatureName: Configuring the maximum number of PIDs
-include::snippets/rosa-classic-support.adoc[]
+//Commenting out until this is confirmed a technology preview.
+//:FeatureName: Configuring the maximum number of PIDs
 
 // Understanding process ID limits
 include::modules/sd-understanding-process-id-limits.adoc[leveloffset=+1]
@@ -32,6 +32,7 @@ include::modules/sd-understanding-process-id-limits.adoc[leveloffset=+1]
 // Risks of setting higher process ID limits
 include::modules/risks-setting-higher-process-id-limits.adoc[leveloffset=+1]
 
+//TODO OSDOCS-10439: Confirm these links work when HCP docs are published separately.
 [role="_additional-resources"]
 .Additional resources
 
@@ -41,5 +42,24 @@ include::modules/risks-setting-higher-process-id-limits.adoc[leveloffset=+1]
 
 * xref:../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[Limits and scalability]
 
-// Setting a higher pid limit on an existing cluster
-include::modules/setting-higher-pid-limit-on-existing-cluster.adoc[leveloffset=+1]
+//TODO OSDOCS-10439: Add conditions back in and remove variant based headings when HCP docs are published separately
+// Setting or removing a higher pid limit on existing clusters
+//ifdef::openshift-rosa-classic[]
+[id="rosa-classic-configuring-pid-limits"]
+== Configuring PID limits on ROSA Classic clusters
+
+include::modules/setting-higher-pid-limit-on-existing-cluster.adoc[leveloffset=+2]
+
+include::modules/removing-custom-config-from-cluster.adoc[leveloffset=+2]
+//endif::openshift-rosa-classic[]
+
+
+//TODO OSDOCS-10439: Add conditions back in and remove variant based headings when HCP docs are published separately
+//ifdef::openshift-rosa-hcp[]
+[id="rosa-hcp-configuring-pid-limits"]
+== Configuring PID limits on ROSA with HCP clusters
+
+include::modules/setting-higher-pid-limit-on-machinepool.adoc[leveloffset=+2]
+
+include::modules/removing-custom-config-from-machinepool.adoc[leveloffset=+2]
+//endif::openshift-rosa-hcp[]


### PR DESCRIPTION
Version(s): 4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-10439

Link to docs preview:
https://75584--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli.html
https://75584--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa-configuring-pid-limits.html

QE review:
- [x] QE has approved this change.

Additional information:
Some comments are still included (`//TODO [OSDOCS-10439](https://issues.redhat.com//browse/OSDOCS-10439)`) as further changes to this content are expected once ROSA HCP and Classic docs are split in the near future.