### PR TITLE
OSDOCS-10531: Documented the 4.14.25 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3319,6 +3319,40 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+[id="ocp-4-14-25"]
+=== RHBA-2024:2789 - {product-title} 4.14.25 bug fix update
+
+Issued: 2024-05-16
+
+{product-title} release 4.14.25 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:2789[RHBA-2024:2789] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:2792[RHBA-2024:2792] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.25 --pullspecs
+----
+
+[id="ocp-4-14-25-bug-fixes"]
+==== Bug fixes
+
+* Previously, timeout values larger than what the Go programming language could parse were not properly validated. Consequently, timeout values larger than what HAProxy could parse caused issues with HAProxy. With this update, if the timeout specifies a value larger than what can be parsed, it is capped at the maximum that HAProxy can parse. As a result, issues are no longer caused for HAProxy. (link:https://issues.redhat.com/browse/OCPBUGS-30773[*OCPBUGS-30773*])
+
+* Previously, when users imported image stream tags, `ImageContentSourcePolicy` (ICSP) could not co-exist with `ImageDigestMirrorSet` (IDMS) and `ImageTagMirrorSet` (ITMS). {product-title} ignored any IDMS/ITMS created by the user and favored ICSP. With this release, the image stream tags can co-exist because importing image stream tags now respect IDMS/ITMS when ICSP is also present. (link:https://issues.redhat.com/browse/OCPBUGS-31509[*OCPBUGS-31509*])
+
+* Previously, after you performed an EUS-to-EUS update on your {product-title} cluster that involved pausing and unpausing the machine config pool, two reboot operations occured after the unpause operation. This additional reboot was not expected and was caused by the performance profile controller being reconciled against an older `MachineConfig` object that is listed in the `MachineConfigPool` object. With this release, the performance profile controller reconciles against the latest `MachineConfig` object that is listed in the `MachineConfigPool` object so that the extra reboot does not occur. (link:https://issues.redhat.com/browse/OCPBUGS-32980[*OCPBUGS-32980*])
+
+* Previously, a kernel regression that was introduced in {product-title} 4.14.14 caused kernel issues, such as nodes crashing and rebooting, in nodes that mounted to CephFS storage. In this release, the regression issue is fixed so that the kernel regression issue no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-33251[*OCPBUGS-33251*])
+
+* Previously, `ovs-if-br-ex.nmconnection.\*` files caused the failure of `ovs-configuration.service`, which resulted in nodes being moved to the `NotReady` state. With this release, `ovs-if-br-ex.nmconnection.*` files are removed from `/etc/NetworkManager/system-connections`, so that this issue no longer exists. (link:https://issues.redhat.com/browse/OCPBUGS-32341[*OCPBUGS-32341*])
+
+[id="ocp-4-14-25-updating"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 [id="ocp-4-14-24"]
 === RHSA-2024:2668 - {product-title} 4.14.24 bug fix update and security update
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-10531](https://issues.redhat.com/browse/OSDOCS-10531)

Link to docs preview:
[z-stream release notes 4.14.25](https://75837--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-25)

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
