### PR TITLE
adoc tags troubleshooting: separate blocks

### DIFF
--- a/modules/machineset-modifying.adoc
+++ b/modules/machineset-modifying.adoc
@@ -33,44 +33,53 @@ end::MAPI[]
 
 . List the compute machine sets in your cluster by running the following command:
 +
+tag::CAPI[]
 [source,terminal]
 ----
-//tag::CAPI[]
 $ oc get machinesets.cluster.x-k8s.io -n openshift-cluster-api
-//end::CAPI[]
-//tag::MAPI[]
-$ oc get machinesets.machine.openshift.io -n openshift-machine-api
-//end::MAPI[]
 ----
+end::CAPI[]
+tag::MAPI[]
+[source,terminal]
+----
+$ oc get machinesets.machine.openshift.io -n openshift-machine-api
+----
+end::MAPI[]
 +
 .Example output
+tag::CAPI[]
 [source,text]
 ----
-//tag::CAPI[]
 NAME                          CLUSTER             REPLICAS   READY   AVAILABLE   AGE   VERSION
 <compute_machine_set_name_1>  <cluster_name>      1          1       1           26m
 <compute_machine_set_name_2>  <cluster_name>      1          1       1           26m
-//end::CAPI[]
-//tag::MAPI[]
+----
+end::CAPI[]
+tag::MAPI[]
+[source,text]
+----
 NAME                           DESIRED   CURRENT   READY   AVAILABLE   AGE
 <compute_machine_set_name_1>   1         1         1       1           55m
 <compute_machine_set_name_2>   1         1         1       1           55m
-//end::MAPI[]
 ----
+end::MAPI[]
 
 . Edit a compute machine set by running the following command:
 +
+tag::CAPI[]
 [source,terminal]
 ----
-//tag::CAPI[]
 $ oc edit machinesets.cluster.x-k8s.io <machine_set_name> \
   -n openshift-cluster-api
-//end::CAPI[]
-//tag::MAPI[]
+----
+end::CAPI[]
+tag::MAPI[]
+[source,terminal]
+----
 $ oc edit machinesets.machine.openshift.io <machine_set_name> \
   -n openshift-machine-api
-//end::MAPI[]
 ----
+end::MAPI[]
 
 . Note the value of the `spec.replicas` field, as you need it when scaling the machine set to apply the changes.
 +
@@ -101,182 +110,217 @@ spec:
 
 . List the machines that are managed by the updated compute machine set by running the following command:
 +
+tag::CAPI[]
 [source,terminal]
 ----
-//tag::CAPI[]
 $ oc get machines.cluster.x-k8s.io \
   -n openshift-cluster-api \
   -l cluster.x-k8s.io/set-name=<machine_set_name>
-//end::CAPI[]
-//tag::MAPI[]
+----
+end::CAPI[]
+tag::MAPI[]
+[source,terminal]
+----
 $ oc get machines.machine.openshift.io \
   -n openshift-machine-api \
   -l machine.openshift.io/cluster-api-machineset=<machine_set_name>
-//end::MAPI[]
 ----
+end::MAPI[]
 +
 .Example output
+tag::CAPI[]
 [source,text]
 ----
-//tag::CAPI[]
 NAME                        CLUSTER          NODENAME                                    PROVIDERID                              PHASE           AGE     VERSION
 <machine_name_original_1>   <cluster_name>   <original_1_ip>.<region>.compute.internal   aws:///us-east-2a/i-04e7b2cbd61fd2075   Running         4h
 <machine_name_original_2>   <cluster_name>   <original_2_ip>.<region>.compute.internal   aws:///us-east-2a/i-04e7b2cbd61fd2075   Running         4h
-//end::CAPI[]
-//tag::MAPI[]
+----
+end::CAPI[]
+tag::MAPI[]
+[source,text]
+----
 NAME                        PHASE     TYPE         REGION      ZONE         AGE
 <machine_name_original_1>   Running   m6i.xlarge   us-west-1   us-west-1a   4h
 <machine_name_original_2>   Running   m6i.xlarge   us-west-1   us-west-1a   4h
-//end::MAPI[]
 ----
+end::MAPI[]
 
 . For each machine that is managed by the updated compute machine set, set the `delete` annotation by running the following command:
 +
+tag::CAPI[]
 [source,terminal]
 ----
-//tag::CAPI[]
 $ oc annotate machines.cluster.x-k8s.io/<machine_name_original_1> \
   -n openshift-cluster-api \
   cluster.x-k8s.io/delete-machine="true"
-//end::CAPI[]
-//tag::MAPI[]
+----
+end::CAPI[]
+tag::MAPI[]
+[source,terminal]
+----
 $ oc annotate machine.machine.openshift.io/<machine_name_original_1> \
   -n openshift-machine-api \
   machine.openshift.io/delete-machine="true"
-//end::MAPI[]
 ----
+end::MAPI[]
 
 . Scale the compute machine set to twice the number of replicas by running the following command:
 +
+tag::CAPI[]
 [source,terminal]
 ----
 $ oc scale --replicas=4 \// <1>
-//tag::CAPI[]
   machinesets.cluster.x-k8s.io <machine_set_name> \
   -n openshift-cluster-api
-//end::CAPI[]
-//tag::MAPI[]
+----
+end::CAPI[]
+tag::MAPI[]
+[source,terminal]
+----
+$ oc scale --replicas=4 \// <1>
   machineset.machine.openshift.io <machine_set_name> \
   -n openshift-machine-api
-//end::MAPI[]
 ----
+end::MAPI[]
 <1> The original example value of `2` is doubled to `4`.
 
 . List the machines that are managed by the updated compute machine set by running the following command:
 +
+tag::CAPI[]
 [source,terminal]
 ----
-//tag::CAPI[]
 $ oc get machines.cluster.x-k8s.io \
   -n openshift-cluster-api \
   -l cluster.x-k8s.io/set-name=<machine_set_name>
-//end::CAPI[]
-//tag::MAPI[]
+----
+end::CAPI[]
+tag::MAPI[]
+[source,terminal]
+----
 $ oc get machines.machine.openshift.io \
   -n openshift-machine-api \
   -l machine.openshift.io/cluster-api-machineset=<machine_set_name>
-//end::MAPI[]
 ----
+end::MAPI[]
 +
-.Example output
+.Example output for an AWS cluster
+tag::CAPI[]
 [source,text]
 ----
-//tag::CAPI[]
 NAME                        CLUSTER          NODENAME                                    PROVIDERID                              PHASE           AGE     VERSION
 <machine_name_original_1>   <cluster_name>   <original_1_ip>.<region>.compute.internal   aws:///us-east-2a/i-04e7b2cbd61fd2075   Running         4h
 <machine_name_original_2>   <cluster_name>   <original_2_ip>.<region>.compute.internal   aws:///us-east-2a/i-04e7b2cbd61fd2075   Running         4h
 <machine_name_updated_1>    <cluster_name>   <updated_1_ip>.<region>.compute.internal    aws:///us-east-2a/i-04e7b2cbd61fd2075   Provisioned     55s
 <machine_name_updated_2>    <cluster_name>   <updated_2_ip>.<region>.compute.internal    aws:///us-east-2a/i-04e7b2cbd61fd2075   Provisioning    55s
-//end::CAPI[]
-//tag::MAPI[]
+----
+end::CAPI[]
+tag::MAPI[]
+[source,text]
+----
 NAME                        PHASE          TYPE         REGION      ZONE         AGE
 <machine_name_original_1>   Running        m6i.xlarge   us-west-1   us-west-1a   4h
 <machine_name_original_2>   Running        m6i.xlarge   us-west-1   us-west-1a   4h
 <machine_name_updated_1>    Provisioned    m6i.xlarge   us-west-1   us-west-1a   55s
 <machine_name_updated_2>    Provisioning   m6i.xlarge   us-west-1   us-west-1a   55s
-//end::MAPI[]
 ----
+end::MAPI[]
 +
 When the new machines are in the `Running` phase, you can scale the compute machine set to the original number of replicas.
 
 . Scale the compute machine set to the original number of replicas by running the following command:
 +
+tag::CAPI[]
 [source,terminal]
 ----
 $ oc scale --replicas=2 \// <1>
-//tag::CAPI[]
   machinesets.cluster.x-k8s.io <machine_set_name> \
   -n openshift-cluster-api
-//end::CAPI[]
-//tag::MAPI[]
+----
+end::CAPI[]
+tag::MAPI[]
+[source,terminal]
+----
+$ oc scale --replicas=2 \// <1>
   machineset.machine.openshift.io <machine_set_name> \
   -n openshift-machine-api
-//end::MAPI[]
 ----
+end::MAPI[]
 <1> The original example value of `2`.
 
 .Verification
 
 * To verify that a machine created by the updated machine set has the correct configuration, examine the relevant fields in the CR for one of the new machines by running the following command:
 +
+tag::CAPI[]
 [source,terminal]
 ----
-//tag::CAPI[]
 $ oc describe machines.cluster.x-k8s.io <machine_name_updated_1> \
   -n openshift-cluster-api
-//end::CAPI[]
-//tag::MAPI[]
+----
+end::CAPI[]
+tag::MAPI[]
+[source,terminal]
+----
 $ oc describe machine.machine.openshift.io <machine_name_updated_1> \
   -n openshift-machine-api
-//end::MAPI[]
 ----
+end::MAPI[]
 
 * To verify that the compute machines without the updated configuration are deleted, list the machines that are managed by the updated compute machine set by running the following command:
 +
+tag::CAPI[]
 [source,terminal]
 ----
-//tag::CAPI[]
 $ oc get machines.cluster.x-k8s.io \
   -n openshift-cluster-api \
   cluster.x-k8s.io/set-name=<machine_set_name>
-//end::CAPI[]
-//tag::MAPI[]
+----
+end::CAPI[]
+tag::MAPI[]
+[source,terminal]
+----
 $ oc get machines.machine.openshift.io \
   -n openshift-machine-api \
   -l machine.openshift.io/cluster-api-machineset=<machine_set_name>
-//end::MAPI[]
 ----
+end::MAPI[]
 +
-.Example output while deletion is in progress
+.Example output while deletion is in progress for an AWS cluster
+tag::CAPI[]
 [source,text]
 ----
-//tag::CAPI[]
 NAME                        CLUSTER          NODENAME                                    PROVIDERID                              PHASE      AGE     VERSION
 <machine_name_original_1>   <cluster_name>   <original_1_ip>.<region>.compute.internal   aws:///us-east-2a/i-04e7b2cbd61fd2075   Running    18m
 <machine_name_original_2>   <cluster_name>   <original_2_ip>.<region>.compute.internal   aws:///us-east-2a/i-04e7b2cbd61fd2075   Running    18m
 <machine_name_updated_1>    <cluster_name>   <updated_1_ip>.<region>.compute.internal    aws:///us-east-2a/i-04e7b2cbd61fd2075   Running    18m
 <machine_name_updated_2>    <cluster_name>   <updated_2_ip>.<region>.compute.internal    aws:///us-east-2a/i-04e7b2cbd61fd2075   Running    18m
-//end::CAPI[]
-//tag::MAPI[]
+----
+end::CAPI[]
+tag::MAPI[]
+[source,text]
+----
 NAME                        PHASE           TYPE         REGION      ZONE         AGE
 <machine_name_original_1>   Deleting        m6i.xlarge   us-west-1   us-west-1a   4h
 <machine_name_original_2>   Deleting        m6i.xlarge   us-west-1   us-west-1a   4h
 <machine_name_updated_1>    Running         m6i.xlarge   us-west-1   us-west-1a   5m41s
 <machine_name_updated_2>    Running         m6i.xlarge   us-west-1   us-west-1a   5m41s
-//end::MAPI[]
 ----
+end::MAPI[]
 +
-.Example output when deletion is complete
+.Example output when deletion is complete for an AWS cluster
+tag::CAPI[]
 [source,text]
 ----
-//tag::CAPI[]
 NAME                        CLUSTER          NODENAME                                    PROVIDERID                              PHASE      AGE     VERSION
 <machine_name_updated_1>    <cluster_name>   <updated_1_ip>.<region>.compute.internal    aws:///us-east-2a/i-04e7b2cbd61fd2075   Running    18m
 <machine_name_updated_2>    <cluster_name>   <updated_2_ip>.<region>.compute.internal    aws:///us-east-2a/i-04e7b2cbd61fd2075   Running    18m
-//end::CAPI[]
-//tag::MAPI[]
+----
+end::CAPI[]
+tag::MAPI[]
+[source,text]
+----
 NAME                        PHASE           TYPE         REGION      ZONE         AGE
 <machine_name_updated_1>    Running         m6i.xlarge   us-west-1   us-west-1a   6m30s
 <machine_name_updated_2>    Running         m6i.xlarge   us-west-1   us-west-1a   6m30s
-//end::MAPI[]
 ----
+end::MAPI[]


### PR DESCRIPTION
Followup to #76324

Attempt method 2: Separate MAPI/CAPI blocks for commands

More info: https://docs.google.com/document/d/165PuwDWjuUxRFBfG7-QWTQhXjaifBVuraEUiv156Wbs/edit

Note: the cherrypick caught a couple example heading updates too, those should have been cherrypicked earlier so this is fine.

Previews:
- [CAPI](https://76453--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster-api-managing-machines.html#machineset-modifying_cluster-api-managing-machines)
- [MAPI](https://76453--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/modifying-machineset.html#machineset-modifying_modifying-machineset)