### PR TITLE
OCPBUGS#33598: The FROM clauses on Containerfile examples of RHCOS image layering are wrong

### DIFF
--- a/machine_configuration/mco-coreos-layering.adoc
+++ b/machine_configuration/mco-coreos-layering.adoc
@@ -74,7 +74,7 @@ content: |-
 [source,yaml]
 ----
 # Using a 4.12.0 image
-FROM quay.io/openshift-release-dev/ocp-release@sha256...
+FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256...
 #Install hotfix rpm
 RUN rpm-ostree override replace https://example.com/myrepo/haproxy-1.0.16-5.el8.src.rpm && \
     rpm-ostree cleanup -m && \


### PR DESCRIPTION
Fixed the format of the rhel-coreos base image on
the `FROM` clauses of the examples.

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-33598

Link to docs preview:

https://75864--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering.html

QE review:
- [x] QE has approved this change.

Additional information:
(none)