### PR TITLE
adoc tags troubleshooting: comment out tags in blocks

### DIFF
--- a/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/_attributes
+++ b/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/_attributes
@@ -1,1 +1,1 @@
-../_attributes/
+../../../_attributes

--- a/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/images
+++ b/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/images
@@ -1,1 +1,1 @@
-../images
+../../../images

--- a/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/modules
+++ b/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/modules
@@ -1,1 +1,1 @@
-../modules
+../../../modules/

--- a/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/snippets
+++ b/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/snippets
@@ -1,1 +1,1 @@
-../snippets
+../../../snippets/

--- a/modules/machineset-modifying.adoc
+++ b/modules/machineset-modifying.adoc
@@ -37,62 +37,62 @@ end::MAPI[]
 +
 [source,terminal]
 ----
-tag::CAPI[]
+//tag::CAPI[]
 $ oc get machinesets.cluster.x-k8s.io -n openshift-cluster-api
-end::CAPI[]
-tag::MAPI[]
+//end::CAPI[]
+//tag::MAPI[]
 $ oc get machinesets.machine.openshift.io -n openshift-machine-api
-end::MAPI[]
+//end::MAPI[]
 ----
 +
 .Example output
 [source,text]
 ----
-tag::CAPI[]
+//tag::CAPI[]
 NAME                          CLUSTER             REPLICAS   READY   AVAILABLE   AGE   VERSION
 <compute_machine_set_name_1>  <cluster_name>      1          1       1           26m
 <compute_machine_set_name_2>  <cluster_name>      1          1       1           26m
-end::CAPI[]
-tag::MAPI[]
+//end::CAPI[]
+//tag::MAPI[]
 NAME                           DESIRED   CURRENT   READY   AVAILABLE   AGE
 <compute_machine_set_name_1>   1         1         1       1           55m
 <compute_machine_set_name_2>   1         1         1       1           55m
-end::MAPI[]
+//end::MAPI[]
 ----
 
 . Edit a compute machine set by running the following command:
 +
 [source,terminal]
 ----
-tag::CAPI[]
+//tag::CAPI[]
 $ oc edit machinesets.cluster.x-k8s.io <machine_set_name> \
   -n openshift-cluster-api
-end::CAPI[]
-tag::MAPI[]
+//end::CAPI[]
+//tag::MAPI[]
 $ oc edit machinesets.machine.openshift.io <machine_set_name> \
   -n openshift-machine-api
-end::MAPI[]
+//end::MAPI[]
 ----
 
 . Note the value of the `spec.replicas` field, because you need it when scaling the machine set to apply the changes.
 +
 [source,yaml]
 ----
-tag::CAPI[]
+#tag::CAPI[]
 apiVersion: cluster.x-k8s.io/v1beta1
-end::CAPI[]
-tag::MAPI[]
+#end::CAPI[]
+#tag::MAPI[]
 apiVersion: machine.openshift.io/v1beta1
-end::MAPI[]
+#end::MAPI[]
 kind: MachineSet
 metadata:
   name: <machine_set_name>
-tag::CAPI[]
+#tag::CAPI[]
   namespace: openshift-cluster-api
-end::CAPI[]
-tag::MAPI[]
+#end::CAPI[]
+#tag::MAPI[]
   namespace: openshift-machine-api
-end::MAPI[]
+#end::MAPI[]
 spec:
   replicas: 2 # <1>
 # ...
@@ -105,47 +105,47 @@ spec:
 +
 [source,terminal]
 ----
-tag::CAPI[]
+//tag::CAPI[]
 $ oc get machines.cluster.x-k8s.io \
   -n openshift-cluster-api \
   -l cluster.x-k8s.io/set-name=<machine_set_name>
-end::CAPI[]
-tag::MAPI[]
+//end::CAPI[]
+//tag::MAPI[]
 $ oc get machines.machine.openshift.io \
   -n openshift-machine-api \
   -l machine.openshift.io/cluster-api-machineset=<machine_set_name>
-end::MAPI[]
+//end::MAPI[]
 ----
 +
 .Example output for an AWS cluster
 [source,text]
 ----
-tag::CAPI[]
+//tag::CAPI[]
 NAME                        CLUSTER          NODENAME                                    PROVIDERID                              PHASE           AGE     VERSION
 <machine_name_original_1>   <cluster_name>   <original_1_ip>.<region>.compute.internal   aws:///us-east-2a/i-04e7b2cbd61fd2075   Running         4h
 <machine_name_original_2>   <cluster_name>   <original_2_ip>.<region>.compute.internal   aws:///us-east-2a/i-04e7b2cbd61fd2075   Running         4h
-end::CAPI[]
-tag::MAPI[]
+//end::CAPI[]
+//tag::MAPI[]
 NAME                        PHASE     TYPE         REGION      ZONE         AGE
 <machine_name_original_1>   Running   m6i.xlarge   us-west-1   us-west-1a   4h
 <machine_name_original_2>   Running   m6i.xlarge   us-west-1   us-west-1a   4h
-end::MAPI[]
+//end::MAPI[]
 ----
 
 . For each machine that is managed by the updated compute machine set, set the `delete` annotation by running the following command:
 +
 [source,terminal]
 ----
-tag::CAPI[]
+//tag::CAPI[]
 $ oc annotate machines.cluster.x-k8s.io/<machine_name_original_1> \
   -n openshift-cluster-api \
   cluster.x-k8s.io/delete-machine="true"
-end::CAPI[]
-tag::MAPI[]
+//end::CAPI[]
+//tag::MAPI[]
 $ oc annotate machine.machine.openshift.io/<machine_name_original_1> \
   -n openshift-machine-api \
   machine.openshift.io/delete-machine="true"
-end::MAPI[]
+//end::MAPI[]
 ----
 
 . To create replacement machines with the new configuration, scale the compute machine set to twice the number of replicas by running the following command:
@@ -153,14 +153,14 @@ end::MAPI[]
 [source,terminal]
 ----
 $ oc scale --replicas=4 \// <1>
-tag::CAPI[]
+//tag::CAPI[]
   machinesets.cluster.x-k8s.io <machine_set_name> \
   -n openshift-cluster-api
-end::CAPI[]
-tag::MAPI[]
+//end::CAPI[]
+//tag::MAPI[]
   machineset.machine.openshift.io <machine_set_name> \
   -n openshift-machine-api
-end::MAPI[]
+//end::MAPI[]
 ----
 <1> The original example value of `2` is doubled to `4`.
 
@@ -168,35 +168,35 @@ end::MAPI[]
 +
 [source,terminal]
 ----
-tag::CAPI[]
+//tag::CAPI[]
 $ oc get machines.cluster.x-k8s.io \
   -n openshift-cluster-api \
   -l cluster.x-k8s.io/set-name=<machine_set_name>
-end::CAPI[]
-tag::MAPI[]
+//end::CAPI[]
+//tag::MAPI[]
 $ oc get machines.machine.openshift.io \
   -n openshift-machine-api \
   -l machine.openshift.io/cluster-api-machineset=<machine_set_name>
-end::MAPI[]
+//end::MAPI[]
 ----
 +
 .Example output for an AWS cluster
 [source,text]
 ----
-tag::CAPI[]
+//tag::CAPI[]
 NAME                        CLUSTER          NODENAME                                    PROVIDERID                              PHASE           AGE     VERSION
 <machine_name_original_1>   <cluster_name>   <original_1_ip>.<region>.compute.internal   aws:///us-east-2a/i-04e7b2cbd61fd2075   Running         4h
 <machine_name_original_2>   <cluster_name>   <original_2_ip>.<region>.compute.internal   aws:///us-east-2a/i-04e7b2cbd61fd2075   Running         4h
 <machine_name_updated_1>    <cluster_name>   <updated_1_ip>.<region>.compute.internal    aws:///us-east-2a/i-04e7b2cbd61fd2075   Provisioned     55s
 <machine_name_updated_2>    <cluster_name>   <updated_2_ip>.<region>.compute.internal    aws:///us-east-2a/i-04e7b2cbd61fd2075   Provisioning    55s
-end::CAPI[]
-tag::MAPI[]
+//end::CAPI[]
+//tag::MAPI[]
 NAME                        PHASE          TYPE         REGION      ZONE         AGE
 <machine_name_original_1>   Running        m6i.xlarge   us-west-1   us-west-1a   4h
 <machine_name_original_2>   Running        m6i.xlarge   us-west-1   us-west-1a   4h
 <machine_name_updated_1>    Provisioned    m6i.xlarge   us-west-1   us-west-1a   55s
 <machine_name_updated_2>    Provisioning   m6i.xlarge   us-west-1   us-west-1a   55s
-end::MAPI[]
+//end::MAPI[]
 ----
 +
 When the new machines are in the `Running` phase, you can scale the compute machine set to the original number of replicas.
@@ -206,14 +206,14 @@ When the new machines are in the `Running` phase, you can scale the compute mach
 [source,terminal]
 ----
 $ oc scale --replicas=2 \// <1>
-tag::CAPI[]
+//tag::CAPI[]
   machinesets.cluster.x-k8s.io <machine_set_name> \
   -n openshift-cluster-api
-end::CAPI[]
-tag::MAPI[]
+//end::CAPI[]
+//tag::MAPI[]
   machineset.machine.openshift.io <machine_set_name> \
   -n openshift-machine-api
-end::MAPI[]
+//end::MAPI[]
 ----
 <1> The original example value of `2`.
 
@@ -223,62 +223,62 @@ end::MAPI[]
 +
 [source,terminal]
 ----
-tag::CAPI[]
+//tag::CAPI[]
 $ oc describe machines.cluster.x-k8s.io <machine_name_updated_1> \
   -n openshift-cluster-api
-end::CAPI[]
-tag::MAPI[]
+//end::CAPI[]
+//tag::MAPI[]
 $ oc describe machine.machine.openshift.io <machine_name_updated_1> \
   -n openshift-machine-api
-end::MAPI[]
+//end::MAPI[]
 ----
 
 * To verify that the compute machines without the updated configuration are deleted, list the machines that are managed by the updated compute machine set by running the following command:
 +
 [source,terminal]
 ----
-tag::CAPI[]
+//tag::CAPI[]
 $ oc get machines.cluster.x-k8s.io \
   -n openshift-cluster-api \
   cluster.x-k8s.io/set-name=<machine_set_name>
-end::CAPI[]
-tag::MAPI[]
+//end::CAPI[]
+//tag::MAPI[]
 $ oc get machines.machine.openshift.io \
   -n openshift-machine-api \
   -l machine.openshift.io/cluster-api-machineset=<machine_set_name>
-end::MAPI[]
+//end::MAPI[]
 ----
 +
 .Example output while deletion is in progress for an AWS cluster
 [source,text]
 ----
-tag::CAPI[]
+//tag::CAPI[]
 NAME                        CLUSTER          NODENAME                                    PROVIDERID                              PHASE      AGE     VERSION
 <machine_name_original_1>   <cluster_name>   <original_1_ip>.<region>.compute.internal   aws:///us-east-2a/i-04e7b2cbd61fd2075   Running    18m
 <machine_name_original_2>   <cluster_name>   <original_2_ip>.<region>.compute.internal   aws:///us-east-2a/i-04e7b2cbd61fd2075   Running    18m
 <machine_name_updated_1>    <cluster_name>   <updated_1_ip>.<region>.compute.internal    aws:///us-east-2a/i-04e7b2cbd61fd2075   Running    18m
 <machine_name_updated_2>    <cluster_name>   <updated_2_ip>.<region>.compute.internal    aws:///us-east-2a/i-04e7b2cbd61fd2075   Running    18m
-end::CAPI[]
-tag::MAPI[]
+//end::CAPI[]
+//tag::MAPI[]
 NAME                        PHASE           TYPE         REGION      ZONE         AGE
 <machine_name_original_1>   Deleting        m6i.xlarge   us-west-1   us-west-1a   4h
 <machine_name_original_2>   Deleting        m6i.xlarge   us-west-1   us-west-1a   4h
 <machine_name_updated_1>    Running         m6i.xlarge   us-west-1   us-west-1a   5m41s
 <machine_name_updated_2>    Running         m6i.xlarge   us-west-1   us-west-1a   5m41s
-end::MAPI[]
+//end::MAPI[]
 ----
 +
 .Example output when deletion is complete for an AWS cluster
 [source,text]
 ----
-tag::CAPI[]
+//tag::CAPI[]
 NAME                        CLUSTER          NODENAME                                    PROVIDERID                              PHASE      AGE     VERSION
 <machine_name_updated_1>    <cluster_name>   <updated_1_ip>.<region>.compute.internal    aws:///us-east-2a/i-04e7b2cbd61fd2075   Running    18m
 <machine_name_updated_2>    <cluster_name>   <updated_2_ip>.<region>.compute.internal    aws:///us-east-2a/i-04e7b2cbd61fd2075   Running    18m
-end::CAPI[]
-tag::MAPI[]
+//end::CAPI[]
+//tag::MAPI[]
 NAME                        PHASE           TYPE         REGION      ZONE         AGE
 <machine_name_updated_1>    Running         m6i.xlarge   us-west-1   us-west-1a   6m30s
 <machine_name_updated_2>    Running         m6i.xlarge   us-west-1   us-west-1a   6m30s
-end::MAPI[]
+//end::MAPI[]
 ----


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[Build failure reported internally](https://redhat-internal.slack.com/archives/C025XCRRH28/p1716322171444459?thread_ts=1716321604.825369&cid=C025XCRRH28)

Link to docs preview:
[CAPI](https://76324--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster-api-managing-machines.html#machineset-modifying_cluster-api-managing-machines)
[MAPI](https://76324--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/modifying-machineset.html#machineset-modifying_modifying-machineset)

QE review:
N/A

Additional information:
First test fix: comment out tags in blocks