### PR TITLE
MIG-1561: Release Notes for MTC 1.7.16

### DIFF
--- a/migration_toolkit_for_containers/release_notes/mtc-release-notes-1-7.adoc
+++ b/migration_toolkit_for_containers/release_notes/mtc-release-notes-1-7.adoc
@@ -17,6 +17,7 @@ You can migrate from xref:../../migrating_from_ocp_3_to_4/about-migrating-from-3
 
 For information on the support policy for {mtc-short}, see link:https://access.redhat.com/support/policy/updates/openshift#app_migration[OpenShift Application and Cluster Migration Solutions], part of the _Red Hat {product-title} Life Cycle Policy_.
 
+include::modules/migration-mtc-release-notes-1-7-16.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-7-15.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-7-14.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-7-13.adoc[leveloffset=+1]

--- a/modules/migration-mtc-release-notes-1-7-16.adoc
+++ b/modules/migration-mtc-release-notes-1-7-16.adoc
@@ -1,0 +1,77 @@
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="migration-mtc-release-notes-1-7-16_{context}"]
+= {mtc-full} 1.7.16 release notes
+
+[id="resolved-issues-1-7-16_{context}"]
+== Resolved issues
+
+This release has the following resolved issues:
+
+.CVE-2023-45290: Golang: `net/http`: Memory exhaustion in the `Request.ParseMultipartForm` method
+
+A flaw was found in the `net/http` Golang standard library package, which impacts earlier versions of {mtc-short}. When parsing a `multipart` form, either explicitly with `Request.ParseMultipartForm` or implicitly with `Request.FormValue`, `Request.PostFormValue`, or `Request.FormFile` methods, limits on the total size of the parsed form are not applied to the memory consumed while reading a single form line. This permits a maliciously crafted input containing long lines to cause the allocation of arbitrarily large amounts of memory, potentially leading to memory exhaustion.
+
+To resolve this issue, upgrade to {mtc-short} 1.7.16.
+
+For more details, see link:https://access.redhat.com/security/cve/CVE-2023-45290[CVE-2023-45290]
+
+.CVE-2024-24783: Golang: `crypto/x509`: Verify panics on certificates with an unknown public key algorithm
+
+A flaw was found in the `crypto/x509` Golang standard library package, which impacts earlier versions of {mtc-short}. Verifying a certificate chain that contains a certificate with an unknown public key algorithm causes `Certificate.Verify` to panic. This affects all `crypto/tls` clients and servers that set `Config.ClientAuth` to `VerifyClientCertIfGiven` or `RequireAndVerifyClientCert`. The default behavior is for TLS servers to not verify client certificates.
+
+To resolve this issue, upgrade to {mtc-short} 1.7.16.
+
+For more details, see link:https://access.redhat.com/security/cve/cve-2024-24783[CVE-2024-24783].
+
+.CVE-2024-24784: Golang: `net/mail`: Comments in display names are incorrectly handled
+
+A flaw was found in the `net/mail` Golang standard library package, which impacts earlier versions of {mtc-short}. The `ParseAddressList` function incorrectly handles comments, text in parentheses, and display names. As this is a misalignment with conforming address parsers, it can result in different trust decisions being made by programs using different parsers.
+
+To resolve this issue, upgrade to {mtc-short} 1.7.16.
+
+For more details, see link:https://access.redhat.com/security/cve/cve-2024-24784[CVE-2024-24784].
+
+.CVE-2024-24785: Golang: `html/template`: Errors returned from `MarshalJSON` methods may break template escaping
+
+A flaw was found in the `html/template` Golang standard library package, which impacts earlier versions of {mtc-short}. If errors returned from `MarshalJSON` methods contain user-controlled data, they could be used to break the contextual auto-escaping behavior of the `html/template` package, allowing subsequent actions to inject unexpected content into templates.
+
+To resolve this issue, upgrade to {mtc-short} 1.7.16.
+
+For more details, see link:https://access.redhat.com/security/cve/cve-2024-24785[CVE-2024-24785].
+
+.CVE-2024-29180: `webpack-dev-middleware`: Lack of URL validation may lead to file leak
+
+A flaw was found in the `webpack-dev-middleware package`, which impacts earlier versions of {mtc-short}. This flaw fails to validate the supplied URL address sufficiently before returning local files, which could allow an attacker to craft URLs to return arbitrary local files from the developer's machine.
+
+To resolve this issue, upgrade to {mtc-short} 1.7.16.
+
+For more details, see link:https://access.redhat.com/security/cve/cve-2024-29180[CVE-2024-29180].
+
+.CVE-2024-30255: `envoy`: HTTP/2 CPU exhaustion due to CONTINUATION frame flood
+
+A flaw was found in how the `envoy` proxy implements the HTTP/2 codec, which impacts earlier versions of {mtc-short}. There are insufficient limitations placed on the number of `CONTINUATION` frames that can be sent within a single stream, even after exceeding the header map limits of `envoy`. This flaw could allow an unauthenticated remote attacker to send packets to vulnerable servers. These packets could consume compute resources and cause a denial of service (DoS).
+
+To resolve this issue, upgrade to {mtc-short} 1.7.16.
+
+For more details, see link:https://access.redhat.com/security/cve/cve-2024-30255[CVE-2024-30255].
+
+
+[id="known-issues-1-7-16_{context}"]
+== Known issues
+
+This release has the following known issues:
+
+.Direct Volume Migration is failing as the Rsync pod on the source cluster goes into an `Error` state
+
+On migrating any application with a Persistent Volume Claim (PVC), the `Stage` migration operation succeeds with warnings, but the Direct Volume Migration (DVM) fails with the `rsync` pod on the source namespace moving into an `error` state. link:https://bugzilla.redhat.com/show_bug.cgi?id=2256141[(BZ#2256141)]
+
+.The conflict condition is briefly cleared after it is created
+
+When creating a new state migration plan that returns a conflict error message, the error message is cleared very shortly after it is displayed. link:https://bugzilla.redhat.com/show_bug.cgi?id=2144299[(BZ#2144299)]
+
+.Migration fails when there are multiple Volume Snapshot Locations of different provider types configured in a cluster
+
+When there are multiple Volume Snapshot Locations (VSLs) in a cluster with different provider types, but you have not set any of them as the default VSL, Velero results in a validation error that causes migration operations to fail. link:https://bugzilla.redhat.com/show_bug.cgi?id=2180565[(BZ#2180565)]


### PR DESCRIPTION
### Jira

* [MIG-1561](https://issues.redhat.com/browse/MIG-1561)

### Version(s):

* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16

### Link to docs preview:

* [Migration Toolkit for Containers 1.7.16 release notes](https://76487--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/release_notes/mtc-release-notes-1-7.html#migration-mtc-release-notes-1-7-16_mtc-release-notes)


### QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
