### PR TITLE
OSDOCS-8766: Add configurable connectivity check

### DIFF
--- a/modules/nw-pod-network-connectivity-configuration.adoc
+++ b/modules/nw-pod-network-connectivity-configuration.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * networking/verifying-connectivity-endpoint.adoc
+
+[id="nw-pod-network-connectivity-configuration_{context}"]
+= Configuring pod connectivity check placement
+
+As a cluster administrator, you can configure which nodes the connectivity check pods run by modifying the `network.config.openshift.io` object named `cluster`.
+
+.Prerequisites
+
+* Install the {oc-first}.
+
+.Procedure
+
+. To edit the connectivity check configuration, enter the following command:
++
+[source,terminal]
+----
+$ oc edit network.config.openshift.io cluster
+----
+
+. In the text editor, update the `networkDiagnostics` stanza to specify the node selectors that you want for the source and target pods.
+
+. To commit your changes, save your changes and exit the text editor.
+
+.Verification
+
+To verify that the source and target pods are running on the intended nodes, enter the following command:
+
+[source,terminal]
+----
+$ oc get pods -n openshift-network-diagnostics -o wide
+----
+
+.Example output
+[source,text]
+----
+NAME                                    READY   STATUS    RESTARTS   AGE     IP           NODE                                        NOMINATED NODE   READINESS GATES
+network-check-source-84c69dbd6b-p8f7n   1/1     Running   0          9h      10.131.0.8   ip-10-0-40-197.us-east-2.compute.internal   <none>           <none>
+network-check-target-46pct              1/1     Running   0          9h      10.131.0.6   ip-10-0-40-197.us-east-2.compute.internal   <none>           <none>
+network-check-target-8kwgf              1/1     Running   0          9h      10.128.2.4   ip-10-0-95-74.us-east-2.compute.internal    <none>           <none>
+network-check-target-jc6n7              1/1     Running   0          9h      10.129.2.4   ip-10-0-21-151.us-east-2.compute.internal   <none>           <none>
+network-check-target-lvwnn              1/1     Running   0          9h      10.128.0.7   ip-10-0-17-129.us-east-2.compute.internal   <none>           <none>
+network-check-target-nslvj              1/1     Running   0          9h      10.130.0.7   ip-10-0-89-148.us-east-2.compute.internal   <none>           <none>
+network-check-target-z2sfx              1/1     Running   0          9h      10.129.0.4   ip-10-0-60-253.us-east-2.compute.internal   <none>           <none>
+----

--- a/modules/nw-pod-network-connectivity-implementation.adoc
+++ b/modules/nw-pod-network-connectivity-implementation.adoc
@@ -12,3 +12,28 @@ The Cluster Network Operator (CNO) deploys several resources to the cluster to s
 Health check source:: This program deploys in a single pod replica set managed by a `Deployment` object. The program consumes `PodNetworkConnectivity` objects and connects to the `spec.targetEndpoint` specified in each object.
 
 Health check target:: A pod deployed as part of a daemon set on every node in the cluster. The pod listens for inbound health checks. The presence of this pod on every node allows for the testing of connectivity to each node.
+
+You can configure the nodes which network connectivity sources and targets run on with a node selector. Additionally, you can specify permissible _tolerations_ for source and target pods. The configuration is defined in the singleton `cluster` custom resource of the `Network` API in the `config.openshift.io/v1` API group.
+
+Pod scheduling occurs after you have updated the configuration. Therefore, you must apply node labels that you intend to use in your selectors before updating the configuration. Labels applied after updating your network connectivity check pod placement are ignored.
+
+Refer to the default configuration in the following YAML:
+
+.Default configuration for connectivity source and target pods
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  # ...
+    networkDiagnostics: <1>
+      mode: "" <2>
+      sourcePlacement: {} <3>
+      targetPlacement: {} <4>
+----
+<1> Specifies the network diagnostics configuration. If a value is not specified or an empty object is specified, and `spec.disableNetworkDiagnostics=true` is set in the `network.operator.openshift.io` custom resource named `cluster`, network diagnostics are disabled. If set, this value overrides `spec.disableNetworkDiagnostics=true`.
+<2> Specifies the diagnostics mode. The value can be the empty string, `All`, or `Disabled`. The empty string is equivalent to specifying `All`.
+<3> Optional: Specifies a selector for connectivity check source pods.
+<4> Optional: Specifies a selector for connectivity check target pods.

--- a/modules/nw-pod-network-connectivity-verify.adoc
+++ b/modules/nw-pod-network-connectivity-verify.adoc
@@ -6,7 +6,7 @@
 [id="nw-pod-network-connectivity-verify_{context}"]
 = Verifying network connectivity for an endpoint
 
-As a cluster administrator, you can verify the connectivity of an endpoint, such as an API server, load balancer, service, or pod.
+As a cluster administrator, you can verify the connectivity of an endpoint, such as an API server, load balancer, service, or pod, and verify that network diagnostics is enabled.
 
 .Prerequisites
 
@@ -14,6 +14,27 @@ As a cluster administrator, you can verify the connectivity of an endpoint, such
 * Access to the cluster as a user with the `cluster-admin` role.
 
 .Procedure
+
+. To confirm that network diagnostics are enabled, enter the following command:
++
+[source,terminal]
+----
+$ oc get network.config.openshift.io cluster -o yaml
+----
++
+.Example output
+[source,text]
+----
+  # ...
+  status:
+  # ...
+    conditions:
+    - lastTransitionTime: "2024-05-27T08:28:39Z"
+      message: ""
+      reason: AsExpected
+      status: "True"
+      type: NetworkDiagnosticsAvailable
+----
 
 . To list the current `PodNetworkConnectivityCheck` objects, enter the following command:
 +

--- a/networking/verifying-connectivity-endpoint.adoc
+++ b/networking/verifying-connectivity-endpoint.adoc
@@ -11,5 +11,6 @@ By reviewing the results of the health checks, you can diagnose connection probl
 
 include::modules/nw-pod-network-connectivity-checks.adoc[leveloffset=+1]
 include::modules/nw-pod-network-connectivity-implementation.adoc[leveloffset=+1]
+include::modules/nw-pod-network-connectivity-configuration.adoc[leveloffset=+1]
 include::modules/nw-pod-network-connectivity-check-object.adoc[leveloffset=+1]
 include::modules/nw-pod-network-connectivity-verify.adoc[leveloffset=+1]


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-8766

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

[Connectivity check source and target placement](https://75944--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/verifying-connectivity-endpoint.html#verifying-connectivity-endpoint-pod-placement)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
