### PR TITLE
[internal-fix] OSDOCS-9577-16-comment

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -32,9 +32,6 @@ Starting with {product-title} 4.14, Red Hat offers a 12-month additional EUS add
 
 For more information about this support, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
 
-//TODO: Add the line below for EUS releases and comment it out for non-EUS releases.
-// {product-title} {product-version} is an Extended Update Support (EUS) release. More information on Red Hat OpenShift EUS is available in link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[OpenShift Life Cycle] and link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
-
 //TODO: The line below should be used when it is next appropriate. Revisit in August 2023 time frame.
 Maintenance support ends for version 4.12 on 25 January 2025 and goes to extended life phase. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
 


### PR DESCRIPTION
The statements updated on https://github.com/openshift/openshift-docs/pull/75913 make the comment now obsolete and confusing.

Version(s):
4.16

Issue:
* [OSDOCS-9577](https://issues.redhat.com/browse/OSDOCS-9577)

Link to docs preview:
(https://76627--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html)