### PR TITLE
OSDOCS-10711: add NW changes MicroShift

### DIFF
--- a/microshift_networking/microshift-cni.adoc
+++ b/microshift_networking/microshift-cni.adoc
@@ -20,6 +20,8 @@ Using configuration files or custom scripts, you can configure the following net
 * You can change the maximum transmission unit (MTU) value.
 * You can configure firewall ingress and egress.
 * You can define network policies in the {microshift-short} cluster, including ingress and egress rules.
+* You can use the {microshift-short} Multus plug-in to chain other CNI plugins.
+* You can configure or remove the ingress router.
 
 include::modules/microshift-cni-customization-matrix.adoc[leveloffset=+1]
 
@@ -43,14 +45,6 @@ Networking features not available with {microshift-short} {product-version}:
 * IPsec: not supported
 * Hardware offload: not supported
 
-[id="_additional-resources_microshift-cni_{context}"]
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../microshift_configuring/microshift-using-config-tools.adoc#microshift-using-config-tools_microshift-config-yaml[Using a YAML configuration file]
-
-* xref:../microshift_networking/microshift-networking-settings.adoc#microshift-config-OVN-K_microshift-networking[Understanding networking settings]
-
 [id="microshift-ip-forward_{context}"]
 == IP forward
 The host network `sysctl net.ipv4.ip_forward` kernel parameter is automatically enabled by the `ovnkube-master` container when started. This is required to forward incoming traffic to the CNI. For example, accessing the NodePort service from outside of a cluster fails if `ip_forward` is disabled.
@@ -70,3 +64,11 @@ include::modules/microshift-nw-components-svcs.adoc[leveloffset=+1]
 Bridge mappings allow provider network traffic to reach the physical network. Traffic leaves the provider network and arrives at the `br-int` bridge. A patch port between `br-int` and `br-ex` then allows the traffic to traverse to and from the provider network and the edge network. Kubernetes pods are connected to the `br-int` bridge through virtual ethernet pair: one end of the virtual ethernet pair is attached to the pod namespace, and the other end is attached to the `br-int` bridge.
 
 include::modules/microshift-nw-topology.adoc[leveloffset=+1]
+
+[id="_additional-resources_microshift-cni_{context}"]
+== Additional resources
+
+* xref:../microshift_configuring/microshift-using-config-tools.adoc#microshift-config-yaml_microshift-configuring[Using a YAML configuration file]
+* xref:../microshift_networking/microshift-networking-settings.adoc#microshift-understanding-networking-settings[Understanding networking settings]
+* xref:../microshift_networking/microshift_multiple_networks/microshift-cni-multus.adoc#microshift-cni-multus[About using multiple networks]
+* xref:../microshift_networking/microshift_network_policy/microshift-network-policy-index.adoc#microshift-network-policies[About network policies]

--- a/microshift_networking/microshift-networking-settings.adoc
+++ b/microshift_networking/microshift-networking-settings.adoc
@@ -16,11 +16,6 @@ Cluster Administrators have several options for exposing applications that run i
 
 By default, Kubernetes allocates each pod an internal IP address for applications running within the pod. Pods and their containers can have traffic between them, but clients outside the cluster do not have direct network access to pods except when exposed with a service such as NodePort.
 
-[NOTE]
-====
-To troubleshoot connection problems with the NodePort service, read about the known issue in the Release Notes.
-====
-
 include::modules/microshift-configuring-ovn.adoc[leveloffset=+1]
 
 include::modules/microshift-restart-ovnkube-master.adoc[leveloffset=+1]
@@ -39,10 +34,13 @@ include::modules/microshift-blocking-nodeport-access.adoc[leveloffset=+1]
 
 include::modules/microshift-mDNS.adoc[leveloffset=+1]
 
-include::modules/microshift-exposed-audit-ports.adoc[leveloffset=+1]
+[id="microshift-exposed-audit-ports_{context}"]
+== Auditing exposed network ports
 
-include::modules/microshift-exposed-audit-ports-hostnetwork.adoc[leveloffset=+1]
+On {microshift-short}, the host port can be opened by a workload in the following cases. You can check logs to view the network services.
 
-include::modules/microshift-exposed-audit-ports-hostport.adoc[leveloffset=+1]
+include::modules/microshift-exposed-audit-ports-hostnetwork.adoc[leveloffset=+2]
 
-include::modules/microshift-exposed-audit-ports-loadbalancer.adoc[leveloffset=+1]
+include::modules/microshift-exposed-audit-ports-hostport.adoc[leveloffset=+2]
+
+include::modules/microshift-exposed-audit-ports-loadbalancer.adoc[leveloffset=+2]

--- a/modules/microshift-cni-customization-matrix.adoc
+++ b/modules/microshift-cni-customization-matrix.adoc
@@ -1,14 +1,14 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="microshift-nw-customization-matrix_{context}"]
-= {microshift-short} networking customization matrix
+= {microshift-short} networking configuration matrix
 
 The following table summarizes the status of networking features and capabilities that are either present as defaults, supported for configuration, or not available with the {microshift-short} service:
 
-.{microshift-short} networking capabilities and customization status
+.{microshift-short} networking features and capabilities overview
 [cols="50%,20%,30%",options="header"]
 |===
-|Network feature|Availability|Customization supported
+|Network capability|Availability|Configuration supported
 
 |Advertise address|Yes|Yes ^[1]^
 
@@ -39,10 +39,15 @@ The following table summarizes the status of networking features and capabilitie
 |IPsec encryption for intra-cluster communication|Not available|N/A
 
 |IPv6|Not available ^[5]^|N/A
+
+|Ingress router|Yes|Yes ^[6]^
+
+|Multiple networks plug-in|Yes|Yes
 |===
 
 1. If unset, the default value is set to the next immediate subnet after the service network. For example, when the service network is `10.43.0.0/16`, the `advertiseAddress` is set to `10.44.0.0/32`.
 2. You can use the multicast DNS protocol (mDNS) to allow name resolution and service discovery within a Local Area Network (LAN) using multicast exposed on the `5353/UDP` port.
 3. There is no built-in transparent proxying of egress traffic in {microshift-short}. Egress must be manually configured.
 4. Setting up the firewalld service is supported by {op-system-ostree}.
-5. IPv6 is not available in any configuration.
+5. IPv6 is not supported. IPv6 can only be used by connecting to other networks with the {microshift-short} Multus CNI plugin.
+6. Configure by using the {microshift-short} `config.yaml` file.

--- a/modules/microshift-exposed-audit-ports-hostnetwork.adoc
+++ b/modules/microshift-exposed-audit-ports-hostnetwork.adoc
@@ -5,11 +5,11 @@
 :_mod-docs-content-type: PROCEDURE
 [id="microshift-exposed-audit-ports-hostnetwork_{context}"]
 
-== hostNetwork
+= hostNetwork
 
 When a pod is configured with the `hostNetwork:true` setting, the pod is running in the host network namespace. This configuration can independently open host ports. {microshift-short} component logs cannot be used to track this case, the ports are subject to firewalld rules. If the port opens in firewalld, you can view the port opening in the firewalld debug log.
 
-.Prerequisites 
+.Prerequisites
 
 * You have root user access to your build host.
 

--- a/modules/microshift-exposed-audit-ports-hostport.adoc
+++ b/modules/microshift-exposed-audit-ports-hostport.adoc
@@ -4,13 +4,13 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="microshift-exposed-audit-ports-hostport_{context}"]
-== hostPort
+= hostPort
 
 You can access the hostPort setting logs in {microshift-short}. The following logs are examples for the hostPort setting:
 
 .Procedure
 
-* You can access the logs by running the following command: 
+* You can access the logs by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/microshift-exposed-audit-ports-loadbalancer.adoc
+++ b/modules/microshift-exposed-audit-ports-loadbalancer.adoc
@@ -2,16 +2,16 @@
 //
 // * microshift_networking/microshift-networking-settings.adoc
 
-:_mod-docs-content-type: PROCEDURE 
+:_mod-docs-content-type: PROCEDURE
 [id="microshift-exposed-audit-ports-loadbalancer_{context}"]
 
-== NodePort and LoadBalancer service
+= NodePort and LoadBalancer services
 
 OVN-Kubernetes opens host ports for `NodePort` and `LoadBalancer` service types. These services add iptables rules that take the ingress traffic from the host port and forwards it to the clusterIP. Logs for the `NodePort` and `LoadBalancer` services are presented in the following examples:
 
-.Procedure 
+.Procedure
 
-. To access the name of your `ovnkube-master` pods, run the following command: 
+. To access the name of your `ovnkube-master` pods, run the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-10711](https://issues.redhat.com/browse/OSDOCS-10711)

Link to docs preview:
[About the CNI, added two bullets above the table; added two rows to the table](https://76634--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-cni.html#microshift-nw-customization-matrix_microshift-about-ovn-k-plugin)
[Update additional resources links](https://76634--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-cni.html#_additional-resources_microshift-cni_microshift-about-ovn-k-plugin)
[Replace one-sentence module with in-assembly text; restructure only, no text changes](https://76634--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-networking-settings.html#microshift-exposed-audit-ports_microshift-networking)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review:
- [ ] SME has approved this change.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
