### PR TITLE
[RHACS] Added a note about Amazon S3 API-compatible storage

### DIFF
--- a/backup_and_restore/backing-up-acs.adoc
+++ b/backup_and_restore/backing-up-acs.adoc
@@ -30,6 +30,13 @@ Backing up the Central database is critical to ensure data integrity and system 
 
 You can use the `roxctl` CLI to take the backups by using the `backup` command. You require an API token or your administrator password to run this command.
 
+[NOTE]
+====
+Red Hat supports backups for the Central database through integration with xref:../integration/integrate-with-amazon-s3.adoc#perform-on-demand-backups-amazon-s3_integrate-with-amazon-s3[Amazon S3] or xref:../integration/integrate-with-google-cloud-storage.adoc#perform-on-demand-backups-google-cloud-storage_integrate-with-google-cloud-storage[Google Cloud Storage].
+
+Backing up to Amazon S3 API-compatible storage might work. However, Red Hat does not test and support Amazon S3 API-compatible storage for backing up {product-title-short}. For example, see link:https://access.redhat.com/solutions/7021082[{product-title-short} backup on MinIO].
+====
+
 include::modules/on-demand-backups-roxctl-api.adoc[leveloffset=+2]
 
 [role="_additional-resources"]


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-20793

Added a note about unsupported S3 API-compatible storage.

Cherrypick in:
- `rhacs-docs-4.5`
- `rhacs-docs-4.4`
- `rhacs-docs-4.3`

Preview: https://76274--ocpdocs-pr.netlify.app/openshift-acs/latest/backup_and_restore/backing-up-acs.html#backing-up-central-db-roxctl

---

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.
