### PR TITLE
OSDOCS-10659: 4.12.58 RN

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -4710,3 +4710,45 @@ $ oc adm release info 4.12.57 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-12-58"]
+=== RHSA-2024:3349 - {product-title} 4.12.58 bug fix and security update
+
+Issued: 2024-05-30
+
+{product-title} release 4.12.58, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:3349[RHSA-2024:3349] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:3351[RHSA-2024:3351] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.58 --pullspecs
+----
+
+[id="ocp-4-12-58-bug-fixes"]
+==== Bug fixes
+
+* Previously, some container processes created by using the `exec` command persisted even when CRI-O stopped the container. Consequently, lingering processes led to tracking issues, causing process leaks and defunct statuses. With this release, CRI-O tracks the `exec` calls processed for a container and ensures that the processes created as part of the `exec` calls are terminated when the container is stopped. (link:https://issues.redhat.com/browse/OCPBUGS-33175[*OCPBUGS-33175*])
+
+* Previously, an issue with NodePort traffic-forwarding caused the Transmission Control Protocol (TCP) traffic to be directed to pods under a terminating state. With this release, the endpoints selection logic fully implements `KEP-1669 ProxyTerminatingEndpoints` and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-33422[*OCPBUGS-33422*])
+
+* Previously, the load balancing algorithm did not differentiate between active and inactive services when determining weights, and it employed the `random` algorithm excessively in environments with many inactive services or environments routing backends with weight 0. This led to increased memory usage and a higher risk of excessive memory consumption. With this release, changes are made to optimize traffic direction towards active services only and prevent unnecessary use of the `random` algorithm with higher weights, reducing the potential for excessive memory consumption. (link:https://issues.redhat.com/browse/OCPBUGS-33517[*OCPBUGS-33517*])
+
+* Previously, the load-balancing algorithm had flaws that led to increased memory usage and a higher risk of excessive memory consumption. With this release, the service filtering logic for load-balancing is updated and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-33778[*OCPBUGS-33778*])
+
+[id="ocp-4-12-58-known-issue"]
+==== Known issue
+
+* Sometimes, the Console Operator status can get stuck in a failed state when the Operator is removed. To work around this issue, patch the Console controller to reset all conditions to the default state when the Console Operator is removed. For example, log in to the cluster and run the following command:
++
+[source,terminal]
+----
+$ oc patch console.operator.openshift.io/cluster --type='merge' -p='{"status":{"conditions":null}}'
+----
++
+(link:https://issues.redhat.com/browse/OCPBUGS-33386[*OCPBUGS-33386*])
+
+[id="ocp-4-12-58-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-10659](https://issues.redhat.com/browse/OSDOCS-10659)

Link to docs preview:
https://76588--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-58

QE review:
N/A

Additional information:
URLs will return 404 until release goes live (5/30/24)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
