### PR TITLE
OCPBUGS33281: fixing cgroupMode version number in procedure

### DIFF
--- a/modules/nodes-clusters-cgroups-2-install.adoc
+++ b/modules/nodes-clusters-cgroups-2-install.adoc
@@ -19,7 +19,7 @@ kind: Node
 metadata:
   name: cluster
 spec:
-  cgroupMode: "v1"
+  cgroupMode: "v2"
 ----
 
 . Proceed with the installation as usual.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: OCPBUGS-33281
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://76616--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/enabling-cgroup-v2.html#nodes-clusters-cgroups-2-install_nodes-cluster-cgroups-2
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
