### PR TITLE
OSDOCS-10590: 4.14.26 RN

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3319,6 +3319,56 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+[id="ocp-4-14-26"]
+=== RHSA-2024:2869 - {product-title} 4.14.26 bug fix update and security update
+
+Issued: 2024-05-23
+
+{product-title} release 4.14.26, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:2869[RHSA-2024:2869] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:2873[RHBA-2024:2873] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.26 --pullspecs
+----
+
+[id="ocp-4-14-26-enhancements"]
+==== Enhancements
+
+The following enhancement is included in this z-stream release:
+
+[id="ocp-4-14-designed-for-fips"]
+===== OperatorHub filter renamed from FIPS Mode to Designed for FIPS
+
+* Previously, OperatorHub included a filter named *FIPS Mode*. With this release, that filter is named *Designed for FIPS*. (link:https://issues.redhat.com/browse/OCPBUGS-33110[*OCPBUGS-33110*])
+
+[id="ocp-4-14-26-bug-fixes"]
+==== Bug fixes
+
+* Previously, when the `ContainerRuntimeConfig` resource was created as an extra manifest for single-node {product-title} installation, the bootstrap failed with the following error message: "more than one ContainerRuntimeConfig found that matches MCP labels". With this release, the incorrect processing of the `ContainerRuntimeConfig` resource is fixed and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-30153[*OCPBUGS-30153*])
+
+* Previously, an issue with NodePort traffic-forwarding caused the Transmission Control Protocol (TCP) traffic to be directed to pods under a terminating state. With this release, the endpoints selection logic fully implements `KEP-1669 ProxyTerminatingEndpoints` and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-32319[*OCPBUGS-32319*])
+
+* Previously, for {product-title} deployments on {rh-openstack-first}, the `MachineSet` object did not correctly apply the value for the `Port Security` parameter. With this release, the `MachineSet` object applies the `port_security_enabled` flag as expected. (link:https://issues.redhat.com/browse/OCPBUGS-32428[*OCPBUGS-32428*])
+
+* Previously, static Persistent Volumes in Azure File on Workload Identity clusters could not be configured due to an issue with the driver. With this release, the issue has been resolved and static Persistent Volumes mount correctly. (link:https://issues.redhat.com/browse/OCPBUGS-33039[*OCPBUGS-33039*])
+
+* Previously, the load-balancing algorithm had flaws that led to increased memory usage and a higher risk of excessive memory consumption. With this release, the service filtering logic for load-balancing is updated and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-33389[*OCPBUGS-33389*])
+
+* Previously, the Ironic Python Agent (IPA) failed when trying to wipe disks because it expected the wrong byte sector size, which caused the node provisioning to fail. With this release, the IPA checks the disk sector size and node provisioning succeeds. (link:https://issues.redhat.com/browse/OCPBUGS-33452[*OCPBUGS-33452*])
+
+* Previously, attempting to remove an alternate service when editing a Route by using the form view did not remove the alternate service from the Route. With this update, the alternate service is removed and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-33462[*OCPBUGS-33462*])
+
+* Previously, the `vsphere-problem-detector` operator could not connect to vCenter because the operator did not have the HTTP(S) proxy configured. With this release, the `vsphere-problem-detector` operator uses the same HTTP(S) proxy as the rest of the cluster and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-33467[*OCPBUGS-33467*])
+
+[id="ocp-4-14-26-updating"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 [id="ocp-4-14-25"]
 === RHBA-2024:2789 - {product-title} 4.14.25 bug fix update
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-10590](https://issues.redhat.com/browse/OSDOCS-10590)

Link to docs preview:
https://76305--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-26

QE review:
N/A

Additional information:
URLs will return 404 until go-live (5/23/24)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
