### PR TITLE
[RHACS] Updated release notes for 4.4.2 patch release

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -55,7 +55,7 @@ endif::[]
 :osp: Red{nbsp}Hat OpenShift
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 4.4.0
+:rhacs-version: 4.4.2
 :ocp-supported-version: 4.11
 :ocp-latest-version: 4.15
 :product-rosa: Red{nbsp}Hat OpenShift Service on AWS

--- a/release_notes/44-release-notes.adoc
+++ b/release_notes/44-release-notes.adoc
@@ -16,6 +16,8 @@ toc::[]
 |{product-title-short} version |Released on
 
 |`4.4.0` | 28 March 2024
+|`4.4.1` | 22 April 2024
+|`4.4.2` | 20 May 2024
 
 |====
 
@@ -562,6 +564,44 @@ With this update, backend calls become asynchronous and an API parameter is intr
 The issue occurred when more than 10 collections were created and a vulnerability report edit was associated with 10 or more collections in {product-title-short} 4.2 and 4.3. The UI retrieved the first 10 collections from the API, possibly resulting in a missing reference to the report area. This behavior might persist in {product-title-short} 4.1 and 4.2.
 +
 This update ensures that the linked collection is retained, avoiding the error message.
+
+[id="resolved-in-version-441_{context}"]
+=== Resolved in version 4.4.1
+
+*Release date*: 22 April 2024
+
+* Fixed an issue that prevented the filtering of newly added or updated policies by category by using the `roxctl` CLI.
+
+[id="resolved-in-version-442_{context}"]
+=== Resolved in version 4.4.2
+
+*Release date*: 20 May 2024
+
+This release provides the following bug fixes:
+
+* Before this update, Collector pods on nodes with 128 or more cores would fail with a `CrashLoopBackOff` status due to issues with how the CO-RE BPF allocated kernel memory. The patch release fixes this issue.
+* This release updates the Scanner baseline vulnerability data to address changes made to the Red{nbsp}Hat security data feeds that were not compatible with earlier data from Scanner's scheduled feed processing. This fixes various issues where vulnerabilities were detected for images containing packages that were incorrectly indicated as affected by a vulnerability.
+* This release fixes a crash and rendering error in the network graph that occurs when Central is running an {product-title-short} release of 4.3.6 or earlier and Sensor is running an {product-title-short} release of 4.4.0 or later.
+* This release includes a new environment variable, `ROX_API_TOKEN_FILE`, that you can use to pass your API's token file path to the `roxctl` CLI.
+* In earlier {product-title-short} versions, {product-title-short} did not update the alerts when violations changed. This release fixes the issue, and {product-title-short} correctly updates the alerts when violations change.
+
+This release provides the following change:
+
+* The default telemetry endpoint is now set to a Red{nbsp}Hat proxy.
+
+This releases updates the following items to patch vulnerabilities:
+
+* Go has been updated to release 1.20.12.
+* The `golang.org/x/net` module has been updated from release v0.22.0 to v0.23.0.
+
+[id="known-issues-440_{context}"]
+== Known issues
+
+*Updated on*: 22 April 2024
+
+* Currently, there is an issue for {ocp} 4.12 on the {ibm-power} architecture where the CORE_BPF collection method does not work properly. From {product-title-short} 4.4.1 and later, Collector automatically uses the EBPF collection method in this particular case when CORE_BPF is selected.
+
+If you are using {ocp} 4.12 on the {ibm-power} architecture and in offline mode, you must use a support package.
 
 [id="image-versions_{context}"]
 == Image versions


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-23495

Based on information from https://github.com/openshift/openshift-docs/pull/75676 (Thank you @kcarmichael08)

cherry-pick into `rhacs-docs-4.4`

---

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.
