### PR TITLE
OSDOCS-10637 Adding warnings re. using shared VPCs for HCP clusters

### DIFF
--- a/rosa_hcp/rosa-hcp-creating-cluster-with-aws-kms-key.adoc
+++ b/rosa_hcp/rosa-hcp-creating-cluster-with-aws-kms-key.adoc
@@ -34,6 +34,8 @@ You must have a Virtual Private Cloud (VPC) to create {hcp-title} cluster. You c
 The Terraform instructions are for testing and demonstration purposes. Your own installation requires some modifications to the VPC for your own use. You should also ensure that when you use this Terraform script it is in the same region that you intend to install your cluster. In these examples, use `us-east-2`.
 ====
 
+include::snippets/imp-rosa-hcp-no-shared-vpc-support.adoc[leveloffset=+0]
+
 [discrete]
 include::modules/rosa-hcp-vpc-terraform.adoc[leveloffset=+3]
 

--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc
@@ -13,6 +13,8 @@ You can create {hcp-title-first} clusters that use external authentication to is
 Since it is not possible to upgrade or convert existing ROSA clusters to a {hcp} architecture, you must create a new cluster to use {hcp-title} functionality. You also cannot convert a cluster that was created to use external authentication providers to use the internal OAuth2 server. You must also create a new cluster.
 ====
 
+include::snippets/imp-rosa-hcp-no-shared-vpc-support.adoc[leveloffset=+0]
+
 [NOTE]
 ====
 {hcp-title} clusters only support {sts-first} authentication.

--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
@@ -20,6 +20,8 @@ Create a {hcp-title} cluster quickly by using the default options and automatic 
 Since it is not possible to upgrade or convert existing ROSA clusters to a {hcp} architecture, you must create a new cluster to use {hcp-title} functionality.
 ====
 
+include::snippets/imp-rosa-hcp-no-shared-vpc-support.adoc[leveloffset=+0]
+
 [NOTE]
 ====
 {hcp-title} clusters only support AWS Security Token Service (STS) authentication.

--- a/rosa_install_access_delete_clusters/rosa-shared-vpc-config.adoc
+++ b/rosa_install_access_delete_clusters/rosa-shared-vpc-config.adoc
@@ -11,6 +11,11 @@ ifdef::openshift-rosa[]
 endif::openshift-rosa[]
 clusters in shared, centrally-managed AWS virtual private clouds (VPCs). 
 
+[IMPORTANT]
+====
+link:https://docs.aws.amazon.com/vpc/latest/userguide/vpc-sharing.html[Sharing VPCs across multiple AWS accounts] is currently only supported for ROSA Classic clusters using STS for authentication.
+====
+
 [NOTE]
 ====
 This process requires *two separate* AWS accounts that belong to the same AWS organization. One account functions as the VPC-owning AWS account (*VPC Owner*), while the other account creates the cluster in the cluster-creating AWS account (*Cluster Creator*).

--- a/snippets/imp-rosa-hcp-no-shared-vpc-support.adoc
+++ b/snippets/imp-rosa-hcp-no-shared-vpc-support.adoc
@@ -1,0 +1,4 @@
+[IMPORTANT]
+====
+link:https://docs.aws.amazon.com/vpc/latest/userguide/vpc-sharing.html[Sharing VPCs across multiple AWS accounts] is not currently supported for {hcp-title}. Do not install a {hcp-title} cluster into subnets shared from another AWS account. See link:https://access.redhat.com/solutions/6980058["Are multiple ROSA clusters in a single VPC supported?"] for more information.
+====


### PR DESCRIPTION
Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-10637

Link to docs preview:
https://76339--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-creating-cluster-with-aws-kms-key.html
https://76339--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.html
https://76339--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html
https://76339--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-shared-vpc-config.html

QE review:
- [x] QE has approved this change.

Additional information:
Thanks to Paul Foster for the report