### PR TITLE
OSDOCS-10564: updates microshift config default values

### DIFF
--- a/modules/microshift-default-settings.adoc
+++ b/modules/microshift-default-settings.adoc
@@ -1,7 +1,6 @@
 // Module included in the following assemblies:
 //
 // * microshift_configuring/microshift-using-config-tools.adoc
-// * microshift_networking/
 
 :_mod-docs-content-type: CONCEPT
 [id="microshift-yaml-default_{context}"]
@@ -19,29 +18,60 @@ $ microshift show-config
 .Default values example output in YAML form
 [source,yaml]
 ----
+apiServer:
+  advertiseAddress: 10.44.0.0/32 # <1>
+  auditLog:
+    maxFileAge: 10
+    maxFileSize: 200
+    maxFiles: 10
+    profile: Default
+  namedCertificates:
+    - certPath: ""
+      keyPath: ""
+      names:
+        - ""
+  subjectAltNames: [] # <2>
+debugging:
+  logLevel: "Normal" # <3>
 dns:
-  baseDomain: microshift.example.com <1>
+  baseDomain: microshift.example.com <4>
+etcd:
+  memoryLimitMB: 0 # <5>
+ingress:
+  listenAddress:
+    - ""
+  ports:
+    http: 80
+    https: 443
+  routeAdmissionPolicy:
+    namespaceOwnership: InterNamespaceAllowed # <6>
+  status: Managed # <7>
+manifests: # <8>
+  kustomizePaths:
+    - /usr/lib/microshift/manifests
+    - /usr/lib/microshift/manifests.d/*
+    - /etc/microshift/manifests
+    - /etc/microshift/manifests.d/*
 network:
   clusterNetwork:
-    - 10.42.0.0/16 <2>
+    - 10.42.0.0/16 # <9>
   serviceNetwork:
-    - 10.43.0.0/16 <3>
-  serviceNodePortRange: 30000-32767 <4>
+    - 10.43.0.0/16 # <10>
+  serviceNodePortRange: 30000-32767 # <11>
 node:
-  hostnameOverride: "" <5>
-  nodeIP: "" <6>
-apiServer:
-  advertiseAddress: 10.44.0.0/32 <7>
-  subjectAltNames: [] <8>
-debugging:
-  logLevel: "Normal" <9>
+  hostnameOverride: "" # <12>
+  nodeIP: "" # <13>
 ----
-<1> Base domain of the cluster. All managed DNS records will be subdomains of this base.
-<2> A block of IP addresses from which Pod IP addresses are allocated.
-<3> A block of virtual IP addresses for Kubernetes services.
-<4> The port range allowed for Kubernetes services of type NodePort.
-<5> The name of the node. The default value is the hostname.
-<6> The IP address of the node. The default value is the IP address of the default route.
-<7> A string that specifies the IP address from which the API server is advertised to members of the cluster. The default value is calculated based on the address of the service network.
-<8> Subject Alternative Names for API server certificates.
-<9> Log verbosity. Valid values for this field are `Normal`, `Debug`, `Trace`, or `TraceAll`.
+<1> A string that specifies the IP address from which the API server is advertised to members of the cluster. The default value is calculated based on the address of the service network.
+<2> Subject Alternative Names for API server certificates.
+<3> Log verbosity. Valid values for this field are `Normal`, `Debug`, `Trace`, or `TraceAll`.
+<4> By default, `etcd` uses as much memory as needed to handle the load on the system. However, in memory constrained systems, it might be preferred or necessary to limit the amount of memory `etcd` can to use at a given time.
+<5> Base domain of the cluster. All managed DNS records are subdomains of this base.
+<6> Describes how host name claims across namespaces are handled. By default, allows routes to claim different paths of the same host name across namespaces. Can also be set as `Strict` to not allow routes in different namespaces to claim the same host. If the value is deleted and a new one is not added, `InterNamespaceAllowed` is automatically set.
+<7> Default router status, can be `Managed` or `Removed`.
+<8> The locations on the filesystem to scan for `kustomization` files to use to load manifests. Set to a list of paths to scan only those paths. Set to an empty list to disable loading manifests. The entries in the list can be glob patterns to match multiple subdirectories.
+<9> A block of IP addresses from which Pod IP addresses are allocated. This field is immutable after installation.
+<10> A block of virtual IP addresses for Kubernetes services. IP address pool for services. A single entry is supported. This field is immutable after installation.
+<11> The port range allowed for Kubernetes services of type NodePort. If not specified, the default range of 30000-32767 is used. Services without a `NodePort` specified are automatically allocated one from this range. This parameter can be updated after the cluster is installed.
+<12> The name of the node. The default value is the hostname. If non-empty, this string is used to identify the node instead of the hostname.
+<13> The IP address of the node. The default value is the IP address of the default route.


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-10564](https://issues.redhat.com/browse/OSDOCS-10564)

Link to docs preview:
[Updated MicroShift default values in YAML form](https://75925--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-using-config-tools.html#microshift-yaml-default_microshift-configuring)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Supports updates for ingress configuration 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
