### PR TITLE
 [enterprise-4.13] TELCODOCS-1785 Improving NROP documentation

### DIFF
--- a/modules/cnf-about-collecting-nro-data.adoc
+++ b/modules/cnf-about-collecting-nro-data.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assembly:
+//
+// * scalability_and_performance/cnf-numa-aware-scheduling.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="cnf-about-collecting-nro-data_{context}"]
+= Collecting NUMA Resources Operator data
+
+You can use the `oc adm must-gather` CLI command to collect information about your cluster, including features and objects associated with the NUMA Resources Operator.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+* You have installed the {oc-first}.
+
+.Procedure
+
+* To collect NUMA Resources Operator data with `must-gather`, you must specify the NUMA Resources Operator `must-gather` image.
++
+[source,terminal,subs="attributes+"]
+----
+$ oc adm must-gather --image=registry.redhat.io/numaresources-must-gather/numaresources-must-gather-rhel9:v{product-version}
+----

--- a/modules/cnf-about-numa-aware-scheduling.adoc
+++ b/modules/cnf-about-numa-aware-scheduling.adoc
@@ -6,13 +6,40 @@
 [id="cnf-about-numa-aware-scheduling_{context}"]
 = About NUMA-aware scheduling
 
-Non-Uniform Memory Access (NUMA) is a compute platform architecture that allows different CPUs to access different regions of memory at different speeds. NUMA resource topology refers to the locations of CPUs, memory, and PCI devices relative to each other in the compute node. Co-located resources are said to be in the same _NUMA zone_. For high-performance applications, the cluster needs to process pod workloads in a single NUMA zone.
+[discrete]
+[id="introduction-to-numa_{context}"]
+== Introduction to NUMA
 
-NUMA architecture allows a CPU with multiple memory controllers to use any available memory across CPU complexes, regardless of where the memory is located. This allows for increased flexibility at the expense of performance. A CPU processing a workload using memory that is outside its NUMA zone is slower than a workload processed in a single NUMA zone. Also, for I/O-constrained workloads, the network interface on a distant NUMA zone slows down how quickly information can reach the application. High-performance workloads, such as telecommunications workloads, cannot operate to specification under these conditions. NUMA-aware scheduling aligns the requested cluster compute resources (CPUs, memory, devices) in the same NUMA zone to process latency-sensitive or high-performance workloads efficiently. NUMA-aware scheduling also improves pod density per compute node for greater resource efficiency.
+Non-Uniform Memory Access (NUMA) is a compute platform architecture that allows different CPUs to access different regions of memory at different speeds. NUMA resource topology refers to the locations of CPUs, memory, and PCI devices relative to each other in the compute node. Colocated resources are said to be in the same _NUMA zone_. For high-performance applications, the cluster needs to process pod workloads in a single NUMA zone.
+
+[discrete]
+[id="performance-considerations_{context}"]
+== Performance considerations
+
+NUMA architecture allows a CPU with multiple memory controllers to use any available memory across CPU complexes, regardless of where the memory is located. This allows for increased flexibility at the expense of performance. A CPU processing a workload using memory that is outside its NUMA zone is slower than a workload processed in a single NUMA zone. Also, for I/O-constrained workloads, the network interface on a distant NUMA zone slows down how quickly information can reach the application. High-performance workloads, such as telecommunications workloads, cannot operate to specification under these conditions. 
+
+[discrete]
+[id="numa-aware-scheduling_{context}"]
+== NUMA-aware scheduling
+
+NUMA-aware scheduling aligns the requested cluster compute resources (CPUs, memory, devices) in the same NUMA zone to process latency-sensitive or high-performance workloads efficiently. NUMA-aware scheduling also improves pod density per compute node for greater resource efficiency.
+
+[discrete]
+[id="integration-with-node-tuning-operator_{context}"]
+== Integration with Node Tuning Operator
 
 By integrating the Node Tuning Operator's performance profile with NUMA-aware scheduling, you can further configure CPU affinity to optimize performance for latency-sensitive workloads.
 
-The default {product-title} pod scheduler scheduling logic considers the available resources of the entire compute node, not individual NUMA zones. If the most restrictive resource alignment is requested in the kubelet topology manager, error conditions can occur when admitting the pod to a node. Conversely, if the most restrictive resource alignment is not requested, the pod can be admitted to the node without proper resource alignment, leading to worse or unpredictable performance. For example, runaway pod creation with `Topology Affinity Error` statuses can occur when the pod scheduler makes suboptimal scheduling decisions for guaranteed pod workloads by not knowing if the pod's requested resources are available. Scheduling mismatch decisions can cause indefinite pod startup delays. Also, depending on the cluster state and resource allocation, poor pod scheduling decisions can cause extra load on the cluster because of failed startup attempts.
+[discrete]
+[id="default-scheduling-logic_{context}"]
+== Default scheduling logic
+
+The default {product-title} pod scheduler scheduling logic considers the available resources of the entire compute node, not individual NUMA zones. If the most restrictive resource alignment is requested in the kubelet topology manager, error conditions can occur when admitting the pod to a node. Conversely, if the most restrictive resource alignment is not requested, the pod can be admitted to the node without proper resource alignment, leading to worse or unpredictable performance. For example, runaway pod creation with `Topology Affinity Error` statuses can occur when the pod scheduler makes suboptimal scheduling decisions for guaranteed pod workloads without knowing if the pod's requested resources are available. Scheduling mismatch decisions can cause indefinite pod startup delays. Also, depending on the cluster state and resource allocation, poor pod scheduling decisions can cause extra load on the cluster because of failed startup attempts.
+
+
+[discrete]
+[id="numa-aware-pod-scheduling-diagram_{context}"]
+== NUMA-aware pod scheduling diagram
 
 The NUMA Resources Operator deploys a custom NUMA resources secondary scheduler and other resources to mitigate against the shortcomings of the default {product-title} pod scheduler. The following diagram provides a high-level overview of NUMA-aware pod scheduling.
 

--- a/modules/cnf-configuring-kubelet-nro.adoc
+++ b/modules/cnf-configuring-kubelet-nro.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// *scalability_and_performance/cnf-numa-aware-scheduling.adoc
+
+:_module-type: PROCEDURE
+[id="cnf-configuring-kubelet-config-nro_{context}"]
+= Creating a KubeletConfig CRD
+
+The recommended way to configure a single NUMA node policy is to apply a performance profile. Another way is by creating and applying a `KubeletConfig` custom resource (CR), as shown in the following procedure.
+
+.Procedure 
+
+. Create the `KubeletConfig` custom resource (CR) that configures the pod admittance policy for the machine profile:
+
+.. Save the following YAML in the `nro-kubeletconfig.yaml` file:
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: worker-tuning
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/worker: "" <1>
+  kubeletConfig:
+    cpuManagerPolicy: "static" <2>
+    cpuManagerReconcilePeriod: "5s"
+    reservedSystemCPUs: "0,1" <3>
+    memoryManagerPolicy: "Static" <4>
+    evictionHard:
+      memory.available: "100Mi"
+    kubeReserved:
+      memory: "512Mi"
+    reservedMemory:
+      - numaNode: 0
+        limits:
+          memory: "1124Mi"
+    systemReserved:
+      memory: "512Mi"
+    topologyManagerPolicy: "single-numa-node" <5>
+----
+<1> Adjust this label to match the the `machineConfigPoolSelector` in the `NUMAResourcesOperator` CR.
+<2> For `cpuManagerPolicy`, `static` must use a lowercase `s`.
+<3> Adjust this based on the CPU on your nodes.
+<4> For `memoryManagerPolicy`, `Static` must use an uppercase `S`.
+<5> `topologyManagerPolicy` must be set to `single-numa-node`.
+
+.. Create the `KubeletConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc create -f nro-kubeletconfig.yaml
+----
++
+[NOTE]
+====
+Applying performance profile or `KubeletConfig` automatically triggers rebooting of the nodes. If no reboot is triggered, you can troubleshoot the issue by looking at the labels in `KubeletConfig` that address the node group. 
+====

--- a/modules/cnf-configuring-node-groups-for-the-numaresourcesoperator.adoc
+++ b/modules/cnf-configuring-node-groups-for-the-numaresourcesoperator.adoc
@@ -46,7 +46,7 @@ spec:
 ----
 <1> Valid values are `Periodic`, `Events`, `PeriodicAndEvents`. Use `Periodic` to poll the kubelet at intervals that you define in `infoRefreshPeriod`. Use `Events` to poll the kubelet at every pod lifecycle event. Use `PeriodicAndEvents` to enable both methods.
 <2> Define the polling interval for `Periodic` or `PeriodicAndEvents` refresh modes. The field is ignored if the refresh mode is `Events`.
-<3> Valid values are `Enabled` or `Disabled`. Setting to `Enabled` is a requirement for the `cacheResyncPeriod` specification in the `NUMAResourcesScheduler`.
+<3> Valid values are `Enabled`, `Disabled`, and `EnabledExclusiveResources`. Setting to `Enabled` is a requirement for the `cacheResyncPeriod` specification in the `NUMAResourcesScheduler`.
 
 .Verification
 

--- a/modules/cnf-configuring-single-numa-policy.adoc
+++ b/modules/cnf-configuring-single-numa-policy.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// *scalability_and_performance/cnf-numa-aware-scheduling.adoc
+
+:_module-type: PROCEDURE
+[id="cnf-configuring-single-numa-policy_{context}"]
+= Configuring a single NUMA node policy
+
+The NUMA Resources Operator requires a single NUMA node policy to be configured on the cluster. This can be achieved in two ways: by creating and applying a performance profile, or by configuring a KubeletConfig. 
+
+[NOTE]
+====
+The preferred way to configure a single NUMA node policy is to apply a performance profile. You can use the Performance Profile Creator (PPC) tool to create the performance profile. If a performance profile is created on the cluster, it automatically creates other tuning components like `KubeletConfig` and the `tuned` profile.
+====
+
+For more information about creating a performance profile, see "About the Performance Profile Creator" in the "Additional Resources" section.

--- a/modules/cnf-creating-nrop-cr.adoc
+++ b/modules/cnf-creating-nrop-cr.adoc
@@ -18,7 +18,7 @@ When you have installed the NUMA Resources Operator, then create the `NUMAResour
 
 . Create the `NUMAResourcesOperator` custom resource:
 
-.. Save the following YAML in the `nrop.yaml` file:
+.. Save the following minimal required YAML file example as `nrop.yaml`:
 +
 [source,yaml]
 ----
@@ -30,8 +30,10 @@ spec:
   nodeGroups:
   - machineConfigPoolSelector:
       matchLabels:
-        pools.operator.machineconfiguration.openshift.io/worker: ""
+        pools.operator.machineconfiguration.openshift.io/worker: "" <1>
 ----
++
+<1> This should match the `MachineConfigPool` that you want to configure the NUMA Resources Operator on. For example, you might have created a `MachineConfigPool` named `worker-cnf` that designates a set of nodes expected to run telecommunications workloads.
 
 .. Create the `NUMAResourcesOperator` CR by running the following command:
 +
@@ -39,10 +41,15 @@ spec:
 ----
 $ oc create -f nrop.yaml
 ----
++
+[NOTE]
+====
+Creating the `NUMAResourcesOperator` triggers a reboot on the corresponding machine config pool and therefore the affected node.
+====
 
 .Verification
 
-* Verify that the NUMA Resources Operator deployed successfully by running the following command:
+. Verify that the NUMA Resources Operator deployed successfully by running the following command:
 +
 [source,terminal]
 ----
@@ -53,5 +60,22 @@ $ oc get numaresourcesoperators.nodetopology.openshift.io
 [source,terminal]
 ----
 NAME                    AGE
-numaresourcesoperator   10m
+numaresourcesoperator   27s
+----
+
+. After a few minutes, run the following command to verify that the required resources deployed successfully:
++
+[source,terminal]
+----
+$ oc get all -n openshift-numaresources
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                                    READY   STATUS    RESTARTS   AGE
+pod/numaresources-controller-manager-7d9d84c58d-qk2mr   1/1     Running   0          12m
+pod/numaresourcesoperator-worker-7d96r                  2/2     Running   0          97s
+pod/numaresourcesoperator-worker-crsht                  2/2     Running   0          97s
+pod/numaresourcesoperator-worker-jp9mw                  2/2     Running   0          97s
 ----

--- a/modules/cnf-deploying-the-numa-aware-scheduler.adoc
+++ b/modules/cnf-deploying-the-numa-aware-scheduler.adoc
@@ -8,59 +8,11 @@
 
 After you install the NUMA Resources Operator, do the following to deploy the NUMA-aware secondary pod scheduler:
 
-* Configure the performance profile. 
-
-* Deploy the NUMA-aware secondary scheduler.
-
-.Prerequisites
-
-* Install the OpenShift CLI (`oc`).
-
-* Log in as a user with `cluster-admin` privileges.
-
-* Create the required machine config pool.
-
-* Install the NUMA Resources Operator.
-
 .Procedure
-
-. Create the `PerformanceProfile` custom resource (CR):
-
-.. Save the following YAML in the `nro-perfprof.yaml` file:
-+
-[source,yaml]
-----
-apiVersion: performance.openshift.io/v2
-kind: PerformanceProfile
-metadata:
-  name: perfprof-nrop
-spec:
-  cpu: <1>
-    isolated: "4-51,56-103" 
-    reserved: "0,1,2,3,52,53,54,55" 
-  nodeSelector:
-    node-role.kubernetes.io/worker: ""
-  numa:
-    topologyPolicy: single-numa-node
-----
-<1> The `cpu.isolated` and `cpu.reserved` specifications define ranges for isolated and reserved CPUs. Enter valid values for your CPU configuration. See the _Additional resources_ section for more information about configuring a performance profile.
-
-.. Create the `PerformanceProfile` CR by running the following command:
-+
-[source,terminal]
-----
-$ oc create -f nro-perfprof.yaml
-----
-+
-.Example output
-[source,terminal]
-----
-performanceprofile.performance.openshift.io/perfprof-nrop created
-----
 
 . Create the `NUMAResourcesScheduler` custom resource that deploys the NUMA-aware custom pod scheduler:
 
-.. Save the following YAML in the `nro-scheduler.yaml` file:
+.. Save the following minimal required YAML in the `nro-scheduler.yaml` file:
 +
 [source,yaml,subs="attributes+"]
 ----
@@ -69,17 +21,8 @@ kind: NUMAResourcesScheduler
 metadata:
   name: numaresourcesscheduler
 spec:
-  imageSpec: "registry.redhat.io/openshift4/noderesourcetopology-scheduler-container-rhel8:v{product-version}"
-  cacheResyncPeriod: "5s" <1> 
+  imageSpec: "registry.redhat.io/openshift4/noderesourcetopology-scheduler-rhel9:v{product-version}"
 ----
-<1> Enter an interval value in seconds for synchronization of the scheduler cache. A value of `5s` is typical for most implementations.
-+
-[NOTE]
-====
-* Enable the `cacheResyncPeriod` specification to help the NUMA Resource Operator report more exact resource availability by monitoring pending resources on nodes and synchronizing this information in the scheduler cache at a defined interval. This also helps to minimize `Topology Affinity Error` errors because of sub-optimal scheduling decisions. The lower the interval the greater the network load. The `cacheResyncPeriod` specification is disabled by default.
-
-* Setting a value of `Enabled` for the `podsFingerprinting` specification in the `NUMAResourcesOperator` CR is a requirement for the implementation of the `cacheResyncPeriod` specification.
-====
 
 .. Create the `NUMAResourcesScheduler` CR by running the following command:
 +
@@ -88,16 +31,7 @@ spec:
 $ oc create -f nro-scheduler.yaml
 ----
 
-.Verification
-
-. Verify that the performance profile was applied by running the following command:
-+
-[source,terminal]
-----
-$ oc describe performanceprofile <performance-profile-name>
-----
-
-. Verify that the required resources deployed successfully by running the following command:
+. After a few seconds, run the following command to confirm the successful deployment of the required resources:
 +
 [source,terminal]
 ----
@@ -108,16 +42,20 @@ $ oc get all -n openshift-numaresources
 [source,terminal]
 ----
 NAME                                                    READY   STATUS    RESTARTS   AGE
-pod/numaresources-controller-manager-7575848485-bns4s   1/1     Running   0          13m
-pod/numaresourcesoperator-worker-dvj4n                  2/2     Running   0          16m
-pod/numaresourcesoperator-worker-lcg4t                  2/2     Running   0          16m
-pod/secondary-scheduler-56994cf6cf-7qf4q                1/1     Running   0          16m
+pod/numaresources-controller-manager-7d9d84c58d-qk2mr   1/1     Running   0          12m
+pod/numaresourcesoperator-worker-7d96r                  2/2     Running   0          97s
+pod/numaresourcesoperator-worker-crsht                  2/2     Running   0          97s
+pod/numaresourcesoperator-worker-jp9mw                  2/2     Running   0          97s
+pod/secondary-scheduler-847cb74f84-9whlm                1/1     Running   0          10m
+
 NAME                                          DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                     AGE
-daemonset.apps/numaresourcesoperator-worker   2         2         2       2            2           node-role.kubernetes.io/worker=   16m
+daemonset.apps/numaresourcesoperator-worker   3         3         3       3            3           node-role.kubernetes.io/worker=   98s
+
 NAME                                               READY   UP-TO-DATE   AVAILABLE   AGE
-deployment.apps/numaresources-controller-manager   1/1     1            1           13m
-deployment.apps/secondary-scheduler                1/1     1            1           16m
+deployment.apps/numaresources-controller-manager   1/1     1            1           12m
+deployment.apps/secondary-scheduler                1/1     1            1           10m
+
 NAME                                                          DESIRED   CURRENT   READY   AGE
-replicaset.apps/numaresources-controller-manager-7575848485   1         1         1       13m
-replicaset.apps/secondary-scheduler-56994cf6cf                1         1         1       16m
+replicaset.apps/numaresources-controller-manager-7d9d84c58d   1         1         1       12m
+replicaset.apps/secondary-scheduler-847cb74f84                1         1         1       10m
 ----

--- a/modules/cnf-installing-numa-resources-operator-console.adoc
+++ b/modules/cnf-installing-numa-resources-operator-console.adoc
@@ -20,7 +20,7 @@ As a cluster administrator, you can install the NUMA Resources Operator using th
 
 .. In the {product-title} web console, click *Operators* -> *OperatorHub*.
 
-.. Choose *NUMA Resources Operator* from the list of available Operators, and then click *Install*.
+.. Choose *numaresources-operator* from the list of available Operators, and then click *Install*.
 
 .. In the *Installed Namespaces* field, select the `openshift-numaresources` namespace, and then click *Install*.
 

--- a/modules/cnf-reporting-more-exact-reource-availability.adoc
+++ b/modules/cnf-reporting-more-exact-reource-availability.adoc
@@ -1,0 +1,143 @@
+// Module included in the following assemblies:
+//
+// *scalability_and_performance/cnf-numa-aware-scheduling.adoc
+
+:_module-type: PROCEDURE
+[id="cnf-reporting-more-exact-resource-availability_{context}"]
+= Reporting more exact resource availability
+
+Enable the `cacheResyncPeriod` specification to help the NUMA Resources Operator report more exact resource availability by monitoring pending resources on nodes and synchronizing this information in the scheduler cache at a defined interval. This also helps to minimize Topology Affinity Error errors because of sub-optimal scheduling decisions. The lower the interval, the greater the network load. The `cacheResyncPeriod` specification is disabled by default.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Delete the currently running `NUMAResourcesScheduler` resource:
+
+.. Get the active `NUMAResourcesScheduler` by running the following command:
++
+[source,terminal]
+----
+$ oc get NUMAResourcesScheduler
+----
++
+.Example output
+[source,terminal]
+----
+NAME                     AGE
+numaresourcesscheduler   92m
+----
+
+.. Delete the secondary scheduler resource by running the following command:
++
+[source,terminal]
+----
+$ oc delete NUMAResourcesScheduler numaresourcesscheduler
+----
++
+.Example output
+[source,terminal]
+----
+numaresourcesscheduler.nodetopology.openshift.io "numaresourcesscheduler" deleted
+----
+
+. Save the following YAML in the file `nro-scheduler-cacheresync.yaml`. This example changes the log level to `Debug`:
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: nodetopology.openshift.io/v1
+kind: NUMAResourcesScheduler
+metadata:
+  name: numaresourcesscheduler
+spec:
+  imageSpec: "registry.redhat.io/openshift4/noderesourcetopology-scheduler-container-rhel8:v{product-version}"
+  cacheResyncPeriod: "5s" <1>
+----
++
+<1> Enter an interval value in seconds for synchronization of the scheduler cache. A value of `5s` is typical for most implementations.
+
+. Create the updated `NUMAResourcesScheduler` resource by running the following command:
++
+[source,terminal]
+----
+$ oc create -f nro-scheduler-cacheresync.yaml
+----
++
+.Example output
+[source,terminal]
+----
+numaresourcesscheduler.nodetopology.openshift.io/numaresourcesscheduler created
+----
+
+.Verification steps
+
+. Check that the NUMA-aware scheduler was successfully deployed:
+
+.. Run the following command to check that the CRD is created succesfully:
++
+[source,terminal]
+----
+$ oc get crd | grep numaresourcesschedulers
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                                              CREATED AT
+numaresourcesschedulers.nodetopology.openshift.io                 2022-02-25T11:57:03Z
+----
+
+.. Check that the new custom scheduler is available by running the following command:
++
+[source,terminal]
+----
+$ oc get numaresourcesschedulers.nodetopology.openshift.io
+----
++
+.Example output
+[source,terminal]
+----
+NAME                     AGE
+numaresourcesscheduler   3h26m
+----
+
+. Check that the logs for the scheduler show the increased log level:
+
+.. Get the list of pods running in the `openshift-numaresources` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-numaresources
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                               READY   STATUS    RESTARTS   AGE
+numaresources-controller-manager-d87d79587-76mrm   1/1     Running   0          46h
+numaresourcesoperator-worker-5wm2k                 2/2     Running   0          45h
+numaresourcesoperator-worker-pb75c                 2/2     Running   0          45h
+secondary-scheduler-7976c4d466-qm4sc               1/1     Running   0          21m
+----
+
+.. Get the logs for the secondary scheduler pod by running the following command:
++
+[source,terminal]
+----
+$ oc logs secondary-scheduler-7976c4d466-qm4sc -n openshift-numaresources
+----
++
+.Example output
+[source,terminal]
+----
+...
+I0223 11:04:55.614788       1 reflector.go:535] k8s.io/client-go/informers/factory.go:134: Watch close - *v1.Namespace total 11 items received
+I0223 11:04:56.609114       1 reflector.go:535] k8s.io/client-go/informers/factory.go:134: Watch close - *v1.ReplicationController total 10 items received
+I0223 11:05:22.626818       1 reflector.go:535] k8s.io/client-go/informers/factory.go:134: Watch close - *v1.StorageClass total 7 items received
+I0223 11:05:31.610356       1 reflector.go:535] k8s.io/client-go/informers/factory.go:134: Watch close - *v1.PodDisruptionBudget total 7 items received
+I0223 11:05:31.713032       1 eventhandlers.go:186] "Add event for scheduled pod" pod="openshift-marketplace/certified-operators-thtvq"
+I0223 11:05:53.461016       1 eventhandlers.go:244] "Delete event for scheduled pod" pod="openshift-marketplace/certified-operators-thtvq"
+----

--- a/modules/cnf-sample-single-numa-policy-from-pp.adoc
+++ b/modules/cnf-sample-single-numa-policy-from-pp.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// *scalability_and_performance/cnf-numa-aware-scheduling.adoc
+
+:_module-type: REFERENCE
+[id="cnf-sample-performance-policy_{context}"]
+= Sample performance profile
+
+This example YAML shows a performance profile created by using the performance profile creator (PPC) tool: 
+
+[source,yaml]
+----
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+spec:
+  cpu:
+    isolated: "3"
+    reserved: 0-2
+  machineConfigPoolSelector:
+    pools.operator.machineconfiguration.openshift.io/worker: "" <1>
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+  numa:
+    topologyPolicy: single-numa-node <2>
+  realTimeKernel:
+    enabled: true
+  workloadHints:
+    highPowerConsumption: true
+    perPodPowerManagement: false
+    realTime: true
+----
+
+<1> This should match the `MachineConfigPool` that you want to configure the NUMA Resources Operator on. For example, you might have created a `MachineConfigPool` named `worker-cnf` that designates a set of nodes that run telecommunications workloads.
+<2> The `topologyPolicy` must be set to `single-numa-node`. Ensure that this is the case by setting the `topology-manager-policy` argument to `single-numa-node` when running the PPC tool.

--- a/modules/cnf-scheduling-numa-aware-workloads-overview.adoc
+++ b/modules/cnf-scheduling-numa-aware-workloads-overview.adoc
@@ -6,3 +6,5 @@
 = Scheduling NUMA-aware workloads
 
 Clusters running latency-sensitive workloads typically feature performance profiles that help to minimize workload latency and optimize performance. The NUMA-aware scheduler deploys workloads based on available node NUMA resources and with respect to any performance profile settings applied to the node. The combination of NUMA-aware deployments, and the performance profile of the workload, ensures that workloads are scheduled in a way that maximizes performance.
+
+For the NUMA Resources Operator to be fully operational, you must deploy the `NUMAResourcesOperator` custom resource and the NUMA-aware secondary pod scheduler. 

--- a/modules/cnf-scheduling-numa-aware-workloads.adoc
+++ b/modules/cnf-scheduling-numa-aware-workloads.adoc
@@ -6,7 +6,7 @@
 [id="cnf-scheduling-numa-aware-workloads_{context}"]
 = Scheduling workloads with the NUMA-aware scheduler
 
-You can schedule workloads with the NUMA-aware scheduler using `Deployment` CRs that specify the minimum required resources to process the workload.
+Now that `topo-aware-scheduler` is installed, the `NUMAResourcesOperator` and `NUMAResourcesScheduler` CRs are applied and your cluster has a matching performance profile or `kubeletconfig`, you can schedule workloads with the NUMA-aware scheduler using deployment CRs that specify the minimum required resources to process the workload.
 
 The following example deployment uses NUMA-aware scheduling for a sample workload.
 
@@ -15,8 +15,6 @@ The following example deployment uses NUMA-aware scheduling for a sample workloa
 * Install the OpenShift CLI (`oc`).
 
 * Log in as a user with `cluster-admin` privileges.
-
-* Install the NUMA Resources Operator and deploy the NUMA-aware secondary scheduler.
 
 .Procedure
 
@@ -30,7 +28,7 @@ $ oc get numaresourcesschedulers.nodetopology.openshift.io numaresourcesschedule
 .Example output
 [source,terminal]
 ----
-topo-aware-scheduler
+"topo-aware-scheduler"
 ----
 
 . Create a `Deployment` CR that uses scheduler named `topo-aware-scheduler`, for example:
@@ -101,27 +99,28 @@ $ oc get pods -n openshift-numaresources
 [source,terminal]
 ----
 NAME                                                READY   STATUS    RESTARTS   AGE
-numa-deployment-1-56954b7b46-pfgw8                  2/2     Running   0          129m
-numaresources-controller-manager-7575848485-bns4s   1/1     Running   0          15h
-numaresourcesoperator-worker-dvj4n                  2/2     Running   0          18h
-numaresourcesoperator-worker-lcg4t                  2/2     Running   0          16h
-secondary-scheduler-56994cf6cf-7qf4q                1/1     Running   0          18h
+numa-deployment-1-6c4f5bdb84-wgn6g                  2/2     Running   0          5m2s
+numaresources-controller-manager-7d9d84c58d-4v65j   1/1     Running   0          18m
+numaresourcesoperator-worker-7d96r                  2/2     Running   4          43m
+numaresourcesoperator-worker-crsht                  2/2     Running   2          43m
+numaresourcesoperator-worker-jp9mw                  2/2     Running   2          43m
+secondary-scheduler-847cb74f84-fpncj                1/1     Running   0          18m
 ----
 
 . Verify that the `topo-aware-scheduler` is scheduling the deployed pod by running the following command:
 +
 [source,terminal]
 ----
-$ oc describe pod numa-deployment-1-56954b7b46-pfgw8 -n openshift-numaresources
+$ oc describe pod numa-deployment-1-6c4f5bdb84-wgn6g -n openshift-numaresources
 ----
 +
 .Example output
 [source,terminal]
 ----
 Events:
-  Type    Reason          Age   From                  Message
-  ----    ------          ----  ----                  -------
-  Normal  Scheduled       130m  topo-aware-scheduler  Successfully assigned openshift-numaresources/numa-deployment-1-56954b7b46-pfgw8 to compute-0.example.com
+  Type    Reason          Age    From                  Message
+  ----    ------          ----   ----                  -------
+  Normal  Scheduled       4m45s  topo-aware-scheduler  Successfully assigned openshift-numaresources/numa-deployment-1-6c4f5bdb84-wgn6g to worker-1
 ----
 +
 [NOTE]
@@ -131,25 +130,25 @@ Deployments that request more resources than is available for scheduling will fa
 
 . Verify that the expected allocated resources are listed for the node.
 
-.. Identify the node that is running the deployment pod by running the following command, replacing <namespace> with the namespace you specified in the `Deployment` CR:
+.. Identify the node that is running the deployment pod by running the following command:
 +
 [source,terminal]
 ----
-$ oc get pods -n <namespace> -o wide
+$ oc get pods -n openshift-numaresources -o wide
 ----
 +
 .Example output
 [source,terminal]
 ----
 NAME                                 READY   STATUS    RESTARTS   AGE   IP            NODE     NOMINATED NODE   READINESS GATES
-numa-deployment-1-65684f8fcc-bw4bw   0/2     Running   0          82m   10.128.2.50   worker-0   <none>  <none>
+numa-deployment-1-6c4f5bdb84-wgn6g   0/2     Running   0          82m   10.128.2.50   worker-1   <none>  <none>
 ----
 +
-.. Run the following command, replacing <node_name> with the name of that node that is running the deployment pod.
+.. Run the following command with the name of that node that is running the deployment pod.
 +
 [source,terminal]
 ----
-$ oc describe noderesourcetopologies.topology.node.k8s.io <node_name>
+$ oc describe noderesourcetopologies.topology.node.k8s.io worker-1
 ----
 +
 .Example output
@@ -191,7 +190,7 @@ Resources consumed by guaranteed pods are subtracted from the available node res
 +
 [source,terminal]
 ----
-$ oc get pod <pod_name> -n <pod_namespace> -o jsonpath="{ .status.qosClass }"
+$ oc get pod numa-deployment-1-6c4f5bdb84-wgn6g -n openshift-numaresources -o jsonpath="{ .status.qosClass }"
 ----
 +
 .Example output

--- a/scalability_and_performance/cnf-numa-aware-scheduling.adoc
+++ b/scalability_and_performance/cnf-numa-aware-scheduling.adoc
@@ -33,23 +33,23 @@ include::modules/cnf-creating-nrop-cr.adoc[leveloffset=+2]
 
 include::modules/cnf-deploying-the-numa-aware-scheduler.adoc[leveloffset=+2]
 
+include::modules/cnf-configuring-single-numa-policy.adoc[leveloffset=+2]
+
 .Additional resources
 
 * xref:../scalability_and_performance/cnf-create-performance-profiles.adoc#cnf-about-the-profile-creator-tool_cnf-create-performance-profiles[About the Performance Profile Creator].
 
+include::modules/cnf-sample-single-numa-policy-from-pp.adoc[leveloffset=+2]
+
+include::modules/cnf-configuring-kubelet-nro.adoc[leveloffset=+2]
+
 include::modules/cnf-scheduling-numa-aware-workloads.adoc[leveloffset=+2]
-
-include::modules/cnf-scheduling-numa-aware-workloads-overview-with-manual-performance-settings.adoc[leveloffset=+1]
-
-include::modules/cnf-creating-nrop-cr-with-manual-performance-settings.adoc[leveloffset=+2]
-
-include::modules/cnf-deploying-the-numa-aware-scheduler-with-manual-performance-settings.adoc[leveloffset=+2]
-
-include::modules/cnf-scheduling-numa-aware-workloads-with-manual-performance-setttings.adoc[leveloffset=+2]
 
 include::modules/cnf-configuring-node-groups-for-the-numaresourcesoperator.adoc[leveloffset=+1]
 
 include::modules/cnf-troubleshooting-numa-aware-workloads.adoc[leveloffset=+1]
+
+include::modules/cnf-reporting-more-exact-reource-availability.adoc[leveloffset=+2]
 
 include::modules/cnf-checking-numa-aware-scheduler-logs.adoc[leveloffset=+2]
 


### PR DESCRIPTION
[TELCODOCS-1785]: Improving NROP documentation

Version(s): 4.13

Issue: https://issues.redhat.com/browse/TELCODOCS-1785

Link to docs preview: https://76572--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-numa-aware-scheduling.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: “Cherry Picked from e81808ac00e0a959f631c459c9d5bc4127c5c2b6 xref: [https://github.com/openshift/openshift-docs/pull/73634]
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
