### PR TITLE
OBSDOCS-1070

### DIFF
--- a/modules/logging-loki-retention.adoc
+++ b/modules/logging-loki-retention.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
-//
-// logging/cluster-logging-loki.adoc
+// 
+// * observability/logging/log_storage/cluster-logging-loki.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="logging-loki-retention_{context}"]
@@ -8,12 +8,14 @@
 
 With Logging version 5.6 and higher, you can configure retention policies based on log streams. Rules for these may be set globally, per tenant, or both. If you configure both, tenant rules apply before global rules.
 
+include::snippets/logging-retention-period-snip.adoc[]
+
 [NOTE]
 ====
 Although logging version 5.9 and higher supports schema v12, v13 is recommended.
 ====
 
-. To enable stream-based retention, create a `LokiStack` custom resource (CR):
+. To enable stream-based retention, create a `LokiStack` CR:
 +
 .Example global stream-based retention for AWS
 [source,yaml]

--- a/snippets/logging-retention-period-snip.adoc
+++ b/snippets/logging-retention-period-snip.adoc
@@ -1,0 +1,14 @@
+// Text snippet included in the following assemblies:
+//
+// * observability/logging/log_storage/cluster-logging-loki.adoc
+//
+// Text snippet included in the following modules:
+//
+// * logging-loki-retention.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+[IMPORTANT]
+====
+If there is no retention period defined on the s3 bucket or in the LokiStack custom resource (CR), then the logs are not pruned and they stay in the s3 bucket forever, which might fill up the s3 storage.
+====


### PR DESCRIPTION
[OBSDOCS-1070](https://issues.redhat.com/browse/OBSDOCS-1070): Loki default retention note
Aligned team: Observability
OCP version for cherry-picking: 4.12+
JIRA issues: [OBSDOCS-1070](https://issues.redhat.com/browse/OBSDOCS-1070)
Preview pages: https://76227--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/log_storage/cluster-logging-loki.html#logging-loki-retention_cluster-logging-loki
SME review **completed**:  @periklis and Saurab Sonigra
QE review **completed**: @kabirbhartiRH
Peer review **completed**: @skopacz1

PS: We have SME approval in Jira comment [here](https://issues.redhat.com/browse/OBSDOCS-1070?focusedId=24767179&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-24767179) and [here](https://issues.redhat.com/browse/OBSDOCS-1070?focusedId=24769255&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-24769255).
