### PR TITLE
Fix Pantheon error in Using build volume

### DIFF
--- a/modules/builds-using-build-volumes.adoc
+++ b/modules/builds-using-build-volumes.adoc
@@ -69,8 +69,12 @@ ifndef::openshift-dedicated,openshift-rosa[]
 <6> Required. This value must be set to `true`. Provides a read-only volume.
 <7> Optional. The volume attributes of the ephemeral CSI volume. Consult the CSI driver's documentation for supported attribute keys and values.
 
-:FeatureName: Shared Resource CSI Driver
-include::snippets/technology-preview.adoc[]
+[IMPORTANT]
+====
+Shared Resource CSI Driver is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope].
+====
 endif::openshift-dedicated,openshift-rosa[]
 --
 
@@ -126,8 +130,12 @@ ifndef::openshift-dedicated,openshift-rosa[]
 <6> Required. This value must be set to `true`. Provides a read-only volume.
 <7> Optional. The volume attributes of the ephemeral CSI volume. Consult the CSI driver's documentation for supported attribute keys and values.
 
-:FeatureName: Shared Resource CSI Driver
-include::snippets/technology-preview.adoc[]
+[IMPORTANT]
+====
+Shared Resource CSI Driver is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope].
+====
 endif::openshift-dedicated,openshift-rosa[]
 --
 

--- a/windows_containers/index.adoc
+++ b/windows_containers/index.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{productwinc} is a feature providing the ability to run Windows compute nodes in an {product-title} cluster. This is possible by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes. With a Red Hat subscription, you can get support for running Windows workloads in {product-title}. Windows instances deployed by the WMCO are configured with the containerd container runtime. For more information, see the xref:../windows_containers/windows-rn/windows-containers-release-notes-10-15-x.adoc#windows-containers-release-notes-10-15-x[release notes].
+{productwinc} is a feature providing the ability to run Windows compute nodes in an {product-title} cluster. This is possible by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes. With a Red Hat subscription, you can get support for running Windows workloads in {product-title}. Windows instances deployed by the WMCO are configured with the containerd container runtime. For more information, see the xref:../windows_containers/wmco_rn/windows-containers-release-notes-10-15-x.adoc#windows-containers-release-notes-10-15-x[release notes].
 
 You can add Windows nodes either by creating a xref:../windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc#creating-windows-machineset-aws[compute machine set] or by specifying existing Bring-Your-Own-Host (BYOH) Window instances through a xref:../windows_containers/byoh-windows-instance.adoc#byoh-windows-instance[configuration map].
 


### PR DESCRIPTION
Fixing [error in Pantheon build](https://gitlab.cee.redhat.com/red-hat-enterprise-openshift-documentation/doc-4.15/tree/3f664309ced511c7db7f320e3a834eebf497df04). The module in question had a snippet in an ifdef section. I believe this is not allowed. Also fixed a broken link. 

enterprise-4.15 only.

No QE, internal problem and fix.