### PR TITLE
RHDEVDOCS-6067-Update Samples Operator config section with deprecation notice for 4.16

### DIFF
--- a/openshift_images/configuring-samples-operator.adoc
+++ b/openshift_images/configuring-samples-operator.adoc
@@ -23,15 +23,9 @@ The Cluster Samples Operator, which operates in the `openshift` namespace, insta
 endif::openshift-rosa,openshift-dedicated[]
 
 [IMPORTANT]
-.Cluster Samples Operator is being downsized  
+.The Cluster Samples Operator is being deprecated  
 ====
-* Starting from {product-title} 4.13, Cluster Samples Operator is downsized. Cluster Samples Operator will stop providing the following updates for non-Source-to-Image (Non-S2I) image streams and templates:
-- new image streams and templates
-- updates to the existing image streams and templates unless it is a CVE update
-
-* Cluster Samples Operator will provide support for Non-S2I image streams and templates as per the link:https://access.redhat.com/support/policy/updates/openshift#dates[{product-title} lifecycle policy dates and support guidelines].
-
-* Cluster Samples Operator will continue to support the S2I builder image streams and templates and accept the updates. S2I image streams and templates include:
+* Starting from {product-title} 4.16, the Cluster Samples Operator is deprecated. No new templates, samples, or non-Source-to-Image (Non-S2I) image streams will be added to the Cluster Samples Operator. However, the existing S2I builder image streams and templates will continue to receive updates until the Cluster Samples Operator is removed in a future release. S2I image streams and templates include:
 - Ruby
 - Python
 - Node.js
@@ -45,7 +39,7 @@ endif::openshift-rosa,openshift-dedicated[]
 - .NET
 - Go
 
-* Starting from {product-title} 4.16, Cluster Samples Operator will stop managing non-S2I image streams and templates. You can contact the image stream or template owner for any requirements and future plans. In addition, refer to the link:https://github.com/openshift/library/blob/master/official.yaml[list of the repositories hosting the image stream or templates].
+* The Cluster Samples Operator will stop managing and providing support to the non-S2I samples (image streams and templates). You can contact the image stream or template owner for any requirements and future plans. In addition, refer to the link:https://github.com/openshift/library/blob/master/official.yaml[list of the repositories hosting the image stream or templates].
 ====
 
 include::modules/samples-operator-overview.adoc[leveloffset=+1]


### PR DESCRIPTION
Jira issue : [RHDEVDOCS-6067](https://issues.redhat.com/browse/RHDEVDOCS-6067)

Aligned team: DevTools 
Cherry-pick to versions: 4.16+

Docs preview:

- [Overview of the Cluster Samples Operator](https://76528--ocpdocs-pr.netlify.app/openshift-dedicated/latest/openshift_images/configuring-samples-operator.html)

SME review: @fbm3307 

QE review: @fbm3307 

Peer review: 

Additional information: This PR is related to #76532. Please review and approve it together. TY!
