### PR TITLE
[OCPBUGS#33312]: Add important note when manually adding a device for IPI installation

### DIFF
--- a/modules/move-etcd-different-disk.adoc
+++ b/modules/move-etcd-different-disk.adoc
@@ -25,6 +25,7 @@ NVMe:: `/dev/nvme*[0-9]\*n*`
 
 .Prerequisites
 
+* You have a backup of your cluster's etcd data.
 * You have installed the {oc-first}.
 * You have access to the cluster with `cluster-admin` privileges.
 * Add additional disks before uploading the machine configuration.
@@ -33,6 +34,11 @@ NVMe:: `/dev/nvme*[0-9]\*n*`
 [NOTE]
 ====
 This procedure does not move parts of the root file system, such as `/var/`, to another disk or partition on an installed node.
+====
+
+[IMPORTANT]
+====
+This procedure is not supported when using control plane machine sets.
 ====
 
 .Procedure


### PR DESCRIPTION
Version(s):
4.13+

Issue: [OCPBUGS-33312](https://issues.redhat.com/browse/OCPBUGS-33312)


Link to docs preview:
[Moving etcd to a different disk](https://75751--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.html#move-etcd-different-disk_recommended-etcd-practices) (Updated 5/20/2024)

QE review:
- [x ] QE has approved this change.

