### PR TITLE
[enterprise-4.14] Fix up LVMS xref due to out-of-sequence PR merging

### DIFF
--- a/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
+++ b/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
@@ -113,7 +113,7 @@ include::modules/lvms-scaling-storage-of-clusters-using-cli.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../../storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc#lvms-reference-file_logical-volume-manager-storage[{lvms} reference YAML file]
+* xref:../../../storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc#about-lvmcluster_logical-volume-manager-storage[About the LVMCluster custom resource]
 
 include::modules/lvms-scaling-storage-of-clusters-using-web-console.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Fixes an `xref` issue on `enterprise-4.14` only that was causing unrelated PRs to fail their Prow check due to:

```
>>> Working on storage book in openshift-enterprise <<<
Transforming the AsciiDoc content to DocBook XML...
�[31m�[1mUnknown ID or title "lvms-reference-file_logical-volume-manager-storage", used as an internal cross reference�[0m
�[31m�[1m>>> Validation of book storage in openshift-enterprise failed <<<�[0m
```

Root cause was that https://github.com/openshift/openshift-docs/pull/74937 was merged first (which removed the `modules/lvms-reference-file.adoc` file and updated related `xref`s) and then I merged https://github.com/openshift/openshift-docs/pull/75066 (which still had `xref`s to the old file that was just removed).

cc @sr1kar99 