### PR TITLE
OBSDOCS-1041

### DIFF
--- a/modules/cluster-logging-deploy-cli.adoc
+++ b/modules/cluster-logging-deploy-cli.adoc
@@ -55,10 +55,10 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging <1>
 spec:
-  targetNamespaces:
-  - openshift-logging <1>
+  targetNamespaces: [ ] <2>
 ----
-<1> You must specify the `openshift-logging` namespace for logging versions 5.7 and older. For logging 5.8 and later versions, you can use any namespace.
+<1> Ensure that the `namespace` field is set to `openshift-logging`.
+<2> For logging versions 5.7 and earlier, set `targetNamespaces` to `openshift-logging`. For logging versions 5.8 and later, the default installation mode is all namespaces on the cluster, or specify a list of namespaces separated by a comma.
 
 . Apply the `OperatorGroup` object by running the following command:
 +


### PR DESCRIPTION
[OBSDOCS-1041](https://issues.redhat.com/browse/OBSDOCS-1041): spec.targetNamespaces: openshift-logging at logging installation is not valid from RHOL 5.8
Aligned team: Observability
OCP version for cherry-picking: 4.12+
JIRA issues: [OBSDOCS-1041](https://issues.redhat.com/browse/OBSDOCS-1041)
Preview pages: https://75652--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/cluster-logging-deploying.html#cluster-logging-deploy-cli_cluster-logging-deploying
SME review **completed**: @r2d2rnd or Adrian Candel
QE review **completed**: @anpingli
Peer review **completed**: @dfitzmau