### PR TITLE
TELCODOCS-1509: RN for new feature

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -125,6 +125,13 @@ With this release, OVN-Kubernetes uses a new `DNSNameResolver` custom resource t
 
 For more information, see xref:../networking/openshift_network_security/configuring-egress-firewall-ovn.adoc#nw-coredns-egress-firewall[Improved DNS resolution and resolving wildcard domain names].
 
+[id="ocp-4-16-networking-sriov-draining"]
+==== Parallel node draining during SR-IOV network policy updates
+
+With this update, you can configure the SR-IOV Network Operator to drain nodes in parallel during network policy updates. The option to drain nodes in parallel enables faster rollouts of SR-IOV network configurations. You can use the `SriovNetworkPoolConfig` custom resource to configure parallel node draining and define the maximum number of nodes in the pool that the Operator can drain in parallel.
+
+For further information, see xref:../networking/hardware_networks/configuring-sriov-device.adoc#configure-sr-iov-operator-parallel-nodes_configuring-sriov-device[Configuring parallel node draining during SR-IOV network policy updates].
+
 [id="ocp-4-16-registry"]
 === Registry
 


### PR DESCRIPTION
[TELCODOCS-1509](https://issues.redhat.com//browse/TELCODOCS-1509): RN for parallel draining option for SR-IOV Network Operator

Version(s):
4.16

Issue:
https://issues.redhat.com/browse/TELCODOCS-1509

Link to docs preview:
https://file.emea.redhat.com/rohennes/TELCODOCS-1509-RN/release_notes/ocp-4-16-release-notes.html#ocp-4-16-networking-sriov-draining

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


