### PR TITLE
[enterprise-4.14] fix-title-ibm-cloud

### DIFF
--- a/installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc
+++ b/installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="configuring-iam-ibm-cloud"]
 = Configuring IAM for {ibm-cloud-title}
-include::_attributes/common-attributes.adoc[]
 :context: configuring-iam-ibm-cloud
 
 toc::[]

--- a/installing/installing_ibm_cloud_public/installation-config-parameters-ibm-cloud-vpc.adoc
+++ b/installing/installing_ibm_cloud_public/installation-config-parameters-ibm-cloud-vpc.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="installation-config-parameters-ibm-cloud-vpc"]
 = Installation configuration parameters for {ibm-cloud-title}
-include::_attributes/common-attributes.adoc[]
 :context: installation-config-parameters-ibm-cloud-vpc
 :platform: {ibm-cloud-title}
 

--- a/installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc
+++ b/installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="installing-ibm-cloud-account"]
 = Configuring an {ibm-cloud-title} account
-include::_attributes/common-attributes.adoc[]
 :context: installing-ibm-cloud-account
 
 toc::[]

--- a/installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
+++ b/installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="installing-ibm-cloud-customizations"]
 = Installing a cluster on {ibm-cloud-title} with customizations
-include::_attributes/common-attributes.adoc[]
 :context: installing-ibm-cloud-customizations
 
 toc::[]

--- a/installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
+++ b/installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="installing-ibm-cloud-network-customizations"]
 = Installing a cluster on {ibm-cloud-title} with network customizations
-include::_attributes/common-attributes.adoc[]
 :context: installing-ibm-cloud-network-customizations
 
 toc::[]

--- a/installing/installing_ibm_cloud_public/installing-ibm-cloud-private.adoc
+++ b/installing/installing_ibm_cloud_public/installing-ibm-cloud-private.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="installing-ibm-cloud-private"]
 = Installing a private cluster on {ibm-cloud-title}
-include::_attributes/common-attributes.adoc[]
 :context: installing-ibm-cloud-private
 
 toc::[]

--- a/installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
+++ b/installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="installing-ibm-cloud-vpc"]
 = Installing a cluster on {ibm-cloud-title} into an existing VPC
-include::_attributes/common-attributes.adoc[]
 :context: installing-ibm-cloud-vpc
 
 toc::[]

--- a/installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud.adoc
+++ b/installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="preparing-to-install-on-ibm-cloud"]
 = Preparing to install on {ibm-cloud-title}
-include::_attributes/common-attributes.adoc[]
 :context: preparing-to-install-on-ibm-cloud
 
 toc::[]

--- a/installing/installing_ibm_cloud_public/uninstalling-cluster-ibm-cloud.adoc
+++ b/installing/installing_ibm_cloud_public/uninstalling-cluster-ibm-cloud.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="uninstalling-cluster-ibm-cloud"]
 = Uninstalling a cluster on {ibm-cloud-title}
-include::_attributes/common-attributes.adoc[]
 :context: uninstalling-cluster-ibm-cloud
 
 toc::[]


### PR DESCRIPTION
On [D.O.C](https://docs.openshift.com/container-platform/4.15/installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud.html) the attribute in the assembly title did not render as expected for the IBM Cloud assemblies.

Cherry-picked from #76143 with commit c78d016d6229b6d2c09d13b032ac8af9a8a9ac33

Version(s):
4.14

Link to docs preview:
[Installing on IBM CLoud](https://76223--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud)

