### PR TITLE
OSDOCS#9399: Added NTP/UDP 123 port in network connectivity requirements table

### DIFF
--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -159,7 +159,7 @@ the Cluster Version Operator on port `9099`.
 |`10250`-`10259`
 |The default ports that Kubernetes reserves
 
-.5+|UDP
+.6+|UDP
 |`4789`
 |VXLAN
 
@@ -174,6 +174,11 @@ the Cluster Version Operator on port `9099`.
 
 |`4500`
 |IPsec NAT-T packets
+
+|`123`
+|Network Time Protocol (NTP) on UDP port `123`
+
+If an external NTP time server is configured, you must open UDP port `123`.
 
 |TCP/UDP
 |`30000`-`32767`


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OSDOCS-9399](https://issues.redhat.com/browse/OSDOCS-9399)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[Ports used for all-machine to all-machine communications](https://75863--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-user-infra#installation-network-connectivity-user-infra_installing-azure-user-infra)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
