### PR TITLE
OSDOCS-10524: Day-2 optional vSphere tags

### DIFF
--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-aws.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-aws.adoc
@@ -23,7 +23,7 @@ include::modules/cpmso-yaml-failure-domain-aws.adoc[leveloffset=+2]
 [id="cpmso-supported-features-aws_{context}"]
 == Enabling {aws-full} features for control plane machines
 
-You can enable the following features by updating values in the control plane machine set.
+You can enable features by updating values in the control plane machine set.
 
 //Restricting the API server to private (AWS control plane machine set version)
 include::modules/private-clusters-setting-api-private.adoc[leveloffset=+2]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc
@@ -23,7 +23,7 @@ include::modules/cpmso-yaml-failure-domain-azure.adoc[leveloffset=+2]
 [id="cpmso-supported-features-azure_{context}"]
 == Enabling {azure-full} features for control plane machines
 
-You can enable the following features by updating values in the control plane machine set.
+You can enable features by updating values in the control plane machine set.
 
 include::modules/private-clusters-setting-api-private.adoc[leveloffset=+2]
 [role="_additional-resources"]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-gcp.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-gcp.adoc
@@ -23,7 +23,7 @@ include::modules/cpmso-yaml-failure-domain-gcp.adoc[leveloffset=+2]
 [id="cpmso-supported-features-gcp_{context}"]
 == Enabling {gcp-full} features for control plane machines
 
-You can enable the following features by updating values in the control plane machine set.
+You can enable features by updating values in the control plane machine set.
 
 //Note: GCP GPU features should be compatible with CPMS, but dev cannot think of a use case. Leaving them out to keep things less cluttered. If a customer use case emerges, we can just add the necessary modules in here.
 

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-openstack.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-openstack.adoc
@@ -23,7 +23,7 @@ include::modules/cpmso-yaml-failure-domain-openstack.adoc[leveloffset=+2]
 [id="cpmso-supported-features-openstack_{context}"]
 == Enabling {rh-openstack-first} features for control plane machines
 
-You can enable the following features by updating values in the control plane machine set.
+You can enable features by updating values in the control plane machine set.
 
 //Changing the OpenStack Nova flavor by using a control plane machine set
 include::modules/cpms-changing-openstack-flavor-type.adoc[leveloffset=+2]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.adoc
@@ -23,3 +23,11 @@ include::modules/cpmso-yaml-failure-domain-vsphere.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../../post_installation_configuration/post-install-vsphere-zones-regions-configuration.adoc#specifying-regions-zones-infrastructure-vsphere_post-install-vsphere-zones-regions-configuration[Specifying multiple regions and zones for your cluster on {vmw-short}]
+
+[id="cpmso-supported-features-vsphere_{context}"]
+== Enabling {vmw-full} features for control plane machines
+
+You can enable features by updating values in the control plane machine set.
+
+//Adding tags to machines by using machine sets
+include::modules/machine-api-vmw-add-tags.adoc[leveloffset=+2,tag=!compute]

--- a/machine_management/creating_machinesets/creating-machineset-vsphere.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-vsphere.adoc
@@ -37,3 +37,6 @@ include::modules/machineset-upi-reqs-ignition-config.adoc[leveloffset=+2]
 
 //Creating a compute machine set
 include::modules/machineset-creating.adoc[leveloffset=+1]
+
+//Adding tags to machines by using machine sets
+include::modules/machine-api-vmw-add-tags.adoc[leveloffset=+1,tag=!controlplane]

--- a/modules/machine-api-vmw-add-tags.adoc
+++ b/modules/machine-api-vmw-add-tags.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating_machinesets/creating-machineset-vsphere.adoc
+// * machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="machine-api-vmw-add-tags_{context}"]
+= Adding tags to machines by using machine sets
+
+{product-title} adds a cluster-specific tag to each virtual machine (VM) that it creates.
+The installation program uses these tags to select the VMs to delete when uninstalling a cluster.
+
+In addition to the cluster-specific tags assigned to VMs, you can configure a machine set to add up to 10 additional {vmw-short} tags to the VMs it provisions.
+
+.Prerequisites
+
+* You have access to an {product-title} cluster installed on {vmw-short} using an account with `cluster-admin` permissions.
+* You have access to the VMware vCenter console associated with your cluster.
+* You have created a tag in the vCenter console.
+* You have installed the {oc-first}.
+
+.Procedure
+
+. Use the vCenter console to find the tag ID for any tag that you want to add to your machines:
+
+.. Log in to the vCenter console.
+
+.. From the *Home* menu, click *Tags & Custom Attributes*.
+
+.. Select a tag that you want to add to your machines.
+
+.. Use the browser URL for the tag that you select to identify the tag ID.
++
+.Example tag URL
+[source,text]
+----
+https://vcenter.example.com/ui/app/tags/tag/urn:vmomi:InventoryServiceTag:208e713c-cae3-4b7f-918e-4051ca7d1f97:GLOBAL/permissions
+----
++
+.Example tag ID
+[source,text]
+----
+urn:vmomi:InventoryServiceTag:208e713c-cae3-4b7f-918e-4051ca7d1f97:GLOBAL
+----
+
+. In a text editor, open the YAML file for an existing machine set or create a new one.
+
+. Edit the following lines under the `providerSpec` field:
++
+[source,yaml]
+----
+tag::compute[]
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+end::compute[]
+tag::controlplane[]
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+end::controlplane[]
+# ...
+spec:
+  template:
+    spec:
+      providerSpec:
+        value:
+          tagIDs: # <1>
+          - <tag_id_value> # <2>
+# ...
+----
+<1> Specify a list of up to 10 tags to add to the machines that this machine set provisions.
+<2> Specify the value of the tag that you want to add to your machines.
+For example, `urn:vmomi:InventoryServiceTag:208e713c-cae3-4b7f-918e-4051ca7d1f97:GLOBAL`.


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-10524](https://issues.redhat.com//browse/OSDOCS-10524)

Link to docs preview:
* [Adding tags to machines by using machine sets](https://75811--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-vsphere.html#machine-api-vmw-add-tags_creating-machineset-vsphere) (compute)
* [Adding tags to machines by using machine sets](https://75811--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.html#machine-api-vmw-add-tags_cpmso-config-options-vsphere) (control plane)

QE review:
- [x] QE has approved this change.

Additional information: