### PR TITLE
Put back cgroups note

### DIFF
--- a/modules/cnf-node-tuning-operator-disabling-cpu-load-balancing-for-dpdk.adoc
+++ b/modules/cnf-node-tuning-operator-disabling-cpu-load-balancing-for-dpdk.adoc
@@ -20,6 +20,11 @@ status:
   runtimeClass: performance-manual
 ----
 
+[NOTE]
+====
+Currently, disabling CPU load balancing is not supported with cgroup v2.
+====
+
 The Node Tuning Operator is responsible for the creation of the high-performance runtime handler config snippet under relevant nodes and for creation of the high-performance runtime class under the cluster. It will have the same content as the default runtime handler except that it enables the CPU load balancing configuration functionality.
 
 To disable the CPU load balancing for the pod, the `Pod` specification must include the following fields:


### PR DESCRIPTION
This manual CP to 4.15 removed a note about cgroups in error: https://github.com/openshift/openshift-docs/pull/75760