### PR TITLE
OCPBUGS#33714: Create different versions of hosted clusters in the same control plane

### DIFF
--- a/modules/hosted-control-planes-version-support.adoc
+++ b/modules/hosted-control-planes-version-support.adoc
@@ -10,11 +10,14 @@
 
 With each major, minor, or patch version release of {product-title}, two components of hosted control planes are released:
 
-* HyperShift Operator
-* Command-line interface (CLI)
+* The HyperShift Operator
+* The `hcp` command-line interface (CLI)
 
-The HyperShift Operator manages the lifecycle of hosted clusters that are represented by `HostedCluster` API resources. The HyperShift Operator is released with each {product-title} release. After the HyperShift Operator is installed, it creates a config map called `supported-versions` in the HyperShift namespace, as shown in the following example. The config map describes the HostedCluster versions that can be deployed.
+The HyperShift Operator manages the lifecycle of hosted clusters that are represented by the `HostedCluster` API resources. The HyperShift Operator is released with each {product-title} release. The HyperShift Operator creates the `supported-versions` config map in the `hypershift` namespace. The config map contains the supported hosted cluster versions.
 
+You can create different versions of hosted clusters in the same control plane.
+
+.Example `supported-versions` config map object
 [source,yaml]
 ----
     apiVersion: v1
@@ -28,11 +31,8 @@ The HyperShift Operator manages the lifecycle of hosted clusters that are repres
       namespace: hypershift
 ----
 
-The CLI is a helper utility for development purposes. The CLI is released as part of any HyperShift Operator release. No compatibility policies are guaranteed.
+The `hcp` CLI is a getting started tool to create hosted clusters.
 
-The API, `hypershift.openshift.io`, provides a way to create and manage lightweight, flexible, heterogeneous {product-title} clusters at scale. The API exposes two user-facing resources: `HostedCluster` and `NodePool`. A `HostedCluster` resource encapsulates the control plane and common data plane configuration. When you create a `HostedCluster` resource, you have a fully functional control plane with no attached nodes. A `NodePool` resource is a scalable set of worker nodes that is attached to a `HostedCluster` resource.
+You can use the `hypershift.openshift.io` API resources, such as, `HostedCluster` and `NodePool`, to create and manage {product-title} clusters at scale. A `HostedCluster` resource contains the control plane and common data plane configuration. When you create a `HostedCluster` resource, you have a fully functional control plane with no attached nodes. A `NodePool` resource is a scalable set of worker nodes that is attached to a `HostedCluster` resource.
 
 The API version policy generally aligns with the policy for link:https://kubernetes.io/docs/reference/using-api/#api-versioning[Kubernetes API versioning].
-
-
-


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
1. PR adds an information that different versions of hosted clusters can be created in the same control plane
2. Also updates the current section


<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-33714
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://75997--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/index.html#hosted-control-planes-version-support_hcp-overview
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
