### PR TITLE
OSDOCS-10496: Added scenarios for adding IPV6s to upgraded dual-stack…

### DIFF
--- a/modules/nw-dual-stack-convert.adoc
+++ b/modules/nw-dual-stack-convert.adoc
@@ -2,9 +2,11 @@
 [id="nw-dual-stack-convert_{context}"]
 = Converting to a dual-stack cluster network
 
-As a cluster administrator, you can convert your single-stack cluster network to a dual-stack cluster network. After converting to a dual-stack networking, new and existing pods have dual-stack networking enabled.
+As a cluster administrator, you can convert your single-stack cluster network to a dual-stack cluster network. After converting to a dual-stack network, new and existing pods have dual-stack networking enabled.
 
 Converting a single-stack cluster network to a dual-stack cluster network consists of creating patches and applying them to the cluster's network and infrastructure.
+
+If you need to add IPv6 Virtual IPs (VIPs) for API and Ingress services to an existing dual-stack-configured cluster, you need to patch only the cluster's infrastructure and not the cluster's network.
 
 [NOTE]
 ====
@@ -52,7 +54,7 @@ $ oc patch network.config.openshift.io cluster \// <1>
 network.config.openshift.io/cluster patched
 ----
 
-. To specify IPv6 Virtual IPs (VIPs) for API and Ingress services for your cluster, create a YAML configuration patch file that has a similar configuration to the following example:
+. To specify IPv6 VIPs for API and Ingress services for your cluster, create a YAML configuration patch file that has a similar configuration to the following example:
 +
 [source,yaml]
 ----


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-10496](https://issues.redhat.com/browse/OSDOCS-10496)

Link to docs preview:
[Converting to a dual-stack cluster network](https://75776--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.html)

- [x] SME has approved this change.
- [x] QE has approved this change.

