### PR TITLE
OSDOCS#10611: Add attributes for multicluster engine operator

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -335,3 +335,5 @@ endif::openshift-origin[]
 // Hosted control planes related attributes
 :hcp-capital: Hosted control planes
 :hcp: hosted control planes
+:mce: multicluster engine for Kubernetes Operator
+:mce-short: multicluster engine Operator

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -81,7 +81,7 @@ Topics:
 - Name: Red Hat OpenShift Cluster Manager
   Distros: openshift-enterprise
   File: ocm-overview-ocp
-- Name: About multicluster engine for Kubernetes operator
+- Name: About the multicluster engine for Kubernetes Operator
   Distros: openshift-enterprise
   File: mce-overview-ocp
 - Name: Control plane architecture

--- a/architecture/mce-overview-ocp.adoc
+++ b/architecture/mce-overview-ocp.adoc
@@ -1,12 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="mce-overview-ocp"]
 include::_attributes/common-attributes.adoc[]
-= About multicluster engine for Kubernetes operator
+= About the {mce}
 :context: mce-overview-ocp
 
 toc::[]
 
-One of the challenges of scaling Kubernetes environments is managing the lifecycle of a growing fleet. To meet that challenge, you can use the multicluster engine for Kubernetes operator. The operator delivers full lifecycle capabilities for managed {product-title} clusters and partial lifecycle management for other Kubernetes distributions. It is available in two ways:
+One of the challenges of scaling Kubernetes environments is managing the lifecycle of a growing fleet. To meet that challenge, you can use the {mce-short}. The operator delivers full lifecycle capabilities for managed {product-title} clusters and partial lifecycle management for other Kubernetes distributions. It is available in two ways:
 
 * As a standalone operator that you install as part of your {product-title} or {oke} subscription
 * As part of link:https://access.redhat.com/products/red-hat-advanced-cluster-management-for-kubernetes[Red Hat Advanced Cluster Management for Kubernetes]

--- a/installing/installing_with_agent_based_installer/preparing-an-agent-based-installed-cluster-for-mce.adoc
+++ b/installing/installing_with_agent_based_installer/preparing-an-agent-based-installed-cluster-for-mce.adoc
@@ -1,12 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="preparing-an-agent-based-installed-cluster-for-mce"]
 include::_attributes/common-attributes.adoc[]
-= Preparing an Agent-based installed cluster for the multicluster engine for Kubernetes operator
+= Preparing an Agent-based installed cluster for the {mce}
 :context: preparing-an-agent-based-installed-cluster-for-mce
 
 toc::[]
 
-You can install the multicluster engine for Kubernetes operator and deploy a hub cluster with the Agent-based {product-title} Installer.
+You can install the {mce-short} and deploy a hub cluster with the Agent-based {product-title} Installer.
 The following procedure is partially automated and requires manual steps after the initial cluster is deployed.
 
 == Prerequisites
@@ -23,7 +23,7 @@ The following procedure is partially automated and requires manual steps after t
 // Preparing an Agent-based cluster deployment for the multicluster engine for Kubernetes operator while disconnected
 include::modules/preparing-an-initial-cluster-deployment-for-mce-disconnected.adoc[leveloffset=+1]
 
-// Preparing an Agent-based cluster deployment for the multicluster engine for Kubernetes operator while connected
+// Preparing an Agent-based cluster deployment for the {mce-short} while connected
 include::modules/preparing-an-initial-cluster-deployment-for-mce-connected.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/modules/hcp-updating-requirements.adoc
+++ b/modules/hcp-updating-requirements.adoc
@@ -6,7 +6,7 @@
 [id="hosted-control-planes-upgrading-requirements_{context}"]
 = Requirements to upgrade {hcp}
 
-The multicluster engine for Kubernetes operator can manage one or more {product-title} clusters. After you create a hosted cluster on {product-title}, you must import your hosted cluster in the multicluster engine operator as a managed cluster. Then, you can use the {product-title} cluster as a management cluster.
+The {mce} can manage one or more {product-title} clusters. After you create a hosted cluster on {product-title}, you must import your hosted cluster in the {mce-short} as a managed cluster. Then, you can use the {product-title} cluster as a management cluster.
 
 Consider the following requirements before you start updating {hcp}:
 
@@ -14,8 +14,8 @@ Consider the following requirements before you start updating {hcp}:
 
 * You must use bare metal or {VirtProductName} as the cloud platform for the hosted cluster. You can find the platform type of your hosted cluster in the `spec.Platform.type` specification of the `HostedCluster` custom resource (CR).
 
-You must upgrade the {product-title} cluster, multicluster engine for Kubernetes operator, hosted cluster, and node pools by completing the following tasks:
+You must upgrade the {product-title} cluster, {mce-short}, hosted cluster, and node pools by completing the following tasks:
 
 . Upgrade an {product-title} cluster to the latest version. For more information, see "Updating a cluster using the web console" or "Updating a cluster using the CLI".
-. Upgrade the multicluster engine for Kubernetes operator to the latest version. For more information, see "Updating installed Operators".
+. Upgrade the {mce-short} to the latest version. For more information, see "Updating installed Operators".
 . Upgrade the hosted cluster and node pools from the previous {product-title} version to the latest version. For more information, see "Updating the hosted cluster for {hcp}" and "Updating node pools for {hcp}".

--- a/modules/hosted-control-planes-concepts-personas.adoc
+++ b/modules/hosted-control-planes-concepts-personas.adoc
@@ -21,7 +21,7 @@ hosted control plane:: An {product-title} control plane that runs on the managem
 
 hosting cluster:: See _management cluster_.
 
-managed cluster:: A cluster that the hub cluster manages. This term is specific to the cluster lifecycle that the multicluster engine for Kubernetes operator manages in Red Hat Advanced Cluster Management. A managed cluster is not the same thing as a _management cluster_. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/about/welcome-to-red-hat-advanced-cluster-management-for-kubernetes#managed-cluster[Managed cluster].
+managed cluster:: A cluster that the hub cluster manages. This term is specific to the cluster lifecycle that the {mce} manages in Red Hat Advanced Cluster Management. A managed cluster is not the same thing as a _management cluster_. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/about/welcome-to-red-hat-advanced-cluster-management-for-kubernetes#managed-cluster[Managed cluster].
 
 management cluster:: An {product-title} cluster where the HyperShift Operator is deployed and where the control planes for hosted clusters are hosted. The management cluster is synonymous with the _hosting cluster_.
 

--- a/modules/hosted-control-planes-overview.adoc
+++ b/modules/hosted-control-planes-overview.adoc
@@ -10,7 +10,7 @@
 
 You can use {hcp} for Red Hat {product-title} to reduce management costs, optimize cluster deployment time, and separate management and workload concerns so that you can focus on your applications.
 
-{hcp-capital} is available by using the link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/clusters/cluster_mce_overview#cluster_mce_overview[multicluster engine for Kubernetes operator version 2.0 or later] on the following platforms:
+{hcp-capital} is available by using the link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/clusters/cluster_mce_overview#cluster_mce_overview[{mce} version 2.0 or later] on the following platforms:
 
 * Bare metal by using the Agent provider
 * {VirtProductName}

--- a/modules/preparing-an-initial-cluster-deployment-for-mce-connected.adoc
+++ b/modules/preparing-an-initial-cluster-deployment-for-mce-connected.adoc
@@ -5,9 +5,9 @@
 :_mod-docs-content-type: PROCEDURE
 [id="preparing-an-initial-cluster-deployment-for-mce-connected_{context}"]
 
-= Preparing an Agent-based cluster deployment for the multicluster engine for Kubernetes operator while connected
+= Preparing an Agent-based cluster deployment for the {mce} while connected
 
-Create the required manifests for the multicluster engine for Kubernetes operator, the Local Storage Operator (LSO), and to deploy an agent-based {product-title} cluster as a hub cluster.
+Create the required manifests for the {mce-short}, the Local Storage Operator (LSO), and to deploy an agent-based {product-title} cluster as a hub cluster.
 
 .Procedure
 

--- a/modules/preparing-an-initial-cluster-deployment-for-mce-disconnected.adoc
+++ b/modules/preparing-an-initial-cluster-deployment-for-mce-disconnected.adoc
@@ -5,9 +5,9 @@
 :_mod-docs-content-type: PROCEDURE
 [id="preparing-an-initial-cluster-deployment-for-mce-disconnected_{context}"]
 
-= Preparing an Agent-based cluster deployment for the multicluster engine for Kubernetes operator while disconnected
+= Preparing an Agent-based cluster deployment for the {mce} while disconnected
 
-You can mirror the required {product-title} container images, the multicluster engine for Kubernetes operator, and the Local Storage Operator (LSO) into your local mirror registry in a disconnected environment.
+You can mirror the required {product-title} container images, the {mce-short}, and the Local Storage Operator (LSO) into your local mirror registry in a disconnected environment.
 Ensure that you note the local DNS hostname and port of your mirror registry.
 
 [NOTE]

--- a/modules/ztp-precaching-downloading-artifacts.adoc
+++ b/modules/ztp-precaching-downloading-artifacts.adoc
@@ -38,11 +38,11 @@ To remove this restriction, you can precede your commands with `taskset 0xffffff
 [id="ztp-preparing-ocp-images_{context}"]
 == Preparing to download the {product-title} images
 
-To download {product-title} container images, you need to know the multicluster engine (MCE) version. When you use the `--du-profile` flag, you also need to specify the {rh-rhacm-first} version running in the hub cluster that is going to provision the {sno}.
+To download {product-title} container images, you need to know the multicluster engine version. When you use the `--du-profile` flag, you also need to specify the {rh-rhacm-first} version running in the hub cluster that is going to provision the {sno}.
 
 .Prerequisites
 
-* You have {rh-rhacm} and MCE installed.
+* You have {rh-rhacm} and the {mce-short} installed.
 * You partitioned the storage device.
 * You have enough space for the images on the partitioned device.
 * You connected the bare-metal server to the Internet.
@@ -50,7 +50,7 @@ To download {product-title} container images, you need to know the multicluster 
 
 .Procedure
 
-. Check the {rh-rhacm} and MCE version by running the following commands in the hub cluster:
+. Check the {rh-rhacm} version and the multicluster engine version by running the following commands in the hub cluster:
 +
 [source,terminal]
 ----
@@ -125,7 +125,7 @@ The {factory-prestaging-tool} allows you to pre-cache all the container images r
 <1> Specifies the downloading function of the {factory-prestaging-tool}.
 <2> Defines the {product-title} release version.
 <3> Defines the {rh-rhacm} version.
-<4> Defines the MCE version.
+<4> Defines the multicluster engine version.
 <5> Defines the folder where you want to download the images on the disk.
 <6> Optional. Defines the repository where you store your additional images. These images are downloaded and pre-cached on the disk.
 
@@ -195,7 +195,7 @@ You can also pre-cache Day-2 Operators used in the 5G Radio Access Network (RAN)
 
 [IMPORTANT]
 ====
-You need to include the {rh-rhacm} hub and MCE Operator versions by using the `--acm-version` and `--mce-version` flags so the {factory-prestaging-tool} can pre-cache the appropriate containers images for the {rh-rhacm} and MCE Operators.
+You need to include the {rh-rhacm} hub and {mce-short} versions by using the `--acm-version` and `--mce-version` flags so the {factory-prestaging-tool} can pre-cache the appropriate containers images for {rh-rhacm} and the {mce-short}.
 ====
 
 .Procedure
@@ -215,7 +215,7 @@ You need to include the {rh-rhacm} hub and MCE Operator versions by using the `-
 <1> Specifies the downloading function of the {factory-prestaging-tool}.
 <2> Defines the {product-title} release version.
 <3> Defines the {rh-rhacm} version.
-<4> Defines the MCE version.
+<4> Defines the multicluster engine version.
 <5> Defines the folder where you want to download the images on the disk.
 <6> Optional. Defines the repository where you store your additional images. These images are downloaded and pre-cached on the disk.
 <7> Specifies pre-caching the Operators included in the DU configuration.
@@ -274,7 +274,7 @@ You can customize the `ImageSetConfiguration` CR in the following ways:
 <1> Specifies the downloading function of the {factory-prestaging-tool}.
 <2> Defines the {product-title} release version.
 <3> Defines the {rh-rhacm} version.
-<4> Defines the MCE version.
+<4> Defines the multicluster engine version.
 <5> Defines the folder where you want to download the images on the disk.
 <6> Optional. Defines the repository where you store your additional images. These images are downloaded and pre-cached on the disk.
 <7> Specifies pre-caching the Operators included in the DU configuration.
@@ -342,7 +342,7 @@ mirror:
             - name: 'stable'
 ----
 <1> The platform versions match the versions passed to the tool.
-<2> The versions of {rh-rhacm} and MCE Operators match the versions passed to the tool.
+<2> The versions of {rh-rhacm} and the {mce-short} match the versions passed to the tool.
 <3> The CR contains all the specified DU Operators.
 
 . Customize the catalog resource in the CR:
@@ -395,7 +395,7 @@ factory-precaching-cli download \ <1>
 <1> Specifies the downloading function of the {factory-prestaging-tool}.
 <2> Defines the {product-title} release version.
 <3> Defines the {rh-rhacm} version.
-<4> Defines the MCE version.
+<4> Defines the multicluster engine version.
 <5> Defines the folder where you want to download the images on the disk.
 <6> Optional. Defines the repository where you store your additional images. These images are downloaded and pre-cached on the disk.
 <7> Specifies pre-caching the Operators included in the DU configuration.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> ---> 
**New attributes**
:mce: multicluster engine for Kubernetes Operator
:mce-short: multicluster engine Operator

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-10611
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://76266--ocpdocs-pr.netlify.app/openshift-enterprise/latest/architecture/mce-overview-ocp
- https://76266--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/
- https://76266--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/#hosted-control-planes-concepts_hcp-overview
- https://76266--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/#hosted-control-planes-upgrading-scenarios_hcp-overview
- https://76266--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks
- https://76266--ocpdocs-pr.netlify.app/openshift-enterprise/latest/architecture/mce-overview-ocp.html
- https://76266--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-an-agent-based-installed-cluster-for-mce.html
- https://76266--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-an-agent-based-installed-cluster-for-mce.html#preparing-an-initial-cluster-deployment-for-mce-disconnected_preparing-an-agent-based-installed-cluster-for-mce
- https://76266--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-an-agent-based-installed-cluster-for-mce.html#preparing-an-initial-cluster-deployment-for-mce-connected_preparing-an-agent-based-installed-cluster-for-mce
- https://76266--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-precaching-tool#ztp-preparing-ocp-images_pre-caching

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: not required.

<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: 
We can use {mce} (the long form) early/as the first instance and the {mce-short} (short form) for later in the topic/modules.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
