### PR TITLE
OSDOCS-10476: ROSA cli proxy configuration not documented

### DIFF
--- a/cli_reference/rosa_cli/rosa-manage-objects-cli.adoc
+++ b/cli_reference/rosa_cli/rosa-manage-objects-cli.adoc
@@ -9,6 +9,11 @@ toc::[]
 
 Managing objects with the {product-title} (ROSA) CLI, `rosa`, such as adding `dedicated-admin` users, managing clusters, and scheduling cluster upgrades.
 
+[NOTE]
+====	
+To access a cluster that is accessible only over an HTTP proxy server, you can set the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` variables. These environment variables are respected by the `rosa` CLI so that all communication with the cluster goes through the HTTP proxy.
+====
+
 include::modules/rosa-common-commands.adoc[leveloffset=+1]
 include::modules/rosa-parent-commands.adoc[leveloffset=+1]
 include::modules/rosa-create-objects.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSDOCS-10476](https://issues.redhat.com//browse/OSDOCS-10476): ROSA cli proxy configuration not documented

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-10476

Link to docs preview:
https://75706--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli#rosa-create_rosa-managing-objects-cli

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
