### PR TITLE
OSDOCS-9816: adds router namespace ownership check to relnotes Micros…

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -74,6 +74,10 @@ With this release, using multiple networks is supported with the {microshift-sho
 ==== Custom configurations for the ingress router are supported
 You can now configure ingress routes to create access to multiple services inside your {microshift-short} cluster. You can use a variety of combinations to customize the endpoint configuration for your use case. See xref:../microshift_networking/microshift-nw-router.adoc#microshift-nw-router-con_microshift-nw-router[About configuring the router].
 
+[id="microshift-4-16-configure-route-admission-policy"]
+==== Configuring the route admission policy now available
+You can now configure the route admission policy to allow routes to claim different paths of the same hostname across namespaces. See xref:../microshift_networking/microshift-nw-router.adoc#microshift-configuring-route-admission_microshift-nw-router[Configuring the route admission policy].
+
 //[id="microshift-4-16-storage"]
 //=== Storage
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-9816](https://issues.redhat.com/browse/OSDOCS-9816)

Link to docs preview:
[Configuring route admission policy now available](https://76320--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-networking)

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.

Additional information:
[Main PR for reference](https://github.com/openshift/openshift-docs/pull/76317)
