### PR TITLE
[Internal-fix] ad-example-for-attribute-title-assembly

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -52,7 +52,18 @@ toc::[]                                                         <7>
 [NOTE]
 ====
 * The `{product-title}` and `{product-version}` common attributes are not defined in the `_attributes/common-attributes.adoc` file. Those attributes are pulled by AsciiBinder from the distro mapping definitions in the https://github.com/openshift/openshift-docs/blob/main/_distro_map.yml[_distro_map.yml] file. See xref:product-name-and-version[Product title and version] and xref:attribute-files[attribute files] for more information on this topic.
-* If you use a variable in the title of the first assembly in a section, move the include attributes directive above the title in this assembly. Otherwise, the variable will not render correctly on access.redhat.com.
+* If you use a variable in the title of the first assembly in a section, move the include attributes directive above the anchor ID in this assembly. Otherwise, the variable will not render correctly on our documentation portals. For example:
++
+[source,text]
+----
+ :_mod-docs-content-type: ASSEMBLY
+ include::_attributes/common-attributes.adoc[]
+ [id="installing-ibm-cloud-private"]
+ = Installing a private cluster on {ibm-cloud-title}
+ :context: installing-ibm-cloud-private
+
+toc::[]
+----
 ====
 +
 <5> Context used for identifying headers in modules that is the same as the anchor ID. Example: cli-developer-commands.


### PR DESCRIPTION
Add an example to a guideline based on the changes required from https://github.com/openshift/openshift-docs/pull/76143 as the attribute in the first assembly did not render on docs.openshift.com. Changes post PR:

* [d.o.c](https://docs.openshift.com/container-platform/4.15/installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud.html)
* [a.r.c](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/installing/installing-on-ibm-cloud#preparing-to-install-on-ibm-cloud)
* [d.r.c](https://docs.redhat.com/en/documentation/openshift_container_platform/4.15/html/installing/installing-on-ibm-cloud)

Preview link: [Assembly file metadata](https://file.emea.redhat.com/dfitzmau/ad-example-for-attribute-title-assembly/doc_guidelines.html)

Add info: 

https://docs.asciidoctor.org/asciidoc/latest/verbatim/literal-blocks/
