### PR TITLE
OCPBUGS-33138 - Update RHACM version

### DIFF
--- a/modules/ztp-telco-ran-software-versions.adoc
+++ b/modules/ztp-telco-ran-software-versions.adoc
@@ -53,7 +53,7 @@ The Red Hat telco RAN DU {product-version} solution has been validated using the
 |4.14
 
 |{rh-rhacm-first}
-|2.8, 2.9
+|2.9, 2.10
 
 |{gitops-title}
 |1.9, 1.10


### PR DESCRIPTION
Update Update RHACM version for ZTP 4.14

Version(s):
enterprise-4.14

Issue:
https://issues.redhat.com/browse/OCPBUGS-33138

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->