### PR TITLE
CNV#34768: Adjust documentation to use the new role 

### DIFF
--- a/modules/virt-cluster-role-VNC.adoc
+++ b/modules/virt-cluster-role-VNC.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virt-accessing-vm-consoles.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-cluster-role-VNC_{context}"]
+= Granting token generation permission for the VNC console by using the cluster role
+
+As a cluster administrator, you can install a cluster role and bind it to a user or service account to allow access to the endpoint that generates tokens for the VNC console.
+
+.Procedure
+
+* Choose to bind the cluster role to either a user or service account.
+
+** Run the following command to bind the cluster role to a user:
++
+[source,terminal]
+----
+$ kubectl create rolebinding "${ROLE_BINDING_NAME}" --clusterrole="token.kubevirt.io:generate" --user="${USER_NAME}"
+----
+
+** Run the following command to bind the cluster role to a service account:
++
+[source,terminal]
+----
+$ kubectl create rolebinding "${ROLE_BINDING_NAME}" --clusterrole="token.kubevirt.io:generate" --serviceaccount="${SERVICE_ACCOUNT_NAME}"
+----

--- a/virt/virtual_machines/virt-accessing-vm-consoles.adoc
+++ b/virt/virtual_machines/virt-accessing-vm-consoles.adoc
@@ -27,6 +27,10 @@ include::modules/virt-connecting-vm-virtctl.adoc[leveloffset=+2]
 include::modules/virt-temporary-token-VNC.adoc[leveloffset=+2]
 :!vnc-console:
 
+:context: vnc-console
+include::modules/virt-cluster-role-VNC.adoc[leveloffset=+3]
+:!vnc-console:
+
 [id="serial-console_virt-accessing-vm-consoles"]
 == Connecting to the serial console
 


### PR DESCRIPTION
Version(s): 4.16

Issue: [CNV-34768](https://issues.redhat.com/browse/CNV-34768)

Link to docs preview: [Granting token generation permission for the VNC console by using the cluster role](https://76122--ocpdocs-pr.netlify.app/openshift-rosa/latest/virt/virtual_machines/virt-accessing-vm-consoles.html#virt-cluster-role-VNC_vnc-console)

QE review:
- [x] QE has approved this change.

Additional information: Peer and merge reviews needed for openshift-enterprise preview/version only.





