### PR TITLE
[enterprise-4.15] Fix typo in CAS docs

### DIFF
--- a/modules/cluster-autoscaler-cr.adoc
+++ b/modules/cluster-autoscaler-cr.adoc
@@ -66,7 +66,9 @@ If you do not specify a value, the default value of `1` is used.
 <14> Optional: Specify the period to wait before deleting a node after a node has recently been _deleted_. If you do not specify a value, the default value of `0s` is used.
 <15> Optional: Specify the period to wait before deleting a node after a scale down failure occurred. If you do not specify a value, the default value of `3m` is used.
 <16> Optional: Specify a period of time before an unnecessary node is eligible for deletion. If you do not specify a value, the default value of `10m` is used.
-<17> Optional:  Specify the _node utilization level_. Nodes below this utilization level are eligible for deletion. If you do not specify a value, the default value of `10m` is used.. The node utilization level is the sum of the requested resources divided by the allocated resources for the node, and must be a value greater than `"0"` but less than `"1"`. If you do not specify a value, the cluster autoscaler uses a default value of `"0.5"`, which corresponds to 50% utilization. This value must be expressed as a string.
+<17> Optional:  Specify the _node utilization level_. Nodes below this utilization level are eligible for deletion.
++
+The node utilization level is the sum of the requested resources divided by the allocated resources for the node, and must be a value greater than `"0"` but less than `"1"`. If you do not specify a value, the cluster autoscaler uses a default value of `"0.5"`, which corresponds to 50% utilization. You must express this value as a string.
 // Might be able to add a formula to show this visually, but need to look into asciidoc math formatting and what our tooling supports.
 
 [NOTE]


### PR DESCRIPTION
Cherrypicked from a927c03e41a1e3f7c71d38e9e707c15ff5846636 xref: #75542