### PR TITLE
[enterprise-4.15] OBSDOCS-1031: Add deprecation info for prometheus-adapter to OCP 4.15…

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -1213,6 +1213,11 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |Deprecated
 
+|`prometheus-adapter` component that queries resource metrics from Prometheus and exposes them in the metrics API.
+|General Availability
+|General Availability
+|Deprecated
+
 |====
 
 [discrete]
@@ -1430,6 +1435,15 @@ With this release, the dedicated service monitors feature for core platform moni
 The ability to enable dedicated service monitors by configuring the `dedicatedServiceMonitors` setting in the `cluster-monitoring-config` config map object in the `openshift-monitoring` namespace will be removed in a future {product-title} release.
 To replace this feature, Prometheus functionality has been improved to ensure that alerts and time aggregations are accurate.
 This improved functionality is active by default and makes the dedicated service monitors feature obsolete.
+
+[id="ocp-4-15-prometheus-adapter-for-core-platform-monitoring"]
+==== Prometheus Adapter for core platform monitoring
+With this release, the Prometheus Adapter component for core platform monitoring is deprecated and is planned to be removed in a future release. 
+Red{nbsp}Hat will provide bug fixes and support for this component during the current release lifecycle, but this component will no longer receive enhancements and will be removed. 
+As a replacement, a new Metrics Server component has been added to the monitoring stack. 
+Metrics Server is a simpler and more lightweight solution because it does not rely on Prometheus for its functionality. 
+Metrics Server also ensures scalability and a more accurate tracking of resource metrics. 
+With this release, the improved functionality of Metrics Server is available by default if you enable the `TechPreviewNoUpgrade` option in the `FeatureGate` custom resource.
 
 [id="ocp-4-15-deprecated-oc-registry-info"]
 ==== oc registry info command is deprecated


### PR DESCRIPTION
Version(s): `enterprise-4.15`

Issue: [OBSDOCS-1031](https://issues.redhat.com/browse/OBSDOCS-1031)

Links to docs preview: 
* [Deprecated and removed features](https://75713--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-deprecated-removed-features)
* [Prometheus Adapter for core platform monitoring](https://75713--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes#ocp-4-15-prometheus-adapter-for-core-platform-monitoring)


**Additional information:** This issue requires to go through the **change management** process:
- [x] QE has approved this change. (@juzhao)
- [x] Eng has approved this change. (@simonpasquier, @jan--f )
- [x] PM has approved this change. (@w1dg3r)
- [x] PX has approved this change. (@Senthamilarasu-STA)
- [x] DPM has approved this change. (@bburt-rh)

**Edit: The change management has been completed.**
