### PR TITLE
OSDOCS-10559: adds assembly for router docs MicroShift

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -406,6 +406,8 @@ Topics:
   File: microshift-cni
 - Name: Using networking settings
   File: microshift-networking-settings
+- Name: Configuring the router
+  File: microshift-nw-router
 - Name: Network policies
   Dir: microshift_network_policy
   Topics:

--- a/microshift_networking/microshift-nw-router.adoc
+++ b/microshift_networking/microshift-nw-router.adoc
@@ -1,0 +1,10 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="microshift-understanding-and-configuring-router"]
+= Understanding and configuring the router
+include::_attributes/attributes-microshift.adoc[]
+:context: microshift-nw-router
+
+toc::[]
+
+Learn about default and custom settings for configuring the router with {microshift-short}.
+


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-10559](https://issues.redhat.com/browse/OSDOCS-10559)

Link to docs preview:
[MicroShift router assembly](https://75899--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-nw-router.html)

SME review:
Done

QE review:
N/A docs structural addition

<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
