### PR TITLE
[enterprise-4.13]  OBSDOCS-919: move COO docs to Observability folder

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2760,6 +2760,18 @@ Topics:
     File: json-flows-format-reference
   - Name: Troubleshooting Network Observability
     File: troubleshooting-network-observability
+- Name: Cluster Observability Operator
+  Dir: cluster_observability_operator
+  Distros: openshift-enterprise,openshift-origin
+  Topics:
+  - Name: Cluster Observability Operator release notes
+    File: cluster-observability-operator-release-notes
+  - Name: Cluster Observability Operator overview
+    File: cluster-observability-operator-overview
+  - Name: Installing the Cluster Observability Operator
+    File: installing-the-cluster-observability-operator
+  - Name: Configuring the Cluster Observability Operator to monitor a service
+    File: configuring-the-cluster-observability-operator-to-monitor-a-service
 ---
 Name: Scalability and performance
 Dir: scalability_and_performance


### PR DESCRIPTION
2nd manual cherry-pick of #74679 to enterprise-4.13 to fix missing topic map entries