### PR TITLE
OSDOCS-9435: configuring router admission policy

### DIFF
--- a/microshift_networking/microshift-nw-router.adoc
+++ b/microshift_networking/microshift-nw-router.adoc
@@ -6,7 +6,7 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-Learn about default and custom settings for configuring the router with {microshift-short}.
+Learn about default and custom settings for configuring the router and route admission policy with {microshift-short}.
 
 include::modules/microshift-nw-router-con.adoc[leveloffset=+1]
 
@@ -27,3 +27,5 @@ include::modules/microshift-nw-router-config-ip-address.adoc[leveloffset=+2]
 * xref:../microshift_configuring/microshift-using-config-tools.adoc#microshift-yaml-default_microshift-using-config-tools[Default settings] ({microshift-short})
 
 * xref:../microshift_networking/microshift_network_policy/microshift-network-policy-index.adoc#microshift-network-policies[About network policies]
+
+include::modules/microshift-nw-config-route-admission.adoc[leveloffset=+1]

--- a/modules/microshift-nw-config-route-admission.adoc
+++ b/modules/microshift-nw-config-route-admission.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * microshift_networking/microshift-nw-router.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-configuring-route-admission_{context}"]
+= Configuring the route admission policy
+
+By default, {microshift-short} allows routes in multiple namespaces to use the same hostname. You can prevent routes from claiming the same hostname in different namespaces by configuring the route admission policy.
+
+.Prerequisites
+
+* You installed {microshift-short}.
+* You created a {microshift-short} `config.yaml` file.
+* You installed the {oc-first}.
++
+[TIP]
+====
+If you complete all the configurations that you need to make in the {microshift-short} `config.yaml` file at the same time, you can minimize system restarts.
+====
+
+.Procedure
+
+. To prevent routes in different namespaces from claiming the same hostname, update the `namespaceOwnership` field value to `Strict` in the {microshift-short} `config.yaml` file. See the following example:
++
+.Example `config.yaml` route admission policy
+[source,yaml]
+----
+# ...
+ingress:
+  routeAdmissionPolicy:
+    namespaceOwnership: Strict <1>
+# ...
+----
+<1> Prevents routes in different namespaces from claiming the same host. Valid values are `Strict` and `InterNamespaceAllowed`. If you delete the value in a customized `config.yaml`, the `InterNamespaceAllowed` value is set automatically.
+. To apply the configuration, restart the {microshift-short} service by running the following command:
++
+[source,terminal]
+----
+$ sudo systemctl restart microshift
+----


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-9435](https://issues.redhat.com/browse/OSDOCS-9435)

Link to docs preview:
[Configuring route admission policy](https://76317--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-nw-router.html)

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.

Additional information:
 [Releated feature PR](https://github.com/openshift/openshift-docs/pull/76100)
 [release notes of this PR](https://github.com/openshift/openshift-docs/pull/76320)
