### PR TITLE
adoc tags troubleshooting: simple exclusion but now singular `tag`

### DIFF
--- a/machine_management/cluster_api_machine_management/cluster-api-managing-machines.adoc
+++ b/machine_management/cluster_api_machine_management/cluster-api-managing-machines.adoc
@@ -19,7 +19,7 @@ include::modules/capi-modifying-machine-template.adoc[leveloffset=+1]
 
 //Modifying a compute machine set by using the CLI
 //tags exclude MAPI, leaving untagged + CAPI
-include::modules/machineset-modifying.adoc[leveloffset=+1,tags=!MAPI]
+include::modules/machineset-modifying.adoc[leveloffset=+1,tag=!MAPI]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc#capi-yaml-machine-set-aws_cluster-api-config-options-aws[Sample YAML for a Cluster API compute machine set resource on {aws-full}]

--- a/machine_management/modifying-machineset.adoc
+++ b/machine_management/modifying-machineset.adoc
@@ -17,7 +17,7 @@ If you need to scale a compute machine set without making other changes, see xre
 
 //Modifying a compute machine set by using the CLI
 //tags exclude CAPI, leaving untagged + MAPI
-include::modules/machineset-modifying.adoc[leveloffset=+1,tags=!CAPI]
+include::modules/machineset-modifying.adoc[leveloffset=+1,tag=!CAPI]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
like #76569 but s/`tags`/`tag`

Previews:

- [CAPI](https://76586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster-api-managing-machines.html#machineset-modifying_cluster-api-managing-machines)
- [MAPI](https://76586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/modifying-machineset.html#machineset-modifying_modifying-machineset)