### PR TITLE
OSDOCS-10496-RN: Documented the OSDOCS-10496 RN

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -179,6 +179,18 @@ With this release, you can view the ingress network flows for {product-title} se
 
 For more information, see xref:../installing/install_config/configuring-firewall.html#network-flow-matrix_configuring-firewall[{product-title} network flow matrix].
 
+[id="ocp-4-16-networking-pathing-existing-dual-stack"]
+==== Patching an existing dual-stack network
+
+With this release, you can add IPv6 virtual IPs (VIPs) for API and Ingress services to an existing dual-stack-configured cluster by patching the cluster infrastructure.
+
+If you have already upgraded your cluster to {product-title} {product-version} and you need to convert the single-stack cluster network to a dual-stack cluster network, you must specify the following for your cluster in the YAML configuration patch file:
+
+* An IPv4 network for API and Ingress services on the first `machineNetwork` configuration.
+* An IPv6 network for API and Ingress services on the second `machineNetwork` configuration.
+
+For more information, see xref:../networking/ovn_kubernetes_network_provider/converting-to-dual-stack.html#nw-dual-stack-convert_converting-to-dual-stack[Converting to a dual-stack cluster network] in _Converting to IPv4/IPv6 dual-stack networking_.
+
 [id="ocp-4-16-registry_{context}"]
 === Registry
 
@@ -262,7 +274,7 @@ The Network Observability Operator releases updates independently from the {prod
 
 [id="workload-partitioning-enhancement_{context}"]
 ==== Workload partitioning enhancement
-With this release, platform pods deployed with a workload annotation that includes both CPU limits and CPU requests have the CPU limits accurately calculated and applied as a CPU quota for the specific pod. In earlier releases, if a workload partitioned pod had both CPU limits and requests set, they were ignored by the webhook. The pod did not benefit from workload partitioning and was not locked down to specific cores. This update ensures the requests and limits are now interpreted correctly by the webhook.
+With this release, platform pods deployed with a workload annotation that includes both CPU limits and CPU requests will have the CPU limits accurately calculated and applied as a CPU quota for the specific pod. In prior releases, if a workload partitioned pod had both CPU limits and requests set, they were ignored by the webhook. The pod did not benefit from workload partitioning and was not locked down to specific cores. This update ensures the requests and limits are now interpreted correctly by the webhook.
 
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-10652](https://issues.redhat.com/browse/OSDOCS-10652)

Link to docs preview:
[Patching an existing dual-stack network](https://76405--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-networking-pathing-existing-dual-stack)

- [x] SME has approved this change.
- [x] QE has approved this change.

