### PR TITLE
OADP-2133: volumeOptionsforStorageClasses is meant for use with Ceph

### DIFF
--- a/modules/oadp-ceph-cephfs-back-up-dba.adoc
+++ b/modules/oadp-ceph-cephfs-back-up-dba.adoc
@@ -58,7 +58,7 @@ spec:
         provider: aws
   configuration:
       restic:
-        enable: false  <1>
+        enable: false  # <1>
       velero:
         defaultPlugins:
           - openshift
@@ -67,9 +67,9 @@ spec:
           - vsm
   features:
       dataMover:
-        credentialName: <restic_secret_name> <2>
-        enable: true <3>
-        volumeOptionsForStorageClasses:
+        credentialName: <restic_secret_name> # <2>
+        enable: true # <3>
+        volumeOptionsForStorageClasses: # <4>
           ocs-storagecluster-cephfs:
             sourceVolumeOptions:
               accessMode: ReadOnlyMany
@@ -80,3 +80,4 @@ spec:
 <1> There is no default value for the `enable` field. Valid values are `true` or `false`.
 <2> Use the Restic `Secret` that you created when you prepared your environment for working with OADP 1.2 Data Mover and Ceph. If you do not use your Restic `Secret`, the CR uses the default value `dm-credential` for this parameter.
 <3> There is no default value for the `enable` field. Valid values are `true` or `false`.
+<4> Optional parameter. You can define a different set of `VolumeOptionsForStorageClass` labels for each `storageClass` volume. This configuration provides a backup for volumes with different providers. The optional `VolumeOptionsForStorageClass` parameter is typically used with CephFS but can be used for any storage type.

--- a/modules/oadp-ceph-split-back-up-dba.adoc
+++ b/modules/oadp-ceph-split-back-up-dba.adoc
@@ -46,9 +46,9 @@ spec:
         - vsm
   features:
     dataMover:
-      credentialName: <restic_secret_name> <1>
+      credentialName: <restic_secret_name> # <1>
       enable: true
-      volumeOptionsForStorageClasses: <2>
+      volumeOptionsForStorageClasses: # <2>
         ocs-storagecluster-cephfs:
           sourceVolumeOptions:
             accessMode: ReadOnlyMany
@@ -59,9 +59,9 @@ spec:
           sourceVolumeOptions:
             storageClassName: ocs-storagecluster-ceph-rbd
             cacheStorageClassName: ocs-storagecluster-ceph-rbd
-        destinationVolumeOptions:
+          destinationVolumeOptions:
             storageClassName: ocs-storagecluster-ceph-rbd
             cacheStorageClassName: ocs-storagecluster-ceph-rbd
 ----
 <1> Use the Restic `Secret` that you created when you prepared your environment for working with OADP 1.2 Data Mover and Ceph. If you do not, then the CR will use the default value `dm-credential` for this parameter.
-<2> A different set of `VolumeOptionsForStorageClass` labels can be defined for each `storageClass` volume, thus allowing a backup to volumes with different providers.
+<2> A different set of `VolumeOptionsForStorageClass` labels can be defined for each `storageClass` volume, thus allowing a backup to volumes with different providers. The `VolumeOptionsForStorageClass` parameter is meant for use with CephFS. However, the optional `VolumeOptionsForStorageClass` parameter could be used for any storage type.


### PR DESCRIPTION
### Jira 

* [OADP-2133](https://issues.redhat.com/browse/OADP-2133)


### Version(s):

* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

### Link to docs preview:

* [Creating a DPA for use with split volumes](https://76149--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/oadp-12-data-mover-ceph-doc.html#oadp-ceph-split-back-up-dba_split)



QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
