### PR TITLE
OCPBUGS-33400 - add missing "oc adm uncordon" command in graceful restart procedure

### DIFF
--- a/modules/graceful-restart.adoc
+++ b/modules/graceful-restart.adoc
@@ -64,7 +64,31 @@ $ oc describe csr <csr_name> <1>
 $ oc adm certificate approve <csr_name>
 ----
 
-. After the control plane nodes are ready, verify that all worker nodes are ready.
+. After the control plane nodes are ready, mark all the nodes in the cluster as schedulable. You can do this from your cloud provider's web console, or by running the following loop:
++
+[source,terminal]
+----
+for node in $(oc get nodes -o jsonpath='{.items[*].metadata.name}'); do echo ${node} ; oc adm uncordon ${node} ; done
+----
++
+.Example output
+[source,terminal]
+----
+ci-ln-mgdnf4b-72292-n547t-master-0
+node/ci-ln-mgdnf4b-72292-n547t-master-0 uncordoned
+ci-ln-mgdnf4b-72292-n547t-master-1
+node/ci-ln-mgdnf4b-72292-n547t-master-1 uncordoned
+ci-ln-mgdnf4b-72292-n547t-master-2
+node/ci-ln-mgdnf4b-72292-n547t-master-2 uncordoned
+ci-ln-mgdnf4b-72292-n547t-worker-a-s7ntl
+node/ci-ln-mgdnf4b-72292-n547t-worker-a-s7ntl uncordoned
+ci-ln-mgdnf4b-72292-n547t-worker-b-cmc9k
+node/ci-ln-mgdnf4b-72292-n547t-worker-b-cmc9k uncordoned
+ci-ln-mgdnf4b-72292-n547t-worker-c-vcmtn
+node/ci-ln-mgdnf4b-72292-n547t-worker-c-vcmtn uncordoned
+----
+
+. Verify that all worker nodes are ready.
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-33400](https://issues.redhat.com/browse/OCPBUGS-33400)

Link to docs preview:
[graceful-cluster-restart.html](https://76328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/graceful-cluster-restart.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
