### PR TITLE
OSDOCS-10570: update RHDE matrix for Microshift 4.16

### DIFF
--- a/modules/about-rhde.adoc
+++ b/modules/about-rhde.adoc
@@ -34,29 +34,29 @@ The latest release notes for each product that is part of {product-title} are av
 [id="device-edge-compatibility_{context}"]
 == {product-title} product release compatibility matrix
 
-{microshift-first} and {op-system} work together as a single solution for device-edge computing. To successfully pair your products, use the verified releases together for each as listed in the following table:
+{op-system-first} and {microshift} work together as a single solution for device-edge computing. You can update each component separately, but the product versions must be compatible. For example, an update of {microshift} from 4.14 to 4.16 requires a {op-system} update. Supported configurations of {product-title} use verified releases for each together as listed in the following table:
 
 [cols="4",%autowidth]
 |===
-^|*{op-system-ostree} version*
-^|*{microshift} version*
-^|*{microshift} release status*
-^|*{microshift} supported updates*
+^|*{op-system-ostree} Version(s)*
+^|*{microshift} Version*
+^|*{microshift} Release Status*
+^|*Supported {microshift} Version&#8594;{microshift} Version Updates*
 
 ^|9.4
 ^|4.16
 ^|Generally Available
-^|4.16.0&#8594;4.16.z and 4.16&#8594;maximum two minor versions
+^|4.16.0&#8594;4.16.z, 4.14&#8594;4.16 and 4.15&#8594;4.16
 
 ^|9.2, 9.3
 ^|4.15
 ^|Generally Available
-^|4.15.0&#8594;4.15.z and 4.15&#8594;future minor version
+^|4.15.0&#8594;4.15.z, 4.14&#8594;4.15 and 4.15&#8594;4.16
 
 ^|9.2, 9.3
 ^|4.14
 ^|Generally Available
-^|4.14.0&#8594;4.14.z and 4.14&#8594;4.15
+^|4.14.0&#8594;4.14.z, 4.14&#8594;4.15 and 4.14&#8594;4.16
 
 ^|9.2
 ^|4.13


### PR DESCRIPTION
Version(s):
N/A (no CPs, version "4" is for Pantheon only; versionless branch in the repo)
Can be merged, but Pantheon sync is EMBARGOED for after OCP 4.16 GA when the rest of the docs are published.

Issue:
[OSDOCS-10570](https://issues.redhat.com/browse/OSDOCS-10570)

Link to docs preview:
[Red Hat Device Edge product release compatibility matrix](https://76000--ocpdocs-pr.netlify.app/openshift-rhde/latest/overview/rhde-overview.html)


QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.

See also https://github.com/openshift/openshift-docs/pull/73988 for an approved version of this table. 
