### PR TITLE
OSDOCS-10291: CCM as optional capability (RNs)

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -62,6 +62,12 @@ This release adds improvements related to the following components and concepts.
 [id="ocp-4-16-installation-and-update"]
 === Installation and update
 
+[id="ocp-4-16-installation-and-update-optional-ccm"]
+==== Optional cloud controller manager cluster capability
+
+In {product-title} {product-version}, you can disable the cloud controller manager capability during installation.
+For more information, see xref:../installing/cluster-capabilities.adoc#cluster-cloud-controller-manager-operator_cluster-capabilities[Cloud controller manager capability].
+
 [id="ocp-4-16-web-console"]
 === Web console
 
@@ -132,7 +138,7 @@ With this update, you can configure the SR-IOV Network Operator to drain nodes i
 
 For further information, see xref:../networking/hardware_networks/configuring-sriov-device.adoc#configure-sr-iov-operator-parallel-nodes_configuring-sriov-device[Configuring parallel node draining during SR-IOV network policy updates].
 [id="ocp-4-16-q-in-q-support"]
-==== Supporting double-tagged packets (QinQ) 
+==== Supporting double-tagged packets (QinQ)
 
 This release introduces 802.1Q-in-802.1Q also known as QinQ support. QinQ introduces a second VLAN tag, where the service provider designates the outer tag for their use, offering them flexibility, while the inner tag remains dedicated to the customer’s VLAN. When two VLAN tags are present in a packet, the outer VLAN tag can be either 802.1Q or 802.1ad. The inner VLAN tag must always be 802.1Q.
 
@@ -524,11 +530,11 @@ In the following tables, features are marked with the following statuses:
 ==== Linux Control Groups version 1 is now deprecated
 
 In {op-system-base-full} 9, the default mode is cgroup v2. When {op-system-base-full} 10 is released, systemd will not support booting in the cgroup v1 mode and only cgroup v2 mode will be available. As such, cgroup v1 is deprecated in {product-title} 4.16 and later. cgroup v1 will be removed in a future {product-title} release.
- 
+
 [id="ocp-4-16-deprecation-samples-operator"]
 ==== Cluster Samples Operator
 
-The Cluster Samples Operator is deprecated with the {product-title} 4.16 release. The Cluster Samples Operator will stop managing and providing support to the non-S2I samples (image streams and templates). No new templates, samples or non-Source-to-Image (Non-S2I) image streams will be added to the Cluster Samples Operator. However, the existing S2I builder image streams and templates will continue to receive updates until the Cluster Samples Operator is removed in a future release. 
+The Cluster Samples Operator is deprecated with the {product-title} 4.16 release. The Cluster Samples Operator will stop managing and providing support to the non-S2I samples (image streams and templates). No new templates, samples or non-Source-to-Image (Non-S2I) image streams will be added to the Cluster Samples Operator. However, the existing S2I builder image streams and templates will continue to receive updates until the Cluster Samples Operator is removed in a future release.
 
 [id="ocp-4-16-removed-features"]
 === Removed features


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-10291](https://issues.redhat.com//browse/OSDOCS-10291)

Link to docs preview:
[Optional cloud controller manager cluster capability](https://75884--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-installation-and-update-optional-ccm)

QE review:
- [x] QE has approved this change.

Additional information:
For #75877 (the specific page link in the output will be off until that PR merged into 4.16, but this will build without it)