### PR TITLE
HCIDOCS-251: Configurating the install-config.yaml file - device path info

### DIFF
--- a/modules/ipi-install-configuring-the-install-config-file.adoc
+++ b/modules/ipi-install-configuring-the-install-config-file.adoc
@@ -102,8 +102,10 @@ sshKey: '<ssh_pub_key>'
 +
 [IMPORTANT]
 ====
-Because the disk discovery order is not guaranteed, the kernel name of the disk can change across booting options for machines with multiple disks. For instance, `/dev/sda` becomes `/dev/sdb` and vice versa.
-To avoid this issue, you must use persistent disk attributes, such as the disk World Wide Name (WWN). To use the disk WWN, replace the `deviceName` parameter with the `wwnWithExtension` parameter. Depending on the parameter that you use, enter the disk name, for example, `/dev/sda` or the disk WWN, for example, `"0x64cd98f04fde100024684cf3034da5c2"`. Ensure that you enter the disk WWN value within quotes so that it is used as a string value and not a hexadecimal value.
+Because the disk discovery order is not guaranteed, the kernel name of the disk can change across booting options for machines with multiple disks. For example, `/dev/sda` becomes `/dev/sdb` and vice versa. To avoid this issue, you must use persistent disk attributes, such as the disk World Wide Name (WWN) or `/dev/disk/by-path/`. It is recommended to use the `/dev/disk/by-path/<device_path>` link to the storage location. To use the disk WWN, replace the `deviceName` parameter with the `wwnWithExtension` parameter. Depending on the parameter that you use, enter either of the following values:
+
+* The disk name. For example, `/dev/sda`, or `/dev/disk/by-path/`.
+* The disk WWN. For example, `"0x64cd98f04fde100024684cf3034da5c2"`. Ensure that you enter the disk WWN value within quotes so that it is used as a string value and not a hexadecimal value.
 
 Failure to meet these requirements for the `rootDeviceHints` parameter might result in the following error:
 


### PR DESCRIPTION
Added a comment on device paths to install-config.yaml module.

Fixes: [HCIDOCS-251](https://issues.redhat.com//browse/HCIDOCS-251)

See https://issues.redhat.com/browse/HCIDOCS-251 for additional details.

Preview URL: http://184.23.213.161:8080/HCIDOCS-251/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-the-install-config-file_ipi-install-installation-workflow

For release(s): 4.13-4.16
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
