### PR TITLE
WMCO 9.0.2 release notes

### DIFF
--- a/windows_containers/windows-containers-release-notes-9-x.adoc
+++ b/windows_containers/windows-containers-release-notes-9-x.adoc
@@ -26,6 +26,17 @@ You must have this separate subscription to receive support for Windows Containe
 For more information, see the Red Hat OpenShift Container Platform Life Cycle Policy document for link:https://access.redhat.com/support/policy/updates/openshift#windows[{productwinc}].
 endif::openshift-origin[]
 
+[id="wmco-9-0-2"]
+== Release notes for Red Hat Windows Machine Config Operator 9.0.2
+
+This release of the WMCO provides new features and bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 9.0.2 were released in link:https://access.redhat.com/errata/RHBA-2024:2830[RHBA-2024:2830].
+
+[id="wmco-9-0-2-bug-fixes"]
+=== Bug fixes
+
+* Previously, the kubelet was unable to authenticate with private ECR registries. Beacuse of this error, the kubelet was not able to pull images from these registries. With this fix, the kubelet is able to pull images from these registries as expected. (link:https://issues.redhat.com/browse/OCPBUGS-32136[*OCPBUGS-32136*])
+
+
 [id="wmco-9-0-1"]
 == Release notes for Red Hat Windows Machine Config Operator 9.0.1
 


### PR DESCRIPTION
Errata: https://errata.devel.redhat.com/advisory/128984

**GA 5/15/24**

**PEER REVIEW** The link to the errata is not live until the errata is shipped on 5/15. The errata live id is shown in [comment 33](https://errata.devel.redhat.com/advisory/128984#c33) in the errata tool (for those with access).

Preview: [Release notes for Red Hat Windows Machine Config Operator 9.0.2](https://75870--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-9-x.html#wmco-9-0-2)