### PR TITLE
OSDOCS#9971.2:Changed additional resources formatting

### DIFF
--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc
@@ -43,8 +43,7 @@ include::modules/rosa-hcp-sts-creating-a-cluster-external-auth-cluster-cli.adoc[
 include::modules/rosa-hcp-sts-creating-a-cluster-external-auth-provider-cli.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="additional-resources_rosa-sts-creating-a-cluster-external-auth-cluster-cli"]
-== Additional resources
+.Additional resources
 * For more information about configuring Entra ID for your IDP, see link:https://learn.microsoft.com/en-us/entra/fundamentals/whatis[What is Microsoft Entra ID?] in the Azure documentation or the xref:../cloud_experts_tutorials/cloud-experts-entra-id-idp.adoc#cloud-experts-entra-id-idp[Configuring Microsoft Entra ID (formerly Azure Active Directory) as an identity provider] tutorial section of the documentation.
 * For information about the similar `idps` tool in the ROSA CLI, see xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-idp_rosa-managing-objects-cli[`create idp`].
 * For more information about options in the ROSA CLI, see xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-external-auth-provider_rosa-managing-objects-cli[`create external-auth-provider`], xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-list-external-auth-provider_rosa-managing-objects-cli[`list external-auth-provider`], and xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-delete-external-auth-provider_rosa-managing-objects-cli[`delete external-auth-provider`].
@@ -53,16 +52,14 @@ include::modules/rosa-hcp-sts-creating-a-cluster-external-auth-provider-cli.adoc
 include::modules/rosa-hcp-sts-creating-a-break-glass-cred-cli.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="additional-resources_rosa-sts-creating-a-break-glass-cred-cli"]
-== Additional resources
+.Additional resources
 * For more information about creating a {hcp-title} cluster with external authentication enabled, see xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc#rosa-hcp-sts-creating-a-cluster-external-auth-cluster-cli_rosa-hcp-sts-creating-a-cluster-ext-auth[Creating a ROSA with HCP cluster that uses external authentication providers].
 * For more information about CLI configurations, see xref:../cli_reference/openshift_cli/managing-cli-profiles.adoc#managing-cli-profiles[Managing CLI profiles].
 
 include::modules/rosa-hcp-sts-accessing-a-break-glass-cred-cli.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="additional-resources_rosa-sts-accessing-a-break-glass-cred-cli"]
-== Additional resources
+.Additional resources
 * For more information about cluster role binding, see xref:../authentication/using-rbac.adoc#rbac-overview[Using RBAC to define and apply permissions].
 
 include::modules/rosa-hcp-sts-revoking-a-break-glass-cred-cli.adoc[leveloffset=+1]


### PR DESCRIPTION
Small edits to #73863 to remove Additional resources titles from the TOC .

Version(s):
4.15+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://75791--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.html


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
