### PR TITLE
Netobserv API doc regeneration

### DIFF
--- a/modules/network-observability-flowcollector-api-specifications.adoc
+++ b/modules/network-observability-flowcollector-api-specifications.adoc
@@ -35,9 +35,14 @@ Type::
 
 | `spec`
 | `object`
-| Defines the desired state of the FlowCollector resource.  +
+| Defines the desired state of the FlowCollector resource.
  +
- *: the mention of "unsupported", or "deprecated" for a feature throughout this document means that this feature is not officially supported by Red Hat. It might have been, for example, contributed by the community and accepted without a formal agreement for maintenance. The product maintainers might provide some support for these features as a best effort only.
+ +
+
+*: the mention of "unsupported" or "deprecated" for a feature throughout this document means that this feature
+is not officially supported by Red Hat. It might have been, for example, contributed by the community
+and accepted without a formal agreement for maintenance. The product maintainers might provide some support
+for these features as a best effort only.
 
 |===
 == .metadata
@@ -57,9 +62,14 @@ Type::
 Description::
 +
 --
-Defines the desired state of the FlowCollector resource.  +
+Defines the desired state of the FlowCollector resource.
  +
- *: the mention of "unsupported", or "deprecated" for a feature throughout this document means that this feature is not officially supported by Red Hat. It might have been, for example, contributed by the community and accepted without a formal agreement for maintenance. The product maintainers might provide some support for these features as a best effort only.
+ +
+
+*: the mention of "unsupported" or "deprecated" for a feature throughout this document means that this feature
+is not officially supported by Red Hat. It might have been, for example, contributed by the community
+and accepted without a formal agreement for maintenance. The product maintainers might provide some support
+for these features as a best effort only.
 --
 
 Type::
@@ -83,9 +93,12 @@ Type::
 | `deploymentModel`
 | `string`
 | `deploymentModel` defines the desired type of deployment for flow processing. Possible values are: +
- - `Direct` (default) to make the flow processor listening directly from the agents. +
- - `Kafka` to make flows sent to a Kafka pipeline before consumption by the processor. +
- Kafka can provide better scalability, resiliency, and high availability (for more details, see https://www.redhat.com/en/topics/integration/what-is-apache-kafka).
+
+- `Direct` (default) to make the flow processor listen directly from the agents. +
+
+- `Kafka` to make flows sent to a Kafka pipeline before consumption by the processor. +
+
+Kafka can provide better scalability, resiliency, and high availability (for more details, see https://www.redhat.com/en/topics/integration/what-is-apache-kafka).
 
 | `exporters`
 | `array`
@@ -105,7 +118,12 @@ Type::
 
 | `processor`
 | `object`
-| `processor` defines the settings of the component that receives the flows from the agent, enriches them, generates metrics, and forwards them to the Loki persistence layer and/or any available exporter.
+| `processor` defines the settings of the component that receives the flows from the agent,
+enriches them, generates metrics, and forwards them to the Loki persistence layer and/or any available exporter.
+
+| `prometheus`
+| `object`
+| `prometheus` defines Prometheus settings, such as querier configuration used to fetch metrics from the Console plugin.
 
 |===
 == .spec.agent
@@ -127,25 +145,21 @@ Type::
 
 | `ebpf`
 | `object`
-| `ebpf` describes the settings related to the eBPF-based flow reporter when `spec.agent.type` is set to `eBPF`.
-
-| `ipfix`
-| `object`
-| `ipfix` [deprecated (*)] - describes the settings related to the IPFIX-based flow reporter when `spec.agent.type` is set to `IPFIX`.
+| `ebpf` describes the settings related to the eBPF-based flow reporter when `spec.agent.type`
+is set to `eBPF`.
 
 | `type`
 | `string`
-| `type` selects the flows tracing agent. Possible values are: +
- - `eBPF` (default) to use Network Observability eBPF agent. +
- - `IPFIX` [deprecated (*)] - to use the legacy IPFIX collector. +
- `eBPF` is recommended as it offers better performances and should work regardless of the CNI installed on the cluster. `IPFIX` works with OVN-Kubernetes CNI (other CNIs could work if they support exporting IPFIX, but they would require manual configuration).
+| `type` [deprecated (*)] selects the flows tracing agent. Previously, this field allowed to select between `eBPF` or `IPFIX`.
+Only `eBPF` is allowed now, so this field is deprecated and is planned for removal in a future version of the API.
 
 |===
 == .spec.agent.ebpf
 Description::
 +
 --
-`ebpf` describes the settings related to the eBPF-based flow reporter when `spec.agent.type` is set to `eBPF`.
+`ebpf` describes the settings related to the eBPF-based flow reporter when `spec.agent.type`
+is set to `eBPF`.
 --
 
 Type::
@@ -160,27 +174,44 @@ Type::
 
 | `advanced`
 | `object`
-| `advanced` allows setting some aspects of the internal configuration of the eBPF agent. This section is aimed mostly for debugging and fine-grained performance optimizations, such as `GOGC` and `GOMAXPROCS` env vars. Set these values at your own risk.
+| `advanced` allows setting some aspects of the internal configuration of the eBPF agent.
+This section is aimed mostly for debugging and fine-grained performance optimizations,
+such as `GOGC` and `GOMAXPROCS` env vars. Set these values at your own risk.
 
 | `cacheActiveTimeout`
 | `string`
-| `cacheActiveTimeout` is the max period during which the reporter aggregates flows before sending. Increasing `cacheMaxFlows` and `cacheActiveTimeout` can decrease the network traffic overhead and the CPU load, however you can expect higher memory consumption and an increased latency in the flow collection.
+| `cacheActiveTimeout` is the max period during which the reporter aggregates flows before sending.
+Increasing `cacheMaxFlows` and `cacheActiveTimeout` can decrease the network traffic overhead and the CPU load,
+however you can expect higher memory consumption and an increased latency in the flow collection.
 
 | `cacheMaxFlows`
 | `integer`
-| `cacheMaxFlows` is the max number of flows in an aggregate; when reached, the reporter sends the flows. Increasing `cacheMaxFlows` and `cacheActiveTimeout` can decrease the network traffic overhead and the CPU load, however you can expect higher memory consumption and an increased latency in the flow collection.
+| `cacheMaxFlows` is the max number of flows in an aggregate; when reached, the reporter sends the flows.
+Increasing `cacheMaxFlows` and `cacheActiveTimeout` can decrease the network traffic overhead and the CPU load,
+however you can expect higher memory consumption and an increased latency in the flow collection.
 
 | `excludeInterfaces`
 | `array (string)`
-| `excludeInterfaces` contains the interface names that are excluded from flow tracing. An entry enclosed by slashes, such as `/br-/`, is matched as a regular expression. Otherwise it is matched as a case-sensitive string.
+| `excludeInterfaces` contains the interface names that are excluded from flow tracing.
+An entry enclosed by slashes, such as `/br-/`, is matched as a regular expression.
+Otherwise it is matched as a case-sensitive string.
 
 | `features`
 | `array (string)`
 | List of additional features to enable. They are all disabled by default. Enabling additional features might have performance impacts. Possible values are: +
- - `PacketDrop`: enable the packets drop flows logging feature. This feature requires mounting the kernel debug filesystem, so the eBPF pod has to run as privileged. If the `spec.agent.ebpf.privileged` parameter is not set, an error is reported. +
- - `DNSTracking`: enable the DNS tracking feature. +
- - `FlowRTT`: enable flow latency (RTT) calculations in the eBPF agent during TCP handshakes. This feature better works with `sampling` set to 1. +
 
+- `PacketDrop`: enable the packets drop flows logging feature. This feature requires mounting
+the kernel debug filesystem, so the eBPF pod has to run as privileged.
+If the `spec.agent.ebpf.privileged` parameter is not set, an error is reported. +
+
+- `DNSTracking`: enable the DNS tracking feature. +
+
+- `FlowRTT`: enable flow latency (sRTT) extraction in the eBPF agent from TCP traffic. +
+
+
+| `flowFilter`
+| `object`
+| `flowFilter` defines the eBPF agent configuration regarding flow filtering.
 
 | `imagePullPolicy`
 | `string`
@@ -188,23 +219,35 @@ Type::
 
 | `interfaces`
 | `array (string)`
-| `interfaces` contains the interface names from where flows are collected. If empty, the agent fetches all the interfaces in the system, excepting the ones listed in ExcludeInterfaces. An entry enclosed by slashes, such as `/br-/`, is matched as a regular expression. Otherwise it is matched as a case-sensitive string.
+| `interfaces` contains the interface names from where flows are collected. If empty, the agent
+fetches all the interfaces in the system, excepting the ones listed in `excludeInterfaces`.
+An entry enclosed by slashes, such as `/br-/`, is matched as a regular expression.
+Otherwise it is matched as a case-sensitive string.
 
 | `kafkaBatchSize`
 | `integer`
-| `kafkaBatchSize` limits the maximum size of a request in bytes before being sent to a partition. Ignored when not using Kafka. Default: 10MB.
+| `kafkaBatchSize` limits the maximum size of a request in bytes before being sent to a partition. Ignored when not using Kafka. Default: 1MB.
 
 | `logLevel`
 | `string`
 | `logLevel` defines the log level for the Network Observability eBPF Agent
 
+| `metrics`
+| `object`
+| `metrics` defines the eBPF agent configuration regarding metrics.
+
 | `privileged`
 | `boolean`
-| Privileged mode for the eBPF Agent container. When ignored or set to `false`, the operator sets granular capabilities (BPF, PERFMON, NET_ADMIN, SYS_RESOURCE) to the container. If for some reason these capabilities cannot be set, such as if an old kernel version not knowing CAP_BPF is in use, then you can turn on this mode for more global privileges. Some agent features require the privileged mode, such as packet drops tracking (see `features`) and SR-IOV support.
+| Privileged mode for the eBPF Agent container. When ignored or set to `false`, the operator sets
+granular capabilities (BPF, PERFMON, NET_ADMIN, SYS_RESOURCE) to the container.
+If for some reason these capabilities cannot be set, such as if an old kernel version not knowing CAP_BPF
+is in use, then you can turn on this mode for more global privileges.
+Some agent features require the privileged mode, such as packet drops tracking (see `features`) and SR-IOV support.
 
 | `resources`
 | `object`
-| `resources` are the compute resources required by this container. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+| `resources` are the compute resources required by this container.
+For more information, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 | `sampling`
 | `integer`
@@ -215,7 +258,9 @@ Type::
 Description::
 +
 --
-`advanced` allows setting some aspects of the internal configuration of the eBPF agent. This section is aimed mostly for debugging and fine-grained performance optimizations, such as `GOGC` and `GOMAXPROCS` env vars. Set these values at your own risk.
+`advanced` allows setting some aspects of the internal configuration of the eBPF agent.
+This section is aimed mostly for debugging and fine-grained performance optimizations,
+such as `GOGC` and `GOMAXPROCS` env vars. Set these values at your own risk.
 --
 
 Type::
@@ -230,14 +275,329 @@ Type::
 
 | `env`
 | `object (string)`
-| `env` allows passing custom environment variables to underlying components. Useful for passing some very concrete performance-tuning options, such as `GOGC` and `GOMAXPROCS`, that should not be publicly exposed as part of the FlowCollector descriptor, as they are only useful in edge debug or support scenarios.
+| `env` allows passing custom environment variables to underlying components. Useful for passing
+some very concrete performance-tuning options, such as `GOGC` and `GOMAXPROCS`, that should not be
+publicly exposed as part of the FlowCollector descriptor, as they are only useful
+in edge debug or support scenarios.
+
+| `scheduling`
+| `object`
+| scheduling controls how the pods are scheduled on nodes.
+
+|===
+== .spec.agent.ebpf.advanced.scheduling
+Description::
++
+--
+scheduling controls how the pods are scheduled on nodes.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `affinity`
+| `object`
+| If specified, the pod's scheduling constraints. For documentation, refer to https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling.
+
+| `nodeSelector`
+| `object (string)`
+| `nodeSelector` allows scheduling of pods only onto nodes that have each of the specified labels.
+For documentation, refer to https://kubernetes.io/docs/concepts/configuration/assign-pod-node/.
+
+| `priorityClassName`
+| `string`
+| If specified, indicates the pod's priority. For documentation, refer to https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#how-to-use-priority-and-preemption.
+If not specified, default priority is used, or zero if there is no default.
+
+| `tolerations`
+| `array`
+| `tolerations` is a list of tolerations that allow the pod to schedule onto nodes with matching taints.
+For documentation, refer to https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling.
+
+|===
+== .spec.agent.ebpf.advanced.scheduling.affinity
+Description::
++
+--
+If specified, the pod's scheduling constraints. For documentation, refer to https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling.
+--
+
+Type::
+  `object`
+
+
+
+
+== .spec.agent.ebpf.advanced.scheduling.tolerations
+Description::
++
+--
+`tolerations` is a list of tolerations that allow the pod to schedule onto nodes with matching taints.
+For documentation, refer to https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling.
+--
+
+Type::
+  `array`
+
+
+
+
+== .spec.agent.ebpf.flowFilter
+Description::
++
+--
+`flowFilter` defines the eBPF agent configuration regarding flow filtering.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `action`
+| `string`
+| `action` defines the action to perform on the flows that match the filter.
+
+| `cidr`
+| `string`
+| `cidr` defines the IP CIDR to filter flows by.
+Examples: `10.10.10.0/24` or `100:100:100:100::/64`
+
+| `destPorts`
+| `integer-or-string`
+| `destPorts` defines the destination ports to filter flows by.
+To filter a single port, set a single port as an integer value. For example: `destPorts: 80`.
+To filter a range of ports, use a "start-end" range in string format. For example: `destPorts: "80-100"`.
+
+| `direction`
+| `string`
+| `direction` defines the direction to filter flows by.
+
+| `enable`
+| `boolean`
+| Set `enable` to `true` to enable the eBPF flow filtering feature.
+
+| `icmpCode`
+| `integer`
+| `icmpCode`, for Internet Control Message Protocol (ICMP) traffic, defines the ICMP code to filter flows by.
+
+| `icmpType`
+| `integer`
+| `icmpType`, for ICMP traffic, defines the ICMP type to filter flows by.
+
+| `peerIP`
+| `string`
+| `peerIP` defines the IP address to filter flows by.
+Example: `10.10.10.10`.
+
+| `ports`
+| `integer-or-string`
+| `ports` defines the ports to filter flows by. It is used both for source and destination ports.
+To filter a single port, set a single port as an integer value. For example: `ports: 80`.
+To filter a range of ports, use a "start-end" range in string format. For example: `ports: "80-100"`.
+
+| `protocol`
+| `string`
+| `protocol` defines the protocol to filter flows by.
+
+| `sourcePorts`
+| `integer-or-string`
+| `sourcePorts` defines the source ports to filter flows by.
+To filter a single port, set a single port as an integer value. For example: `sourcePorts: 80`.
+To filter a range of ports, use a "start-end" range in string format. For example: `sourcePorts: "80-100"`.
+
+|===
+== .spec.agent.ebpf.metrics
+Description::
++
+--
+`metrics` defines the eBPF agent configuration regarding metrics.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `disableAlerts`
+| `array (string)`
+| `disableAlerts` is a list of alerts that should be disabled.
+Possible values are: +
+
+`NetObservDroppedFlows`, which is triggered when the eBPF agent is dropping flows, such as when the BPF hashmap is full or the capacity limiter is being triggered. +
+
+
+| `enable`
+| `boolean`
+| Set `enable` to `false` to disable eBPF agent metrics collection. It is enabled by default.
+
+| `server`
+| `object`
+| Metrics server endpoint configuration for the Prometheus scraper.
+
+|===
+== .spec.agent.ebpf.metrics.server
+Description::
++
+--
+Metrics server endpoint configuration for the Prometheus scraper.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `port`
+| `integer`
+| The metrics server HTTP port.
+
+| `tls`
+| `object`
+| TLS configuration.
+
+|===
+== .spec.agent.ebpf.metrics.server.tls
+Description::
++
+--
+TLS configuration.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `insecureSkipVerify`
+| `boolean`
+| `insecureSkipVerify` allows skipping client-side verification of the provided certificate.
+If set to `true`, the `providedCaFile` field is ignored.
+
+| `provided`
+| `object`
+| TLS configuration when `type` is set to `Provided`.
+
+| `providedCaFile`
+| `object`
+| Reference to the CA file when `type` is set to `Provided`.
+
+| `type`
+| `string`
+| Select the type of TLS configuration: +
+
+- `Disabled` (default) to not configure TLS for the endpoint.
+- `Provided` to manually provide cert file and a key file. [Unsupported (*)].
+- `Auto` to use {product-title} auto generated certificate using annotations.
+
+|===
+== .spec.agent.ebpf.metrics.server.tls.provided
+Description::
++
+--
+TLS configuration when `type` is set to `Provided`.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `certFile`
+| `string`
+| `certFile` defines the path to the certificate file name within the config map or secret.
+
+| `certKey`
+| `string`
+| `certKey` defines the path to the certificate private key file name within the config map or secret. Omit when the key is not necessary.
+
+| `name`
+| `string`
+| Name of the config map or secret containing certificates.
+
+| `namespace`
+| `string`
+| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+
+| `type`
+| `string`
+| Type for the certificate reference: `configmap` or `secret`.
+
+|===
+== .spec.agent.ebpf.metrics.server.tls.providedCaFile
+Description::
++
+--
+Reference to the CA file when `type` is set to `Provided`.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `file`
+| `string`
+| File name within the config map or secret.
+
+| `name`
+| `string`
+| Name of the config map or secret containing the file.
+
+| `namespace`
+| `string`
+| Namespace of the config map or secret containing the file. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+
+| `type`
+| `string`
+| Type for the file reference: "configmap" or "secret".
 
 |===
 == .spec.agent.ebpf.resources
 Description::
 +
 --
-`resources` are the compute resources required by this container. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+`resources` are the compute resources required by this container.
+For more information, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 --
 
 Type::
@@ -252,105 +612,15 @@ Type::
 
 | `limits`
 | `integer-or-string`
-| Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+| Limits describes the maximum amount of compute resources allowed.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 | `requests`
 | `integer-or-string`
-| Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-
-|===
-== .spec.agent.ipfix
-Description::
-+
---
-`ipfix` [deprecated (*)] - describes the settings related to the IPFIX-based flow reporter when `spec.agent.type` is set to `IPFIX`.
---
-
-Type::
-  `object`
-
-
-
-
-[cols="1,1,1",options="header"]
-|===
-| Property | Type | Description
-
-| `cacheActiveTimeout`
-| `string`
-| `cacheActiveTimeout` is the max period during which the reporter aggregates flows before sending.
-
-| `cacheMaxFlows`
-| `integer`
-| `cacheMaxFlows` is the max number of flows in an aggregate; when reached, the reporter sends the flows.
-
-| `clusterNetworkOperator`
-| `object`
-| `clusterNetworkOperator` defines the settings related to the {product-title} Cluster Network Operator, when available.
-
-| `forceSampleAll`
-| `boolean`
-| `forceSampleAll` allows disabling sampling in the IPFIX-based flow reporter. It is not recommended to sample all the traffic with IPFIX, as it might generate cluster instability. If you REALLY want to do that, set this flag to `true`. Use at your own risk. When it is set to `true`, the value of `sampling` is ignored.
-
-| `ovnKubernetes`
-| `object`
-| `ovnKubernetes` defines the settings of the OVN-Kubernetes CNI, when available. This configuration is used when using OVN's IPFIX exports, without {product-title}. When using {product-title}, refer to the `clusterNetworkOperator` property instead.
-
-| `sampling`
-| `integer`
-| `sampling` is the sampling rate on the reporter. 100 means one flow on 100 is sent. To ensure cluster stability, it is not possible to set a value below 2. If you really want to sample every packet, which might impact the cluster stability, refer to `forceSampleAll`. Alternatively, you can use the eBPF Agent instead of IPFIX.
-
-|===
-== .spec.agent.ipfix.clusterNetworkOperator
-Description::
-+
---
-`clusterNetworkOperator` defines the settings related to the {product-title} Cluster Network Operator, when available.
---
-
-Type::
-  `object`
-
-
-
-
-[cols="1,1,1",options="header"]
-|===
-| Property | Type | Description
-
-| `namespace`
-| `string`
-| Namespace  where the config map is going to be deployed.
-
-|===
-== .spec.agent.ipfix.ovnKubernetes
-Description::
-+
---
-`ovnKubernetes` defines the settings of the OVN-Kubernetes CNI, when available. This configuration is used when using OVN's IPFIX exports, without {product-title}. When using {product-title}, refer to the `clusterNetworkOperator` property instead.
---
-
-Type::
-  `object`
-
-
-
-
-[cols="1,1,1",options="header"]
-|===
-| Property | Type | Description
-
-| `containerName`
-| `string`
-| `containerName` defines the name of the container to configure for IPFIX.
-
-| `daemonSetName`
-| `string`
-| `daemonSetName` defines the name of the DaemonSet controlling the OVN-Kubernetes pods.
-
-| `namespace`
-| `string`
-| Namespace where OVN-Kubernetes pods are deployed.
+| Requests describes the minimum amount of compute resources required.
+If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+otherwise to an implementation-defined value. Requests cannot exceed Limits.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 |===
 == .spec.consolePlugin
@@ -372,7 +642,9 @@ Type::
 
 | `advanced`
 | `object`
-| `advanced` allows setting some aspects of the internal configuration of the console plugin. This section is aimed mostly for debugging and fine-grained performance optimizations, such as `GOGC` and `GOMAXPROCS` env vars. Set these values at your own risk.
+| `advanced` allows setting some aspects of the internal configuration of the console plugin.
+This section is aimed mostly for debugging and fine-grained performance optimizations,
+such as `GOGC` and `GOMAXPROCS` env vars. Set these values at your own risk.
 
 | `autoscaler`
 | `object`
@@ -380,7 +652,7 @@ Type::
 
 | `enable`
 | `boolean`
-| Enables the console plugin deployment. `spec.loki.enable` must also be `true`
+| Enables the console plugin deployment.
 
 | `imagePullPolicy`
 | `string`
@@ -404,14 +676,17 @@ Type::
 
 | `resources`
 | `object`
-| `resources`, in terms of compute resources, required by this container. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+| `resources`, in terms of compute resources, required by this container.
+For more information, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 |===
 == .spec.consolePlugin.advanced
 Description::
 +
 --
-`advanced` allows setting some aspects of the internal configuration of the console plugin. This section is aimed mostly for debugging and fine-grained performance optimizations, such as `GOGC` and `GOMAXPROCS` env vars. Set these values at your own risk.
+`advanced` allows setting some aspects of the internal configuration of the console plugin.
+This section is aimed mostly for debugging and fine-grained performance optimizations,
+such as `GOGC` and `GOMAXPROCS` env vars. Set these values at your own risk.
 --
 
 Type::
@@ -426,11 +701,17 @@ Type::
 
 | `args`
 | `array (string)`
-| `args` allows passing custom arguments to underlying components. Useful for overriding some parameters, such as an url or a configuration path, that should not be publicly exposed as part of the FlowCollector descriptor, as they are only useful in edge debug or support scenarios.
+| `args` allows passing custom arguments to underlying components. Useful for overriding
+some parameters, such as a URL or a configuration path, that should not be
+publicly exposed as part of the FlowCollector descriptor, as they are only useful
+in edge debug or support scenarios.
 
 | `env`
 | `object (string)`
-| `env` allows passing custom environment variables to underlying components. Useful for passing some very concrete performance-tuning options, such as `GOGC` and `GOMAXPROCS`, that should not be publicly exposed as part of the FlowCollector descriptor, as they are only useful in edge debug or support scenarios.
+| `env` allows passing custom environment variables to underlying components. Useful for passing
+some very concrete performance-tuning options, such as `GOGC` and `GOMAXPROCS`, that should not be
+publicly exposed as part of the FlowCollector descriptor, as they are only useful
+in edge debug or support scenarios.
 
 | `port`
 | `integer`
@@ -438,9 +719,79 @@ Type::
 
 | `register`
 | `boolean`
-| `register` allows, when set to `true`, to automatically register the provided console plugin with the {product-title} Console operator. When set to `false`, you can still register it manually by editing console.operator.openshift.io/cluster with the following command: `oc patch console.operator.openshift.io cluster --type='json' -p '[{"op": "add", "path": "/spec/plugins/-", "value": "netobserv-plugin"}]'`
+| `register` allows, when set to `true`, to automatically register the provided console plugin with the {product-title} Console operator.
+When set to `false`, you can still register it manually by editing console.operator.openshift.io/cluster with the following command:
+`oc patch console.operator.openshift.io cluster --type='json' -p '[{"op": "add", "path": "/spec/plugins/-", "value": "netobserv-plugin"}]'`
+
+| `scheduling`
+| `object`
+| `scheduling` controls how the pods are scheduled on nodes.
 
 |===
+== .spec.consolePlugin.advanced.scheduling
+Description::
++
+--
+`scheduling` controls how the pods are scheduled on nodes.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `affinity`
+| `object`
+| If specified, the pod's scheduling constraints. For documentation, refer to https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling.
+
+| `nodeSelector`
+| `object (string)`
+| `nodeSelector` allows scheduling of pods only onto nodes that have each of the specified labels.
+For documentation, refer to https://kubernetes.io/docs/concepts/configuration/assign-pod-node/.
+
+| `priorityClassName`
+| `string`
+| If specified, indicates the pod's priority. For documentation, refer to https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#how-to-use-priority-and-preemption.
+If not specified, default priority is used, or zero if there is no default.
+
+| `tolerations`
+| `array`
+| `tolerations` is a list of tolerations that allow the pod to schedule onto nodes with matching taints.
+For documentation, refer to https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling.
+
+|===
+== .spec.consolePlugin.advanced.scheduling.affinity
+Description::
++
+--
+If specified, the pod's scheduling constraints. For documentation, refer to https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling.
+--
+
+Type::
+  `object`
+
+
+
+
+== .spec.consolePlugin.advanced.scheduling.tolerations
+Description::
++
+--
+`tolerations` is a list of tolerations that allow the pod to schedule onto nodes with matching taints.
+For documentation, refer to https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling.
+--
+
+Type::
+  `array`
+
+
+
+
 == .spec.consolePlugin.autoscaler
 Description::
 +
@@ -477,7 +828,8 @@ Type::
 
 | `portNames`
 | `object (string)`
-| `portNames` defines additional port names to use in the console, for example, `portNames: {"3100": "loki"}`.
+| `portNames` defines additional port names to use in the console,
+for example, `portNames: {"3100": "loki"}`.
 
 |===
 == .spec.consolePlugin.quickFilters
@@ -519,7 +871,8 @@ Required::
 
 | `filter`
 | `object (string)`
-| `filter` is a set of keys and values to be set when this filter is selected. Each key can relate to a list of values using a coma-separated string, for example, `filter: {"src_namespace": "namespace1,namespace2"}`.
+| `filter` is a set of keys and values to be set when this filter is selected. Each key can relate to a list of values using a coma-separated string,
+for example, `filter: {"src_namespace": "namespace1,namespace2"}`.
 
 | `name`
 | `string`
@@ -530,7 +883,8 @@ Required::
 Description::
 +
 --
-`resources`, in terms of compute resources, required by this container. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+`resources`, in terms of compute resources, required by this container.
+For more information, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 --
 
 Type::
@@ -545,11 +899,15 @@ Type::
 
 | `limits`
 | `integer-or-string`
-| Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+| Limits describes the maximum amount of compute resources allowed.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 | `requests`
 | `integer-or-string`
-| Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+| Requests describes the minimum amount of compute resources required.
+If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+otherwise to an implementation-defined value. Requests cannot exceed Limits.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 |===
 == .spec.exporters
@@ -716,19 +1074,20 @@ Type::
 
 | `file`
 | `string`
-| File name within the config map or secret
+| File name within the config map or secret.
 
 | `name`
 | `string`
-| Name of the config map or secret containing the file
+| Name of the config map or secret containing the file.
 
 | `namespace`
 | `string`
-| Namespace of the config map or secret containing the file. If omitted, the default is to use the same namespace as where Network Observability is deployed. If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+| Namespace of the config map or secret containing the file. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
 
 | `type`
 | `string`
-| Type for the file reference: "configmap" or "secret"
+| Type for the file reference: "configmap" or "secret".
 
 |===
 == .spec.exporters[].kafka.sasl.clientSecretReference
@@ -750,19 +1109,20 @@ Type::
 
 | `file`
 | `string`
-| File name within the config map or secret
+| File name within the config map or secret.
 
 | `name`
 | `string`
-| Name of the config map or secret containing the file
+| Name of the config map or secret containing the file.
 
 | `namespace`
 | `string`
-| Namespace of the config map or secret containing the file. If omitted, the default is to use the same namespace as where Network Observability is deployed. If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+| Namespace of the config map or secret containing the file. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
 
 | `type`
 | `string`
-| Type for the file reference: "configmap" or "secret"
+| Type for the file reference: "configmap" or "secret".
 
 |===
 == .spec.exporters[].kafka.tls
@@ -792,7 +1152,8 @@ Type::
 
 | `insecureSkipVerify`
 | `boolean`
-| `insecureSkipVerify` allows skipping client-side verification of the server certificate. If set to `true`, the `caCert` field is ignored.
+| `insecureSkipVerify` allows skipping client-side verification of the server certificate.
+If set to `true`, the `caCert` field is ignored.
 
 | `userCert`
 | `object`
@@ -818,7 +1179,7 @@ Type::
 
 | `certFile`
 | `string`
-| `certFile` defines the path to the certificate file name within the config map or secret
+| `certFile` defines the path to the certificate file name within the config map or secret.
 
 | `certKey`
 | `string`
@@ -826,15 +1187,16 @@ Type::
 
 | `name`
 | `string`
-| Name of the config map or secret containing certificates
+| Name of the config map or secret containing certificates.
 
 | `namespace`
 | `string`
-| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed. If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
 
 | `type`
 | `string`
-| Type for the certificate reference: `configmap` or `secret`
+| Type for the certificate reference: `configmap` or `secret`.
 
 |===
 == .spec.exporters[].kafka.tls.userCert
@@ -856,7 +1218,7 @@ Type::
 
 | `certFile`
 | `string`
-| `certFile` defines the path to the certificate file name within the config map or secret
+| `certFile` defines the path to the certificate file name within the config map or secret.
 
 | `certKey`
 | `string`
@@ -864,15 +1226,16 @@ Type::
 
 | `name`
 | `string`
-| Name of the config map or secret containing certificates
+| Name of the config map or secret containing certificates.
 
 | `namespace`
 | `string`
-| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed. If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
 
 | `type`
 | `string`
-| Type for the certificate reference: `configmap` or `secret`
+| Type for the certificate reference: `configmap` or `secret`.
 
 |===
 == .spec.kafka
@@ -961,19 +1324,20 @@ Type::
 
 | `file`
 | `string`
-| File name within the config map or secret
+| File name within the config map or secret.
 
 | `name`
 | `string`
-| Name of the config map or secret containing the file
+| Name of the config map or secret containing the file.
 
 | `namespace`
 | `string`
-| Namespace of the config map or secret containing the file. If omitted, the default is to use the same namespace as where Network Observability is deployed. If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+| Namespace of the config map or secret containing the file. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
 
 | `type`
 | `string`
-| Type for the file reference: "configmap" or "secret"
+| Type for the file reference: "configmap" or "secret".
 
 |===
 == .spec.kafka.sasl.clientSecretReference
@@ -995,19 +1359,20 @@ Type::
 
 | `file`
 | `string`
-| File name within the config map or secret
+| File name within the config map or secret.
 
 | `name`
 | `string`
-| Name of the config map or secret containing the file
+| Name of the config map or secret containing the file.
 
 | `namespace`
 | `string`
-| Namespace of the config map or secret containing the file. If omitted, the default is to use the same namespace as where Network Observability is deployed. If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+| Namespace of the config map or secret containing the file. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
 
 | `type`
 | `string`
-| Type for the file reference: "configmap" or "secret"
+| Type for the file reference: "configmap" or "secret".
 
 |===
 == .spec.kafka.tls
@@ -1037,7 +1402,8 @@ Type::
 
 | `insecureSkipVerify`
 | `boolean`
-| `insecureSkipVerify` allows skipping client-side verification of the server certificate. If set to `true`, the `caCert` field is ignored.
+| `insecureSkipVerify` allows skipping client-side verification of the server certificate.
+If set to `true`, the `caCert` field is ignored.
 
 | `userCert`
 | `object`
@@ -1063,7 +1429,7 @@ Type::
 
 | `certFile`
 | `string`
-| `certFile` defines the path to the certificate file name within the config map or secret
+| `certFile` defines the path to the certificate file name within the config map or secret.
 
 | `certKey`
 | `string`
@@ -1071,15 +1437,16 @@ Type::
 
 | `name`
 | `string`
-| Name of the config map or secret containing certificates
+| Name of the config map or secret containing certificates.
 
 | `namespace`
 | `string`
-| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed. If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
 
 | `type`
 | `string`
-| Type for the certificate reference: `configmap` or `secret`
+| Type for the certificate reference: `configmap` or `secret`.
 
 |===
 == .spec.kafka.tls.userCert
@@ -1101,7 +1468,7 @@ Type::
 
 | `certFile`
 | `string`
-| `certFile` defines the path to the certificate file name within the config map or secret
+| `certFile` defines the path to the certificate file name within the config map or secret.
 
 | `certKey`
 | `string`
@@ -1109,15 +1476,16 @@ Type::
 
 | `name`
 | `string`
-| Name of the config map or secret containing certificates
+| Name of the config map or secret containing certificates.
 
 | `namespace`
 | `string`
-| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed. If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
 
 | `type`
 | `string`
-| Type for the certificate reference: `configmap` or `secret`
+| Type for the certificate reference: `configmap` or `secret`.
 
 |===
 == .spec.loki
@@ -1139,40 +1507,57 @@ Type::
 
 | `advanced`
 | `object`
-| `advanced` allows setting some aspects of the internal configuration of the Loki clients. This section is aimed mostly for debugging and fine-grained performance optimizations.
+| `advanced` allows setting some aspects of the internal configuration of the Loki clients.
+This section is aimed mostly for debugging and fine-grained performance optimizations.
 
 | `enable`
 | `boolean`
-| Set `enable` to `true` to store flows in Loki. It is required for the {product-title} Console plugin installation.
+| Set `enable` to `true` to store flows in Loki.
+The Console plugin can use either Loki or Prometheus as a data source for metrics (see also `spec.prometheus.querier`), or both.
+Not all queries are transposable from Loki to Prometheus. Hence, if Loki is disabled, some features of the plugin are disabled as well,
+such as getting per-pod information or viewing raw flows.
+If both Prometheus and Loki are enabled, Prometheus takes precedence and Loki is used as a fallback for queries that Prometheus cannot handle.
+If they are both disabled, the Console plugin is not deployed.
 
 | `lokiStack`
 | `object`
-| Loki configuration for `LokiStack` mode. This is useful for an easy loki-operator configuration. It is ignored for other modes.
+| Loki configuration for `LokiStack` mode. This is useful for an easy Loki Operator configuration.
+It is ignored for other modes.
 
 | `manual`
 | `object`
-| Loki configuration for `Manual` mode. This is the most flexible configuration. It is ignored for other modes.
+| Loki configuration for `Manual` mode. This is the most flexible configuration.
+It is ignored for other modes.
 
 | `microservices`
 | `object`
-| Loki configuration for `Microservices` mode. Use this option when Loki is installed using the microservices deployment mode (https://grafana.com/docs/loki/latest/fundamentals/architecture/deployment-modes/#microservices-mode). It is ignored for other modes.
+| Loki configuration for `Microservices` mode.
+Use this option when Loki is installed using the microservices deployment mode (https://grafana.com/docs/loki/latest/fundamentals/architecture/deployment-modes/#microservices-mode).
+It is ignored for other modes.
 
 | `mode`
 | `string`
 | `mode` must be set according to the installation mode of Loki: +
- - Use `LokiStack` when Loki is managed using the Loki Operator +
- - Use `Monolithic` when Loki is installed as a monolithic workload +
- - Use `Microservices` when Loki is installed as microservices, but without Loki Operator +
- - Use `Manual` if none of the options above match your setup +
+
+- Use `LokiStack` when Loki is managed using the Loki Operator +
+
+- Use `Monolithic` when Loki is installed as a monolithic workload +
+
+- Use `Microservices` when Loki is installed as microservices, but without Loki Operator +
+
+- Use `Manual` if none of the options above match your setup +
 
 
 | `monolithic`
 | `object`
-| Loki configuration for `Monolithic` mode. Use this option when Loki is installed using the monolithic deployment mode (https://grafana.com/docs/loki/latest/fundamentals/architecture/deployment-modes/#monolithic-mode). It is ignored for other modes.
+| Loki configuration for `Monolithic` mode.
+Use this option when Loki is installed using the monolithic deployment mode (https://grafana.com/docs/loki/latest/fundamentals/architecture/deployment-modes/#monolithic-mode).
+It is ignored for other modes.
 
 | `readTimeout`
 | `string`
-| `readTimeout` is the maximum console plugin loki query total time limit. A timeout of zero means no timeout.
+| `readTimeout` is the maximum console plugin loki query total time limit.
+A timeout of zero means no timeout.
 
 | `writeBatchSize`
 | `integer`
@@ -1184,14 +1569,16 @@ Type::
 
 | `writeTimeout`
 | `string`
-| `writeTimeout` is the maximum Loki time connection / request limit. A timeout of zero means no timeout.
+| `writeTimeout` is the maximum Loki time connection / request limit.
+A timeout of zero means no timeout.
 
 |===
 == .spec.loki.advanced
 Description::
 +
 --
-`advanced` allows setting some aspects of the internal configuration of the Loki clients. This section is aimed mostly for debugging and fine-grained performance optimizations.
+`advanced` allows setting some aspects of the internal configuration of the Loki clients.
+This section is aimed mostly for debugging and fine-grained performance optimizations.
 --
 
 Type::
@@ -1225,7 +1612,8 @@ Type::
 Description::
 +
 --
-Loki configuration for `LokiStack` mode. This is useful for an easy loki-operator configuration. It is ignored for other modes.
+Loki configuration for `LokiStack` mode. This is useful for an easy Loki Operator configuration.
+It is ignored for other modes.
 --
 
 Type::
@@ -1251,7 +1639,8 @@ Type::
 Description::
 +
 --
-Loki configuration for `Manual` mode. This is the most flexible configuration. It is ignored for other modes.
+Loki configuration for `Manual` mode. This is the most flexible configuration.
+It is ignored for other modes.
 --
 
 Type::
@@ -1267,18 +1656,26 @@ Type::
 | `authToken`
 | `string`
 | `authToken` describes the way to get a token to authenticate to Loki. +
- - `Disabled` does not send any token with the request. +
- - `Forward` forwards the user token for authorization. +
- - `Host` [deprecated (*)] - uses the local pod service account to authenticate to Loki. +
- When using the Loki Operator, this must be set to `Forward`.
+
+- `Disabled` does not send any token with the request. +
+
+- `Forward` forwards the user token for authorization. +
+
+- `Host` [deprecated (*)] - uses the local pod service account to authenticate to Loki. +
+
+When using the Loki Operator, this must be set to `Forward`.
 
 | `ingesterUrl`
 | `string`
-| `ingesterUrl` is the address of an existing Loki ingester service to push the flows to. When using the Loki Operator, set it to the Loki gateway service with the `network` tenant set in path, for example https://loki-gateway-http.netobserv.svc:8080/api/logs/v1/network.
+| `ingesterUrl` is the address of an existing Loki ingester service to push the flows to. When using the Loki Operator,
+set it to the Loki gateway service with the `network` tenant set in path, for example
+https://loki-gateway-http.netobserv.svc:8080/api/logs/v1/network.
 
 | `querierUrl`
 | `string`
-| `querierUrl` specifies the address of the Loki querier service. When using the Loki Operator, set it to the Loki gateway service with the `network` tenant set in path, for example https://loki-gateway-http.netobserv.svc:8080/api/logs/v1/network.
+| `querierUrl` specifies the address of the Loki querier service.
+When using the Loki Operator, set it to the Loki gateway service with the `network` tenant set in path, for example
+https://loki-gateway-http.netobserv.svc:8080/api/logs/v1/network.
 
 | `statusTls`
 | `object`
@@ -1286,11 +1683,17 @@ Type::
 
 | `statusUrl`
 | `string`
-| `statusUrl` specifies the address of the Loki `/ready`, `/metrics` and `/config` endpoints, in case it is different from the Loki querier URL. If empty, the `querierUrl` value is used. This is useful to show error messages and some context in the frontend. When using the Loki Operator, set it to the Loki HTTP query frontend service, for example https://loki-query-frontend-http.netobserv.svc:3100/. `statusTLS` configuration is used when `statusUrl` is set.
+| `statusUrl` specifies the address of the Loki `/ready`, `/metrics` and `/config` endpoints, in case it is different from the
+Loki querier URL. If empty, the `querierUrl` value is used.
+This is useful to show error messages and some context in the frontend.
+When using the Loki Operator, set it to the Loki HTTP query frontend service, for example
+https://loki-query-frontend-http.netobserv.svc:3100/.
+`statusTLS` configuration is used when `statusUrl` is set.
 
 | `tenantID`
 | `string`
-| `tenantID` is the Loki `X-Scope-OrgID` that identifies the tenant for each request. When using the Loki Operator, set it to `network`, which corresponds to a special tenant mode.
+| `tenantID` is the Loki `X-Scope-OrgID` that identifies the tenant for each request.
+When using the Loki Operator, set it to `network`, which corresponds to a special tenant mode.
 
 | `tls`
 | `object`
@@ -1324,7 +1727,8 @@ Type::
 
 | `insecureSkipVerify`
 | `boolean`
-| `insecureSkipVerify` allows skipping client-side verification of the server certificate. If set to `true`, the `caCert` field is ignored.
+| `insecureSkipVerify` allows skipping client-side verification of the server certificate.
+If set to `true`, the `caCert` field is ignored.
 
 | `userCert`
 | `object`
@@ -1350,7 +1754,7 @@ Type::
 
 | `certFile`
 | `string`
-| `certFile` defines the path to the certificate file name within the config map or secret
+| `certFile` defines the path to the certificate file name within the config map or secret.
 
 | `certKey`
 | `string`
@@ -1358,15 +1762,16 @@ Type::
 
 | `name`
 | `string`
-| Name of the config map or secret containing certificates
+| Name of the config map or secret containing certificates.
 
 | `namespace`
 | `string`
-| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed. If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
 
 | `type`
 | `string`
-| Type for the certificate reference: `configmap` or `secret`
+| Type for the certificate reference: `configmap` or `secret`.
 
 |===
 == .spec.loki.manual.statusTls.userCert
@@ -1388,7 +1793,7 @@ Type::
 
 | `certFile`
 | `string`
-| `certFile` defines the path to the certificate file name within the config map or secret
+| `certFile` defines the path to the certificate file name within the config map or secret.
 
 | `certKey`
 | `string`
@@ -1396,15 +1801,16 @@ Type::
 
 | `name`
 | `string`
-| Name of the config map or secret containing certificates
+| Name of the config map or secret containing certificates.
 
 | `namespace`
 | `string`
-| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed. If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
 
 | `type`
 | `string`
-| Type for the certificate reference: `configmap` or `secret`
+| Type for the certificate reference: `configmap` or `secret`.
 
 |===
 == .spec.loki.manual.tls
@@ -1434,7 +1840,8 @@ Type::
 
 | `insecureSkipVerify`
 | `boolean`
-| `insecureSkipVerify` allows skipping client-side verification of the server certificate. If set to `true`, the `caCert` field is ignored.
+| `insecureSkipVerify` allows skipping client-side verification of the server certificate.
+If set to `true`, the `caCert` field is ignored.
 
 | `userCert`
 | `object`
@@ -1460,7 +1867,7 @@ Type::
 
 | `certFile`
 | `string`
-| `certFile` defines the path to the certificate file name within the config map or secret
+| `certFile` defines the path to the certificate file name within the config map or secret.
 
 | `certKey`
 | `string`
@@ -1468,15 +1875,16 @@ Type::
 
 | `name`
 | `string`
-| Name of the config map or secret containing certificates
+| Name of the config map or secret containing certificates.
 
 | `namespace`
 | `string`
-| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed. If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
 
 | `type`
 | `string`
-| Type for the certificate reference: `configmap` or `secret`
+| Type for the certificate reference: `configmap` or `secret`.
 
 |===
 == .spec.loki.manual.tls.userCert
@@ -1498,7 +1906,7 @@ Type::
 
 | `certFile`
 | `string`
-| `certFile` defines the path to the certificate file name within the config map or secret
+| `certFile` defines the path to the certificate file name within the config map or secret.
 
 | `certKey`
 | `string`
@@ -1506,22 +1914,25 @@ Type::
 
 | `name`
 | `string`
-| Name of the config map or secret containing certificates
+| Name of the config map or secret containing certificates.
 
 | `namespace`
 | `string`
-| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed. If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
 
 | `type`
 | `string`
-| Type for the certificate reference: `configmap` or `secret`
+| Type for the certificate reference: `configmap` or `secret`.
 
 |===
 == .spec.loki.microservices
 Description::
 +
 --
-Loki configuration for `Microservices` mode. Use this option when Loki is installed using the microservices deployment mode (https://grafana.com/docs/loki/latest/fundamentals/architecture/deployment-modes/#microservices-mode). It is ignored for other modes.
+Loki configuration for `Microservices` mode.
+Use this option when Loki is installed using the microservices deployment mode (https://grafana.com/docs/loki/latest/fundamentals/architecture/deployment-modes/#microservices-mode).
+It is ignored for other modes.
 --
 
 Type::
@@ -1578,7 +1989,8 @@ Type::
 
 | `insecureSkipVerify`
 | `boolean`
-| `insecureSkipVerify` allows skipping client-side verification of the server certificate. If set to `true`, the `caCert` field is ignored.
+| `insecureSkipVerify` allows skipping client-side verification of the server certificate.
+If set to `true`, the `caCert` field is ignored.
 
 | `userCert`
 | `object`
@@ -1604,7 +2016,7 @@ Type::
 
 | `certFile`
 | `string`
-| `certFile` defines the path to the certificate file name within the config map or secret
+| `certFile` defines the path to the certificate file name within the config map or secret.
 
 | `certKey`
 | `string`
@@ -1612,15 +2024,16 @@ Type::
 
 | `name`
 | `string`
-| Name of the config map or secret containing certificates
+| Name of the config map or secret containing certificates.
 
 | `namespace`
 | `string`
-| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed. If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
 
 | `type`
 | `string`
-| Type for the certificate reference: `configmap` or `secret`
+| Type for the certificate reference: `configmap` or `secret`.
 
 |===
 == .spec.loki.microservices.tls.userCert
@@ -1642,7 +2055,7 @@ Type::
 
 | `certFile`
 | `string`
-| `certFile` defines the path to the certificate file name within the config map or secret
+| `certFile` defines the path to the certificate file name within the config map or secret.
 
 | `certKey`
 | `string`
@@ -1650,22 +2063,25 @@ Type::
 
 | `name`
 | `string`
-| Name of the config map or secret containing certificates
+| Name of the config map or secret containing certificates.
 
 | `namespace`
 | `string`
-| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed. If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
 
 | `type`
 | `string`
-| Type for the certificate reference: `configmap` or `secret`
+| Type for the certificate reference: `configmap` or `secret`.
 
 |===
 == .spec.loki.monolithic
 Description::
 +
 --
-Loki configuration for `Monolithic` mode. Use this option when Loki is installed using the monolithic deployment mode (https://grafana.com/docs/loki/latest/fundamentals/architecture/deployment-modes/#monolithic-mode). It is ignored for other modes.
+Loki configuration for `Monolithic` mode.
+Use this option when Loki is installed using the monolithic deployment mode (https://grafana.com/docs/loki/latest/fundamentals/architecture/deployment-modes/#monolithic-mode).
+It is ignored for other modes.
 --
 
 Type::
@@ -1718,7 +2134,8 @@ Type::
 
 | `insecureSkipVerify`
 | `boolean`
-| `insecureSkipVerify` allows skipping client-side verification of the server certificate. If set to `true`, the `caCert` field is ignored.
+| `insecureSkipVerify` allows skipping client-side verification of the server certificate.
+If set to `true`, the `caCert` field is ignored.
 
 | `userCert`
 | `object`
@@ -1744,7 +2161,7 @@ Type::
 
 | `certFile`
 | `string`
-| `certFile` defines the path to the certificate file name within the config map or secret
+| `certFile` defines the path to the certificate file name within the config map or secret.
 
 | `certKey`
 | `string`
@@ -1752,15 +2169,16 @@ Type::
 
 | `name`
 | `string`
-| Name of the config map or secret containing certificates
+| Name of the config map or secret containing certificates.
 
 | `namespace`
 | `string`
-| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed. If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
 
 | `type`
 | `string`
-| Type for the certificate reference: `configmap` or `secret`
+| Type for the certificate reference: `configmap` or `secret`.
 
 |===
 == .spec.loki.monolithic.tls.userCert
@@ -1782,7 +2200,7 @@ Type::
 
 | `certFile`
 | `string`
-| `certFile` defines the path to the certificate file name within the config map or secret
+| `certFile` defines the path to the certificate file name within the config map or secret.
 
 | `certKey`
 | `string`
@@ -1790,22 +2208,24 @@ Type::
 
 | `name`
 | `string`
-| Name of the config map or secret containing certificates
+| Name of the config map or secret containing certificates.
 
 | `namespace`
 | `string`
-| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed. If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
 
 | `type`
 | `string`
-| Type for the certificate reference: `configmap` or `secret`
+| Type for the certificate reference: `configmap` or `secret`.
 
 |===
 == .spec.processor
 Description::
 +
 --
-`processor` defines the settings of the component that receives the flows from the agent, enriches them, generates metrics, and forwards them to the Loki persistence layer and/or any available exporter.
+`processor` defines the settings of the component that receives the flows from the agent,
+enriches them, generates metrics, and forwards them to the Loki persistence layer and/or any available exporter.
 --
 
 Type::
@@ -1820,11 +2240,14 @@ Type::
 
 | `addZone`
 | `boolean`
-| `addZone` allows availability zone awareness by labelling flows with their source and destination zones. This feature requires the "topology.kubernetes.io/zone" label to be set on nodes.
+| `addZone` allows availability zone awareness by labelling flows with their source and destination zones.
+This feature requires the "topology.kubernetes.io/zone" label to be set on nodes.
 
 | `advanced`
 | `object`
-| `advanced` allows setting some aspects of the internal configuration of the flow processor. This section is aimed mostly for debugging and fine-grained performance optimizations, such as `GOGC` and `GOMAXPROCS` env vars. Set these values at your own risk.
+| `advanced` allows setting some aspects of the internal configuration of the flow processor.
+This section is aimed mostly for debugging and fine-grained performance optimizations,
+such as `GOGC` and `GOMAXPROCS` env vars. Set these values at your own risk.
 
 | `clusterName`
 | `string`
@@ -1836,7 +2259,8 @@ Type::
 
 | `kafkaConsumerAutoscaler`
 | `object`
-| `kafkaConsumerAutoscaler` is the spec of a horizontal pod autoscaler to set up for `flowlogs-pipeline-transformer`, which consumes Kafka messages. This setting is ignored when Kafka is disabled. Refer to HorizontalPodAutoscaler documentation (autoscaling/v2).
+| `kafkaConsumerAutoscaler` is the spec of a horizontal pod autoscaler to set up for `flowlogs-pipeline-transformer`, which consumes Kafka messages.
+This setting is ignored when Kafka is disabled. Refer to HorizontalPodAutoscaler documentation (autoscaling/v2).
 
 | `kafkaConsumerBatchSize`
 | `integer`
@@ -1848,7 +2272,8 @@ Type::
 
 | `kafkaConsumerReplicas`
 | `integer`
-| `kafkaConsumerReplicas` defines the number of replicas (pods) to start for `flowlogs-pipeline-transformer`, which consumes Kafka messages. This setting is ignored when Kafka is disabled.
+| `kafkaConsumerReplicas` defines the number of replicas (pods) to start for `flowlogs-pipeline-transformer`, which consumes Kafka messages.
+This setting is ignored when Kafka is disabled.
 
 | `logLevel`
 | `string`
@@ -1857,10 +2282,14 @@ Type::
 | `logTypes`
 | `string`
 | `logTypes` defines the desired record types to generate. Possible values are: +
- - `Flows` (default) to export regular network flows +
- - `Conversations` to generate events for started conversations, ended conversations as well as periodic "tick" updates +
- - `EndedConversations` to generate only ended conversations events +
- - `All` to generate both network flows and all conversations events +
+
+- `Flows` (default) to export regular network flows +
+
+- `Conversations` to generate events for started conversations, ended conversations as well as periodic "tick" updates +
+
+- `EndedConversations` to generate only ended conversations events +
+
+- `All` to generate both network flows and all conversations events +
 
 
 | `metrics`
@@ -1873,14 +2302,22 @@ Type::
 
 | `resources`
 | `object`
-| `resources` are the compute resources required by this container. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+| `resources` are the compute resources required by this container.
+For more information, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+| `subnetLabels`
+| `object`
+| `subnetLabels` allows to define custom labels on subnets and IPs or to enable automatic labelling of recognized subnets in {product-title}, which is used to identify cluster external traffic.
+When a subnet matches the source or destination IP of a flow, a corresponding field is added: `SrcSubnetLabel` or `DstSubnetLabel`.
 
 |===
 == .spec.processor.advanced
 Description::
 +
 --
-`advanced` allows setting some aspects of the internal configuration of the flow processor. This section is aimed mostly for debugging and fine-grained performance optimizations, such as `GOGC` and `GOMAXPROCS` env vars. Set these values at your own risk.
+`advanced` allows setting some aspects of the internal configuration of the flow processor.
+This section is aimed mostly for debugging and fine-grained performance optimizations,
+such as `GOGC` and `GOMAXPROCS` env vars. Set these values at your own risk.
 --
 
 Type::
@@ -1895,7 +2332,8 @@ Type::
 
 | `conversationEndTimeout`
 | `string`
-| `conversationEndTimeout` is the time to wait after a network flow is received, to consider the conversation ended. This delay is ignored when a FIN packet is collected for TCP flows (see `conversationTerminatingTimeout` instead).
+| `conversationEndTimeout` is the time to wait after a network flow is received, to consider the conversation ended.
+This delay is ignored when a FIN packet is collected for TCP flows (see `conversationTerminatingTimeout` instead).
 
 | `conversationHeartbeatInterval`
 | `string`
@@ -1907,7 +2345,7 @@ Type::
 
 | `dropUnusedFields`
 | `boolean`
-| `dropUnusedFields` allows, when set to `true`, to drop fields that are known to be unused by OVS, to save storage space.
+| `dropUnusedFields` [deprecated (*)] this setting is not used anymore.
 
 | `enableKubeProbes`
 | `boolean`
@@ -1915,7 +2353,10 @@ Type::
 
 | `env`
 | `object (string)`
-| `env` allows passing custom environment variables to underlying components. Useful for passing some very concrete performance-tuning options, such as `GOGC` and `GOMAXPROCS`, that should not be publicly exposed as part of the FlowCollector descriptor, as they are only useful in edge debug or support scenarios.
+| `env` allows passing custom environment variables to underlying components. Useful for passing
+some very concrete performance-tuning options, such as `GOGC` and `GOMAXPROCS`, that should not be
+publicly exposed as part of the FlowCollector descriptor, as they are only useful
+in edge debug or support scenarios.
 
 | `healthPort`
 | `integer`
@@ -1923,18 +2364,89 @@ Type::
 
 | `port`
 | `integer`
-| Port of the flow collector (host port). By convention, some values are forbidden. It must be greater than 1024 and different from 4500, 4789 and 6081.
+| Port of the flow collector (host port).
+By convention, some values are forbidden. It must be greater than 1024 and different from
+4500, 4789 and 6081.
 
 | `profilePort`
 | `integer`
 | `profilePort` allows setting up a Go pprof profiler listening to this port
 
+| `scheduling`
+| `object`
+| scheduling controls how the pods are scheduled on nodes.
+
 |===
+== .spec.processor.advanced.scheduling
+Description::
++
+--
+scheduling controls how the pods are scheduled on nodes.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `affinity`
+| `object`
+| If specified, the pod's scheduling constraints. For documentation, refer to https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling.
+
+| `nodeSelector`
+| `object (string)`
+| `nodeSelector` allows scheduling of pods only onto nodes that have each of the specified labels.
+For documentation, refer to https://kubernetes.io/docs/concepts/configuration/assign-pod-node/.
+
+| `priorityClassName`
+| `string`
+| If specified, indicates the pod's priority. For documentation, refer to https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#how-to-use-priority-and-preemption.
+If not specified, default priority is used, or zero if there is no default.
+
+| `tolerations`
+| `array`
+| `tolerations` is a list of tolerations that allow the pod to schedule onto nodes with matching taints.
+For documentation, refer to https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling.
+
+|===
+== .spec.processor.advanced.scheduling.affinity
+Description::
++
+--
+If specified, the pod's scheduling constraints. For documentation, refer to https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling.
+--
+
+Type::
+  `object`
+
+
+
+
+== .spec.processor.advanced.scheduling.tolerations
+Description::
++
+--
+`tolerations` is a list of tolerations that allow the pod to schedule onto nodes with matching taints.
+For documentation, refer to https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling.
+--
+
+Type::
+  `array`
+
+
+
+
 == .spec.processor.kafkaConsumerAutoscaler
 Description::
 +
 --
-`kafkaConsumerAutoscaler` is the spec of a horizontal pod autoscaler to set up for `flowlogs-pipeline-transformer`, which consumes Kafka messages. This setting is ignored when Kafka is disabled. Refer to HorizontalPodAutoscaler documentation (autoscaling/v2).
+`kafkaConsumerAutoscaler` is the spec of a horizontal pod autoscaler to set up for `flowlogs-pipeline-transformer`, which consumes Kafka messages.
+This setting is ignored when Kafka is disabled. Refer to HorizontalPodAutoscaler documentation (autoscaling/v2).
 --
 
 Type::
@@ -1962,14 +2474,24 @@ Type::
 
 | `disableAlerts`
 | `array (string)`
-| `disableAlerts` is a list of alerts that should be disabled. Possible values are: +
- `NetObservNoFlows`, which is triggered when no flows are being observed for a certain period. +
- `NetObservLokiError`, which is triggered when flows are being dropped due to Loki errors. +
+| `disableAlerts` is a list of alerts that should be disabled.
+Possible values are: +
+
+`NetObservNoFlows`, which is triggered when no flows are being observed for a certain period. +
+
+`NetObservLokiError`, which is triggered when flows are being dropped due to Loki errors. +
 
 
 | `includeList`
 | `array (string)`
-| `includeList` is a list of metric names to specify which ones to generate. The names correspond to the names in Prometheus without the prefix. For example, `namespace_egress_packets_total` shows up as `netobserv_namespace_egress_packets_total` in Prometheus. Note that the more metrics you add, the bigger is the impact on Prometheus workload resources. Metrics enabled by default are: `namespace_flows_total`, `node_ingress_bytes_total`, `workload_ingress_bytes_total`, `namespace_drop_packets_total` (when `PacketDrop` feature is enabled), `namespace_rtt_seconds` (when `FlowRTT` feature is enabled), `namespace_dns_latency_seconds` (when `DNSTracking` feature is enabled). More information, with full list of available metrics: https://github.com/netobserv/network-observability-operator/blob/main/docs/Metrics.md
+| `includeList` is a list of metric names to specify which ones to generate.
+The names correspond to the names in Prometheus without the prefix. For example,
+`namespace_egress_packets_total` shows up as `netobserv_namespace_egress_packets_total` in Prometheus.
+Note that the more metrics you add, the bigger is the impact on Prometheus workload resources.
+Metrics enabled by default are:
+`namespace_flows_total`, `node_ingress_bytes_total`, `workload_ingress_bytes_total`, `namespace_drop_packets_total` (when `PacketDrop` feature is enabled),
+`namespace_rtt_seconds` (when `FlowRTT` feature is enabled), `namespace_dns_latency_seconds` (when `DNSTracking` feature is enabled).
+More information, with full list of available metrics: https://github.com/netobserv/network-observability-operator/blob/main/docs/Metrics.md
 
 | `server`
 | `object`
@@ -1995,7 +2517,7 @@ Type::
 
 | `port`
 | `integer`
-| The prometheus HTTP port
+| The metrics server HTTP port.
 
 | `tls`
 | `object`
@@ -2021,7 +2543,8 @@ Type::
 
 | `insecureSkipVerify`
 | `boolean`
-| `insecureSkipVerify` allows skipping client-side verification of the provided certificate. If set to `true`, the `providedCaFile` field is ignored.
+| `insecureSkipVerify` allows skipping client-side verification of the provided certificate.
+If set to `true`, the `providedCaFile` field is ignored.
 
 | `provided`
 | `object`
@@ -2034,7 +2557,10 @@ Type::
 | `type`
 | `string`
 | Select the type of TLS configuration: +
- - `Disabled` (default) to not configure TLS for the endpoint. - `Provided` to manually provide cert file and a key file. - `Auto` to use {product-title} auto generated certificate using annotations.
+
+- `Disabled` (default) to not configure TLS for the endpoint.
+- `Provided` to manually provide cert file and a key file. [Unsupported (*)].
+- `Auto` to use {product-title} auto generated certificate using annotations.
 
 |===
 == .spec.processor.metrics.server.tls.provided
@@ -2056,7 +2582,7 @@ Type::
 
 | `certFile`
 | `string`
-| `certFile` defines the path to the certificate file name within the config map or secret
+| `certFile` defines the path to the certificate file name within the config map or secret.
 
 | `certKey`
 | `string`
@@ -2064,15 +2590,16 @@ Type::
 
 | `name`
 | `string`
-| Name of the config map or secret containing certificates
+| Name of the config map or secret containing certificates.
 
 | `namespace`
 | `string`
-| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed. If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
 
 | `type`
 | `string`
-| Type for the certificate reference: `configmap` or `secret`
+| Type for the certificate reference: `configmap` or `secret`.
 
 |===
 == .spec.processor.metrics.server.tls.providedCaFile
@@ -2094,26 +2621,28 @@ Type::
 
 | `file`
 | `string`
-| File name within the config map or secret
+| File name within the config map or secret.
 
 | `name`
 | `string`
-| Name of the config map or secret containing the file
+| Name of the config map or secret containing the file.
 
 | `namespace`
 | `string`
-| Namespace of the config map or secret containing the file. If omitted, the default is to use the same namespace as where Network Observability is deployed. If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+| Namespace of the config map or secret containing the file. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
 
 | `type`
 | `string`
-| Type for the file reference: "configmap" or "secret"
+| Type for the file reference: "configmap" or "secret".
 
 |===
 == .spec.processor.resources
 Description::
 +
 --
-`resources` are the compute resources required by this container. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+`resources` are the compute resources required by this container.
+For more information, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 --
 
 Type::
@@ -2128,10 +2657,295 @@ Type::
 
 | `limits`
 | `integer-or-string`
-| Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+| Limits describes the maximum amount of compute resources allowed.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 | `requests`
 | `integer-or-string`
-| Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+| Requests describes the minimum amount of compute resources required.
+If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+otherwise to an implementation-defined value. Requests cannot exceed Limits.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+|===
+== .spec.processor.subnetLabels
+Description::
++
+--
+`subnetLabels` allows to define custom labels on subnets and IPs or to enable automatic labelling of recognized subnets in {product-title}, which is used to identify cluster external traffic.
+When a subnet matches the source or destination IP of a flow, a corresponding field is added: `SrcSubnetLabel` or `DstSubnetLabel`.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `customLabels`
+| `array`
+| `customLabels` allows to customize subnets and IPs labelling, such as to identify cluster-external workloads or web services.
+If you enable `openShiftAutoDetect`, `customLabels` can override the detected subnets in case they overlap.
+
+| `openShiftAutoDetect`
+| `boolean`
+| `openShiftAutoDetect` allows, when set to `true`, to detect automatically the machines, pods and services subnets based on the
+{product-title} install configuration and the Cluster Network Operator configuration. Indirectly, this is a way to accurately detect
+external traffic: flows that are not labeled for those subnets are external to the cluster. Enabled by default on {product-title}.
+
+|===
+== .spec.processor.subnetLabels.customLabels
+Description::
++
+--
+`customLabels` allows to customize subnets and IPs labelling, such as to identify cluster-external workloads or web services.
+If you enable `openShiftAutoDetect`, `customLabels` can override the detected subnets in case they overlap.
+--
+
+Type::
+  `array`
+
+
+
+
+== .spec.processor.subnetLabels.customLabels[]
+Description::
++
+--
+SubnetLabel allows to label subnets and IPs, such as to identify cluster-external workloads or web services.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `cidrs`
+| `array (string)`
+| List of CIDRs, such as `["1.2.3.4/32"]`.
+
+| `name`
+| `string`
+| Label name, used to flag matching flows.
+
+|===
+== .spec.prometheus
+Description::
++
+--
+`prometheus` defines Prometheus settings, such as querier configuration used to fetch metrics from the Console plugin.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `querier`
+| `object`
+| Prometheus querying configuration, such as client settings, used in the Console plugin.
+
+|===
+== .spec.prometheus.querier
+Description::
++
+--
+Prometheus querying configuration, such as client settings, used in the Console plugin.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `enable`
+| `boolean`
+| When `enable` is `true`, the Console plugin queries flow metrics from Prometheus instead of Loki whenever possible.
+It is enbaled by default: set it to `false` to disable this feature.
+The Console plugin can use either Loki or Prometheus as a data source for metrics (see also `spec.loki`), or both.
+Not all queries are transposable from Loki to Prometheus. Hence, if Loki is disabled, some features of the plugin are disabled as well,
+such as getting per-pod information or viewing raw flows.
+If both Prometheus and Loki are enabled, Prometheus takes precedence and Loki is used as a fallback for queries that Prometheus cannot handle.
+If they are both disabled, the Console plugin is not deployed.
+
+| `manual`
+| `object`
+| Prometheus configuration for `Manual` mode.
+
+| `mode`
+| `string`
+| `mode` must be set according to the type of Prometheus installation that stores Network Observability metrics: +
+
+- Use `Auto` to try configuring automatically. In {product-title}, it uses the Thanos querier from {product-title} Cluster Monitoring +
+
+- Use `Manual` for a manual setup +
+
+
+| `timeout`
+| `string`
+| `timeout` is the read timeout for console plugin queries to Prometheus.
+A timeout of zero means no timeout.
+
+|===
+== .spec.prometheus.querier.manual
+Description::
++
+--
+Prometheus configuration for `Manual` mode.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `forwardUserToken`
+| `boolean`
+| Set `true` to forward logged in user token in queries to Prometheus
+
+| `tls`
+| `object`
+| TLS client configuration for Prometheus URL.
+
+| `url`
+| `string`
+| `url` is the address of an existing Prometheus service to use for querying metrics.
+
+|===
+== .spec.prometheus.querier.manual.tls
+Description::
++
+--
+TLS client configuration for Prometheus URL.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `caCert`
+| `object`
+| `caCert` defines the reference of the certificate for the Certificate Authority
+
+| `enable`
+| `boolean`
+| Enable TLS
+
+| `insecureSkipVerify`
+| `boolean`
+| `insecureSkipVerify` allows skipping client-side verification of the server certificate.
+If set to `true`, the `caCert` field is ignored.
+
+| `userCert`
+| `object`
+| `userCert` defines the user certificate reference and is used for mTLS (you can ignore it when using one-way TLS)
+
+|===
+== .spec.prometheus.querier.manual.tls.caCert
+Description::
++
+--
+`caCert` defines the reference of the certificate for the Certificate Authority
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `certFile`
+| `string`
+| `certFile` defines the path to the certificate file name within the config map or secret.
+
+| `certKey`
+| `string`
+| `certKey` defines the path to the certificate private key file name within the config map or secret. Omit when the key is not necessary.
+
+| `name`
+| `string`
+| Name of the config map or secret containing certificates.
+
+| `namespace`
+| `string`
+| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+
+| `type`
+| `string`
+| Type for the certificate reference: `configmap` or `secret`.
+
+|===
+== .spec.prometheus.querier.manual.tls.userCert
+Description::
++
+--
+`userCert` defines the user certificate reference and is used for mTLS (you can ignore it when using one-way TLS)
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `certFile`
+| `string`
+| `certFile` defines the path to the certificate file name within the config map or secret.
+
+| `certKey`
+| `string`
+| `certKey` defines the path to the certificate private key file name within the config map or secret. Omit when the key is not necessary.
+
+| `name`
+| `string`
+| Name of the config map or secret containing certificates.
+
+| `namespace`
+| `string`
+| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+
+| `type`
+| `string`
+| Type for the certificate reference: `configmap` or `secret`.
 
 |===


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
Merge to only the no-1.6 branch - no cherrypicks are required.
This PR is part of an experiment for simplifying merges for asynchronous content, and I will open one PR against main to incorporate all of the Network Observability 1.6 content just before its GA
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://76593--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/flowcollector-api.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
Notes to peer reviewers:

- There are about 9 (I think) instances of `spec...advanced.scheduling` that contain the same specs for `tolerations`, `priorityClassName`, `nodeSelector`,  and affinity. After you look at one, feel free to glaze over the others :)
- There are some minor deprecation updates. If you ctrl+f for "deprecated" you should be able to see those changes.
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
