### PR TITLE
TELCODOCS-1850: Delay Garbage Collection for successful builds / signing jobs

### DIFF
--- a/modules/kmm-building-in-cluster.adoc
+++ b/modules/kmm-building-in-cluster.adoc
@@ -45,3 +45,5 @@ Otherwise, KMM creates a `Build` resource to build your image. After the image i
 <6> Required.
 <7> Optional: Avoid using this parameter. If set to `true`, KMM will be allowed to check if the container image already exists using plain HTTP.
 <8> Optional: Avoid using this parameter. If set to `true`, KMM will skip any TLS server certificate validation when checking if the container image already exists.
+
+Successful build pods are garbage collected immediately, unless the `job.gcDelay` parameter is set in the Operator configuration. Failed build pods are always preserved and must be deleted manually by the administrator for the build to be restarted.

--- a/modules/kmm-configuring-kmmo.adoc
+++ b/modules/kmm-configuring-kmmo.adoc
@@ -24,6 +24,8 @@ $ oc edit configmap -n "$namespace" kmm-operator-manager-config
 [source,yaml]
 ----
 healthProbeBindAddress: :8081
+job:
+  gcDelay: 1h
 leaderElection:
   enabled: true
   resourceID: kmm.sigs.x-k8s.io
@@ -48,6 +50,9 @@ worker:
 
 | `healthProbeBindAddress`
 | Defines the address on which the Operator monitors for kubelet health probes. The recommended value is `:8081`.
+
+|`job.gcDelay`
+|Defines the duration that successful build pods should be preserved for before they are deleted. There is no recommended value for this setting. For information about the valid values for this setting, see link:https://pkg.go.dev/time#ParseDuration[ParseDuration].
 
 |`leaderElection.enabled`
 |Determines whether leader election is used to ensure that only one replica of the KMM Operator is running at any time. For more information, see https://kubernetes.io/docs/concepts/architecture/leases/[Leases]. The recommended value is `true`.


### PR DESCRIPTION
D/S Docs: [DOCS] Delay Garbage Collection for successful builds / signing jobs

Jira: https://issues.redhat.com/browse/TELCODOCS-1850?src=confmacro

Version(s): openshift-4.12, openshift-4.13, openshift-4.14, openshift-4.15, openshift-4.16

Fix version: KMMO 2.1

Links to docs preview: https://76669--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html#kmm-configuring-kmmo_kernel-module-management-operator

https://76669--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html#kmm-building-in-cluster_kernel-module-management-operator



Dev review: @qbarrand 
QE review: @cdvultur
