### PR TITLE
TELCODOCS-1836 - Adding telco core 4.14.z RDS updates

### DIFF
--- a/modules/telco-core-ref-application-workloads.adoc
+++ b/modules/telco-core-ref-application-workloads.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * telco_ref_design_specs/ran/telco-ran-ref-design-spec.adoc
+// * telco_ref_design_specs/core/telco-core-rds-use-cases.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-ref-application-workloads_{context}"]
@@ -14,7 +14,7 @@ Pods running network functions that do not require the high throughput and low l
 
 Description of limits::
 
-* CNF applications should conform to the latest version of the _CNF Best Practices_ guide.
+* CNF applications should conform to the latest version of link:https://test-network-function.github.io/cnf-best-practices-guide/[Red Hat Best Practices for Kubernetes].
 * For a mix of best-effort and burstable QoS pods.
 ** Guaranteed QoS pods might be used but require correct configuration of reserved and isolated CPUs in the `PerformanceProfile`.
 ** Guaranteed QoS Pods must include annotations for fully isolating CPUs.
@@ -22,6 +22,13 @@ Description of limits::
 * Exec probes should be avoided unless there is no viable alternative.
 ** Do not use exec probes if a CNF is using CPU pinning.
 ** Other probe implementations, for example `httpGet/tcpSocket`, should be used.
+
++
+[NOTE]
+====
+Startup probes require minimal resources during steady-state operation.
+The limitation on exec probes applies primarily to liveness and readiness probes.
+====
 
 Signaling workload::
 

--- a/modules/telco-ran-du-application-workloads.adoc
+++ b/modules/telco-ran-du-application-workloads.adoc
@@ -22,7 +22,6 @@ Use other probe implementations, for example, `httpGet` or `tcpSocket`.
 ** When you need to use exec probes, limit the exec probe frequency and quantity.
 The maximum number of exec probes must be kept below 10, and frequency must not be set to less than 10 seconds.
 
-+
 [NOTE]
 ====
 Startup probes require minimal resources during steady-state operation.


### PR DESCRIPTION
Adding telco core 4.14.z RDS updates. LGTMs are in https://github.com/openshift/openshift-docs/pull/75650

Version(s):
enterprise-4.14+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1836

Link to docs preview:
https://file.emea.redhat.com/aireilly/4.14.z-telco-core-rds/telco_ref_design_specs/core/telco-core-rds-use-cases.html#telco-core-ref-application-workloads_ran-core-design-overview


QE review:
- [x] QE review not required.