### PR TITLE
OBSDOCS-1095-: fix-incorrect-audit-values-for-k8sprometheusadapter-in-cmo-config-map-ref

### DIFF
--- a/observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+++ b/observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
@@ -198,7 +198,7 @@ Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 [options="header"]
 |===
 | Property | Type | Description
-|audit|*Audit|Defines the audit configuration used by the Prometheus Adapter instance. Possible profile values are: `metadata`, `request`, `requestresponse`, and `none`. The default value is `metadata`.
+|audit|*Audit|Defines the audit configuration used by the Prometheus Adapter instance. Possible profile values are: `Metadata`, `Request`, `RequestResponse`, and `None`. The default value is `Metadata`.
 
 |nodeSelector|map[string]string|Defines the nodes on which the pods are scheduled.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12-4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1095
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://76654--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.html#k8sprometheusadapter
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: @juzhao 
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR fixes incorrect audit value names in the k8sprometheusadapter table in the CMO config map reference for OCP 4.12-4.15.

This PR is for the 4.15 branch, but when I merge it, I will cherry-pick it to the 4.12-4.14 branches.

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
