### PR TITLE
OSDOCS-10435: Issue in file rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly

### DIFF
--- a/modules/rosa-hcp-sts-creating-a-cluster-cli.adoc
+++ b/modules/rosa-hcp-sts-creating-a-cluster-cli.adoc
@@ -69,7 +69,7 @@ $ rosa create cluster --private --cluster-name=<cluster_name> \
 ----
 $ rosa create cluster --cluster-name=<cluster_name> --mode=auto \ 
     --hosted-cp --operator-roles-prefix=$OPERATOR_ROLES_PREFIX \
-    --oidc-config-id=$OIDC_CONFIG --subnet-ids=$SUBNET_IDS
+    --oidc-config-id=$OIDC_ID --subnet-ids=$SUBNET_IDS
 ----
 +
 . Check the status of your cluster by running the following command:


### PR DESCRIPTION
[OSDOCS-10435](https://issues.redhat.com//browse/OSDOCS-10435): Issue in file rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-10435

Link to docs preview:
https://75703--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
