### PR TITLE
OCPBUGS-9290: Not clear where to enable multipathing with kernel arguments

### DIFF
--- a/modules/rhcos-enabling-multipath.adoc
+++ b/modules/rhcos-enabling-multipath.adoc
@@ -29,7 +29,7 @@ The following procedure enables multipath at installation time and appends kerne
 
 .Procedure
 
-. To enable multipath and start the `multipathd` daemon, run the following command:
+. To enable multipath and start the `multipathd` daemon, run the following command on the installation host:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):  4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-9290
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: (Note to reviewers: the change was to only one module but the automation tracked where the module occurs and provided three previews)

https://75733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html
https://75733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal-network-customizations.html
https://75733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-restricted-networks-bare-metal.html

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
