### PR TITLE
albo, extdns: remove premature namespace selection in installation module

### DIFF
--- a/modules/installing-aws-load-balancer-operator.adoc
+++ b/modules/installing-aws-load-balancer-operator.adoc
@@ -20,7 +20,6 @@ You can install the AWS Load Balancer Operator by using the web console.
 
 . Navigate to *Operators* → *OperatorHub* in the {product-title} web console.
 . Select the *AWS Load Balancer Operator*. You can use the *Filter by keyword* text box or use the filter list to search for the AWS Load Balancer Operator from the list of Operators.
-. Select the `aws-load-balancer-operator` namespace.
 . On the *Install Operator* page, select the following options:
 .. *Update the channel* as *stable-v1*.
 .. *Installation mode* as *All namespaces on the cluster (default)*.

--- a/modules/nw-installing-external-dns-operator.adoc
+++ b/modules/nw-installing-external-dns-operator.adoc
@@ -13,7 +13,6 @@ You can install the External DNS Operator by using the {product-title} OperatorH
 . Click *Operators* -> *OperatorHub* in the {product-title} web console.
 . Click *External DNS Operator*.
   You can use the *Filter by keyword* text box or the filter list to search for External DNS Operator from the list of Operators.
-. Select the `external-dns-operator` namespace.
 . On the *External DNS Operator* page, click *Install*.
 . On the *Install Operator* page, ensure that you selected the following options:
 .. Update the channel as *stable-v1*.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15, 4.14, 4.13

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://76161--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/aws_load_balancer_operator/install-aws-load-balancer-operator.html
https://76161--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/external_dns_operator/nw-installing-external-dns-operator-on-cloud-providers.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
The namespace selection happens later in the procedure. The installation page doesn't have a box for the field:
![operatorhub-install-page](https://github.com/openshift/openshift-docs/assets/18031474/5abe4792-d3b1-4a03-b850-c12e4dcb6165)

