### PR TITLE
OCPBUGS#33878: Extract custom certificate for *.apps routes if exts rather then the default one

### DIFF
--- a/modules/registry-configuring-registry-storage-rhodf-nooba.adoc
+++ b/modules/registry-configuring-registry-storage-rhodf-nooba.adoc
@@ -79,7 +79,7 @@ $ route_host=$(oc get route s3 -n openshift-storage -o=jsonpath='{.spec.host}')
 +
 [source,terminal]
 ----
-$ oc extract secret/router-certs-default  -n openshift-ingress  --confirm
+$ oc extract secret/$(oc get ingresscontroller -n openshift-ingress-operator default -o json | jq '.spec.defaultCertificate.name // "router-certs-default"' -r) -n openshift-ingress --confirm
 ----
 +
 [source,terminal]


### PR DESCRIPTION
In the OpenShift Image Registry procedure using Nooba storage as backed is reported to extract the default certificate from router apps by default, but if a user set-up a custom certificate for  `*.apps` endpoint, this certificate is needed to be used instead of the default one (created during the installation).

Version(s):
4.12 and higher 

Issue:
https://issues.redhat.com/browse/OCPBUGS-33878

Link to docs preview:
Pending 

QE review:
- [X] QE has approved this change.

Additional information:

