### PR TITLE
OADP- 3949 -SSE-C Encryption backups by default

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
@@ -25,6 +25,7 @@ include::modules/migration-configuring-aws-s3.adoc[leveloffset=+1]
 include::modules/oadp-about-backup-snapshot-locations-secrets.adoc[leveloffset=+1]
 include::modules/oadp-creating-default-secret.adoc[leveloffset=+2]
 include::modules/oadp-secrets-for-different-credentials.adoc[leveloffset=+2]
+include::modules/oadp-ssec-encrypted-backups.adoc[leveloffset=+2]
 
 [id="configuring-dpa-aws"]
 == Configuring the Data Protection Application

--- a/modules/oadp-ssec-encrypted-backups.adoc
+++ b/modules/oadp-ssec-encrypted-backups.adoc
@@ -12,7 +12,15 @@
 
 Amazon Web Services (AWS) S3 now applies server-side encryption with Amazon S3 managed keys (SSE-S3) as the base level of encryption for every bucket in Amazon S3. It is important to note that OpenShift API for Data Protection (OADP) encrypts data by using SSL/TLS, HTTPS, and the velero-repo-credentials secret when transferring the data off cluster to storage.
 
-It is important to include an additional layer of encryption to prevent backed up data from becoming unencrypted in case of lost or stolen AWS credentials. The https://github.com/openshift/velero-plugin-for-aws/blob/konveyor-dev/backupstoragelocation.md[OpenShift velero-plugin-for-aws] provides several additional encryption methods, review the configuration options and consider implementing additional encryption.
+It is important to include an additional layer of encryption to prevent backed up data from becoming unencrypted in case of lost or stolen AWS credentials.
+
+.Openshift velero-plugin-for-aws
+[source,git]
+----
+include::https://github.com/openshift/velero-plugin-for-aws/blob/konveyor-dev/backupstoragelocation.md[]
+----
+
+The link:https://github.com/openshift/velero-plugin-for-aws/blob/konveyor-dev/backupstoragelocation.md[OpenShift velero-plugin-for-aws] provides several additional encryption methods, review the configuration options and consider implementing additional encryption.
 
 Server-side encryption with customer-provided keys (SSE-C), provides Red Hat users the ability to store your own encryption keys. This provides additional required security if the AWS credentials become exposed.
 

--- a/modules/oadp-ssec-encrypted-backups.adoc
+++ b/modules/oadp-ssec-encrypted-backups.adoc
@@ -10,13 +10,13 @@
 [id="oadp-ssec-encrypted-backups_{context}"]
 = OADP SSE-C encrypted backups
 
-Amazon Web Services (AWS) S3 now applies server-side encryption with Amazon S3 managed keys (SSE-S3) as the base level of encryption for every bucket in Amazon S3. It is important to note that OpenShift API for Data Protection (OADP) encrypts data by using SSL/TLS, HTTPS, and the velero-repo-credentials secret when transferring the data off cluster to storage.
+{aws-first} S3 now applies server-side encryption with Amazon S3 managed keys (SSE-S3) as the base level of encryption for every bucket in Amazon S3. It is important to note that {oadp-first} encrypts data by using SSL/TLS, HTTPS, and uses the `velero-repo-credentials` secret when transferring the data from the cluster to storage.
 
-It is important to include an additional layer of encryption to prevent backed up data from becoming unencrypted in case of lost or stolen AWS credentials.
+It is important to include an additional layer of encryption to prevent backed-up data from being exposed if you lose or have your AWS credentials stolen.
 
-The _OpenShift velero-plugin-for-aws_ provides several additional encryption methods, review the configuration options and consider implementing additional encryption.
+The _OpenShift velero-plugin-for-aws_ provides several additional encryption methods. You should review the configuration options and consider implementing additional encryption.
 
-Server-side encryption with customer-provided keys (SSE-C), provides Red Hat users the ability to store your own encryption keys. This provides additional required security if the AWS credentials become exposed.
+Server-side encryption with customer-provided keys (SSE-C), provides you with the ability to store your own encryption keys. This provides additional required security if your AWS credentials become exposed.
 
 [WARNING]
 ====
@@ -52,7 +52,7 @@ ln -s sse_encoded.key customer-key
 
 . Create an OpenShift secret.
 
-.. If you are initially installing and configuring OADP, you can create the aws credential and encryption key secret at the same time by running the following command:
+.. If you are initially installing and configuring {oadp-short}, you can create the AWS credential and encryption key secret at the same time by running the following command:
 +
 [source,terminal]
 ----
@@ -71,7 +71,7 @@ kind: Secret
 # ...
 ----
 
-. Edit the value of the `customerKeyEncryptionFile` attribute in the `backupLocations` block of `DataProtectionApplication` CR manifest, as in the following example:
+. Edit the value of the `customerKeyEncryptionFile` attribute in the `backupLocations` block of the `DataProtectionApplication` CR manifest, as in the following example:
 
 +
 [source,yaml]
@@ -90,11 +90,11 @@ spec:
 Existing installations require you to restart the Velero pod to remount the secret credentials properly.
 ====
 
-The installation is complete, and you can back up and restore OpenShift resources. The data saved in AWS s3 storage is encrypted with the new key and cannot be downloaded from the AWS S3 console or API without the additional encryption key.
+The installation is complete, and you can back up and restore OpenShift resources. The data saved in AWS S3 storage is encrypted with the new key, and you cannot download it from the AWS S3 console or API without the additional encryption key.
 
 .Verification
 
-Test to verify that encrypted files cannot be downloaded without the additional key.
+The purpose of this test is to verify that you cannot download the encrypted files without the inclusion of an additional key.
 
 . Create a test file by running the following command:
 
@@ -117,7 +117,7 @@ $ aws s3api put-object \
   --sse-customer-algorithm AES256
 ----
 
-. Try to download the file, which should fail because the file is now encrypted with an additional key, by using the S3 web console or the terminal by running the following command:
+. Try to download the file, this should fail because the file is now encrypted with an additional key. In either the Amazon web console or the terminal, run the following command:
 
 +
 [source,terminal]
@@ -144,7 +144,7 @@ $ cat downloaded.txt
 encrypt me please
 ----
 
-. You can run the same download call on velero backed up files by running the following command:
+. You can run the same download call on the files backed up with Velero by running the following command:
 
 +
 [source,terminal]

--- a/modules/oadp-ssec-encrypted-backups.adoc
+++ b/modules/oadp-ssec-encrypted-backups.adoc
@@ -10,20 +10,20 @@
 [id="oadp-ssec-encrypted-backups_{context}"]
 = OADP SSE-C encrypted backups
 
-Amazon Web Services (AWS) S3 now applies server-side encryption with Amazon S3 managed keys (SSE-S3) as the base level of encryption for every bucket in Amazon S3. It is to note that OpenShift API for Data Protection (OADP) encrypt data via SSL/TLS, HTTPS, and the velero-repo-credentials secret while data is transferred off cluster to storage.
+Amazon Web Services (AWS) S3 now applies server-side encryption with Amazon S3 managed keys (SSE-S3) as the base level of encryption for every bucket in Amazon S3. It is important to note that OpenShift API for Data Protection (OADP) encrypts data via SSL/TLS, HTTPS, and the velero-repo-credentials secret while data is transferred off cluster to storage.
 
 It is recommended to include an additional layer of encryption to prevent backed up data from being unencrypted in case of lost or stolen AWS credentials. The https://github.com/openshift/velero-plugin-for-aws/blob/konveyor-dev/backupstoragelocation.md[OpenShift velero-plugin-for-aws] provides several additional encryption methods, review the configuration options and consider implementing additional encryption.
 
-SSE-C encryption provides Red Hat users server-side encryption with customer-provided keys (SSE-C), so that you can store your own encryption keys. This will provide required additional security if the AWS credentials have been exposed.
+SSE-C encryption provides Red Hat users server-side encryption with customer-provided keys (SSE-C), so that you can store your own encryption keys. This provides additional required security if the AWS credentials have been exposed.
 
 [WARNING]
 ====
-it is strongly advised to secure cryptographic keys in a secure and safe manner. Encrypted data and backups will not be recoverable in the absence of the encryption key.
+It is advised to secure cryptographic keys in a secure and safe manner. Encrypted data and backups will not be recoverable in the absence of the encryption key.
 ====
 
 .Prerequisites / Known issues
 
-You may receive `credentials not found` errors. To avoid this issue you can create a workaround by adding a volumeSnapshot configuration to your DPA without specifying a credential:
+You may receive `credentials not found` errors. To avoid this issue you can create a workaround by adding a volumeSnapshot configuration to your DPA without specifying a credential as in the following example:
 [source,yaml]
 ----
  snapshotLocations:
@@ -37,7 +37,7 @@ You may receive `credentials not found` errors. To avoid this issue you can crea
 
 .Procedure
 
-You can configure an SSE-C encryption to provide additional security by using following these steps.
+You can configure an SSE-C encryption to provide additional security by applying the following steps.
 
 . Create an encryption key by running the following command:
 +
@@ -88,11 +88,11 @@ spec:
 Existing installations require the Velero pod to be restarted to remount the secret credentials properly.
 ====
 
-The installation is complete, and you can back up and restore OpenShift resources. The data saved in AWS s3 storage is encrypted with the new key and can not be downloaded via the AWS S3 console or API without the supplied encryption key.
+The installation is complete, and you can back up and restore OpenShift resources. The data saved in AWS s3 storage is encrypted with the new key and can not be downloaded via the AWS S3 console or API without the additional encryption key.
 
 .Verification
 
-Test to verify that encrypted files cannot be downloaded without the extra key.
+Test to verify that encrypted files cannot be downloaded without the additional key.
 
 . Create a test file by running the following command:
 
@@ -114,3 +114,45 @@ $ aws s3api put-object \
   --sse-customer-key fileb://sse.key \
   --sse-customer-algorithm AES256
 ----
+
+. Attempt to download the file, which should fail because the file is now encrypted with an additional key, by using the S3 web console or the terminal by running the following command:
+
++
+[source,terminal]
+----
+$ s3cmd get s3://<bucket>/test.txt test.txt
+----
+
+. Download the file with the additional encryption key by running the following commands:
+
++
+[source,terminal]
+----
+$ aws s3api get-object \
+    --bucket <bucket> \
+    --key test.txt \
+    --sse-customer-key fileb://sse.key \
+    --sse-customer-algorithm AES256 \
+    downloaded.txt
+----
++
+[source,terminal]
+----
+$ cat downloaded.txt
+encrypt me please
+----
+
+. The same download call can be executed on velero backed up files by running the following command:
+
++
+[source,terminal]
+----
+$ aws s3api get-object \
+  --bucket <bucket> \
+  --key velero/backups/mysql-persistent-customerkeyencryptionfile4/mysql-persistent-customerkeyencryptionfile4.tar.gz \
+  --sse-customer-key fileb://sse.key \
+  --sse-customer-algorithm AES256 \
+  --debug \
+  velero_download.tar.gz
+----
+

--- a/modules/oadp-ssec-encrypted-backups.adoc
+++ b/modules/oadp-ssec-encrypted-backups.adoc
@@ -14,13 +14,7 @@ Amazon Web Services (AWS) S3 now applies server-side encryption with Amazon S3 m
 
 It is important to include an additional layer of encryption to prevent backed up data from becoming unencrypted in case of lost or stolen AWS credentials.
 
-.Openshift velero-plugin-for-aws
-[source,git]
-----
-include::https://github.com/openshift/velero-plugin-for-aws/blob/konveyor-dev/backupstoragelocation.md[]
-----
-
-The link:https://github.com/openshift/velero-plugin-for-aws/blob/konveyor-dev/backupstoragelocation.md[OpenShift velero-plugin-for-aws] provides several additional encryption methods, review the configuration options and consider implementing additional encryption.
+The _OpenShift velero-plugin-for-aws_ provides several additional encryption methods, review the configuration options and consider implementing additional encryption.
 
 Server-side encryption with customer-provided keys (SSE-C), provides Red Hat users the ability to store your own encryption keys. This provides additional required security if the AWS credentials become exposed.
 

--- a/modules/oadp-ssec-encrypted-backups.adoc
+++ b/modules/oadp-ssec-encrypted-backups.adoc
@@ -10,43 +10,25 @@
 [id="oadp-ssec-encrypted-backups_{context}"]
 = OADP SSE-C encrypted backups
 
-First and foremost it is important to note Amazon S3 now applies server-side encryption with Amazon S3 managed keys (SSE-S3) as the base level of encryption for every bucket in Amazon S3 [1]. It is also important to note that OpenShift and OADP encrypt data via SSL, HTTPS, and the velero-repo-credentials secret while data is transfered off cluster to storage. [2]
-Comment
-Suggest edit
+Amazon Web Services (AWS) S3 now applies server-side encryption with Amazon S3 managed keys (SSE-S3) as the base level of encryption for every bucket in Amazon S3. It is to note that OpenShift API for Data Protection (OADP) encrypt data via SSL/TLS, HTTPS, and the velero-repo-credentials secret while data is transferred off cluster to storage.
 
-Red Hat strongly recommends using an additional layer of encryption to help prevent backed up data from being unencrypted in the case of lost or stolen AWS credentials. The OpenShift velero-plugin-for-aws provides several additional encryption methods [3]. Red Hat recommends reviewing the configuration options and implementing additional encryption.
+It is recommended to include an additional layer of encryption to prevent backed up data from being unencrypted in case of lost or stolen AWS credentials. The https://github.com/openshift/velero-plugin-for-aws/blob/konveyor-dev/backupstoragelocation.md[OpenShift velero-plugin-for-aws] provides several additional encryption methods, review the configuration options and consider implementing additional encryption.
 
-SSE-C encryption provides Red Hat customers server-side encryption with customer-provided keys (SSE-C), such that customers can store their own encryption keys. This will provide the required addtional security in the case where AWS credentials have been exposed. [4]
+SSE-C encryption provides Red Hat users server-side encryption with customer-provided keys (SSE-C), so that you can store your own encryption keys. This will provide required additional security if the AWS credentials have been exposed.
 
-You create a default `Secret` if your backup and snapshot locations use the same credentials or if you do not require a snapshot location.
-
-ifdef::installing-oadp-aws,installing-oadp-azure,installing-oadp-gcp,installing-oadp-mcg[]
-The default name of the `Secret` is `{credentials}`.
-endif::[]
-ifdef::installing-oadp-ocs[]
-The default name of the `Secret` is `{credentials}`, unless your backup storage provider has a default plugin, such as `aws`, `azure`, or `gcp`. In that case, the default name is specified in the provider-specific OADP installation procedure.
-endif::[]
-
-[NOTE]
+[WARNING]
 ====
-The `DataProtectionApplication` custom resource (CR) requires a default `Secret`.  Otherwise, the installation will fail. If the name of the backup location `Secret` is not specified, the default name is used.
-
-If you do not want to use the backup location credentials during the installation, you can create a `Secret` with the default name by using an empty `credentials-velero` file.
+it is strongly advised to secure cryptographic keys in a secure and safe manner. Encrypted data and backups will not be recoverable in the absence of the encryption key.
 ====
 
 .Prerequisites
 
-* Your object storage and cloud storage, if any, must use the same credentials.
-* You must configure object storage for Velero.
-* You must create a `credentials-velero` file for the object storage in the appropriate format.
+XXXX
 
 .Procedure
 
-* Create a `Secret` with the default name:
-+
-[source,terminal,subs="attributes+"]
-----
-$ oc create secret generic {credentials} -n openshift-adp --from-file cloud=credentials-velero
-----
+XXXX
 
-The `Secret` is referenced in the `spec.backupLocations.credential` block of the `DataProtectionApplication` CR when you install the Data Protection Application.
+.Verification
+
+XXXX

--- a/modules/oadp-ssec-encrypted-backups.adoc
+++ b/modules/oadp-ssec-encrypted-backups.adoc
@@ -21,9 +21,19 @@ SSE-C encryption provides Red Hat users server-side encryption with customer-pro
 it is strongly advised to secure cryptographic keys in a secure and safe manner. Encrypted data and backups will not be recoverable in the absence of the encryption key.
 ====
 
-.Prerequisites
+.Prerequisites / Known issues
 
-XXXX
+You may receive `credentials not found` errors. To avoid this issue you can create a workaround by adding a volumeSnapshot configuration to your DPA without specifying a credential:
+[source,yaml]
+----
+ snapshotLocations:
+  - velero:
+      config:
+        profile: default
+        region: <region>
+      provider: aws
+# ...
+----
 
 .Procedure
 

--- a/modules/oadp-ssec-encrypted-backups.adoc
+++ b/modules/oadp-ssec-encrypted-backups.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="oadp-ssec-encrypted-backups_{context}"]
+= OADP SSE-C encrypted backups
+
+First and foremost it is important to note Amazon S3 now applies server-side encryption with Amazon S3 managed keys (SSE-S3) as the base level of encryption for every bucket in Amazon S3 [1]. It is also important to note that OpenShift and OADP encrypt data via SSL, HTTPS, and the velero-repo-credentials secret while data is transfered off cluster to storage. [2]
+Comment
+Suggest edit
+
+Red Hat strongly recommends using an additional layer of encryption to help prevent backed up data from being unencrypted in the case of lost or stolen AWS credentials. The OpenShift velero-plugin-for-aws provides several additional encryption methods [3]. Red Hat recommends reviewing the configuration options and implementing additional encryption.
+
+SSE-C encryption provides Red Hat customers server-side encryption with customer-provided keys (SSE-C), such that customers can store their own encryption keys. This will provide the required addtional security in the case where AWS credentials have been exposed. [4]
+
+You create a default `Secret` if your backup and snapshot locations use the same credentials or if you do not require a snapshot location.
+
+ifdef::installing-oadp-aws,installing-oadp-azure,installing-oadp-gcp,installing-oadp-mcg[]
+The default name of the `Secret` is `{credentials}`.
+endif::[]
+ifdef::installing-oadp-ocs[]
+The default name of the `Secret` is `{credentials}`, unless your backup storage provider has a default plugin, such as `aws`, `azure`, or `gcp`. In that case, the default name is specified in the provider-specific OADP installation procedure.
+endif::[]
+
+[NOTE]
+====
+The `DataProtectionApplication` custom resource (CR) requires a default `Secret`.  Otherwise, the installation will fail. If the name of the backup location `Secret` is not specified, the default name is used.
+
+If you do not want to use the backup location credentials during the installation, you can create a `Secret` with the default name by using an empty `credentials-velero` file.
+====
+
+.Prerequisites
+
+* Your object storage and cloud storage, if any, must use the same credentials.
+* You must configure object storage for Velero.
+* You must create a `credentials-velero` file for the object storage in the appropriate format.
+
+.Procedure
+
+* Create a `Secret` with the default name:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc create secret generic {credentials} -n openshift-adp --from-file cloud=credentials-velero
+----
+
+The `Secret` is referenced in the `spec.backupLocations.credential` block of the `DataProtectionApplication` CR when you install the Data Protection Application.

--- a/modules/oadp-ssec-encrypted-backups.adoc
+++ b/modules/oadp-ssec-encrypted-backups.adoc
@@ -37,6 +37,52 @@ You may receive `credentials not found` errors. To avoid this issue you can crea
 
 .Procedure
 
+You can configure an SSE-C encryption to provide additional security by using following these steps.
+
+. Create an encryption key by running the following command:
++
+[source,terminal]
+----
+dd if=/dev/urandom bs=1 count=32 > sse.key
+cat sse.key | base64 > sse_encoded.key
+ln -s sse_encoded.key customer-key
+----
+
+. Create an OpenShift secret.
+
+.. If you are initially installing and configuring OADP, you may create the aws credential and encryption key secret at the same time by running the following command:
++
+[source,terminal]
+----
+$ oc create secret generic cloud-credentials --namespace openshift-adp --from-file cloud=<path>/openshift_aws_credentials,customer-key=<path>/sse_encoded.key
+----
+
+.. If you are updating an existing installation, edit the values of the `cloud-credential` `secret` block of the `DataProtectionApplication` CR manifest, as in the following example:
++
+[source,yaml]
+----
+apiVersion: v1
+data:
+  cloud: W2Rfa2V5X2lkPSJBS0lBVkJRWUIyRkQ0TlFHRFFPQiIKYXdzX3NlY3JldF9hY2Nlc3Nfa2V5P<snip>rUE1mNWVSbTN5K2FpeWhUTUQyQk1WZHBOIgo=
+  customer-key: v+<snip>TFIiq6aaXPbj8dhos=
+kind: Secret
+# ...
+----
+
+. Edit the value of the `customerKeyEncryptionFile` attribute in the `backupLocations` block of `DataProtectionApplication` CR manifest, as in the following example:
+
++
+[source,yaml]
+----
+spec:
+  backupLocations:
+    - velero:
+        config:
+          customerKeyEncryptionFile: /credentials/customer-key
+          profile: default
+# ...
+----
+
 XXXX
 
 .Verification

--- a/modules/oadp-ssec-encrypted-backups.adoc
+++ b/modules/oadp-ssec-encrypted-backups.adoc
@@ -83,8 +83,34 @@ spec:
 # ...
 ----
 
-XXXX
+[WARNING]
+====
+Existing installations require the Velero pod to be restarted to remount the secret credentials properly.
+====
+
+The installation is complete, and you can back up and restore OpenShift resources. The data saved in AWS s3 storage is encrypted with the new key and can not be downloaded via the AWS S3 console or API without the supplied encryption key.
 
 .Verification
 
-XXXX
+Test to verify that encrypted files cannot be downloaded without the extra key.
+
+. Create a test file by running the following command:
+
++
+[source,terminal]
+----
+$ echo "encrypt me please" > test.txt
+----
+
+. Upload the test file by running the following command:
+
++
+[source,terminal]
+----
+$ aws s3api put-object \
+  --bucket <bucket> \
+  --key test.txt \
+  --body test.txt \
+  --sse-customer-key fileb://sse.key \
+  --sse-customer-algorithm AES256
+----

--- a/modules/oadp-ssec-encrypted-backups.adoc
+++ b/modules/oadp-ssec-encrypted-backups.adoc
@@ -10,20 +10,20 @@
 [id="oadp-ssec-encrypted-backups_{context}"]
 = OADP SSE-C encrypted backups
 
-Amazon Web Services (AWS) S3 now applies server-side encryption with Amazon S3 managed keys (SSE-S3) as the base level of encryption for every bucket in Amazon S3. It is important to note that OpenShift API for Data Protection (OADP) encrypts data via SSL/TLS, HTTPS, and the velero-repo-credentials secret while data is transferred off cluster to storage.
+Amazon Web Services (AWS) S3 now applies server-side encryption with Amazon S3 managed keys (SSE-S3) as the base level of encryption for every bucket in Amazon S3. It is important to note that OpenShift API for Data Protection (OADP) encrypts data by using SSL/TLS, HTTPS, and the velero-repo-credentials secret when transferring the data off cluster to storage.
 
-It is recommended to include an additional layer of encryption to prevent backed up data from being unencrypted in case of lost or stolen AWS credentials. The https://github.com/openshift/velero-plugin-for-aws/blob/konveyor-dev/backupstoragelocation.md[OpenShift velero-plugin-for-aws] provides several additional encryption methods, review the configuration options and consider implementing additional encryption.
+It is important to include an additional layer of encryption to prevent backed up data from becoming unencrypted in case of lost or stolen AWS credentials. The https://github.com/openshift/velero-plugin-for-aws/blob/konveyor-dev/backupstoragelocation.md[OpenShift velero-plugin-for-aws] provides several additional encryption methods, review the configuration options and consider implementing additional encryption.
 
-SSE-C encryption provides Red Hat users server-side encryption with customer-provided keys (SSE-C), so that you can store your own encryption keys. This provides additional required security if the AWS credentials have been exposed.
+Server-side encryption with customer-provided keys (SSE-C), provides Red Hat users the ability to store your own encryption keys. This provides additional required security if the AWS credentials become exposed.
 
 [WARNING]
 ====
-It is advised to secure cryptographic keys in a secure and safe manner. Encrypted data and backups will not be recoverable in the absence of the encryption key.
+It is important to secure cryptographic keys in a secure and safe manner. Encrypted data and backups will not be recoverable in the absence of the encryption key.
 ====
 
 .Prerequisites / Known issues
 
-You may receive `credentials not found` errors. To avoid this issue you can create a workaround by adding a volumeSnapshot configuration to your DPA without specifying a credential as in the following example:
+You might receive `credentials not found` errors. To avoid this issue you can create a workaround by adding a `volumeSnapshot` configuration to your `DPA` without specifying a credential as in the following example:
 [source,yaml]
 ----
  snapshotLocations:
@@ -37,20 +37,20 @@ You may receive `credentials not found` errors. To avoid this issue you can crea
 
 .Procedure
 
-You can configure an SSE-C encryption to provide additional security by applying the following steps.
+You can configure an SSE-C encryption to offer additional security by applying the following steps.
 
 . Create an encryption key by running the following command:
 +
 [source,terminal]
 ----
-dd if=/dev/urandom bs=1 count=32 > sse.key
+$ dd if=/dev/urandom bs=1 count=32 > sse.key
 cat sse.key | base64 > sse_encoded.key
 ln -s sse_encoded.key customer-key
 ----
 
 . Create an OpenShift secret.
 
-.. If you are initially installing and configuring OADP, you may create the aws credential and encryption key secret at the same time by running the following command:
+.. If you are initially installing and configuring OADP, you can create the aws credential and encryption key secret at the same time by running the following command:
 +
 [source,terminal]
 ----
@@ -85,10 +85,10 @@ spec:
 
 [WARNING]
 ====
-Existing installations require the Velero pod to be restarted to remount the secret credentials properly.
+Existing installations require you to restart the Velero pod to remount the secret credentials properly.
 ====
 
-The installation is complete, and you can back up and restore OpenShift resources. The data saved in AWS s3 storage is encrypted with the new key and can not be downloaded via the AWS S3 console or API without the additional encryption key.
+The installation is complete, and you can back up and restore OpenShift resources. The data saved in AWS s3 storage is encrypted with the new key and cannot be downloaded from the AWS S3 console or API without the additional encryption key.
 
 .Verification
 
@@ -115,7 +115,7 @@ $ aws s3api put-object \
   --sse-customer-algorithm AES256
 ----
 
-. Attempt to download the file, which should fail because the file is now encrypted with an additional key, by using the S3 web console or the terminal by running the following command:
+. Try to download the file, which should fail because the file is now encrypted with an additional key, by using the S3 web console or the terminal by running the following command:
 
 +
 [source,terminal]
@@ -142,7 +142,7 @@ $ cat downloaded.txt
 encrypt me please
 ----
 
-. The same download call can be executed on velero backed up files by running the following command:
+. You can run the same download call on velero backed up files by running the following command:
 
 +
 [source,terminal]


### PR DESCRIPTION
OADP 1.3.2

OCP 4.13+

Resolves - https://issues.redhat.com/browse/OADP-3949

Display preview - https://75825--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html#oadp-ssec-encrypted-backups_installing-oadp-aws
