### PR TITLE
OSDOCS-9968: Incorporate out-of-scope comments

### DIFF
--- a/modules/rosa-accessing-your-cluster-quick.adoc
+++ b/modules/rosa-accessing-your-cluster-quick.adoc
@@ -30,7 +30,7 @@ $ rosa create admin --cluster=<cluster_name>
 W: It is recommended to add an identity provider to login to this cluster. See 'rosa create idp --help' for more information.
 I: Admin account has been added to cluster 'cluster_name'. It may take up to a minute for the account to become active.
 I: To login, run the following command:
-oc login https://api.cluster-name.t6k4.i1.oragnization.org:6443 \ <1>
+oc login https://api.cluster-name.t6k4.i1.organization.org:6443 \// <1>
 --username cluster-admin \
 --password FWGYL-2mkJI-3ZTTZ-rINns
 ----
@@ -42,10 +42,12 @@ oc login https://api.cluster-name.t6k4.i1.oragnization.org:6443 \ <1>
 .Example output
 [source,terminal]
 ----
-$ oc login https://api.cluster_name.t6k4.i1.oragnization.org:6443 \ <1>
+$ oc login https://api.cluster_name.t6k4.i1.organization.org:6443 \// <1>
 >  --username cluster-admin \
 >  --password FWGYL-2mkJI-3ZTTZ-rINns
-Login successful.                                                                                                                                                                                                                                                       You have access to 77 projects, the list has been suppressed. You can list all projects with ' projects'
+Login successful.
+
+You have access to 77 projects, the list has been suppressed. You can list all projects with 'projects'
 ----
 <1> For a {hcp-title} cluster, the port number should be `443`.
 


### PR DESCRIPTION
This PR incorporates out-of-scope comments from https://github.com/openshift/openshift-docs/pull/72868.

Version(s):
* enterprise-4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-9968 

Link to docs preview:


QE review:
- Not required


