### PR TITLE
Add Ceph Rados GW to storage list

### DIFF
--- a/modules/oadp-about-backup-snapshot-locations-secrets.adoc
+++ b/modules/oadp-about-backup-snapshot-locations-secrets.adoc
@@ -16,7 +16,7 @@ You specify backup and snapshot locations and their secrets in the `DataProtecti
 [discrete]
 == Backup locations
 
-You specify AWS S3-compatible object storage, such as Multicloud Object Gateway or MinIO, as a backup location.
+You specify AWS S3-compatible object storage as a backup location, such as Multicloud Object Gateway; Ceph RADOS Gateway, also known as Ceph Object Gateway;  or MinIO.
 
 Velero backs up {product-title} resources, Kubernetes objects, and internal images as an archive file on object storage.
 

--- a/modules/oadp-s3-compatible-backup-storage-providers.adoc
+++ b/modules/oadp-s3-compatible-backup-storage-providers.adoc
@@ -18,6 +18,7 @@ The following AWS S3 compatible object storage providers are fully supported by 
 * Multicloud Object Gateway (MCG)
 * Amazon Web Services (AWS) S3
 * {ibm-cloud-name} Object Storage S3
+* Ceph RADOS Gateway (Ceph Object Gateway)
 
 [NOTE]
 ====


### PR DESCRIPTION
OADP 1.4.1 but can be published before GA; OCP 4.12+

Resolves https://issues.redhat.com/browse/OADP-1841 by adding Ceph RADOS Gateway - also known as Ceph Object Gateway to a list of backup locations that appears in the description of configuring OADP per platform. 

Preview:  https://76507--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html#oadp-about-backup-snapshot-locations_installing-oadp-aws [repeats per platform] 
