### PR TITLE
OSDOCS-10589: Documented the 4.15.14 -zstream RNs

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2718,6 +2718,49 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+[id="ocp-4-15-14"]
+=== RHSA-2024:2865 - {product-title} 4.15.14 bug fix and security update
+
+Issued: 2024-05-21
+
+{product-title} release 4.15.14, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:2865[RHSA-2024:2865] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:2870[RHBA-2024:2870] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.14 --pullspecs
+----
+
+[id="ocp-4-15-14-bug-fixes"]
+==== Bug fixes
+
+* Previously, if traffic was forwarded to terminating endpoints that were not functioning, communications problems occured unless the readiness probes on these endpoints were configured to quickly flag the endpoints as not serving. This occurred because the the endpoint selection for services partially implemented KEP-1669 `ProxyTerminatingEndpoints` traffic to services inside the {product-title} cluster. As a result, this traffic was forwarded to all endpoints that were either ready, such as `ready=true`, `serving=true`, `terminating=false`,  or terminating and serving, such as `ready=false`, `serving=true`, `terminating=true`. This caused communication issues when traffic was forwarded to terminating endpoints and the readiness probes on these endpoints were not configured to quickly flag the endpoints as not serving, `serving=false`, when they were no longer functional. With this release, the endpoints selection logic now fully implements KEP-1669 `ProxyTerminatingEndpoints` for any given service so that all ready endpoints are selected. If no ready endpoints are found, functional terminating and serving endpoints are used.(link:https://issues.redhat.com/browse/OCPBUGS-27852[*OCPBUGS-27852*])
+
+* Previously, if you configured an {product-title} cluster with a high number of internal services or user-managed load balancer IP addresses, you experienced a delayed startup time for the OVN-Kubernetes service. This delay occurred when the OVN-Kubernetes service attempted to install `iptables` rules on a node. With this release, the OVN-Kubernetes service can process a large number of services in a few seconds. Additionally, you can access a new log to view the status of installing `iptables` rules on a node. (link:https://issues.redhat.com/browse/OCPBUGS-32426[*OCPBUGS-32426*])
+
+* Previously, some container processes created by using the `exec` command persisted even when CRI-O stopped the container. Consequently, lingering processes led to tracking issues, causing process leaks and defunct statuses. With this release, CRI-O tracks the `exec` calls processed for a container and ensures that the processes created as part of the `exec` calls are terminated when the container is stopped. (link:https://issues.redhat.com/browse/OCPBUGS-32481[*OCPBUGS-32481*])
+
+* Previously, the *Topology* view in the {product-title} web console did not show the visual connector between a virtual machine (VM) node and other non-VM components. With this release, the visual connector shows interaction activity of a component. (link:https://issues.redhat.com/browse/OCPBUGS-32505[*OCPBUGS-32505*])
+
+* Previously, a logo in the masthead element of the {product-title} web console could grow beyond 60 pixels in height. This caused the masthead to increase in height. With this release, the masthead logo is constrained to a `max-height` of 60 pixels. (link:https://issues.redhat.com/browse/OCPBUGS-33548[*OCPBUGS-33548*])
+
+* Previously, if you need the *Form* view in the {product-title} web console to remove an alternate service from a `Route` resource, the alternate service remained in the cluster. With this release, if you delete an alternate service in this way, the alternate service is fully removed from the cluster. (link:https://issues.redhat.com/browse/OCPBUGS-33058[*OCPBUGS-33058*])
+
+* Previously, {product-title} cluster connections to the {azure-first} API were delayed because of an issue with the API's codebase. With this release, a timeout schedule is set for any calls to the {azure-short} API, so that an API call that hangs for a period of time is terminated. (link:https://issues.redhat.com/browse/OCPBUGS-33127[*OCPBUGS-33127*])
+
+* Previously, a kernel regression that was introduced in {product-title} 4.15.0 caused kernel issues, such as nodes crashing and rebooting, in nodes that mounted to CephFS storage. In this release, the regression issue is fixed so that the kernel regression issue no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-33250[*OCPBUGS-33250*])
+
+* Previously, the {vmw-first} Problem Detector Operator did not have HTTP and HTTPS proxies configured for it. This resulted in invalid cluster configuration error messages because connection issues between the Operator and the {vmw-full} vCenter server. With this release, the {vmw-short} Problem Detector Operator uses the same HTTP and HTTPS proxies as other {product-title} cluster Operators so that the {vmw-short} Problem Detector Operator can connect to the {vmw-full} vCenter. (link:https://issues.redhat.com/browse/OCPBUGS-33466[*OCPBUGS-33466*])
+
+* Previously, Alertmanager would send notification emails that contained a backlink to the Thanos Querier web interface. This web interface is an unreachable web service. With this release, monitoring alert notification emails contain a backlink to the {product-title} web console's **Alerts* page. (link:https://issues.redhat.com/browse/OCPBUGS-33512[*OCPBUGS-33512*])
+
+[id="ocp-4-15-14-updating"]
+==== Updating
+To update an existing {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 [id="ocp-4-15-13"]
 === RHSA-2024:2773 - {product-title} 4.15.13 bug fix and security update
 


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-10589](https://issues.redhat.com/browse/OSDOCS-10589)

Link to docs preview:
[4.15.14](https://76234--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-14)

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
