### PR TITLE
OBSDOCS-1061 - Logging 5.9.2 Release Notes

### DIFF
--- a/modules/logging-release-notes-5-9-2.adoc
+++ b/modules/logging-release-notes-5-9-2.adoc
@@ -1,0 +1,36 @@
+/module included in logging-5-9-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-5-9-2_{context}"]
+= Logging 5.9.2
+This release includes link:https://access.redhat.com/errata/RHSA-2024:2933[OpenShift Logging Bug Fix Release 5.9.2]
+
+[id="logging-release-notes-5-9-2-bug-fixes"]
+== Bug Fixes
+
+* Before this update, changes to the Logging Operator caused an error due to an incorrect configuration in the `ClusterLogForwarder` CR. As a result, upgrades to {logging} deleted the daemonset collector. With this update, the Logging Operator re-creates collector daemonsets except when a `Not authorized to collect` error occurs. (link:https://issues.redhat.com/browse/LOG-4910[LOG-4910])
+
+* Before this update, the rotated infrastructure log files were sent to the application index in some scenarios due to an incorrect configuration in the Vector log collector. With this update, the Vector log collector configuration avoids collecting any rotated infrastructure log files. (link:https://issues.redhat.com/browse/LOG-5156[LOG-5156])
+
+* Before this update, the Logging Operator did not monitor changes to the `grafana-dashboard-cluster-logging` config map. With this update, the Logging Operator monitors changes in the `ConfigMap` objects, ensuring the system stays synchronized and responds effectively to config map modifications. (link:https://issues.redhat.com/browse/LOG-5308[LOG-5308])
+
+* Before this update, an issue in the metrics collection code of the Logging Operator caused it to report stale telemetry metrics. With this update, the Logging Operator does not report stale telemetry metrics. (link:https://issues.redhat.com/browse/LOG-5426[LOG-5426])
+
+* Before this change, the Fluentd `out_http` plugin ignored the `no_proxy` environment variable. With this update, the Fluentd patches the `HTTP#start` method of ruby to honor the `no_proxy` environment variable. (link:https://issues.redhat.com/browse/LOG-5466[LOG-5466])
+
+[id="logging-release-notes-5-9-2-CVEs"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2022-48554[CVE-2022-48554]
+* link:https://access.redhat.com/security/cve/CVE-2023-2975[CVE-2023-2975]
+* link:https://access.redhat.com/security/cve/CVE-2023-3446[CVE-2023-3446]
+* link:https://access.redhat.com/security/cve/CVE-2023-3817[CVE-2023-3817]
+* link:https://access.redhat.com/security/cve/CVE-2023-5678[CVE-2023-5678]
+* link:https://access.redhat.com/security/cve/CVE-2023-6129[CVE-2023-6129]
+* link:https://access.redhat.com/security/cve/CVE-2023-6237[CVE-2023-6237]
+* link:https://access.redhat.com/security/cve/CVE-2023-7008[CVE-2023-7008]
+* link:https://access.redhat.com/security/cve/CVE-2023-45288[CVE-2023-45288]
+* link:https://access.redhat.com/security/cve/CVE-2024-0727[CVE-2024-0727]
+* link:https://access.redhat.com/security/cve/CVE-2024-22365[CVE-2024-22365]
+* link:https://access.redhat.com/security/cve/CVE-2024-25062[CVE-2024-25062]
+* link:https://access.redhat.com/security/cve/CVE-2024-28834[CVE-2024-28834]
+* link:https://access.redhat.com/security/cve/CVE-2024-28835[CVE-2024-28835]

--- a/observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-9-2.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-9-1.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-9-0.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Logging Z-Stream Release Notes - 5.9.2
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1061

Fix Version: 4.13+

Doc Preview: https://76275--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/logging_release_notes/logging-5-9-release-notes.html#logging-release-notes-5-9-2_logging-5-9-release-notes

SME Review: @cahartma @periklis 
QE Review: @kabirbhartiRH 
Peer Review: @JoeAldinger 