### PR TITLE
OSDOCS-9932: Issue in file cloud_experts_tutorials/cloud-experts-consistent-egress-ip.adoc

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-consistent-egress-ip.adoc
+++ b/cloud_experts_tutorials/cloud-experts-consistent-egress-ip.adoc
@@ -1,7 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-consistent-egress-ip"]
-= Tutorial: Assigning consistent egress IP for external traffic
+= Tutorial: Assigning a consistent egress IP for external traffic
 include::_attributes/attributes-openshift-dedicated.adoc[]
+include::_attributes/common-attributes.adoc[]
 :context: cloud-experts-consistent-egress-ip
 
 toc::[]
@@ -16,31 +17,44 @@ toc::[]
 //  - 'Dustin Scott'
 // ---
 
-It might be desirable to assign a consistent IP address for traffic that leaves the cluster when configuring items such as security groups or other sorts of security controls which require an IP-based configuration. By default, {product-title} (ROSA) (using the OVN-Kubernetes CNI) assigns random IP addresses from a pool which makes configuring security lockdowns unpredictable or unnecessarily open. This guide shows you how to configure a set of predictable IP addresses for egress cluster traffic to meet common security standards and guidance and other potential use cases.
+You can assign a consistent IP address for traffic that leaves your cluster such as security groups which require an IP-based configuration to meet security standards.
 
-See the link:https://docs.openshift.com/container-platform/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html[OpenShift documentation on this topic] for more information.
+By default, {product-title} (ROSA) uses the OVN-Kubernetes container network interface (CNI) to assign random IP addresses from a pool. This can make configuring security lockdowns unpredictable or open.
 
-== Prerequisites
+See xref:../networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc#configuring-egress-ips-ovn[Configuring an egress IP address] for more information.
 
-* ROSA cluster deployed with OVN-Kubernetes
-* OpenShift CLI (`oc`)
-* ROSA CLI (`rosa`)
-* `jq`
+.Objectives
 
-=== Environment
+* Learn how to configure a set of predictable IP addresses for egress cluster traffic.
 
-This sets environment variables for the tutorial so that you do not need to copy/paste in your own. Be sure to replace the `ROSA_MACHINE_POOL_NAME` variable if you wish to target a different Machine Pool.:
+.Prerequisites
 
+* A ROSA cluster deployed with OVN-Kubernetes
+* The xref:../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[OpenShift CLI] (`oc`)
+* The xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-get-started-cli[ROSA CLI] (`rosa`)
+* link:https://stedolan.github.io/jq/[`jq`]
+
+== Setting your environment variables
+
+* Set your environment variables by running the following command:
++
+[NOTE]
+====
+Replace the value of the `ROSA_MACHINE_POOL_NAME` variable to target a different machine pool.
+====
++
 [source,terminal]
 ----
 $ export ROSA_CLUSTER_NAME=$(oc get infrastructure cluster -o=jsonpath="{.status.infrastructureName}"  | sed 's/-[a-z0-9]\{5\}$//')
-$ export ROSA_MACHINE_POOL_NAME=Default
+$ export ROSA_MACHINE_POOL_NAME=worker
 ----
 
-== Ensure capacity
+== Ensuring capacity
 
-For each public cloud provider, there is a limit on the number of IP addresses that may be assigned per node. This can affect the ability to assign an egress IP address. To verify sufficient capacity, you can run the following command to print out the currently assigned IP addresses versus the total capacity in order to identify any nodes which may affected:
-
+The number of IP addresses assigned to each node is limited for each public cloud provider. 
+ 
+* Verify sufficient capacity by running the following command:
++
 [source,terminal]
 ----
 $ oc get node -o json | \
@@ -51,8 +65,9 @@ $ oc get node -o json | \
             "capacity": (.metadata.annotations."cloud.network.openshift.io/egress-ipconfig" | fromjson[] | .capacity.ipv4)
         }'
 ----
-
++
 .Example output
++
 [source,terminal]
 ---
 {
@@ -71,32 +86,30 @@ $ oc get node -o json | \
 }
 ---
 
+== Creating the egress IP rules
+
+. Before creating the egress IP rules, identify which egress IPs you will use.
++
 [NOTE]
 ====
-The above example uses `jq` as a friendly filter. If you do not have `jq` installed, you can review the `metadata.annotations['cloud.network.openshift.io/egress-ipconfig']` field of each node manually to verify node capacity.
+The egress IPs that you select should exist as a part of the subnets in which the worker nodes are provisioned.
 ====
++
+. *Optional*: Reserve the egress IPs that you requested to avoid conflicts with the AWS Virtual Private Cloud (VPC) Dynamic Host Configuration Protocol (DHCP) service.
++
+Request explicit IP reservations on the link:https://docs.aws.amazon.com/vpc/latest/userguide/subnet-cidr-reservation.html[AWS documentation for CIDR reservations] page.
 
-== Create the egress IP rule(s)
+== Assigning an egress IP to a namespace
 
-=== Identify the egress IPs
-
-Before creating the rules, we should identify which egress IPs that we will use. It should be noted that the egress IPs that you select should exist as a part of the subnets in which the worker nodes are provisioned into.
-
-=== Reserve the egress IPs
-
-It is recommended, but not required, to reserve the egress IPs that you have requested to avoid conflicts with the AWS VPC DHCP service. To do so, you can request explicit IP reservations by link:https://docs.aws.amazon.com/vpc/latest/userguide/subnet-cidr-reservation.html[following the AWS documentation for CIDR reservations].
-
-== Deploy an egress IP to a namespace
-
-Create a project to demonstrate assigning egress IP addresses based on a namespace selection:
-
+. Create a new project by running the following command:
++
 [source,terminal]
 ----
-$ oc create -f demo-egress-pod.yaml
+$ oc new-project demo-egress-ns
 ----
-
-Create the egress rule. This rule will ensure that egress traffic will be applied to all pods within the namespace that we just created using the `spec.namespaceSelector` field:
-
++
+. Create the egress rule for all pods within the namespace by running the following command:
++
 [source,terminal]
 ----
 $ cat <<EOF | oc apply -f -
@@ -117,17 +130,22 @@ spec:
 EOF
 ----
 
-=== Assign an egress IP to a pod
+== Assigning an egress IP to a pod
 
-Create a project to demonstrate assigning egress IP addresses based on a pod selection:
-
+. Create a new project by running the following command:
++
 [source,terminal]
 ----
 $ oc new-project demo-egress-pod
 ----
-
-Create the egress rule. This rule will ensure that egress traffic will be applied to the pod which we just created using the `spec.podSelector` field. It should be noted that `spec.namespaceSelector` is a mandatory field:
-
++
+. Create the egress rule for the pod by running the following command:
++
+[NOTE]
+==== 
+`spec.namespaceSelector` is a mandatory field.
+====
++
 [source,terminal]
 ----
 $ cat <<EOF | oc apply -f -
@@ -151,10 +169,15 @@ spec:
 EOF
 ----
 
-=== Label the nodes
+=== Labeling the nodes
 
-You can run `oc get egressips` and see that the egress IP assignments are pending.
-
+. Obtain your pending egress IP assignments by running the following command:
++
+[source,terminal]
+----
+$ oc get egressips
+----
++
 .Example output
 [source,terminal]
 ----
@@ -162,16 +185,16 @@ NAME              EGRESSIPS       ASSIGNED NODE   ASSIGNED EGRESSIPS
 demo-egress-ns    10.10.100.253
 demo-egress-pod   10.10.100.254
 ----
-
-To complete the egress IP assignment, we need to assign a specific label to the nodes. The egress IP rule that you created in a previous step only applies to nodes with the `k8s.ovn.org/egress-assignable` label. We want to ensure that label exists on only a specific machinepool as set using an environment variable in the set environment variables step.
-
-Assign the necessary label to your machine pool using the following command:
-
++
+The egress IP rule that you created only applies to nodes with the `k8s.ovn.org/egress-assignable` label. Make sure that the label is only on a specific machine pool.
++
+. Assign the label to your machine pool using the following command:
++
 [WARNING]
 ====
-If you are reliant upon any node labels for your machinepool, this command will replace those labels. Be sure to input your desired labels into the `--labels` field to ensure your node labels persist.
+If you rely on node labels for your machine pool, this command will replace those labels. Be sure to input your desired labels into the `--labels` field to ensure your node labels remain.
 ====
-
++
 [source,terminal]
 ----
 $ rosa update machinepool ${ROSA_MACHINE_POOL_NAME} \
@@ -179,10 +202,15 @@ $ rosa update machinepool ${ROSA_MACHINE_POOL_NAME} \
   --labels "k8s.ovn.org/egress-assignable="
 ----
 
-=== Review the egress IPs
+=== Reviewing the egress IPs
 
-You can review the egress IP assignments by running `oc get egressips` which will produce output as follows:
-
+* Review the egress IP assignments by running the following command:
++
+[source,terminal]
+----
+$ oc get egressips
+----
++
 .Example output
 [source,terminal]
 ----
@@ -191,21 +219,21 @@ demo-egress-ns    10.10.100.253   ip-10-10-156-122.ec2.internal   10.10.150.253
 demo-egress-pod   10.10.100.254   ip-10-10-156-122.ec2.internal   10.10.150.254
 ----
 
-== Test the egress IP rule
+== Verification
 
-=== Deploy a sample application
+=== Deploying a sample application
 
-To test the rule, we will create a service which is locked down only to the egress IP addresses in which we have specified. This will simulate an external service which is expecting a small subset of IP addresses.
+To test the egress IP rule, create a service that is restricted to the egress IP addresses which we have specified. This simulates an external service that is expecting a small subset of IP addresses.
 
-Run the echoserver which gives us some helpful information:
-
+. Run the `echoserver` command to replicate a request:
++
 [source,terminal]
 ----
 $ oc -n default run demo-service --image=gcr.io/google_containers/echoserver:1.4
 ----
-
-Expose the pod as a service, limiting the ingress (via the `.spec.loadBalancerSourceRanges` field) to the service to only the egress IP addresses in which we specified our pods should be using:
-
++
+. Expose the pod as a service and limit the ingress to the egress IP addresses you specified by running the following command:
++
 [source,terminal]
 ----
 $ cat <<EOF | oc apply -f -
@@ -239,18 +267,18 @@ spec:
     - 10.10.200.253/32
 EOF
 ----
-
-Retrieve the load balancer hostname as the `LOAD_BALANCER_HOSTNAME` environment variable which you can copy and use for following steps:
-
++
+. Retrieve the load balancer hostname and save it as an environment variable by running the following command:
++
 [source,terminal]
 ----
 $ export LOAD_BALANCER_HOSTNAME=$(oc get svc -n default demo-service -o json | jq -r '.status.loadBalancer.ingress[].hostname')
 ----
 
-=== Test namespace egress
+=== Testing the namespace egress
 
-Test the namespace egress rule which was created previously. The following starts an interactive shell which allows you to run curl against the demo service:
-
+. Start an interactive shell to test the namespace egress rule:
++
 [source,terminal]
 ----
 $ oc run \
@@ -261,17 +289,23 @@ $ oc run \
   --image=registry.access.redhat.com/ubi9/ubi -- \
   bash
 ----
-
-Once inside the pod, you can send a request to the load balancer, ensuring that you can successfully connect:
-
++
+. Send a request to the load balancer and ensure that you can successfully connect:
++
 [source,terminal]
 ----
 $ curl -s http://$LOAD_BALANCER_HOSTNAME
 ----
-
-You should see output similar to the following, indicating a successful connection. It should be noted that the `client_address` below is the internal IP address of the load balancer rather than our egress IP. Successful connectivity (by limiting the service to `.spec.loadBalancerSourceRanges`) is what provides a successful demonstration:
-
++
+. Check the output for a successful connection: 
++
+[NOTE]
+====
+The `client_address` is the internal IP address of the load balancer not your egress IP. You can verify that you have  configured the client address correctly by connecting with your service limited to `.spec.loadBalancerSourceRanges`.
+====
++
 .Example output
++
 [source,terminal]
 ----
 CLIENT VALUES:
@@ -292,18 +326,18 @@ user-agent=curl/7.76.1
 BODY:
 -no body in request-
 ----
-
-You can safely exit the pod once you are done:
-
++
+. Exit the pod by running the following command:
++
 [source,terminal]
 ----
 $ exit
 ----
 
-=== Test pod egress
+=== Testing the pod egress
 
-Test the pod egress rule which was created previously. The following starts an interactive shell which allows you to run curl against the demo service:
-
+. Start an interactive shell to test the pod egress rule:
++
 [source,terminal]
 ----
 $ oc run \
@@ -314,17 +348,23 @@ $ oc run \
   --image=registry.access.redhat.com/ubi9/ubi -- \
   bash
 ----
-
-Once inside the pod, you can send a request to the load balancer, ensuring that you can successfully connect:
-
++
+. Send a request to the load balancer by running the following command:
++
 [source,terminal]
 ----
 $ curl -s http://$LOAD_BALANCER_HOSTNAME
 ----
-
-You should see output similar to the following, indicating a successful connection. It should be noted that the `client_address` below is the internal IP address of the load balancer rather than our egress IP. Successful connectivity (by limiting the service to `.spec.loadBalancerSourceRanges`) is what provides a successful demonstration:
-
++
+. Check the output for a successful connection: 
++
+[NOTE]
+====
+The `client_address` is the internal IP address of the load balancer not your egress IP. You can verify that you have  configured the client address correctly by connecting with your service limited to `.spec.loadBalancerSourceRanges`.
+====
++
 .Example output
++
 [source,terminal]
 ----
 CLIENT VALUES:
@@ -345,18 +385,18 @@ user-agent=curl/7.76.1
 BODY:
 -no body in request-
 ----
-
-You can safely exit the pod once you are done:
-
++
+. Exit the pod by running the following command:
++
 [source,terminal]
 ----
 $ exit
 ----
 
-=== Test blocked egress
+=== Optional: Testing blocked egress
 
-Alternatively to a successful connection, you can see that the traffic is successfully blocked when the egress rules do not apply. Unsuccessful connectivity (by limiting the service to `.spec.loadBalancerSourceRanges`) is what provides a successful demonstration in this scenario:
-
+. *Optional:* Test that the traffic is successfully blocked when the egress rules do not apply by running the following command:
++
 [source,terminal]
 ----
 $ oc run \
@@ -367,25 +407,26 @@ $ oc run \
   --image=registry.access.redhat.com/ubi9/ubi -- \
   bash
 ----
-
-Once inside the pod, you can send a request to the load balancer:
-
++
+. Send a request to the load balancer by running the following command:
++
 [source,terminal]
 ----
 $ curl -s http://$LOAD_BALANCER_HOSTNAME
 ----
-
-The above command should hang. You can safely exit the pod once you are done:
-
++
+. If the command is unsuccessful, egress is successfully blocked.
+. Exit the pod by running the following command:
++
 [source,terminal]
 ----
 $ exit
 ----
 
-== Clean up
+== Cleaning up your cluster
 
-You can cleanup your cluster by running the following commands:
-
+. Clean up your cluster by running the following commands:
++
 [source,terminal]
 ----
 $ oc delete svc demo-service -n default; \
@@ -395,14 +436,14 @@ $ oc delete project demo-egress-pod; \
 $ oc delete egressip demo-egress-ns; \
 $ oc delete egressip demo-egress-pod
 ----
-
-You can cleanup the assigned node labels by running the following commands:
-
++
+. Clean up the assigned node labels by running the following command:
++
 [WARNING]
 ====
-If you are reliant upon any node labels for your machinepool, this command will replace those labels. Be sure to input your desired labels into the `--labels` field to ensure your node labels persist.
+If you rely on node labels for your machine pool, this command replaces those labels. Input your desired labels into the `--labels` field to ensure your node labels remain.
 ====
-
++
 [source,terminal]
 ----
 $ rosa update machinepool ${ROSA_MACHINE_POOL_NAME} \


### PR DESCRIPTION
[OSDOCS-9932](https://issues.redhat.com//browse/OSDOCS-9932): Issue in file cloud_experts_tutorials/cloud-experts-consistent-egress-ip.adoc

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-9932

Link to docs preview:
https://75708--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-consistent-egress-ip.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
