### PR TITLE
ROX-23496: Add patch release info for 4.3.7

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -55,7 +55,7 @@ endif::[]
 :osp: Red Hat OpenShift
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 4.3.6
+:rhacs-version: 4.3.7
 :ocp-supported-version: 4.11
 :product-rosa: Red Hat OpenShift Service on AWS
 :product-rosa-short: ROSA

--- a/release_notes/43-release-notes.adoc
+++ b/release_notes/43-release-notes.adoc
@@ -22,6 +22,7 @@ toc::[]
 |`4.3.4` | 22 January 2024
 |`4.3.5` | 13 March 2024
 |`4.3.6` | 27 March 2024
+|`4.3.7` | 9 May 2024
 
 |====
 
@@ -326,6 +327,26 @@ It also provides the following security fixes:
 
 * Helm: Missing YAML content leads to panic link:https://access.redhat.com/security/cve/cve-2024-26147[(CVE-2024-26147)]
 * Helm: Shows secrets with `--dry-run` option in clear text link:https://access.redhat.com/security/cve/cve-2019-25210[(CVE-2019-25210)]
+
+[id="resolved-in-version-437_{context}"]
+=== Resolved in version 4.3.7
+
+*Release date*: 9 May 2024
+
+This release provides the following bug fixes:
+
+* This release fixes an issue where the Central pod failed with a `SQLSTATE 23503` error after updating {product-title-short} to release 4.3.6. This resulted in the collector pods showing the `CrashLoopBackoff` state because the collector probe was unavailable.
+* This release updates the Scanner baseline vulnerability data to address changes made to the Red{nbsp}Hat security data feeds that were not compatible with earlier data from Scanner's scheduled feed processing. This fixes various issues where vulnerabilities were detected for images containing packages that were incorrectly indicated as affected by a vulnerability.
+* This release fixes a crash and rendering error in the network graph that occurs when Central is running an {product-title-short} release of 4.3.6 or earlier and Sensor is running an {product-title-short} release of 4.4.0 or later.
+
+This release provides the following change:
+
+* The default telemetry endpoint is now set to a Red{nbsp}Hat proxy.
+
+This releases updates the following items to patch vulnerabilities:
+
+* Go has been updated to release 1.20.12.
+* The `golang.org/x/net` module has been updated from release v0.22.0 to v0.23.0.
 
 [id="known-issues-430_{context}"]
 == Known issues


### PR DESCRIPTION
Version(s):
RHACS 4.3

[Issue](https://issues.redhat.com/browse/ROX-23496)

[Link to docs preview
](https://75676--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/43-release-notes#resolved-in-version-437_release-notes-43)

QE review: **ACS has no QE, approved by SMEs**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
