### PR TITLE
OSDOCS-10291: CCM as optional capability

### DIFF
--- a/installing/cluster-capabilities.adoc
+++ b/installing/cluster-capabilities.adoc
@@ -40,6 +40,9 @@ include::modules/cluster-bare-metal-operator.adoc[leveloffset=+2]
 // Build capability
 include::modules/build-config-capability.adoc[leveloffset=+2]
 
+// Cloud controller manager capability
+include::modules/cluster-cloud-controller-manager-operator.adoc[leveloffset=+2]
+
 // Cloud credential capability
 include::modules/cloud-credential-operator.adoc[leveloffset=+2]
 

--- a/modules/cluster-cloud-controller-manager-operator.adoc
+++ b/modules/cluster-cloud-controller-manager-operator.adoc
@@ -2,11 +2,42 @@
 //
 // * operators/operator-reference.adoc
 
+ifeval::["{context}" == "cluster-operators-ref"]
+:operators:
+endif::[]
+ifeval::["{context}" == "cluster-capabilities"]
+:cluster-caps:
+endif::[]
+
 [id="cluster-cloud-controller-manager-operator_{context}"]
-= Cluster Cloud Controller Manager Operator
+ifdef::operators[= Cloud Controller Manager Operator]
+ifdef::cluster-caps[= Cloud controller manager capability]
 
 [discrete]
 == Purpose
+
+ifdef::cluster-caps[]
+The Cloud Controller Manager Operator provides features for the `CloudControllerManager` capability.
+
+[NOTE]
+====
+Currently, disabling the `CloudControllerManager` capability is not supported on all platforms.
+====
+
+You can determine if your cluster supports disabling the `CloudControllerManager` capability by checking values in the installation configuration (`install-config.yaml`) file for your cluster.
+
+In the `install-config.yaml` file, locate the `platform` parameter.
+
+* If the value of the `platform` parameter is `Baremetal` or `None`, you can disable the `CloudControllerManager` capability on your cluster.
+
+* If the value of the `platform` parameter is `External`, locate the `platform.external.cloudControllerManager` parameter.
+If the value of the `platform.external.cloudControllerManager` parameter is `None`, you can disable the `CloudControllerManager` capability on your cluster.
+
+[IMPORTANT]
+====
+If these parameters contain any other values than those listed, you cannot disable the `CloudControllerManager` capability on your cluster.
+====
+endif::cluster-caps[]
 
 [NOTE]
 ====
@@ -15,7 +46,7 @@ The status of this Operator is General Availability for {aws-first}, {gcp-first}
 The Operator is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for {alibaba} and {ibm-power-server-name}.
 ====
 
-The Cluster Cloud Controller Manager Operator manages and updates the cloud controller managers deployed on top of {product-title}. The Operator is based on the Kubebuilder framework and `controller-runtime` libraries. It is installed via the Cluster Version Operator (CVO).
+The Cloud Controller Manager Operator manages and updates the cloud controller managers deployed on top of {product-title}. The Operator is based on the Kubebuilder framework and `controller-runtime` libraries. It is installed via the Cluster Version Operator (CVO).
 
 It contains the following components:
 
@@ -24,7 +55,16 @@ It contains the following components:
 
 By default, the Operator exposes Prometheus metrics through the `metrics` service.
 
+ifdef::operators[]
 [discrete]
 == Project
 
 link:https://github.com/openshift/cluster-cloud-controller-manager-operator[cluster-cloud-controller-manager-operator]
+endif::operators[]
+
+ifeval::["{context}" == "cluster-operators-ref"]
+:!operators:
+endif::[]
+ifeval::["{context}" == "cluster-capabilities"]
+:!cluster-caps:
+endif::[]

--- a/modules/installation-initializing-manual.adoc
+++ b/modules/installation-initializing-manual.adoc
@@ -89,7 +89,7 @@ Installing the cluster requires that you manually create the installation config
 ifdef::vsphere-upi,restricted-upi[]
 [IMPORTANT]
 ====
-The Cluster Cloud Controller Manager Operator performs a connectivity check on a provided hostname or IP address. Ensure that you specify a hostname or an IP address to a reachable vCenter server. If you provide metadata to a non-existent vCenter server, installation of the cluster fails at the bootstrap stage.
+The Cloud Controller Manager Operator performs a connectivity check on a provided hostname or IP address. Ensure that you specify a hostname or an IP address to a reachable vCenter server. If you provide metadata to a non-existent vCenter server, installation of the cluster fails at the bootstrap stage.
 ====
 endif::vsphere-upi,restricted-upi[]
 

--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -150,7 +150,7 @@ If you must specify VMs across multiple datastores, use a `datastore` object to 
 +
 [IMPORTANT]
 ====
-The Cluster Cloud Controller Manager Operator performs a connectivity check on a provided hostname or IP address. Ensure that you specify a hostname or an IP address to a reachable vCenter server. If you provide metadata to a non-existent vCenter server, installation of the cluster fails at the bootstrap stage.
+The Cloud Controller Manager Operator performs a connectivity check on a provided hostname or IP address. Ensure that you specify a hostname or an IP address to a reachable vCenter server. If you provide metadata to a non-existent vCenter server, installation of the cluster fails at the bootstrap stage.
 ====
 <13> The vSphere disk provisioning method.
 ifndef::openshift-origin[]

--- a/snippets/capabilities-table.adoc
+++ b/snippets/capabilities-table.adoc
@@ -25,6 +25,9 @@ The following table describes the `baselineCapabilitySet` values.
 |`v4.15`
 |Specify this option when you want to enable the default capabilities for {product-title} 4.15. By specifying `v4.15`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.15 are `baremetal`, `MachineAPI`, `marketplace`, `OperatorLifecycleManager`, `openshift-samples`, `Console`, `Insights`, `Storage`, `CSISnapshot`, `NodeTuning`, `ImageRegistry`, `Build`, `CloudCredential`, and `DeploymentConfig`.
 
+|`v4.16`
+|Specify this option when you want to enable the default capabilities for {product-title} 4.16. By specifying `v4.16`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.16 are `baremetal`, `MachineAPI`, `marketplace`, `OperatorLifecycleManager`, `openshift-samples`, `Console`, `Insights`, `Storage`, `CSISnapshot`, `NodeTuning`, `ImageRegistry`, `Build`, `CloudCredential`, `DeploymentConfig`, and `CloudControllerManager`.
+
 |`None`
 |Specify when the other sets are too large, and you do not need any capabilities or want to fine-tune via `additionalEnabledCapabilities`.
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-10291](https://issues.redhat.com//browse/OSDOCS-10291)

Link to docs preview:
* [Cloud controller manager capability](https://75877--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/cluster-capabilities#cluster-cloud-controller-manager-operator_cluster-capabilities)
* [Cloud Controller Manager Operator](https://75877--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator-reference#cluster-cloud-controller-manager-operator_cluster-operators-ref)

QE review:
- [x] QE has approved this change.

Additional information:
Also fixed CCM name in a couple places