### PR TITLE
RHEL9-downward_metrics

### DIFF
--- a/modules/virt-viewing-downward-metrics-tool.adoc
+++ b/modules/virt-viewing-downward-metrics-tool.adoc
@@ -8,6 +8,11 @@
 
 To view downward metrics, install the `vm-dump-metrics` tool and then use the tool to expose the metrics results.
 
+[NOTE]
+====
+On Red Hat Enterprise Linux (RHEL) 9, use the command line to view downward metrics. The vm-dump-metrics tool is not supported on the Red Hat Enterprise Linux (RHEL) 9 platform.
+====
+
 .Procedure
 
 . Install the `vm-dump-metrics` tool by running the following command:

--- a/modules/virt-viewing-downward-metrics.adoc
+++ b/modules/virt-viewing-downward-metrics.adoc
@@ -11,3 +11,7 @@ You can view downward metrics by using either of the following options:
 * The command line interface (CLI)
 * The `vm-dump-metrics` tool
 
+[NOTE]
+====
+On Red Hat Enterprise Linux (RHEL) 9, use the command line to view downward metrics. The vm-dump-metrics tool is not supported on the Red Hat Enterprise Linux (RHEL) 9 platform.
+====

--- a/virt/monitoring/virt-exposing-downward-metrics.adoc
+++ b/virt/monitoring/virt-exposing-downward-metrics.adoc
@@ -10,6 +10,13 @@ As an administrator, you can expose a limited set of host and virtual machine (V
 
 Users can view the metrics results by using the command line or the `vm-dump-metrics tool`.
 
+[NOTE]
+====
+On Red Hat Enterprise Linux (RHEL) 9, use the command line to view downward metrics. See xref:../../virt/monitoring/virt-exposing-downward-metrics.adoc#virt-viewing-downward-metrics-cli_virt-exposing-downward-metrics[Viewing downward metrics by using the command line].
+
+The vm-dump-metrics tool is not supported on the Red Hat Enterprise Linux (RHEL) 9 platform.
+====
+
 [id="virt-enabling-disabling-feature-gate"]
 == Enabling or disabling the downwardMetrics feature gate
 


### PR DESCRIPTION
Version(s): 4.16

Issue:
Adding that the vm-dump-tool is not supported on RHEL 9. RHEL 9 users must use the command line option.

Links to doc previews:
[Exposing downward metrics for virtual machines](https://75930--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-exposing-downward-metrics.html)
[Viewing downward metrics](https://75930--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-exposing-downward-metrics.html#virt-viewing-downward-metrics_virt-exposing-downward-metrics)
[Viewing downward metrics by using the vm-dump-metrics tool](https://75930--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-exposing-downward-metrics.html#virt-viewing-downward-metrics-tool_virt-exposing-downward-metrics)


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

- Associated Jira (created later): [CNV-43034](https://issues.redhat.com/browse/CNV-43034)

- Follow-up to [CNV-27866](https://issues.redhat.com/browse/CNV-27866)/[PR](https://github.com/openshift/openshift-docs/pull/74920)

