### PR TITLE
TELCODOCS-1882: QE review

### DIFF
--- a/modules/kmm-adding-the-keys-for-secureboot.adoc
+++ b/modules/kmm-adding-the-keys-for-secureboot.adoc
@@ -30,7 +30,7 @@ $ oc create secret generic my-signing-key --from-file=key=<my_signing_key.priv>
 +
 [source,terminal]
 ----
-$ oc create secret generic my-signing-key-pub --from-file=key=<my_signing_key_pub.der>
+$ oc create secret generic my-signing-key-pub --from-file=cert=<my_signing_key_pub.der>
 ----
 +
 * Add the files by base64 encoding them:


### PR DESCRIPTION
QE review of BUG

D/S Docs: [DOCS] KMM key secureboot section for secrets addition typo
Jira: https://issues.redhat.com/browse/TELCODOCS-1882?src=confmacro

Version(s):  openshift-4.15, openshift-4.14, openshift-4.13, openshift-4.12 

Link to docs preview: https://75924--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html#kmm-adding-the-keys-for-secureboot_kernel-module-management-operator

QE review: @cdvultur
