### PR TITLE
OSDOCS-10539: Added note about upgrading existing dual-stack net to 4.16

### DIFF
--- a/modules/nw-dual-stack-convert.adoc
+++ b/modules/nw-dual-stack-convert.adoc
@@ -6,11 +6,26 @@ As a cluster administrator, you can convert your single-stack cluster network to
 
 Converting a single-stack cluster network to a dual-stack cluster network consists of creating patches and applying them to the cluster's network and infrastructure.
 
-If you need to add IPv6 Virtual IPs (VIPs) for API and Ingress services to an existing dual-stack-configured cluster, you need to patch only the cluster's infrastructure and not the cluster's network.
-
 [NOTE]
 ====
 Each patch operation that changes `clusterNetwork`, `serviceNetwork`, `apiServerInternalIPs`, and `ingressIP` objects triggers a restart of the cluster. Changing the `MachineNetworks` object does not cause a reboot of the cluster.
+====
+
+If you need to add IPv6 virtual IPs (VIPs) for API and Ingress services to an existing dual-stack-configured cluster, you need to patch only the cluster's infrastructure and not the cluster's network.
+
+[IMPORTANT]
+====
+If you already upgraded your cluster to {product-title} 4.16 or later and you need to convert the single-stack cluster network to a dual-stack cluster network, you must specify an existing IPv4 `machineNetwork` network configuration from the `install-config.yaml` file for API and Ingress services in the YAML configuration patch file. This configuration ensures that IPv4 traffic exists in the same network interface as the default gateway.
+
+.Example YAML configuration file with an added IPv4 address block for the `machineNetwork` network
+[source,yaml]
+----
+- op: add
+  path: /spec/platformSpec/baremetal/machineNetworks/- <1>
+  value: 192.168.1.0/24
+  # ...
+----
+<1> Ensure that you specify an address block for the `machineNetwork` network where your machines operate. You must select both API and Ingress IP addresses for the machine network.
 ====
 
 .Prerequisites
@@ -23,7 +38,7 @@ Each patch operation that changes `clusterNetwork`, `serviceNetwork`, `apiServer
 
 .Procedure
 
-. To specify IPv6 address blocks for the cluster and service networks, create a YAML configuration patch file that has a similar configuration to the following example:
+. To specify IPv6 address blocks for cluster and service networks, create a YAML configuration patch file that has a similar configuration to the following example:
 +
 [source,yaml]
 ----


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-10539](https://issues.redhat.com/browse/OSDOCS-10539)

Link to docs preview:
* [Converting to a dual-stack cluster network](https://76001--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.html#nw-dual-stack-convert_converting-to-dual-stack)

- [x] SME has approved this change
- [x] QE has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
