### PR TITLE
OSDOCS-9421: router configuration MicroShift

### DIFF
--- a/microshift_networking/microshift-nw-router.adoc
+++ b/microshift_networking/microshift-nw-router.adoc
@@ -8,3 +8,22 @@ toc::[]
 
 Learn about default and custom settings for configuring the router with {microshift-short}.
 
+include::modules/microshift-nw-router-con.adoc[leveloffset=+1]
+
+include::modules/microshift-nw-router-disable.adoc[leveloffset=+1]
+
+[id="microshift-configuring-router-ingress_{context}"]
+== Configuring router ingress
+
+If your {microshift-short} applications need to listen only for data traffic, you can configure the `listenAddress` setting to isolate your devices. You can also configure specific ports and IP addresses for network connections. Use the combination required to customize the endpoint configuration for your use case.
+
+include::modules/microshift-nw-router-config-ports.adoc[leveloffset=+2]
+
+include::modules/microshift-nw-router-config-ip-address.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="additional-resources_microshift-understanding-and-configuring-router_{context}"]
+== Additional resources
+* xref:../microshift_configuring/microshift-using-config-tools.adoc#microshift-yaml-default_microshift-using-config-tools[Default settings] ({microshift-short})
+
+* xref:../microshift_networking/microshift_network_policy/microshift-network-policy-index.adoc#microshift-network-policies[About network policies]

--- a/modules/microshift-default-settings.adoc
+++ b/modules/microshift-default-settings.adoc
@@ -21,32 +21,32 @@ $ microshift show-config
 apiServer:
   advertiseAddress: 10.44.0.0/32 # <1>
   auditLog:
-    maxFileAge: 10
-    maxFileSize: 200
-    maxFiles: 10
-    profile: Default
+    maxFileAge: 0 # <2>
+    maxFileSize: 200 # <3>
+    maxFiles: 10 # <4>
+    profile: Default # <5>
   namedCertificates:
     - certPath: ""
       keyPath: ""
       names:
         - ""
-  subjectAltNames: [] # <2>
+  subjectAltNames: [] # <6>
 debugging:
-  logLevel: "Normal" # <3>
+  logLevel: "Normal" # <7>
 dns:
-  baseDomain: microshift.example.com <4>
+  baseDomain: microshift.example.com # <8>
 etcd:
-  memoryLimitMB: 0 # <5>
+  memoryLimitMB: 0 # <9>
 ingress:
   listenAddress:
-    - ""
-  ports:
+    - "" # <10>
+  ports: # <11>
     http: 80
     https: 443
   routeAdmissionPolicy:
-    namespaceOwnership: InterNamespaceAllowed # <6>
-  status: Managed # <7>
-manifests: # <8>
+    namespaceOwnership: InterNamespaceAllowed # <12>
+  status: Managed # <13>
+manifests: # <14>
   kustomizePaths:
     - /usr/lib/microshift/manifests
     - /usr/lib/microshift/manifests.d/*
@@ -54,24 +54,30 @@ manifests: # <8>
     - /etc/microshift/manifests.d/*
 network:
   clusterNetwork:
-    - 10.42.0.0/16 # <9>
+    - 10.42.0.0/16 # <15>
   serviceNetwork:
-    - 10.43.0.0/16 # <10>
-  serviceNodePortRange: 30000-32767 # <11>
+    - 10.43.0.0/16 # <16>
+  serviceNodePortRange: 30000-32767 # <17>
 node:
-  hostnameOverride: "" # <12>
-  nodeIP: "" # <13>
+  hostnameOverride: "" # <18>
+  nodeIP: "" # <19>
 ----
 <1> A string that specifies the IP address from which the API server is advertised to members of the cluster. The default value is calculated based on the address of the service network.
-<2> Subject Alternative Names for API server certificates.
-<3> Log verbosity. Valid values for this field are `Normal`, `Debug`, `Trace`, or `TraceAll`.
-<4> By default, `etcd` uses as much memory as needed to handle the load on the system. However, in memory constrained systems, it might be preferred or necessary to limit the amount of memory `etcd` can to use at a given time.
-<5> Base domain of the cluster. All managed DNS records are subdomains of this base.
-<6> Describes how host name claims across namespaces are handled. By default, allows routes to claim different paths of the same host name across namespaces. Can also be set as `Strict` to not allow routes in different namespaces to claim the same host. If the value is deleted and a new one is not added, `InterNamespaceAllowed` is automatically set.
-<7> Default router status, can be `Managed` or `Removed`.
-<8> The locations on the filesystem to scan for `kustomization` files to use to load manifests. Set to a list of paths to scan only those paths. Set to an empty list to disable loading manifests. The entries in the list can be glob patterns to match multiple subdirectories.
-<9> A block of IP addresses from which Pod IP addresses are allocated. This field is immutable after installation.
-<10> A block of virtual IP addresses for Kubernetes services. IP address pool for services. A single entry is supported. This field is immutable after installation.
-<11> The port range allowed for Kubernetes services of type NodePort. If not specified, the default range of 30000-32767 is used. Services without a `NodePort` specified are automatically allocated one from this range. This parameter can be updated after the cluster is installed.
-<12> The name of the node. The default value is the hostname. If non-empty, this string is used to identify the node instead of the hostname.
-<13> The IP address of the node. The default value is the IP address of the default route.
+<2> How long log files are kept before automatic deletion. The default value of `0` in the `maxFileAge` parameter means a log file is never deleted based on age. This value can be configured.
+<3> By default, when the `audit.log` file reaches the `maxFileSize` limit, the `audit.log` file is rotated and {microshift-short} begins writing to a new `audit.log` file. This value can be configured.
+<4> The total number of log files kept. By default, {microshift-short} retains 10 log files. The oldest is deleted when an excess file is created. This value can be configured.
+<5> Logs only metadata for read and write requests; does not log request bodies except for OAuth access token requests. If you do not specify this field, the `Default` profile is used.
+<6> Subject Alternative Names for API server certificates.
+<7> Log verbosity. Valid values for this field are `Normal`, `Debug`, `Trace`, or `TraceAll`.
+<8> By default, `etcd` uses as much memory as needed to handle the load on the system. However, in memory constrained systems, it might be preferred or necessary to limit the amount of memory `etcd` can to use at a given time.
+<9> Base domain of the cluster. All managed DNS records are subdomains of this base.
+<10> The `ingress.listenAddress` value defaults to the entire network of the host. The valid configurable value is a list that can be either a single IP address or NIC name or multiple IP addresses and NIC names.
+<11> Default ports shown. Configurable. Valid values for both port entries are a single, unique port in the 1-65535 range. The values of the `ports.http` and `ports.https` fields cannot be the same.
+<12> Describes how hostname claims across namespaces are handled. By default, allows routes to claim different paths of the same hostname across namespaces. Valid values are `Strict` and `InterNamespaceAllowed`. Specifying `Strict` prevents routes in different namespaces from claiming the same hostname. If the value is deleted in a customized {microshift-short} `config.yaml`, the `InterNamespaceAllowed` value is automatically set.
+<13> Default router status, can be `Managed` or `Removed`.
+<14> The locations on the file system to scan for `kustomization` files to use to load manifests. Set to a list of paths to scan only those paths. Set to an empty list to disable loading manifests. The entries in the list can be glob patterns to match multiple subdirectories.
+<15> A block of IP addresses from which pod IP addresses are allocated. This field is immutable after installation.
+<16> A block of virtual IP addresses for Kubernetes services. IP address pool for services. A single entry is supported. This field is immutable after installation.
+<17> The port range allowed for Kubernetes services of type `NodePort`. If not specified, the default range of 30000-32767 is used. Services without a `NodePort` specified are automatically allocated one from this range. This parameter can be updated after the cluster is installed.
+<18> The name of the node. The default value is the hostname. If non-empty, this string is used to identify the node instead of the hostname.
+<19> The IP address of the node. The default value is the IP address of the default route.

--- a/modules/microshift-nw-router-con.adoc
+++ b/modules/microshift-nw-router-con.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// * microshift_networking/microshift-nw-router.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-about-router-config_{context}"]
+= About configuring the router
+
+To make ingress optional, you can configure {microshift-short} ingress router settings to manage which ports, if any, are exposed to network traffic. Specified routing is an example of ingress load balancing.
+
+* The default ingress router is always on, running on all IP addresses on the `http: 80` and `https: 443` ports.
+* Default router settings allow access to any namespace.
+
+Some applications running on top of {microshift-short} might not require the default router and instead create their own. You can configure the router to control both ingress and namespace access.
+
+[TIP]
+====
+You can check for the presence of the default router in your {microshift-short} installation before you begin configurations by using the `oc get deployment -n openshift-ingress` command, which returns the following output:
+
+[source,terminal]
+----
+NAME             READY   UP-TO-DATE   AVAILABLE   AGE
+router-default   1/1     1            1           2d23h
+----
+====
+
+[id="microshift-router-csettings_{context}"]
+== Router settings and valid values
+
+The ingress router settings consist of the following parameters and valid values:
+
+.Example `config.yaml` router settings
+[source,yaml]
+----
+# ...
+ingress:
+  listenAddress:
+    - ""  # <1>
+  ports: # <2>
+    http: 80
+    https: 443
+  routeAdmissionPolicy:
+    namespaceOwnership: InterNamespaceAllowed # <3>
+  status: Managed # <4>
+# ...
+----
+<1> The `ingress.listenAddress` value defaults to the entire network of the host. Valid customizable values can be a single IP address or host name or a list of IP addresses or host names.
+<2> Valid values for both port entries are a single, unique port in the 1-65535 range. The values of the `ports.http` and `ports.https` fields cannot be the same.
+<3> Default value. Allows routes to claim different paths of the same host name across namespaces.
+<4> Default value. `Managed` is required for the ingress ports to remain open.
+
+[IMPORTANT]
+====
+The firewalld service is bypassed by the default {microshift-short} router and by configurations that enable the router. Ingress and egress must be controlled by setting network policies when the router is active.
+====

--- a/modules/microshift-nw-router-config-ip-address.adoc
+++ b/modules/microshift-nw-router-config-ip-address.adoc
@@ -1,0 +1,77 @@
+// Module included in the following assemblies:
+//
+// * microshift_networking/microshift-nw-router.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-config-ip-addresses_{context}"]
+= Configuring router IP addresses
+
+You can restrict the network traffic to the router by configuring specific IP addresses. For example:
+
+* Use cases where the router is reachable only on internal networks, but not on northbound public networks
+* Use cases where the router is reachable only by northbound public networks, but not on internal networks
+* Use cases where the router is reachable by both internal networks and northbound public networks, but on separate IP addresses
+
+.Prerequisites
+
+* You installed {microshift-short}.
+* You created a {microshift-short} `config.yaml` file.
+* The {oc-first} is installed.
+
+[TIP]
+====
+If you complete all the configurations that you need to make in the {microshift-short} `config.yaml` file at the same time, you can minimize system restarts.
+====
+
+.Procedure
+
+. Update the list in the `ingress.listenAddress` field in the {microshift-short} `config.yaml` according to your requirements and as shown in the following examples:
++
+.Default router IP address list
+[source,yaml]
+----
+# ...
+ingress:
+  listenAddress:
+    - "<host_network>" # <1>
+# ...
+----
+<1> The `ingress.listenAddress` value defaults to the entire network of the host. To continue to use the default list, remove the `listen.Address` field from the {microshift-short} `config.yaml` file. To customize this parameter, use a list. The list can contain either a single IP address or NIC name or multiple IP addresses and NIC names.
++
+[IMPORTANT]
+====
+You must either remove the `listenAddress` parameter or add values to it in the form of a list when using the `config.yaml` file. Do not leave the field empty or {microshift-short} crashes on restart.
+====
++
+.Example router setting with a single host IP address
+[source,yaml]
+----
+# ...
+ingress:
+  listenAddress:
+    - 10.2.1.100
+# ...
+----
++
+.Example router setting with a combination of IP addresses and NIC names
+[source,yaml]
+----
+# ...
+ingress:
+  listenAddress:
+    - 10.2.1.100
+    - 10.2.2.10
+    - ens3
+# ...
+----
+
+. Restart the {microshift-short} service by running the following command:
++
+[source,terminal]
+----
+$ sudo systemctl restart microshift
+----
+
+.Verification
+
+* To verify that your settings are applied, make sure that the `ingress.listenAddress` IP addresses are reachable, then you can `curl` the route with the destination to one of these load balancer IP address.

--- a/modules/microshift-nw-router-config-ports.adoc
+++ b/modules/microshift-nw-router-config-ports.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * microshift_networking/microshift-nw-router.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-config-router-ports_{context}"]
+= Configuring router ports
+
+You can control which ports your devices use by configuring the router ingress fields.
+
+.Prerequisites
+
+* You installed {microshift-short}.
+* You created a {microshift-short} `config.yaml` file.
+* The {oc-first} is installed.
+
+[TIP]
+====
+If you complete all the configurations that you need to make in the {microshift-short} `config.yaml` file at the same time, you can minimize system restarts.
+====
+
+.Procedure
+
+. Update the {microshift-short} `config.yaml` port values in the `ingress.ports.http` and `ingress.ports.https` fields to the ports you want to use:
++
+.Example `config.yaml` router settings
+[source,yaml]
+----
+# ...
+ingress:
+  ports: # <1>
+    http: 80
+    https: 443
+  routeAdmissionPolicy:
+    namespaceOwnership: InterNamespaceAllowed
+  status: Managed # <2>
+# ...
+----
+<1> Default ports shown. Customizable. Valid values for both port entries are a single, unique port in the 1-65535 range. The values of the `ports.http` and `ports.https` fields cannot be the same.
+<2> The default value. `Managed` is required for the ingress ports to remain open.
+
+. Restart the {microshift-short} service by running the following command:
++
+[source,terminal]
+----
+$ sudo systemctl restart microshift
+----

--- a/modules/microshift-nw-router-disable.adoc
+++ b/modules/microshift-nw-router-disable.adoc
@@ -1,0 +1,65 @@
+// Module included in the following assemblies:
+//
+// * microshift_networking/microshift-nw-router.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-disabling-the-router_{context}"]
+= Disabling the router
+
+In use cases such as industrial IoT spaces where {microshift-short} pods only need to connect to southbound operational systems and northbound cloud-data systems, inbound services are not needed. Use this procedure to disable the router in such egress-only use cases.
+
+.Prerequisites
+
+* You installed {microshift-short}.
+* You created a {microshift-short} `config.yaml` file.
+* The {oc-first} is installed.
+
+[TIP]
+====
+If you complete all the configurations that you need to make in the {microshift-short} `config.yaml` file at the same time, you can minimize system restarts.
+====
+
+.Procedure
+
+. Update the value of `ingress.status` field to `Removed` in the {microshift-short} `config.yaml` file as shown in the following example:
++
+.Example `config.yaml` ingress stanza
+[source,yaml]
+----
+# ...
+ingress:
+  ports:
+    http: 80
+    https: 443
+  routeAdmissionPolicy:
+    namespaceOwnership: InterNamespaceAllowed
+  status: Removed # <1>
+# ...
+----
+<1> When the value is set to `Removed`, the ports listed in `ingress.ports` are automatically closed. Any other settings in the `ingress` stanza are ignored, for example, any values in the `routeAdmissionPolicy.namespaceOwnership` field.
+
+. Restart the {microshift-short} service by running the following command:
++
+[source,terminal]
+----
+$ sudo systemctl restart microshift
+----
++
+[NOTE]
+====
+The {microshift-short} service outputs current configurations during restarts.
+====
+
+.Verification
+* After the system restarts, verify that the router has been removed and that ingress is stopped by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-ingress get svc
+----
++
+.Expected output
+[source,text]
+----
+No resources found in openshift-ingress namespace.
+----


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-9421](https://issues.redhat.com/browse/OSDOCS-9421)

Link to docs preview:
[Configuring the router](https://76100--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-nw-router.html)
[Footnote update default config `listenAddress`](https://76100--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-cni.html#microshift-yaml-default_microshift-about-ovn-k-plugin)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review:
- [x] SME has approved this change.

Related work:
[Release note](https://github.com/openshift/openshift-docs/pull/76290)
[Related work](https://github.com/openshift/openshift-docs/pull/76317)
[Audit log updates](https://github.com/openshift/openshift-docs/pull/76743)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
