### PR TITLE
Flow format reference regeneration

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2692,7 +2692,7 @@ Topics:
     File: network-observability-operator-monitoring
   - Name: API reference
     File: flowcollector-api
-  - Name: JSON flows format reference
+  - Name: Flows format reference
     File: json-flows-format-reference
   - Name: Troubleshooting Network Observability
     File: troubleshooting-network-observability

--- a/modules/network-observability-flows-format.adoc
+++ b/modules/network-observability-flows-format.adoc
@@ -9,105 +9,132 @@ The "Filter ID" column shows which related name to use when defining Quick Filte
 
 The "Loki label" column is useful when querying Loki directly: label fields need to be selected using link:https://grafana.com/docs/loki/latest/logql/log_queries/#log-stream-selector[stream selectors].
 
+The "Cardinality" column gives information about the implied metric cardinality if this field was to be used as a Prometheus label with the `FlowMetrics` API. Refer to the `FlowMetrics` documentation for more information on using this API.
 
-[cols="1,1,3,1,1",options="header"]
+
+[cols="1,1,3,1,1,1",options="header"]
 |===
-| Name | Type | Description | Filter ID | Loki label
+| Name | Type | Description | Filter ID | Loki label | Cardinality
 | `Bytes`
 | number
 | Number of bytes
 | n/a
 | no
+| avoid
 | `DnsErrno`
 | number
 | Error number returned from DNS tracker ebpf hook function
 | `dns_errno`
 | no
+| fine
 | `DnsFlags`
 | number
 | DNS flags for DNS record
 | n/a
 | no
+| fine
 | `DnsFlagsResponseCode`
 | string
 | Parsed DNS header RCODEs name
 | `dns_flag_response_code`
 | no
+| fine
 | `DnsId`
 | number
 | DNS record id
 | `dns_id`
 | no
+| avoid
 | `DnsLatencyMs`
 | number
 | Time between a DNS request and response, in milliseconds
 | `dns_latency`
 | no
+| avoid
 | `Dscp`
 | number
 | Differentiated Services Code Point (DSCP) value
 | `dscp`
 | no
+| fine
 | `DstAddr`
 | string
 | Destination IP address (ipv4 or ipv6)
 | `dst_address`
 | no
+| avoid
 | `DstK8S_HostIP`
 | string
 | Destination node IP
 | `dst_host_address`
 | no
+| fine
 | `DstK8S_HostName`
 | string
 | Destination node name
 | `dst_host_name`
 | no
+| fine
 | `DstK8S_Name`
 | string
 | Name of the destination Kubernetes object, such as Pod name, Service name or Node name.
 | `dst_name`
 | no
+| careful
 | `DstK8S_Namespace`
 | string
 | Destination namespace
 | `dst_namespace`
 | yes
+| fine
 | `DstK8S_OwnerName`
 | string
 | Name of the destination owner, such as Deployment name, StatefulSet name, etc.
 | `dst_owner_name`
 | yes
+| fine
 | `DstK8S_OwnerType`
 | string
 | Kind of the destination owner, such as Deployment, StatefulSet, etc.
 | `dst_kind`
 | no
+| fine
 | `DstK8S_Type`
 | string
 | Kind of the destination Kubernetes object, such as Pod, Service or Node.
 | `dst_kind`
 | yes
+| fine
 | `DstK8S_Zone`
 | string
 | Destination availability zone
 | `dst_zone`
 | yes
+| fine
 | `DstMac`
 | string
 | Destination MAC address
 | `dst_mac`
 | no
+| avoid
 | `DstPort`
 | number
 | Destination port
 | `dst_port`
 | no
+| careful
+| `DstSubnetLabel`
+| string
+| Destination subnet label
+| `dst_subnet_label`
+| no
+| fine
 | `Duplicate`
 | boolean
 | Indicates if this flow was also captured from another interface on the same host
 | n/a
 | yes
+| fine
 | `Flags`
 | number
 | Logical OR combination of unique TCP flags comprised in the flow, as per RFC-9293, with additional custom flags to represent the following per-packet combinations: +
@@ -116,164 +143,202 @@ The "Loki label" column is useful when querying Loki directly: label fields need
 - RST+ACK (0x400)
 | n/a
 | no
+| fine
 | `FlowDirection`
 | number
-| Flow direction from the node observation point. Can be one of: +
+| Flow interpreted direction from the node observation point. Can be one of: +
 - 0: Ingress (incoming traffic, from the node observation point) +
 - 1: Egress (outgoing traffic, from the node observation point) +
 - 2: Inner (with the same source and destination node)
-| `direction`
+| `node_direction`
 | yes
+| fine
 | `IcmpCode`
 | number
 | ICMP code
 | `icmp_code`
 | no
+| fine
 | `IcmpType`
 | number
 | ICMP type
 | `icmp_type`
 | no
-| `IfDirection`
+| fine
+| `IfDirections`
 | number
-| Flow direction from the network interface observation point. Can be one of: +
+| Flow directions from the network interface observation point. Can be one of: +
 - 0: Ingress (interface incoming traffic) +
 - 1: Egress (interface outgoing traffic)
-| n/a
+| `ifdirections`
 | no
-| `Interface`
+| fine
+| `Interfaces`
 | string
-| Network interface
-| `interface`
+| Network interfaces
+| `interfaces`
 | no
+| careful
 | `K8S_ClusterName`
 | string
 | Cluster name or identifier
 | `cluster_name`
 | yes
+| fine
 | `K8S_FlowLayer`
 | string
 | Flow layer: 'app' or 'infra'
 | `flow_layer`
 | no
+| fine
 | `Packets`
 | number
 | Number of packets
 | n/a
 | no
+| avoid
 | `PktDropBytes`
 | number
 | Number of bytes dropped by the kernel
 | n/a
 | no
+| avoid
 | `PktDropLatestDropCause`
 | string
 | Latest drop cause
 | `pkt_drop_cause`
 | no
+| fine
 | `PktDropLatestFlags`
 | number
 | TCP flags on last dropped packet
 | n/a
 | no
+| fine
 | `PktDropLatestState`
 | string
 | TCP state on last dropped packet
 | `pkt_drop_state`
 | no
+| fine
 | `PktDropPackets`
 | number
 | Number of packets dropped by the kernel
 | n/a
 | no
+| avoid
 | `Proto`
 | number
 | L4 protocol
 | `protocol`
 | no
+| fine
 | `SrcAddr`
 | string
 | Source IP address (ipv4 or ipv6)
 | `src_address`
 | no
+| avoid
 | `SrcK8S_HostIP`
 | string
 | Source node IP
 | `src_host_address`
 | no
+| fine
 | `SrcK8S_HostName`
 | string
 | Source node name
 | `src_host_name`
 | no
+| fine
 | `SrcK8S_Name`
 | string
 | Name of the source Kubernetes object, such as Pod name, Service name or Node name.
 | `src_name`
 | no
+| careful
 | `SrcK8S_Namespace`
 | string
 | Source namespace
 | `src_namespace`
 | yes
+| fine
 | `SrcK8S_OwnerName`
 | string
 | Name of the source owner, such as Deployment name, StatefulSet name, etc.
 | `src_owner_name`
 | yes
+| fine
 | `SrcK8S_OwnerType`
 | string
 | Kind of the source owner, such as Deployment, StatefulSet, etc.
 | `src_kind`
 | no
+| fine
 | `SrcK8S_Type`
 | string
 | Kind of the source Kubernetes object, such as Pod, Service or Node.
 | `src_kind`
 | yes
+| fine
 | `SrcK8S_Zone`
 | string
 | Source availability zone
 | `src_zone`
 | yes
+| fine
 | `SrcMac`
 | string
 | Source MAC address
 | `src_mac`
 | no
+| avoid
 | `SrcPort`
 | number
 | Source port
 | `src_port`
 | no
+| careful
+| `SrcSubnetLabel`
+| string
+| Source subnet label
+| `src_subnet_label`
+| no
+| fine
 | `TimeFlowEndMs`
 | number
 | End timestamp of this flow, in milliseconds
 | n/a
 | no
+| avoid
 | `TimeFlowRttNs`
 | number
 | TCP Smoothed Round Trip Time (SRTT), in nanoseconds
 | `time_flow_rtt`
 | no
+| avoid
 | `TimeFlowStartMs`
 | number
 | Start timestamp of this flow, in milliseconds
 | n/a
 | no
+| avoid
 | `TimeReceived`
 | number
 | Timestamp when this flow was received and processed by the flow collector, in seconds
 | n/a
 | no
+| avoid
 | `_HashId`
 | string
 | In conversation tracking, the conversation identifier
 | `id`
 | no
+| avoid
 | `_RecordType`
 | string
 | Type of record: 'flowLog' for regular flow logs, or 'newConnection', 'heartbeat', 'endConnection' for conversation tracking
 | `type`
 | yes
+| fine
 |===


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
Merge to only the no-1.6 branch - no cherrypicks are required.
This PR is part of an experiment for simplifying merges for asynchronous content, and I will open one PR against main to incorporate all of the Network Observability 1.6 content just before its GA
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://76599--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/json-flows-format-reference.html
QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
