### PR TITLE
RHDEVDOCS-6054: Content creation for GitOps 1.10.6 RN

### DIFF
--- a/modules/gitops-release-notes-1-10-6.adoc
+++ b/modules/gitops-release-notes-1-10-6.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assembly:
+//
+// * release_notes/gitops-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="release-notes-for-gitops-1-10-6_{context}"]
+= Release Notes for {gitops-title} 1.10.6
+
+{gitops-title} 1.10.6 is now available on {OCP} 4.12, 4.13, and 4.14.
+
+[id="errata-updates-1-10-6_{context}"]
+== Errata updates
+
+[id="rhsa-2024:3369-gitops-1-10-6-security-update-advisory_{context}"]
+=== RHSA-2024:3369 - {gitops-title} 1.10.6 security update advisory
+
+Issued: 2024-05-28
+
+The list of security fixes that are included in this release is documented in the following advisory:
+
+* link:https://access.redhat.com/errata/RHSA-2024:3369[RHSA-2024:3369]
+
+If you have installed the {gitops-title} Operator, run the following command to view the container images in this release:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-operators
+----
+
+[id="fixed-issues-1-10-6_{context}"]
+== Fixed issues
+
+* Before this update, pods in a different namespace could access the Redis server on port `6379` to obtain read and write access to the data. This update fixes the issue by enabling secure authentication.

--- a/release_notes/gitops-release-notes.adoc
+++ b/release_notes/gitops-release-notes.adoc
@@ -49,6 +49,9 @@ include::modules/gitops-release-notes-1-11-1.adoc[leveloffset=+1]
 // Release notes for Red Hat OpenShift GitOps 1.11.0
 include::modules/gitops-release-notes-1-11-0.adoc[leveloffset=+1]
 
+// Release notes for Red Hat OpenShift GitOps 1.10.6
+include::modules/gitops-release-notes-1-10-6.adoc[leveloffset=+1]
+
 // Release notes for Red Hat OpenShift GitOps 1.10.5
 include::modules/gitops-release-notes-1-10-5.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):

GitOps 1.10, GitOps 1.11, GitOps 1.12

Issue:

https://issues.redhat.com/browse/RHDEVDOCS-6054

Link to docs preview:

Release Notes change: https://75961--ocpdocs-pr.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes.html#release-notes-for-gitops-1-10-6_gitops-release-notes

SME review: @reginapizza
QE review: @varshab1210
Internal peer review: @eromanova97
Peer review: @tmalove 

QE review:

QE has approved this change.
 
Additional information: