### PR TITLE
OSDOCS#10469: Removed inapplicable architecture content in ROSA/OSD docs

### DIFF
--- a/architecture/control-plane.adoc
+++ b/architecture/control-plane.adoc
@@ -2,25 +2,34 @@
 [id="control-plane"]
 = Control plane architecture
 include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: control-plane
 
 toc::[]
 
-The _control plane_, which is composed of control plane machines, manages the {product-title} cluster. The control plane machines manage workloads on the compute machines, which are also known as worker machines. The cluster itself manages all upgrades to the machines by the actions of the Cluster Version Operator (CVO), the Machine Config Operator, and a set of individual Operators.
+The _control plane_, which is composed of control plane machines, manages the {product-title} cluster.
+The control plane machines manage workloads on the compute machines, which are also known as worker machines.
+The cluster itself manages all upgrades to the machines by the actions of the Cluster Version Operator (CVO),
+ifndef::openshift-dedicated,openshift-rosa[]
+the Machine Config Operator,
+endif::openshift-dedicated,openshift-rosa[]
+and a set of individual Operators.
 
+ifdef::openshift-rosa[]
+:FeatureName: This control plane architecture
+include::snippets/rosa-classic-support.adoc[]
+endif::openshift-rosa[]
+
+// This module does not apply to OSD/ROSA
+ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/architecture-machine-config-pools.adoc[leveloffset=+1]
+endif::openshift-dedicated,openshift-rosa[]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
-ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../post_installation_configuration/machine-configuration-tasks.adoc#machine-config-drift-detection_post-install-machine-configuration-tasks[Understanding configuration drift detection]
 endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-rosa[]
-* xref:../rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.adoc#machine-pools[Machine pools]
-endif::openshift-rosa[]
-ifdef::openshift-dedicated[]
-* xref:../osd_cluster_admin/osd_nodes/osd-nodes-machinepools-about.adoc#machine-pools[Machine pools]
-endif::openshift-dedicated[]
 
 include::modules/architecture-machine-roles.adoc[leveloffset=+1]
 
@@ -52,7 +61,10 @@ include::modules/arch-platform-operators.adoc[leveloffset=+2]
 * xref:../installing/cluster-capabilities.adoc#cluster-capabilities[Cluster capabilities]
 endif::[]
 
+// This module does not apply to OSD/ROSA
+ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/understanding-machine-config-operator.adoc[leveloffset=+1]
+endif::openshift-dedicated,openshift-rosa[]
 
 // These additional resources do not apply to OSD/ROSA
 ifndef::openshift-dedicated,openshift-rosa[]


### PR DESCRIPTION
This PR is to remove two modules that were incorrectly included in a content port from OCP (#70602). These two modules do not apply to ROSA Classic or OSD.

Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-10469

Link to docs preview:

- OSD Docs Update: [Control plane architecture](https://75649--ocpdocs-pr.netlify.app/openshift-dedicated/latest/architecture/control-plane.html)

- ROSA Docs Update: [Control plane architecture](https://75649--ocpdocs-pr.netlify.app/openshift-rosa/latest/architecture/control-plane.html)

Peer review:
- [x] Peer reviewer has approved this change.

QE review:
- [x] QE has approved this change.  
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
