### PR TITLE
HCIDOCS-132: Remove 'hardwareProfile' from BareMetalHost examples

### DIFF
--- a/modules/bmo-getting-the-baremetalhost-resource.adoc
+++ b/modules/bmo-getting-the-baremetalhost-resource.adoc
@@ -66,7 +66,6 @@ spec:
     namespace: openshift-machine-api
   customDeploy:
     method: install_coreos
-  hardwareProfile: unknown
   online: true
   rootDeviceHints:
     deviceName: /dev/disk/by-id/scsi-<serial_number>
@@ -115,7 +114,6 @@ status:
       manufacturer: HPE
       productName: ProLiant DL380 Gen10 (868703-B21)
       serialNumber: CZ200606M3
-  hardwareProfile: unknown
   lastUpdated: "2022-06-16T11:41:42Z"
   operationalStatus: OK
   poweredOn: true
@@ -137,5 +135,4 @@ status:
       name: openshift-worker-0-bmc-secret
       namespace: openshift-machine-api
     credentialsVersion: "16120"
-
 ----

--- a/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
+++ b/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
@@ -82,7 +82,6 @@ spec:
   bootMACAddress: <NIC1_mac_address> <5>
   bootMode: UEFI
   externallyProvisioned: false
-  hardwareProfile: unknown
   online: true
 EOF
 ----

--- a/modules/ipi-install-troubleshooting-cluster-nodes-will-not-pxe.adoc
+++ b/modules/ipi-install-troubleshooting-cluster-nodes-will-not-pxe.adoc
@@ -14,18 +14,16 @@ When {product-title} cluster nodes will not PXE boot, execute the following chec
 
 . Ensure PXE is enabled on the NIC for the `provisioning` network and PXE is disabled for all other NICs.
 
-. Verify that the `install-config.yaml` configuration file has the proper hardware profile and boot MAC address for the NIC connected to the `provisioning` network. For example:
+. Verify that the `install-config.yaml` configuration file includes the `rootDeviceHints` parameter and boot MAC address for the NIC connected to the `provisioning` network. For example:
 +
 .control plane node settings
 +
 ----
 bootMACAddress: 24:6E:96:1B:96:90 # MAC of bootable provisioning NIC
-hardwareProfile: default          #control plane node settings
 ----
 +
 .Worker node settings
 +
 ----
 bootMACAddress: 24:6E:96:1B:96:90 # MAC of bootable provisioning NIC
-hardwareProfile: unknown          #worker node settings
 ----


### PR DESCRIPTION
**Fixes:** [HCIDOCS-132](https://issues.redhat.com/browse/HCIDOCS-132)

**For:** Version 4.12+

**Previews:**
[Expanding the Cluster](https://76318--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html)
[IPI Install Troubleshooting](https://76318--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-troubleshooting.html)
[Bare Metal Configuration](https://76318--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/bare-metal-configuration.html)

**QE review:**
- [x] QE has approved this change.
