### PR TITLE
OSDOCS-10563: me-central-1 ROSA with HCP clusters will be installable and available in additional AWS regions

### DIFF
--- a/modules/rosa-sdpolicy-am-regions-az.adoc
+++ b/modules/rosa-sdpolicy-am-regions-az.adoc
@@ -61,9 +61,7 @@ endif::rosa-with-hcp[]
 * eu-south-2 (Spain)
 * eu-central-2 (Zurich, AWS opt-in required)
 * me-south-1 (Bahrain, AWS opt-in required)
-ifndef::rosa-with-hcp[]
 * me-central-1 (UAE, AWS opt-in required)
-endif::rosa-with-hcp[]
 * sa-east-1 (São Paulo)
 ifndef::rosa-with-hcp[]
 * us-gov-east-1 (AWS GovCloud - US-East)

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -23,6 +23,7 @@ toc::[]
 ** Hong Kong (`ap-east-1`)
 ** Osaka (`ap-northeast-3`)
 ** Spain (`eu-south-2`)
+** UAE (`me-central-1`)
 +
 For more information on region availabilities, see xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc#rosa-sdpolicy-regions-az_rosa-hcp-service-definition[Regions and availability zones].
 


### PR DESCRIPTION
[OSDOCS-10563](https://issues.redhat.com//browse/OSDOCS-10563): me-central-1 ROSA with HCP clusters will be installable and available in additional AWS regions

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-10563

Link to docs preview:
Service definition page: https://75935--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-regions-az_rosa-hcp-service-definition
What's new page: https://75935--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
