### PR TITLE
[internal-fix] Manual CP to 4.14 - Level 1 heading attributes not resolving - move attributes include ahead of heading

### DIFF
--- a/installing/installing_ibm_power/installation-config-parameters-ibm-power.adoc
+++ b/installing/installing_ibm_power/installation-config-parameters-ibm-power.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="installation-config-parameters-ibm-power"]
 = Installation configuration parameters for {ibm-power-title}
-include::_attributes/common-attributes.adoc[]
 :context: installation-config-parameters-ibm-power
 :platform: IBM Power
 

--- a/installing/installing_ibm_power/installing-ibm-power.adoc
+++ b/installing/installing_ibm_power/installing-ibm-power.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="installing-ibm-power"]
 = Installing a cluster on {ibm-power-title}
-include::_attributes/common-attributes.adoc[]
 :context: installing-ibm-power
 
 toc::[]

--- a/installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+++ b/installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="installing-restricted-networks-ibm-power"]
 = Installing a cluster on {ibm-power-title} in a restricted network
-include::_attributes/common-attributes.adoc[]
 :context: installing-restricted-networks-ibm-power
 
 toc::[]

--- a/installing/installing_ibm_power/preparing-to-install-on-ibm-power.adoc
+++ b/installing/installing_ibm_power/preparing-to-install-on-ibm-power.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="preparing-to-install-on-ibm-power"]
 = Preparing to install on {ibm-power-title}
-include::_attributes/common-attributes.adoc[]
 :context: preparing-to-install-on-ibm-power
 
 toc::[]

--- a/installing/installing_ibm_powervs/creating-ibm-power-vs-workspace.adoc
+++ b/installing/installing_ibm_powervs/creating-ibm-power-vs-workspace.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="creating-ibm-power-vs-workspace"]
 = Creating an {ibm-power-server-title} workspace
-include::_attributes/common-attributes.adoc[]
 :context: creating-ibm-power-vs-workspace
 
 :FeatureName: {ibm-power-server-name} using installer-provisioned infrastructure

--- a/installing/installing_ibm_powervs/installation-config-parameters-ibm-power-vs.adoc
+++ b/installing/installing_ibm_powervs/installation-config-parameters-ibm-power-vs.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="installation-config-parameters-ibm-power-vs"]
 = Installation configuration parameters for {ibm-power-server-title}
-include::_attributes/common-attributes.adoc[]
 :context: installation-config-parameters-ibm-power-vs
 :platform: {ibm-power-server-title}
 

--- a/installing/installing_ibm_powervs/installing-ibm-cloud-account-power-vs.adoc
+++ b/installing/installing_ibm_powervs/installing-ibm-cloud-account-power-vs.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="installing-ibm-cloud-account-power-vs"]
 = Configuring an {ibm-cloud-title} account
-include::_attributes/common-attributes.adoc[]
 :context: installing-ibm-cloud-account-power-vs
 
 toc::[]

--- a/installing/installing_ibm_powervs/installing-ibm-power-vs-customizations.adoc
+++ b/installing/installing_ibm_powervs/installing-ibm-power-vs-customizations.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="installing-ibm-power-vs-customizations"]
 = Installing a cluster on {ibm-power-server-title} with customizations
-include::_attributes/common-attributes.adoc[]
 :context: installing-ibm-power-vs-customizations
 
 toc::[]

--- a/installing/installing_ibm_powervs/installing-ibm-power-vs-private-cluster.adoc
+++ b/installing/installing_ibm_powervs/installing-ibm-power-vs-private-cluster.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="installing-ibm-power-vs-private-cluster"]
 = Installing a private cluster on {ibm-power-server-title}
-include::_attributes/common-attributes.adoc[]
 :context: installing-ibm-power-vs-private-cluster
 
 toc::[]

--- a/installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.adoc
+++ b/installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="installing-restricted-networks-ibm-power-vs"]
 = Installing a cluster on {ibm-power-server-title} in a restricted network
-include::_attributes/common-attributes.adoc[]
 :context: installing-restricted-networks-ibm-power-vs
 
 toc::[]

--- a/installing/installing_ibm_powervs/preparing-to-install-on-ibm-power-vs.adoc
+++ b/installing/installing_ibm_powervs/preparing-to-install-on-ibm-power-vs.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="preparing-to-install-on-ibm-power-vs"]
 = Preparing to install on {ibm-power-server-title}
-include::_attributes/common-attributes.adoc[]
 :context: preparing-to-install-on-ibm-power-vs
 
 toc::[]

--- a/installing/installing_ibm_powervs/uninstalling-cluster-ibm-power-vs.adoc
+++ b/installing/installing_ibm_powervs/uninstalling-cluster-ibm-power-vs.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="uninstalling-cluster-ibm-power-vs"]
 = Uninstalling a cluster on {ibm-power-server-title}
-include::_attributes/common-attributes.adoc[]
 :context: uninstalling-cluster-ibm-power-vs
 
 toc::[]

--- a/installing/installing_ibm_z/installation-config-parameters-ibm-z.adoc
+++ b/installing/installing_ibm_z/installation-config-parameters-ibm-z.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="installation-config-parameters-ibm-z"]
 = Installation configuration parameters for {ibm-z-title} and {ibm-linuxone-title}
-include::_attributes/common-attributes.adoc[]
 :context: installation-config-parameters-ibm-z
 :platform: IBM Z
 

--- a/installing/installing_ibm_z/installing-ibm-z-kvm.adoc
+++ b/installing/installing_ibm_z/installing-ibm-z-kvm.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="installing-ibm-z-kvm"]
 = Installing a cluster with {op-system-base} KVM on {ibm-z-title} and {ibm-linuxone-title}
-include::_attributes/common-attributes.adoc[]
 :context: installing-ibm-z-kvm
 
 toc::[]

--- a/installing/installing_ibm_z/installing-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-ibm-z.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="installing-ibm-z"]
 = Installing a cluster with z/VM on {ibm-z-title} and {ibm-linuxone-title}
-include::_attributes/common-attributes.adoc[]
 :context: installing-ibm-z
 
 toc::[]

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="installing-restricted-networks-ibm-z-kvm"]
 = Installing a cluster with {op-system-base} KVM on {ibm-z-title} and {ibm-linuxone-title} in a restricted network
-include::_attributes/common-attributes.adoc[]
 :context: installing-restricted-networks-ibm-z-kvm
 
 toc::[]

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="installing-restricted-networks-ibm-z"]
 = Installing a cluster with z/VM on {ibm-z-title} and {ibm-linuxone-title} in a restricted network
-include::_attributes/common-attributes.adoc[]
 :context: installing-restricted-networks-ibm-z
 
 toc::[]

--- a/installing/installing_ibm_z/preparing-to-install-on-ibm-z.adoc
+++ b/installing/installing_ibm_z/preparing-to-install-on-ibm-z.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="preparing-to-install-on-ibm-z"]
 = Preparing to install on {ibm-z-title} and {ibm-linuxone-title}
-include::_attributes/common-attributes.adoc[]
 :context: preparing-to-install-on-ibm-z
 
 toc::[]

--- a/storage/container_storage_interface/persistent-storage-csi-ibm-powervs-block.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-ibm-powervs-block.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="persistent-storage-csi-ibm-powervs-block"]
 = {ibm-power-server-title} Block CSI Driver Operator
-include::_attributes/common-attributes.adoc[]
 :context: persistent-storage-csi-ibm-powervs-block
 
 toc::[]

--- a/storage/container_storage_interface/persistent-storage-csi-ibm-vpc-block.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-ibm-vpc-block.adoc
@@ -1,6 +1,6 @@
+include::_attributes/common-attributes.adoc[]
 [id="persistent-storage-csi-ibm-vpc-block"]
 = {ibm-title} VPC Block CSI Driver Operator
-include::_attributes/common-attributes.adoc[]
 :context: persistent-storage-csi-ibm-vpc-block
 
 toc::[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):  4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: CP to 4.14 failed in this PR: https://github.com/openshift/openshift-docs/pull/76136#issuecomment-2117614420
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
