### PR TITLE
OBSDOCS-1064 - Logging 5.6.18 Release Notes

### DIFF
--- a/modules/logging-release-notes-5-6-19.adoc
+++ b/modules/logging-release-notes-5-6-19.adoc
@@ -1,0 +1,23 @@
+// module included in /logging/logging-5-6-release-notes
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-5-6-19_{context}"]
+= Logging 5.6.19
+This release includes link:https://access.redhat.com/errata/RHSA-2024:2929[OpenShift Logging Bug Fix 5.6.19]
+
+[id="logging-release-notes-5-6-19-bug-fixes"]
+== Bug fixes
+
+* Before this update, an issue in the metrics collection code of the Logging Operator caused it to report stale telemetry metrics. With this update, the Logging Operator does not report stale telemetry metrics. (link:https://issues.redhat.com/browse/LOG-5529[LOG-5529])
+
+[id="logging-release-notes-5-6-19-CVEs"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2023-45288[CVE-2023-45288]
+* link:https://access.redhat.com/security/cve/CVE-2023-52425[CVE-2023-52425]
+* link:https://access.redhat.com/security/cve/CVE-2024-2961[CVE-2024-2961]
+* link:https://access.redhat.com/security/cve/CVE-2024-21011[CVE-2024-21011]
+* link:https://access.redhat.com/security/cve/CVE-2024-21012[CVE-2024-21012]
+* link:https://access.redhat.com/security/cve/CVE-2024-21068[CVE-2024-21068]
+* link:https://access.redhat.com/security/cve/CVE-2024-21085[CVE-2024-21085]
+* link:https://access.redhat.com/security/cve/CVE-2024-21094[CVE-2024-21094]
+* link:https://access.redhat.com/security/cve/CVE-2024-28834[CVE-2024-28834]

--- a/observability/logging/logging_release_notes/logging-5-6-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-6-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-6-19.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-6-18.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-6-17.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Logging Z-Stream Release Notes - 5.6.19
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1064

Fix Version: 4.12, 4.13

Doc Preview: https://76278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging_release_notes/logging-5-6-release-notes.html#logging-release-notes-5-6-19_logging-5-6-release-notes

SME Review: @periklis 
QE Review: @anpingli 
Peer Review: @GroceryBoyJr 