### PR TITLE
MGMT-16744: KMM_MANAGED 

### DIFF
--- a/modules/kmm-hub-running-kmm-on-the-spoke.adoc
+++ b/modules/kmm-hub-running-kmm-on-the-spoke.adoc
@@ -6,13 +6,11 @@
 [id="kmm-hub-running-kmm-on-the-spoke_{context}"]
 = Running KMM on the spoke
 
-After installing KMM on the spoke, no further action is required. Create a `ManagedClusterModule` object from the hub to deploy kernel modules on spoke clusters.
+After installing Kernel Module Management (KMM) on the spoke, no further action is required. Create a `ManagedClusterModule` object from the hub to deploy kernel modules on spoke clusters.
 
 .Procedure
 
-You can install KMM on the spokes cluster through a RHACM `Policy` object.
-In addition to installing KMM from the Operator hub and running it in a lightweight spoke mode,
-the `Policy` configures additional RBAC required for the RHACM agent to be able to manage `Module` resources.
+You can install KMM on the spokes cluster through a RHACM `Policy` object. In addition to installing KMM from the OperatorHub and running it in a lightweight spoke mode, the `Policy` configures additional RBAC required for the RHACM agent to be able to manage `Module` resources.
 
 * Use the following RHACM policy to install KMM on spoke clusters:
 +
@@ -62,7 +60,7 @@ spec:
                 channel: stable
                 config:
                   env:
-                    - name: KMM_MANAGED
+                    - name: KMM_MANAGED <1>
                       value: "1"
                 installPlanApproval: Automatic
                 name: kernel-module-management
@@ -98,7 +96,7 @@ kind: PlacementRule
 metadata:
   name: all-managed-clusters
 spec:
-  clusterSelector: <1>
+  clusterSelector: <2>
     matchExpressions: []
 ---
 apiVersion: policy.open-cluster-management.io/v1
@@ -114,4 +112,5 @@ subjects:
     kind: Policy
     name: install-kmm
 ----
-<1> The `spec.clusterSelector` field can be customized to target select clusters only.
+<1> This environment variable is required when running KMM on a spoke cluster.
+<2> The `spec.clusterSelector` field can be customized to target select clusters only.


### PR DESCRIPTION
BUG

D/S Docs: [DOCS] Spoke subscription example does not include KMM_MANAGED config
Jira: https://issues.redhat.com/browse/MGMT-16744?src=confmacro

Version(s): openshift-4.13, openshift-4.14, openshift-4.15, openshift-4.16

Link to docs preview: https://75907--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html#kmm-hub-running-kmm-on-the-spoke_kernel-module-management-operator

QE review: @cdvultur
