### PR TITLE
HCIDOCS-300: Incorrect example for dual port NIC in day 1 metal IPI

### DIFF
--- a/modules/ipi-install-configuring-host-dual-network-interfaces-in-the-install-config.yaml-file.adoc
+++ b/modules/ipi-install-configuring-host-dual-network-interfaces-in-the-install-config.yaml-file.adoc
@@ -27,90 +27,93 @@ Errors in the YAML syntax might result in a failure to apply the network configu
 +
 [source,yaml]
 ----
-hosts:
-  - hostname: worker-1
-    interfaces:
-      - name: eno1
-        macAddress: 0c:42:a1:55:f3:06
-      - name: eno2
-        macAddress: 0c:42:a1:55:f3:07
-    networkConfig: <1>
-      interfaces: <2>
-        - name: eno1 <3>
-          type: ethernet <4>
-          state: up
-          mac-address: 0c:42:a1:55:f3:06
-          ipv4:
-            enabled: true
-            dhcp: false <5>
-          ethernet:
-            sr-iov:
-              total-vfs: 2 <6>
-          ipv6:
-            enabled: false
-            dhcp: false
-        - name: sriov:eno1:0
-          type: ethernet
-          state: up <7>
-          ipv4:
-            enabled: false <8>
-          ipv6:
-            enabled: false
-        - name: sriov:eno1:1
-          type: ethernet
-          state: down
-        - name: eno2
-          type: ethernet
-          state: up
-          mac-address: 0c:42:a1:55:f3:07
-          ipv4:
-            enabled: true
-          ethernet:
-            sr-iov:
-              total-vfs: 2
-          ipv6:
-            enabled: false
-        - name: sriov:eno2:0
-          type: ethernet
-          state: up
-          ipv4:
-            enabled: false
-          ipv6:
-            enabled: false
-        - name: sriov:eno2:1
-          type: ethernet
-          state: down
-        - name: bond0
-          type: bond
-          state: up
-          min-tx-rate: 100 <9>
-          max-tx-rate: 200 <10>
-          link-aggregation:
-            mode: active-backup <11>
-            options:
-              primary: sriov:eno1:0 <12>
-            port:
-              - sriov:eno1:0
-              - sriov:eno2:0
-          ipv4:
-            address:
-              - ip: 10.19.16.57 <13>
-                prefix-length: 23
-            dhcp: false
-            enabled: true
-          ipv6:
-            enabled: false
-          dns-resolver:
-            config:
-              server:
-                - 10.11.5.160
-                - 10.2.70.215
-          routes:
-            config:
-              - destination: 0.0.0.0/0
-                next-hop-address: 10.19.17.254
-                next-hop-interface: bond0 <14>
-                table-id: 254
+    hosts:
+      - name: worker-0
+        role: worker
+        bmc:
+          address: redfish+http://<out_of_band_ip>/redfish/v1/Systems/
+          username: <user>
+          password: <password>
+          disableCertificateVerification: false
+        bootMACAddress: <NIC1_mac_address>
+        bootMode: UEFI
+        networkConfig: <1>
+          interfaces: <2>
+           - name: eno1 <3>
+             type: ethernet <4> 
+             state: up
+             mac-address: 0c:42:a1:55:f3:06
+             ipv4:
+               enabled: true
+               dhcp: false <5>
+             ethernet:
+               sr-iov:
+                 total-vfs: 2 <6>
+             ipv6:
+               enabled: false
+               dhcp: false
+           - name: sriov:eno1:0
+             type: ethernet
+             state: up <7>
+             ipv4:
+               enabled: false <8>
+             ipv6:
+               enabled: false
+           - name: sriov:eno1:1
+             type: ethernet
+             state: down
+           - name: eno2
+             type: ethernet
+             state: up
+             mac-address: 0c:42:a1:55:f3:07
+             ipv4:
+               enabled: true
+             ethernet:
+               sr-iov:
+                 total-vfs: 2
+             ipv6:
+               enabled: false
+           - name: sriov:eno2:0
+             type: ethernet
+             state: up
+             ipv4:
+               enabled: false
+             ipv6:
+               enabled: false
+           - name: sriov:eno2:1
+             type: ethernet
+             state: down
+           - name: bond0 
+             type: bond
+             state: up
+             min-tx-rate: 100 <9>
+             max-tx-rate: 200 <10>
+             link-aggregation:
+               mode: active-backup <11> 
+               options:
+                 primary: sriov:eno1:0 <12>
+               port:
+                 - sriov:eno1:0
+                 - sriov:eno2:0
+             ipv4:
+               address:
+                 - ip: 10.19.16.57 <13>
+                   prefix-length: 23
+               dhcp: false
+               enabled: true
+             ipv6:
+               enabled: false
+             dns-resolver:
+               config:
+                 server:
+                   - 10.11.5.160
+                   - 10.2.70.215
+             routes:
+               config:
+                 - destination: 0.0.0.0/0
+                   next-hop-address: 10.19.17.254
+                   next-hop-interface: bond0 <14>
+                   table-id: 254
 ----
 <1> The `networkConfig` field contains information about the network configuration of the host, with subfields including `interfaces`, `dns-resolver`, and `routes`.
 <2> The `interfaces` field is an array of network interfaces defined for the host.


### PR DESCRIPTION
Updated configuration from feedback.

Fixes: [HCIDOCS-300](https://issues.redhat.com//browse/HCIDOCS-300)

See https://issues.redhat.com/browse/HCIDOCS-300 for additional details.

Preview URL: http://184.23.213.161:8080/HCIDOCS-300/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-host-dual-network-interfaces-in-the-install-config-yaml-file_ipi-install-installation-workflow

For release(s): 4.13-4.16
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
