### PR TITLE
[RHACS] fix date for 4.3.7 release notes

### DIFF
--- a/release_notes/43-release-notes.adoc
+++ b/release_notes/43-release-notes.adoc
@@ -22,7 +22,7 @@ toc::[]
 |`4.3.4` | 22 January 2024
 |`4.3.5` | 13 March 2024
 |`4.3.6` | 27 March 2024
-|`4.3.7` | 9 May 2024
+|`4.3.7` | 13 May 2024
 
 |====
 
@@ -331,7 +331,7 @@ It also provides the following security fixes:
 [id="resolved-in-version-437_{context}"]
 === Resolved in version 4.3.7
 
-*Release date*: 9 May 2024
+*Release date*: 13 May 2024
 
 This release provides the following bug fixes:
 


### PR DESCRIPTION
Version(s):

4.3

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[75919--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/43-release-notes.html](https://75919--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/43-release-notes.html)

QE review: **N/A**
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Release was delayed but I forgot to update the date before merging.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
