### PR TITLE
OSDOCS-10605: updated /var/lib/tuned/ references

### DIFF
--- a/modules/cluster-node-tuning-operator-default-profiles-set.adoc
+++ b/modules/cluster-node-tuning-operator-default-profiles-set.adoc
@@ -20,7 +20,7 @@ spec:
   - data: |
       [main]
       summary=Optimize systems running OpenShift (provider specific parent profile)
-      include=-provider-${f:exec:cat:/var/lib/tuned/provider},openshift
+      include=-provider-${f:exec:cat:/var/lib/ocp-tuned/provider},openshift
     name: openshift
   recommend:
   - profile: openshift-control-plane

--- a/modules/custom-tuning-specification.adoc
+++ b/modules/custom-tuning-specification.adoc
@@ -348,7 +348,7 @@ ifdef::rosa-hcp-tuning[]
 machine pools.
 endif::rosa-hcp-tuning[]
 
-This functionality takes advantage of `spec.providerID` node object values in the form of `<cloud-provider>://<cloud-provider-specific-id>` and writes the file `/var/lib/tuned/provider` with the value `<cloud-provider>` in NTO operand containers.  The content of this file is then used by TuneD to load `provider-<cloud-provider>` profile if such profile exists.
+This functionality takes advantage of `spec.providerID` node object values in the form of `<cloud-provider>://<cloud-provider-specific-id>` and writes the file `/var/lib/ocp-tuned/provider` with the value `<cloud-provider>` in NTO operand containers. The content of this file is then used by TuneD to load `provider-<cloud-provider>` profile if such profile exists.
 
 The `openshift` profile that both `openshift-control-plane` and `openshift-node` profiles inherit settings from is now updated to use this functionality through the use of conditional profile loading. Neither NTO nor TuneD currently include any Cloud provider-specific profiles. However, it is possible to create a custom profile `provider-<cloud-provider>` that will be applied to all Cloud provider-specific cluster nodes.
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-10605

Link to docs preview (VPN required):
[Default profiles set on a cluster](https://file.rdu.redhat.com/antaylor/nto-docs-4.16/scalability_and_performance/using-node-tuning-operator.html#custom-tuning-default-profiles-set_node-tuning-operator)
[Custom tuning examples](https://file.rdu.redhat.com/antaylor/nto-docs-4.16/scalability_and_performance/using-node-tuning-operator.html#custom-tuning-example_node-tuning-operator)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
None