### PR TITLE
CMA 2.12.1-394 release notes

### DIFF
--- a/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.adoc
+++ b/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.adoc
@@ -10,6 +10,21 @@ The following release notes are for previous versions of the Custom Metrics Auto
 
 For the current version, see xref:../../../nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc#nodes-cma-autoscaling-custom-rn[Custom Metrics Autoscaler Operator release notes].
 
+[id="nodes-pods-autoscaling-custom-rn-2121-384_{context}"]
+== Custom Metrics Autoscaler Operator 2.12.1-384 release notes
+
+This release of the Custom Metrics Autoscaler Operator 2.12.1-384 provides a bug fix for running the Operator in an {product-title} cluster. The following advisory is available for the link:https://access.redhat.com/errata/RHBA-2024:2043[RHBA-2024:2043].
+
+[IMPORTANT]
+====
+Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of KEDA.
+====
+
+[id="nodes-pods-autoscaling-custom-rn-2121-384-bugs_{context}"]
+=== Bug fixes
+
+* Previously, the `custom-metrics-autoscaler` and `custom-metrics-autoscaler-adapter` images were missing time zone information. As a consequence, scaled objects with `cron` triggers failed to work because the controllers were unable to find time zone information. With this fix, the image builds are updated to include time zone information. As a result, scaled objects containing `cron` triggers now function properly. (link:https://issues.redhat.com/browse/OCPBUGS-32395[*OCPBUGS-32395*]) 
+
 [id="nodes-pods-autoscaling-custom-rn-2121-376_{context}"]
 == Custom Metrics Autoscaler Operator 2.12.1-376 release notes
 

--- a/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
+++ b/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
@@ -43,17 +43,27 @@ The following table defines the Custom Metrics Autoscaler Operator versions for 
 |General availability
 |===
 
-[id="nodes-pods-autoscaling-custom-rn-2121-384_{context}"]
-== Custom Metrics Autoscaler Operator 2.12.1-384 release notes
+[id="nodes-pods-autoscaling-custom-rn-2121-394_{context}"]
+== Custom Metrics Autoscaler Operator 2.12.1-394 release notes
 
-This release of the Custom Metrics Autoscaler Operator 2.12.1-384 provides a bug fix for running the Operator in an {product-title} cluster. The following advisory is available for the link:https://access.redhat.com/errata/RHBA-2024:2043[RHBA-2024:2043].
+This release of the Custom Metrics Autoscaler Operator 2.12.1-394 provides a bug fix for running the Operator in an {product-title} cluster. The following advisory is available for the link:https://access.redhat.com/errata/RHSA-2024:2901[RHSA-2024:2901].
 
 [IMPORTANT]
 ====
 Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of KEDA.
 ====
 
-[id="nodes-pods-autoscaling-custom-rn-2121-384-bugs_{context}"]
+[id="nodes-pods-autoscaling-custom-rn-2121-394-bugs_{context}"]
 === Bug fixes
 
-* Previously, the `custom-metrics-autoscaler` and `custom-metrics-autoscaler-adapter` images were missing time zone information. As a consequence, scaled objects with `cron` triggers failed to work because the controllers were unable to find time zone information. With this fix, the image builds are updated to include time zone information. As a result, scaled objects containing `cron` triggers now function properly. (link:https://issues.redhat.com/browse/OCPBUGS-32395[*OCPBUGS-32395*]) 
+* Previously, the `protojson.Unmarshal` function entered into an infinite loop when unmarshaling certain forms of invalid JSON. This condition could occur when unmarshaling into a message that contains a `google.protobuf.Any` value or when the `UnmarshalOptions.DiscardUnknown` option is set. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30305[*OCPBUGS-30305*])
+
+* Previously, when parsing a multipart form, either explicitly with the `Request.ParseMultipartForm` method or implicitly with the `Request.FormValue`, `Request.PostFormValue`, or `Request.FormFile` method, the limits on the total size of the parsed form were not applied to the memory consumed while reading a single form line. This could have permitted a maliciously crafted input containing very long lines to cause allocation of arbitrarily large amounts of memory, potentially leading to memory exhaustion. With this fix, the parsing process now correctly limits the maximum size of form lines. (link:https://issues.redhat.com/browse/OCPBUGS-30360[*OCPBUGS-30360*])
+
+* Previously, when following an HTTP redirect to a domain that is not on a  matching subdomain or on an exact match of the initial domain, an HTTP client would not forward sensitive headers, such as `Authorization` or `Cookie`. For example, a redirect from example.com to www.example.com would forward the `Authorization` header; but a redirect to www.example.org would not forward the header. A maliciously crafted HTTP redirect could have caused sensitive headers to be unexpectedly forwarded. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30365[*OCPBUGS-30365*])
+
+* Previously, verifying a certificate chain that contains a certificate with an unknown public key algorithm caused the certificate verification process to panic. This condition affected all crypto and TLS clients and servers that set the `Config.ClientAuth` parameter to the `VerifyClientCertIfGiven` or `RequireAndVerifyClientCert` value. The default behavior is for TLS servers to not verify client certificates. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30370[*OCPBUGS-30370*])
+
+* Previously, if errors returned from the `MarshalJSON` method contained user-controlled data, the data could have been used to break the contextual auto-escaping behavior of the HTML template package. This condition would allow for subsequent actions to inject unexpected content into the templates. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30397[*OCPBUGS-30397*])
+
+* Previously, the `net/http` and `golang.org/x/net/http2` Go packages did not limit the number of `CONTINUATION` frames that were read for an HTTP/2 request. This condition could permit an attacker to provide an arbitrarily large set of headers for a single request, which would be read, decoded, and subsequently discarded. This could result in excessive CPU consumption. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30894[*OCPBUGS-30894*])


### PR DESCRIPTION
Errata: https://errata.devel.redhat.com/docs/show/131744

Peer review: [Custom Metrics Autoscaler Operator 2.12.1-394 release notes](https://76042--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.html#nodes-pods-autoscaling-custom-rn-2121-394_nodes-cma-autoscaling-custom-rn) 

**Planned GA 5/20/24**