### PR TITLE
OSSM-6383: OSSM in clusterwide mode can include ALL cluster projects

### DIFF
--- a/modules/ossm-excluding-namespaces-from-cluster-wide-mesh-cli.adoc
+++ b/modules/ossm-excluding-namespaces-from-cluster-wide-mesh-cli.adoc
@@ -5,8 +5,13 @@
 [id="ossm-excluding-namespaces-from-cluster-wide-mesh-cli_{context}"]
 = Including and excluding namespaces from a cluster-wide mesh by using the CLI
 
-By default, the {SMProductName} Operator uses discovery selectors to identify the namespaces that make up the mesh. Namespaces that do not contain the label defined in the `ServiceMeshMemberRoll` resource are not matched by the discovery selector and are excluded from the mesh.  
- 
+Using the {product-title} CLI, you can add discovery selectors to the `ServiceMeshControlPlane` resource in a cluster-wide mesh. Discovery selectors define the namespaces that the control plane can discover. The control plane ignores any namespace that does not match one of the discovery selectors, which excludes the namespace from the mesh.
+
+[NOTE]
+====
+If you install ingress or egress gateways in the control plane namespace, you must include the control plane namespace in the discovery selectors.
+====
+
 .Prerequisites
 
 * You have installed the {SMProductName} Operator.
@@ -25,7 +30,14 @@ $ oc -n istio-system edit smcp <name> <1>
 ----
 <1> `<name>` represents the name of the `ServiceMeshControlPlane` resource.
 
-. Modify the YAML file so that the `spec.discoverySelectors` field of the `ServiceMeshMemberRoll` resource includes the discovery selector. The following example uses `istio-discovery: enabled`:
+. Modify the YAML file so that the `spec.meshConfig` field of the `ServiceMeshControlPlane` resource includes the discovery selector. 
++
+[NOTE]
+====
+When configuring namespaces that the `Istiod` service can discover, exclude namespaces that might contain sensitive services that should not be exposed to the rest of the mesh.
+====
++
+In the following example, the `Istiod` service discovers any namespace that is labeled `istio-discovery: enabled` or any namespace that has the name `bookinfo`, `httpbin` or `istio-system`:
 +
 [source,yaml]
 ----
@@ -41,12 +53,15 @@ spec:
         istio-discovery: enabled <1>
     - matchExpressions:
       - key: kubernetes.io/metadata.name <2>
-        operator: NotIn
+        operator: In
         values:
         - bookinfo
         - httpbin
+        - istio-system
 ----
-<1> Ensures that the mesh discovers namespaces that contain the label `istio-discovery: enabled`. The mesh does not discover namespaces that do not contain the label.
-<2> Ensures that the mesh does not discover namespaces `bookinfo` and `httpbin`.
+<1> Ensures that the mesh discovers namespaces that contain the label `istio-discovery: enabled`. 
+<2> Ensures that the mesh discovers namespaces `bookinfo`, `httpbin` and `istio-system`.
++
+If a namespace matches any of the discovery selectors, then the mesh discovers the namespace. The mesh excludes namespaces that do not match any of the discovery selectors.
 
 . Save the file and exit the editor.

--- a/modules/ossm-excluding-namespaces-from-cluster-wide-mesh-console.adoc
+++ b/modules/ossm-excluding-namespaces-from-cluster-wide-mesh-console.adoc
@@ -4,9 +4,14 @@
 :_mod-docs-content-type: PROCEDURE
 [id="ossm-excluding-namespaces-from-cluster-wide-mesh-console_{context}"]
 = Including and excluding namespaces from a cluster-wide mesh by using the web console
- 
-By default, the {SMProductName} Operator uses discovery selectors to identify the namespaces that make up the mesh. Namespaces that do not contain the label defined in the `ServiceMeshMemberRoll` resource are not matched by the discovery selector and are excluded from the mesh.  
- 
+
+Using the {product-title} web console, you can add discovery selectors to the `ServiceMeshControlPlane` resource in a cluster-wide mesh. Discovery selectors define the namespaces that the control plane can discover. The control plane ignores any namespace that does not match one of the discovery selectors, which excludes the namespace from the mesh.
+
+[NOTE]
+====
+If you install ingress or egress gateways in the control plane namespace, you must include the control plane namespace in the discovery selectors.
+====
+
 .Prerequisites
 
 * You have installed the {SMProductName} Operator.
@@ -27,7 +32,14 @@ By default, the {SMProductName} Operator uses discovery selectors to identify th
 
 . Click *YAML*.
 
-. Modify the YAML file so that the `spec.discoverySelectors` field of the `ServiceMeshMemberRoll` resource includes the discovery selector. The following example uses `istio-discovery: enabled`:
+. Modify the YAML file so that the `spec.meshConfig` field of the `ServiceMeshControlPlane` resource includes the discovery selector. 
++
+[NOTE]
+====
+When configuring namespaces that the `Istiod` service can discover, exclude namespaces that might contain sensitive services that should not be exposed to the rest of the mesh.
+====
++
+In the following example, the `Istiod` service discovers any namespace that is labeled `istio-discovery: enabled` or any namespace that has the name `bookinfo`, `httpbin` or `istio-system`:
 +
 [source,yaml]
 ----
@@ -43,12 +55,15 @@ spec:
         istio-discovery: enabled <1>
     - matchExpressions:
       - key: kubernetes.io/metadata.name <2>
-        operator: NotIn
+        operator: In
         values:
         - bookinfo
         - httpbin
+        - istio-system
 ----
-<1> Ensures that the mesh discovers namespaces that contain the label `istio-discovery: enabled`. The mesh does not discover namespaces that do not contain the label.
-<2> Ensures that the mesh does not discover namespaces `bookinfo` and `httpbin`.
+<1> Ensures that the mesh discovers namespaces that contain the label `istio-discovery: enabled`. 
+<2> Ensures that the mesh discovers namespaces `bookinfo`, `httpbin` and `istio-system`.
++
+If a namespace matches any of the discovery selectors, then the mesh discovers the namespace. The mesh excludes namespaces that do not match any of the discovery selectors.
 
 . Save the file.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15, 4.14, 4.13, 4.12

<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSSM-6383
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://75873--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-deployment-models.html#ossm-excluding-namespaces-from-cluster-wide-mesh-console_ossm-deployment-models
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
