### PR TITLE
OBSDOCS-1051: Add a table listing supported monitoring component vers…

### DIFF
--- a/modules/monitoring-support-policy-for-monitoring-operators.adoc
+++ b/modules/monitoring-support-policy-for-monitoring-operators.adoc
@@ -3,7 +3,7 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="unmanaged-monitoring-operators_{context}"]
+[id="support-policy-for-monitoring-operators_{context}"]
 = Support policy for monitoring Operators
 
 Monitoring Operators ensure that {product-title} monitoring resources function as designed and tested. If Cluster Version Operator (CVO) control of an Operator is overridden, the Operator does not respond to configuration changes, reconcile the intended state of cluster objects, or receive updates.

--- a/modules/monitoring-support-version-matrix-for-monitoring-components.adoc
+++ b/modules/monitoring-support-version-matrix-for-monitoring-components.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * observability/monitoring/configuring-the-monitoring-stack.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="support-version-matrix-for-monitoring-components_{context}"]
+= Support version matrix for monitoring components
+
+The following matrix contains information about versions of monitoring components for {product-title} 4.12 and later releases:
+
+.{product-title} and component versions
+|===
+|{product-title} |Prometheus Operator |Prometheus  |Prometheus Adapter |Metrics Server (Technology Preview) |Alertmanager |kube-state-metrics agent |monitoring-plugin |node-exporter agent |Thanos
+
+|4.16 |0.73.2 |2.51.2 |0.11.2 |0.7.1 |0.26.0 |2.12.0 |1.0.0 |1.8.0 |0.35.0
+
+|4.15 |0.70.0 |2.48.0 |0.11.2 |0.6.4 |0.26.0 |2.10.1 |1.0.0 |1.7.0 |0.32.5
+
+|4.14 |0.67.1 |2.46.0 |0.10.0 |N/A |0.25.0 |2.9.2 |1.0.0 |1.6.1 |0.30.2
+
+|4.13 |0.63.0 |2.42.0 |0.10.0 |N/A |0.25.0 |2.8.1 |N/A |1.5.0 |0.30.2
+
+|4.12 |0.60.1 |2.39.1 |0.10.0 |N/A |0.24.0 |2.6.0 |N/A |1.4.0 |0.28.1
+|===
+
+[NOTE]
+====
+The openshift-state-metrics agent and Telemeter Client are OpenShift-specific components. Therefore, their versions correspond with the versions of {product-title}.
+====

--- a/observability/monitoring/configuring-the-monitoring-stack.adoc
+++ b/observability/monitoring/configuring-the-monitoring-stack.adoc
@@ -53,8 +53,10 @@ endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/monitoring-support-considerations.adoc[leveloffset=+2]
 ifndef::openshift-dedicated,openshift-rosa[]
-include::modules/monitoring-unmanaged-monitoring-operators.adoc[leveloffset=+2]
+include::modules/monitoring-support-policy-for-monitoring-operators.adoc[leveloffset=+2]
 endif::openshift-dedicated,openshift-rosa[]
+
+include::modules/monitoring-support-version-matrix-for-monitoring-components.adoc[leveloffset=+2]
 
 ifndef::openshift-dedicated,openshift-rosa[]
 // Preparing to configure the monitoring stack


### PR DESCRIPTION
Version(s): `enterprise-4.16` 

Issue: [OBSDOCS-1051](https://issues.redhat.com/browse/OBSDOCS-1051)

Link to docs preview: [Support version matrix for monitoring components](https://75844--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#support-version-matrix-for-monitoring-components_configuring-the-monitoring-stack)

QE review:
- [x] QE has approved this change.

**Additional information:**