### PR TITLE
[OSDOCS-10642]: OSD-GCP Docs: Enable NVIDIA A100-enabled A2 8g and 16g machine type

### DIFF
--- a/modules/sdpolicy-am-gcp-compute-types.adoc
+++ b/modules/sdpolicy-am-gcp-compute-types.adoc
@@ -88,4 +88,6 @@
 * a2-highgpu-1g (12 vCPU, 85 GiB)
 * a2-highgpu-2g (24 vCPU, 170 GiB)
 * a2-highgpu-4g (48 vCPU, 340 GiB)
+* a2-highgpu-8g (96 vCPU, 680 GiB)
+* a2-megagpu-16g (96 vCPU, 1.33 TiB)
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.15+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-10642
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://76635--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-service-definition.html#gcp-compute-types_osd-service-definition
QE review:
- [X ] QE has approved this change. See https://redhat-internal.slack.com/archives/C06SUBSJ6HX/p1716989048653439?thread_ts=1716413521.517839&cid=C06SUBSJ6HX
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
