### PR TITLE
OSDOCS-10038:Updated support for transparent forward proxy info

### DIFF
--- a/modules/cluster-wide-proxy-preqs.adoc
+++ b/modules/cluster-wide-proxy-preqs.adoc
@@ -29,9 +29,9 @@ endif::openshift-dedicated[]
 +
 These endpoints are required to complete requests from the nodes to the AWS EC2 API. Because the proxy works at the container level and not at the node level, you must route these requests to the AWS EC2 API through the AWS private network. Adding the public IP address of the EC2 API to your allowlist in your proxy server is not enough.
 +
-[NOTE]
+[IMPORTANT]
 ====
-When using a cluster-wide proxy, you must configure the `s3.<aws_region>.amazonaws.com` endpoint as type `Gateway`. Also, you can configure the `ec2.<aws_region>.amazonaws.com` and `elasticloadbalancing.<aws_region>.amazonaws.com` endpoints only as type `Interface`.
+When using a cluster-wide proxy, you must configure the `s3.<aws_region>.amazonaws.com` endpoint as type `Gateway`.
 ====
 
 [discrete]

--- a/modules/configuring-a-proxy-after-installation-cli.adoc
+++ b/modules/configuring-a-proxy-after-installation-cli.adoc
@@ -36,7 +36,7 @@ $ rosa edit cluster \
 +
 --
 <1> The `additional-trust-bundle-file`, `http-proxy`, and `https-proxy` arguments are all optional.
-<2> The `additional-trust-bundle-file` argument is a file path pointing to a bundle of PEM-encoded X.509 certificates, which are all concatenated together. The `additionalTrustBundle` parameter is required unless the identity certificate of the proxy is signed by an authority from the {op-system} trust bundle. If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional CAs, you must provide the MITM CA certificate.
+<2> The `additional-trust-bundle-file` argument is a file path pointing to a bundle of PEM-encoded X.509 certificates, which are all concatenated together. The additional-trust-bundle-file argument is a file path pointing to a bundle of PEM-encoded X.509 certificates, which are all concatenated together. The additional-trust-bundle-file argument is required for users who use a TLS-inspecting proxy unless the identity certificate for the proxy is signed by an authority from the {op-system-first} trust bundle. This applies regardless of whether the proxy is transparent or requires explicit configuration using the `http-proxy` and `https-proxy` arguments.
 +
 [NOTE]
 ====

--- a/modules/configuring-a-proxy-after-installation-ocm.adoc
+++ b/modules/configuring-a-proxy-after-installation-ocm.adoc
@@ -37,9 +37,7 @@ endif::openshift-dedicated[]
 .. Enter a value in at least one of the following fields:
 ** Specify a valid *HTTP proxy URL*.
 ** Specify a valid *HTTPS proxy URL*.
-** In the *Additional trust bundle* field, provide a PEM encoded X.509 certificate bundle. If you are replacing an existing trust bundle file, select *Replace file* to view the field. The bundle is added to the trusted certificate store for the cluster nodes. An additional trust bundle file is required unless the identity certificate for the proxy is signed by an authority from the {op-system-first} trust bundle.
-+
-If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional certificate authorities (CAs), you must provide the MITM CA certificate.
+** In the *Additional trust bundle* field, provide a PEM encoded X.509 certificate bundle. If you are replacing an existing trust bundle file, select *Replace file* to view the field. The bundle is added to the trusted certificate store for the cluster nodes. An additional trust bundle file is required if you use a TLS-inspecting proxy unless the identity certificate for the proxy is signed by an authority from the {op-system-first} trust bundle. This requirement applies regardless of whether the proxy is transparent or requires explicit configuration using the `http-proxy` and `https-proxy` arguments.
 +
 .. Click *Confirm*.
 

--- a/modules/configuring-a-proxy-during-installation-cli.adoc
+++ b/modules/configuring-a-proxy-during-installation-cli.adoc
@@ -30,7 +30,7 @@ $ rosa create cluster \
 +
 --
 <1> The `additional-trust-bundle-file`, `http-proxy`, and `https-proxy` arguments are all optional.
-<2> The `additional-trust-bundle-file` argument is a file path pointing to a bundle of PEM-encoded X.509 certificates, which are all concatenated together. The `additionalTrustBundle` parameter is required unless the identity certificate of the proxy is signed by an authority from the {op-system} trust bundle. If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional CAs, you must provide the MITM CA certificate.
+<2> The `additional-trust-bundle-file` argument is a file path pointing to a bundle of PEM-encoded X.509 certificates, which are all concatenated together. The additional-trust-bundle-file argument is required for users who use a TLS-inspecting proxy unless the identity certificate for the proxy is signed by an authority from the {op-system-first} trust bundle. This applies regardless of whether the proxy is transparent or requires explicit configuration using the http-proxy and https-proxy arguments.
 <3> The `http-proxy` and `https-proxy` arguments must point to a valid URL.
 <4> A comma-separated list of destination domain names, IP addresses, or network CIDRs to exclude proxying.
 +

--- a/modules/osd-create-cluster-ccs.adoc
+++ b/modules/osd-create-cluster-ccs.adoc
@@ -304,15 +304,12 @@ For more information, see the requirements for _Security groups_ under _Addition
 endif::osd-on-aws[]
 . If you opted to configure a cluster-wide proxy, provide your proxy configuration details on the *Cluster-wide proxy* page:
 +
---
 .. Enter a value in at least one of the following fields:
 ** Specify a valid *HTTP proxy URL*.
 ** Specify a valid *HTTPS proxy URL*.
-** In the *Additional trust bundle* field, provide a PEM encoded X.509 certificate bundle. The bundle is added to the trusted certificate store for the cluster nodes. An additional trust bundle file is required unless the identity certificate for the proxy is signed by an authority from the {op-system-first} trust bundle.
+** In the *Additional trust bundle* field, provide a PEM encoded X.509 certificate bundle. The bundle is added to the trusted certificate store for the cluster nodes. An additional trust bundle file is required if you use a TLS-inspecting proxy unless the identity certificate for the proxy is signed by an authority from the {op-system-first} trust bundle. This requirement applies regardless of whether the proxy is transparent or requires explicit configuration using the `http-proxy` and `https-proxy` arguments.
 +
-If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional certificate authorities (CAs), you must provide the MITM CA certificate.
 .. Click *Next*.
---
 +
 For more information about configuring a proxy with {product-title}, see _Configuring a cluster-wide proxy_.
 

--- a/modules/osd-create-cluster-gcp-account.adoc
+++ b/modules/osd-create-cluster-gcp-account.adoc
@@ -127,20 +127,12 @@ If you are installing a cluster into a Shared VPC, the VPC name and subnets are 
 . Click *Next*.
 . If you opted to configure a cluster-wide proxy, provide your proxy configuration details on the *Cluster-wide proxy* page:
 +
---
 .. Enter a value in at least one of the following fields:
 ** Specify a valid *HTTP proxy URL*.
 ** Specify a valid *HTTPS proxy URL*.
-** In the *Additional trust bundle* field, provide a PEM encoded X.509 certificate bundle. The bundle is added to the trusted certificate store for the cluster nodes. An additional trust bundle file is required unless the identity certificate for the proxy is signed by an authority from the {op-system-first} trust bundle.
+** In the *Additional trust bundle* field, provide a PEM encoded X.509 certificate bundle. The bundle is added to the trusted certificate store for the cluster nodes. An additional trust bundle file is required if you use a TLS-inspecting proxy unless the identity certificate for the proxy is signed by an authority from the {op-system-first} trust bundle. This requirement applies regardless of whether the proxy is transparent or requires explicit configuration using the `http-proxy` and `https-proxy` arguments.
 +
-If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional certificate authorities (CAs), you must provide the MITM CA certificate.
-+
-[NOTE]
-====
-If you upload an additional trust bundle file without specifying an HTTP or HTTPS proxy URL, the bundle is set on the cluster but is not configured to be used with the proxy.
-====
 .. Click *Next*.
---
 +
 For more information about configuring a proxy with {product-title}, see _Configuring a cluster-wide proxy_.
 

--- a/modules/osd-create-cluster-rhm-gcp-account.adoc
+++ b/modules/osd-create-cluster-rhm-gcp-account.adoc
@@ -126,20 +126,12 @@ If you are installing a cluster into a Shared VPC, the VPC name and subnets are 
 . Click *Next*.
 . If you opted to configure a cluster-wide proxy, provide your proxy configuration details on the *Cluster-wide proxy* page:
 +
---
 .. Enter a value in at least one of the following fields:
 ** Specify a valid *HTTP proxy URL*.
 ** Specify a valid *HTTPS proxy URL*.
-** In the *Additional trust bundle* field, provide a PEM encoded X.509 certificate bundle. The bundle is added to the trusted certificate store for the cluster nodes. An additional trust bundle file is required unless the identity certificate for the proxy is signed by an authority from the {op-system-first} trust bundle.
+** In the *Additional trust bundle* field, provide a PEM encoded X.509 certificate bundle. The bundle is added to the trusted certificate store for the cluster nodes. An additional trust bundle file is required if you use a TLS-inspecting proxy unless the identity certificate for the proxy is signed by an authority from the {op-system-first} trust bundle. This requirement applies regardless of whether the proxy is transparent or requires explicit configuration using the `http-proxy` and `https-proxy` arguments.
 +
-If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional certificate authorities (CAs), you must provide the MITM CA certificate.
-+
-[NOTE]
-====
-If you upload an additional trust bundle file without specifying an HTTP or HTTPS proxy URL, the bundle is set on the cluster but is not configured to be used with the proxy.
-====
 .. Click *Next*.
---
 +
 For more information about configuring a proxy with {product-title}, see _Configuring a cluster-wide proxy_.
 

--- a/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
@@ -318,20 +318,11 @@ For more information, see the requirements for _Security groups_ under _Addition
 
 . If you opted to configure a cluster-wide proxy, provide your proxy configuration details on the *Cluster-wide proxy* page:
 +
---
 .. Enter a value in at least one of the following fields:
 ** Specify a valid *HTTP proxy URL*.
 ** Specify a valid *HTTPS proxy URL*.
-** In the *Additional trust bundle* field, provide a PEM encoded X.509 certificate bundle. The bundle is added to the trusted certificate store for the cluster nodes. An additional trust bundle file is required unless the identity certificate for the proxy is signed by an authority from the {op-system-first} trust bundle.
-+
-If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional certificate authorities (CAs), you must provide the MITM CA certificate.
-+
-[NOTE]
-====
-If you upload an additional trust bundle file without specifying an HTTP or HTTPS proxy URL, the bundle is set on the cluster but is not configured to be used with the proxy.
-====
+** In the *Additional trust bundle* field, provide a PEM encoded X.509 certificate bundle. The bundle is added to the trusted certificate store for the cluster nodes. An additional trust bundle file is required if you use a TLS-inspecting proxy unless the identity certificate for the proxy is signed by an authority from the {op-system-first} trust bundle. This requirement applies regardless of whether the proxy is transparent or requires explicit configuration using the `http-proxy` and `https-proxy` arguments.
 .. Click *Next*.
---
 +
 For more information about configuring a proxy with {product-title}, see _Configuring a cluster-wide proxy_.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-10038

Link to docs preview:

OSD Docs:
- https://75977--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/configuring-cluster-wide-proxy.html
- https://75977--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-a-gcp-cluster.html
- https://75977--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-an-aws-cluster.html

ROSA Docs:
- https://75977--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/configuring-cluster-wide-proxy.html
- https://75977--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.html

Peer reviewer:
- [x] Peer reviewer has approved this change.

SME review:
- [x] SME has approved this change.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
