### PR TITLE
[RHACS] Updated the default values and listed assemblies

### DIFF
--- a/modules/secured-cluster-configuration-options-operator.adoc
+++ b/modules/secured-cluster-configuration-options-operator.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * installing/install-ocp-operator.adoc
+// * installing/installing_ocp/install-secured-cluster-config-options-ocp.adoc
 :_mod-docs-content-type: CONCEPT
 [id="secured-cluster-configuration-options-operator_{context}"]
 = Secured Cluster services configuration options
@@ -35,7 +35,7 @@ To change the name, you must delete and re-create the object.
 
 | `admissionControl.listenOnCreates`
 | Specify `true` to enable preventive policy enforcement for object creations.
-The default value is `false`.
+The default value is `true`.
 
 | `admissionControl.listenOnEvents`
 | Specify `true` to enable monitoring and enforcement for Kubernetes events, such as `port-forward` and `exec` events.
@@ -45,7 +45,7 @@ The default value is `true`.
 | `admissionControl.listenOnUpdates`
 | Specify `true` to enable preventive policy enforcement for object updates.
 It will not have any effect unless `Listen On Creates` is set to `true` as well.
-The default value is `false`.
+The default value is `true`.
 
 | `admissionControl.nodeSelector`
 | If you want this component to only run on specific nodes, you can configure a node selector using this parameter.

--- a/modules/secured-cluster-services-config.adoc
+++ b/modules/secured-cluster-services-config.adoc
@@ -1,6 +1,9 @@
 // Module included in the following assemblies:
 //
-// * dir/filename.adoc
+// * installing/installing_ocp/install-secured-cluster-ocp.adoc
+// * installing/installing_other/install-secured-cluster-other.adoc
+// * cloud_service/installing_cloud_other/install-secured-cluster-cloud-other.adoc
+// * cloud_service/installing_cloud_ocp/install-secured-cluster-cloud-ocp.adoc
 :_mod-docs-content-type: CONCEPT
 [id="secured-cluster-services-config_{context}"]
 = Configuration parameters


### PR DESCRIPTION
For https://issues.redhat.com/browse/OSDOCS-10647

- Updated the list of assemblies in which the module appears.
- Updated the default values.

Preview: https://76541--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-config-options-ocp.html#admission-controller-settings_install-secured-cluster-config-options-ocp

Cherry-pick in:
- `rhacs-docs-4.5`
- `rhacs-docs-4.4`