### PR TITLE
OSDOCS-4028#adding clarification

### DIFF
--- a/modules/nodes-descheduler-about.adoc
+++ b/modules/nodes-descheduler-about.adoc
@@ -25,7 +25,7 @@ When the descheduler decides to evict pods from a node, it employs the following
 
 * Pods in the `openshift-*` and `kube-system` namespaces are never evicted.
 * Critical pods with `priorityClassName` set to `system-cluster-critical` or `system-node-critical` are never evicted.
-* Static, mirrored, or stand-alone pods that are not part of a replication controller, replica set, deployment, or job are never evicted because these pods will not be recreated.
+* Static, mirrored, or stand-alone pods that are not part of a replication controller, replica set, deployment, StatefulSet, or job are never evicted because these pods will not be recreated.
 * Pods associated with daemon sets are never evicted.
 * Pods with local storage are never evicted.
 * Best effort pods are evicted before burstable and guaranteed pods.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Versions:
4.12, 4.13, 4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-4028

Link to docs preview:
https://75589--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/descheduler/index.html#nodes-descheduler-about_nodes-descheduler-about

QE review:
- [x] QE has approved this change (see comment in https://issues.redhat.com/browse/OSDOCS-4028)

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
