### PR TITLE
OCPBUGS-33407 - Adding missing PTP features to TP table

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2054,6 +2054,20 @@ In the following tables, features are marked with the following statuses:
 |Not Available
 |Technology Preview
 
+|Dual-NIC hardware as PTP boundary clock
+|General Availability
+|General Availability
+|General Availability
+
+|Intel E810 Westport Channel NIC as PTP grandmaster clock
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|Dual Intel E810 Westport Channel NICs as PTP grandmaster clock
+|Not Available
+|Technology Preview
+|Technology Preview
 |====
 
 [discrete]


### PR DESCRIPTION
Some PTP features are missing from the TP table in the release notes. These features were missed when the TP table was split into smaller tables for 4.15. 

Preview:
https://75658--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-technology-preview-tables

Version(s):
enterprise-4.15

Issue:
https://issues.redhat.com/browse/OCPBUGS-33407

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE review not required.