### PR TITLE
Adds anonymous pulls procedure for image registry

### DIFF
--- a/modules/anonymous-pulls.adoc
+++ b/modules/anonymous-pulls.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * registry/accessing-the-registry.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="anonymous-pulls_{context}"]
+= Anonymous pulls
+
+In some cases, administrators might want to enable anonymous pulls from the image registry, for example, when using CI/CD pipelines to streamline access to base images or reduce authentication overhead. To enable anonymous pulls, administrators must add unauthenticated groups to the `self-access-review` Cluster Role and grant the `system:image-puller` role to the `system:unauthenticated` group.

--- a/modules/enabling-anonymous-pulls.adoc
+++ b/modules/enabling-anonymous-pulls.adoc
@@ -1,0 +1,130 @@
+// Module included in the following assemblies:
+//
+// * registry/accessing-the-registry.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="enabling-anonymous-pulls_{context}"]
+= Enabling anonymous pulls
+
+The following procedure shows you how to check if your cluster has the proper roles and permissions for anonymous pulls and, if it does not, how to enable anonymous pulls.
+
+.Procedure 
+
+. Enter the following command to see if the `system:unauthenticated` group is included in the `subjects` parameter of your `ClusterRoleBinding` object:
++
+[source,terminal]
+----
+$ oc get clusterrolebindings self-access-reviewers -o yaml
+----
++
+.Example output
++
+[source,terminal]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  creationTimestamp: "2024-01-17T20:50:41Z"
+  name: self-access-reviewers
+  resourceVersion: "14477"
+  uid: d0ae964c-89ce-4b24-8905-a2318484fdd5
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: self-access-reviewer
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+----
+
+. If your cluster has the `self-access-reviewer` cluster role binding available to the `system:unauthenticated` group, you do not need to create a new cluster role binding, and can move on to the following step.
++
+If `self-access-reviewer` is not available to the `system:unauthenticated` group, or the cluster role binding does not exist, you can create a file named `add-self-access-review-unauth.yaml` and apply it with the following command:
++
+[source,yaml]
+----
+cat <<EOF | oc apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: restore-self-access-reviewers-unauth
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: self-access-reviewer
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:unauthenticated
+EOF
+----
++
+.Example output
++
+[source,terminal]
+----
+clusterrolebinding.rbac.authorization.k8s.io/restore-self-access-reviewers-unauth created
+----
+
+. Enter the following command to grant the `system:image-puller` role to the `system:unauthenticated` group in the specified namespace, enabling anonymous users to pull images:
++
+[source,terminal]
+----
+$ oc adm policy add-role-to-group system:image-puller system:unauthenticated --namespace <namespace>
+----
+
+.Verification
+
+. Enter the following command to patch the image registry configuration and enable the default route:
++
+[source,terminal]
+----
+$ oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge
+----
++
+.Example output
++
+[source,terminal]
+----
+config.imageregistry.operator.openshift.io/cluster patched
+----
+
+. Enter the following command to get the route URL of the image registry:
++
+[source,terminal]
+----
+$ HOST=$(oc get route default-route -n openshift-image-registry --template='{{ .spec.host }}')
+----
+
+. Enter the following command to test pulling an image anonymously:
++
+[source,terminal]
+----
+$ oc image info --insecure "${HOST}/openshift/cli:latest"
+----
++
+.Example output
++
+[source,terminal]
+----
+...
+Digest:      sha256:504f69082c90b3885d737888d3cea231f6577eb517424c80372745ca688a0379
+Media Type:  application/vnd.docker.distribution.manifest.v2+json
+Created:     265d ago
+Image Size:  198MB in 5 layers
+Layers:      79.52MB sha256:97da74cc6d8fa5d1634eb1760fd1da5c6048619c264c23e62d75f3bf6b8ef5c4
+             1.438kB sha256:d8190195889efb5333eeec18af9b6c82313edd4db62989bd3a357caca4f13f0e
+             45.57MB sha256:60db511796dd988014e9075c0e2a57f15d383cebe51a5b1bf3e6b51fbf35f89b
+             11.21MB sha256:1360931a72a010f034ab9a24e115d8ef5b39377eef7a0d1fb4bd009351fe0ef8
+             61.69MB sha256:2e4b8f633289f0b995734a89a3e7e1a3f5bc8dba7702834bb67433ee8e8dfc1a
+OS:          linux
+Arch:        amd64
+Command:     /bin/bash
+Environment: PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+...
+----

--- a/registry/accessing-the-registry.adoc
+++ b/registry/accessing-the-registry.adoc
@@ -67,3 +67,6 @@ more information.
 * For more information on configuring an identity provider, see
 xref:../authentication/understanding-identity-provider.adoc[Understanding identity provider configuration].
 endif::openshift-dedicated,openshift-rosa[]
+
+include::modules/anonymous-pulls.adoc[leveloffset=+1]
+include::modules/enabling-anonymous-pulls.adoc[leveloffset=+2]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OCPBUGS-33723

Link to docs preview:
https://76038--ocpdocs-pr.netlify.app/openshift-enterprise/latest/registry/accessing-the-registry.html#enabling-anonymous-pulls_accessing-the-registry


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
