### PR TITLE
OSDOCS-10584: adds supported arches to MicroShift docs

### DIFF
--- a/modules/microshift-install-system-requirements.adoc
+++ b/modules/microshift-install-system-requirements.adoc
@@ -8,7 +8,8 @@
 
 The following conditions must be met prior to installing {microshift-short}:
 
-* A supported version of {op-system} or {op-system-ostree}.
+* A compatible version of {op-system} or {op-system-ostree}.
+* AArch64 or x86_64 system architecture.
 * 2 CPU cores.
 * 2 GB RAM for {microshift-short} or 3 GB RAM, required by {op-system} for networked-based HTTPs or FTP installations.
 * 10 GB of storage.


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-10584](https://issues.redhat.com/browse/OSDOCS-10584)

Link to docs preview:
[System requirements module](https://76086--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree.html#microshift-install-system-requirements_microshift-embed-in-rpm-ostree)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
