### PR TITLE
Runbook fix: incorrect example

### DIFF
--- a/modules/virt-runbook-hcoinstallationincomplete.adoc
+++ b/modules/virt-runbook-hcoinstallationincomplete.adoc
@@ -35,11 +35,11 @@ default values:
 [source,terminal]
 ----
 $ cat <<EOF | oc apply -f -
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
 metadata:
-  name: hco-operatorgroup
-  namespace: kubevirt-hyperconverged
+  name: kubevirt-hyperconverged
+  namespace: openshift-cnv
 spec: {}
 EOF
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: none currently
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: related to discussion on https://github.com/kubevirt/monitoring/pull/240/files
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

@tiraboschi @dbasunag please review, thanks!
cc @machadovilaca 