### PR TITLE
OSDOCS#9535 updating install requirements for RHEL 9.2

### DIFF
--- a/modules/installation-minimum-resource-requirements.adoc
+++ b/modules/installation-minimum-resource-requirements.adoc
@@ -240,6 +240,17 @@ ifdef::vsphere[]
 2. As with all user-provisioned installations, if you choose to use {op-system-base} compute machines in your cluster, you take responsibility for all operating system life cycle management and maintenance, including performing system updates, applying patches, and completing all other required tasks. Use of {op-system-base} 7 compute machines is deprecated and has been removed in {product-title} 4.10 and later.
 endif::vsphere[]
 --
+[NOTE]
+====
+As of {product-title} version 4.13, RHCOS is based on RHEL version 9.2, which updates the micro-architecture requirements. The following list contains the minimum instruction set architectures (ISA) that each architecture requires:
+
+* x86-64 architecture requires x86-64-v2 ISA
+* ARM64 architecture requires ARMv8.0-A ISA
+* IBM Power architecture requires Power 9 ISA
+* s390x architecture requires z14 ISA
+
+For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/9.0_release_notes/index#architectures[RHEL Architectures].
+====
 
 ifdef::azure[]
 [IMPORTANT]

--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -41,6 +41,10 @@ You must ensure that the time on your ESXi hosts is synchronized before you inst
 |Optional: Networking (NSX-T)
 |vSphere 7.0 Update 2 or later; vSphere 8.0 Update 1 or later
 |At a minimum, vSphere 7.0 Update 2 or vSphere 8.0 Update 1 is required for {product-title}. For more information about the compatibility of NSX and {product-title}, see the Release Notes section of VMware's link:https://docs.vmware.com/en/VMware-NSX-Container-Plugin/index.html[NSX container plugin documentation].
+
+|CPU micro-architecture
+|x86-64-v2 or higher
+|OpenShift 4.13 and later are based on RHEL 9.2 host operating system which raised the microarchitecture requirements to x86-64-v2. See the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/9.0_release_notes/index#architectures[RHEL Microarchitecture requirements documentation]. You can verify compatibility by following the procedures outlined in link:https://access.redhat.com/solutions/7052996[this KCS article].
 |===
 
 [IMPORTANT]


### PR DESCRIPTION
Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-9535

Link to docs preview:
[AWS install with customizations](https://75630--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-customizations.html)
[vSphere installation requirements](https://75630--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.html)
[same change applies to AWS, GCP, Azure, and IBM install docs]

QE review:
- [x] QE has approved this change.

