### PR TITLE
OSDOCS-9277-new:State NMState wait-ip parameter in dual-stack network…

### DIFF
--- a/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
@@ -28,6 +28,23 @@ serviceNetwork:
 - fd03::/112
 ----
 
+[IMPORTANT]
+====
+If you specified an NMState configuration in the `networkConfig` section of your `install-config.yaml` file, ensure you add `interfaces.wait-ip: ipv4+ipv6` to the NMState YAML file to resolve an issue that prevents your cluster from deploying on a dual-stack network.
+
+.Example NMState YAML configuration file that includes the `wait-ip` parameter
+[source,yaml]
+----
+networkConfig:
+  nmstate:
+    interfaces:
+    - name: <interface_name>
+# ...
+      wait-ip: ipv4+ipv6
+# ...
+----
+====
+
 To provide an interface to the cluster for applications that use IPv4 and IPv6 addresses, configure IPv4 and IPv6 virtual IP (VIP) address endpoints for the Ingress VIP and API VIP services. To configure IPv4 and IPv6 address endpoints, edit the `apiVIPs` and `ingressVIPs` configuration settings in the `install-config.yaml` file . The `apiVIPs` and `ingressVIPs` configuration settings use a list format. The order of the list indicates the primary and secondary VIP address for each service.
 
 ifdef::vsphere[]


### PR DESCRIPTION
WILL NEED A CHANGE MANAGEMENT NOTIFICATION. After QE approve, I'll send out a CM for 4.12 to 4.15 changes.

Version(s):
4.12 to 4.16

Issue:
[OSDOCS-9277](https://issues.redhat.com/browse/OSDOCS-9277)

Link to docs preview:
[Optional: Deploying with dual-stack networking](https://75869--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#modifying-install-config-for-dual-stack-network_ipi-install-installation-workflow)

- [x] SME has approved this change.
- [x] QE has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
