### PR TITLE
OSDOCS 10722 move an include outside conditionals

### DIFF
--- a/modules/builds-using-build-volumes.adoc
+++ b/modules/builds-using-build-volumes.adoc
@@ -68,9 +68,6 @@ ifndef::openshift-dedicated,openshift-rosa[]
 <5> Required. The driver that provides the ephemeral CSI volume.
 <6> Required. This value must be set to `true`. Provides a read-only volume.
 <7> Optional. The volume attributes of the ephemeral CSI volume. Consult the CSI driver's documentation for supported attribute keys and values.
-
-:FeatureName: Shared Resource CSI Driver
-include::snippets/technology-preview.adoc[]
 endif::openshift-dedicated,openshift-rosa[]
 --
 
@@ -125,13 +122,15 @@ ifndef::openshift-dedicated,openshift-rosa[]
 <5> Required. The driver that provides the ephemeral CSI volume.
 <6> Required. This value must be set to `true`. Provides a read-only volume.
 <7> Optional. The volume attributes of the ephemeral CSI volume. Consult the CSI driver's documentation for supported attribute keys and values.
-
-:FeatureName: Shared Resource CSI Driver
-include::snippets/technology-preview.adoc[]
 endif::openshift-dedicated,openshift-rosa[]
 --
 
 endif::sourcestrategy[]
+
+ifndef::openshift-dedicated,openshift-rosa[]
+:FeatureName: Shared Resource CSI Driver
+include::snippets/technology-preview.adoc[]
+endif::openshift-dedicated,openshift-rosa[]
 
 ifeval::["{context}" == "build-strategies-docker"]
 :!dockerstrategy:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

please cp to enterprise-4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
OSDOCS 10722

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://76671--ocpdocs-pr.netlify.app/openshift-enterprise/latest/cicd/builds/build-strategies.html#builds-using-build-volumes_build-strategies-docker

QE review:
n/a - no doc content change
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

A previous PR added an include inside a non-distro conditional. This configuration is not supported by the existing Portal conversion script. Moving the include outside the conditional doesn't change much - the formatting is slightly affected but the impact is very small. Properly fixing the script for this rare case is harder. (The case is rare because most conditionals are by distro, already processed correctly). 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
