### PR TITLE
OSDOCS-10427: Created an NMState OP section for stat reporting

### DIFF
--- a/modules/k8s-nmstate-installing-the-kubernetes-nmstate-operator.adoc
+++ b/modules/k8s-nmstate-installing-the-kubernetes-nmstate-operator.adoc
@@ -40,4 +40,4 @@ The name restriction is a known issue. The instance is a singleton for the entir
 
 .Summary
 
-Once complete, the Operator has deployed the NMState State Controller as a daemon set across all of the cluster nodes.
+After you install the Kubernetes NMState Operator, the Operator has deployed the NMState State Controller as a daemon set across all of the cluster nodes.

--- a/modules/viewing-stats-collected-kubernetes-nmtate-op.adoc
+++ b/modules/viewing-stats-collected-kubernetes-nmtate-op.adoc
@@ -1,0 +1,95 @@
+// This is included in the following assemblies:
+//
+// networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="viewing-stats-collected-kubernetes-nmtate-op_{context}"]
+= Viewing metrics collected by the Kubernetes NMState Operator
+
+The Kubernetes NMState Operator, `kubernetes-nmstate-operator`, can collect metrics from the `kubernetes_nmstate_features_applied` component and expose them as ready-to-use metrics. As a use case for viewing metrics, consider a situation where you created a `NodeNetworkConfigurationPolicy` custom resource and you want to confirm that the policy is active.
+
+[NOTE]
+====
+The `kubernetes_nmstate_features_applied` metrics are not an API and might change between {product-title} versions.
+====
+
+In the *Developer* and *Administrator* perspectives, the Metrics UI includes some predefined CPU, memory, bandwidth, and network packet queries for the selected project. You can run custom Prometheus Query Language (PromQL) queries for CPU, memory, bandwidth, network packet and application metrics for the project.
+
+The following example demonstrates a `NodeNetworkConfigurationPolicy` manifest example that is applied to an {product-title} cluster:
+
+[source,yaml]
+----
+# ...
+interfaces:
+  - name: br1
+    type: linux-bridge
+    state: up
+    ipv4:
+      enabled: true
+      dhcp: true
+      dhcp-custom-hostname: foo
+    bridge:
+      options:
+        stp:
+          enabled: false
+      port: []
+# ...
+----
+
+The `NodeNetworkConfigurationPolicy` manifest exposes metrics and makes them available to the Cluster Monitoring Operator (CMO). The following example shows some exposed metrics:
+
+[source,terminal]
+----
+controller_runtime_reconcile_time_seconds_bucket{controller="nodenetworkconfigurationenactment",le="0.005"} 16
+controller_runtime_reconcile_time_seconds_bucket{controller="nodenetworkconfigurationenactment",le="0.01"} 16
+controller_runtime_reconcile_time_seconds_bucket{controller="nodenetworkconfigurationenactment",le="0.025"} 16
+...
+# HELP kubernetes_nmstate_features_applied Number of nmstate features applied labeled by its name
+# TYPE kubernetes_nmstate_features_applied gauge
+kubernetes_nmstate_features_applied{name="dhcpv4-custom-hostname"} 1
+----
+
+.Prerequisites
+
+* You have installed the {oc-first}.
+* You have logged in to the web console as the administrator and installed the Kubernetes NMState Operator.
+* You have access to the cluster as a developer or as a user with view permissions for the project that you are viewing metrics for.
+* You have enabled monitoring for user-defined projects.
+* You have deployed a service in a user-defined project.
+* You have created a `NodeNetworkConfigurationPolicy` manifest and applied it to your cluster.
+
+.Procedure
+
+. If you want to view the metrics from the *Developer* perspective in the {product-title} web console, complete the following tasks:
++
+.. Click *Observe*.
++
+.. To view the metrics of a specific project, select the project in the *Project:* list. For example, `openshift-nmstate`.
++
+.. Click the *Metrics* tab.
++
+.. To visualize the metrics on the plot, select a query from the *Select query* list or create a custom PromQL query based on the selected query by selecting *Show PromQL*.
++
+[NOTE]
+====
+In the *Developer* perspective, you can only run one query at a time.
+====
+
+. If you want to view the metrics from the *Administrator* perspective in the {product-title} web console, complete the following tasks:
++
+.. Click *Observe* -> *Metrics*.
++
+.. Enter `kubernetes_nmstate_features_applied` in the *Expression* field.
++
+.. Click *Add query* and then *Run queries*.
+
+. To explore the visualized metrics, do any of the following tasks:
++
+.. To zoom into the plot and change the time range, do any of the following tasks:
++
+** To visually select the time range, click and drag on the plot horizontally.
+** To select the time range, use the menu which is in the upper left of the console.
++
+.. To reset the time range, select *Reset zoom*.
++
+.. To display the output for all the queries at a specific point in time, hold the mouse cursor on the plot at that point. The query output displays in a pop-up box.

--- a/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
@@ -38,5 +38,19 @@ Node networking is monitored and updated by the following objects:
 
 You can install the Kubernetes NMState Operator by using the web console or the CLI.
 
+// Installing the Kubernetes NMState Operator by using the web console
 include::modules/k8s-nmstate-installing-the-kubernetes-nmstate-operator.adoc[leveloffset=+2]
+
+// Installing the Kubernetes NMState Operator using the CLI
 include::modules/k8s-nmstate-deploying-nmstate-CLI.adoc[leveloffset=+2]
+
+// Viewing statistics collected by the Kubernetes NMState Operator
+include::modules/viewing-stats-collected-kubernetes-nmtate-op.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="additional-resources_k8s-nmstate-view-stats_{context}"]
+== Additional resources
+
+* xref:../../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#installing-the-kubernetes-nmstate-operator-cli[Installing the Kubernetes NMState Operator]
+* xref:../../networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc#virt-creating-interface-on-nodes_k8s_nmstate-updating-node-network-config[Creating an interface on nodes]
+


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-10427](https://issues.redhat.com/browse/OSDOCS-10427)

Link to docs preview:
[Viewing statistics collected by the Kubernetes NMState Operator](https://75781--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.html#viewing-stats-collected-kubernetes-nmtate-op_k8s-nmstate-operator)

- [x] SME has approved this change. (Mat Kowalski, Enrique Llorente Pastora, Simon Pasquier, and Shirly Radco)
- [x] QE has approved this change (Menia LI).

Additional information:
* https://github.com/nmstate/kubernetes-nmstate/pull/1221
* https://github.com/nmstate/nmstate/pull/2420
* https://github.com/nmstate/nmstate/blob/base/rust/src/lib/statistic/feature/features.rs#L11-L36
* https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html-single/virtualization/index#querying-metrics-for-user-defined-projects-as-a-developer_virt-prometheus-queries
* https://docs.openshift.com/container-platform/4.15/nodes/cma/nodes-cma-autoscaling-custom-metrics.html#nodes-cma-autoscaling-custom-metrics-access_nodes-cma-autoscaling-custom-metrics
* https://rhobs-handbook.netlify.app/products/openshiftmonitoring/faq.md/#how-do-i-understand-why-targets-arent-discovered-and-metrics-are-missing
