### PR TITLE
[enterprise-4.14] OBSDOCS-1054: Add a table listing supported monitoring component vers…

### DIFF
--- a/modules/monitoring-support-policy-for-monitoring-operators.adoc
+++ b/modules/monitoring-support-policy-for-monitoring-operators.adoc
@@ -3,7 +3,7 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="unmanaged-monitoring-operators_{context}"]
+[id="support-policy-for-monitoring-operators_{context}"]
 = Support policy for monitoring Operators
 
 Monitoring Operators ensure that {product-title} monitoring resources function as designed and tested. If Cluster Version Operator (CVO) control of an Operator is overridden, the Operator does not respond to configuration changes, reconcile the intended state of cluster objects, or receive updates.

--- a/modules/monitoring-support-version-matrix-for-monitoring-components.adoc
+++ b/modules/monitoring-support-version-matrix-for-monitoring-components.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * observability/monitoring/configuring-the-monitoring-stack.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="support-version-matrix-for-monitoring-components_{context}"]
+= Support version matrix for monitoring components
+
+The following matrix contains information about versions of monitoring components for {product-title} 4.12 and later releases:
+
+.{product-title} and component versions
+|===
+|{product-title} |Prometheus Operator |Prometheus  |Prometheus Adapter |Alertmanager |kube-state-metrics agent |monitoring-plugin |node-exporter agent |Thanos
+
+|4.14 |0.67.1 |2.46.0 |0.10.0 |0.25.0 |2.9.2 |1.0.0 |1.6.1 |0.30.2
+
+|4.13 |0.63.0 |2.42.0 |0.10.0 |0.25.0 |2.8.1 |N/A |1.5.0 |0.30.2
+
+|4.12 |0.60.1 |2.39.1 |0.10.0 |0.24.0 |2.6.0 |N/A |1.4.0 |0.28.1
+|===
+
+[NOTE]
+====
+The openshift-state-metrics agent and Telemeter Client are OpenShift-specific components. Therefore, their versions correspond with the versions of {product-title}.
+====
+

--- a/observability/monitoring/configuring-the-monitoring-stack.adoc
+++ b/observability/monitoring/configuring-the-monitoring-stack.adoc
@@ -53,8 +53,10 @@ endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/monitoring-support-considerations.adoc[leveloffset=+2]
 ifndef::openshift-dedicated,openshift-rosa[]
-include::modules/monitoring-unmanaged-monitoring-operators.adoc[leveloffset=+2]
+include::modules/monitoring-support-policy-for-monitoring-operators.adoc[leveloffset=+2]
 endif::openshift-dedicated,openshift-rosa[]
+
+include::modules/monitoring-support-version-matrix-for-monitoring-components.adoc[leveloffset=+2]
 
 ifndef::openshift-dedicated,openshift-rosa[]
 // Preparing to configure the monitoring stack


### PR DESCRIPTION
Based on #75844

Version:  `enterprise-4.14`.

Jira: [OBSDOCS-1054](https://issues.redhat.com/browse/OBSDOCS-1054)

Preview: https://75903--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#support-version-matrix-for-monitoring-components_configuring-the-monitoring-stack
