### PR TITLE
ROX#23256: Add redirect for ACS Cloud architecture page

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -151,6 +151,8 @@ AddType text/vtt                            vtt
     RewriteRule ^(acs/(?:4\.3/)?)?installing/acs-installation-platforms\.html$ /acs/4.3/installing/acs-high-level-overview.html [NE,R=301]
     #redirects for 4.4 pages in ACS GUI per ROX-23005
     RewriteRule ^(acs/(?:4\.4/)?)?installing/acs-installation-platforms\.html$ /acs/4.4/installing/acs-high-level-overview.html [NE,R=301]
+    #redirect Architecture page for ACS Cloud into Cloud directory
+    RewriteRule ^acs/(4\.4)/architecture/acscs-architecture\.html$ /acs/latest/cloud_service/acscs-architecture.html [NE,R=302]
 
       # remove aro docs to just the welcome page
     RewriteRule aro/4/(?!welcome)(.*)?$ /container-platform/latest/$1 [L,R=301]


### PR DESCRIPTION
Version(s):
main 

[Issue](https://issues.redhat.com/browse/ROX-23256)

Link to docs preview: **N/A**
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: **N/A**
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- Redirect needed because of moved page in #76208 
- 4.5 isn't released/published yet, so no redirect is needed for 4.5, only 4.4
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
