### PR TITLE
OSDOCS-10596: adds 4.14.27 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -522,3 +522,12 @@ Issued: 2024-05-23
 {product-title} release 4.14.26 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:2872[RHBA-2024:2872] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:2869[RHSA-2024:2869] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-14-27-dp"]
+=== RHBA-2024:3334 - {microshift-short} 4.14.27 bug fix and enhancement advisory
+
+Issued: 2024-05-30
+
+{product-title} release 4.14.27 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:3334[RHBA-2024:3334] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:3331[RHSA-2024:3331] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-10596](https://issues.redhat.com/browse/OSDOCS-10596)

Link to docs preview:
[4.14.27 release note](https://76549--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes.html#microshift-4-14-27-dp)

QE review:
- N/A, stock text

Additional info:
Errata links are not expected to work until the advisory is `Shipped Live` on the release date.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
