### PR TITLE
OSDOCS-30188: Typo fix for StorageClass plug-iin to plug-in

### DIFF
--- a/modules/dynamic-provisioning-storage-class-definition.adoc
+++ b/modules/dynamic-provisioning-storage-class-definition.adoc
@@ -32,5 +32,4 @@ parameters: <6>
 <3> (required) The name of the storage class.
 <4> (optional) Annotations for the storage class.
 <5> (required) The type of provisioner associated with this storage class.
-<6> (optional) The parameters required for the specific provisioner, this
-will change from plugin to plug-iin.
+<6> (optional) The parameters required for the specific provisioner, this will change from plug-in to plug-in.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-30188](https://issues.redhat.com/browse/OCPBUGS-30188)

Link to docs preview:
https://75772--ocpdocs-pr.netlify.app/
https://75772--ocpdocs-pr.netlify.app/openshift-dedicated/latest/storage/dynamic-provisioning.html
https://75772--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/storage-configuration.html
https://75772--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/dynamic-provisioning.html
https://75772--ocpdocs-pr.netlify.app/openshift-rosa/latest/storage/dynamic-provisioning.html

QE review:
N/A

Additional information:
Multiple previews are included because the module was referenced in multiple places :) 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
