### PR TITLE
OADP-3170: Release Notes for OADP 1.1.8

### DIFF
--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-1.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-1.adoc
@@ -9,6 +9,7 @@ toc::[]
 
 The release notes for OpenShift API for Data Protection (OADP) 1.1 describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
 
+include::modules/oadp-release-notes-1-1-8.adoc[leveloffset=+1]
 
 include::modules/oadp-release-notes-1-1-7.adoc[leveloffset=+1]
 

--- a/modules/oadp-release-notes-1-1-8.adoc
+++ b/modules/oadp-release-notes-1-1-8.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-release-notes-1-1.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="migration-oadp-release-notes-1-1-8_{context}"]
+= {oadp-short} 1.1.8 release notes
+
+The {oadp-first} 1.1.8 release notes lists any known issues. There are no resolved issues in this release.
+
+[id="known-issues1-1-8_{context}"]
+== Known issues
+
+For a complete list of all known issues in {oadp-short} 1.1.8, see the list of link:https://issues.redhat.com/issues/?filter=12435971[OADP 1.1.8 known issues] in Jira.
+
+// filter - project = OADP AND issuetype = Bug AND status not in  (Verified, "Release Pending", Closed)  AND affectedVersion in ("OADP 1.1.0", "OADP 1.1.1", "OADP 1.1.2", "OADP 1.1.3", "oadp 1.1.4", "oadp 1.1.5", "OADP 1.1.6", "OADP 1.1.7", "OADP 1.1.8")  AND component not in (Documentation, "Migration QE Infra", QE-Task) ORDER BY priority DESC, Rank DESC


### PR DESCRIPTION
### JIRA

* [OADP-3170](https://issues.redhat.com/browse/OADP-3170)

### GA

* 21st May

### Version(s):

* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16

<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

### Link to docs preview:

* [Release Notes OADP 1.1.8](https://75824--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-1#migration-oadp-release-notes-1-1-8_oadp-release-notes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X ] QE has [**approved this change**](https://github.com/openshift/openshift-docs/pull/75824#pullrequestreview-2066182813).
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
