### PR TITLE
RHDEVDOCS-6067-Update Release Notes with Sampes Operator deprecation  notice for 4.16

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -305,19 +305,14 @@ In the following tables, features are marked with the following statuses:
 [discrete]
 === Images deprecated and removed features
 
-.Images deprecated and removed tracker
+.Cluster Samples Operator deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
 |Feature |4.14 |4.15 |4.16
 
-|`ImageChangesInProgress` condition for Cluster Samples Operator
-|Deprecated
-|Deprecated
-|Deprecated
-
-|`MigrationInProgress` condition for Cluster Samples Operator
-|Deprecated
-|Deprecated
+|Cluster Samples Operator
+|General Availability
+|General Availability
 |Deprecated
 
 |====
@@ -528,7 +523,12 @@ In the following tables, features are marked with the following statuses:
 [id="ocp-4-14-nodes-cgroupv1-deprecated"]
 ==== Linux Control Groups version 1 is now deprecated
 
-In {op-system-base-full} 9, the default mode is cgroup v2. When {op-system-base-full} 10 is released, systemd will not support booting in the cgroup v1 mode and only cgroup v2 mode will be available. As such, cgroup v1 is deprecated in {product-title} 4.16 and later. cgroup v1 will be removed in a future {product-title} release. 
+In {op-system-base-full} 9, the default mode is cgroup v2. When {op-system-base-full} 10 is released, systemd will not support booting in the cgroup v1 mode and only cgroup v2 mode will be available. As such, cgroup v1 is deprecated in {product-title} 4.16 and later. cgroup v1 will be removed in a future {product-title} release.
+ 
+[id="ocp-4-16-deprecation-samples-operator"]
+==== Cluster Samples Operator
+
+The Cluster Samples Operator is deprecated with the {product-title} 4.16 release. The Cluster Samples Operator will stop managing and providing support to the non-S2I samples (image streams and templates). No new templates, samples or non-Source-to-Image (Non-S2I) image streams will be added to the Cluster Samples Operator. However, the existing S2I builder image streams and templates will continue to receive updates until the Cluster Samples Operator is removed in a future release. 
 
 [id="ocp-4-16-removed-features"]
 === Removed features


### PR DESCRIPTION
Jira issue : [RHDEVDOCS-6067](https://issues.redhat.com/browse/RHDEVDOCS-6067)

Aligned team: DevTools 

Docs preview:

- [Deprecated and removed features](https://76532--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-deprecated-removed-features)
- [Cluster Samples Operator](https://76532--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-deprecation-samples-operator)

SME review: @fbm3307

QE review: @fbm3307

Peer review: 

Additional information: This PR is related to #76528. Please review and approve it together. TY!
