### PR TITLE
OADP-2328: Label selector syntax not correct in Backup CR

### DIFF
--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr.adoc
@@ -64,14 +64,14 @@ spec:
   ttl: 720h0m0s
   labelSelector: <5>
     matchLabels:
-      app=<label_1>
-      app=<label_2>
-      app=<label_3>
+      app: <label_1>
+      app: <label_2>
+      app: <label_3>
   orLabelSelectors: <6>
   - matchLabels:
-      app=<label_1>
-      app=<label_2>
-      app=<label_3>
+      app: <label_1>
+      app: <label_2>
+      app: <label_3>
 ----
 <1> Specify an array of namespaces to back up.
 <2> Optional: Specify an array of resources to include in the backup. Resources might be shortcuts (for example, 'po' for 'pods') or fully-qualified. If unspecified, all resources are included.


### PR DESCRIPTION
### JIRA

* [OADP-2328](https://issues.redhat.com/browse/OADP-2328)

### VERSION

* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16

### Link to docs preview:

* [Creating a Backup CR](https://76043--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr.html) 

### QE review:
- [ ] QE has approved this change.
