### PR TITLE
OBSDOCS-1077

### DIFF
--- a/modules/logging-set-input-rate-limit.adoc
+++ b/modules/logging-set-input-rate-limit.adoc
@@ -33,7 +33,7 @@ spec:
       application:
         selector:
           matchLabels: { example: label } <2>
-      containerLimit:
+        containerLimit:
           maxRecordsPerSecond: 0 <3>
 # ...
 ----
@@ -54,12 +54,12 @@ spec:
     - name: <input_name> <1>
       application:
         namespaces: [ example-ns-1, example-ns-2 ] <2>
-      containerLimit:
-        maxRecordsPerSecond: 10 <3>
+        containerLimit:
+          maxRecordsPerSecond: 10 <3>
     - name: <input_name>
       application:
         namespaces: [ test ]
-      containerLimit:
+        containerLimit:
           maxRecordsPerSecond: 1000
 # ...
 ----


### PR DESCRIPTION
[OBSDOCS-1077](https://issues.redhat.com/browse/OBSDOCS-1077): Flow Control Spec Indentation is incorrect
Aligned team: Observability
OCP version for cherry-picking: 4.12+
JIRA issues: [OBSDOCS-1077](https://issues.redhat.com/browse/OBSDOCS-1077)
Preview pages: https://76491--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/performance_reliability/logging-flow-control-mechanisms.html#logging-set-input-rate-limit_logging-flow-control-mechanisms
SME review **completed**: @cahartma
QE review **completed**: @anpingli
Peer review **completed**: @dfitzmau
