### PR TITLE
4.14.25-missing-note

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3338,6 +3338,8 @@ $ oc adm release info 4.14.25 --pullspecs
 [id="ocp-4-14-25-bug-fixes"]
 ==== Bug fixes
 
+* Previously, some container processes created by using the `exec` command persisted even when CRI-O stopped the container. Consequently, lingering processes led to tracking issues, causing process leaks and defunct statuses. With this release, CRI-O tracks the `exec` calls processed for a container and ensures that the processes created as part of the `exec` calls are terminated when the container is stopped. (link:https://issues.redhat.com/browse/OCPBUGS-32482[*OCPBUGS-32482*])
+
 * Previously, timeout values larger than what the Go programming language could parse were not properly validated. Consequently, timeout values larger than what HAProxy could parse caused issues with HAProxy. With this update, if the timeout specifies a value larger than what can be parsed, it is capped at the maximum that HAProxy can parse. As a result, issues are no longer caused for HAProxy. (link:https://issues.redhat.com/browse/OCPBUGS-30773[*OCPBUGS-30773*])
 
 * Previously, when users imported image stream tags, `ImageContentSourcePolicy` (ICSP) could not co-exist with `ImageDigestMirrorSet` (IDMS) and `ImageTagMirrorSet` (ITMS). {product-title} ignored any IDMS/ITMS created by the user and favored ICSP. With this release, the image stream tags can co-exist because importing image stream tags now respect IDMS/ITMS when ICSP is also present. (link:https://issues.redhat.com/browse/OCPBUGS-31509[*OCPBUGS-31509*])


### PR DESCRIPTION
z-stream update so no SME or QE approvals needed. https://issues.redhat.com/browse/OCPBUGS-32482 was inadvertently skipped from https://github.com/openshift/openshift-docs/pull/75837.

Version(s):
4.14

Link to docs preview: [4.14.25](https://76301--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-25)


