### PR TITLE
OSDOCS#10509: RHEL deprecation notice in OTA docs

### DIFF
--- a/updating/updating_a_cluster/updating-cluster-rhel-compute.adoc
+++ b/updating/updating_a_cluster/updating-cluster-rhel-compute.adoc
@@ -14,6 +14,11 @@ To do: Remove this comment once 4.13 docs are EOL.
 
 You can perform minor version and patch updates on an {product-title} cluster. If your cluster contains {op-system-base-full} machines, you must take additional steps to update those machines.
 
+[IMPORTANT]
+====
+The use of {op-system-base} compute machines on {product-title} clusters has been deprecated and will be removed in a future release.
+====
+
 == Prerequisites
 
 * Have access to the cluster as a user with `admin` privileges.


### PR DESCRIPTION
[OSDOCS-10509](https://issues.redhat.com/browse/OSDOCS-10509)

Version(s): 4.16+

This PR adds a deprecation notice for RHEL compute machines in the update procedure for clusters with RHEL machines.

QE review:
- [x] QE has approved this change.

Preview: [Updating a cluster that includes RHEL compute machines](https://75731--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-cluster-rhel-compute)
