### PR TITLE
OSDOCS-10416: Support cluster migration to Entra Workload ID

### DIFF
--- a/modules/cco-ccoctl-configuring.adoc
+++ b/modules/cco-ccoctl-configuring.adoc
@@ -1,11 +1,14 @@
 // Module included in the following assemblies:
 //
+//Postinstall  and update content
+// * post_installation_configuration/cluster-tasks.adoc
+// * updating/preparing_for_updates/preparing-manual-creds-update.adoc
+//
 //Platforms that must use `ccoctl` and update content
 // * installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc
 // * installing/installing_ibm_powervs/preparing-to-install-on-ibm-power-vs.doc
 // * installing/installing_alibaba/manually-creating-alibaba-ram.adoc
 // * installing/installing_nutanix/preparing-to-install-on-nutanix.adoc
-// * updating/preparing_for_updates/preparing-manual-creds-update.adoc
 //
 // AWS assemblies:
 // * installing/installing_aws/installing-aws-customizations.adoc
@@ -34,7 +37,15 @@
 // * installing/installing_azure/installing-azure-vnet.adoc
 // * installing/installing_azure/installing-restricted-networks-azure-installer-provisioned.adoc
 
-//Platforms that must use `ccoctl` and update content
+//Postinstall  and update content
+ifeval::["{context}" == "post-install-cluster-tasks"]
+:postinstall:
+endif::[]
+ifeval::["{context}" == "preparing-manual-creds-update"]
+:update:
+endif::[]
+
+//Platforms that must use `ccoctl`
 ifeval::["{context}" == "configuring-iam-ibm-cloud"]
 :ibm-cloud:
 endif::[]
@@ -43,9 +54,6 @@ ifeval::["{context}" == "manually-creating-alibaba-ram"]
 endif::[]
 ifeval::["{context}" == "preparing-to-install-on-nutanix"]
 :nutanix:
-endif::[]
-ifeval::["{context}" == "preparing-manual-creds-update"]
-:update:
 endif::[]
 ifeval::["{context}" == "preparing-to-install-on-ibm-power-vs"]
 :ibm-power-vs:
@@ -138,10 +146,15 @@ ifdef::ibm-power-vs[]
 The Cloud Credential Operator (CCO) manages cloud provider credentials as Kubernetes custom resource definitions (CRDs). To install a cluster on {ibm-power-server-name}, you must set the CCO to `manual` mode as part of the installation process.
 endif::ibm-power-vs[]
 
-//Alibaba Cloud uses ccoctl, but creates different kinds of resources than other clouds, so this applies to everyone else. The upgrade procs also have a different intro, so they are excluded here.
-ifndef::alibabacloud,update[]
+//Alibaba Cloud uses ccoctl, but creates different kinds of resources than other clouds, so this applies to everyone else. The upgrade and postinstall procs also have a different intro, so they are excluded here.
+ifndef::alibabacloud,update,postinstall[]
 To create and manage cloud credentials from outside of the cluster when the Cloud Credential Operator (CCO) is operating in manual mode, extract and prepare the CCO utility (`ccoctl`) binary.
-endif::alibabacloud,update[]
+endif::alibabacloud,update,postinstall[]
+
+//Intro for the postinstall procs.
+ifdef::postinstall[]
+To configure an existing cluster to create and manage cloud credentials from outside of the cluster, extract and prepare the Cloud Credential Operator utility (`ccoctl`) binary.
+endif::postinstall[]
 
 //Intro for the upgrade procs.
 ifdef::update[]
@@ -317,14 +330,19 @@ endif::google-cloud-platform[]
 
 .Procedure
 
-ifndef::update[]
-. Obtain the {product-title} release image by running the following command:
+. Set a variable for the {product-title} release image by running the following command:
 +
 [source,terminal]
+ifndef::update,postinstall[]
 ----
 $ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}')
 ----
-endif::update[]
+endif::update,postinstall[]
+ifdef::update,postinstall[]
+----
+$ RELEASE_IMAGE=$(oc get clusterversion -o jsonpath={..desired.image})
+----
+endif::update,postinstall[]
 
 . Obtain the CCO container image from the {product-title} release image by running the following command:
 +
@@ -384,6 +402,14 @@ Flags:
 Use "ccoctl [command] --help" for more information about a command.
 ----
 
+//Postinstall and update content
+ifeval::["{context}" == "post-install-cluster-tasks"]
+:!postinstall:
+endif::[]
+ifeval::["{context}" == "preparing-manual-creds-update"]
+:!update:
+endif::[]
+
 //Platforms that must use `ccoctl` and update content
 ifeval::["{context}" == "configuring-iam-ibm-cloud"]
 :!ibm-cloud:
@@ -393,9 +419,6 @@ ifeval::["{context}" == "manually-creating-alibaba-ram"]
 endif::[]
 ifeval::["{context}" == "preparing-to-install-on-nutanix"]
 :!nutanix:
-endif::[]
-ifeval::["{context}" == "preparing-manual-creds-update"]
-:!update:
 endif::[]
 ifeval::["{context}" == "preparing-to-install-on-ibm-power-vs"]
 :!ibm-power-vs:

--- a/modules/cco-ccoctl-install-verifying.adoc
+++ b/modules/cco-ccoctl-install-verifying.adoc
@@ -1,12 +1,13 @@
 // Module included in the following assemblies:
 //
 // * installing/validating-an-installation.adoc
+// * post_installation_configuration/cluster-tasks.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="cco-ccoctl-install-verifying_{context}"]
-= Clusters that use short-term credentials: Verifying the credentials configuration
+= Verifying that a cluster uses short-term credentials
 
-You can verify that your cluster is using short-term security credentials for individual components.
+You can verify that a cluster uses short-term security credentials for individual components by checking the Cloud Credential Operator (CCO) configuration and other values in the cluster.
 
 .Prerequisites
 
@@ -14,16 +15,32 @@ You can verify that your cluster is using short-term security credentials for in
 
 * You installed the {oc-first}.
 
+* You are logged in as a user with `cluster-admin` privileges.
 
 .Procedure
 
-. Log in as a user with `cluster-admin` privileges.
-
-. Verify that the cluster does not have `root` credentials by running the following command:
+* Verify that the CCO is configured to operate in manual mode by running the following command:
 +
 [source,terminal]
 ----
-$ oc get secrets -n kube-system <secret_name>
+$ oc get cloudcredentials cluster \
+  -o=jsonpath={.spec.credentialsMode}
+----
++
+The following output confirms that the CCO is operating in manual mode:
++
+.Example output
+[source,text]
+----
+Manual
+----
+
+* Verify that the cluster does not have `root` credentials by running the following command:
++
+[source,terminal]
+----
+$ oc get secrets \
+  -n kube-system <secret_name>
 ----
 +
 where `<secret_name>` is the name of the root secret for your cloud provider.
@@ -33,26 +50,26 @@ where `<secret_name>` is the name of the root secret for your cloud provider.
 |Platform
 |Secret name
 
-|AWS
+|{aws-first}
 |`aws-creds`
 
-|Azure
+|{azure-first}
 |`azure-credentials`
 
-|GCP
+|{gcp-first}
 |`gcp-credentials`
 
 |===
 +
-An error confirms that the root secret is not present on the cluster. The following example shows the expected output from an AWS cluster:
+An error confirms that the root secret is not present on the cluster.
 +
-.Example output
+.Example output for an {aws-short} cluster
 [source,text]
 ----
 Error from server (NotFound): secrets "aws-creds" not found
 ----
 
-. Verify that the components are using short-term security credentials for individual components by running the following command:
+* Verify that the components are using short-term security credentials for individual components by running the following command:
 +
 [source,terminal]
 ----
@@ -61,4 +78,32 @@ $ oc get authentication cluster \
   --template='{ .spec.serviceAccountIssuer }'
 ----
 +
-This command displays the value of the `.spec.serviceAccountIssuer` parameter in the cluster `Authentication` object. An output of a URL that is associated with your cloud provider indicates that the cluster is using manual mode with short-term credentials that are created and managed from outside of the cluster.
+This command displays the value of the `.spec.serviceAccountIssuer` parameter in the cluster `Authentication` object.
+An output of a URL that is associated with your cloud provider indicates that the cluster is using manual mode with short-term credentials that are created and managed from outside of the cluster.
+
+* {azure-short} clusters: Verify that the components are assuming the {azure-short} client ID that is specified in the secret manifests by running the following command:
++
+[source,terminal]
+----
+$ oc get secrets \
+  -n openshift-image-registry installer-cloud-credentials \
+  -o jsonpath='{.data}'
+----
++
+An output that contains the `azure_client_id` and `azure_federated_token_file` felids confirms that the components are assuming the {azure-short} client ID.
+
+* {azure-short} clusters: Verify that the pod identity webhook is running by running the following command:
++
+[source,terminal]
+----
+$ oc get pods \
+  -n openshift-cloud-credential-operator
+----
++
+.Example output
+[source,text]
+----
+NAME                                         READY   STATUS    RESTARTS   AGE
+cloud-credential-operator-59cf744f78-r8pbq   2/2     Running   2          71m
+pod-identity-webhook-548f977b4c-859lz        1/1     Running   1          70m
+----

--- a/modules/enabling-entra-workload-id-existing-cluster.adoc
+++ b/modules/enabling-entra-workload-id-existing-cluster.adoc
@@ -1,0 +1,249 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="enabling-entra-workload-id-existing-cluster_{context}"]
+= Enabling {entra-first} on an existing cluster
+
+If you did not configure your {azure-first} {product-title} cluster to use {entra-first} during installation, you can enable this authentication method on an existing cluster.
+
+[IMPORTANT]
+====
+The process to enable {entra-short} on an existing cluster is disruptive and takes a significant amount of time.
+Before proceeding, observe the following considerations:
+
+* Read the following steps and ensure that you understand and accept the time requirement.
+The exact time requirement varies depending on the individual cluster, but it is likely to require at least one hour.
+
+* During this process, you must refresh all service accounts and restart all pods on the cluster.
+These actions are disruptive to workloads.
+To mitigate this impact, you can temporarily halt these services and then redeploy them when the cluster is ready.
+
+* After starting this process, do not attempt to update the cluster until it is complete.
+If an update is triggered, the process to enable {entra-short} on an existing cluster fails.
+====
+
+.Prerequisites
+
+* You have installed an {product-title} cluster on {azure-first}.
+* You have access to the cluster using an account with `cluster-admin` permissions.
+* You have installed the {oc-first}.
+* You have extracted and prepared the Cloud Credential Operator utility (`ccoctl`) binary.
+* You have access to your {azure-short} account by using the {azure-short} CLI (`az`).
+
+.Procedure
+
+. Create an output directory for the manifests that the `ccoctl` utility generates.
+This procedure uses `./output_dir` as an example.
+
+. Extract the service account public signing key for the cluster to the output directory by running the following command:
++
+[source,terminal]
+----
+$ oc get configmap \
+  --namespace openshift-kube-apiserver bound-sa-token-signing-certs \
+  --output 'go-template={{index .data "service-account-001.pub"}}' > ./output_dir/serviceaccount-signer.public <1>
+----
+<1> This procedure uses a file named `serviceaccount-signer.public` as an example.
+
+. Use the extracted service account public signing key to create an OpenID Connect (OIDC) issuer and {azure-short} blob storage container with OIDC configuration files by running the following command:
++
+[source,terminal]
+----
+$ ./ccoctl azure create-oidc-issuer \
+  --name <azure_infra_name> \// <1>
+  --output-dir ./output_dir \
+  --region <azure_region> \// <2>
+  --subscription-id <azure_subscription_id> \// <3>
+  --tenant-id <azure_tenant_id> \
+  --public-key-file ./output_dir/serviceaccount-signer.public <4>
+----
+<1> The value of the `name` parameter is used to create an Azure resource group.
+To use an existing Azure resource group instead of creating a new one, specify the `--oidc-resource-group-name` argument with the existing group name as its value.
+<2> Specify the region of the existing cluster.
+<3> Specify the subscription ID of the existing cluster.
+<4> Specify the file that contains the service account public signing key for the cluster.
+
+. Verify that the configuration file for the Azure pod identity webhook was created by running the following command:
++
+[source,terminal]
+----
+$ ll ./output_dir/manifests
+----
++
+.Example output
++
+[source,text]
+----
+total 8
+-rw-------. 1 cloud-user cloud-user 193 May 22 02:29 azure-ad-pod-identity-webhook-config.yaml <1>
+-rw-------. 1 cloud-user cloud-user 165 May 22 02:29 cluster-authentication-02-config.yaml
+----
+<1> The file `azure-ad-pod-identity-webhook-config.yaml` contains the Azure pod identity webhook configuration.
+
+. Set an `OIDC_ISSUER_URL` variable with the OIDC issuer URL from the generated manifests in the output directory by running the following command:
++
+[source,terminal]
+----
+$ OIDC_ISSUER_URL=`awk '/serviceAccountIssuer/ { print $2 }' ./output_dir/manifests/cluster-authentication-02-config.yaml`
+----
+
+. Update the `spec.serviceAccountIssuer` parameter of the cluster `authentication` configuration by running the following command:
++
+[source,terminal]
+----
+$ oc patch authentication cluster \
+  --type=merge \
+  -p "{\"spec\":{\"serviceAccountIssuer\":\"${OIDC_ISSUER_URL}\"}}"
+----
+
+. Monitor the configuration update progress by running the following command:
++
+[source,terminal]
+----
+$ oc adm wait-for-stable-cluster
+----
++
+This process might take 15 minutes or longer.
+The following output indicates that the process is complete:
++
+[source,text]
+----
+All clusteroperators are stable
+----
+
+. Restart all of the pods in the cluster by running the following command:
++
+[source,terminal]
+----
+$ oc adm reboot-machine-config-pool mcp/worker mcp/master
+----
++
+Restarting a pod updates the `serviceAccountIssuer` field and refreshes the service account public signing key.
+
+. Monitor the restart and update process by running the following command:
++
+[source,terminal]
+----
+$ oc adm wait-for-node-reboot nodes --all
+----
++
+This process might take 15 minutes or longer.
+The following output indicates that the process is complete:
++
+[source,text]
+----
+All nodes rebooted
+----
+
+. Update the Cloud Credential Operator `spec.credentialsMode` parameter to `Manual` by running the following command:
++
+[source,terminal]
+----
+$ oc patch cloudcredential cluster \
+  --type=merge \
+  --patch '{"spec":{"credentialsMode":"Manual"}}'
+----
+
+. Extract the list of `CredentialsRequest` objects from the {product-title} release image by running the following command:
++
+[source,terminal]
+----
+$ oc adm release extract \
+  --credentials-requests \
+  --included \
+  --to <path_to_directory_for_credentials_requests> \
+  --registry-config ~/.pull-secret
+----
++
+[NOTE]
+====
+This command might take a few moments to run.
+====
+
+. Set an `AZURE_INSTALL_RG` variable with the {azure-short} resource group name by running the following command:
++
+[source,terminal]
+----
+$ AZURE_INSTALL_RG=`oc get infrastructure cluster -o jsonpath --template '{ .status.platformStatus.azure.resourceGroupName }'`
+----
+
+. Use the `ccoctl` utility to create managed identities for all `CredentialsRequest` objects by running the following command:
++
+[source,terminal]
+----
+$ ccoctl azure create-managed-identities \
+  --name <azure_infra_name> \
+  --output-dir ./output_dir \
+  --region <azure_region> \
+  --subscription-id <azure_subscription_id> \
+  --credentials-requests-dir <path_to_directory_for_credentials_requests> \
+  --issuer-url "${OIDC_ISSUER_URL}" \
+  --dnszone-resource-group-name <azure_dns_zone_resourcegroup_name> \// <1>
+  --installation-resource-group-name "${AZURE_INSTALL_RG}"
+----
+<1> Specify the name of the resource group that contains the DNS zone.
+
+. Apply the {azure-short} pod identity webhook configuration for {entra-short} by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f ./output_dir/manifests/azure-ad-pod-identity-webhook-config.yaml
+----
+
+. Apply the secrets generated by the `ccoctl` utility by running the following command:
++
+[source,terminal]
+----
+$ find ./output_dir/manifests -iname "openshift*yaml" -print0 | xargs -I {} -0 -t oc replace -f {}
+----
++
+This process might take several minutes.
+
+
+. Restart all of the pods in the cluster by running the following command:
++
+[source,terminal]
+----
+$ oc adm reboot-machine-config-pool mcp/worker mcp/master
+----
++
+Restarting a pod updates the `serviceAccountIssuer` field and refreshes the service account public signing key.
+
+. Monitor the restart and update process by running the following command:
++
+[source,terminal]
+----
+$ oc adm wait-for-node-reboot nodes --all
+----
++
+This process might take 15 minutes or longer.
+The following output indicates that the process is complete:
++
+[source,text]
+----
+All nodes rebooted
+----
+
+. Monitor the configuration update progress by running the following command:
++
+[source,terminal]
+----
+$ oc adm wait-for-stable-cluster
+----
++
+This process might take 15 minutes or longer.
+The following output indicates that the process is complete:
++
+[source,text]
+----
+All clusteroperators are stable
+----
+
+. Optional: Remove the {azure-short} root credentials secret by running the following command:
++
+[source,terminal]
+----
+$ oc delete secret -n kube-system azure-credentials
+----

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -717,6 +717,28 @@ include::modules/manually-removing-cloud-creds.adoc[leveloffset=+2]
 * xref:../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc#about-cloud-credential-operator[About the Cloud Credential Operator]
 * xref:../authentication/managing_cloud_provider_credentials/cco-mode-passthrough.adoc#admin-credentials-root-secret-formats_cco-mode-passthrough[Admin credentials root secret format]
 
+[id="post-install-enable-token-auth"]
+== Enabling token-based authentication
+//Today, just Entra. But this should be a section that anticipates the addition of AWS STS and GCP WID.
+
+After installing an {azure-first} {product-title} cluster, you can enable {entra-first} to use short-term credentials.
+
+To determine which cloud credentials strategy your cluster uses, see xref:../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc#cco-determine-mode_about-cloud-credential-operator[Determining the Cloud Credential Operator mode].
+
+//Configuring the Cloud Credential Operator utility
+include::modules/cco-ccoctl-configuring.adoc[leveloffset=+2]
+
+//Enabling {entra-first} on an existing cluster
+include::modules/enabling-entra-workload-id-existing-cluster.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc#cco-short-term-creds-azure_cco-short-term-creds[Microsoft Entra Workload ID]
+* xref:../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-with-short-term-creds_installing-azure-customizations[Configuring an Azure cluster to use short-term credentials]
+
+//Verifying the credentials configuration
+include::modules/cco-ccoctl-install-verifying.adoc[leveloffset=+2]
+
 [id="post-install-must-gather-disconnected"]
 == Configuring image streams for a disconnected cluster
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-10416](https://issues.redhat.com//browse/OSDOCS-10416)

Link to docs preview:
[Enabling token-based authentication](https://75627--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#post-install-enable-token-auth)

QE review:
- [x] QE has approved this change.

Additional information: