### PR TITLE
OCPBUGS#34068: Adds KI to the 4.15 release notes

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2681,6 +2681,8 @@ include::snippets/opm-rhel8-known-issue.adoc[]
 //[id="ocp-telco-ran-4-15-known-issues"]
 //
 
+* There is a known issue in this release preventing the creation of web terminals when logged into the cluster as `kubeadmin`. The terminal will return the message: `Error Loading OpenShift command line terminal: User is not a owner of the requested workspace.` This issue will be fixed in a future {product-title} release. (link:https://issues.redhat.com/browse/WTO-262[*WTO-262*])
+
 [id="ocp-telco-core-4-15-known-issues"]
 
 * Currently, defining a `sysctl` value for a setting with a slash in its name, such as for bond devices, in the `profile` field of a Tuned resource might not work. Values with a slash in the `sysctl` option name are not mapped correctly to the `/proc` filesystem. As a workaround, create a `MachineConfig` resource that places a configuration file with the required values in the `/etc/sysctl.d` node directory. (link:https://issues.redhat.com/browse/RHEL-3707[*RHEL-3707*])


### PR DESCRIPTION
There is a known issue with the web terminal operator preventing its use when logged in as kubeadmin. This PR adds it to the 4.15 release notes.

Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OCPBUGS-34068

Link to docs preview:
https://76311--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-known-issues:~:text=Container%20Platform%204.14.-,There%20is%20a%20known%20issue,-in%20this%20release

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Will need to go through change management 

@kalexand-rh @jerolimov @psrna @sferich888 

CC @cbippley @dfitzmau @obrown1205 
