### PR TITLE
RHDEVDOCS-5819 Update _distro_map.yml

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -345,6 +345,9 @@ openshift-gitops:
     gitops-docs-1.12:
       name: '1.12'
       dir: gitops/1.12
+    gitops-docs-1.13:
+      name: '1.13'
+      dir: gitops/1.13
 openshift-pipelines:
   name: Red Hat OpenShift Pipelines
   author: OpenShift documentation team <openshift-docs@redhat.com>


### PR DESCRIPTION
**Version(s):** `main` only

**Issue:**
-  [RHDEVDOCS 5819](https://issues.redhat.com/browse/RHDEVDOCS-5819)

**Link to docs preview:** N/A
**SME and QE review:** Not applicable


**Additional information:** This PR updates the distro map in main for the 1.13 GitOps standalone doc. It does not alter documentation content, so no documentation preview is available.