### PR TITLE
OBSDOCS-1083:Update the Tech preview status table for Metrics Server GA

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -1002,7 +1002,7 @@ In the following tables, features are marked with the following statuses:
 |Metrics Server
 |Not Available
 |Technology Preview
-|Technology Preview
+|General Availability
 
 |====
 


### PR DESCRIPTION
Version(s): `enterprise-4.16`  only

Issue: [OBSDOCS-909](https://issues.redhat.com/browse/OBSDOCS-909)

Link to docs preview: https://76545--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-technology-preview-tables

QE review:
- [x] QE has approved this change.

**Additional information:** This issue updates the TP feature table. The release note text will be added as part of [RN new features](https://issues.redhat.com/browse/OBSDOCS-838) issue