### PR TITLE
OSDOCS-9971-9614-HCP:Added new HCP assembly to HCP topic map

### DIFF
--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -228,6 +228,8 @@ Topics:
   File: rosa-hcp-creating-cluster-with-aws-kms-key
 - Name: Creating a private cluster on ROSA with HCP
   File: rosa-hcp-aws-private-creating-cluster
+- Name: Creating ROSA with HCP clusters with external authentication
+  File: rosa-hcp-sts-creating-a-cluster-ext-auth
 - Name: Using the Node Tuning Operator on ROSA with HCP
   File: rosa-tuning-config
 # ---


### PR DESCRIPTION
This PR adds the new _Creating ROSA with HCP clusters with external authentication_ assembly from **OSDOCS-9614** with updates from **OSDOCS-9971** to the ROSA HCP topic map.

Version(s):
4.15+


Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
