### PR TITLE
CNV#29984: Document auto setting of mem and CPU resource limits

### DIFF
--- a/modules/virt-about-cpu-and-memory-quota-namespace.adoc
+++ b/modules/virt-about-cpu-and-memory-quota-namespace.adoc
@@ -8,5 +8,6 @@
 
 A _resource quota_, defined by the `ResourceQuota` object, imposes restrictions on a namespace that limit the total amount of compute resources that can be consumed by resources within that namespace.
 
-The `HyperConverged` custom resource (CR) defines the user configuration for the Containerized Data Importer (CDI). The CPU and memory request and limit values are set to a default value of `0`.
-This ensures that pods created by CDI that do not specify compute resource requirements are given the default values and are allowed to run in a namespace that is restricted with a quota.
+The `HyperConverged` custom resource (CR) defines the user configuration for the Containerized Data Importer (CDI). The CPU and memory request and limit values are set to a default value of `0`. This ensures that pods created by CDI that do not specify compute resource requirements are given the default values and are allowed to run in a namespace that is restricted with a quota.
+
+When the `AutoResourceLimits` feature gate is enabled, {VirtProductName} automatically manages CPU and memory limits. If a namespace has both CPU and memory quotas, the memory limit is set to double the base allocation and the CPU limit is one per vCPU.


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/CNV-29984

Link to docs preview:
https://75865--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-configuring-cdi-for-namespace-resourcequota.html#virt-about-cpu-and-memory-quota-namespace_virt-configuring-cdi-for-namespace-resourcequota

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
