### PR TITLE
HCIDOCS-302: [doc] Remove terraform from BM IPI installer

### DIFF
--- a/modules/ipi-install-troubleshooting-cleaning-up-previous-installations.adoc
+++ b/modules/ipi-install-troubleshooting-cleaning-up-previous-installations.adoc
@@ -31,10 +31,3 @@ do
   sudo virsh pool-undefine $i;
 done
 ----
-
-. Remove the following from the `clusterconfigs` directory to prevent Terraform from failing:
-+
-[source,terminal]
-----
-$ rm -rf ~/clusterconfigs/auth ~/clusterconfigs/terraform* ~/clusterconfigs/tls ~/clusterconfigs/metadata.json
-----


### PR DESCRIPTION
Removed terraform content from IPI install.

Fixes: [HCIDOCS-302](https://issues.redhat.com//browse/HCIDOCS-302)

See https://issues.redhat.com/browse/HCIDOCS-302 for additional details.

Preview URL: http://184.23.213.161:8080/HCIDOCS-302/installing/installing_bare_metal_ipi/ipi-install-troubleshooting.html#ipi-install-troubleshooting-cleaning-up-previous-installations_ipi-install-troubleshooting

For release(s): 4.16
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
