### PR TITLE
OBSDOCS-1066

### DIFF
--- a/modules/logging-input-spec-filter-labels-expressions.adoc
+++ b/modules/logging-input-spec-filter-labels-expressions.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="logging-input-spec-filter-labels-expressions_{context}"]
-= Filtering application logs at input ny including the label expressions or a matching label key and values
+= Filtering application logs at input by including the label expressions or a matching label key and values
 
 You can include the application logs based on the label expressions or a matching label key and its values by using the `input` selector.
 


### PR DESCRIPTION
[OBSDOCS-1066](https://issues.redhat.com/browse/OBSDOCS-1066): Issue in file observability/logging/performance_reliability/logging-input-spec-filtering.adoc
Aligned team: Observability
OCP version for cherry-picking: 4.13+
JIRA issues: [OBSDOCS-1066](https://issues.redhat.com/browse/OBSDOCS-1066)
Preview pages: https://76048--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/performance_reliability/logging-input-spec-filtering.html#logging-input-spec-filter-labels-expressions_logging-input-spec-filtering
SME review **requested**: NA
QE review **requested**: NA
Peer review **completed**: @JoeAldinger
