### PR TITLE
OSDOCS-10713: Documented the 4.15.15 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2732,6 +2732,52 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.15.15
+[id="ocp-4-15-15"]
+=== RHSA-2024:3327 - {product-title} 4.15.15 bug fix and security update
+
+Issued: 2024-05-29
+
+{product-title} release 4.15.15, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:3327[RHSA-2024:3327] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:3332[RHBA-2024:3332] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.15 --pullspecs
+----
+
+[id="ocp-4-15-15-bug-fixes"]
+==== Bug fixes
+
+* Previously, certain situations caused transfer of an Egress IP address from one node to a different node to fail, and this failure impacted the OVN-Kubernetes network. The network failed to send gratuitous Address Resolution Protocol (ARP) requests to peers to inform them of the new node's medium access control (MAC) address. As a result, peers would temporarily send reply traffic to an old node and this traffic led to failover issues. With this release, the OVN-Kubernetes network correctly sends a gratuitous ARP to peers to inform them of the new Egress IP node MAC address, so that each peer can send reply traffic to the new node without causing failover time issues. (link:https://issues.redhat.com/browse/OCPBUGS-33960[*OCPBUGS-33960*])
+
+* Previously, when mirroring Operator catalogs, the `oc-mirror` CLI plugin rebuilt the catalogs and regenerated the catalog's internal cache according to the `imagesetconfig` catalog filtering specifications. This operation required the use of the `opm` binary found within the catalogs. In {product-title} 4.15, Operator catalogs include the `opm` {op-system-base-full} 9 binary, and this caused the mirroring process to fail when running on {op-system-base} 8 systems. With this release, `oc-mirror` no longer builds catalogs by default. Instead, catalogs are mirrored directly to their destination registries. (link:https://issues.redhat.com/browse/OCPBUGS-33575[*OCPBUGS-33575*])
+
+* Previously, the image registry did not support Amazon Web Services (AWS) region `ca-west-1`. With this release, the image registry can now be deployed in this region. (link:https://issues.redhat.com/browse/OCPBUGS-33672[*OCPBUGS-33672*])
+
+* Previously, service accounts (SAs) could not be used as OAuth2 clients because there were no tokens associated with the SAs. With this release, the OAuth registry client has been modified to anticipate this case and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-33210[*OCPBUGS-33210*])
+
+* Previously, the proxy information set in the `install-config.yaml` file was not applied to the bootstrap process. With this release, the proxy information is applied to the bootstrap Ignition data which is applied to the bootstrap machine and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-33205[*OCPBUGS-33205*])
+
+* Previously, the information from the `imageRegistryOverrides` setting was only extracted once on the HyperShift Operator initialization and did not refresh. With this release, the Hypershift Operator retrieves the new `ImageContentSourcePolicy` files from the management cluster and adds them to the Hypershift Operator and Control Plane Operator in every reconciliation loop. (link:https://issues.redhat.com/browse/OCPBUGS-33117[*OCPBUGS-33117*])
+
+* Previously, the Hypershift Operator was not using the `RegistryOverrides` mechanism to inspect the image from the internal registry. With this release, the metadata inspector works as expected during the Hypershift Operator reconciliation, and the `OverrideImages` are properly populated. (link:https://issues.redhat.com/browse/OCPBUGS-32220[*OCPBUGS-32220*])
+
+* Previously, attempting to update the {vmw-first} connection configuration for {product-title} failed if the configuration included `””` characters. With this release, the characters are stored correctly and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-31863[*OCPBUGS-31863*])
+
+[id="ocp-4-15-15-known-issues"]
+==== Known issue
+
+* Previously, after upgrading to {product-title} 4.15.6, attempting to use the `oc-mirror` CLI plugin within a cluster failed. With this release, there is now a FIPS-compliant version of `oc-mirror` for RHEL 9 and a version of `oc-mirror` for RHEL 8 that is not FIPS-compliant. (link:https://issues.redhat.com/browse/OCPBUGS-31609[*OCPBUGS-31609*])
+
+[id="ocp-4-15-15-updating"]
+==== Updating
+To update an existing {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+//4.15.14
 [id="ocp-4-15-14"]
 === RHSA-2024:2865 - {product-title} 4.15.14 bug fix and security update
 


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-10713](https://issues.redhat.com/browse/OSDOCS-10713)

Link to docs preview:
[4.15.15](https://76653--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-15)

