### PR TITLE
OCPBUGS-33138 - Adding step for ArgoCD multicluster-operators-subscription

### DIFF
--- a/snippets/ztp-patch-argocd-hub-cluster.adoc
+++ b/snippets/ztp-patch-argocd-hub-cluster.adoc
@@ -1,5 +1,71 @@
 :_mod-docs-content-type: SNIPPET
-. To install the {ztp} plugin, patch the ArgoCD instance in the hub cluster by using the patch file that you previously extracted into the `out/argocd/deployment/` directory.
+. To install the {ztp} plugin, patch the ArgoCD instance in the hub cluster with the relevant multicluster engine (MCE) subscription image.
+Customize the patch file that you previously extracted into the `out/argocd/deployment/` directory for your environment.
+
+.. Select the `multicluster-operators-subscription` image that matches your {rh-rhacm} version.
++
+--
+.`multicluster-operators-subscription` image versions
+[cols="1,1,1,1,3", options="header"]
+|====
+|{product-title} version
+|{rh-rhacm} version
+|MCE version
+|MCE RHEL version
+|MCE image
+
+|4.14, 4.15, 4.16
+|2.8, 2.9
+|2.8, 2.9
+|RHEL 8
+|`registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8:v2.8`
+
+`registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8:v2.9`
+
+|4.14, 4.15, 4.16
+|2.10
+|2.10
+|RHEL 9
+|`registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9:v2.10`
+|====
+
+[IMPORTANT]
+====
+The version of the `multicluster-operators-subscription` image should match the {rh-rhacm} version.
+Beginning with the MCE 2.10 release, RHEL 9 is the base image for `multicluster-operators-subscription` images.
+====
+--
+
+.. Add the following configuration to the `out/argocd/deployment/argocd-openshift-gitops-patch.json` file:
++
+--
+[source,json]
+----
+{
+  "args": [
+    "-c",
+    "mkdir -p /.config/kustomize/plugin/policy.open-cluster-management.io/v1/policygenerator && cp /policy-generator/PolicyGenerator-not-fips-compliant /.config/kustomize/plugin/policy.open-cluster-management.io/v1/policygenerator/PolicyGenerator" <1>
+  ],
+  "command": [
+    "/bin/bash"
+  ],
+  "image": "registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9:v2.10", <2> <3>
+  "name": "policy-generator-install",
+  "imagePullPolicy": "Always",
+  "volumeMounts": [
+    {
+      "mountPath": "/.config",
+      "name": "kustomize"
+    }
+  ]
+}
+----
+<1> Optional: For RHEL 9 images, copy the required universal executable in the `/policy-generator/PolicyGenerator-not-fips-compliant` folder for the ArgoCD version.
+<2> Match the `multicluster-operators-subscription` image to the {rh-rhacm} version.
+<3> In disconnected environments, replace the URL for the `multicluster-operators-subscription` image with the disconnected registry equivalent for your environment.
+--
+
+.. Patch the ArgoCD instance.
 Run the following command:
 +
 [source,terminal]


### PR DESCRIPTION
Updating the ArgoCD install steps to include the `multicluster-operators-subscription`.

Version(s):
enterprise-4.14+

Issue:
https://issues.redhat.com/browse/OCPBUGS-33138

Link to docs preview:
https://76343--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-preparing-the-hub-cluster#ztp-configuring-hub-cluster-with-argocd_ztp-preparing-the-hub-cluster

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->