### PR TITLE
OSDOCS-10059 Updated Cluster Maximum Guidelines

### DIFF
--- a/modules/sd-planning-cluster-maximums.adoc
+++ b/modules/sd-planning-cluster-maximums.adoc
@@ -19,23 +19,16 @@ ifdef::openshift-dedicated[]
 endif::[]
 cluster.
 
-These guidelines are based on a cluster of 102 compute (also known as worker) nodes in a multiple availability zone configuration. For smaller clusters, the maximums are lower.
+These guidelines are based on a cluster of 180 compute (also known as worker) nodes in a multiple availability zone configuration. For smaller clusters, the maximums are lower.
 
-[NOTE]
-====
-The OpenShift Container Platform version used in all of the tests is OCP 4.8.0.
-====
 
 .Tested cluster maximums
 [options="header",cols="50,50"]
 |===
-|Maximum type |4.8 tested maximum
-
-|Number of nodes
-|102
+|Maximum type |4.x tested maximum
 
 |Number of pods ^[1]^
-|20,400
+|25,000
 
 |Number of pods per node
 |250
@@ -44,29 +37,27 @@ The OpenShift Container Platform version used in all of the tests is OCP 4.8.0.
 |There is no default value
 
 |Number of namespaces ^[2]^
-|3,400
+|5,000
 
 |Number of pods per namespace ^[3]^
-|20,400
+|25,000
 
 |Number of services ^[4]^
 |10,000
 
 |Number of services per namespace
-|10,000
+|5,000
 
 |Number of back ends per service
-|10,000
+|5,000
 
 |Number of deployments per namespace ^[3]^
-|1,000
+|2,000
 |===
 [.small]
 --
-1. The pod count displayed here is the number of test pods. The actual number of pods depends on the application’s memory, CPU, and storage requirements.
+1. The pod count displayed here is the number of test pods. The actual number of pods depends on the memory, CPU, and storage requirements of the application.
 2. When there are a large number of active projects, etcd can suffer from poor performance if the keyspace grows excessively large and exceeds the space quota. Periodic maintenance of etcd, including defragmentation, is highly recommended to make etcd storage available.
-3. There are a number of control loops in the system that must iterate over all objects in a given namespace as a reaction to some changes in state. Having a large number of objects of a type, in a single namespace, can make those loops expensive and slow down processing the state changes. The limit assumes that the system has enough CPU, memory, and disk to satisfy the application requirements.
-4. Each service port and each service back end has a corresponding entry in iptables. The number of back ends of a given service impacts the size of the endpoints objects, which then impacts the size of data that is sent throughout the system.
+3. There are several control loops in the system that must iterate over all objects in a given namespace as a reaction to some changes in state. Having a large number of objects of a type, in a single namespace, can make those loops expensive and slow down processing the state changes. The limit assumes that the system has enough CPU, memory, and disk to satisfy the application requirements.
+4. Each service port and each service back end has a corresponding entry in `iptables`. The number of back ends of a given service impacts the size of the endpoints objects, which then impacts the size of data sent throughout the system.
 --
-
-In OpenShift Container Platform 4.8, half of a CPU core (500 millicore) is reserved by the system compared to previous versions of OpenShift Container Platform.


### PR DESCRIPTION
Updated cluster maximums table to make it complaint with 4.x in ROSA and HCP. 

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.16 +
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-10059

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://75611--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-limits-scalability.html
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
