### PR TITLE
OSDOCS-9814: adds ingress relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -30,14 +30,7 @@ This release adds improvements related to the following components and concepts.
 //L3 major categories with features in each as L4s
 [id="microshift-4-16-rhel"]
 === {op-system-base-full}
-* {microshift-short} now runs on {op-system-base-full} 9.4.
-
-// Some details of the next note are adapted from https://kubernetes.io/blog/2022/08/31/cgroupv2-ga-1-25/
-* {microshift-short} uses crun and Control Group v2 (cgroup v2). If workloads rely on the cgroup file system layout, they might need to be updated to be compatible with cgroup v2.
-
-** If you run third-party monitoring and security agents that depend on the cgroup file system, update the agents to versions that support cgroup v2.
-** If you run cAdvisor as a standalone DaemonSet for monitoring pods and containers, update it to v0.43.0 or later.
-** If you deploy Java applications with JDK, ensure you are using JDK 11.0.16 and later or JDK 15 and later, which fully support cgroup v2.
+* {microshift-short} {product-version} runs on {op-system-base-full} 9.4.
 
 [id="microshift-4-16-updating"]
 === Updating
@@ -68,8 +61,7 @@ With this release, you can configure a custom server certificate that has been i
 [id="microshift-4-16-audit-logging-config"]
 ==== Configurable policies for log file rotation and retention
 
-You can now configure audit logging policies to manage the retention policies for log files, ensuring that edge devices with limited storage capacities are not hampered by accumulated logging data. To configure audit log policies, use settings such as a maximum file size limit and maximum retained files to set a limit on log storage size. You can also choose an audit policy profile to specify the data collected.
-//TODO add xref after feature PR merges
+You can now configure audit logging policies to manage the retention policies for log files, ensuring that edge devices with limited storage capacities are not hampered by accumulated logging data. To configure audit log policies, use settings such as a maximum file size limit and maximum retained files to set a limit on log storage size. You can also choose an audit policy profile to specify the data collected. See xref:../microshift_configuring/microshift-audit-logs-config.adoc#microshift-audit-logs-config[Configuring audit logs].
 
 [id="microshift-4-16-networking"]
 === Networking
@@ -78,11 +70,12 @@ You can now configure audit logging policies to manage the retention policies fo
 ==== Multiple networks capability now available
 With this release, using multiple networks is supported with the {microshift-short} Multus plugin. If you have advanced networking requirements, you can attach additional networks to a pod for high-performance network configurations. After installing the {microshift-short} Multus RPM package, you can use the Bridge, MACVLAN, or IPVLAN plugins to create additional networks. See xref:../microshift_networking/microshift_multiple_networks/microshift-cni-multus.adoc#microshift-multus-intro_microshift-cni-multus[Additional networks in {microshift-short}].
 
+[id="microshift-4-16-configure-ingress-router"]
+==== Custom configurations for the ingress router are supported
+You can now configure ingress routes to create access to multiple services inside your {microshift-short} cluster. You can use a variety of combinations to customize the endpoint configuration for your use case. See xref:../microshift_networking/microshift-nw-router.adoc#microshift-nw-router-con_microshift-nw-router[About configuring the router].
+
 //[id="microshift-4-16-storage"]
 //=== Storage
-
-//[id="microshift-4-16-updating"]
-//=== Updating
 
 [id="microshift-4-16-running-apps"]
 === Running applications
@@ -97,7 +90,7 @@ See xref:../microshift_running_apps/microshift-gitops.adoc#microshift-gitops[Aut
 
 [id="microshift-4-16-support-updates"]
 ==== Getting a cluster ID
-With this release, you can get the cluster ID of a {microshift-short} cluster. When opening a support case, you can provide the cluster ID to Red{nbsp}Hat Support to help in identifying issues with your cluster.
+With this release, you can get the ID of a {microshift-short} cluster. When opening a support case, you can provide the cluster ID to Red{nbsp}Hat Support to help in identifying issues with your cluster. See xref:../microshift_support/microshift-getting-cluster-id.adoc#microshift-getting-cluster-id[Getting your cluster ID] for more information.
 
 //[id="microshift-4-16-security"]
 //=== Security and compliance
@@ -106,40 +99,36 @@ With this release, you can get the cluster ID of a {microshift-short} cluster. W
 //=== Documentation enhancements
 //Doc enhancements include additions for RFEs and other continuous improvement items that are substantial and are not tied to new features or bug fixes already listed here. These can also go under the relevant section as applicable.
 
-//TODO: determine the guidelines for how long to maintain this table when nothing has been deprecated or removed in x number of releases
-[id="microshift-4-16-deprecated-and-removed"]
-== Deprecated and removed features
+//[id="microshift-4-16-deprecated-and-removed"]
+//== Deprecated and removed features
 
-Some features available in previous releases of {microshift-short} have been deprecated or removed.
+//Some features available in previous releases of {microshift-short} have been deprecated or removed.
 
-Deprecated functionality is still included in {microshift-short} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments. For the most recent list of major functionality deprecated and removed within {microshift-short} {product-version}, see the following table.
+//Deprecated functionality is still included in {microshift-short} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments. For the most recent list of major functionality deprecated and removed within {microshift-short} {product-version}, see the following table.
 
-In the following table, features are marked with the following statuses:
+//In the following table, features are marked with the following statuses:
 
-* _Available_
+//* _Deprecated_
 
-* _Deprecated_
+//* _Removed_
 
-* _Removed_
+//.{product-title} deprecated and removed features tracker
+//[cols="5,1,1,1",options="header"]
+//|====
+//|Feature |4.14 |4.15 |4.16
 
-.{product-title} deprecated and removed features tracker
-[cols="5,1,1,1",options="header"]
-|====
-|Feature |4.14 |4.15 |4.16
+//|Network configuration flags
+//|Removed
+//|-
+//|-
 
-|Network configuration flags
-|Removed
-|-
-|-
+//|CIDR notation
+//|Removed
+//|-
+//|-
+//|====
 
-|CIDR notation
-|Removed
-|-
-|-
-
-|====
-
-//NOTE: Current decision is to NOT repeat bug fixes already noted in previous z-streams
+//NOTE: Do NOT repeat bug fixes already noted in previous version z-streams
 [id="microshift-4-16-bug-fixes"]
 == Bug fixes
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-9814](https://issues.redhat.com/browse/OSDOCS-9814)

Link to docs preview:
[Configurable ingress release note](https://76290--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-configure-ingress-router)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[Feature PR for reference](https://github.com/openshift/openshift-docs/pull/76100)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
