### PR TITLE
OSDOCS#10152: Added ARM64 to the Supported Architectures table

### DIFF
--- a/modules/olm-arch-os-support.adoc
+++ b/modules/olm-arch-os-support.adoc
@@ -15,6 +15,9 @@ The following strings are supported in Operator Lifecycle Manager (OLM) on {prod
 |AMD64
 |`amd64`
 
+|ARM64
+|`arm64`
+
 |{ibm-power-name}
 |`ppc64le`
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OSDOCS-10152](https://issues.redhat.com/browse/OSDOCS-10152)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[Architecture and operating system support for Operators](https://75862--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-generating-csvs.html#olm-arch-os-support_osdk-generating-csvs)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->