### PR TITLE
PR for SRVKS-1192: Document the option to not generate the default Serving network policies and include Knative Eventing content in same procedure

### DIFF
--- a/integrations/serverless-ossm-setup.adoc
+++ b/integrations/serverless-ossm-setup.adoc
@@ -59,7 +59,6 @@ include::modules/serverless-ossm-installing-and-configuring-openshift-serverless
 include::modules/serverless-ossm-verifying-the-integration.adoc[leveloffset=+2]
 
 include::modules/serverless-ossm-enabling-serving-metrics.adoc[leveloffset=+1]
-
-
+include::modules/serverless-ossm-disabling-network-policies.adoc[leveloffset=+1]
 // with kourier
 include::modules/serverless-ossm-secret-filtering-net-istio.adoc[leveloffset=+1]

--- a/modules/serverless-ossm-disabling-network-policies.adoc
+++ b/modules/serverless-ossm-disabling-network-policies.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * /serverless/integrations/serverless-ossm-setup.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-ossm-disabling-network-policies_{context}"]
+= Disabling the default network policies 
+
+The {ServerlessOperatorName} generates the network policies by default. To disable the default network policy generation, you can add the `serverless.openshift.io/disable-istio-net-policies-generation` annotation in the `KnativeEventing` and `KnativeServing` custom resources (CRs).
+
+.Prerequisites
+
+* You have one of the following permissions to access the cluster: 
+** Cluster administrator permissions on {ocp-product-title}
+** Cluster administrator permissions on {rosa-product-title}
+** Dedicated administrator permissions on {dedicated-product-title}
+* You have installed the OpenShift CLI (`oc`).
+* You have access to a project with the appropriate roles and permissions to create applications and other workloads.
+* You have installed the {ServerlessOperatorName}, Knative Serving, and Knative Eventing on your cluster.
+* You have installed {SMProductName} with the mTLS functionality enabled.
+
+.Procedure
+
+* Add the `serverless.openshift.io/disable-istio-net-policies-generation: "true"` annotation to your Knative custom resources.
++
+[NOTE]
+====
+The {ServerlessOperatorName} generates the required network policies by default. When you configure `ServiceMeshControlPlane` with `manageNetworkPolicy: false`, you must disable the default network policy generation to ensure proper event delivery. To disable the default network policy generation, you can add the `serverless.openshift.io/disable-istio-net-policies-generation` annotation in the `KnativeEventing` and `KnativeServing` custom resources (CRs).
+====
+
+.. Annotate the `KnativeEventing` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit KnativeEventing -n knative-eventing
+----
++
+.Example `KnativeEventing` CR
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing
+  annotations:
+    serverless.openshift.io/disable-istio-net-policies-generation: "true"
+----
+
+.. Annotate the `KnativeServing` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit KnativeServing -n knative-serving
+----
++
+.Example `KnativeServing` CR
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+  annotations:
+    serverless.openshift.io/disable-istio-net-policies-generation: "true"
+----
+

--- a/modules/serverless-ossm-enabling-serving-metrics.adoc
+++ b/modules/serverless-ossm-enabling-serving-metrics.adoc
@@ -4,19 +4,20 @@
 
 :_content-type: PROCEDURE
 [id="serverless-ossm-enabling-serving-metrics_{context}"]
-= Enabling Knative Serving metrics when using Service Mesh with mTLS
+= Enabling Knative Serving and Knative Eventing metrics when using Service Mesh with mTLS
 
-If Service Mesh is enabled with mTLS, metrics for Knative Serving are disabled by default, because Service Mesh prevents Prometheus from scraping metrics. This section shows how to enable Knative Serving metrics when using Service Mesh and mTLS.
+If Service Mesh is enabled with Mutual Transport Layer Security (mTLS), metrics for Knative Serving and Knative Eventing are disabled by default, because Service Mesh prevents Prometheus from scraping metrics. You can enable Knative Serving and Knative Eventing metrics when using Service Mesh and mTLS.
 
 .Prerequisites
 
-* You have installed the {ServerlessOperatorName} and Knative Serving on your cluster.
+* You have one of the following permissions to access the cluster: 
+** Cluster administrator permissions on {ocp-product-title}
+** Cluster administrator permissions on {rosa-product-title}
+** Dedicated administrator permissions on {dedicated-product-title}
+* You have installed the OpenShift CLI (`oc`).
+* You have access to a project with the appropriate roles and permissions to create applications and other workloads.
+* You have installed the {ServerlessOperatorName}, Knative Serving, and Knative Eventing on your cluster.
 * You have installed {SMProductName} with the mTLS functionality enabled.
-
-* You have cluster administrator permissions on {ocp-product-title}, or you have cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
-
-* Install the OpenShift CLI (`oc`).
-* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads.
 
 .Procedure
 
@@ -28,6 +29,7 @@ apiVersion: operator.knative.dev/v1beta1
 kind: KnativeServing
 metadata:
   name: knative-serving
+  namespace: knative-serving
 spec:
   config:
     observability:
@@ -36,23 +38,26 @@ spec:
 ----
 +
 This step prevents metrics from being disabled by default.
++
+[NOTE]
+====
+When you configure `ServiceMeshControlPlane` with `manageNetworkPolicy: false`, you must use the annotation on KnativeEventing to ensure proper event delivery.
+====
 
-. Apply the following network policy to allow traffic from the Prometheus namespace:
++ 
+The same mechanism is used for Knative Eventing. To enable metrics for Knative Eventing, you need to specify `prometheus` as the `metrics.backend-destination` in the `observability` spec of the Knative Eventing custom resource (CR) as follows: 
 +
 [source,yaml]
 ----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeEventing
 metadata:
-  name: allow-from-openshift-monitoring-ns
-  namespace: knative-serving
+  name: knative-eventing
+  namespace: knative-eventing
 spec:
-  ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          name: "openshift-monitoring"
-  podSelector: {}
+  config:
+    observability:
+      metrics.backend-destination: "prometheus"
 ...
 ----
 


### PR DESCRIPTION
**Affected versions for cherry-picking:** `serverless-docs-1.33`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVKS-1192

**Doc preview:** 

- [Enabling Knative Serving and Knative Eventing metrics when using Service Mesh with mTLS](
 https://76398--ocpdocs-pr.netlify.app/openshift-serverless/latest/integrations/serverless-ossm-setup.html#serverless-ossm-enabling-serving-metrics_serverless-ossm-setup)
- [Disabling the default network policies](https://76398--ocpdocs-pr.netlify.app/openshift-serverless/latest/integrations/serverless-ossm-setup.html#serverless-ossm-disabling-network-policies.adoc_serverless-ossm-setup)

As per the Jira requirement and the comments I have updated the procedure and included the content for Knative Eventing as well.

