### PR TITLE
OSDOCS-10532: 4.12.57 RN

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -4684,3 +4684,29 @@ $ oc adm release info 4.12.56 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-12-57"]
+=== RHSA-2024:2782 - {product-title} 4.12.57 bug fix and security update
+
+Issued: 2024-05-16
+
+{product-title} release 4.12.57, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:2782[RHSA-2024:2782] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:2784[RHSA-2024:2784] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.57 --pullspecs
+----
+
+[id="ocp-4-12-57-bug-fixes"]
+==== Bug fixes
+
+* Previously, the `clear-irqbalance-banned-cpus.sh` script set an empty value for `IRQBALANCE_BANNED_CPUS` in the `/etc/sysconfig/irqbalance` pod annotation. As a result, the IRQs only balanced over the reserved CPUs. With this release, the `clear-irqbalance-banned-cpus.sh` script sets the banned mask to zeros on startup and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-31442[*OCPBUGS-31442*])
+
+* Previously, a kernel regression introduced in {product-title} versions 4.15.0, 4.14.14, 4.13.36, and 4.12.54 led to potential kernel panics in nodes and mounted CephFS volumes. In this release, the regression issue is fixed so that the kernel regression issue no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-33253[*OCPBUGS-33253*])
+
+[id="ocp-4-12-57-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-10532](https://issues.redhat.com/browse/OSDOCS-10532)

Link to docs preview:
https://75999--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-57

QE review:
N/A

Additional information:
URLs will return 404 until go-live (5/16/24)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
