### PR TITLE
[enterprise-4.13] OCPBUGS#31543: Adding TopoLVM to the storage tables

### DIFF
--- a/modules/persistent-storage-csi-drivers-supported.adoc
+++ b/modules/persistent-storage-csi-drivers-supported.adoc
@@ -40,6 +40,9 @@ endif::openshift-rosa[]
 ifndef::openshift-dedicated,openshift-rosa[]
 |{ibmpowerProductName} Virtual Server Block | - | - | ✅ | -
 |IBM VPC Block | ✅^[3]^ | - | ✅^[3]^| -
+endif::openshift-dedicated,openshift-rosa[]
+|LVM Storage | ✅ | ✅ | ✅ | -
+ifndef::openshift-dedicated,openshift-rosa[]
 |Microsoft Azure Disk | ✅ | ✅ | ✅| -
 |Microsoft Azure Stack Hub | ✅ | ✅ | ✅| -
 |Microsoft Azure File | - | - | ✅| ✅

--- a/modules/storage-persistent-storage-block-volume.adoc
+++ b/modules/storage-persistent-storage-block-volume.adoc
@@ -44,6 +44,9 @@ ifndef::openshift-dedicated,openshift-rosa[]
 |IBM VPC Disk | ✅ | ✅ | ✅
 |iSCSI | ✅ | | ✅
 |Local volume | ✅ || ✅
+endif::openshift-dedicated,openshift-rosa[]
+|LVM Storage | ✅ | ✅ | ✅
+ifndef::openshift-dedicated,openshift-rosa[]
 |NFS | | |
 |{rh-storage-first} | ✅ | ✅ | ✅
 |VMware vSphere  | ✅ | ✅ | ✅

--- a/modules/storage-persistent-storage-pv.adoc
+++ b/modules/storage-persistent-storage-pv.adoc
@@ -172,6 +172,9 @@ ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 |IBM VPC Disk | ✅ | - |  -
 |iSCSI  | ✅ | ✅ |  ✅ ^[3]^
 |Local volume | ✅ | - |  -
+endif::[]
+|LVM Storage | ✅ | - | -
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 |NFS  | ✅ | ✅ | ✅
 |OpenStack Manila  | - | - | ✅
 |{rh-storage-first}  | ✅ | - | ✅


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Cherry-picked from: 4e4f2c86ac5c3274e737182516a17928ecd83e75

xref: https://github.com/openshift/openshift-docs/pull/75537

Preview:

- [Supported CSI drivers and features in OpenShift Container Platform](https://75711--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi)
- [Supported access modes for PVs](https://75711--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/understanding-persistent-storage.html#pv-access-modes_understanding-persistent-storage)
- [Block storage support](https://75711--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/understanding-persistent-storage.html#block-volume-support_understanding-persistent-storage)