### PR TITLE
Update ROSA HCP topic map

### DIFF
--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -692,15 +692,73 @@ Topics:
 # ---
 # Name: CI/CD
 # Dir: cicd
-# Distros: openshift-rosa-hcp
+# Distros: openshift-rosa
 # Topics:
-# - Name: Builds
-#   Dir: builds
-#   Distros: openshift-rosa-hcp
+# - Name: CI/CD overview
+#   File: index
+# This can be included when Shipwright is ported.
+# - Name: Builds using Shipwright
+#   Dir: builds_using_shipwright
 #   Topics:
-#   - Name: Setting up additional trusted certificate authorities for builds
-#     File: setting-up-trusted-ca
-#     Distros: openshift-rosa-hcp
+#   - Name: Overview of Builds
+#     File: overview-openshift-builds
+# - Name: Builds using BuildConfig
+#   Dir: builds
+#   Topics:
+#   - Name: Understanding image builds
+#     File: understanding-image-builds
+#   - Name: Understanding build configurations
+#     File: understanding-buildconfigs
+#   - Name: Creating build inputs
+#     File: creating-build-inputs
+#   - Name: Managing build output
+#     File: managing-build-output
+#   - Name: Using build strategies
+#     File: build-strategies
+#   - Name: Custom image builds with Buildah
+#     File: custom-builds-buildah
+#   - Name: Performing and configuring basic builds
+#     File: basic-build-operations
+#   - Name: Triggering and modifying builds
+#     File: triggering-builds-build-hooks
+#   - Name: Performing advanced builds
+#     File: advanced-build-operations
+#   - Name: Using Red Hat subscriptions in builds
+#     File: running-entitled-builds
+# Dedicated-admin cannot secure builds by strategy
+#   - Name: Securing builds by strategy
+#     File: securing-builds-by-strategy
+# Dedicated-admin cannot edit build configuration resources
+#  - Name: Build configuration resources
+#    File: build-configuration
+#  - Name: Troubleshooting builds
+#    File: troubleshooting-builds
+#  - Name: Setting up additional trusted certificate authorities for builds
+#    File: setting-up-trusted-ca
+# This can be included when Pipelines is ported.
+#  - Name: Pipelines
+#    Dir: pipelines
+#    Topics:
+#    - Name: About OpenShift Pipelines
+#      File: about-pipelines
+# This can be included when GitOps is ported.
+#  - Name: GitOps
+#    Dir: gitops
+#    Topics:
+#    - Name: About OpenShift GitOps
+#      File: about-redhat-openshift-gitops
+# - Name: Jenkins
+#   Dir: jenkins
+#   Topics:
+#   - Name: Configuring Jenkins images
+#     File: images-other-jenkins
+#   - Name: Jenkins agent
+#     File: images-other-jenkins-agent
+# Include this when Pipelines is ported:
+#   - Name: Migrating from Jenkins to OpenShift Pipelines
+#     File: migrating-from-jenkins-to-openshift-pipelines
+#   - Name: Important changes to OpenShift Jenkins images
+#     File: important-changes-to-openshift-jenkins-images
 # ---
 # Name: Images
 # Dir: openshift_images


### PR DESCRIPTION
In https://github.com/openshift/openshift-docs/pull/73661, I neglected to add the updated CI/CD content to the ROSA HCP topic map. This PR adds it.

Version(s):
- enterprise-4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-9984

Link to docs preview:
N/A - The added content is commented-out for now.

QE review:
- Not needed
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Note to peer reviewer: This PR has a M size, but it's really more of an XS. It's just a copy-and-paste of the CI/CD content from the ROSA topic map to the ROSA HCP topic map, with everything commented out.
