### PR TITLE
MIG-1548: Release Notes for MTC 1.8.4

### DIFF
--- a/migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
+++ b/migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
@@ -11,12 +11,11 @@ The release notes for {mtc-full} ({mtc-short}) describe new features and enhance
 
 The {mtc-short} enables you to migrate application workloads between {product-title} clusters at the granularity of a namespace.
 
-You can migrate from xref:../../migrating_from_ocp_3_to_4/about-migrating-from-3-to-4.adoc#about-migrating-from-3-to-4[{product-title} 3 to {product-version}] and between {product-title} 4 clusters.
-
 {mtc-short} provides a web console and an API, based on Kubernetes custom resources, to help you control the migration and minimize application downtime.
 
 For information on the support policy for {mtc-short}, see link:https://access.redhat.com/support/policy/updates/openshift#app_migration[OpenShift Application and Cluster Migration Solutions], part of the _Red Hat {product-title} Life Cycle Policy_.
 
+include::modules/migration-mtc-release-notes-1-8-4.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-8-3.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-8-2.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-8-1.adoc[leveloffset=+1]

--- a/modules/logging-input-spec-filter-labels-expressions.adoc
+++ b/modules/logging-input-spec-filter-labels-expressions.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="logging-input-spec-filter-labels-expressions_{context}"]
-= Filtering application logs at input by including the label expressions or a matching label key and values
+= Filtering application logs at input by including either the label expressions or matching label key and values
 
 You can include the application logs based on the label expressions or a matching label key and its values by using the `input` selector.
 

--- a/modules/migration-mtc-release-notes-1-8-1.adoc
+++ b/modules/migration-mtc-release-notes-1-8-1.adoc
@@ -8,7 +8,7 @@
 [id="resolved-issues-1-8-1_{context}"]
 == Resolved issues
 
-This release has the following major resolved issues:
+{mtc-full} ({mtc-short}) 1.8.1 has the following major resolved issues:
 
 .CVE-2023-39325: golang: net/http, x/net/http2: rapid stream resets can cause excessive work
 
@@ -23,4 +23,8 @@ For more details, see link:https://access.redhat.com/security/cve/cve-2023-39325
 [id="known-issues-1-8-1_{context}"]
 == Known issues
 
-There are no major known issues in this release.
+{mtc-full} ({mtc-short}) 1.8.1 has the following known issues:
+
+.Ansible Operator is broken when {VirtProductName} is installed
+
+There is a bug in the `python3-openshift` package that installing {VirtProductName} exposes. An exception, `ValueError: too many values to unpack`, is returned during the task. {mtc-short} 1.8.4 has implemented a workaround. Updating to {mtc-short} 1.8.4 means you are no longer affected by this issue. link:https://issues.redhat.com/browse/OCPBUGS-38116[(OCPBUGS-38116)]

--- a/modules/migration-mtc-release-notes-1-8-2.adoc
+++ b/modules/migration-mtc-release-notes-1-8-2.adoc
@@ -30,4 +30,8 @@ For more details, see link:https://access.redhat.com/security/cve/cve-2022-25883
 [id="known-issues-1-8-2_{context}"]
 == Known issues
 
-There are no major known issues in this release.
+{mtc-full} ({mtc-short}) 1.8.2 has the following known issues:
+
+.Ansible Operator is broken when {VirtProductName} is installed
+
+There is a bug in the `python3-openshift` package that installing {VirtProductName} exposes, with an exception, `ValueError: too many values to unpack`, returned during the task. {mtc-short} 1.8.4 has implemented a workaround. Updating to {mtc-short} 1.8.4 means you are no longer affected by this issue. link:https://issues.redhat.com/browse/OCPBUGS-38116[(OCPBUGS-38116)]

--- a/modules/migration-mtc-release-notes-1-8-3.adoc
+++ b/modules/migration-mtc-release-notes-1-8-3.adoc
@@ -17,7 +17,7 @@
 [id="resolved-issues-1-8-3_{context}"]
 == Resolved issues
 
-This release has the following major resolved issues:
+{mtc-full} ({mtc-short}) 1.8.3 has the following major resolved issues:
 
 .CVE-2024-24786: Flaw in Golang `protobuf` module causes `unmarshal` function to enter infinite loop
 
@@ -52,7 +52,11 @@ For a complete list of all resolved issues, see the list of link:https://issues.
 [id="known-issues-1-8-3_{context}"]
 == Known issues
 
-{mtc-short} has the following known issues:
+{mtc-full} ({mtc-short}) 1.8.3 has the following known issues:
+
+.Ansible Operator is broken when {VirtProductName} is installed
+
+There is a bug in the `python3-openshift` package that installing {VirtProductName} exposes, with an exception, `ValueError: too many values to unpack`, returned during the task. {mtc-short} 1.8.4 has implemented a workaround. Updating to {mtc-short} 1.8.4 means you are no longer affected by this issue. link:https://issues.redhat.com/browse/OCPBUGS-38116[(OCPBUGS-38116)]
 
 .The associated SCC for service account cannot be migrated in {OCP} 4.12
 

--- a/modules/migration-mtc-release-notes-1-8-4.adoc
+++ b/modules/migration-mtc-release-notes-1-8-4.adoc
@@ -1,0 +1,77 @@
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="migration-mtc-release-notes-1-8-4_{context}"]
+= {mtc-full} 1.8.4 release notes
+
+[id="technical-changes-1-8-4_{context}"]
+== Technical changes
+
+{mtc-full} ({mtc-short}) 1.8.4 has the following technical changes:
+
+* {mtc-short} 1.8.4 extends its dependency resolution to include support for using {oadp-first} 1.4.
+
+.Support for KubeVirt Virtual Machines with DirectVolumeMigration
+
+{mtc-short} 1.8.4 adds support for KubeVirt Virtual Machines (VMs) with Direct Volume Migration (DVM).
+
+[id="resolved-issues-1-8-4_{context}"]
+== Resolved issues
+
+{mtc-full} ({mtc-short}) 1.8.4 has the following major resolved issues:
+
+.Ansible Operator is broken when {VirtProductName} is installed
+
+There is a bug in the `python3-openshift` package that installing {VirtProductName} exposes, with an exception, `ValueError: too many values to unpack`, returned during the task. Earlier versions of {mtc-short} are impacted, while {mtc-short} 1.8.4 has implemented a workaround. Updating to {mtc-short} 1.8.4 means you are no longer affected by this issue. link:https://issues.redhat.com/browse/OCPBUGS-38116[(OCPBUGS-38116)]
+
+.UI stuck at Namespaces while creating a migration plan
+
+When trying to create a migration plan from the {mtc-short} UI, the migration plan wizard becomes stuck at the *Namespaces* step. This issue has been resolved in {mtc-short} 1.8.4. link:https://issues.redhat.com/browse/MIG-1597[(MIG-1597)]
+
+.Migration fails with error of no matches for kind Virtual machine in version kubevirt/v1
+
+During the migration of an application, all the necessary steps, including the backup, DVM, and restore, are successfully completed. However, the migration is marked as unsuccessful with the error message `no matches for kind Virtual machine in version kubevirt/v1`. link:https://issues.redhat.com/browse/MIG-1594[(MIG-1594)]
+
+.Direct Volume Migration fails when migrating to a namespace different from the source namespace
+
+On performing a migration from source cluster to target cluster, with the target namespace different from the source namespace, the DVM fails. link:https://issues.redhat.com/browse/MIG-1592[(MIG-1592)]
+
+.Direct Image Migration does not respect label selector on migplan
+
+When using Direct Image Migration (DIM), if a label selector is set on the migration plan, DIM does not respect it and attempts to migrate all imagestreams in the namespace. link:https://issues.redhat.com/browse/MIG-1533[(MIG-1533)]
+
+[id="known-issues-1-8-4_{context}"]
+== Known issues
+
+{mtc-full} ({mtc-short}) 1.8.4 has the following known issues:
+
+.The associated SCC for service account cannot be migrated in {OCP} 4.12
+
+The associated Security Context Constraints (SCCs) for service accounts in {OCP} 4.12 cannot be migrated. This issue is planned to be resolved in a future release of {mtc-short}. link:https://issues.redhat.com/browse/MIG-1454[(MIG-1454)].
+
+.Rsync pod fails to start causing the DVM phase to fail
+
+The DVM phase fails due to the Rsync pod failing to start, because of a permission issue.
+
+link:https://bugzilla.redhat.com/show_bug.cgi?id=2231403[(BZ#2231403)]
+
+.Migrated builder pod fails to push to image registry
+
+When migrating an application including `BuildConfig` from source to target cluster, the builder pod results in error, failing to push the image to the image registry.
+
+link:https://bugzilla.redhat.com/show_bug.cgi?id=2234781[(BZ#2234781)]
+
+.Conflict condition gets cleared briefly after it is created
+
+When creating a new state migration plan that results in a conflict error, that error is cleared shorty after it is displayed.
+
+link:https://bugzilla.redhat.com/show_bug.cgi?id=2144299[(BZ#2144299)]
+
+.PvCapacityAdjustmentRequired Warning Not Displayed After Setting pv_resizing_threshold
+
+The `PvCapacityAdjustmentRequired` warning fails to appear in the migration plan after the `pv_resizing_threshold` is adjusted.
+
+link:https://bugzilla.redhat.com/show_bug.cgi?id=2270160[(BZ#2270160)]
+
+// For a complete list of all known issues, see the list of link:https://issues.redhat.com/issues/?filter=12435661[{mtc-short} 1.8.4 known issues] in Jira.

--- a/modules/migration-mtc-release-notes-1-8.adoc
+++ b/modules/migration-mtc-release-notes-1-8.adoc
@@ -8,41 +8,46 @@
 [id="resolved-issues-1-8_{context}"]
 == Resolved issues
 
-This release has the following resolved issues:
+{mtc-full} ({mtc-short}) 1.8.0 has the following resolved issues:
 
 .Indirect migration is stuck on backup stage
 
 In previous releases, an indirect migration became stuck at the backup stage, due to `InvalidImageName` error.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=2233097[*BZ#2233097*])
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2233097[(BZ#2233097)])
 
 .PodVolumeRestore remain In Progress keeping the migration stuck at Stage Restore
 
-In previous releases, on performing an indirect migration, the migration became stuck at the `Stage Restore` step, waiting for the `podvolumerestore` to be completed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2233868[*BZ#2233868*])
+In previous releases, on performing an indirect migration, the migration became stuck at the `Stage Restore` step, waiting for the `podvolumerestore` to be completed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2233868[(BZ#2233868)])
 
 .Migrated application unable to pull image from internal registry on target cluster
 
-In previous releases, on migrating an application to the target cluster, the migrated application failed to pull the image from the internal image registry resulting in an `application failure`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2233103[*BZ#2233103*])
+In previous releases, on migrating an application to the target cluster, the migrated application failed to pull the image from the internal image registry resulting in an `application failure`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2233103[(BZ#2233103)])
 
 .Migration failing on Azure due to authorization issue
 
-In previous releases, on an Azure cluster, when backing up to Azure storage, the migration failed at the `Backup` stage. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2238974[*BZ#2238974*])
+In previous releases, on an Azure cluster, when backing up to Azure storage, the migration failed at the `Backup` stage. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2238974[(BZ#2238974)])
 
 [id="known-issues-1-8_{context}"]
 == Known issues
 
-This release has the following known issues:
+{mtc-full} ({mtc-short}) 1.8.0 has the following known issues:
+
+.Ansible Operator is broken when {VirtProductName} is installed
+
+There is a bug in the `python3-openshift` package that installing {VirtProductName} exposes, with an exception `ValueError: too many values to unpack` returned during the task. {mtc-short} 1.8.4 has implemented a workaround. Updating to {mtc-short} 1.8.4 means you are no longer affected by this issue. link:https://issues.redhat.com/browse/OCPBUGS-38116[(OCPBUGS-38116)]
+
 
 .Old Restic pods are not getting removed on upgrading MTC 1.7.x -> 1.8.x
 
-In this release, on upgrading the MTC Operator from 1.7.x to 1.8.x, the old Restic pods are not being removed. Therefore after the upgrade, both Restic and node-agent pods are visible in the namespace. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2236829[*BZ#2236829*])
+In this release, on upgrading the {mtc-short} Operator from 1.7.x to 1.8.x, the old Restic pods are not being removed. Therefore after the upgrade, both Restic and node-agent pods are visible in the namespace. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2236829[(BZ#2236829)])
 
 .Migrated builder pod fails to push to image registry
 
-In this release, on migrating an application including a `BuildConfig` from a source to target cluster, builder pod results in `error`, failing to push the image to the image registry. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2234781[*BZ#2234781*])
+In this release, on migrating an application including a `BuildConfig` from a source to target cluster, builder pod results in `error`, failing to push the image to the image registry. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2234781[(BZ#2234781)])
 
 .[UI] CA bundle file field is not properly cleared
 
-In this release, after enabling `Require SSL verification` and adding content to the CA bundle file for an MCG NooBaa bucket in MigStorage, the connection fails as expected. However, when reverting these changes by removing the CA bundle content and clearing `Require SSL verification`, the connection still fails. The issue is only resolved by deleting and re-adding the repository. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2240052[*BZ#2240052*])
+In this release, after enabling `Require SSL verification` and adding content to the CA bundle file for an MCG NooBaa bucket in MigStorage, the connection fails as expected. However, when reverting these changes by removing the CA bundle content and clearing `Require SSL verification`, the connection still fails. The issue is only resolved by deleting and re-adding the repository. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2240052[(BZ#2240052)])
 
 
 .Backup phase fails after setting custom CA replication repository


### PR DESCRIPTION
### JIRA

* [MIG-1548](https://issues.redhat.com//browse/MIG-1548)

### REVIEW

* [Migration Toolkit for Containers 1.8.4 release notes](https://75798--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/release_notes/mtc-release-notes.html#migration-mtc-release-notes-1-8-4_mtc-release-notes)

### Version(s):

* OCP 4.13 +

### QE review:

- [ ] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
