### PR TITLE
[internal-fix] Multiarch compute level 1 titles attributes not resolving

### DIFF
--- a/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-bare-metal.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-bare-metal.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
 :context: creating-multi-arch-compute-nodes-bare-metal
+include::_attributes/common-attributes.adoc[]
 [id="creating-multi-arch-compute-nodes-bare-metal"]
 = Creating a cluster with multi-architecture compute machines on bare metal, {ibm-power-title}, or {ibm-z-title}
-include::_attributes/common-attributes.adoc[]
 
 toc::[]
 

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-power.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-power.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
 :context: creating-multi-arch-compute-nodes-ibm-power
+include::_attributes/common-attributes.adoc[]
 [id="creating-multi-arch-compute-nodes-ibm-power"]
 = Creating a cluster with multi-architecture compute machines on {ibm-power-title}
-include::_attributes/common-attributes.adoc[]
 
 toc::[]
 

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z-kvm.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z-kvm.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
 :context: creating-multi-arch-compute-nodes-ibm-z-kvm
+include::_attributes/common-attributes.adoc[]
 [id="creating-multi-arch-compute-nodes-ibm-z-kvm"]
 = Creating a cluster with multi-architecture compute machines on {ibm-z-title} and {ibm-linuxone-title} with {op-system-base} KVM
-include::_attributes/common-attributes.adoc[]
 
 toc::[]
 

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
 :context: creating-multi-arch-compute-nodes-ibm-z
+include::_attributes/common-attributes.adoc[]
 [id="creating-multi-arch-compute-nodes-ibm-z"]
 = Creating a cluster with multi-architecture compute machines on {ibm-z-title} and {ibm-linuxone-title} with z/VM
-include::_attributes/common-attributes.adoc[]
 
 toc::[]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+ 

Issue: common attributes don't resolve in level 1 headings common attribute include needs to be moved before the heading
Related PR where these files where missed: https://github.com/openshift/openshift-docs/pull/76136
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [NA this is an internal fix] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
