### PR TITLE
HCIDOCS-193: [4.12] tcp port missing in the table deploying-installer-provisioned-clusters-on-bare-metal

### DIFF
--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -30,11 +30,15 @@ Certain ports must be open between cluster nodes for installer-provisioned insta
 
 |`5050`| The Ironic Inspector API runs on the control plane nodes and listens on port `5050`. The Inspector API is responsible for hardware introspection, which collects information about the hardware characteristics of the bare metal nodes.
 
+|`5051`| Port `5050` uses port `5051` as a proxy.
+
 |`6180`| When deploying with virtual media and not using TLS, the provisioner node and the control plane nodes must have port `6180` open on the `baremetal` machine network interface so that the baseboard management controller (BMC) of the worker nodes can access the {op-system} image. Starting with {product-title} 4.13, the default HTTP port is `6180`.
 
 |`6183`| When deploying with virtual media and using TLS, the provisioner node and the control plane nodes must have port `6183` open on the `baremetal` machine network interface so that the BMC of the worker nodes can access the {op-system} image.
 
 |`6385`| The Ironic API server runs initially on the bootstrap VM and later on the control plane nodes and listens on port `6385`. The Ironic API allows clients to interact with Ironic for bare metal node provisioning and management, including operations like enrolling new nodes, managing their power state, deploying images, and cleaning the hardware.
+
+|`6388`| Port `6385` uses port `6388` as a proxy.
 
 |`8080`| When using image caching without TLS, port `8080` must be open on the provisioner node and accessible by the BMC interfaces of the cluster nodes.
 


### PR DESCRIPTION
Added additional ports.

Fixes: [HCIDOCS-193](https://issues.redhat.com//browse/HCIDOCS-193)

See https://issues.redhat.com/browse/HCIDOCS-193 for additional details.

Preview URL: http://184.23.213.161:8080/HCIDOCS-193/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#network-requirements-ensuring-required-ports-are-open_ipi-install-prerequisites

For release(s): 4.12-4.16
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
