### PR TITLE
OSDOCS-3799 External DNS install CLI instructions

### DIFF
--- a/modules/nw-installing-external-dns-operator-cli.adoc
+++ b/modules/nw-installing-external-dns-operator-cli.adoc
@@ -1,0 +1,154 @@
+// Module included in the following assemblies:
+//
+// * networking/external_dns_operator/nw-installing-external-dns-operator-on-cloud-providers.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-installing-external-dns-operator-cli_{context}"]
+= Installing the External DNS Operator by using the CLI
+
+You can install the External DNS Operator by using the CLI.
+
+.Prerequisites
+
+* You are logged in to the {product-title} web console as a user with `cluster-admin` permissions.
+
+* You are logged into the OpenShift CLI (`oc`).
+
+.Procedure
+
+. Create a `Namespace` object:
+
+.. Create a YAML file that defines the `Namespace` object:
++
+.Example `namespace.yaml` file
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-dns-operator
+----
+
+.. Create the `Namespace` object by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f namespace.yaml
+----
+
+. Create an `OperatorGroup` object:
+
+.. Create a YAML file that defines the `OperatorGroup` object:
++
+.Example `operatorgroup.yaml` file
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: external-dns-operator
+  namespace: external-dns-operator
+spec:
+  upgradeStrategy: Default
+  targetNamespaces:
+  - external-dns-operator
+----
+
+.. Create the `OperatorGroup` object by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f operatorgroup.yaml
+----
+
+. Create a `Subscription` object:
+
+.. Create a YAML file that defines the `Subscription` object:
++
+.Example `subscription.yaml` file
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: external-dns-operator
+  namespace: external-dns-operator
+spec:
+  channel: stable-v1
+  installPlanApproval: Automatic
+  name: external-dns-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+----
+
+.. Create the `Subscription` object by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f subscription.yaml
+----
+
+.Verification
+
+. Get the name of the install plan from the subscription by running the following command:
++
+[source,terminal]
+----
+$ oc -n external-dns-operator \
+    get subscription external-dns-operator \
+    --template='{{.status.installplan.name}}{{"\n"}}'
+----
+
+. Verify that the status of the install plan is `Complete` by running the following command:
++
+[source,terminal]
+----
+$ oc -n external-dns-operator \
+    get ip <install_plan_name> \
+    --template='{{.status.phase}}{{"\n"}}'
+----
+
+. Verify that the status of the `external-dns-operator` pod is `Running` by running the following command:
++
+[source,terminal]
+----
+$ oc -n external-dns-operator get pod
+----
+
++
+.Example output
+[source,terminal]
+----
+NAME                                     READY   STATUS    RESTARTS   AGE
+external-dns-operator-5584585fd7-5lwqm   2/2     Running   0          11m
+----
+
+. Verify that the catalog source of the subscription is `redhat-operators` by running the following command:
++
+[source,terminal]
+----
+$ oc -n external-dns-operator get subscription
+----
+
++
+.Example output
+[source,terminal]
+----
+NAME                    PACKAGE                 SOURCE             CHANNEL
+external-dns-operator   external-dns-operator   redhat-operators   stable-v1
+----
+
+. Check the `external-dns-operator` version by running the following command:
++
+[source,terminal]
+----
+$ oc -n external-dns-operator get csv
+----
+
++
+.Example output
+[source,terminal]
+----
+NAME                           DISPLAY                VERSION   REPLACES   PHASE
+external-dns-operator.v<1.y.z>   ExternalDNS Operator   <1.y.z>                Succeeded
+----

--- a/modules/nw-installing-external-dns-operator.adoc
+++ b/modules/nw-installing-external-dns-operator.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-installing-external-dns-operator_{context}"]
-= Installing the External DNS Operator
+= Installing the External DNS Operator with OperatorHub
 
 You can install the External DNS Operator by using the {product-title} OperatorHub.
 

--- a/networking/external_dns_operator/nw-installing-external-dns-operator-on-cloud-providers.adoc
+++ b/networking/external_dns_operator/nw-installing-external-dns-operator-on-cloud-providers.adoc
@@ -9,3 +9,5 @@ toc::[]
 You can install the External DNS Operator on cloud providers such as AWS, Azure, and GCP.
 
 include::modules/nw-installing-external-dns-operator.adoc[leveloffset=+1]
+
+include::modules/nw-installing-external-dns-operator-cli.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-3799
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://76037--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/external_dns_operator/nw-installing-external-dns-operator-on-cloud-providers.html#nw-installing-external-dns-operator-cli_installing-external-dns-on-cloud-providers
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
