### PR TITLE
[OSDOCS-10694]: OSD-GCP - Document GCP Workload Identity Federation

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -123,6 +123,8 @@ Topics:
   File: creating-an-aws-cluster
 - Name: Creating a GCP Private Service Connect enabled private cluster
   File: creating-a-gcp-psc-enabled-private-cluster
+- Name: Creating a cluster on GCP with Workload Identity Federation
+  File: creating-a-gcp-cluster-with-workload-identity-federation
 - Name: Creating a cluster on GCP
   File: creating-a-gcp-cluster
 - Name: Configuring your identity providers

--- a/modules/ccs-gcp-customer-procedure-serviceaccount.adoc
+++ b/modules/ccs-gcp-customer-procedure-serviceaccount.adoc
@@ -1,0 +1,71 @@
+// Module included in the following assemblies:
+//
+// * osd_planning/gcp-ccs.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="ccs-gcp-customer-procedure-sa_{context}"]
+
+= Service account authentication type procedure
+// TODO: Same as other module - Better procedure heading that tells you what this is doing
+
+Besides the required customer procedures listed in _Required customer procedure_, there are other specific actions that you must take when creating an {product-title} cluster on {GCP} using a service account as the authentication type.
+
+.Procedure
+
+. To ensure that Red Hat can perform necessary actions, you must create an `osd-ccs-admin` IAM link:https://cloud.google.com/iam/docs/creating-managing-service-accounts#creating_a_service_account[service account] user within the GCP project.
+
++
+
+The following roles must be link:https://cloud.google.com/iam/docs/granting-roles-to-service-accounts#granting_access_to_a_service_account_for_a_resource[granted to the service account]:
++
+.Required roles
+[cols="2a,3a",options="header"]
+
+|===
+
+|Role|Console role name
+
+|Compute Admin
+|`roles/compute.admin`
+
+|DNS Administrator
+|`roles/dns.admin`
+
+|Organization Policy Viewer
+|`roles/orgpolicy.policyViewer`
+
+|Service Management Administrator
+|`roles/servicemanagement.admin`
+
+|Service Usage Admin
+|`roles/serviceusage.serviceUsageAdmin`
+
+|Storage Admin
+|`roles/storage.admin`
+
+|Compute Load Balancer Admin
+|`roles/compute.loadBalancerAdmin`
+
+|Role Viewer
+|`roles/viewer`
+
+|Role Administrator
+|`roles/iam.roleAdmin`
+
+|Security Admin
+|`roles/iam.securityAdmin`
+
+|Service Account Key Admin
+|`roles/iam.serviceAccountKeyAdmin`
+
+|Service Account Admin
+|`roles/iam.serviceAccountAdmin`
+
+|Service Account User
+|`roles/iam.serviceAccountUser`
+
+|===
+
++
+
+. link:https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys[Create the service account key] for the `osd-ccs-admin` IAM service account. Export the key to a file named `osServiceAccount.json`; this JSON file will be uploaded in {cluster-manager-first} when you create your cluster.
+

--- a/modules/ccs-gcp-customer-procedure-wif.adoc
+++ b/modules/ccs-gcp-customer-procedure-wif.adoc
@@ -1,0 +1,63 @@
+// Module included in the following assemblies:
+//
+// * osd_planning/gcp-ccs.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="ccs-gcp-customer-procedure-wif_{context}"]
+
+= Workload Identity Federation authentication type procedure
+// TODO: Same as other module - Better procedure heading that tells you what this is doing
+Besides the required customer procedures listed in _Required customer procedure_, there are other specific actions that you must take when creating an {product-title} cluster on {GCP} using Workload Identity Federation as the authentication type.
+
+.Procedure
+
+. Assign the following roles to the link:https://cloud.google.com/iam/docs/granting-roles-to-service-accounts#granting_access_to_a_service_account_for_a_resource[service account] of the user implementing the Workload Identity Federation authentication type:
++
+.Required roles
+[cols="2a,3a,3a",options="header"]
+
+|===
+
+|Role|Console role name|Role purpose
+
+|Role Administrator
+|`roles/iam.roleAdmin`
+|Required by the GCP client in the OCM CLI for creating custom roles.
+
+|Service Account Admin
+|`roles/iam.serviceAccountAdmin`
+|Required to pre-create the services account required by the OSD deployer, support and operators.
+
+|Workload Identity Pool Admin
+|`roles/iam.workloadIdentityPoolAdmin`
+|Required to create and configure the workload identity pool.
+
+|Project IAM Admin
+|`roles/resourcemanager.projectIamAdmin`
+|Required for assigning roles to the service account and giving permissions to those roles that are necessary to perform operations on cloud resources.
+
+|===
+
+. Install the link:https://console.redhat.com/openshift/downloads[OpenShift Cluster Manager API command-line interface (`ocm`)].
++
+To use the OCM CLI, you must authenticate against your Red Hat {cluster-manager} account. This is accomplished with the {cluster-manager} API token.
++
+You can obtain your token link:https://console.redhat.com/openshift/token/show[here].
+
+. To authenticate against your Red Hat {cluster-manager} account, run the following command:
++
+[source,terminal]
+----
+$ ocm login --token <token> <1>
+----
+<1> Replace `<token>` with your {cluster-manager} API token.
++
+[IMPORTANT]
+====
+[subs="attributes+"]
+OpenShift Cluster Manager API command-line interface (`ocm`) is a Technology Preview feature only.
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+
+. Install the link:https://cloud.google.com/sdk/docs/install[gcloud CLI].
++
+.  Authenticate the gcloud CLI with the link:https://cloud.google.com/docs/authentication/provide-credentials-adc[Application Default Credentials (ADC)].

--- a/modules/ccs-gcp-customer-procedure.adoc
+++ b/modules/ccs-gcp-customer-procedure.adoc
@@ -9,6 +9,10 @@
 
 
 The Customer Cloud Subscription (CCS) model allows Red Hat to deploy and manage {product-title} into a customer's Google Cloud Platform (GCP) project. Red Hat requires several prerequisites to provide these services.
+[NOTE]
+====
+The following requirements in this topic apply to {product-title} on {GCP} clusters created using both the service account and Workload Identity Federation authentication type. For additional requirements that apply to the service account authentication type only, see _Service account authentication type procedure_. For additional requirements that apply to the Workload Identity Federation authentication type only, see _Workload Identity Federation authentication type procedure_.
+====
 
 [WARNING]
 ====
@@ -28,13 +32,13 @@ To use {product-title} in your GCP project, the following GCP organizational pol
 +
 .Required API services
 [cols="2a,3a",options="header"]
-|===
-|API service |Console service name
 
+|===
+
+|API service |Console service name
 
 |link:https://console.cloud.google.com/apis/library/deploymentmanager.googleapis.com?pli=1&project=openshift-gce-devel&folder=&organizationId=[Cloud Deployment Manager V2 API]
 |`deploymentmanager.googleapis.com`
-
 
 |link:https://console.cloud.google.com/apis/library/compute.googleapis.com?project=openshift-gce-devel&folder=&organizationId=[Compute Engine API]
 |`compute.googleapis.com`
@@ -73,57 +77,3 @@ To use {product-title} in your GCP project, the following GCP organizational pol
 |`orgpolicy.googleapis.com`
 
 |===
-
-. To ensure that Red Hat can perform necessary actions, you must create an `osd-ccs-admin` IAM link:https://cloud.google.com/iam/docs/creating-managing-service-accounts#creating_a_service_account[service account] user within the GCP project.
-+
-The following roles must be link:https://cloud.google.com/iam/docs/granting-roles-to-service-accounts#granting_access_to_a_service_account_for_a_resource[granted to the service account]:
-+
-.Required roles
-[cols="2a,3a",options="header"]
-
-|===
-
-|Role|Console role name
-
-|Compute Admin
-|`roles/compute.admin`
-
-|DNS Administrator
-|`roles/dns.admin`
-
-|Organization Policy Viewer
-|`roles/orgpolicy.policyViewer`
-
-|Service Management Administrator
-|`roles/servicemanagement.admin`
-
-|Service Usage Admin
-|`roles/serviceusage.serviceUsageAdmin`
-
-|Storage Admin
-|`roles/storage.admin`
-
-|Compute Load Balancer Admin
-|`roles/compute.loadBalancerAdmin`
-
-|Role Viewer
-|`roles/viewer`
-
-|Role Administrator
-|`roles/iam.roleAdmin`
-
-|Security Admin
-|`roles/iam.securityAdmin`
-
-|Service Account Key Admin
-|`roles/iam.serviceAccountKeyAdmin`
-
-|Service Account Admin
-|`roles/iam.serviceAccountAdmin`
-
-|Service Account User
-|`roles/iam.serviceAccountUser`
-
-|===
-
-. link:https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys[Create the service account key] for the `osd-ccs-admin` IAM service account. Export the key to a file named `osServiceAccount.json`; this JSON file will be uploaded in {cluster-manager-first} when you create your cluster.

--- a/modules/ccs-gcp-customer-requirements.adoc
+++ b/modules/ccs-gcp-customer-requirements.adoc
@@ -13,7 +13,7 @@
 
 * The customer ensures that link:https://cloud.google.com/storage/quotas[Google Cloud limits] are sufficient to support {product-title} provisioned within the customer-provided GCP account.
 
-* The customer-provided GCP account should be in the customer's Google Cloud Organization with the applicable Service Account applied.
+* The customer-provided GCP account should be in the customer's Google Cloud Organization.
 
 * The customer-provided GCP account must not be transferable to Red Hat.
 

--- a/modules/ccs-gcp-iam.adoc
+++ b/modules/ccs-gcp-iam.adoc
@@ -8,6 +8,11 @@
 
 Red Hat is responsible for creating and managing the following IAM Google Cloud Platform (GCP) resources.
 
+[IMPORTANT]
+=====
+The _IAM service account and roles_ and _IAM group and roles_ topics are only applicable to clusters created using the service account authentication type.
+=====
+
 [id="ccs-gcp-iam-service-account-roles_{context}"]
 == IAM service account and roles
 
@@ -63,6 +68,11 @@ When applied to an individual *bucket*, control applies only to the specified bu
 
 The `sd-sre-platform-gcp-access` Google group is granted access to the GCP project to allow Red Hat Site Reliability Engineering (SRE) access to the console for emergency troubleshooting purposes.
 
+[NOTE]
+====
+* For information regarding the roles within the `sd-sre-platform-gcp-access`  group that are specific to clusters created when using the Workload Identity Federation (WIF) authentication type, see link:https://github.com/openshift/managed-cluster-config/blob/master/resources/wif/4.17/vanilla.yaml[managed-cluster-config].
+* For information about creating a cluster using the Workload Identity Federation authentication type, see _Additional resources_.
+====
 The following roles are attached to the group:
 
 .IAM roles for sd-sre-platform-gcp-access

--- a/modules/ccs-gcp-understand.adoc
+++ b/modules/ccs-gcp-understand.adoc
@@ -11,4 +11,10 @@ Red Hat {product-title} provides a Customer Cloud Subscription (CCS) model that 
 
 Red Hat recommends the usage of GCP project, managed by the customer, to organize all of your GCP resources. A project consists of a set of users and APIs, as well as billing, authentication, and monitoring settings for those APIs.
 
-It is recommended for the {product-title} cluster using a CCS model to be hosted in a GCP project within a GCP organization. The Organization resource is the root node of the GCP resource hierarchy and all resources that belong to an organization are grouped under the organization node. An IAM service account with certain roles granted is created and applied to the GCP project. When you make calls to the API, you typically provide service account keys for authentication. Each service account is owned by a specific project, but service accounts can be provided roles to access resources for other projects.
+It is recommended for the {product-title} cluster using a CCS model to be hosted in a GCP project within a GCP organization. The Organization resource is the root node of the GCP resource hierarchy and all resources that belong to an organization are grouped under the organization node. Customers have the choice of using service account keys or Workload Identity Federation when creating the roles and credentials necessary to  access Google Cloud resources within a GCP project.
+// When you make calls to the API, you typically provide service account keys for authentication. Each service account is owned by a specific project, but service accounts can be provided roles to access resources for other projects.
+
+[IMPORTANT]
+====
+Unless specified, the information provided in this topic is applicable to {product-title} on {GCP} clusters that use service account keys or Workload Identity Federation (WIF) to grant the required necessary credentials.
+====

--- a/modules/create-wif-cluster-cli.adoc
+++ b/modules/create-wif-cluster-cli.adoc
@@ -1,0 +1,206 @@
+// Module included in the following assemblies:
+//
+// * osd_install_access_delete_cluster/creating-a-gcp-cluster-with-workload-identity-federation.adoc
+
+
+:_mod-docs-content-type: PROCEDURE
+[id="create-wif-cluster-cli_{context}"]
+= Creating a Workload Identity Federation cluster using the OCM CLI
+
+You can create an {product-title} on {GCP} cluster with Workload Identity Federation (WIF) using the OpenShift Cluster Manager CLI (`ocm`) in interactive or non-interactive mode.
+
+[IMPORTANT]
+====
+To create a WIF-enabled cluster, the OpenShift Cluster Manager CLI (`ocm`) must be version 1.0.2 or greater.
+====
+
+Before creating the cluster, you must first create a WIF configuration.
+[NOTE]
+====
+Migrating an existing non-WIF cluster to a WIF configuration is not supported. This feature can only be enabled during new cluster creation.
+====
+
+[id="create-wif-configuration_{context}"]
+== Creating a WIF configuration
+
+.Procedure
+You can create a WIF configuration using the `auto` mode or the `manual` mode.
+
+The `auto` mode enables you to automatically create the service accounts for {product-title} components as well as other IAM resources.
+
+Alternatively, you can use the `manual` mode. In `manual` mode, you are provided with commands within a `script.sh` file which you use to manually create the service accounts for {product-title} components as well as other IAM resources.
+
+* Based on your mode preference, run one of the following commands to create a WIF configuration:
+
+** Create a WIF configuration in auto mode by running the following command:
++
+[source,terminal]
+----
+$ ocm gcp create wif-config --name <wif_name> \ <1>
+  --project <gcp_project_id> \ <2>
+----
+<1> Replace `<wif_name>` with the name of your WIF configuration.
+<2> Replace `<gcp_project_id>` with the ID of the {GCP} project where the WIF configuration will be implemented.
++
+--
+.Example output
+[source,terminal]
+----
+2024/09/26 13:05:41 Creating workload identity configuration...
+2024/09/26 13:05:47 Workload identity pool created with name 2e1kcps6jtgla8818vqs8tbjjls4oeub
+2024/09/26 13:05:47 workload identity provider created with name oidc
+2024/09/26 13:05:48 IAM service account osd-worker-oeub created
+2024/09/26 13:05:49 IAM service account osd-control-plane-oeub created
+2024/09/26 13:05:49 IAM service account openshift-gcp-ccm-oeub created
+2024/09/26 13:05:50 IAM service account openshift-gcp-pd-csi-driv-oeub created
+2024/09/26 13:05:50 IAM service account openshift-image-registry-oeub created
+2024/09/26 13:05:51 IAM service account openshift-machine-api-gcp-oeub created
+2024/09/26 13:05:51 IAM service account osd-deployer-oeub created
+2024/09/26 13:05:52 IAM service account cloud-credential-operator-oeub created
+2024/09/26 13:05:52 IAM service account openshift-cloud-network-c-oeub created
+2024/09/26 13:05:53 IAM service account openshift-ingress-gcp-oeub created
+2024/09/26 13:05:55 Role "osd_deployer_v4.17" updated
+----
+--
++
+** Create a WIF configuration in manual mode by running the following command:
++
+[source,terminal]
+----
+$ ocm gcp create wif-config --name <wif_name> \ <1>
+  --project <gcp_project_id> \ <2>
+  --mode=manual
+----
+<1> Replace `<wif_name>` with the name of your WIF configuration.
+<2> Replace `<gcp_project_id>` with the ID  of the {GCP} project where the WIF configuration will be implemented.
++
+Once the WIF is configured, the following service accounts, roles, and groups are created.
++
+.WIF configuration service accounts, group and roles
+[cols="2a,3a",options="header"]
+|===
+
+|Service Account/Group
+|GCP pre-defined roles and Red Hat custom roles
+
+
+|osd-deployer
+|osd_deployer_v4.17
+
+
+|osd-control-plane
+|- compute.instanceAdmin
+- compute.networkAdmin
+- compute.securityAdmin
+- compute.storageAdmin
+
+|osd-worker
+|- compute.storageAdmin
+- compute.viewer
+
+|cloud-credential-operator-gcp-ro-creds
+|cloud_credential_operator_gcp_ro_creds_v4.17
+
+|openshift-cloud-network-config-controller-gcp
+|openshift_cloud_network_config_controller_gcp_v4.17
+
+|openshift-gcp-ccm
+|openshift_gcp_ccm_v4.17
+
+|openshift-gcp-pd-csi-driver-operator
+|- compute.storageAdmin
+- iam.serviceAccountUser
+- resourcemanager.tagUser
+- openshift_gcp_pd_csi_driver_operator_v4.17
+
+|openshift-image-registry-gcp
+|openshift_image_registry_gcs_v4.17
+
+|openshift-ingress-gcp
+|openshift_ingress_gcp_v4.17
+
+|openshift-machine-api-gcp
+|openshift_machine_api_gcp_v4.17
+
+|Access via SRE group:sd-sre-platform-gcp-access
+|sre_managed_support
+
+|===
+
+For further details about WIF configuration roles and their assigned permissions, see link:https://github.com/openshift/managed-cluster-config/blob/master/resources/wif/4.17/vanilla.yaml[managed-cluster-config].
+
+[id="create-wif-cluster_{context}"]
+== Creating a WIF cluster
+
+.Procedure
+You can create a WIF cluster using the `interactive` mode or the `non-interactive` mode.
+
+In `interactive` mode, cluster attributes are displayed automatically as prompts during the creation of the cluster. You enter the values for those prompts based on specified requirements in the fields provided.
+
+In `non-interactive` mode, you specify the values for specific parameters within the command.
+
+* Based on your mode preference, run one of the following commands to create an {product-title} on (GCP) cluster with WIF configuration:
+
+** Create a cluster in interactive mode by running the following command:
++
+[source,terminal]
+----
+$ ocm create cluster --interactive <1>
+----
+<1> `interactive` mode enables you to specify configuration options at the interactive prompts.
++
+** Create a cluster in non-interactive mode by running the following command:
++
+[NOTE]
+====
+The following example is made up optional and required parameters and may differ from your `non-interactive` mode command. Parameters not identified as optional are required. For additional details about these and other parameters, run the `ocm create cluster --help flag` command in you terminal window.
+====
++
+[source,terminal]
+----
+$ ocm create cluster <cluster_name> \ <1>
+--provider=gcp \ <2>
+--ccs=true \ <3>
+--wif-config <wif_name> \ <4>
+--region <gcp_region> \ <5>
+--subscription-type=marketplace-gcp \ <6>
+--marketplace-gcp-terms=true \ <7>
+--version <version> \ <8>
+--multi-az=true  \ <9>
+--enable-autoscaling=true \ <10>
+--min-replicas=3 \ <11>
+--max-replicas=6 \ <12>
+--secure-boot-for-shielded-vms=true <13>
+----
+<1> Replace `<cluster_name>` with a name for your cluster.
+<2> Set value to `gcp`.
+<3> Set value to `true`.
+<4> Replace `<wif_name>` with the name of your WIF configuration.
+<5> Replace `<gcp_region>` with the {GCP} region where the new cluster will be deployed.
+<6> Optional: The subscription billing model for the cluster.
+<7> Optional: If you provided a value of `marketplace-gcp` for the `subscription-type` parameter, `marketplace-gcp-terms` must be equal to `true`.
+<8> Optional: The desired OpenShift version.
+<9> Optional: Deploy to multiple data centers.
+<10> Optional: Enable autoscaling of compute nodes.
+<11> Optional: Minimum number of compute nodes.
+<12> Optional: Maximum number of compute nodes.
+<13> Optional: Secure Boot enables the use of Shielded VMs in the Google Cloud Platform.
+
+[id="wif-configuration-update_{context}"]
+== Updating a WIF configuration
+
+[NOTE]
+====
+Updating a WIF configuration is only applicable for y-stream updates. For an overview of the update process, including details regarding version semantics, see link:https://www.redhat.com/en/blog/the-ultimate-guide-to-openshift-release-and-upgrade-process-for-cluster-administrators#:~:text=Ongoing%20security%20patches%20and%20bug,is%20the%20dark%20green%20bar.[The Ultimate Guide to OpenShift Release and Upgrade Process for Cluster Administrators].
+====
+Before updating a WIF-enabled {product-title} cluster to a newer version, you must update the wif-config to that version as well. If you do not update the wif-config version before attempting to update the cluster version, the cluster version update will fail.
+
+You can update a wif-config to a specific {product-title} version by running the following command:
+
+[source,terminal]
+----
+ocm gcp update wif-config --version <version> \ <1>
+--name <wif_name> <2>
+----
+<1> Replace `<version>` with the {product-title} y-stream version you plan to update the cluster to.
+<2> Replace `<wif_name>` with the name of the WIF configuration you want to update.

--- a/modules/create-wif-cluster-ocm.adoc
+++ b/modules/create-wif-cluster-ocm.adoc
@@ -1,0 +1,206 @@
+// Module included in the following assemblies:
+//
+// * osd_install_access_delete_cluster/creating-a-gcp-cluster-with-workload-identity-federation.adoc
+
+
+:_mod-docs-content-type: PROCEDURE
+[id="create-wif-cluster-ocm_{context}"]
+= Creating a Workload Identity Federation cluster using {cluster-manager}
+
+.Procedure
+
+. Log in to {cluster-manager-url} and click *Create cluster* on the {product-title} card.
+
+. Under *Billing model*, configure the subscription type and infrastructure type.
++
+[IMPORTANT]
+====
+Workload Identity Federation is supported by the Customer Cloud Subscription (CCS) infrastructure type only.
+====
++
+.. Select a subscription type. For information about {product-title} subscription options, see link:https://access.redhat.com/documentation/en-us/openshift_cluster_manager/1-latest/html-single/managing_clusters/index#assembly-cluster-subscriptions[Cluster subscriptions and registration] in the {cluster-manager} documentation.
++
+
+.. Select the *Customer cloud subscription* infrastructure type.
+
+.. Click *Next*.
+. Select *Run on Google Cloud Platform*.
+. Select *Workload Identity Federation* as the Authentication type.
+.. Read and complete all the required prerequisites.
+
+.. Click the checkbox indicating that you have read and completed all the required prerequisites.
++
+. To create a new WIF configuration, open a terminal window and run the following OCM CLI command.
++
+
+[source,terminal]
+----
+$ ocm gcp create wif-config --name <wif_name> \ <1>
+  --project <gcp_project_id> \ <2>
+----
+<1> Replace `<wif_name>` with the name of your WIF configuration.
+<2> Replace `<gcp_project_id>` with the ID of the {GCP} project where the WIF configuration will be implemented.
++
+. Select a configured WIF configuration from the *WIF configuration* drop-down list. If you want to select the WIF configuration you created in the last step, click *Refresh* first.
++
+
+. Click *Next*.
+. On the *Details* page, provide a name for your cluster and specify the cluster details:
+.. In the *Cluster name* field, enter a name for your cluster.
+.. Optional: Cluster creation generates a domain prefix as a subdomain for your provisioned cluster on `openshiftapps.com`. If the cluster name is less than or equal to 15 characters, that name is used for the domain prefix. If the cluster name is longer than 15 characters, the domain prefix is randomly generated as a 15-character string.
++
+To customize the subdomain prefix, select the *Create custom domain prefix* checkbox, and enter your domain prefix name in the *Domain prefix* field. The domain prefix cannot be longer than 15 characters, must be unique within your organization, and cannot be changed after cluster creation.
+.. Select a cluster version from the *Version* drop-down menu.
++
+[NOTE]
+====
+Workload Identity Federation (WIF) is only supported on {product-title} version 4.17 and later.
+====
++
+.. Select a cloud provider region from the *Region* drop-down menu.
+.. Select a *Single zone* or *Multi-zone* configuration.
++
+.. Optional: Select *Enable Secure Boot for Shielded VMs* to use Shielded VMs when installing your cluster. For more information, see link:https://cloud.google.com/security/products/shielded-vm[Shielded VMs].
++
+[IMPORTANT]
+====
+To successfully create a cluster, you must select *Enable Secure Boot support for Shielded VMs* if your organization has the policy constraint `constraints/compute.requireShieldedVm` enabled. For more information regarding GCP organizational policy constraints, see link:https://cloud.google.com/resource-manager/docs/organization-policy/org-policy-constraints[Organization policy constraints].
+====
++
+.. Leave *Enable user workload monitoring* selected to monitor your own projects in isolation from Red Hat Site Reliability Engineer (SRE) platform metrics. This option is enabled by default.
+
+. Optional: Expand *Advanced Encryption* to make changes to encryption settings.
+
+.. Select *Use custom KMS keys* to use custom KMS keys. If you prefer not to use custom KMS keys, leave the default setting *Use default KMS Keys*.
+
+.. With *Use Custom KMS keys* selected:
+
+... Select a key ring location from the *Key ring location* drop-down menu.
+... Select a key ring from the *Key ring* drop-down menu.
+... Select a key name from the *Key name* drop-down menu.
+... Provide the *KMS Service Account*.
+
+.. Optional: Select *Enable FIPS cryptography* if you require your cluster to be FIPS validated.
++
+[NOTE]
+====
+If *Enable FIPS cryptography* is selected, *Enable additional etcd encryption* is enabled by default and cannot be disabled. You can select *Enable additional etcd encryption* without selecting *Enable FIPS cryptography*.
+====
++
+.. Optional: Select *Enable additional etcd encryption* if you require etcd key value encryption.
+With this option, the etcd key values are encrypted, but not the keys. This option is in addition to the control plane storage encryption that encrypts the etcd volumes in {product-title} clusters by default.
++
+[NOTE]
+====
+By enabling etcd encryption for the key values in etcd, you incur a performance overhead of approximately 20%. The overhead is a result of introducing this second layer of encryption, in addition to the default control plane storage encryption that encrypts the etcd volumes. Consider enabling etcd encryption only if you specifically require it for your use case.
+====
++
+. Click *Next*.
+
+. On the *Machine pool* page, select a *Compute node instance type* and a *Compute node count*. The number and types of nodes that are available depend on your {product-title} subscription. If you are using multiple availability zones, the compute node count is per zone.
+
+. Optional: Expand *Add node labels* to add labels to your nodes. Click *Add additional label* to add more node labels.
++
+[IMPORTANT]
+====
+This step refers to labels within Kubernetes, not Google Cloud. For more information regarding Kubernetes labels, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/[Labels and Selectors].
+====
++
+. Click *Next*.
+
+. In the *Cluster privacy* dialog, select *Public* or *Private* to use either public or private API endpoints and application routes for your cluster.
+
+. Optional: To install the cluster in an existing GCP Virtual Private Cloud (VPC):
+.. Select *Install into an existing VPC*.
+.. If you are installing into an existing VPC and you want to enable an HTTP or HTTPS proxy for your cluster, select *Configure a cluster-wide proxy*.
+
+. Click *Next*.
+
+. Optional: To install the cluster into a GCP Shared VPC, follow these steps.
++
+[IMPORTANT]
+====
+The VPC owner of the host project must enable a project as a host project in their Google Cloud console and add the *Computer Network Administrator*, *Compute Security Administrator*, and *DNS Administrator* roles to the following service accounts prior to cluster installation:
+
+* **osd-deployer**
+* **osd-control-plane**
+* **openshift-machine-api-gcp**
+
+Failure to do so will cause the cluster go into the "Installation Waiting" state. If this occurs, you must contact the VPC owner of the host project to assign the roles to the service accounts listed above.
+The VPC owner of the host project has 30 days to grant the listed permissions before the cluster creation fails.
+For more information, see link:https://cloud.google.com/vpc/docs/provisioning-shared-vpc#set-up-shared-vpc[Enable a host project] and link:https://cloud.google.com/vpc/docs/provisioning-shared-vpc#migs-service-accounts[Provision Shared VPC].
+====
++
+.. Select *Install into GCP Shared VPC*.
+.. Specify the *Host project ID*. If the specified host project ID is incorrect, cluster creation fails.
+
++
+.. If you opted to install the cluster in an existing GCP VPC, provide your *Virtual Private Cloud (VPC) subnet settings* and select *Next*.
+You must have created the Cloud network address translation (NAT) and a Cloud router. See _Additional resources_ for information about Cloud NATs and Google VPCs.
++
+[NOTE]
+====
+If you are installing a cluster into a Shared VPC, the VPC name and subnets are shared from the host project.
+====
++
+. Click *Next*.
+. If you opted to configure a cluster-wide proxy, provide your proxy configuration details on the *Cluster-wide proxy* page:
++
+.. Enter a value in at least one of the following fields:
+** Specify a valid *HTTP proxy URL*.
+** Specify a valid *HTTPS proxy URL*.
+** In the *Additional trust bundle* field, provide a PEM encoded X.509 certificate bundle. The bundle is added to the trusted certificate store for the cluster nodes. An additional trust bundle file is required if you use a TLS-inspecting proxy unless the identity certificate for the proxy is signed by an authority from the {op-system-first} trust bundle. This requirement applies regardless of whether the proxy is transparent or requires explicit configuration using the `http-proxy` and `https-proxy` arguments.
++
+.. Click *Next*.
++
+For more information about configuring a proxy with {product-title}, see _Configuring a cluster-wide proxy_.
+
++
+. In the *CIDR ranges* dialog, configure custom classless inter-domain routing (CIDR) ranges or use the defaults that are provided.
++
+[IMPORTANT]
+====
+CIDR configurations cannot be changed later. Confirm your selections with your network administrator before proceeding.
+
+If the cluster privacy is set to *Private*, you cannot access your cluster until you configure private connections in your cloud provider.
+====
+
+. On the *Cluster update strategy* page, configure your update preferences:
+.. Choose a cluster update method:
+** Select *Individual updates* if you want to schedule each update individually. This is the default option.
+** Select *Recurring updates* to update your cluster on your preferred day and start time, when updates are available.
++
+[NOTE]
+====
+You can review the end-of-life dates in the update lifecycle documentation for {product-title}. For more information, see link:https://access.redhat.com/documentation/en-us/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#osd-life-cycle[OpenShift Dedicated update life cycle].
+====
++
+.. Provide administrator approval based on your cluster update method:
+** Individual updates: If you select an update version that requires approval, provide an administrator’s acknowledgment and click *Approve and continue*.
+** Recurring updates: If you selected recurring updates for your cluster, provide an administrator’s acknowledgment and click *Approve and continue*. {cluster-manager} does not start scheduled y-stream updates for minor versions without receiving an administrator’s acknowledgment.
++
+.. If you opted for recurring updates, select a preferred day of the week and upgrade start time in UTC from the drop-down menus.
+.. Optional: You can set a grace period for *Node draining* during cluster upgrades. A *1 hour* grace period is set by default.
+.. Click *Next*.
++
+[NOTE]
+====
+In the event of critical security concerns that significantly impact the security or stability of a cluster, Red Hat Site Reliability Engineering (SRE) might schedule automatic updates to the latest z-stream version that is not impacted. The updates are applied within 48 hours after customer notifications are provided. For a description of the critical impact security rating, see link:https://access.redhat.com/security/updates/classification[Understanding Red Hat security ratings].
+====
+
+. Review the summary of your selections and click *Create cluster* to start the cluster installation. The installation takes approximately 30-40 minutes to complete.
++
+. Optional: On the *Overview* tab, you can enable the delete protection feature by selecting *Enable*, which is located directly under *Delete Protection: Disabled*. This will prevent your cluster from being deleted. To disable delete protection, select *Disable*.
+By default, clusters are created with the delete protection feature disabled.
++
+
+.Verification
+
+* You can monitor the progress of the installation in the *Overview* page for your cluster. You can view the installation logs on the same page. Your cluster is ready when the *Status* in the *Details* section of the page is listed as *Ready*.
+
+ifeval::["{context}" == "osd-creating-a-cluster-on-aws"]
+:!osd-on-aws:
+endif::[]
+ifeval::["{context}" == "osd-creating-a-cluster-on-gcp"]
+:!osd-on-gcp:
+endif::[]

--- a/modules/policy-identity-access-management.adoc
+++ b/modules/policy-identity-access-management.adoc
@@ -1,10 +1,15 @@
 // Module included in the following assemblies:
 //
-// * osd_architecture/osd_policy/policy-process-security.adoc
+// * osd_architecture/osd_policy/osd-sre-access.adoc
 
 [id="policy-identity-access-management_{context}"]
 = Identity and access management
 Most access by Red Hat site reliability engineering (SRE) teams is done by using cluster Operators through automated configuration management.
+
+[NOTE]
+====
+{product-title} on {GCP} clusters that are created with the Workload Identify Federation (WIF) authentication type do not use Operators for SRE access. Instead, the required roles necessary for SRE account access are assigned to the sd-sre-platform-gcp-access group as part of the WIF configuration creation and are validated prior to the deployment of the cluster by the {cluster-manager}. For more information about WIF configurations, see _Additional resources_.
+====
 
 [id="subprocessors_{context}"]
 == Subprocessors

--- a/modules/wif-overview.adoc
+++ b/modules/wif-overview.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * osd_install_access_delete_cluster/creating-a-gcp-cluster-with-workload-identity-federation.adoc
+
+
+:_mod-docs-content-type: CONCEPT
+[id="workload-identity-federation-overview_{context}"]
+= Workload Identity Federation Overview
+
+// Workload Identity Federation (WIF) allows {product-title} on {GCP} customers to use federated identities instead of service account keys when creating the necessary credentials needed to access GCP resources. Credentials created using WIF are short-term and more secure, while credentials created using service account keys are long-term and less secure. WIF minimizes the rights granted to third parties such as Red Hat, and ensures all Google Cloud native IAM and best practices for securing Google Cloud services and infrastructure are followed.
+Workload Identity Federation (WIF) is a {GCP} Identity and Access Management (IAM) feature that provides third parties a secure method to access resources on a customer's cloud account. WIF eliminates the need for service account keys, and is Google Cloud's preferred method of credential authentication.
+
+While service account keys can provide powerful access to your Google Cloud resources, they must be maintained by the end user and can be a security risk if they are not managed properly. WIF does not use service keys as an access method for your Google cloud resources. Instead, WIF grants access by using credentials from external identity providers to generate short-lived credentials for workloads. The workloads can then use these credentials to temporarily impersonate service accounts and access Google Cloud resources. This removes the burden of having to properly maintain service account keys, and removes the risk of unauthorized users gaining access to service account keys.
+
+The following bulleted items provides a basic overview of the Workload Identity Federation process:
+
+* The owner of the {GCP} project configures a workload identity pool with an identity provider, allowing {product-title} to  access the project's associated service accounts using short-lived credentials.
+* This workload identity pool is configured to authenticate requests using an Identity Provider (IP) that the user defines.
+* For applications to get access to cloud resources, they first pass credentials to Google's Security Token Service (STS). STS uses the specified identity provider to verify the credentials.
+* Once the credentials are verified, STS returns a temporary access token to the caller, giving the application the ability to impersonate the service account bound to that identity.
+
+Operators also need access to cloud resources. By using WIF instead of service account keys to grant this access, cluster security is further strengthened, as service account keys are no longer stored in the cluster. Instead, operators are given temporary access tokens that impersonate the service accounts. These tokens are short-lived and regularly rotated.
+
+// * External applications authenticate to the identity provider.
+// * The external application calls Google Security Token Service to exchange the account credentials for a short-lived Google Cloud access token.
+// * The token can then be used to impersonate a service account and access Google Cloud resources.
+
+For more information about Workload Identity Federation, refer to the link:https://cloud.google.com/iam/docs/workload-identity-federation[Google Cloud Platform documentation].
+
+[IMPORTANT]
+====
+Workload Identity Federation (WIF) is only supported on {product-title} version 4.17 and later.
+====
+

--- a/osd_architecture/osd_policy/osd-sre-access.adoc
+++ b/osd_architecture/osd_policy/osd-sre-access.adoc
@@ -10,3 +10,7 @@ include::modules/policy-identity-access-management.adoc[leveloffset=+1]
 include::modules/sre-cluster-access.adoc[leveloffset=+1]
 include::modules/how-service-accounts-assume-aws-iam-roles-in-sre-owned-projects.adoc[leveloffset=+1]
 
+[id="additional-resources_{context}"]
+== Additional resources
+
+For more information about WIF configuration and SRE access roles, see xref:../../osd_install_access_delete_cluster/creating-a-gcp-cluster-with-workload-identity-federation.adoc#create-wif-cluster-cli_osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a WIF configuration].

--- a/osd_install_access_delete_cluster/creating-a-gcp-cluster-with-workload-identity-federation.adoc
+++ b/osd_install_access_delete_cluster/creating-a-gcp-cluster-with-workload-identity-federation.adoc
@@ -1,0 +1,39 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="osd-creating-a-cluster-on-gcp-with-workload-identity-federation"]
+= Creating a cluster on GCP with Workload Identity Federation
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: osd-creating-a-cluster-on-gcp-with-workload-identity-federation
+
+toc::[]
+
+include::modules/wif-overview.adoc[leveloffset=+1]
+
+[id="osd-creating-a-cluster-on-gcp-prerequisites1_{context}"]
+== Prerequisites
+The following prerequisites must be completed prior to xref:../osd_install_access_delete_cluster/creating-a-gcp-cluster-with-workload-identity-federation.adoc#create-wif-cluster-ocm_osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a Workload Identity Federation cluster using OpenShift Cluster Manager] and xref:../osd_install_access_delete_cluster/creating-a-gcp-cluster-with-workload-identity-federation.adoc#create-wif-cluster-cli_osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a Workload Identity Federation cluster using the OCM CLI].
+
+
+* You have confirmed your Google Cloud account has the necessary resource quotas and limits to support your desired cluster size according to the cluster resource requirements.
+
+[NOTE]
+====
+For more information regarding resource quotas and limits, see _Additional resources_.
+====
+
+* You reviewed the xref:../osd_architecture/osd-understanding.adoc#osd-understanding[introduction to {product-title}] and the documentation on xref:../architecture/index.adoc#architecture-overview[architecture concepts].
+* You reviewed the xref:../osd_getting_started/osd-understanding-your-cloud-deployment-options.adoc#osd-understanding-your-cloud-deployment-options[{product-title} cloud deployment options].
+
+* You have read and completed the xref:../osd_planning/gcp-ccs.adoc#ccs-gcp-customer-procedure_gcp-ccs[Required customer procedure].
+
+include::modules/create-wif-cluster-ocm.adoc[leveloffset=+1]
+include::modules/create-wif-cluster-cli.adoc[leveloffset=+1]
+
+== Additional resources
+
+* For information about {product-title} clusters using a Customer Cloud Subscription (CCS) model on {GCP}, see xref:../osd_planning/gcp-ccs.adoc#ccs-gcp-customer-requirements_gcp-ccs[Customer requirements].
+* For information about resource quotas, xref:../applications/quotas/quotas-setting-per-project.adoc[Resource quotas per project].
+* For information about limits, xref:../osd_planning/gcp-ccs.adoc#gcp-limits_gcp-ccs[GCP account limits].
+* For information about required  APIs, see xref:../osd_planning/gcp-ccs.adoc#ccs-gcp-customer-procedure_gcp-ccs[Required customer procedure].
+* For information about managing workload identity pools, see link:https://cloud.google.com/iam/docs/manage-workload-identity-pools-providers[Manage workload identity pools and providers].
+* For information about managing roles and permissions in your Google Cloud account, see link:https://cloud.google.com/iam/docs/roles-overview[Roles and permissions].
+* For a list of the supported maximums, see xref:../osd_planning/osd-limits-scalability.adoc#tested-cluster-maximums-sd_osd-limits-scalability[Cluster maximums].

--- a/osd_install_access_delete_cluster/creating-a-gcp-cluster.adoc
+++ b/osd_install_access_delete_cluster/creating-a-gcp-cluster.adoc
@@ -7,6 +7,11 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
+[IMPORTANT]
+=====
+The following topic addresses creating an {product-title} on {GCP} cluster using a service account key, which creates credentials required for cluster access. Service account keys produce long-lived credentials. To install and interact with an {product-title} on {GCP} cluster using Workload Identity Federation (WIF), which is the recommended authentication type because it provides enhanced security, see the topic xref:../osd_install_access_delete_cluster/creating-a-gcp-cluster-with-workload-identity-federation.adoc#osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a cluster on GCP with Workload Identity Federation].
+=====
+
 You can install {product-title} on {GCP} by using your own GCP account through the Customer Cloud Subscription (CCS) model or by using a GCP infrastructure account that is owned by Red Hat.
 
 [id="osd-creating-a-cluster-on-gcp-prerequisites_{context}"]

--- a/osd_planning/gcp-ccs.adoc
+++ b/osd_planning/gcp-ccs.adoc
@@ -12,6 +12,8 @@ toc::[]
 include::modules/ccs-gcp-understand.adoc[leveloffset=+1]
 include::modules/ccs-gcp-customer-requirements.adoc[leveloffset=+1]
 include::modules/ccs-gcp-customer-procedure.adoc[leveloffset=+1]
+include::modules/ccs-gcp-customer-procedure-serviceaccount.adoc[leveloffset=+2]
+include::modules/ccs-gcp-customer-procedure-wif.adoc[leveloffset=+2]
 include::modules/ccs-gcp-iam.adoc[leveloffset=+1]
 include::modules/ccs-gcp-provisioned.adoc[leveloffset=+1]
 include::modules/gcp-limits.adoc[leveloffset=+1]
@@ -21,3 +23,7 @@ include::modules/osd-gcp-psc-firewall-prerequisites.adoc[leveloffset=+1]
 == Additional resources
 
 *  xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
+
+* For more information about creating an {product-title} cluster with the Workload Identity Federation (WIF) authentication type, see xref:../osd_install_access_delete_cluster/creating-a-gcp-cluster-with-workload-identity-federation.adoc#create-wif-cluster-cli_osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a WIF configuration].
+
+* For more information about the specific roles and permissions that are specific to clusters created when using the Workload Identity Federation (WIF) authentication type, see link:https://github.com/openshift/managed-cluster-config/blob/master/resources/wif/4.17/vanilla.yaml[managed-cluster-config].


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.17+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-10694
https://issues.redhat.com/browse/OSDOCS-11239
https://issues.redhat.com/browse/OSDOCS-11429
https://issues.redhat.com/browse/OSDOCS-11428
https://issues.redhat.com/browse/OSDOCS-11803
https://issues.redhat.com/browse/OSDOCS-11969
https://issues.redhat.com/browse/OSDOCS-11927


Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
**Reviews Broken Down By JIRA Ticket When Applicable**
https://issues.redhat.com/browse/OSDOCS-10694 (OVERVIEW): https://76600--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-a-gcp-cluster-with-workload-identity-federation.html#workload-identity-federation-overview_osd-creating-a-cluster-on-gcp-with-workload-identity-federation

https://issues.redhat.com/browse/OSDOCS-11239 (Prereqs): https://76600--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-a-gcp-cluster-with-workload-identity-federation.html#osd-creating-a-cluster-on-gcp-prerequisites1_osd-creating-a-cluster-on-gcp-with-workload-identity-federation

https://issues.redhat.com/browse/OSDOCS-11428(Creating a WIF cluster with OCM): https://76600--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-a-gcp-cluster-with-workload-identity-federation.html#create-wif-cluster-ocm_osd-creating-a-cluster-on-gcp-with-workload-identity-federation

https://issues.redhat.com/browse/OSDOCS-11429 (Creating a WIF cluster with the CLI): https://76600--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-a-gcp-cluster-with-workload-identity-federation.html#create-wif-cluster-cli_osd-creating-a-cluster-on-gcp-with-workload-identity-federation
 
https://issues.redhat.com/browse/OSDOCS-11803 (Shared VPC): https://76600--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-a-gcp-cluster-with-workload-identity-federation.html#create-wif-cluster-ocm_osd-creating-a-cluster-on-gcp-with-workload-identity-federation (step 18)






https://76600--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-a-gcp-cluster-with-workload-identity-federation.html
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
