### PR TITLE
OADP-682 Support for insecure TLS connections

### DIFF
--- a/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
@@ -100,6 +100,7 @@ include::modules/migration-using-must-gather.adoc[leveloffset=+1]
 .Additional resources
 * xref:../../support/gathering-cluster-data.adoc#gathering-cluster-data[Gathering cluster data]
 
+include::modules/support-insecure-tls-connections.adoc[leveloffset=+2]
 include::modules/migration-combining-must-gather.adoc[leveloffset=+2]
 include::modules/oadp-monitoring.adoc[leveloffset=+1]
 [role="_additional-resources"]

--- a/modules/support-insecure-tls-connections.adoc
+++ b/modules/support-insecure-tls-connections.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+// * backup_and_restore/application_backup_and_restore/troubleshooting.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="support-insecure-tls-connections_{context}"]
+= Using must-gather with insecure TLS connections
+
+If a custom CA certificate is used, the `must-gather` pod fails to grab the output for `velero logs/describe`. To use the `must-gather` tool with  insecure TLS connections, you can pass the `gather_without_tls` flag to the `must-gather` command.
+
+.Procedure
+* Pass the `gather_without_tls` flag, with value set to `true`, to the `must-gather` tool by using the following command:
+
+[source,terminal]
+----
+$ oc adm must-gather --image=registry.redhat.io/oadp/oadp-mustgather-rhel9:v1.3 -- /usr/bin/gather_without_tls <true/false>
+----
+
+By default, the flag value is set to `false`. Set the value to `true` to allow insecure TLS connections.


### PR DESCRIPTION
OADP 1,3,x, OCP 4.12-4.15

Resolves https://issues.redhat.com/browse/OADP-682 by adding a new section to the 'Troubleshooting" section of the OADP user guide, "Support for insecure TLS connections" 

Preview: https://75994--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting.html#support-insecure-tls-connections_oadp-troubleshooting

Note: the first requirement of the Jira, replacing references to `registry.redhat.io/oadp/oadp-mustgather-rhel8:v1.0` with `registry.redhat.io/oadp/oadp-mustgather-rhel8:1.1`, was implemented previously.    