### PR TITLE
OSDOCS-10599: updating the compatibility table for Microshift 4.16

### DIFF
--- a/snippets/microshift-rhde-compatibility-table-snip.adoc
+++ b/snippets/microshift-rhde-compatibility-table-snip.adoc
@@ -7,29 +7,29 @@
 
 .{op-system-bundle} release compatibility matrix
 
-{op-system-base-full} and {microshift-short} work together as a single solution for device-edge computing. Supported configurations of {op-system-bundle} use verified releases for each together as listed in the following table:
+{op-system-base-full} and {microshift-short} work together as a single solution for device-edge computing. You can update each component separately, but the product versions must be compatible. For example, an update of {microshift-short} from 4.14 to 4.16 requires a {op-system} update. Supported configurations of {op-system-bundle} use verified releases for each together as listed in the following table:
 
 [cols="4",%autowidth]
 |===
 ^|*{op-system-ostree} Version(s)*
 ^|*{microshift-short} Version*
 ^|*{microshift-short} Release Status*
-^|*{microshift-short} Supported Updates*
+^|*Supported {microshift-short} Version&#8594;{microshift-short} Version Updates*
 
 ^|9.4
 ^|4.16
 ^|Generally Available
-^|4.16.0&#8594;4.16.z and 4.16&#8594;maximum two minor versions
+^|4.16.0&#8594;4.16.z, 4.14&#8594;4.16 and 4.15&#8594;4.16
 
 ^|9.2, 9.3
 ^|4.15
 ^|Generally Available
-^|4.15.0&#8594;4.15.z and 4.15&#8594;maximum two minor versions
+^|4.15.0&#8594;4.15.z, 4.14&#8594;4.15 and 4.15&#8594;4.16
 
 ^|9.2, 9.3
 ^|4.14
 ^|Generally Available
-^|4.14.0&#8594;4.14.z and 4.14&#8594;maximum two minor versions
+^|4.14.0&#8594;4.14.z, 4.14&#8594;4.15 and 4.14&#8594;4.16
 
 ^|9.2
 ^|4.13


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-10599](https://issues.redhat.com/browse/OSDOCS-10599)

Link to docs preview:
installing:
[RHEL for edge](https://76329--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree.html)
[Install from RPM package](https://76329--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-install-rpm.html)
[RHEL for edge offline](https://76329--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree-offline-use.html)

Updating:
[About updates](https://76329--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-about-updates.html)
[update options](https://76329--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-options.html)
[updates with rpm ostree](https://76329--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-rpms-ostree.html)

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.

Additional information:
[similar to this PR](https://github.com/openshift/openshift-docs/pull/76000)