### PR TITLE
Adds anonymous pulls technical change to 416 release notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -225,6 +225,21 @@ For more information, see xref:../scalability_and_performance/enabling-workload-
 
 SHA1 certificates are no longer supported for use with HaProxy. Both existing and new routes using SHA1 certificates in {product-version} are rejected and no longer function.
 
+[discrete]
+[id="ocp-4-16-anonymous-pulls-internal-image-registry"]
+=== Changes to anonymous pulls from the internal image registry
+
+Previously, configuring the internal image registry to accept anonymous pulls consisted of running the following command:
+
+[source,terminal]
+----
+$ oc adm policy add-role-to-group system:image-puller system:unauthenticated --namespace openshift
+----
+
+With {product-title} {product-version}, changes made to the API server and the `selfsubjectaccessreviews` resource now require administrators to add unauthenticated groups to the `self-access-review` Cluster Role. This is only required for new clusters installed from {product-title} {product-version}; clusters that are upgrading to {product-version} should be able to use the `oc adm policy add-role-to-group system:image-puller system:unauthenticated --namespace openshift` command. 
+
+For more information, see . . .
+
 [id="ocp-4-16-deprecated-removed-features"]
 == Deprecated and removed features
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OCPBUGS-33723

Link to docs preview:
https://76032--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-notable-technical-changes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
