### PR TITLE
OSDOCS#10394: Added machine pool tagging instructions to the docs

### DIFF
--- a/modules/rosa-create-objects.adoc
+++ b/modules/rosa-create-objects.adoc
@@ -650,6 +650,9 @@ a|--cluster <cluster_name>\|<cluster_id>
 |--replicas
 |Required when autoscaling is not configured. The number (integer) of machines for this machine pool.
 
+|--tags                            
+|Apply user defined tags to all resources created by ROSA in AWS. Tags are comma separated, for example: 'key value, foo bar'
+
 |--taints
 |Taints for the machine pool. This string value should be formatted as a comma-separated list of `key=value:ScheduleType`. This list will overwrite any modifications made to Node taints on an ongoing basis.
 |===
@@ -699,6 +702,13 @@ Add a machine pool with labels to a cluster.
 [source,terminal]
 ----
 $ rosa create machinepool --cluster=mycluster --replicas=2 --instance-type=r5.2xlarge --labels=foo=bar,bar=baz --name=mp-1
+----
+
+Add a machine pool with tags to a cluster.
+
+[source,terminal]
+----
+$ rosa create machinepool --cluster=mycluster --replicas=2 --instance-type=r5.2xlarge --tags=foo:bar,bar:baz --name=mp-1
 ----
 
 [id="rosa-create-ocm-role_{context}"]


### PR DESCRIPTION
Version(s):
`enterprise-4.15+`

Issue:
- **[OSDOCS-10394](https://issues.redhat.com/browse/OSDOCS-10394)**
- **[OSDOCS-10030](https://issues.redhat.com/browse/OSDOCS-10030)**

Link to docs preview:
- [`rosa create machinepool`](https://file.rdu.redhat.com/eponvell/OSDOCS-10394_Machine-Pool-Tagging/cli_reference/rosa_cli/rosa-manage-objects-cli.html#rosa-create-machinepool_rosa-managing-objects-cli) updates

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR adds information about tagging machine pools on clusters. It is applicable for both ROSA Classic and ROSA with HCP.