### PR TITLE
HCIDOCS-189: Add note with link to OCP docs about exposed CoreDNS port

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-overview.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-overview.adoc
@@ -29,6 +29,16 @@ image::210_OpenShift_Baremetal_IPI_Deployment_updates_0122_2.png[Deployment phas
 
 After this point, the node used by the provisioner can be removed or repurposed. From here, all additional provisioning tasks are carried out by the control plane.
 
+[NOTE]
+====
+For installer-provisioned infrastructure installations, CoreDNS exposes port 53 at the node level, making it accessible from other routable networks.
+====
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../networking/dns-operator.adoc#nw-dns-forward_dns-operator[Using DNS forwarding]
+
 [IMPORTANT]
 ====
 The provisioning network is optional, but it is required for PXE booting. If you deploy without a provisioning network, you must use a virtual media baseboard management controller (BMC) addressing option such as `redfish-virtualmedia` or `idrac-virtualmedia`.

--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -44,11 +44,6 @@ Certain ports must be open between cluster nodes for installer-provisioned insta
 
 |====
 
-[NOTE]
-====
-For installer-provisioned infrastructure installations, CoreDNS exposes port 53 at the node level, making it accessible from other routable networks.
-====
-
 [id="network-requirements-increase-mtu_{context}"]
 == Increase the network MTU
 


### PR DESCRIPTION
Moved an admonition from network requirements to overview and added a link to the DNS forwarding module.

Fixes: [HCIDOCS-189](https://issues.redhat.com//browse/HCIDOCS-189)

See https://issues.redhat.com/browse/HCIDOCS-189 for additional details.

Preview URL: http://184.23.213.161:8080/HCIDOCS-189/installing/installing_bare_metal_ipi/ipi-install-overview.html

For release(s): 4.14-4.16
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
