### PR TITLE
TELCODOCS-1703 moving section and making clear for telco perf profile

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -175,17 +175,6 @@ For more information, see _Managing machines with the Cluster API_.
 [id="ocp-4-16-nodes"]
 === Nodes
 
-[id="ocp-4-14-nodes-cgroupv2-default"]
-==== Linux Control Groups version 2 is now generally available (GA)
-
-Beginning with {product-title} 4.16, Control Groups version 2 (cgroup v2), also known as cgroup2 or cgroupsv2, is enabled by default for all new deployments, even when performance profiles are present. 
-
-Since {product-title} 4.14, cgroups v2 has been the default, but the performance profile feature required the use of cgroups v1. This issue has been resolved.
-
-cgroup v1 is still used in upgraded clusters with performance profiles that have initial installation dates before {product-title} 4.16. cgroup v1 can still be used in the current version by changing the `cgroupMode` field in the `node.config` object to `v1`.
-
-For more information, see xref:../nodes/clusters/nodes-cluster-cgroups-2.adoc#nodes-clusters-cgroups-2[Configuring the Linux cgroup version on your nodes].
-
 [id="ocp-4-16-monitoring"]
 === Monitoring
 
@@ -206,6 +195,18 @@ It is expected that if the values for CPU limits are different from the value fo
 ====
 
 For more information, see xref:../scalability_and_performance/enabling-workload-partitioning.adoc#enabling-workload-partitioning[Workload partitioning].
+
+[id="ocp-4-14-nodes-cgroupv2-default"]
+==== Linux Control Groups version 2 is now supported with the performance profile feature
+
+Beginning with {product-title} 4.16, Control Groups version 2 (cgroup v2), also known as cgroup2 or cgroupsv2, is enabled by default for all new deployments, even when performance profiles are present. 
+
+Since {product-title} 4.14, cgroups v2 has been the default, but the performance profile feature required the use of cgroups v1. This issue has been resolved.
+
+cgroup v1 is still used in upgraded clusters with performance profiles that have initial installation dates before {product-title} 4.16. cgroup v1 can still be used in the current version by changing the `cgroupMode` field in the `node.config` object to `v1`.
+
+For more information, see xref:../nodes/clusters/nodes-cluster-cgroups-2.adoc#nodes-clusters-cgroups-2[Configuring the Linux cgroup version on your nodes].
+
 
 [id="ocp-4-16-edge-computing"]
 === Edge computing


### PR DESCRIPTION
[TELCODOCS-1703]: Make Cgroups V2 GA for performance profile

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16 RN
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/CNF-10853
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://76399--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-14-nodes-cgroupv2-default
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Already merged in https://github.com/openshift/openshift-docs/pull/75674 here I  am moving to put under Scalability (where perf profile lives). I am making it clear here this is for Performance profile v2 was GA In 4.13 already now working with perf profile

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
