### PR TITLE
OBSDOCS-1068: Update supported monitoring component versions matrix f…

### DIFF
--- a/modules/monitoring-support-version-matrix-for-monitoring-components.adoc
+++ b/modules/monitoring-support-version-matrix-for-monitoring-components.adoc
@@ -10,17 +10,17 @@ The following matrix contains information about versions of monitoring component
 
 .{product-title} and component versions
 |===
-|{product-title} |Prometheus Operator |Prometheus  |Prometheus Adapter |Metrics Server (Technology Preview) |Alertmanager |kube-state-metrics agent |monitoring-plugin |node-exporter agent |Thanos
+|{product-title} |Prometheus Operator |Prometheus  |Metrics Server |Alertmanager |kube-state-metrics agent |monitoring-plugin |node-exporter agent |Thanos
 
-|4.16 |0.73.2 |2.51.2 |0.11.2 |0.7.1 |0.26.0 |2.12.0 |1.0.0 |1.8.0 |0.35.0
+|4.16 |0.73.2 |2.52.0 |0.7.1 |0.26.0 |2.12.0 |1.0.0 |1.8.0 |0.35.0
 
-|4.15 |0.70.0 |2.48.0 |0.11.2 |0.6.4 |0.26.0 |2.10.1 |1.0.0 |1.7.0 |0.32.5
+|4.15 |0.70.0 |2.48.0 |0.6.4 |0.26.0 |2.10.1 |1.0.0 |1.7.0 |0.32.5
 
-|4.14 |0.67.1 |2.46.0 |0.10.0 |N/A |0.25.0 |2.9.2 |1.0.0 |1.6.1 |0.30.2
+|4.14 |0.67.1 |2.46.0 |N/A |0.25.0 |2.9.2 |1.0.0 |1.6.1 |0.30.2
 
-|4.13 |0.63.0 |2.42.0 |0.10.0 |N/A |0.25.0 |2.8.1 |N/A |1.5.0 |0.30.2
+|4.13 |0.63.0 |2.42.0 |N/A |0.25.0 |2.8.1 |N/A |1.5.0 |0.30.2
 
-|4.12 |0.60.1 |2.39.1 |0.10.0 |N/A |0.24.0 |2.6.0 |N/A |1.4.0 |0.28.1
+|4.12 |0.60.1 |2.39.1 |N/A |0.24.0 |2.6.0 |N/A |1.4.0 |0.28.1
 |===
 
 [NOTE]


### PR DESCRIPTION
Version(s): `enterprise-4.16` and later

Issue: [OBSDOCS-1068](https://issues.redhat.com/browse/OBSDOCS-1068)

Link to docs preview: [Support version matrix for monitoring components
](https://76333--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#support-version-matrix-for-monitoring-components_configuring-the-monitoring-stack)

QE review:
- [x] QE has approved this change.
