### PR TITLE
OSDOCS-7075-nutanix: Added user-managed LB to Nutanix docs

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -6,10 +6,13 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+// Installing {op-system-base} on the provisioner node
 include::modules/ipi-install-installing-rhel-on-the-provisioner-node.adoc[leveloffset=+1]
 
+// Preparing the provisioner node for {product-title} installation
 include::modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc[leveloffset=+1]
 
+// Checking NTP server synchronization
 include::modules/ipi-install-checking-ntp-sync.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -19,15 +22,19 @@ include::modules/ipi-install-checking-ntp-sync.adoc[leveloffset=+1]
 
 * xref:../../installing/installing_bare_metal_ipi/ipi-install-prerequisites.adoc#network-requirements-ntp_ipi-install-prerequisites[Network Time Protocol (NTP)]
 
+// Configuring networking
 include::modules/ipi-install-configuring-networking.adoc[leveloffset=+1]
 
 // Establishing communication between subnets
 include::modules/ipi-install-establishing-communication-between-subnets.adoc[leveloffset=+1]
 
+// Retrieving the {product-title} installer
 include::modules/ipi-install-retrieving-the-openshift-installer.adoc[leveloffset=+1]
 
+// Extracting the {product-title} installer
 include::modules/ipi-install-extracting-the-openshift-installer.adoc[leveloffset=+1]
 
+// Optional: Creating an {op-system} images cache
 include::modules/ipi-install-creating-an-rhcos-images-cache.adoc[leveloffset=+1]
 
 // Services for a user-managed load balancer
@@ -36,38 +43,53 @@ include::modules/nw-osp-services-external-load-balancer.adoc[leveloffset=+1]
 // Configuring a user-managed load balancer
 include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+2]
 
+// Setting the cluster node hostnames through DHCP
 include::modules/ipi-install-setting-cluster-node-hostnames-dhcp.adoc[leveloffset=+1]
 
 [id="ipi-install-configuration-files"]
 [id="additional-resources_config"]
 == Configuring the install-config.yaml file
 
+// Configuring the install-config.yaml file
 include::modules/ipi-install-configuring-the-install-config-file.adoc[leveloffset=+2]
 
+// Additional `install-config` parameters
 include::modules/ipi-install-additional-install-config-parameters.adoc[leveloffset=+2]
 
+// BMC addressing
 include::modules/ipi-install-bmc-addressing.adoc[leveloffset=+2]
 
+// BMC addressing for Dell iDRAC
 include::modules/ipi-install-bmc-addressing-for-dell-idrac.adoc[leveloffset=+2]
 
+// BMC addressing for HPE iLO
 include::modules/ipi-install-bmc-addressing-for-hpe-ilo.adoc[leveloffset=+2]
 
+// BMC addressing for Fujitsu iRMC
 include::modules/ipi-install-bmc-addressing-for-fujitsu-irmc.adoc[leveloffset=+2]
 
+// Root device hints
 include::modules/ipi-install-root-device-hints.adoc[leveloffset=+2]
 
+// Optional: Setting proxy settings
 include::modules/ipi-install-setting-proxy-settings-within-install-config.adoc[leveloffset=+2]
 
+// Optional: Deploying with no provisioning network
 include::modules/ipi-install-modifying-install-config-for-no-provisioning-network.adoc[leveloffset=+2]
 
+// Optional: Deploying with dual-stack networking
 include::modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc[leveloffset=+2]
 
+// Optional: Configuring host network interfaces
 include::modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc[leveloffset=+2]
 
+// Configuring host network interfaces for subnets
 include::modules/ipi-install-configuring-host-network-interfaces-for-subnets.adoc[leveloffset=+2]
 
+// Optional: Configuring address generation modes for SLAAC in dual-stack networks
 include::modules/ipi-install-modifying-install-config-for-slaac-dual-stack-network.adoc[leveloffset=+2]
 
+// Optional: Configuring host network interfaces for dual port NIC
 include::modules/ipi-install-configuring-host-dual-network-interfaces-in-the-install-config.yaml-file.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -75,21 +97,28 @@ include::modules/ipi-install-configuring-host-dual-network-interfaces-in-the-ins
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_networking/configuring-network-bonding_configuring-and-managing-networking[Configuring network bonding]
 
+// Configuring multiple cluster nodes
 include::modules/ipi-install-configure-multiple-cluster-nodes.adoc[leveloffset=+2]
 
+// Optional: Configuring managed Secure Boot
 include::modules/ipi-install-configuring-managed-secure-boot-in-the-install-config-file.adoc[leveloffset=+2]
 
 [id="ipi-install-manifest-configuration-files"]
 == Manifest configuration files
 
+// Creating the {product-title} manifests
 include::modules/ipi-install-creating-the-openshift-manifests.adoc[leveloffset=+2]
 
+// Optional: Configuring NTP for disconnected clusters
 include::modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc[leveloffset=+2]
 
+// Configuring network components to run on the control plane
 include::modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc[leveloffset=+2]
 
+// Optional: Deploying routers on worker nodes
 include::modules/ipi-install-deploying-routers-on-worker-nodes.adoc[leveloffset=+2]
 
+// Optional: Configuring the BIOS
 include::modules/ipi-install-configuring-the-bios.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -98,8 +127,10 @@ include::modules/ipi-install-configuring-the-bios.adoc[leveloffset=+2]
 
 * xref:../../post_installation_configuration/bare-metal-configuration.adoc#post-install-bare-metal-configuration[Bare metal configuration]
 
+// Optional: Configuring the RAID
 include::modules/ipi-install-configuring-the-raid.adoc[leveloffset=+2]
 
+// Optional: Configuring storage on nodes
 include::modules/ipi-install-configuring-storage-on-nodes.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -110,6 +141,7 @@ include::modules/ipi-install-configuring-storage-on-nodes.adoc[leveloffset=+2]
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/managing_storage_devices/index#partition-naming-scheme_disk-partitions[Partition naming scheme]
 
+// Creating a disconnected registry
 include::modules/ipi-install-creating-a-disconnected-registry.adoc[leveloffset=+1]
 
 [discrete]
@@ -118,20 +150,28 @@ include::modules/ipi-install-creating-a-disconnected-registry.adoc[leveloffset=+
 
 * If you have already prepared a mirror registry for xref:../../installing/disconnected_install/installing-mirroring-installation-images.adoc#prerequisites_installing-mirroring-installation-images[Mirroring images for a disconnected installation], you can skip directly to xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#ipi-modify-install-config-for-a-disconnected-registry_ipi-install-installation-workflow[Modify the install-config.yaml file to use the disconnected registry].
 
+// Preparing the registry node to host the mirrored registry
 include::modules/ipi-install-preparing-a-disconnected-registry.adoc[leveloffset=+2]
 
+// Mirroring the {product-title} image repository for a disconnected registry
 include::modules/ipi-install-mirroring-for-disconnected-registry.adoc[leveloffset=+2]
 
+// Modify the install-config.yaml file to use the disconnected registry
 include::modules/ipi-modify-install-config-for-a-disconnected-registry.adoc[leveloffset=+2]
 
+// Validation checklist for installation
 include::modules/ipi-install-validation-checklist-for-installation.adoc[leveloffset=+1]
 
+// Deploying the cluster via the {product-title} installer
 include::modules/ipi-install-deploying-the-cluster-via-the-openshift-installer.adoc[leveloffset=+1]
 
+// Following the installation
 include::modules/ipi-install-following-the-installation.adoc[leveloffset=+1]
 
+// Verifying static IP address configuration
 include::modules/ipi-install-verifying-static-ip-address-configuration.adoc[leveloffset=+1]
 
+// Preparing to reinstall a cluster on bare metal
 include::modules/ipi-preparing-reinstall-cluster-bare-metal.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/installing/installing_bare_metal_ipi/ipi-install-overview.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-overview.adoc
@@ -21,7 +21,7 @@ In phase 2 of the deployment, the provisioner destroys the bootstrap VM automati
 
 The `keepalived.conf` file sets the control plane machines with a lower Virtual Router Redundancy Protocol (VRRP) priority than the bootstrap VM, which ensures that the API on the control plane machines is fully functional before the API VIP moves from the bootstrap VM to the control plane. Once the API VIP moves to one of the control plane nodes, traffic sent from external clients to the API VIP routes to an `haproxy` load balancer running on that control plane node. This instance of `haproxy` load balances the API VIP traffic across the control plane nodes.
 
-The Ingress VIP moves to the worker nodes. The `keepalived` instance also manages the Ingress VIP.
+The Ingress VIP moves to the compute nodes. The `keepalived` instance also manages the Ingress VIP.
 
 The following diagram illustrates phase 2 of deployment:
 

--- a/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
@@ -12,8 +12,3 @@ include::modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc[leve
 
 include::modules/nw-enabling-a-provisioning-network-after-installation.adoc[leveloffset=+1]
 
-// Configuring a user-managed load balancer
-include::modules/nw-osp-services-external-load-balancer.adoc[leveloffset=+1]
-
-// Services for a user-managed load balancer
-include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+2]

--- a/installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
+++ b/installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
@@ -56,6 +56,13 @@ include::modules/manually-configure-iam-nutanix.adoc[leveloffset=+1]
 
 include::modules/installation-nutanix-ccm.adoc[leveloffset=+1]
 
+// Services for a user-managed load balancer
+include::modules/nw-osp-services-external-load-balancer.adoc[leveloffset=+1]
+
+// Configuring a user-managed load balancer
+include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+2]
+
+// Deploying the cluster
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 
 include::modules/registry-configuring-storage-nutanix.adoc[leveloffset=+1]

--- a/modules/ipi-install-additional-install-config-parameters.adoc
+++ b/modules/ipi-install-additional-install-config-parameters.adoc
@@ -38,7 +38,7 @@ and the `bmc` parameter for the `install-config.yaml` file.
 
 | `sshKey`
 |
-| The `sshKey` configuration setting contains the key in the `~/.ssh/id_rsa.pub` file required to access the control plane nodes and worker nodes. Typically, this key is from the `provisioner` node.
+| The `sshKey` configuration setting contains the key in the `~/.ssh/id_rsa.pub` file required to access the control plane nodes and compute nodes. Typically, this key is from the `provisioner` node.
 
 | `pullSecret`
 |
@@ -69,7 +69,7 @@ compute:
   - name: worker
 ----
 |
-|The {product-title} cluster requires a name be provided for worker (or compute) nodes even if there are zero nodes.
+|The {product-title} cluster requires a name be provided for compute nodes even if there are zero nodes.
 
 
 a|
@@ -78,7 +78,7 @@ compute:
     replicas: 2
 ----
 |
-|Replicas sets the number of worker (or compute) nodes in the {product-title} cluster.
+|Replicas sets the number of compute nodes in the {product-title} cluster.
 
 
 a|
@@ -87,7 +87,7 @@ controlPlane:
     name: master
 ----
 |
-|The {product-title} cluster requires a name for control plane (master) nodes.
+|The {product-title} cluster requires a name for control plane nodes.
 
 
 a|
@@ -96,7 +96,7 @@ controlPlane:
     replicas: 3
 ----
 |
-|Replicas sets the number of control plane (master) nodes included as part of the {product-title} cluster.
+|Replicas sets the number of control plane nodes included as part of the {product-title} cluster.
 
 a| `provisioningNetworkInterface` |  | The name of the network interface on nodes connected to the provisioning network. For {product-title} 4.9 and later releases, use the `bootMACAddress` configuration setting to enable Ironic to identify the IP address of the NIC instead of using the `provisioningNetworkInterface` configuration setting to identify the name of the NIC.
 
@@ -211,7 +211,7 @@ The `hosts` parameter is a list of separate bare metal assets used to build the 
 
 | `role`
 |
-| The role of the bare metal node. Either `master` or `worker`.
+| The role of the bare metal node. Either `master` (control plane node) or `worker` (compute node).
 
 
 | `bmc`

--- a/modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc
+++ b/modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc
@@ -12,18 +12,18 @@ endif::[]
 [id='configure-network-components-to-run-on-the-control-plane_{context}']
 = Configuring network components to run on the control plane
 
-You can configure networking components to run exclusively on the control plane nodes. By default, {product-title} allows any node in the machine config pool to host the `ingressVIP` virtual IP address. However, some environments deploy worker nodes in separate subnets from the control plane nodes, which requires configuring the `ingressVIP` virtual IP address to run on the control plane nodes.
+You can configure networking components to run exclusively on the control plane nodes. By default, {product-title} allows any node in the machine config pool to host the `ingressVIP` virtual IP address. However, some environments deploy compute nodes in separate subnets from the control plane nodes, which requires configuring the `ingressVIP` virtual IP address to run on the control plane nodes.
 
 ifdef::vSphere[]
 [NOTE]
 ====
-You can scale the remote workers by creating a worker machineset in a separate subnet.
+You can scale the remote nodes by creating a compute machine set in a separate subnet.
 ====
 endif::vSphere[]
 
 [IMPORTANT]
 ====
-When deploying remote workers in separate subnets, you must place the `ingressVIP` virtual IP address exclusively with the control plane nodes.
+When deploying remote nodes in separate subnets, you must place the `ingressVIP` virtual IP address exclusively with the control plane nodes.
 ====
 
 ifdef::bare[]

--- a/modules/ipi-install-configuring-host-network-interfaces-for-subnets.adoc
+++ b/modules/ipi-install-configuring-host-network-interfaces-for-subnets.adoc
@@ -33,7 +33,7 @@ networking:
   networkType: OVNKubernetes
 ----
 
-. Add the gateway and DNS configuration to the `networkConfig` parameter of each edge worker node using NMState syntax when using a static IP address or advanced networking such as bonds:
+. Add the gateway and DNS configuration to the `networkConfig` parameter of each edge compute node using NMState syntax when using a static IP address or advanced networking such as bonds:
 +
 [source,yaml]
 ----

--- a/modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc
+++ b/modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc
@@ -12,15 +12,15 @@
 
 {product-title} installs the `chrony` Network Time Protocol (NTP) service on the cluster nodes.
 ifeval::["{context}" == "ipi-install-configuration-files"]
-Use the following procedure to configure NTP servers on the control plane nodes and configure worker nodes as NTP clients of the control plane nodes before deployment.
+Use the following procedure to configure NTP servers on the control plane nodes and configure compute nodes as NTP clients of the control plane nodes before deployment.
 endif::[]
 ifeval::["{context}" == "ipi-install-post-installation-configuration"]
-Use the following procedure to configure NTP servers on the control plane nodes and configure worker nodes as NTP clients of the control plane nodes after a successful deployment.
+Use the following procedure to configure NTP servers on the control plane nodes and configure compute nodes as NTP clients of the control plane nodes after a successful deployment.
 endif::[]
 
 image::152_OpenShift_Config_NTP_0421.png[Configuring NTP for disconnected clusters]
 
-{product-title} nodes must agree on a date and time to run properly. When worker nodes retrieve the date and time from the NTP servers on the control plane nodes, it enables the installation and operation of clusters that are not connected to a routable network and thereby do not have access to a higher stratum NTP server.
+{product-title} nodes must agree on a date and time to run properly. When compute nodes retrieve the date and time from the NTP servers on the control plane nodes, it enables the installation and operation of clusters that are not connected to a routable network and thereby do not have access to a higher stratum NTP server.
 
 .Procedure
 
@@ -69,7 +69,7 @@ storage:
           logdir /var/log/chrony
 
           # Configure the control plane nodes to serve as local NTP servers
-          # for all worker nodes, even if they are not in sync with an
+          # for all compute nodes, even if they are not in sync with an
           # upstream NTP server.
 
           # Allow NTP client access from the local network.
@@ -87,7 +87,7 @@ storage:
 $ butane 99-master-chrony-conf-override.bu -o 99-master-chrony-conf-override.yaml
 ----
 
-. Create a Butane config, `99-worker-chrony-conf-override.bu`, including the contents of the `chrony.conf` file for the worker nodes that references the NTP servers on the control plane nodes.
+. Create a Butane config, `99-worker-chrony-conf-override.bu`, including the contents of the `chrony.conf` file for the compute nodes that references the NTP servers on the control plane nodes.
 +
 [source,yaml,subs="attributes+"]
 .Butane config example
@@ -161,7 +161,7 @@ $ oc apply -f 99-master-chrony-conf-override.yaml
 machineconfig.machineconfiguration.openshift.io/99-master-chrony-conf-override created
 ----
 
-. Apply the `99-worker-chrony-conf-override.yaml` policy to the worker nodes.
+. Apply the `99-worker-chrony-conf-override.yaml` policy to the compute nodes.
 +
 [source,terminal]
 ----

--- a/modules/ipi-install-configuring-the-install-config-file.adoc
+++ b/modules/ipi-install-configuring-the-install-config-file.adoc
@@ -93,7 +93,7 @@ sshKey: '<ssh_pub_key>'
 ----
 +
 --
-<1> Scale the worker machines based on the number of worker nodes that are part of the {product-title} cluster. Valid options for the `replicas` value are `0` and integers greater than or equal to `2`. Set the number of replicas to `0` to deploy a three-node cluster, which contains only three control plane machines. A three-node cluster is a smaller, more resource-efficient cluster that can be used for testing, development, and production. You cannot install the cluster with only one worker.
+<1> Scale the compute machines based on the number of compute nodes that are part of the {product-title} cluster. Valid options for the `replicas` value are `0` and integers greater than or equal to `2`. Set the number of replicas to `0` to deploy a three-node cluster, which contains only three control plane machines. A three-node cluster is a smaller, more resource-efficient cluster that can be used for testing, development, and production. You cannot install the cluster with only one compute node.
 <2> When deploying a cluster with static IP addresses, you must set the `bootstrapExternalStaticIP` configuration setting to specify the static IP address of the bootstrap VM when there is no DHCP server on the bare-metal network.
 <3> When deploying a cluster with static IP addresses, you must set the `bootstrapExternalStaticGateway` configuration setting to specify the gateway IP address for the bootstrap VM when there is no DHCP server on the bare-metal network.
 <4> When deploying a cluster with static IP addresses, you must set the `bootstrapExternalStaticDNS` configuration setting to specify the DNS address for the bootstrap VM when there is no DHCP server on the bare-metal network.

--- a/modules/ipi-install-deploying-routers-on-worker-nodes.adoc
+++ b/modules/ipi-install-deploying-routers-on-worker-nodes.adoc
@@ -5,18 +5,18 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="deploying-routers-on-worker-nodes_{context}"]
-= Optional: Deploying routers on worker nodes
+= Optional: Deploying routers on compute nodes
 
-During installation, the installer deploys router pods on worker nodes. By default, the installer installs two router pods. If a deployed cluster requires additional routers to handle external traffic loads destined for services within the {product-title} cluster, you can create a `yaml` file to set an appropriate number of router replicas.
+During installation, the installation program deploys router pods on compute nodes. By default, the installation program installs two router pods. If a deployed cluster requires additional routers to handle external traffic loads destined for services within the {product-title} cluster, you can create a `yaml` file to set an appropriate number of router replicas.
 
 [IMPORTANT]
 ====
-Deploying a cluster with only one worker node is not supported. While modifying the router replicas will address issues with the `degraded` state when deploying with one worker, the cluster loses high availability for the ingress API, which is not suitable for production environments.
+Deploying a cluster with only one compute node is not supported. While modifying the router replicas will address issues with the `degraded` state when deploying with one compute node, the cluster loses high availability for the ingress API, which is not suitable for production environments.
 ====
 
 [NOTE]
 ====
-By default, the installer deploys two routers. If the cluster has no worker nodes, the installer deploys the two routers on the control plane nodes by default.
+By default, the installation program deploys two routers. If the cluster has no compute nodes, the installation program deploys the two routers on the control plane nodes by default.
 ====
 
 .Procedure
@@ -42,7 +42,7 @@ spec:
 +
 [NOTE]
 ====
-Replace `<num-of-router-pods>` with an appropriate value. If working with just one worker node, set `replicas:` to `1`. If working with more than 3 worker nodes, you can increase `replicas:` from the default value `2` as appropriate.
+Replace `<num-of-router-pods>` with an appropriate value. If working with just one compute node, set `replicas:` to `1`. If working with more than 3 compute nodes, you can increase `replicas:` from the default value `2` as appropriate.
 ====
 
 . Save and copy the `router-replicas.yaml` file to the `clusterconfigs/openshift` directory:

--- a/modules/ipi-install-establishing-communication-between-subnets.adoc
+++ b/modules/ipi-install-establishing-communication-between-subnets.adoc
@@ -23,7 +23,7 @@ Running control plane nodes in a multiple subnet environment requires completion
 Deploying a cluster with multiple subnets requires using virtual media, such as `redfish-virtualmedia` and `idrac-virtualmedia`.
 ====
 
-The procedure details the network configuration required to allow the remote nodes in the second subnet to communicate effectively with the control plane nodes in the first subnet and to allow the control plane nodes in the first subnet to communicate effectively with the remote nodes in the second subnet.
+This procedure details the network configuration required to allow the remote compute nodes in the second subnet to communicate effectively with the control plane nodes in the first subnet and to allow the control plane nodes in the first subnet to communicate effectively with the remote compute nodes in the second subnet.
 
 In this procedure, the cluster spans two subnets:
 
@@ -89,7 +89,7 @@ Adjust the commands to match your actual interface names and gateway.
 
 . Configure the second subnet to communicate with the first subnet:
 
-.. Log in as `root` to a remote worker node by running the following command:
+.. Log in as `root` to a remote compute node by running the following command:
 +
 [source,terminal]
 ----
@@ -135,7 +135,7 @@ Replace `<interface_name>` with the interface name.
 # ip route
 ----
 
-.. Repeat the previous steps for each worker node in the second subnet.
+.. Repeat the previous steps for each compute node in the second subnet.
 +
 [NOTE]
 ====
@@ -160,4 +160,4 @@ If the ping is successful, it means the control plane nodes in the first subnet 
 $ ping <control_plane_node_ip_address>
 ----
 +
-If the ping is successful, it means the remote nodes in the second subnet can reach the control plane in the first subnet. If you do not receive a response, review the network configurations and repeat the procedure for the node.
+If the ping is successful, it means the remote compute nodes in the second subnet can reach the control plane in the first subnet. If you do not receive a response, review the network configurations and repeat the procedure for the node.

--- a/modules/ipi-install-validation-checklist-for-installation.adoc
+++ b/modules/ipi-install-validation-checklist-for-installation.adoc
@@ -13,6 +13,6 @@
 * [ ] The `bmc` parameter for the `install-config.yaml` has been configured.
 * [ ] Conventions for the values configured in the `bmc` `address` field have been applied.
 * [ ] Created the {product-title} manifests.
-* [ ] (Optional) Deployed routers on worker nodes.
+* [ ] (Optional) Deployed routers on compute nodes.
 * [ ] (Optional) Created a disconnected registry.
 * [ ] (Optional) Validate disconnected registry settings if in use.

--- a/modules/ipi-preparing-reinstall-cluster-bare-metal.adoc
+++ b/modules/ipi-preparing-reinstall-cluster-bare-metal.adoc
@@ -7,7 +7,7 @@
 Before you reinstall a cluster on bare metal, you must perform cleanup operations.
 
 .Procedure
-. Remove or reformat the disks for the bootstrap, control plane node, and worker nodes. If you are working in a hypervisor environment, you must add any disks you removed.
+. Remove or reformat the disks for the bootstrap, control plane node, and compute nodes. If you are working in a hypervisor environment, you must add any disks you removed.
 . Delete the artifacts that the previous installation generated:
 +
 [source,terminal]

--- a/modules/nw-osp-configuring-external-load-balancer.adoc
+++ b/modules/nw-osp-configuring-external-load-balancer.adoc
@@ -1,10 +1,11 @@
 // Module included in the following assemblies:
 
-// OpenStack
-// * networking/load-balancing-openstack.adoc
 // Bare metal
 // * installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
-// * installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
+// OpenStack
+// * networking/load-balancing-openstack.adoc
+// Nutanix
+// * installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
 // vSphere
 // * installing/installing-vsphere-installer-provisioned-customizations.adoc
 // * installing/installing-vsphere-installer-provisioned-network-customizations.adoc
@@ -13,15 +14,30 @@
 ifeval::["{context}" == "ipi-install-installation-workflow"]
 :bare-metal:
 endif::[]
+ifeval::["{context}" == "load-balancing-openstack"]
+:openstack:
+endif::[]
+ifeval::["{context}" == "installing-nutanix-installer-provisioned"]
+:nutanix:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-customizations"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-installer-provisioned-vsphere"]
+:vsphere:
+endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-osp-configuring-external-load-balancer_{context}"]
 = Configuring a user-managed load balancer
 
 You can configure an {product-title} cluster
-ifeval::["{context}" == "load-balancing-openstack"]
+ifdef::openstack[]
 on {rh-openstack-first}
-endif::[]
+endif::openstack[]
 to use a user-managed load balancer in place of the default load balancer.
 
 [IMPORTANT]
@@ -308,14 +324,24 @@ A record pointing to Load Balancer Front End
 DNS propagation might take some time for each DNS record to become available. Ensure that each DNS record propagates before validating each record.
 ====
 
-ifdef::bare-metal[]
 . For your {product-title} cluster to use the user-managed load balancer, you must specify the following configuration in your cluster's `install-config.yaml` file:
 +
 [source,yaml]
 ----
 # ...
 platform:
+ifdef::bare-metal[]
   baremetal:
+endif::bare-metal[]
+ifdef::openstack[]
+  openstack:
+endif::openstack[]
+ifdef::nutanix[]
+  nutanix:
+endif::nutanix[]
+ifdef::vsphere[]
+  vsphere:
+endif::vsphere[]
     loadBalancer:
       type: UserManaged <1>
       apiVIPs:
@@ -327,7 +353,6 @@ platform:
 <1> Set `UserManaged` for the `type` parameter to specify a user-managed load balancer for your cluster. The parameter defaults to `OpenShiftManagedDefault`, which denotes the default internal load balancer. For services defined in an `openshift-kni-infra` namespace, a user-managed load balancer can deploy the `coredns` service to pods in your cluster but ignores `keepalived` and `haproxy` services.
 <2> Required parameter when you specify a user-managed load balancer. Specify the user-managed load balancer's public IP address, so that the Kubernetes API can communicate with the user-managed load balancer.
 <3> Required parameter when you specify a user-managed load balancer. Specify the user-managed load balancer's public IP address, so that the user-managed load balancer can manage ingress traffic for your cluster.
-endif::bare-metal[]
 
 .Verification
 
@@ -425,4 +450,19 @@ cache-control: private
 
 ifeval::["{context}" == "ipi-install-installation-workflow"]
 :!bare-metal:
+endif::[]
+ifeval::["{context}" == "load-balancing-openstack"]
+:!openstack:
+endif::[]
+ifeval::["{context}" == "installing-nutanix-installer-provisioned"]
+:!nutanix:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-customizations"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-installer-provisioned-vsphere"]
+:!vsphere:
 endif::[]

--- a/modules/nw-osp-services-external-load-balancer.adoc
+++ b/modules/nw-osp-services-external-load-balancer.adoc
@@ -1,10 +1,11 @@
 // Module included in the following assemblies:
 
-// OpenStack
-// * networking/load-balancing-openstack.adoc
 // Bare metal
 // * installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
-// * installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
+// OpenStack
+// * networking/load-balancing-openstack.adoc
+// Nutanix
+// * installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
 // vSphere
 // * installing/installing-vsphere-installer-provisioned-customizations.adoc
 // * installing/installing-vsphere-installer-provisioned-network-customizations.adoc


### PR DESCRIPTION
Version(s):
4.16

Issue:
* [OSDOCS-7075](https://issues.redhat.com/browse/OSDOCS-7075)

Link to docs preview:
* [BM DAY 0](https://76524--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#nw-osp-services-external-load-balancer_ipi-install-installation-workflow)
* [BM DAY 2](https://76524--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.html#nw-osp-services-external-load-balancer_ipi-install-post-installation-configuration)
* [Nutanix](https://76524--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned.html#nw-osp-services-external-load-balancer_installing-nutanix-installer-provisioned)
* [vSphere restricted](https://76524--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.html#nw-osp-services-external-load-balancer_installing-restricted-networks-installer-provisioned-vsphere)
* [vSphere customizations](https://76524--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.html#nw-osp-services-external-load-balancer_installing-vsphere-installer-provisioned-customizations)
* [vSphere network customizations](https://76524--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations.html#nw-osp-services-external-load-balancer_installing-vsphere-installer-provisioned-network-customizations)
* [OpenStack](https://76524--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/load-balancing-openstack.html#nw-osp-services-external-load-balancer_load-balancing-openstack)

- [x] SME has approved this change.
- [x] QE has approved this change.

Additional information:

* I removed the user-managed LB docs for the bare-metal day 2 docs because of support issues. Although it might work with no issues, the use-case as a day 2 task has not been fully tested.