### PR TITLE
OSDOCS-9277: 4.12 dual-stack networking issue on 4.12

### DIFF
--- a/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
@@ -8,6 +8,11 @@
 
 For dual-stack networking in {product-title} clusters, you can configure IPv4 and IPv6 address endpoints for cluster nodes. To configure IPv4 and IPv6 address endpoints for cluster nodes, edit the `machineNetwork`, `clusterNetwork`, and `serviceNetwork` configuration settings in the `install-config.yaml` file. Each setting must have two CIDR entries each. Ensure the first CIDR entry is the IPv4 setting and the second CIDR entry is the IPv6 setting.
 
+[IMPORTANT]
+====
+If you specified an NMState configuration in the `networkConfig` section of your your `install-config.yaml` file , ensure you add `wait-ip: ipv4` and `wait-ip: ipv6` to the NMSate YAML file to resolve an issue that prevents your cluster from deploying on a dual-stack network.
+====
+
 [source,yaml]
 ----
 machineNetwork:
@@ -25,10 +30,10 @@ serviceNetwork:
 
 [IMPORTANT]
 ====
-The API VIP IP address and the Ingress VIP address must be of the primary IP address family when using dual-stack networking. Currently, Red Hat does not support dual-stack VIPs or dual-stack networking with IPv6 as the primary IP address family. However, Red Hat does support dual-stack networking with IPv4 as the primary IP address family. Therefore, the IPv4 entries must go *before* the IPv6 entries.
+The API and Ingress virtual IP (VIP) addresses must be of the primary IP address family when using dual-stack networking. Currently, Red Hat does not support dual-stack VIPs or dual-stack networking with IPv6 as the primary IP address family. However, Red Hat does support dual-stack networking with IPv4 as the primary IP address family. Therefore, the IPv4 entries must go *before* the IPv6 entries.
 ====
 
-To provide an interface to the cluster for applications that use IPv4 and IPv6 addresses, configure IPv4 and IPv6 virtual IP (VIP) address endpoints for the Ingress VIP and API VIP services. To configure IPv4 and IPv6 address endpoints, edit the `apiVIPs` and `ingressVIPs` configuration settings in the `install-config.yaml` file . The `apiVIPs` and `ingressVIPs` configuration settings use a list format. The order of the list indicates the primary and secondary VIP address for each service.
+To provide an interface to the cluster for applications that use IPv4 and IPv6 addresses, configure IPv4 and IPv6 VIP address endpoints for the Ingress VIP and API VIP services. To configure IPv4 and IPv6 address endpoints, edit the `apiVIPs` and `ingressVIPs` configuration settings in the `install-config.yaml` file . The `apiVIPs` and `ingressVIPs` configuration settings use a list format. The order of the list indicates the primary and secondary VIP address for each service.
 
 [source,yaml]
 ----


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-9277](https://issues.redhat.com/browse/OSDOCS-9277)

Link to docs preview:
[Optional: Deploying with dual-stack networking](https://75664--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#modifying-install-config-for-dual-stack-network_ipi-install-installation-workflow)

- [] SME has approved this change.
- [ ] QE has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
