### PR TITLE
OSDOCS-10590: Documented the 4.14.27 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3319,6 +3319,38 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.14.27
+[id="ocp-4-14-27"]
+=== RHSA-2024:3331 - {product-title} 4.14.27 bug fix update and security update
+
+Issued: 2024-05-30
+
+{product-title} release 4.14.27, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:3331[RHSA-2024:3331] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:3335[RHBA-2024:3335] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.27 --pullspecs
+----
+
+[id="ocp-4-14-27-bug-fixes"]
+==== Bug fixes
+
+* Previously, if you configured an {product-title} cluster with a high number of internal services or user-managed load balancer IP addresses, you experienced a delayed startup time for the OVN-Kubernetes service. This delay occurred when the OVN-Kubernetes service attempted to install `iptables` rules on a node. With this release, the OVN-Kubernetes service can process a large number of services in a few seconds. Additionally, you can access a new log to view the status of installing `iptables` rules on a node. (link:https://issues.redhat.com/browse/OCPBUGS-33537[*OCPBUGS-33537*])
+
+* Previously, the *Topology* view in the {product-title} web console did not show the visual connector between a virtual machine (VM) node and other non-VM components. With this release, the visual connector shows interaction activity of a component. (link:https://issues.redhat.com/browse/OCPBUGS-33640[*OCPBUGS-33640*])
+
+* Previously, a logo in the masthead element of the {product-title} web console could grow beyond 60 pixels in height. This caused the masthead to increase in height. With this release, the masthead logo is constrained to a `max-height` of 60 pixels. (link:https://issues.redhat.com/browse/OCPBUGS-33635[*OCPBUGS-33635*])
+
+[id="ocp-4-14-27-updating"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+// 4.14.26
 [id="ocp-4-14-26"]
 === RHSA-2024:2869 - {product-title} 4.14.26 bug fix update and security update
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-10658](https://issues.redhat.com//browse/OSDOCS-10658)

Link to docs preview:
[4.14.27](https://76509--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-27)

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
