### PR TITLE
OSDOCS#10325: Added optional tags parameter in install config

### DIFF
--- a/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
+++ b/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
@@ -42,7 +42,7 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
-  networkType: OVNKubernetes <9>
+  networkType: OVNKubernetes <11>
   serviceNetwork:
   - 172.30.0.0/16
 endif::network[]
@@ -62,6 +62,8 @@ platform:
         - <VM_Network_name>
         resourcePool: "/<datacenter>/host/<cluster>/Resources/<resourcePool>" <7>
         folder: "/<datacenter_name>/vm/<folder_name>/<subfolder_name>"
+        tagIDs: <8>
+        - <tag_id>  <9>
       zone: <default_zone_name>
     ingressVIPs:
     - 10.0.0.2
@@ -72,9 +74,9 @@ platform:
       port: 443
       server: <fully_qualified_domain_name>
       user: administrator@vsphere.local
-    diskType: thin <8>
+    diskType: thin <10>
 ifdef::restricted[]
-    clusterOSImage: http://mirror.example.com/images/rhcos-47.83.202103221318-0-vmware.x86_64.ova <9>
+    clusterOSImage: http://mirror.example.com/images/rhcos-47.83.202103221318-0-vmware.x86_64.ova <11>
 endif::restricted[]
 ifndef::openshift-origin[]
 fips: false
@@ -83,15 +85,15 @@ ifndef::restricted[]
 pullSecret: '{"auths": ...}'
 endif::restricted[]
 ifdef::restricted[]
-pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <10>
+pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <12>
 endif::restricted[]
 sshKey: 'ssh-ed25519 AAAA...'
 ifdef::restricted[]
-additionalTrustBundle: | <11>
+additionalTrustBundle: | <13>
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
   -----END CERTIFICATE-----
-imageContentSources: <12>
+imageContentSources: <14>
 - mirrors:
   - <mirror_host_name>:<mirror_port>/<repo_name>/release
   source: <source_image_1>
@@ -114,18 +116,20 @@ You can specify the path of any datastore that exists in a datastore cluster. By
 If you must specify VMs across multiple datastores, use a `datastore` object to specify a failure domain in your cluster's `install-config.yaml` configuration file. For more information, see "VMware vSphere region and zone enablement".
 ====
 <7> Optional: Provides an existing resource pool for machine creation. If you do not specify a value, the installation program uses the root resource pool of the vSphere cluster.
-<8> The vSphere disk provisioning method.
+<8> Optional: Each VM created by {product-title} is assigned a unique tag that is specific to the cluster. The assigned tag enables the installation program to identify and remove the associated VMs when a cluster is decommissioned. You can list up to ten additional tag IDs to be attached to the VMs provisioned by the installation program.
+<9> The ID of the tag to be associated by the installation program. For example, `urn:vmomi:InventoryServiceTag:208e713c-cae3-4b7f-918e-4051ca7d1f97:GLOBAL`. For more information about determining the tag ID, see the link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vcenterhost.doc/GUID-E8E854DD-AA97-4E0C-8419-CE84F93C4058.html[vSphere Tags and Attributes documentation].
+<10> The vSphere disk provisioning method.
 ifdef::network[]
-<9> The cluster network plugin to install. The default value `OVNKubernetes` is the only supported value.
+<11> The cluster network plugin to install. The default value `OVNKubernetes` is the only supported value.
 endif::network[]
 ifdef::restricted[]
-<9> The location of the {op-system-first} image that is accessible from the bastion server.
-<10> For `<local_registry>`, specify the registry domain name, and optionally the
+<11> The location of the {op-system-first} image that is accessible from the bastion server.
+<12> For `<local_registry>`, specify the registry domain name, and optionally the
 port, that your mirror registry uses to serve content. For example
 `registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
 specify the base64-encoded user name and password for your mirror registry.
-<11> Provide the contents of the certificate file that you used for your mirror registry.
-<12> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+<13> Provide the contents of the certificate file that you used for your mirror registry.
+<14> Provide the `imageContentSources` section from the output of the command to mirror the repository.
 endif::restricted[]
 
 [NOTE]


### PR DESCRIPTION
Version(s): 4.16

Issue: https://issues.redhat.com/browse/OSDOCS-10325

Link to docs preview: https://75757--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.html#installation-installer-provisioned-vsphere-config-yaml_installing-restricted-networks-installer-provisioned-vsphere

Review:
- [x] QE has approved this change. @WenXinWei 
- [x] SME has approved this change. @rvanderp3 