### PR TITLE
Fixing tables with no borders

### DIFF
--- a/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
+++ b/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
@@ -14,8 +14,7 @@ Red Hat does not test every combination of firmware, hardware, or other third-pa
 ====
 
 .Firmware compatibility for HP hardware with Redfish virtual media
-[frame="topbot", options="header"]
-[cols="1,1,1"]
+[cols="1,1,1",options="header"]
 |====
 | Model | Management | Firmware versions
 | 10th Generation | iLO5 | 2.63 or later
@@ -23,7 +22,7 @@ Red Hat does not test every combination of firmware, hardware, or other third-pa
 |====
 
 .Firmware compatibility for Dell hardware with Redfish virtual media
-[frame="topbot", options="header"]
+[cols="1,1,1",options="header"]
 |====
 | Model | Management | Firmware versions
 


### PR DESCRIPTION
This PR fixes tables with incorrect format. No QE needed. 

[Preview](https://75615--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#ipi-install-firmware-requirements-for-installing-with-virtual-media_ipi-install-prerequisites).  Table 1 and 2 have borders; currently, the tables have no border.  See [current docs](https://docs.openshift.com/container-platform/4.15/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#ipi-install-firmware-requirements-for-installing-with-virtual-media_ipi-install-prerequisites).