### PR TITLE
EUS update format fix

### DIFF
--- a/modules/updating-eus-to-eus-upgrade-cli.adoc
+++ b/modules/updating-eus-to-eus-upgrade-cli.adoc
@@ -139,9 +139,8 @@ $ oc get mcp
 ====
 When you update a cluster that contains {op-system-base-full} compute machines, those machines temporarily become unavailable during the update process. You must run the upgrade playbook against each {op-system-base} machine as it enters the `NotReady` state for the cluster to finish updating. For more information, see "Updating a cluster that includes RHEL compute machines" in the additional resources section.
 ====
-
-.Example output
 +
+.Example output
 [source,terminal]
 ----
 NAME 	   CONFIG                                            UPDATED     UPDATING


### PR DESCRIPTION
Version(s): 4.14+

This PR fixes a small formatting error introduced in [this line](https://github.com/openshift/openshift-docs/pull/75655/files#diff-affd169770dc0fe1beea7874ae542d49fbc6001188182099945287131b5b77dcR142) of #75655 which unintentionally removes the nesting of that step's example output, and shows an unwanted + in the rendered docs.

QE: N/A for typo/formatting fix

Live doc: [EUS-to-EUS update using the CLI](https://docs.openshift.com/container-platform/4.15/updating/updating_a_cluster/eus-eus-update.html#updating-eus-to-eus-upgrade-cli_eus-to-eus-update)

Preview: [EUS-to-EUS update using the CLI](https://75885--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/eus-eus-update.html#updating-eus-to-eus-upgrade-cli_eus-to-eus-update)