### PR TITLE
Adjust private registry support statement

### DIFF
--- a/modules/windows-containers-release-notes-limitations.adoc
+++ b/modules/windows-containers-release-notes-limitations.adoc
@@ -21,8 +21,6 @@ Note the following limitations when working with Windows nodes managed by the WM
 ** link:https://access.redhat.com/documentation/en-us/cost_management_service/2022/html/getting_started_with_cost_management/assembly-introduction-cost-management?extIdCarryOver=true&sc_cid=701f2000001OH74AAG#about-cost-management_getting-started[Red Hat cost management]
 ** link:https://developers.redhat.com/products/openshift-local/overview[Red Hat OpenShift Local]
 
-* Windows nodes do not support pulling container images from private registries. You can use images from public registries or pre-pull the images.
-
 * Windows nodes do not support workloads created by using deployment configs. You can use a deployment or other method to deploy workloads.
 
 * Windows nodes are not supported in clusters that are in a disconnected environment.


### PR DESCRIPTION
After WINC discussions with a customer and internal testing, it was determined that WINC nodes are able to pull container images from private registries. This PR removes this limitation from the WMCO docs.  

[Preview](https://76262--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-6-x.html#windows-containers-release-notes-limitations_windows-containers-release-notes) -- WMCO release notes -> Known limitations -> bullet 3  (_Windows nodes do not support pulling container images from private registries..._) removed.

[Current docs](https://docs.openshift.com/container-platform/4.14/windows_containers/wmco_rn/windows-containers-release-notes-9-x-past.html#windows-containers-release-notes-limitations_windows-containers-release-notes-9-x-past) -- WMCO release notes -> Known limitations -> bullet 3 (_Windows nodes do not support pulling container images from private registries..._) present.

Issue:
https://github.com/openshift/windows-machine-config-operator/pull/2168

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Change management:
- [x] Eric Rich has approved this change.
- [x] Aruna Naik has approved this change.
- [x] Duncan Hardie has approved this change.
- [x] Kathryn Alexander has approved this change.
