### PR TITLE
OSDOCS-10608: Remove MCD metrics from ROSA docs

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1367,8 +1367,8 @@ Topics:
 #    File: nodes-nodes-managing-max-pods
   - Name: Using the Node Tuning Operator
     File: nodes-node-tuning-operator
-  - Name: Remediating, fencing, and maintaining nodes
-    File: nodes-remediating-fencing-maintaining-rhwa
+#  - Name: Remediating, fencing, and maintaining nodes
+#    File: nodes-remediating-fencing-maintaining-rhwa
 # Cannot create namespace needed to oc debug and reboot; revisit after Operator book converted
 #  - Name: Understanding node rebooting
 #    File: nodes-nodes-rebooting
@@ -1387,8 +1387,8 @@ Topics:
 #    Distros: openshift-rosa
 #  - Name: Monitoring for problems in your nodes
 #    File: nodes-nodes-problem-detector
-  - Name: Machine Config Daemon metrics
-    File: nodes-nodes-machine-config-daemon-metrics
+#  - Name: Machine Config Daemon metrics
+#    File: nodes-nodes-machine-config-daemon-metrics
 # cannot patch resource "nodes"
 #  - Name: Creating infrastructure nodes
 #    File: nodes-nodes-creating-infrastructure-nodes


### PR DESCRIPTION
This PR removes the MCD metrics assembly from the ROSA docs.

Version(s):
* enterprise-4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-10608

Link to docs preview:
* OCP: https://76322--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-machine-config-daemon-metrics (the MCD metrics page is still available)
* ROSA: https://76322--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/nodes/nodes-remediating-fencing-maintaining-rhwa (the MCD metrics page is no longer available)

QE review:
- [ ] QE has approved this change.
