### PR TITLE
RN cgroup v1 is deprecated in 4.16

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -461,6 +461,11 @@ In the following tables, features are marked with the following statuses:
 |Deprecated
 |Deprecated
 
+|cgroup v1
+|General Availability
+|General Availability
+|Deprecated
+
 |====
 
 [discrete]
@@ -503,6 +508,11 @@ In the following tables, features are marked with the following statuses:
 
 [id="ocp-4-16-deprecated-features"]
 === Deprecated features
+
+[id="ocp-4-14-nodes-cgroupv1-deprecated"]
+==== Linux Control Groups version 1 is now deprecated
+
+In {op-system-base-full} 9, the default mode is cgroup v2. When {op-system-base-full} 10 is released, systemd will not support booting in the cgroup v1 mode and only cgroup v2 mode will be available. As such, cgroup v1 is deprecated in {product-title} 4.16 and later. cgroup v1 will be removed in a future {product-title} release. 
 
 [id="ocp-4-16-removed-features"]
 === Removed features


### PR DESCRIPTION
Release note for https://issues.redhat.com/browse/OSDOCS-10339

Previews: 
[Linux Control Groups version 1 is now deprecated](https://76363--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-14-nodes-cgroupv1-deprecated)
[Table 11. Node deprecated and removed tracker](https://76363--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-deprecated-removed-features)