### PR TITLE
[OSDOCS#10565]: Add release notes for etcd tuning profiles

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -240,6 +240,16 @@ For more information, see xref:../edge_computing/cnf-talm-for-cluster-upgrades.a
 
 SHA1 certificates are no longer supported for use with HaProxy. Both existing and new routes using SHA1 certificates in {product-version} are rejected and no longer function.
 
+[discrete]
+[id="ocp-4-16-etcd-tuning-profiles"]
+=== etcd tuning parameters
+
+With this release, the etcd tuning parameters can be set to values that optimize performance and decrease latency, as follows.
+
+* `""` (Default)
+* `Standard`
+* `Slower`
+
 [id="ocp-4-16-deprecated-removed-features"]
 == Deprecated and removed features
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-10565](https://issues.redhat.com/browse/OSDOCS-10565)

Link to docs preview:
[Notable technical changes](https://75958--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-notable-technical-changes) (Updated 5/20/2024)

QE review:
- [ x] QE has approved this change.
