### PR TITLE
OCPBUGS#26016: Remove `iam:TagInstanceProfile`

### DIFF
--- a/modules/installation-aws-permissions.adoc
+++ b/modules/installation-aws-permissions.adoc
@@ -146,7 +146,6 @@ If you use an existing Virtual Private Cloud (VPC), your account does not requir
 * `iam:PutRolePolicy`
 * `iam:RemoveRoleFromInstanceProfile`
 * `iam:SimulatePrincipalPolicy`
-* `iam:TagInstanceProfile`
 * `iam:TagRole`
 
 [NOTE]


### PR DESCRIPTION
Version(s): 4.14

Issue: https://issues.redhat.com/browse/OCPBUGS-26016

Link to docs preview:

[Required AWS permissions for the IAM user](https://76503--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account#installation-aws-permissions_installing-aws-account)

QE review:
- [x] QE has approved this change.
