### PR TITLE
OCPBUGS#33525: Updates custom logo size constraints

### DIFF
--- a/modules/adding-a-custom-logo.adoc
+++ b/modules/adding-a-custom-logo.adoc
@@ -11,7 +11,7 @@ You can create custom branding by adding a custom logo or custom product name. Y
 .Prerequisites
 
 * You must have administrator privileges.
-* Create a file of the logo that you want to use. The logo can be a file in any common image format, including GIF, JPG, PNG, or SVG, and is constrained to a `max-width` of `200px` and a max-height` of `68px`. Image size must not exceed 1 MB due to constraints on the `ConfigMap` object size.
+* Create a file of the logo that you want to use. The logo can be a file in any common image format, including GIF, JPG, PNG, or SVG, and is constrained to a `max-height` of `60px`. Image size must not exceed 1 MB due to constraints on the `ConfigMap` object size.
 
 .Procedure
 


### PR DESCRIPTION
Masthead logo is now restricted to a max-height of 60px.

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-33525

Link to docs preview:
https://75780--ocpdocs-pr.netlify.app/openshift-enterprise/latest/web_console/customizing-the-web-console.html#adding-a-custom-logo_customizing-web-console

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
