### PR TITLE
OCPBUGS-33400 - add missing uncordon command in graceful restart procedure

### DIFF
--- a/modules/graceful-restart.adoc
+++ b/modules/graceful-restart.adoc
@@ -149,5 +149,13 @@ ip-10-0-182-134.ec2.internal   Ready    worker   70m   v1.29.4
 ip-10-0-211-16.ec2.internal    Ready    master   82m   v1.29.4
 ip-10-0-250-100.ec2.internal   Ready    worker   69m   v1.29.4
 ----
-
++
 If the cluster did not start properly, you might need to restore your cluster using an etcd backup.
+
+. After the control plane and worker nodes are ready, mark all the nodes in the cluster as schedulable.
+Run the following command:
++
+[source,terminal]
+----
+for node in $(oc get nodes -o jsonpath='{.items[*].metadata.name}'); do echo ${node} ; oc adm uncordon ${node} ; done
+----


### PR DESCRIPTION
Completing work started by @kleinffm in https://github.com/openshift/openshift-docs/pull/76328

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-33400

Link to docs preview:
https://76400--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/graceful-cluster-restart.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->