### PR TITLE
OSDOCS#10604: Add a node pool definition and move glossary one level up

### DIFF
--- a/hosted_control_planes/index.adoc
+++ b/hosted_control_planes/index.adoc
@@ -8,6 +8,7 @@ You can deploy {product-title} clusters by using two different control plane con
 
 toc::[]
 
+include::modules/hosted-control-planes-concepts-personas.adoc[leveloffset=+1]
 include::modules/hosted-control-planes-overview.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -15,7 +16,6 @@ include::modules/hosted-control-planes-overview.adoc[leveloffset=+1]
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/clusters/cluster_mce_overview#hosted-control-planes-intro[{hcp-capital}]
 
-include::modules/hosted-control-planes-concepts-personas.adoc[leveloffset=+1]
 include::modules/hosted-control-planes-version-support.adoc[leveloffset=+1]
 include::modules/hosted-control-planes-support-matrix.adoc[leveloffset=+1]
 

--- a/modules/hosted-control-planes-concepts-personas.adoc
+++ b/modules/hosted-control-planes-concepts-personas.adoc
@@ -27,6 +27,8 @@ management cluster:: An {product-title} cluster where the HyperShift Operator is
 
 management cluster infrastructure:: Network, compute, and storage resources of the management cluster.
 
+node pool:: A resource that contains the compute nodes. The control plane contains node pools. The compute nodes run applications and workloads.
+
 [id="hosted-control-planes-personas_{context}"]
 == Personas
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
The PR adds a definition for a node pool and moves glossary one level up above the architecture

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-10604
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:  https://76215--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/index.html

https://76215--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/index.html#hosted-control-planes-concepts_hcp-overview
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
