### PR TITLE
OCPBUGS-34129: Update Minimal permissions for GCP installs

### DIFF
--- a/modules/minimum-required-permissions-ipi-gcp.adoc
+++ b/modules/minimum-required-permissions-ipi-gcp.adoc
@@ -28,10 +28,16 @@ If your organization’s security policies require a more restrictive set of per
 * `compute.forwardingRules.get`
 * `compute.forwardingRules.list`
 * `compute.forwardingRules.setLabels`
+* `compute.globalAddresses.create`
+* `compute.globalAddresses.get`
+* `compute.globalAddresses.use`
+* `compute.globalForwardingRules.create`
+* `compute.globalForwardingRules.get`
 * `compute.networks.create`
 * `compute.networks.get`
 * `compute.networks.list`
 * `compute.networks.updatePolicy`
+* `compute.networks.use`
 * `compute.routers.create`
 * `compute.routers.get`
 * `compute.routers.list`
@@ -47,6 +53,11 @@ If your organization’s security policies require a more restrictive set of per
 .Required permissions for creating load balancer resources
 [%collapsible]
 ====
+* `compute.backendServices.create`
+* `compute.backendServices.get`
+* `compute.backendServices.list`
+* `compute.backendServices.update`
+* `compute.backendServices.use`
 * `compute.regionBackendServices.create`
 * `compute.regionBackendServices.get`
 * `compute.regionBackendServices.list`
@@ -58,6 +69,9 @@ If your organization’s security policies require a more restrictive set of per
 * `compute.targetPools.list`
 * `compute.targetPools.removeInstance`
 * `compute.targetPools.use`
+* `compute.targetTcpProxies.create`
+* `compute.targetTcpProxies.get`
+* `compute.targetTcpProxies.use`
 ====
 
 .Required permissions for creating DNS resources
@@ -140,6 +154,9 @@ If your organization’s security policies require a more restrictive set of per
 * `compute.httpHealthChecks.get`
 * `compute.httpHealthChecks.list`
 * `compute.httpHealthChecks.useReadOnly`
+* `compute.regionHealthChecks.create`
+* `compute.regionHealthChecks.get`
+* `compute.regionHealthChecks.useReadOnly`
 ====
 
 .Required permissions to get GCP zone and region related information
@@ -147,6 +164,7 @@ If your organization’s security policies require a more restrictive set of per
 ====
 * `compute.globalOperations.get`
 * `compute.regionOperations.get`
+* `compute.regions.get`
 * `compute.regions.list`
 * `compute.zoneOperations.get`
 * `compute.zones.get`
@@ -185,10 +203,15 @@ If your organization’s security policies require a more restrictive set of per
 * `compute.addresses.delete`
 * `compute.addresses.deleteInternal`
 * `compute.addresses.list`
+* `compute.addresses.setLabels`
 * `compute.firewalls.delete`
 * `compute.firewalls.list`
 * `compute.forwardingRules.delete`
 * `compute.forwardingRules.list`
+* `compute.globalAddresses.delete`
+* `compute.globalAddresses.list`
+* `compute.globalForwardingRules.delete`
+* `compute.globalForwardingRules.list`
 * `compute.networks.delete`
 * `compute.networks.list`
 * `compute.networks.updatePolicy`
@@ -202,10 +225,14 @@ If your organization’s security policies require a more restrictive set of per
 .Required permissions for deleting load balancer resources
 [%collapsible]
 ====
+* `compute.backendServices.delete`
+* `compute.backendServices.list`
 * `compute.regionBackendServices.delete`
 * `compute.regionBackendServices.list`
 * `compute.targetPools.delete`
 * `compute.targetPools.list`
+* `compute.targetTcpProxies.delete`
+* `compute.targetTcpProxies.list`
 ====
 
 .Required permissions for deleting DNS resources
@@ -259,6 +286,8 @@ If your organization’s security policies require a more restrictive set of per
 * `compute.healthChecks.list`
 * `compute.httpHealthChecks.delete`
 * `compute.httpHealthChecks.list`
+* `compute.regionHealthChecks.delete`
+* `compute.regionHealthChecks.list`
 ====
 
 .Required Images permissions for deletion

--- a/modules/minimum-required-permissions-upi-gcp.adoc
+++ b/modules/minimum-required-permissions-upi-gcp.adoc
@@ -29,10 +29,17 @@ If your organization’s security policies require a more restrictive set of per
 * `compute.forwardingRules.get`
 * `compute.forwardingRules.list`
 * `compute.forwardingRules.setLabels`
+* `compute.globalAddresses.create`
+* `compute.globalAddresses.get`
+* `compute.globalAddresses.setLabels`
+* `compute.globalAddresses.use`
+* `compute.globalForwardingRules.create`
+* `compute.globalForwardingRules.get`
 * `compute.networks.create`
 * `compute.networks.get`
 * `compute.networks.list`
 * `compute.networks.updatePolicy`
+* `compute.networks.use`
 * `compute.routers.create`
 * `compute.routers.get`
 * `compute.routers.list`
@@ -48,6 +55,11 @@ If your organization’s security policies require a more restrictive set of per
 .Required permissions for creating load balancer resources
 [%collapsible]
 ====
+* `compute.backendServices.create`
+* `compute.backendServices.get`
+* `compute.backendServices.list`
+* `compute.backendServices.update`
+* `compute.backendServices.use`
 * `compute.regionBackendServices.create`
 * `compute.regionBackendServices.get`
 * `compute.regionBackendServices.list`
@@ -59,6 +71,9 @@ If your organization’s security policies require a more restrictive set of per
 * `compute.targetPools.list`
 * `compute.targetPools.removeInstance`
 * `compute.targetPools.use`
+* `compute.targetTcpProxies.create`
+* `compute.targetTcpProxies.get`
+* `compute.targetTcpProxies.use`
 ====
 
 .Required permissions for creating DNS resources
@@ -141,6 +156,10 @@ If your organization’s security policies require a more restrictive set of per
 * `compute.httpHealthChecks.get`
 * `compute.httpHealthChecks.list`
 * `compute.httpHealthChecks.useReadOnly`
+* `compute.regionHealthCheckServices.list`
+* `compute.regionHealthChecks.create`
+* `compute.regionHealthChecks.get`
+* `compute.regionHealthChecks.useReadOnly`
 ====
 
 .Required permissions to get GCP zone and region related information
@@ -148,6 +167,7 @@ If your organization’s security policies require a more restrictive set of per
 ====
 * `compute.globalOperations.get`
 * `compute.regionOperations.get`
+* `compute.regions.get`
 * `compute.regions.list`
 * `compute.zoneOperations.get`
 * `compute.zones.get`
@@ -189,10 +209,15 @@ If your organization’s security policies require a more restrictive set of per
 * `compute.addresses.delete`
 * `compute.addresses.deleteInternal`
 * `compute.addresses.list`
+* `compute.addresses.setLabels`
 * `compute.firewalls.delete`
 * `compute.firewalls.list`
 * `compute.forwardingRules.delete`
 * `compute.forwardingRules.list`
+* `compute.globalAddresses.delete`
+* `compute.globalAddresses.list`
+* `compute.globalForwardingRules.delete`
+* `compute.globalForwardingRules.list`
 * `compute.networks.delete`
 * `compute.networks.list`
 * `compute.networks.updatePolicy`
@@ -206,10 +231,14 @@ If your organization’s security policies require a more restrictive set of per
 .Required permissions for deleting load balancer resources
 [%collapsible]
 ====
+* `compute.backendServices.delete`
+* `compute.backendServices.list`
 * `compute.regionBackendServices.delete`
 * `compute.regionBackendServices.list`
 * `compute.targetPools.delete`
 * `compute.targetPools.list`
+* `compute.targetTcpProxies.delete`
+* `compute.targetTcpProxies.list`
 ====
 
 .Required permissions for deleting DNS resources
@@ -263,6 +292,8 @@ If your organization’s security policies require a more restrictive set of per
 * `compute.healthChecks.list`
 * `compute.httpHealthChecks.delete`
 * `compute.httpHealthChecks.list`
+* `compute.regionHealthChecks.delete`
+* `compute.regionHealthChecks.list`
 ====
 
 .Required Images permissions for deletion


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. --> 
4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OCPBUGS-34129

Link to docs preview:
https://76407--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html
https://76407--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html
https://76407--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

** Due to the addition of CAPG resources, the installer destroy code requires additional minimal permissions. Even though the minimal install does not use CAPG, the search for resources remains the same no matter the type of install.

** NOTE: This does not include the ability to delete these new resources as that is not part of the minimal install and destroy, these additional permissions allow the user to list those resources.


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
