### PR TITLE
OADP-3919: Release Notes for OADP 1.3.2

### DIFF
--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
@@ -9,6 +9,7 @@ toc::[]
 
 The release notes for OpenShift API for Data Protection (OADP) describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
 
+include::modules/oadp-release-notes-1-3-2.adoc[leveloffset=+1]
 include::modules/oadp-release-notes-1-3-1.adoc[leveloffset=+1]
 include::modules/oadp-release-notes-1-3-0.adoc[leveloffset=+1]
 include::modules/oadp-upgrade-from-oadp-data-mover-1-2-0.adoc[leveloffset=+3]

--- a/modules/oadp-release-notes-1-3-2.adoc
+++ b/modules/oadp-release-notes-1-3-2.adoc
@@ -1,0 +1,64 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-release-notes-1-3.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="oadp-release-notes-1-3-2_{context}"]
+= {oadp-short} 1.3.2 release notes
+
+The {oadp-first} 1.3.2 release notes list resolved issues and known issues.
+
+//[id="new-features-1-3-2_{context}"]
+//== New features
+
+
+[id="resolved-issues-1-3-2_{context}"]
+== Resolved issues
+
+.DPA fails to reconcile if a valid custom secret is used for BSL
+
+DPA fails to reconcile if a valid custom secret is used for Backup Storage Location (BSL), but the default secret is missing. The workaround is to create the required default `cloud-credentials` initially. When the custom secret is re-created, it can be used and checked for its existence. 
+
+link:https://issues.redhat.com/browse/OADP-3193[OADP-3193]
+
+.CVE-2023-45290: `oadp-velero-container`: Golang `net/http`: Memory exhaustion in `Request.ParseMultipartForm`
+
+A flaw was found in the `net/http` Golang standard library package, which impacts previous versions of {oadp-short}. When parsing a `multipart` form, either explicitly with `Request.ParseMultipartForm` or implicitly with `Request.FormValue`, `Request.PostFormValue`, or `Request.FormFile`, limits on the total size of the parsed form are not applied to the memory consumed while reading a single form line. This permits a maliciously crafted input containing long lines to cause the allocation of arbitrarily large amounts of memory, potentially leading to memory exhaustion. This flaw has been resolved in {oadp-short} 1.3.2.
+
+For more details, see link:https://access.redhat.com/security/cve/cve-2023-45290[CVE-2023-45290].
+
+.CVE-2023-45289: `oadp-velero-container`: Golang `net/http/cookiejar`: Incorrect forwarding of sensitive headers and cookies on HTTP redirect
+
+A flaw was found in the `net/http/cookiejar` Golang standard library package, which impacts previous versions of {oadp-short}. When following an HTTP redirect to a domain that is not a subdomain match or exact match of the initial domain, an `http.Client` does not forward sensitive headers such as `Authorization` or `Cookie`. A maliciously crafted HTTP redirect could cause sensitive headers to be unexpectedly forwarded. This flaw has been resolved in {oadp-short} 1.3.2.
+
+For more details, see link:https://access.redhat.com/security/cve/cve-2023-45289[CVE-2023-45289].
+
+.CVE-2024-24783: `oadp-velero-container`: Golang `crypto/x509`: Verify panics on certificates with an unknown public key algorithm
+
+A flaw was found in the `crypto/x509` Golang standard library package, which impacts previous versions of {oadp-short}. Verifying a certificate chain that contains a certificate with an unknown public key algorithm causes `Certificate.Verify` to panic. This affects all `crypto/tls` clients and servers that set `Config.ClientAuth` to `VerifyClientCertIfGiven` or `RequireAndVerifyClientCert`. The default behavior is for TLS servers to not verify client certificates. This flaw has been resolved in {oadp-short} 1.3.2.
+
+For more details, see link:https://access.redhat.com/security/cve/cve-2024-24783[CVE-2024-24783].
+
+.CVE-2024-24784: `oadp-velero-plugin-container`: Golang `net/mail`: Comments in display names are incorrectly handled
+
+A flaw was found in the `net/mail` Golang standard library package, which impacts previous versions of {oadp-short}. The `ParseAddressList` function incorrectly handles comments, text in parentheses, and display names. Because this is a misalignment with conforming address parsers, it can result in different trust decisions being made by programs using different parsers. This flaw has been resolved in {oadp-short} 1.3.2.
+
+For more details, see link:https://access.redhat.com/security/cve/cve-2024-24784[CVE-2024-24784].
+
+.CVE-2024-24785: `oadp-velero-container`: Golang: html/template: errors returned from `MarshalJSON` methods may break template escaping
+
+A flaw was found in the `html/template` Golang standard library package, which impacts previous versions of {oadp-short}. If errors returned from `MarshalJSON` methods contain user-controlled data, they may be used to break the contextual auto-escaping behavior of the HTML/template package, allowing subsequent actions to inject unexpected content into the templates. This flaw has been resolved in {oadp-short} 1.3.2.
+
+For more details, see link:https://access.redhat.com/security/cve/cve-2024-24785[CVE-2024-24785].
+
+For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12436254[OADP 1.3.2 resolved issues] in Jira.
+
+
+[id="known-issues-1-3-2_{context}"]
+== Known issues
+
+.Cassandra application pods enter into the `CrashLoopBackoff` status after restoring OADP
+
+After {oadp-short} restores, the Cassandra application pods might enter in the `CrashLoopBackoff` status. To work around this problem, delete the `StatefulSet` pods that are returning an error or the `CrashLoopBackoff` state after restoring {oadp-short}. The `StatefulSet` controller recreates these pods and it runs normally.
+
+link:https://issues.redhat.com/browse/OADP-3767[OADP-3767]


### PR DESCRIPTION
### Jira

* [OADP-3919](https://issues.redhat.com/browse/OADP-3919)

* Release notes for OADP 1.3.2

### Version(s):

* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

### Link to docs preview:

* [OADP 1.3.2 release notes](https://76332--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.html)

### QE review:
* [X ] QE has approved this change. Amos approved in the [JIRA ticket comments](https://issues.redhat.com/browse/OADP-3919)
