### PR TITLE
"drop" config should be an array in ClusterLogForwarder

### DIFF
--- a/modules/logging-content-filter-drop-records.adoc
+++ b/modules/logging-content-filter-drop-records.adoc
@@ -32,7 +32,7 @@ spec:
   - name: <filter_name>
     type: drop # <1>
     drop: # <2>
-      test: # <3>
+    - test: # <3>
       - field: .kubernetes.labels."foo-bar/baz" # <4>
         matches: .+ # <5>
       - field: .kubernetes.pod_name


### PR DESCRIPTION
When creating CLF with "drop" log record functionality: 
```
cat clf.yaml 
apiVersion: logging.openshift.io/v1
kind: ClusterLogForwarder
metadata:
  name: instance
  namespace: openshift-logging
spec:
  filters:
  - name: important
    type: drop
    drop:
      test:
      - field: .kubernetes.namespace_name
        matches: "^open"
      test:
      - field: .log_type
        matches: "application"
      - field: .kubernetes.pod_name
        notMatches: "my-pod"
  pipelines:
  - name: test 
    filterRefs: ["abc"]
    inputRefs:
    - application
    outputRefs:
    - default
```

$ oc create -f clf.yaml 
The ClusterLogForwarder "instance" is invalid: spec.filters[0].drop: Invalid value: "object": spec.filters[0].drop in body must be of type array: "object"

"drop" should be an array and same is correct in the docs.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
RHOCP 4.13, 4.14, 4.15

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
