### PR TITLE
[enterprise-4.13] TELCODOCS-1886: Add recommended one time time-sycn for worked and control plane nodes

### DIFF
--- a/modules/ztp-sno-du-configuring-time-sync.adoc
+++ b/modules/ztp-sno-du-configuring-time-sync.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ztp-sno-du-configuring-time-sync_{context}"]
+= Configuring cluster time synchronization
+
+Run a one-time system time synchronization job for control plane or worker nodes.
+
+.Recommended one time time-sync for control plane nodes (`99-sync-time-once-master.yaml`)
+[source,yaml]
+----
+include::snippets/ztp_99-sync-time-once-master.yaml[]
+----
+
+.Recommended one time time-sync for worker nodes (`99-sync-time-once-worker.yaml`)
+[source,yaml]
+----
+include::snippets/ztp_99-sync-time-once-worker.yaml[]
+----

--- a/scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc
@@ -74,6 +74,8 @@ include::modules/ztp-sno-du-configuring-logging-locally-and-forwarding.adoc[leve
 
 include::modules/ztp-sno-du-configuring-performance-addons.adoc[leveloffset=+2]
 
+include::modules/ztp-sno-du-configuring-time-sync.adoc[leveloffset=+2]
+
 include::modules/ztp-sno-du-configuring-ptp.adoc[leveloffset=+2]
 
 include::modules/ztp-sno-du-tuning-the-performance-patch.adoc[leveloffset=+2]

--- a/snippets/ztp_99-sync-time-once-master.yaml
+++ b/snippets/ztp_99-sync-time-once-master.yaml
@@ -1,0 +1,26 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 99-sync-time-once-master
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+        - contents: |
+            [Unit]
+            Description=Sync time once
+            After=network.service
+            [Service]
+            Type=oneshot
+            TimeoutStartSec=300
+            ExecCondition=/bin/bash -c 'systemctl is-enabled chronyd.service --quiet && exit 1 || exit 0'
+            ExecStart=/usr/sbin/chronyd -n -f /etc/chrony.conf -q
+            RemainAfterExit=yes
+            [Install]
+            WantedBy=multi-user.target
+          enabled: true
+          name: sync-time-once.service

--- a/snippets/ztp_99-sync-time-once-worker.yaml
+++ b/snippets/ztp_99-sync-time-once-worker.yaml
@@ -1,0 +1,26 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 99-sync-time-once-worker
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+        - contents: |
+            [Unit]
+            Description=Sync time once
+            After=network.service
+            [Service]
+            Type=oneshot
+            TimeoutStartSec=300
+            ExecCondition=/bin/bash -c 'systemctl is-enabled chronyd.service --quiet && exit 1 || exit 0'
+            ExecStart=/usr/sbin/chronyd -n -f /etc/chrony.conf -q
+            RemainAfterExit=yes
+            [Install]
+            WantedBy=multi-user.target
+          enabled: true
+          name: sync-time-once.service


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-1886
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://76294--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.html#ztp-sno-du-configuring-time-sync_sno-configure-for-vdu
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Content is already in 4.14+, [preview](https://docs.openshift.com/container-platform/4.14/scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.html#ztp-sno-du-configuring-time-sync_sno-configure-for-vdu)
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
