### PR TITLE
OSDOCS-9535: RHEL 9.2 Micro-architecture update 4.14+

### DIFF
--- a/updating/preparing_for_updates/updating-cluster-prepare.adoc
+++ b/updating/preparing_for_updates/updating-cluster-prepare.adoc
@@ -14,6 +14,16 @@ To do: Remove this comment once 4.13 docs are EOL.
 
 Learn more about administrative tasks that cluster admins must perform to successfully initialize an update, as well as optional guidelines for ensuring a successful update.
 
+[id="rhel-micro-architecture-update-requirements"]
+== {op-system-base} 9.2 micro-architecture requirement change
+
+{product-title} is now based on the {op-system-base} 9.2 host operating system. The micro-architecture requirements are now increased to x86_64-v2, Power9, and Z14. See the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/9.0_release_notes/index#architectures[RHEL micro-architecture requirements documentation]. You can verify compatibility before updating by following the procedures outlined in this link:https://access.redhat.com/solutions/7052996[KCS article].
+
+[IMPORTANT]
+====
+Without the correct micro-architecture requirements, the update process will fail. Make sure you purchase the appropriate subscription for each architecture. For more information, see link:https://access.redhat.com/products/red-hat-enterprise-linux#addl-arch[Get Started with Red Hat Enterprise Linux - additional architectures]
+====
+
 [id="kube-api-removals_{context}"]
 == Kubernetes API removals
 


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-9535](https://issues.redhat.com/browse/OSDOCS-9535)

Link to docs preview:
https://75626--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
No change management required - confirmed 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
