### PR TITLE
PR for SRVLOGIC-189: Added the installtion and uninstallation assemblies for Openshift Serverless Logic docs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -108,6 +108,7 @@
 :ServerlessProductName: OpenShift Serverless
 :ServerlessProductShortName: Serverless
 :ServerlessOperatorName: OpenShift Serverless Operator
+:ServerlessLogicOperatorName: OpenShift Serverless Logic Operator
 :FunctionsProductName: OpenShift Serverless Functions
 :ServerlessProductVersion: 1.31.0
 //service mesh v2

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -37,6 +37,10 @@ Topics:
   File: kube-rbac-proxy-kafka
 - Name: Configuring OpenShift Serverless Functions
   File: configuring-serverless-functions
+- Name: Installing the OpenShift Serverless Logic Operator
+  File: install-serverless-logic-operator
+- Name: Installing the OpenShift Serverless Logic Knative Workflow plugin
+  File: serverless-logic-install-kn-workflow-plugin-cli
 - Name: OpenShift Serverless upgrades
   File: serverless-upgrades
 ---
@@ -450,5 +454,7 @@ Topics:
   File: uninstalling-knative-serving
 - Name: Removing OpenShift Serverless Operator
   File: removing-serverless-operator
+- Name: Removing the OpenShift Serverless Logic Operator
+  File: removing-openshift-serverless-logic-operator
 - Name: Deleting OpenShift Serverless CRDs
   File: deleting-serverless-crds

--- a/install/install-serverless-logic-operator.adoc
+++ b/install/install-serverless-logic-operator.adoc
@@ -1,0 +1,21 @@
+:_content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="install-serverless-logic-operator"]
+= Installing the {ServerlessLogicOperatorName}
+:context: install-serverless-logic-operator
+
+toc::[]
+
+Installing the {ServerlessLogicOperatorName} enables you to install and use link:https://serverlessworkflow.io[Serverless Workflow] on a {ocp-product-title} cluster. The {ServerlessLogicOperatorName} manages Kubernetes custom resource definitions (CRDs) to configure and deploy the workflows.
+
+//install doc
+include::modules/serverless-logic-install-web-console.adoc[leveloffset=+1]
+
+[id="additional-resources_install-serverless-logic-operator"]
+[role="_additional-resources"]
+== Additional resources
+* link:https://docs.openshift.com/container-platform/latest/operators/understanding/crds/crd-managing-resources-from-crds.html[Managing resources from custom resource definitions]
+* link:https://docs.openshift.com/container-platform/latest/storage/understanding-persistent-storage.html#understanding-persistent-storage[Understanding persistent storage]
+* link:https://docs.openshift.com/container-platform/latest/networking/configuring-a-custom-pki.html[Configuring a custom PKI]
+
+

--- a/install/serverless-logic-install-kn-workflow-plugin-cli.adoc
+++ b/install/serverless-logic-install-kn-workflow-plugin-cli.adoc
@@ -1,0 +1,12 @@
+:_content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="serverless-logic-install-kn-workflow-plugin-cli"]
+= Installing the OpenShift Serverless Logic Knative Workflow plugin
+:context: serverless-logic-install-kn-workflow-artifact-images
+
+toc::[]
+
+OpenShift Serverless Logic provides a plugin named `kn-workflow` for the Knative CLI, enabling you to set up a local workflow project using the command line.
+
+//install doc
+include::modules/serverless-logic-install-kn-workflow-artifact-images.adoc[leveloffset=+1]

--- a/modules/serverless-logic-install-kn-workflow-artifact-images.adoc
+++ b/modules/serverless-logic-install-kn-workflow-artifact-images.adoc
@@ -1,0 +1,157 @@
+// Module included in the following assemblies:
+//
+// * /serverless/install/serverless-logic-install-kn-workflow-plugin-cli.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-logic-install-kn-workflow-artifact-images_{context}"]
+= Installing the OpenShift Serverless Logic Knative Workflow plugin using the artifacts image
+
+.Prerequisites
+
+* You have installed the Knative (`kn`) CLI.
+* You have installed Podman on your local machine. 
+
+.Procedure
+
+. Download the Knative Workflow plugin using the `logic-kn-workflow-cli-artifacts-rhel8` image by running the following commands:
+
+.. Log in to the Red{nbsp}Hat Registry by running the following command:
++
+[source,terminal]
+----
+$ podman login registry.redhat.io
+----
++
+You can use your Red{nbsp}Hat Customer Portal account or a registry service account.
+
+.. Set a variable for `KN_IMAGE` to start the `logic-kn-workflow-cli-artifacts-rhel8` image by running the following command:
++
+[source,terminal]
+----
+$ export KN_IMAGE=registry.redhat.io/openshift-serverless-1/logic-kn-workflow-cli-artifacts-rhel8:1.33.0
+----
+
+.. Set a variable for `KN_CONTAINER_ID` by running the following command:
++
+[source,terminal]
+----
+$ export KN_CONTAINER_ID=$(podman run -di $KN_IMAGE)
+----
+
+.. Copy the Knative Workflow plugin binary file by running the following command:
++
+[source,terminal]
+----
+$ podman cp $KN_CONTAINER_ID:<path_to_binary> .
+----
++
+where `<path_to_binary>` is the path to the file for your environment:
++
+[cols=2,options=header]
+|===
+|Environment
+|Path to binary file
+
+|Linux amd64 architecture
+|`/usr/share/kn/linux_amd64/kn-workflow-linux-amd64.tar.gz`
+
+|Linux arm64 architecture
+|`/usr/share/kn/linux_arm64/kn-workflow-linux-arm64.tar.gz`
+
+|macOS amd64 architecture
+|`/usr/share/kn/macos_amd64/kn-workflow-macos-amd64.tar.gz`
+
+|macOS arm64 architecture
+|`/usr/share/kn/macos_arm64/kn-workflow-macos-arm64.tar.gz`
+
+|Windows amd64 architecture
+|`/usr/share/kn/windows/kn-workflow-windows-amd64.zip`
+|===
+
+.. Stop the container by running the following command:
++
+[source,terminal]
+----
+$ podman stop $KN_CONTAINER_ID
+----
+
+.. Delete the container by running the following command:
++
+[source,terminal]
+----
+$ podman rm $KN_CONTAINER_ID
+----
+
+.. Extract the selected Knative Workflow plugin binary file by running the following command:
++
+[source,terminal]
+----
+$ tar xvzf kn-workflow-linux-amd64.tar.gz
+----
+
+.. Rename the Knative Workflow plugin binary file to `kn-workflow` by running the following command:
++
+[source,terminal]
+----
+$ mv kn kn-workflow
+----
+
+. Install the `kn-workflow` command as a plugin of the Knative CLI by running the following commands:
+
+.. Copy the `kn-workflow` binary file to a directory in your PATH, such as `/usr/local/bin`, and ensure the file name is `kn-workflow`:
++
+[source,terminal]
+----
+$ cp path/to/downloaded/kn-workflow /usr/local/bin/kn-workflow
+----
+
+.. Make the binary file executable:
++
+[source,terminal]
+----
+$ chmod +x /usr/local/bin/kn-workflow
+----
+
+.Verification
+. Run the following command to verify that the `kn-workflow` plugin is installed successfully:
++
+[source,terminal]
+----
+$ kn plugin list
+----
+
+. After installing the plugin, you can use `kn-workflow` to run the related subcommands.
++
+.Aliases to use workflow subcommand
+[source,terminal]
+----
+kn-workflow
+----
++
+.Example output of `kn-workflow help` command
+[source,terminal]
+----
+Manage OpenShift Serverless Logic Workflow projects
+
+Usage:
+  kn workflow [command]
+
+Aliases:
+  kn workflow, kn-workflow
+
+Available Commands:
+  completion  Generate the autocompletion script for the specified shell
+  create      Creates a new OpenShift Serverless Logic Workflow project
+  deploy      Deploy an OpenShift Serverless Logic Workflow project on Kubernetes via SonataFlow Operator
+  help        Help about any command
+  quarkus     Manage OpenShift Serverless Logic Workflow projects built in Quarkus
+  run         Run an OpenShift Serverless Logic Workflow project in development mode
+  undeploy    Undeploy an OpenShift Serverless Logic Workflow project on Kubernetes via SonataFlow Operator
+  version     Show the version
+
+Flags:
+  -h, --help      help for kn
+  -v, --version   version for kn
+
+Use "kn [command] --help" for more information about a command.
+----

--- a/modules/serverless-logic-install-web-console.adoc
+++ b/modules/serverless-logic-install-web-console.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// * /serverless/install/install-serverless-operator.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-logic-install-web-console_{context}"]
+= Installing the {ServerlessLogicOperatorName} from the web console
+
+You can install the {ServerlessLogicOperatorName} from OperatorHub by using the {ocp-product-title} web console.
+
+.Prerequisites
+
+* You have cluster administrator permissions on {ocp-product-title}, or you have cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
+* For {ocp-product-title}, your cluster has the Marketplace capability enabled or the Red{nbsp}Hat-provided Operator catalogs source configured manually.
+* You have logged in to the  web console.
+
+.Procedure
+
+. In the web console, navigate to the *Operators* -> *OperatorHub* page.
+
+. Scroll, or type the keyword *Serverless Logic* into the *Filter by keyword* box to find the {ServerlessLogicOperatorName}.
+
+. Review the information about the Operator and click *Install*.
+
+. On the *Install Operator* page, ensure that the configuration uses the following settings:
+
+.. The *Installation Mode* is *All namespaces on the cluster (default)*. This mode installs the Operator in the default `openshift-serverless-logic` namespace to watch and be made available to all namespaces in the cluster.
+
+.. The *Installed Namespace* is `openshift-serverless-logic`.
+
+.. Select the *stable* channel as the *Update Channel*. The *stable* channel will enable installation of the latest stable release of the {ServerlessLogicOperatorName}.
+
+.. Select *Automatic* or *Manual* approval strategy.
+
+. Click *Install* to make the Operator available to the selected namespaces on this {ocp-product-title} cluster.
+
+. From the *Catalog* -> *Operator Management* page, you can monitor the {ServerlessLogicOperatorName} subscription's installation and upgrade progress.
+
+** If you selected a *Manual* approval strategy, the subscription's upgrade status will remain *Upgrading* until you review and approve its install plan. After approving on the *Install Plan* page, the subscription upgrade status moves to *Up to date*.
+
+** If you selected an *Automatic* approval strategy, the upgrade status should resolve to *Up to date* without intervention.
+
+.Verification
+
+* After the subscription's upgrade status is *Up to date*, select *Catalog* -> *Installed Operators* to verify that the {ServerlessLogicOperatorName} eventually shows up and its *Status* ultimately resolves to *InstallSucceeded* in the relevant namespace.
++
+If it does not, check the following items:
+
+.. Switch to the *Catalog* -> *Operator Management* page and inspect the *Operator Subscriptions* and *Install Plans* tabs for any failure or errors under *Status*.
+
+.. Check the logs in any pods in the `openshift-serverless-logic` project on the *Workloads* -> *Pods* page that are reporting issues to troubleshoot further.

--- a/removing/removing-openshift-serverless-logic-operator.adoc
+++ b/removing/removing-openshift-serverless-logic-operator.adoc
@@ -1,0 +1,13 @@
+:_content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="removing-openshift-serverless-logic-operator"]
+= Removing the OpenShift Serverless Logic Operator
+:context: uninstalling-openshift-serverless-logic-operator
+
+If you need to remove OpenShift Serverless Logic from your cluster, you can do so by manually removing the {ServerlessLogicOperatorName} and other OpenShift Serverless Logic components.
+
+You can delete the {ServerlessLogicOperatorName} by using the web console. 
+
+* link:https://docs.openshift.com/container-platform/latest/operators/admin/olm-deleting-operators-from-cluster.html#olm-deleting-operators-from-a-cluster-using-web-console_olm-deleting-operators-from-a-cluster[Deleting Operators from a cluster using the web console]
+
+* link:https://docs.openshift.com/container-platform/latest/operators/admin/olm-deleting-operators-from-cluster.html#olm-refresh-subs_olm-deleting-operators-from-a-cluster[Refreshing failing subscriptions]


### PR DESCRIPTION
**Affected versions for cherry-picking**: `serverless-docs-1.33`

**Tracking JIRA**: https://issues.redhat.com/browse/SRVLOGIC-189

**Doc previews**

- [Installing the OpenShift Serverless Logic Operator](https://76488--ocpdocs-pr.netlify.app/openshift-serverless/latest/install/install-serverless-logic-operator)
- [Installing the OpenShift Serverless Logic Knative Workflow plugin using the artifacts image](https://76488--ocpdocs-pr.netlify.app/openshift-serverless/latest/install/serverless-logic-install-kn-workflow-plugin-cli#serverless-logic-install-kn-workflow-artifact-images_{context})
- [Removing OpenShift Serverless Logic Operator](https://76488--ocpdocs-pr.netlify.app/openshift-serverless/latest/removing/removing-openshift-serverless-logic-operator)
