### PR TITLE
MIG-1329: Compatibility guidelines for migrating from OCP 3 to OCP 4 

### DIFF
--- a/migrating_from_ocp_3_to_4/installing-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/installing-3-4.adoc
@@ -17,7 +17,7 @@ After you have installed {mtc-short}, you must configure an object storage to us
 
 To uninstall {mtc-short}, see xref:../migrating_from_ocp_3_to_4/installing-3-4.adoc#migration-uninstalling-mtc-clean-up_installing-3-4[Uninstalling {mtc-short} and deleting resources].
 
-include::modules/migration-compatibility-guidelines.adoc[leveloffset=+1]
+include::modules/migration-compatibility-guidelines-3-to-4.adoc[leveloffset=+1]
 include::modules/migration-installing-legacy-operator.adoc[leveloffset=+1]
 include::modules/migration-installing-mtc-on-ocp-4.adoc[leveloffset=+1]
 include::modules/migration-about-configuring-proxies.adoc[leveloffset=+1]

--- a/migrating_from_ocp_3_to_4/installing-restricted-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/installing-restricted-3-4.adoc
@@ -21,7 +21,7 @@ By default, the {mtc-short} web console and the `Migration Controller` pod run o
 
 To uninstall {mtc-short}, see xref:../migrating_from_ocp_3_to_4/installing-restricted-3-4.adoc#migration-uninstalling-mtc-clean-up_installing-restricted-3-4[Uninstalling {mtc-short} and deleting resources].
 
-include::modules/migration-compatibility-guidelines.adoc[leveloffset=+1]
+include::modules/migration-compatibility-guidelines-3-to-4.adoc[leveloffset=+1]
 include::modules/migration-installing-mtc-on-ocp-4.adoc[leveloffset=+1]
 include::modules/migration-installing-legacy-operator.adoc[leveloffset=+1]
 include::modules/migration-about-configuring-proxies.adoc[leveloffset=+1]

--- a/modules/migration-compatibility-guidelines-3-to-4.adoc
+++ b/modules/migration-compatibility-guidelines-3-to-4.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * migrating_from_ocp_3_to_4/installing-3-4.adoc
+// * migrating_from_ocp_3_to_4/installing-restricted-3-4.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="migration-compatibility-guidelines-3-to-4_{context}"]
+= Compatibility guidelines
+
+You must install the {mtc-full} ({mtc-short}) Operator that is compatible with your {product-title} version.
+
+.Definitions
+
+control cluster:: The cluster that runs the {mtc-short} controller and GUI.
+remote cluster:: A source or destination cluster for a migration that runs Velero. The Control Cluster communicates with Remote clusters using the Velero API to drive migrations.
+
+You must use the compatible {mtc-short} version for migrating your {product-title} clusters. For the migration to succeed, both your source cluster and the destination cluster must use the same version of {mtc-short}.
+
+{mtc-short} 1.7 supports migrations from {product-title} 3.11 to 4.16.
+
+{mtc-short} 1.8 only supports migrations from {product-title} 4.14 and later.
+
+.{mtc-short} compatibility: Migrating from {product-title} 3 to 4
+|===
+|Details |{product-title} 3.11 |{product-title} 4.14 or later
+
+|Stable {mtc-short} version
+|{mtc-short} v.1.7._z_
+|{mtc-short} v.1.8._z_
+
+|Installation
+|As described in this guide
+|Install with OLM, release channel `release-v1.8`
+|===
+
+Edge cases exist where network restrictions prevent {product-title} 4 clusters from connecting to other clusters involved in the migration. For example, when migrating from an {product-title} 3.11 cluster on premises to a {product-title} 4 cluster in the cloud,  the {product-title} 4 cluster might have trouble connecting to the {product-title} 3.11 cluster. In this case, it is possible to designate the {product-title} 3.11 cluster as the control cluster and push workloads to the remote {product-title} 4 cluster.

--- a/modules/migration-compatibility-guidelines.adoc
+++ b/modules/migration-compatibility-guidelines.adoc
@@ -1,7 +1,5 @@
 // Module included in the following assemblies:
 //
-// * migrating_from_ocp_3_to_4/installing-3-4.adoc
-// * migrating_from_ocp_3_to_4/installing-restricted-3-4.adoc
 // * migration_toolkit_for_containers/installing-mtc.adoc
 // * migration_toolkit_for_containers/installing-mtc-restricted.adoc
 


### PR DESCRIPTION
MTC 1.7-8; OCP 4.14+

Resolves https://issues.redhat.com/browse/MIG-1329 by updating the compatibility guidelines for migrating from OCP 3 to OCP 4 
Previews:
1. https://76564--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/installing-3-4.html#migration-compatibility-guidelines-3-to-4_installing-3-4  [Unrestricted environments] 
2. https://76564--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/installing-restricted-3-4.html#migration-compatibility-guidelines-3-to-4_installing-restricted-3-4 [Restricted environments] 

MTC QE approved. 