### PR TITLE
Enterprise-4.13 - OSDOCS10255: Updated release notes for cert manager 1.13.1

### DIFF
--- a/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
@@ -12,8 +12,26 @@ These release notes track the development of {cert-manager-operator}.
 
 For more information, see xref:../../security/cert_manager_operator/index.adoc#cert-manager-operator-about[About the {cert-manager-operator}].
 
-[id="cert-manager-operator-release-notes-1-13"]
-== Release notes for {cert-manager-operator} 1.13.0
+[id="cert-manager-operator-release-notes-1-13-1"]
+== {cert-manager-operator} 1.13.1
+
+Issued: 2024-05-15
+
+The following advisory is available for the {cert-manager-operator} 1.13.1:
+
+* link:https://access.redhat.com/errata/RHEA-2024:2849[RHEA-2024:2849]
+
+Version `1.13.1` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.13.6`. For more information, see the link:https://cert-manager.io/docs/releases/release-notes/release-notes-1.13#v1136[cert-manager project release notes for v1.13.6].
+
+[id="cert-manager-operator-1-13-1-CVEs"]
+=== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2023-45288[CVE-2023-45288]
+* link:https://access.redhat.com/security/cve/CVE-2023-48795[CVE-2023-48795]
+* link:https://access.redhat.com/security/cve/CVE-2024-24783[CVE-2024-24783]
+
+[id="cert-manager-operator-release-notes-1-13-0"]
+== {cert-manager-operator} 1.13.0
 
 Issued: 2024-01-16
 
@@ -23,7 +41,7 @@ The following advisory is available for the {cert-manager-operator} 1.13.0:
 
 Version `1.13.0` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.13.3`. For more information, see the link:https://cert-manager.io/docs/release-notes/release-notes-1.13/#v1133[cert-manager project release notes for v1.13.0].
 
-[id="cert-manager-operator-new-features-1-13"]
+[id="cert-manager-operator-new-features-1-13-0"]
 === New features and enhancements
 
 * You can now manage certificates for API Server and Ingress Controller by using the {cert-manager-operator}.
@@ -34,7 +52,7 @@ For more information, see xref:../../security/cert_manager_operator/cert-manager
 * With this release, you can use DNS over HTTPS (DoH) for performing the self-checks during the ACME DNS-01 challenge verification. The DNS self-check method can be controlled by using the command line flags, `--dns01-recursive-nameservers-only` and `--dns01-recursive-nameservers`.
 For more information, see xref:../../security/cert_manager_operator/cert-manager-customizing-api-fields.html#cert-manager-override-arguments_cert-manager-customizing-api-fields[Customizing cert-manager by overriding arguments from the cert-manager Operator API].
 
-[id="cert-manager-operator-1-13-CVEs"]
+[id="cert-manager-operator-1-13-0-CVEs"]
 === CVEs
 
 * link:https://access.redhat.com/security/cve/CVE-2023-39615[CVE-2023-39615]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->
Cherry Picked from [commit ID](d4c38a63003800cc3f15b3a2ae4f4ee5316cdca4) xref: [OSDOCS 10255](https://github.com/openshift/openshift-docs/pull/75962)

Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->



Link to docs preview: [Preview](https://75981--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-operator-release-notes.html)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
