### PR TITLE
Adds Whereabouts CNI plugin enhancement to 416 release notes + GA table

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -870,6 +870,18 @@ For more information about these configuration fields, see xref:../networking/cl
 The Telemetry and the Insights Operator collects telemetry on IPsec connections. For more information, see xref:../support/remote_health_monitoring/showing-data-collected-by-remote-health-monitoring.adoc#showing-data-collected-from-the-cluster_showing-data-collected-by-remote-health-monitoring[Showing data collected by Telemetry].
 
 [id="ocp-4-16-registry_{context}"]
+[id="overlapping-ip-configuration-multi-tenant-networks-whereabouts"]
+==== Overlapping IP configuration for multi-tenant networks with Whereabouts
+
+Previously, it was not possible to configure the same CIDR range twice and to have the Whereabouts CNI plugin assign IP addresses from these ranges independently. This limitation caused issues in multi-tenant environments where different groups might need to select overlapping CIDR ranges. 
+
+With this release, the Whereabouts CNI plugin supports overlapping IP address ranges through the inclusion of a `network_name` parameter. Administrators can use the `network_name` parameter to configure the same CIDR range multiple times within separate `NetworkAttachmentDefinitions`, which enables independent IP address assignments for each range.
+
+This feature also includes enhanced namespace handling, stores `IPPool` custom resources (CRs) in the appropriate namespaces, and supports cross-namespaces when permitted by Multus. These improvements provide greater flexibility and management capabilities in multi-tenant environments.
+
+For more information about this feature, see xref:../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-whereabouts_configuring-additional-network[Dynamic IP address assignment configuration with Whereabouts].
+
+[id="ocp-4-16-registry"]
 === Registry
 
 [id="ocp-4-16-storage_{context}"]
@@ -2576,6 +2588,11 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 
 | Live migration to OVN-Kubernetes from OpenShift SDN
+| Not Available
+| Not Available
+| General Availability
+
+| Overlapping IP configuration for multi-tenant networks with Whereabouts
 | Not Available
 | Not Available
 | General Availability


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-9479

Link to docs preview:
https://76374--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#overlapping-ip-configuration-multi-tenant-networks-whereabouts

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
