### PR TITLE
Fix errant registry names

### DIFF
--- a/modules/images-configuration-registry-mirror-configuring.adoc
+++ b/modules/images-configuration-registry-mirror-configuring.adoc
@@ -58,11 +58,11 @@ spec:
     mirrorSourcePolicy: AllowContactingSource <7>
   - mirrors:
     - mirror.example.com/redhat
-    source: registry.redhat.io/openshift4 <8>
+    source: registry.example.com/redhat <8>
     mirrorSourcePolicy: AllowContactingSource
   - mirrors:
     - mirror.example.com
-    source: registry.redhat.io <9>
+    source: registry.example.com <9>
     mirrorSourcePolicy: AllowContactingSource
   - mirrors:
     - mirror.example.net/image
@@ -220,7 +220,7 @@ short-name-mode = ""
 
 [[registry]]
   prefix = ""
-  location = "registry.redhat.io"
+  location = "registry.example.com"
 
   [[registry.mirror]]
     location = "mirror.example.com"
@@ -228,7 +228,7 @@ short-name-mode = ""
 
 [[registry]]
   prefix = ""
-  location = "registry.redhat.io/openshift4"
+  location = "registry.example.com/redhat"
 
   [[registry.mirror]]
     location = "mirror.example.com/redhat"


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
N/A

Issue:
Some of our examples here referred to registry.redhat.io specifically, and you can't create ICSPs for that entire registry in OSD/ROSA (it's blocked). Swapped with generic example domain.


Link to docs preview:
https://76014--ocpdocs-pr.netlify.app/openshift-rosa/latest/openshift_images/image-configuration.html#images-configuration-registry-mirror-configuring_image-configuration

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
