### PR TITLE
OCPBUGS#34068:Adds KI to the 4.14 release notes

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3300,6 +3300,8 @@ Contact Red Hat Support for additional details and assistance.
 
 (link:https://issues.redhat.com/browse/OCPBUGS-17895[*OCPBUGS-17895*])
 
+* There is a known issue in this release preventing access to the Web Terminal Operator after it has been installed. This issue will be fixed in a future {product-title} release. (link:https://issues.redhat.com/browse/OCPBUGS-14463[*OCPBUGS-14463*])
+
 [id="ocp-4-14-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
There is a known issue with the web terminal operator preventing its use when logged in as kubeadmin. This PR adds it to the 4.14 release notes.

This PR is related to the KI in #76311 

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OCPBUGS-34068

Link to docs preview:
https://76312--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-asynchronous-errata-updates:~:text=OCPBUGS%2D17895)-,There%20is%20a%20known,-issue%20in%20this

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Will need to go through change management

@kalexand-rh @jerolimov @psrna @sferich888

CC @cbippley @dfitzmau @obrown1205 
