### PR TITLE
OSDOCS6774: Created new section to update support router to load secrets

### DIFF
--- a/modules/nw-ingress-integrating-route-secret-certificate.adoc
+++ b/modules/nw-ingress-integrating-route-secret-certificate.adoc
@@ -1,0 +1,6 @@
+//
+// * ingress/routes.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-ingress-integrating-route-secret-certificate_{context}"]
+= Securing route with external certificates in TLS secrets

--- a/modules/nw-ingress-route-secret-load-external-cert.adoc
+++ b/modules/nw-ingress-route-secret-load-external-cert.adoc
@@ -1,0 +1,82 @@
+// Module included in the following assemblies:
+//
+// * networking/routes/secured-routes.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-ingress-route-secret-load-external-cert_{context}"]
+= Creating a route with externally managed certificate
+
+:FeatureName: Securing route with external certificates in TLS secrets
+include::snippets/technology-preview.adoc[]
+
+You can configure {product-title} routes with third-party certificate management solutions by using the `.spec.tls.externalCertificate` field of the route API. You can reference externally managed TLS certificates via secrets, eliminating the need for manual certificate management. Using the externally managed certificate reduces errors ensuring a smoother rollout of certificate updates, enabling the OpenShift router to serve renewed certificates promptly. 
+
+[NOTE]
+====
+This feature applies to both edge routes and re-encrypt routes.
+====
+
+.Prerequisites
+
+* You must enable the `RouteExternalCertificate` feature gate.
+* You must have the `create` and `update` permissions on the `routes/custom-host`.
+* You must have a secret containing a valid certificate/key pair in PEM-encoded format of type `kubernetes.io/tls`, which includes both `tls.key` and `tls.crt` keys.
+* You must place the referenced secret in the same namespace as the route you want to secure.
+
+.Procedure
+
+. Create a `role` in the same namespace as the secret to allow the router service account read access by running the following command:
++
+[source,terminal]
+----
+$ oc create role secret-reader --verb=get,list,watch --resource=secrets --resource-name=<secret-name> \ <1> 
+--namespace=<current-namespace> <2>
+----
+<1> Specify the actual name of your secret.
+<2> Specify the namespace where both your secret and route reside.
+
+. Create a `rolebinding` in the same namespace as the secret and bind the router service account to the newly created role by running the following command:
++
+[source,terminal]
+----
+$ oc create rolebinding secret-reader-binding --role=secret-reader --serviceaccount=openshift-ingress:router --namespace=<current-namespace> <1>
+----
+<1> Specify the namespace where both your secret and route reside.
+
+. Create a YAML file that defines the `route` and specifies the secret containing your certificate using the following example. 
++
+.YAML definition of the secure route
+[source,yaml]
+----
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: myedge
+  namespace: test
+spec:
+  host: myedge-test.apps.example.com
+  tls:
+    externalCertificate:
+      name: <secret-name> <1>
+    termination: edge
+    [...]
+[...]
+----
+<1> Specify the actual name of your secret.
+
+. Create a `route` resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <route.yaml> <1>
+----
+<1> Specify the generated YAML filename.
+
+If the secret exists and has a certificate/key pair, the router will serve the generated certificate if all prerequisites are met.
+
+[NOTE]
+====
+If `.spec.tls.externalCertificate` is not provided, the router will use default generated certificates. 
+
+You cannot provide the `.spec.tls.certificate` field  or the `.spec.tls.key` field when using the `.spec.tls.externalCertificate` field.
+====

--- a/networking/routes/secured-routes.adoc
+++ b/networking/routes/secured-routes.adoc
@@ -25,3 +25,10 @@ include::modules/nw-ingress-creating-a-reencrypt-route-with-a-custom-certificate
 include::modules/nw-ingress-creating-an-edge-route-with-a-custom-certificate.adoc[leveloffset=+1]
 
 include::modules/nw-ingress-creating-a-passthrough-route.adoc[leveloffset=+1]
+
+include::modules/nw-ingress-route-secret-load-external-cert.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For troubleshooting routes with externally managed certificates, check the {product-title} router pod logs for errors, see xref:../../support/troubleshooting/investigating-pod-issues.adoc[Investigating pod issues].


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS 6774](https://issues.redhat.com/browse/OSDOCS-6774)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Preview](https://76392--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/routes/secured-routes.html#nw-ingress-route-secret-load-external-cert_secured-routes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
