### PR TITLE
Add release note for network connectivity check

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -200,6 +200,11 @@ You can configure the `linuxptp` services `ptp4l` and `phc2sys` as a highly avai
 
 For more information, see xref:../networking/ptp/configuring-ptp.adoc#ptp-configuring-linuxptp-services-as-ha-bc-for-dual-nic_configuring-ptp[Configuring linuxptp as a highly available system clock for dual-NIC Intel E810 PTP boundary clocks]
 
+[id="ocp-4-16-networking-connectivity-pod-placement_{context}"]
+==== Configuring pod placement to check network connectivity
+
+To periodically test network connectivity amongst cluster components, the Cluster Network Operator (CNO) creates the `network-check-source` deployment and the `network-check-target` daemon set. In {product-title} 4.16, you can configure the nodes by setting node selectors and run the source and target pods to check the network connectivity. For more information, see xref:../networking/verifying-connectivity-endpoint.adoc#verifying-connectivity-endpoint[Verifying connectivity to an endpoint].
+
 [id="ocp-4-16-networking-multiple-cidr_{context}"]
 ==== Define multiple CIDR blocks for one network security group (NSG) rule
 


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-8766

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Configurable placement of network connectivity check pods](https://75856--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-networking-connectivity-pod-placement)


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
