### PR TITLE
OSDOCS-10536: adds 4.14.26 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -288,7 +288,7 @@ Issued: 2023-10-31
 
 {product-title} release 4.14.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:5008[RHSA-2023:5008] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:5006[RHSA-2023:5006] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-1-dp"]
 === RHSA-2023:6155 - {microshift-short} 4.14.1 bug fix advisory
@@ -297,7 +297,7 @@ Issued: 2023-11-1
 
 {product-title} release 4.14.1 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:6155[RHBA-2023:6155] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:6153[RHBA-2023:6153] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-2-dp"]
 === RHSA-2023:6839 - {microshift-short} 4.14.2 bug fix and security update advisory
@@ -306,7 +306,7 @@ Issued: 2023-11-16
 
 {product-title} release 4.14.2, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:6839[RHSA-2023:6839] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:6837[RHSA-2023:6837] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-3-dp"]
 === RHBA-2023:7319 - {microshift-short} 4.14.3 bug fix update advisory
@@ -315,7 +315,7 @@ Issued: 2023-11-21
 
 {product-title} release 4.14.3, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:7319[RHBA-2023:7319] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7315[RHSA-2023:7315] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-4-dp"]
 === RHBA-2023:7472 - {microshift-short} 4.14.4 bug fix update advisory
@@ -324,7 +324,7 @@ Issued: 2023-11-29
 
 {product-title} release 4.14.4, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:7472[RHBA-2023:7472] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7470[RHSA-2023:7470] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-4-bug-fixes"]
 ==== Bug fixes
@@ -340,7 +340,7 @@ Issued: 2023-12-05
 
 {product-title} release 4.14.5, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:7601[RHBA-2023:7601] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7599[RHSA-2023:7599] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-5-bug-fixes"]
 ==== Bug fixes
@@ -354,7 +354,7 @@ Issued: 2023-12-12
 
 {product-title} release 4.14.6, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:7684[RHBA-2023:7684] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7682[RHSA-2023:7682] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-7-dp"]
 === RHBA-2023:7833 - {microshift-short} 4.14.7 bug fix update advisory
@@ -363,7 +363,7 @@ Issued: 2024-01-03
 
 {product-title} release 4.14.7, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:7833[RHBA-2023:7833] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7831[RHSA-2023:7831] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-8-dp"]
 === RHBA-2024:0052 - {microshift-short} 4.14.8 bug fix update advisory
@@ -372,7 +372,7 @@ Issued: 2024-01-09
 
 {product-title} release 4.14.8, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0052[RHBA-2024:0052] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0050[RHSA-2024:0050] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-9-dp"]
 === RHBA-2024:0206 - {microshift-short} 4.14.9 bug fix update advisory
@@ -381,7 +381,7 @@ Issued: 2024-01-17
 
 {product-title} release 4.14.9, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0206[RHBA-2024:0206] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0204[RHSA-2024:0204] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-10-dp"]
 === RHSA-2024:0292 - {microshift-short} 4.14.10 bug fix update and security advisory
@@ -390,7 +390,7 @@ Issued: 2024-01-24
 
 {product-title} release 4.14.10, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:0292[RHSA-2024:0292] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0290[RHSA-2024:0290] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-11-dp"]
 === RHBA-2024:0644 - {microshift-short} 4.14.11 bug fix update and security advisory
@@ -399,7 +399,7 @@ Issued: 2024-02-07
 
 {product-title} release 4.14.11, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0644[RHBA-2024:0644] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0642[RHSA-2024:0642] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-12-dp"]
 === RHBA-2024:0737 - {microshift-short} 4.14.12 bug fix update and security advisory
@@ -408,7 +408,7 @@ Issued: 2024-02-13
 
 {product-title} release 4.14.12, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:0737[RHBA-2024:0737] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0735[RHSA-2024:0735] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-14-13-dp"]
 === RHBA-2024:0839 - {microshift-short} 4.14.13 bug fix update and security advisory
@@ -511,5 +511,14 @@ For the latest images included with {microshift-short}, view the contents of the
 Issued: 2024-05-15
 
 {product-title} release 4.14.25, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:2791[RHBA-2024:2791] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:2789[RHBA-2024:2789] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-14-26-dp"]
+=== RHBA-2024:2872 - {microshift-short} 4.14.26 bug fix and security update advisory
+
+Issued: 2024-05-23
+
+{product-title} release 4.14.26 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:2872[RHBA-2024:2872] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:2869[RHSA-2024:2869] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-10536](https://issues.redhat.com/browse/OSDOCS-10536)

Link to docs preview:
[4.14.26 async release note](https://76222--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes.html#microshift-4-14-26-dp)
[Embedding MicroShift containers for offline deployments from 4.14.0 - 4.14.13](https://76222--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes.html#microshift-4-14-0-dp)


QE review:
- [x] QE has approved this change.
