### PR TITLE
TELCODOCS-1849: Add commands for webhook logs

### DIFF
--- a/modules/kmm-reading-operator-logs.adoc
+++ b/modules/kmm-reading-operator-logs.adoc
@@ -8,16 +8,30 @@
 
 You can use the `oc logs` command to read Operator logs, as in the following examples.
 
-.Example command for KMM
+.Example command for KMM controller
 
 [source,terminal]
 ----
 $ oc logs -fn openshift-kmm deployments/kmm-operator-controller
 ----
 
-.Example command for KMM-Hub
+.Example command for KMM webhook server
+
+[source,terminal]
+----
+$ oc logs -fn openshift-kmm deployments/kmm-operator-webhook-server
+----
+
+.Example command for KMM-Hub controller
 
 [source,terminal]
 ----
 $ oc logs -fn openshift-kmm-hub deployments/kmm-operator-hub-controller
+----
+
+.Example command for KMM-Hub webhook server
+
+[source,terminal]
+----
+$ oc logs -fn openshift-kmm deployments/kmm-operator-hub-webhook-server
 ----


### PR DESCRIPTION
D/S Docs: [MGMT-16640] Move webhooks to a separated deployment. Add commands for webhook logs.

Jira: https://issues.redhat.com/browse/TELCODOCS-1849

Version(s): openshift-4.16.0, openshift-4.15.0, openshift-4.14.0, openshift-4.13.0, openshift-4.12.0

Link to docs preview: https://76309--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html#kmm-reading-operator-logs_kernel-module-management-operator

SME review: @qbarrand
QE review: @cdvultur
