### PR TITLE
Docs for OCPSTRAT-748 On Cluster Layering: Phase 2 (tech preview)

### DIFF
--- a/modules/coreos-layering-configuring-on.adoc
+++ b/modules/coreos-layering-configuring-on.adoc
@@ -1,0 +1,232 @@
+// Module included in the following assemblies:
+//
+// * post-installation_configuration/coreos-layering.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="coreos-layering-configuring-on_{context}"]
+= Using on-cluster layering to apply a custom layered image
+
+To apply a custom layered image to your cluster by using the on-cluster build process, make a `MachineOSConfig` custom resource that includes a Containerfile, a machine config pool reference, repository push and pull secrets, and other parameters as described in the prerequisites. 
+
+When you create the object, the Machine Config Operator (MCO) creates a `MachineOSBuild` object and a `machine-os-builder` pod. The build process also creates transient objects, such as config maps, which are cleaned up after the build is complete. 
+
+When the build is complete, the MCO pushes the new custom layered image to your repository for use when deploying new nodes. You can see the digested image pull spec for the new custom layered image in the `MachineOSBuild` object and `machine-os-builder` pod.
+
+You should not need to interact with these new objects or the `machine-os-builder` pod. However, you can use all of these resources for troubleshooting, if necessary.
+
+You need a separate `MachineOSConfig` CR for each machine config pool where you want to use a custom layered image.
+
+:FeatureName: On-cluster image layering
+include::snippets/technology-preview.adoc[]
+
+.Prerequisites
+
+* You have enabled the `TechPreviewNoUpgrade` feature set by using the feature gates. For more information, see "Enabling features using feature gates".
+
+* You have the pull secret in the `openshift-machine-config-operator` namespace that the MCO needs to pull the base operating system image.
+
+* You have the push secret that the MCO needs to push the new custom layered image to your registry.
+
+* You have a pull secret that your nodes need to pull the new custom layered image from your registry. This should be a different secret than the one used to push the image to the repository.
+
+* You are familiar with how to configure a Containerfile. Instructions on how to create a Containerfile are beyond the scope of this documentation.
+
+* Optional: You have a separate machine config pool for the nodes where you want to apply the custom layered image.
+
+.Procedure
+
+. Create a `MachineOSConfig` object:
+
+.. Create a YAML file similar to the following:
++
+[source,terminal]
+----
+apiVersion: machineconfiguration.openshift.io/v1alpha1
+kind: MachineOSConfig
+metadata:
+  name: layered
+spec:
+  machineConfigPool:
+    name: <mcp_name> <1>
+  buildInputs:
+    containerFile: # <2>
+    - containerfileArch: noarch
+      content: |-
+        FROM configs AS final
+        RUN rpm-ostree install cowsay && \
+          ostree container commit
+    imageBuilder: # <3>
+      imageBuilderType: PodImageBuilder
+    baseImagePullSecret: # <4>
+      name: global-pull-secret-copy
+    renderedImagePushspec: image-registry.openshift-image-registry.svc:5000/openshift/os-image:latest  # <5>
+    renderedImagePushSecret: # <6>
+      name: builder-dockercfg-7lzwl
+  buildOutputs: # <7>
+    currentImagePullSecret:
+      name: builder-dockercfg-7lzwl
+----
+<1> Specifies the name of the machine config pool associated with the nodes where you want to deploy the custom layered image.
+<2> Specifies the Containerfile to configure the custom layered image.
+<3> Specifies the name of the image builder to use. This must be `PodImageBuilder`.
+<4> Specifies the name of the pull secret that the MCO needs to pull the base operating system image from the registry.
+<5> Specifies the image registry to push the newly-built custom layered image to. This can be any registry that your cluster has access to. This example uses the internal {product-title} registry.
+<6> Specifies the name of the push secret that the MCO needs to push the newly-built custom layered image to that registry.
+<7> Specifies the secret required by the image registry that the nodes need to pull the newly-built custom layered image. This should be a different secret than the one used to push the image to your repository.
+
+.. Create the `MachineOSConfig` object:
++
+[source,terminal]
+----
+$ oc create -f <file_name>.yaml
+----
+
+. If necessary, when the `MachineOSBuild` object has been created and is in the `READY` state, modify the node spec for the nodes where you want to use the new custom layered image:
+
+.. Check that the `MachineOSBuild` object is `READY`. When the `SUCCEEDED` value is `True`, the build is complete.
++
+[source,terminal]
+----
+$ oc get machineosbuild
+----
++
+.Example output showing that the `MachineOSBuild` object is ready
+[source,terminal]
+----
+NAME                                                                PREPARED   BUILDING   SUCCEEDED   INTERRUPTED   FAILED
+layered-rendered-layered-ad5a3cad36303c363cf458ab0524e7c0-builder   False      False      True        False         False
+----
+
+.. Edit the nodes where you want to deploy the custom layered image by adding a label for the machine config pool you specified in the `MachineOSConfig` object:
++
+[source,terminal]
+----
+$ oc label node <node_name> 'node-role.kubernetes.io/<mcp_name>='
+----
++
+--
+where:
+
+node-role.kubernetes.io/<mcp_name>=:: Specifies a node selector that identifies the nodes to deploy the custom layered image. 
+--
++
+When you save the changes, the MCO drains, cordons, and reboots the nodes. After the reboot, the node will be using the new custom layered image.
+
+.Verification
+
+. Verify that the new pods are running by using the following command:
++
+[source,terminal]
+----
+$ oc get pods -n <machineosbuilds_namespace>
+----
++
+[source,terminal]
+----
+NAME                                                              READY   STATUS    RESTARTS   AGE
+build-rendered-layered-ad5a3cad36303c363cf458ab0524e7c0           2/2     Running   0          2m40s # <1>
+# ...
+machine-os-builder-6fb66cfb99-zcpvq                               1/1     Running   0          2m42s # <2>
+----
+<1> This is the build pod where the custom layered image is building.
+<2> This pod can be used for troubleshooting.
+
+. Verify that the `MachineOSConfig` object contains a reference to the new custom layered image:
++
+[source,terminal]
+----
+$ oc describe MachineOSConfig <object_name>
+----
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1alpha1
+kind: MachineOSConfig
+metadata:
+  name: layered
+spec:
+  buildInputs:
+    baseImagePullSecret:
+      name: global-pull-secret-copy
+    containerFile:
+    - containerfileArch: noarch
+      content: ""
+    imageBuilder:
+      imageBuilderType: PodImageBuilder
+    renderedImagePushSecret:
+      name: builder-dockercfg-ng82t-canonical
+    renderedImagePushspec: image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/os-image:latest
+  buildOutputs:
+    currentImagePullSecret:
+      name: global-pull-secret-copy
+  machineConfigPool:
+    name: layered
+status:
+  currentImagePullspec: image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/os-image@sha256:f636fa5b504e92e6faa22ecd71a60b089dab72200f3d130c68dfec07148d11cd # <1>
+----
+<1> Digested image pull spec for the new custom layered image.
+
+. Verify that the `MachineOSBuild` object contains a reference to the new custom layered image.
++
+[source,terminal]
+----
+$ oc describe machineosbuild <object_name>
+----
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1alpha1
+kind: MachineOSBuild
+metadata:
+  name: layered-rendered-layered-ad5a3cad36303c363cf458ab0524e7c0-builder
+spec:
+  desiredConfig:
+    name: rendered-layered-ad5a3cad36303c363cf458ab0524e7c0
+  machineOSConfig:
+    name: layered
+  renderedImagePushspec: image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/os-image:latest
+# ...
+status:
+  conditions:
+    - lastTransitionTime: "2024-05-21T20:25:06Z"
+      message: Build Ready
+      reason: Ready
+      status: "True"
+      type: Succeeded
+  finalImagePullspec: image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/os-image@sha256:f636fa5b504e92e6faa22ecd71a60b089dab72200f3d130c68dfec07148d11cd # <1>
+----
+<1> Digested image pull spec for the new custom layered image.
+
+. Verify that the appropriate nodes are using the new custom layered image:
+
+.. Start a debug session as root for a control plane node:
++
+[source,terminal]
+----
+$ oc debug node/<node_name>
+----
+
+.. Set `/host` as the root directory within the debug shell:
++
+[source,terminal]
+----
+sh-4.4# chroot /host
+----
+
+.. Run the `rpm-ostree status` command to view that the custom layered image is in use:
++
+[source,terminal]
+----
+sh-5.1# rpm-ostree status
+----
++
+.Example output
+[source,terminal]
+----
+# ...
+Deployments:
+* ostree-unverified-registry:quay.io/openshift-release-dev/os-image@sha256:f636fa5b504e92e6faa22ecd71a60b089dab72200f3d130c68dfec07148d11cd # <1>
+                   Digest: sha256:bcea2546295b2a55e0a9bf6dd4789433a9867e378661093b6fdee0031ed1e8a4
+                  Version: 416.94.202405141654-0 (2024-05-14T16:58:43Z)
+----
+<1> Digested image pull spec for the new custom layered image.

--- a/modules/coreos-layering-configuring.adoc
+++ b/modules/coreos-layering-configuring.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="coreos-layering-configuring_{context}"]
-= Applying a {op-system} custom layered image
+= Using out-of-cluster layering to apply a custom layered image
 
 You can easily configure {op-system-first} image layering on the nodes in specific machine config pools. The Machine Config Operator (MCO) reboots those nodes with the new custom layered image, overriding the base {op-system-first} image.
 

--- a/post_installation_configuration/coreos-layering.adoc
+++ b/post_installation_configuration/coreos-layering.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="coreos-layering"]
 = {op-system} image layering
-include::_attributes/common-attributes.adoc[]
 :context: coreos-layering
 
 toc::[]
@@ -9,7 +9,12 @@ toc::[]
 
 {op-system-first} image layering allows you to easily extend the functionality of your base {op-system} image by _layering_ additional images onto the base image. This layering does not modify the base {op-system} image. Instead, it creates a _custom layered image_ that includes all {op-system} functionality and adds additional functionality to specific nodes in the cluster.
 
-You create a custom layered image by using a Containerfile and applying it to nodes by using a `MachineConfig` object. The Machine Config Operator overrides the base {op-system} image, as specified by the `osImageURL` value in the associated machine config, and boots the new image. You can remove the custom layered image by deleting the machine config, The MCO reboots the nodes back to the base {op-system} image.
+[id="coreos-layering-about_{context}"]
+== About {op-system} image layering
+
+Image layering allows you to customize the underlying node operating system on any of your cluster worker nodes. This helps keep everything up-to-date, including the node operating system and any added customizations such as specialized software.
+
+You create a custom layered image by using a Containerfile and applying it to nodes by using a custom object. At any time, you can remove the custom layered image by deleting that custom object. 
 
 With {op-system} image layering, you can install RPMs into your base image, and your custom content will be booted alongside {op-system}. The Machine Config Operator (MCO) can roll out these custom layered images and monitor these custom containers in the same way it does for the default {op-system} image. {op-system} image layering gives you greater flexibility in how you manage your {op-system} nodes.
 
@@ -22,12 +27,26 @@ Installing realtime kernel and extensions RPMs as custom layered content is not 
 
 As soon as you apply the custom layered image to your cluster, you effectively _take ownership_ of your custom layered images and those nodes. While Red Hat remains responsible for maintaining and updating the base {op-system} image on standard nodes, you are responsible for maintaining and updating images on nodes that use a custom layered image. You assume the responsibility for the package you applied with the custom layered image and any issues that might arise with the package.
 
-To apply a custom layered image, you create a Containerfile that references an {product-title} image and the RPM that you want to apply. You then push the resulting custom layered image to an image registry. In a non-production {product-title} cluster, create a `MachineConfig` object for the targeted node pool that points to the new image.
+There are two methods for deploying a custom layered image onto your nodes:
 
-[NOTE]
+On-cluster layering:: With xref:../post_installation_configuration/coreos-layering.adoc#coreos-layering-configuring-on_coreos-layering[on-cluster layering], you create a `MachineOSConfig` object where you include the Containerfile and other parameters. The build is performed on your cluster and the resulting custom layered image is automatically pushed to your repository and applied to the machine config pool that you specified in the `MachineOSConfig` object. The entire process is performed completely within your cluster. 
++
+--
+:FeatureName: On-cluster image layering
+include::snippets/technology-preview.adoc[]
+--
+
+Out-of-cluster layering:: With xref:../post_installation_configuration/coreos-layering.adoc#coreos-layering-configuring_coreos-layering[out-of-cluster layering], you create a Containerfile that references an {product-title} image and the RPM that you want to apply, build the layered image in your own environment, and push the image to your repository. Then, in your cluster, create a `MachineConfig` object for the targeted node pool that points to the new image. The Machine Config Operator overrides the base {op-system} image, as specified by the `osImageURL` value in the associated machine config, and boots the new image.
+
+There is no functional difference between the custom layered images created by using either method. You can choose on- or off-cluster builds depending upon the needs of your organization. 
+
+[IMPORTANT]
 ====
-Use the same base {op-system} image installed on the rest of your cluster. Use the `oc adm release info --image-for rhel-coreos` command to obtain the base image used in your cluster.
+For both methods, use the same base {op-system} image installed on the rest of your cluster. Use the `oc adm release info --image-for rhel-coreos` command to obtain the base image used in your cluster.
 ====
+
+[id="coreos-layering-examples_{context}"]
+== Example Containerfiles
 
 {op-system} image layering allows you to use the following types of images to create custom layered images:
 
@@ -40,7 +59,20 @@ Some Hotfixes require a Red Hat Support Exception and are outside of the normal 
 +
 In the event you want a Hotfix, it will be provided to you based on link:https://access.redhat.com/solutions/2996001[Red Hat Hotfix policy]. Apply it on top of the base image and test that new custom layered image in a non-production environment. When you are satisfied that the custom layered image is safe to use in production, you can roll it out on your own schedule to specific node pools. For any reason, you can easily roll back the custom layered image and return to using the default {op-system}.
 +
-.Example Containerfile to apply a Hotfix
+.Example on-cluster Containerfile to apply a Hotfix
+[source,yaml]
+----
+# Using a 4.12.0 image
+containerfileArch: noarch
+content: |-
+  FROM configs AS final
+  #Install hotfix rpm
+  RUN rpm-ostree override replace https://example.com/myrepo/haproxy-1.0.16-5.el8.src.rpm && \
+      rpm-ostree cleanup -m && \
+      ostree container commit
+----
++
+.Example out-of-cluster Containerfile to apply a Hotfix
 [source,yaml]
 ----
 # Using a 4.12.0 image
@@ -53,24 +85,13 @@ RUN rpm-ostree override replace https://example.com/myrepo/haproxy-1.0.16-5.el8.
 
 * *{op-system-base} packages*. You can download {op-system-base-full} packages from the link:https://access.redhat.com/downloads/content/479/ver=/rhel---9/9.1/x86_64/packages[Red Hat Customer Portal], such as chrony, firewalld, and iputils.
 +
-.Example Containerfile to apply the firewalld utility
-[source,yaml]
-----
-FROM quay.io/openshift-release-dev/ocp-release@sha256...
-ADD configure-firewall-playbook.yml .
-RUN rpm-ostree install firewalld ansible && \
-    ansible-playbook configure-firewall-playbook.yml && \
-    rpm -e ansible && \
-    ostree container commit
-----
-+
-.Example Containerfile to apply the libreswan utility
+.Example out-of-cluster Containerfile to apply the libreswan utility
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/rhcos-image-layering-examples/master/libreswan/Containerfile[]
 ----
 +
-Because libreswan requires additional RHEL packages, the image must be built on an entitled {op-system-base} host.
+Because libreswan requires additional {op-system-base} packages, the image must be built on an entitled {op-system-base} host. For RHEL entitlements to work, you must copy the `etc-pki-entitlement` secret into the `openshift-machine-api` namespace. 
 
 * *Third-party packages*. You can download and install RPMs from third-party organizations, such as the following types of packages:
 +
@@ -82,19 +103,41 @@ Because libreswan requires additional RHEL packages, the image must be built on 
 ** SSH Key management packages.
 --
 +
-.Example Containerfile to apply a third-party package from EPEL
+.Example on-cluster Containerfile to apply a third-party package from EPEL
+[source,yaml]
+----
+FROM configs AS final
+
+#Enable EPEL (more info at https://docs.fedoraproject.org/en-US/epel/ ) and install htop
+RUN rpm-ostree install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+    rpm-ostree install htop && \
+    ostree container commit
+----
++
+.Example out-of-cluster Containerfile to apply a third-party package from EPEL
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/rhcos-image-layering-examples/master/htop/Containerfile[]
 ----
 +
-.Example Containerfile to apply a third-party package that has {op-system-base} dependencies
+This Containerfile installs the {op-system-base} fish program. Because fish requires additional {op-system-base} packages, the image must be built on an entitled {op-system-base} host. For {op-system-base} entitlements to work, you must copy the `etc-pki-entitlement` secret into the `openshift-machine-api` namespace. 
++
+.Example on-cluster Containerfile to apply a third-party package that has {op-system-base} dependencies
+[source,yaml]
+----
+FROM configs AS final
+
+# RHEL entitled host is needed here to access RHEL packages
+# Install fish as third party package from EPEL
+RUN rpm-ostree install https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/f/fish-3.3.1-3.el9.x86_64.rpm && \
+    ostree container commit
+----
++
+.Example out-of-cluster Containerfile to apply a third-party package that has {op-system-base} dependencies
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/rhcos-image-layering-examples/master/fish/Containerfile[]
 ----
-+
-This Containerfile installs the Linux fish program. Because fish requires additional RHEL packages, the image must be built on an entitled {op-system-base} host.
 
 After you create the machine config, the Machine Config Operator (MCO) performs the following steps:
 
@@ -108,6 +151,11 @@ After you create the machine config, the Machine Config Operator (MCO) performs 
 ====
 It is strongly recommended that you test your images outside of your production environment before rolling out to your cluster.
 ====
+
+include::modules/coreos-layering-configuring-on.adoc[leveloffset=+1]
+
+.Additional resources
+* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
 
 include::modules/coreos-layering-configuring.adoc[leveloffset=+1]
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-7168

enterprise-4.16+

Previews 
[RHCOS image layering](https://75955--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/coreos-layering.html) -- Added text from _There are two methods for deploying_ to Examples.
[Example Containerfiles](https://75955--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/coreos-layering.html#coreos-layering-examples) -- Added examples for _on-cluster_ methods. No change to the _off-cluster_ examples, other than a new heading.
[Using on-cluster layering](https://75955--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/coreos-layering.html#coreos-layering-configuring-on_coreos-layering) -- All new text.
[RHCOS image layering](https://75955--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/coreos-layering.html) -- Added _Enabling features using feature gates_ additional ref after _Using on-cluster layering_.
[Using out-of-cluster layering](https://75955--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/coreos-layering.html#coreos-layering-configuring_coreos-layering) -- Changed heading only.