### PR TITLE
[enterprise-4.13] Removes unnecessary CIDR information from subnet parameter

### DIFF
--- a/modules/configuration-ovnk-network-plugin-json-object.adoc
+++ b/modules/configuration-ovnk-network-plugin-json-object.adoc
@@ -30,7 +30,7 @@ namespaces can communicate over the same secondary network. However, those two d
 
 |`subnets`
 |`string`
-| The subnet to use for the network across the cluster. When specifying `layer2` for the `topology`, only include the CIDR for the node. For example, `10.100.200.0/24`.
+|The subnet to use for the network across the cluster.
 
 For `"topology":"layer2"` deployments, IPv6 (`2001:DBB::/64`) and dual-stack (`192.168.100.0/24,2001:DBB::/64`) subnets are supported.
 


### PR DESCRIPTION
Cherry picked from 1d4675d5db166923514c22e2093b09f52ca4a3fd

XREF: https://github.com/openshift/openshift-docs/pull/75365