### PR TITLE
OSDOCS#10265: Updated the command for adding tab completion

### DIFF
--- a/modules/cli-configuring-completion-zsh.adoc
+++ b/modules/cli-configuring-completion-zsh.adoc
@@ -19,6 +19,8 @@ After you install the OpenShift CLI (`oc`), you can enable tab completion to aut
 [source,terminal]
 ----
 $ cat >>~/.zshrc<<EOF
+autoload -Uz compinit
+compinit
 if [ $commands[oc] ]; then
   source <(oc completion zsh)
   compdef _oc oc


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OSDOCS-10265](https://issues.redhat.com/browse/OSDOCS-10265)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[Enabling tab completion for Zsh](https://75853--ocpdocs-pr.netlify.app/openshift-enterprise/latest/cli_reference/openshift_cli/configuring-cli.html)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->