### PR TITLE
[enterprise-4.14] OCPBUGS#23262 Azure content appears in vSphere restricted docs

### DIFF
--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -586,11 +586,13 @@ publish: Internal
 ----
 +
 By setting this option, you create an internal Ingress Controller and a private load balancer.
+ifdef::azure[]
 +
 [IMPORTANT]
 ====
 Azure Firewall link:https://learn.microsoft.com/en-us/azure/firewall/integrate-lb[does not work seamlessly] with Azure Public Load balancers. Thus, when using Azure Firewall for restricting internet access, the `publish` field in `install-config.yaml` should be set to `Internal`.
 ====
+endif::azure[]
 endif::restricted[]
 endif::nutanix[]
 ifdef::nutanix[]


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OCPBUGS-23262

Link to docs preview:
[Azure restricted install](https://76353--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-restricted-networks-azure-installer-provisioned#installation-initializing_installing-restricted-networks-azure-installer-provisioned) (warning appears in step 3.e)
[vSphere IPI restricted install](https://76353--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere#installation-initializing_installing-restricted-networks-installer-provisioned-vsphere) (warning does not appear in step 3.d)

QE review:
- [x] QE has approved this change.