### PR TITLE
CP-OSDOCS-10535-4.15: adds 4.15.15 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -313,3 +313,12 @@ Issued: 2024-05-21
 The {product-title} release 4.15.14 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:2868[RHBA-2024:2868] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:2865[RHSA-2024:2865] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-15-15-dp"]
+=== RHBA-2024:3330 - {microshift-short} 4.15.15 bug fix and security update advisory
+
+Issued: 2024-05-29
+
+The {product-title} release 4.15.15 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:3330[RHBA-2024:3330] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:3327[RHSA-2024:3327] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-10535](https://issues.redhat.com/browse/OSDOCS-10535)

Link to docs preview:
[4.15.15 async release note](https://76655--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-15-dp)

QE review:
- N/A stock text, no other release notes

Additional information:
This PR replaces the PR https://github.com/openshift/openshift-docs/pull/76504