### PR TITLE
OBSDOCS-1082: Remove the Tech Preview admonition from the MetricsServ…

### DIFF
--- a/observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+++ b/observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
@@ -237,9 +237,6 @@ Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 
 === Description
 
-:FeatureName: Metrics Server
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 The `MetricsServerConfig` resource defines settings for the Metrics Server component. Note that this setting only applies when the `TechPreviewNoUpgrade` feature gate is enabled.
 
 Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]


### PR DESCRIPTION
Version(s): `enterprise-4.16` and later

Issue: [OBSDOCS-909](https://issues.redhat.com/browse/OBSDOCS-909)

Link to docs preview: 

QE review:
- [ ] QE has approved this change.
