### PR TITLE
[enterprise-4.12] OBSDOCS-1056: Add a table listing supported monitoring component vers…

### DIFF
--- a/modules/monitoring-support-policy-for-monitoring-operators.adoc
+++ b/modules/monitoring-support-policy-for-monitoring-operators.adoc
@@ -3,7 +3,7 @@
 // * observability/monitoring/configuring-the-monitoring-stack.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="unmanaged-monitoring-operators_{context}"]
+[id="support-policy-for-monitoring-operators_{context}"]
 = Support policy for monitoring Operators
 
 Monitoring Operators ensure that {product-title} monitoring resources function as designed and tested. If Cluster Version Operator (CVO) control of an Operator is overridden, the Operator does not respond to configuration changes, reconcile the intended state of cluster objects, or receive updates.

--- a/modules/monitoring-support-version-matrix-for-monitoring-components.adoc
+++ b/modules/monitoring-support-version-matrix-for-monitoring-components.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * observability/monitoring/configuring-the-monitoring-stack.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="support-version-matrix-for-monitoring-components_{context}"]
+= Support version matrix for monitoring components
+
+The following matrix contains information about versions of monitoring components for {product-title} 4.10 and later releases:
+
+.{product-title} and component versions
+|===
+|{product-title} |Prometheus Operator |Prometheus  |Prometheus Adapter |Alertmanager |kube-state-metrics agent |node-exporter agent |Thanos
+
+|4.12 |0.60.1 |2.39.1 |0.10.0 |0.24.0 |2.6.0|1.4.0 |0.28.1
+
+|4.11 |0.57.0 |2.36.2 |0.9.1 |0.24.0 |2.5.0 |1.3.1 |0.26.0
+
+|4.10 |0.53.1 |2.32.1 |0.9.1 |0.23.0 |2.3.0 |1.3.1 |0.23.2
+|===
+
+[NOTE]
+====
+The openshift-state-metrics agent and Telemeter Client are OpenShift-specific components. Therefore, their versions correspond with the versions of {product-title}.
+====

--- a/observability/monitoring/configuring-the-monitoring-stack.adoc
+++ b/observability/monitoring/configuring-the-monitoring-stack.adoc
@@ -39,7 +39,8 @@ Installing another Prometheus instance is not supported by the Red Hat Site Reli
 ====
 
 include::modules/monitoring-support-considerations.adoc[leveloffset=+2]
-include::modules/monitoring-unmanaged-monitoring-operators.adoc[leveloffset=+2]
+include::modules/monitoring-support-policy-for-monitoring-operators.adoc[leveloffset=+2]
+include::modules/monitoring-support-version-matrix-for-monitoring-components.adoc[leveloffset=+2]
 
 // Preparing to configure the monitoring stack
 [id="preparing-to-configure-the-monitoring-stack"]


### PR DESCRIPTION
Based on #75844

Version:  `enterprise-4.12`.

Jira: [OBSDOCS-1056](https://issues.redhat.com/browse/OBSDOCS-1056)

Preview: https://75906--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#support-version-matrix-for-monitoring-components_configuring-the-monitoring-stack
