### PR TITLE
OBSDOCS-944 - Power Monitoring - Add Redfish support in power monitoring

### DIFF
--- a/modules/power-monitoring-configuring-kepler-redfish.adoc
+++ b/modules/power-monitoring-configuring-kepler-redfish.adoc
@@ -1,0 +1,94 @@
+// Module included in the following assemblies:
+
+// * power_monitoring/configuring-power-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="power-monitoring-configuring-kepler-redfish_{context}"]
+= Configuring {PM-kepler} to use Redfish
+
+You can configure {PM-kepler} to use Redfish as the source for running or hosting containers. {PM-kepler} can then monitor the power usage of these containers.
+
+.Prerequisites
+* You have access to the {product-title} web console.
+* You are logged in as a user with the `cluster-admin` role.
+* You have installed the {PM-operator}.
+
+.Procedure
+
+. In the *Administrator* perspective of the web console, click *Operators* -> *Installed Operators*.
+
+. Click *{PM-title-c}* from the *Installed Operators* list and click the *{PM-kepler}* tab.
+
+. Click *Create {PM-kepler}*. If you already have a {PM-kepler} instance created, click *Edit Kepler*.
+
+. Configure `.spec.exporter.redfish` of the {PM-kepler} instance by specifying the mandatory `secretRef` field. You can also configure the optional `probeInterval` and `skipSSLVerify` fields to meet your needs.
++
+.Example {PM-kepler} instance
+[source,yaml]
+----
+apiVersion: kepler.system.sustainable.computing.io/v1alpha1
+kind: Kepler
+metadata:
+  name: kepler
+spec:
+  exporter:
+    deployment:
+# ... 
+    redfish:
+      secretRef: <secret_name> required <1>
+      probeInterval: 60s <2>
+      skipSSLVerify: false <3>
+# ...
+----
+<1> Required: Specifies the name of the secret that contains the credentials for accessing the Redfish server.
+<2> Optional: Controls the frequency at which the power information is queried from Redfish. The default value is `60s`.
+<3> Optional: Controls if {PM-kepler} skips verifying the Redfish server certificate. The default value is `false`.
++
+[NOTE]
+====
+After {PM-kepler} is deployed, the `openshift-power-monitoring` namespace is created.
+====
+. Create the `redfish.csv` file with the following data format:
++
+[source,csv]
+----
+<your_kubelet_node_name>,<redfish_username>,<redfish_password>,https://<redfish_ip_or_hostname>/
+----
++
+.Example `redfish.csv` file
+[source,csv]
+----
+control-plane,exampleuser,examplepass,https://redfish.nodes.example.com
+worker-1,exampleuser,examplepass,https://redfish.nodes.example.com
+worker-2,exampleuser,examplepass,https://another.redfish.nodes.example.com
+----
+. Create the secret under the `openshift-power-monitoring` namespace. You must create the secret with the following conditions:
++
+--
+* The secret type is `Opaque`.
+* The credentials are stored under the `redfish.csv` key in the `data` field of the secret.
+--
++
+[source,terminal]
+----
+$ oc -n openshift-power-monitoring \
+      create secret generic redfish-secret \
+      --from-file=redfish.csv
+----
++
+.Example output
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redfish-secret
+data:
+  redfish.csv: YmFyCg==
+  # ...
+----
++
+[IMPORTANT]
+====
+The {PM-kepler} deployment will not continue until the Redfish secret is created. You can find this information in the `status` of a {PM-kepler} instance.
+====

--- a/modules/power-monitoring-kepler-configuration.adoc
+++ b/modules/power-monitoring-kepler-configuration.adoc
@@ -10,7 +10,7 @@ You can configure {PM-kepler} with the `spec` field of the `{PM-kepler}` resourc
 
 [IMPORTANT]
 ====
-Ensure that the name of your {PM-kepler} instance is `kepler`. All other instances are ignored by the {PM-operator}.
+Ensure that the name of your {PM-kepler} instance is `kepler`. All other instances are rejected by the {PM-operator} Webhook.
 ====
 
 The following is the list of configuration options:

--- a/observability/power_monitoring/configuring-power-monitoring.adoc
+++ b/observability/power_monitoring/configuring-power-monitoring.adoc
@@ -14,3 +14,5 @@ The `{PM-kepler}` resource is a Kubernetes custom resource definition (CRD) that
 include::modules/power-monitoring-kepler-configuration.adoc[leveloffset=+1]
 
 include::modules/power-monitoring-monitoring-kepler-status.adoc[leveloffset=+1]
+
+include::modules/power-monitoring-configuring-kepler-redfish.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Power Monitoring - Add Redfish support in power monitoring
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-944

Fix Version: 4.14+

Doc Preview: https://76231--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/power_monitoring/configuring-power-monitoring#power-monitoring-configuring-kepler-redfish_configuring-power-monitoring

SME Review: @sthaha @stleerh @vimalk78 
QE Review: @vprashar2929 
Peer Review: @dfitzmau 