### PR TITLE
OSDOCS-9838: adds audit log policy relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -63,8 +63,13 @@ See the following list for details:
 
 [id="microshift-4-16-custom-cert-auths"]
 ==== Customizable certificate authorities for the API server are supported
-With this release, you can configure a custom server certificate that has been issued by an external certificate authority (CA). The default API server certificate is issued by an internal {microshift-short} cluster CA. You can now replace this certificate with one that is issued by a CA that clients trust.
-//TODO add xref after section merges
+With this release, you can configure a custom server certificate that has been issued by an external certificate authority (CA). The default API server certificate is issued by an internal {microshift-short} cluster CA. You can now replace this certificate with one that is issued by a CA that clients trust. See xref:../microshift_configuring/microshift-custom-ca.adoc#microshift-custom-ca[Configuring custom certificate authorities] for details.
+
+[id="microshift-4-16-audit-logging-config"]
+==== Configurable policies for log file rotation and retention
+
+You can now configure audit logging policies to manage the retention policies for log files, ensuring that edge devices with limited storage capacities are not hampered by accumulated logging data. To configure audit log policies, use settings such as a maximum file size limit and maximum retained files to set a limit on log storage size. You can also choose an audit policy profile to specify the data collected.
+//TODO add xref after feature PR merges
 
 [id="microshift-4-16-networking"]
 === Networking


### PR DESCRIPTION
Version(s):
4.16 only

Issue:
[OSDOCS-9838](https://issues.redhat.com/browse/OSDOCS-9838)

Link to docs preview:
[Audit Log policy release note](https://75867--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-audit-logging-config)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[Main feature PR](https://github.com/openshift/openshift-docs/pull/75233)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
