### PR TITLE
OSDOCS-10373 remove misplaced banner

### DIFF
--- a/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc
@@ -16,7 +16,7 @@ This section provides information about the service definition for {product-titl
 include::modules/rosa-sdpolicy-am-billing.adoc[leveloffset=+2]
 include::modules/rosa-sdpolicy-am-cluster-self-service.adoc[leveloffset=+2]
 include::modules/rosa-sdpolicy-am-compute.adoc[leveloffset=+2]
-include::snippets/pid-limits.adoc[]
+
 
 [role="_additional-resources"]
 .Additional Resources

--- a/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
@@ -16,7 +16,7 @@ This section provides information about the service definition for {product-titl
 include::modules/rosa-sdpolicy-am-billing.adoc[leveloffset=+2]
 include::modules/rosa-sdpolicy-am-cluster-self-service.adoc[leveloffset=+2]
 include::modules/rosa-sdpolicy-am-compute.adoc[leveloffset=+2]
-include::snippets/pid-limits.adoc[]
+
 
 [role="_additional-resources"]
 .Additional Resources

--- a/rosa_cluster_admin/rosa-configuring-pid-limits.adoc
+++ b/rosa_cluster_admin/rosa-configuring-pid-limits.adoc
@@ -21,6 +21,8 @@ A process identifier (PID) is a unique identifier assigned by the Linux kernel t
 
 In {product-title} 4.11 and later, by default, a pod can have a maximum of 4,096 PIDs. If your workload requires more than that, you can increase the allowed maximum number of PIDs by configuring a `KubeletConfig` object.
 
+{product-title} clusters running versions earlier than 4.11 use a default PID limit of `1024`.
+
 :FeatureName: Configuring the maximum number of PIDs
 include::snippets/rosa-classic-support.adoc[]
 

--- a/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.adoc
+++ b/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.adoc
@@ -10,7 +10,6 @@ toc::[]
 
 The primary resources are machines, compute machine sets, and machine pools.
 
-include::snippets/pid-limits.adoc[]
 
 == Machines
 A machine is a fundamental unit that describes the host for a worker node.

--- a/snippets/pid-limits.adoc
+++ b/snippets/pid-limits.adoc
@@ -4,13 +4,13 @@
 //
 // * /osd_architecture/osd-service-definition.adoc
 //
-// * /rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
+// * /rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc *removed due to inappropriate context*
 //
 // MACHINE POOL REFERENCES
 //
 // * /osd_cluster_admin/osd_nodes/osd-nodes-machinepools-about.adoc
 //
-// * /rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.adoc
+// * /rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.adoc *removed due to inappropriate context*
 //
 
 :_mod-docs-content-type: SNIPPET
@@ -19,7 +19,7 @@
 
 [IMPORTANT]
 ====
-As of {product-title} 4.11, the default per-pod PID limit is `4096`. If you want to enable this PID limit, you must upgrade your {product-title} clusters to this version or later. {product-title} clusters running on earlier versions use a default PID limit of `1024`.
+As of {product-title} 4.11, the default per-pod PID limit is `4096`. If you want to enable this PID limit, you must upgrade your {product-title} clusters to this version or later. {product-title} clusters running versions earlier than 4.11 use a default PID limit of `1024`.
 
 ifdef::openshift-rosa[]
 You can configure the per-pod PID limit on a {product-title} cluster by using the ROSA CLI. For more information, see "Configuring PID limits".


### PR DESCRIPTION
Removed PID note from sections where it was no longer relevant. Added a quick note about PID limits in older versions of ROSA to the relevant section. 

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.15+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-10373
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->


Removed sections:
https://76236--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html
https://76236--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html
https://76236--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.html

new note:
https://76236--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa-configuring-pid-limits.html




QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
