### PR TITLE
[Internal fix]OCPBUGS-33676: Remove the floating

### DIFF
--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -130,7 +130,7 @@ endif::upi[]
 `VirtualMachine.Provisioning.DeployTemplate`
 
 |vSphere vCenter Datacenter
-|If the installation program creates the virtual machine folder. For user-provisioned infrastructure, `VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API. See the "Minimum permissions for the Machine API" table. 
+|If the installation program creates the virtual machine folder. For user-provisioned infrastructure, `VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API. See the "Minimum permissions for the Machine API" table.
 |
 [%hardbreaks]
 `InventoryService.Tagging.ObjectAttachable`
@@ -366,9 +366,9 @@ For more information about creating an account with only the required privileges
 [id="installation-vsphere-installer-infra-minimum-requirements_{context}"]
 == Minimum required vCenter account privileges
 
-After you create a custom role and assign privileges to it, you can create permissions by selecting specific vSphere objects and then assigning the custom role to a user or group for each object. 
+After you create a custom role and assign privileges to it, you can create permissions by selecting specific vSphere objects and then assigning the custom role to a user or group for each object.
 
-Before you create permissions or request for the creation of permissions for a vSphere object, determine what minimum permissions apply to the vSphere object. By doing this task, you can ensure a basic interaction exists between a vSphere object and {product-title} architecture. 
+Before you create permissions or request for the creation of permissions for a vSphere object, determine what minimum permissions apply to the vSphere object. By doing this task, you can ensure a basic interaction exists between a vSphere object and {product-title} architecture.
 
 [IMPORTANT]
 ====
@@ -379,11 +379,10 @@ Consider creating a custom role when an account with global administrative privi
 
 [IMPORTANT]
 ====
-Accounts that are not configured with the required privileges are unsupported. Installing an {product-title} cluster in a vCenter is tested against a full list of privileges as described in the "Required vCenter account privileges" section. By adhering to the full list of privileges, you can reduce the possibility of unexpected behaviors that might occur when creating a custom role with a restricted set of privileges. 
+Accounts that are not configured with the required privileges are unsupported. Installing an {product-title} cluster in a vCenter is tested against a full list of privileges as described in the "Required vCenter account privileges" section. By adhering to the full list of privileges, you can reduce the possibility of unexpected behaviors that might occur when creating a custom role with a restricted set of privileges.
 ====
 
 The following tables list the minimum permissions for a vSphere object that interacts with specific {product-title} architecture.
-`VApp.Import`
 
 ifndef::upi[]
 [id="installation-vsphere-minimum-permissions-ipi_{context}"]
@@ -656,7 +655,7 @@ endif::upi[]
 `VirtualMachine.Config.AddRemoveDevice`
 
 |vSphere vCenter Datacenter
-|If the installation program creates the virtual machine folder. For user-provisioned infrastructure, `VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API. If your cluster does use the Machine API and you want to set the minimum set of permissions for the API, see the "Minimum permissions for the Machine API" table. 
+|If the installation program creates the virtual machine folder. For user-provisioned infrastructure, `VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API. If your cluster does use the Machine API and you want to set the minimum set of permissions for the API, see the "Minimum permissions for the Machine API" table.
 |
 [%hardbreaks]
 `VirtualMachine.Config.AddExistingDisk`


### PR DESCRIPTION
Version(s):
4.16 and 4.15

Issue:
[OCPBUGS-33676](https://issues.redhat.com/browse/OCPBUGS-33676)

Link to docs preview:
* [Minimum required vCenter account privileges IPI](https://75966--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.html#installation-vsphere-installer-infra-requirements_ipi-vsphere-installation-reqs)
* [Minimum required vCenter account privileges UPI](https://75966--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/upi-vsphere-installation-reqs.html#installation-vsphere-installer-infra-requirements_upi-vsphere-installation-reqs)

