### PR TITLE
Add release note for changing OVN-Kubernetes internal subnet

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -167,7 +167,6 @@ For further information, see xref:../networking/hardware_networks/configuring-sr
 As of {product-title} 4.16, the SR-IOV Network Operator no longer automatically creates a `SriovOperatorConfig` custom resource (CR). Create the `SriovOperatorConfig` CR using the procedure described in xref:../networking/hardware_networks/configuring-sriov-operator.adoc#nw-sriov-configuring-operator_configuring-sriov-operator[Configuring the SR-IOV Network Operator].
 
 [id="ocp-4-16-q-in-q-support_{context}"]
-[id="ocp-4-16-q-in-q-support"]
 ==== Supporting double-tagged packets (QinQ)
 
 This release introduces 802.1Q-in-802.1Q also known as QinQ support. QinQ introduces a second VLAN tag, where the service provider designates the outer tag for their use, offering them flexibility, while the inner tag remains dedicated to the customer’s VLAN. When two VLAN tags are present in a packet, the outer VLAN tag can be either 802.1Q or 802.1ad. The inner VLAN tag must always be 802.1Q.
@@ -208,6 +207,17 @@ If you have already upgraded your cluster to {product-title} {product-version} a
 * An IPv6 network for API and Ingress services on the second `machineNetwork` configuration.
 
 For more information, see xref:../networking/ovn_kubernetes_network_provider/converting-to-dual-stack.html#nw-dual-stack-convert_converting-to-dual-stack[Converting to a dual-stack cluster network] in _Converting to IPv4/IPv6 dual-stack networking_.
+
+[id="ocp-4-16-networking-changing-ovn-kubernetes-network-plugin-internal-range_{context}"]
+==== Support for changing the OVN-Kubernetes network plugin internal IP address ranges
+
+If you use the OVN-Kubernetes network plugin, you can configure the transit, join, and masquerade subnets. The transit and join subnets can be configured either during cluster installation or after. The masquerade subnet must be configured during installation and cannot be changed after. The subnet defaults are:
+
+- Transit subnet: `100.88.0.0/16` and `fd97::/64`
+- Join subnet: `100.64.0.0/16` and `fd98::/64`
+- Masquerade subnet: `169.254.169.0/29` and `fd69::/125`
+
+For more information about these configuration fields, see xref:../networking/cluster-network-operator.adoc#nw-operator-cr-cno-object_cluster-network-operator[Cluster Network Operator configuration object]. For more information about configuring the transit and join subnets on an existing cluster, see Configure OVN-Kubernetes internal IP address subnets.
 
 [id="ocp-4-16-registry_{context}"]
 === Registry


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-4969
- https://issues.redhat.com/browse/SDN-3516

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

[Support for changing the OVN-Kubernetes network plugin internal IP address ranges](https://76472--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-networking-changing-ovn-kubernetes-network-plugin-internal-range_release-notes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
