### PR TITLE
OSSM-6424: Incorrect procedure for installing the ossmconsole CR

### DIFF
--- a/modules/ossm-kiali-ossmc-plugin-install-web-console.adoc
+++ b/modules/ossm-kiali-ossmc-plugin-install-web-console.adoc
@@ -17,9 +17,11 @@ You can install the {SMPlugin} using the {product-title} web console.
 
 .Procedure
 
-. Navigate to *Installed Operators* -> *Operator details*.
+. Navigate to *Installed Operators*.
+. Click *{KialiProduct}*.
+. Click *Create instance* on the *{SMProductName}* tile.
 . Use the *Create OSSMConsole* form to create an instance of the `OSSMConsole` custom resource (CR).
-* *Name* and *Version* are required fields.*Name* and *Version* are required fields.
+* *Name* and *Version* are required fields.
 +
 [NOTE]
 ====


### PR DESCRIPTION
[OSSM-6424](https://issues.redhat.com//browse/OSSM-6424): Incorrect procedure for installing the ossmconsole CR

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSSM-6424

Link to docs preview:
https://75738--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-kiali-ossmc-plugin.html#ossm-kiali-ossmc-plugin-install-web-console_ossm-kiali-ossmc-plugin 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
