### PR TITLE
OSDOCS#10557: Disconnected Operator annotation description edit

### DIFF
--- a/modules/osdk-csv-annotations-infra.adoc
+++ b/modules/osdk-csv-annotations-infra.adoc
@@ -19,7 +19,7 @@ The `features.operators.openshift.io` infrastructure feature annotations depreca
 |Annotation |Description |Valid values^[1]^
 
 |`features.operators.openshift.io/disconnected`
-|Specify whether an Operator leverages the `spec.relatedImages` CSV field and can run without an internet connection by referring to any related image by its digest.
+|Specify whether an Operator supports being mirrored into disconnected catalogs, including all dependencies, and does not require internet access. The Operator leverages the `spec.relatedImages` CSV field to refer to any related image by its digest.
 |`"true"` or `"false"`
 
 |`features.operators.openshift.io/fips-compliant`


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-10557

4.14+

Follow-up to https://github.com/openshift/openshift-docs/pull/69171 to re-introduce explicit language for supporting being mirrored into disconnected catalogs.

Preview: https://75929--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-generating-csvs.html#osdk-csv-annotations-infra_osdk-generating-csvs