### PR TITLE
Adds live migration procedures for sdn to ovnk

### DIFF
--- a/modules/how-the-live-migration-process-works.adoc
+++ b/modules/how-the-live-migration-process-works.adoc
@@ -1,7 +1,6 @@
 // Module included in the following assemblies:
 //
 // * networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
-// * networking/openshift_sdn/migrate-to-openshift-sdn.adoc
 
 ifeval::["{context}" == "migrate-to-openshift-sdn"]
 :sdn: OpenShift SDN
@@ -14,38 +13,34 @@ ifeval::["{context}" == "migrate-from-openshift-sdn"]
 :type: OVNKubernetes
 endif::[]
 
-[id="how-the-migration-process-works_{context}"]
-= How the offline migration process works
+[id="how-the-live-migration-process-works_{context}"]
+= How the live migration process works
 
-The following table summarizes the migration process by segmenting between the user-initiated steps in the process and the actions that the migration performs in response.
+The following table summarizes the live migration process by segmenting between the user-initiated steps in the process and the actions that the migration script performs in response.
 
-.Offline migration to {sdn} from {previous-sdn}
+.Live migration to OVNKubernetes from OpenShiftSDN
 [cols="1,1a",options="header"]
 |===
-
 |User-initiated steps|Migration activity
+ifdef::openshift-rosa,openshift-dedicated[]
+| Add the `unsupported-red-hat-internal-testing` annotation to the cluster-level network configuration. 
+| The Cluster Network Operator (CNO) acknowledges the unsupported testing environment.
+endif::[]
 
-|
-Set the `migration` field of the `Network.operator.openshift.io` custom resource (CR) named `cluster` to `{type}`. Make sure the `migration` field is `null` before setting it to a value.
-|
-Cluster Network Operator (CNO):: Updates the status of the `Network.config.openshift.io` CR named `cluster` accordingly.
-Machine Config Operator (MCO):: Rolls out an update to the systemd configuration necessary for {sdn}; the MCO updates a single machine per pool at a time by default, causing the total time the migration takes to increase with the size of the cluster.
-
-|Update the `networkType` field of the `Network.config.openshift.io` CR.
-|
-CNO:: Performs the following actions:
+| Patch the cluster-level networking configuration by changing the `networkType` from `OpenShiftSDN` to `OVNKubernetes`.
+| 
+Cluster Network Operator (CNO)::
 +
 --
-* Destroys the {previous-sdn} control plane pods.
-* Deploys the {sdn} control plane pods.
-* Updates the Multus daemon sets and config map objects to reflect the new network plugin.
+* Sets migration-related fields in the `network.operator` custom resource (CR) and waits for routable MTUs to be applied to all nodes.
+* Patches the `network.operator` CR to set the migration mode to `Live` for OVN-Kubernetes and deploys the OpenShift SDN network plugin in migration mode.
+* Deploys OVN-Kubernetes with hybrid overlay enabled, ensuring that no racing conditions occur.
+* Waits for the OVN-Kubernetes deployment and updates the conditions in the status of the `network.config` CR.
+* Triggers the Machine Config Operator (MCO) to apply the new machine config to each machine config pool, which includes node cordoning, draining, and rebooting.
+* OVN-Kubernetes adds nodes to the appropriate zones and recreates pods using OVN-Kubernetes as the default CNI plugin.
+* Removes migration-related fields from the network.operator CR and performs cleanup actions, such as deleting OpenShift SDN resources and redeploying OVN-Kubernetes in normal mode with the necessary configurations.
+* Waits for the OVN-Kubernetes redeployment and updates the status conditions in the `network.config` CR to indicate migration completion. If your migration is blocked, see "Checking live migration metrics" for information on troubleshooting the issue.
 --
-
-|
-Reboot each node in the cluster.
-|
-Cluster:: As nodes reboot, the cluster assigns IP addresses to pods on the {sdn} cluster network.
-
 |===
 
 ////
@@ -93,6 +88,7 @@ MCO:: Rolls out an update to the systemd configuration necessary for OpenShift S
 
 |===
 endif::[]
+
 ////
 
 ifdef::sdn[]

--- a/modules/live-migration-metrics-information.adoc
+++ b/modules/live-migration-metrics-information.adoc
@@ -1,0 +1,54 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="live-migration-metrics-information"]
+= Information about live migration metrics
+
+The following table shows you the available metrics and the label values populated from the `openshift_network_operator_live_migration_procedure` expression. Use this information to monitor progress or to troubleshoot the migration.
+
+
+.Live migration metrics
+[cols="1a,1a",options="header"]
+|===
+| Metric | Label values
+| 
+*`openshift_network_operator_live_migration_blocked:`*::
++
+--
+A Prometheus gauge vector metric. A metric that contains a constant `1` value labeled with the reason that the CNI live migration might not have started. This metric is available when the CNI live migration has started by annotating the `Network` custom resource. +
+This metric is not published unless the live migration is blocked. 
+--
+| 
+The list of label values includes the following::
++
+--
+* `UnsupportedCNI`: Unable to migrate to the unsupported target CNI. Valid CNI is `OVNKubernetes` when migrating from OpenShift SDN.
+* `UnsupportedHyperShiftCluster`: Live migration is unsupported within an HCP cluster.
+* `UnsupportedSDNNetworkIsolationMode`: OpenShift SDN is configured with an unsupported network isolation mode `Multitenant`. Migrate to a supported network isolation mode before performing live migration.
+* `UnsupportedMACVLANInterface`: Remove the egress router or any pods which contain the pod annotation `pod.network.openshift.io/assign-macvlan`. 
+Find the offending pod's namespace or pod name with the following command: +
+ +
+`oc get pods -Ao=jsonpath='{range .items[?(@.metadata.annotations.pod\.network\.openshift\.io/assign-macvlan=="")]}{@.metadata.namespace}{"\t"}{@.metadata.name}{"\n"}'`.
+--
+
+| 
+*`openshift_network_operator_live_migration_condition:`*::
++
+--
+A metric which represents the status of each condition type for the CNI live migration. The set of status condition types is defined for `network.config` to support observability of the CNI live migration. +
+A `1` value represents condition status `true`. A `0` value represents `false`. `-1` represents unknown. This metric is available when the CNI live migration has started by annotating the `Network` custom resource (CR). +
+This metric is only available when the live migration has been triggered by adding the relevant annotation to the `Network` CR cluster, otherwise, it is not published. If the following condition types are not present within the Network CR cluster, the metric and their labels are cleared.
+--
+| 
+The list of label values includes the following::
++
+--
+* `NetworkTypeMigrationInProgress`
+* `NetworkTypeMigrationTargetCNIAvailable`
+* `NetworkTypeMigrationTargetCNIInUse`
+* `NetworkTypeMigrationOriginalCNIPurged`
+* `NetworkTypeMigrationMTUReady`
+--
+|===

--- a/modules/nw-ovn-kubernetes-checking-live-migration-metrics.adoc
+++ b/modules/nw-ovn-kubernetes-checking-live-migration-metrics.adoc
@@ -1,0 +1,75 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="checking-live-migration-metrics"]
+= Checking live migration metrics 
+
+Metrics are available to monitor the progress of the live migration. Metrics can be viewed on the {product-title} web console, or by using the `oc` CLI.
+
+.Prerequisites
+
+* You have initiated a live migration to OVN-Kubernetes.
+
+.Procedure
+
+. To view live migration metrics on the {product-title} web console:
+
+.. Click *Observe* -> *Metrics*.
+
+.. In the *Expression* box, type *openshift_network* and click the *openshift_network_operator_live_migration_procedure* option. 
+
+. To view metrics by using the `oc` CLI:
+
+.. Enter the following command to generate a token for the `prometheus-k8s` service account in the `openshift-monitoring` namespace:
++
+[source,terminal]
+----
+$ oc create token prometheus-k8s -n openshift-monitoring
+----
++
+.Example output
++
+[source,terminal]
+----
+eyJhbGciOiJSUzI1NiIsImtpZCI6IlZiSUtwclcwbEJ2VW9We...
+----
+
+.. Enter the following command to request information about the `openshift_network_operator_live_migration_condition` metric:
++
+[source,terminal]
+----
+$ oc -n openshift-monitoring exec -c prometheus prometheus-k8s-0 -- curl -k -H "Authorization: <eyJhbGciOiJSUzI1NiIsImtpZCI6IlZiSUtwclcwbEJ2VW9We...>" "https://<openshift_API_endpoint>" --data-urlencode "query=openshift_network_operator_live_migration_condition" | jq`
+----
++
+.Example output
++
+[source,terminal]
+----
+ "status": "success",
+  "data": {
+    "resultType": "vector",
+    "result": [
+      {
+        "metric": {
+          "__name__": "openshift_network_operator_live_migration_condition",
+          "container": "network-operator",
+          "endpoint": "metrics",
+          "instance": "10.0.83.62:9104",
+          "job": "metrics",
+          "namespace": "openshift-network-operator",
+          "pod": "network-operator-6c87754bc6-c8qld",
+          "prometheus": "openshift-monitoring/k8s",
+          "service": "metrics",
+          "type": "NetworkTypeMigrationInProgress"
+        },
+        "value": [
+          1717653579.587,
+          "1"
+        ]
+      },
+...
+----
+
+The table in "Information about live migration metrics" shows you the available metrics and the label values populated from the `openshift_network_operator_live_migration_procedure` expression. Use this information to monitor progress or to troubleshoot the migration.

--- a/modules/nw-ovn-kubernetes-live-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-live-migration-about.adoc
@@ -1,0 +1,88 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+
+[id="nw-ovn-kubernetes-live-migration-about_{context}"]
+= Live migration to the OVN-Kubernetes network plugin overview
+
+The live migration method is the process in which the OpenShift SDN network plugin and its network configurations, connections, and associated resources, are migrated to the OVN-Kubernetes network plugin without service interruption. It is available for {product-title}, {product-dedicated}, {product-rosa}, and Azure Red Hat OpenShift deployment types. It is not available for HyperShift deployment types. This migration method is valuable for deployment types that require constant service availability and offers the following benefits:
+
+* Continuous service availability
+* Minimized downtime
+* Automatic node rebooting
+* Seamless transition from the OpenShift SDN network plugin to the OVN-Kubernetes network plugin
+
+Although a rollback procedure is provided, the live migration is intended to be a one-way process.
+
+include::snippets/sdn-deprecation-statement.adoc[]
+
+The following sections provide more information about the live migration method.
+
+[id="supported-platforms-live-migrating-ovn-kubernetes"]
+== Supported platforms when using the live migration method
+
+The following table provides information about the supported platforms for the live migration type.
+
+.Supported platforms for the live migration method
+[cols="1,1", options="header"]
+|===
+| Platform              | Live Migration
+
+| Bare metal hardware (IPI and UPI)             |&#10003;
+| Amazon Web Services (AWS) (IPI and UPI)       |&#10003;
+| Google Cloud Platform (GCP) (IPI and UPI)     |&#10003;
+| {ibm-cloud-name} (IPI and UPI)                |&#10003;
+| Microsoft Azure (IPI and UPI)                 |&#10003;
+| {rh-openstack-first} (IPI and UPI)            |&#10003;
+| VMware vSphere (IPI and UPI)                  |&#10003;
+| AliCloud (IPI and UPI)                        |&#10003;
+| Nutanix (IPI and UPI)                         |&#10003;
+|===
+
+[id="considerations-live-migrating-ovn-kubernetes-network-provider_{context}"]
+== Considerations for live migration to the OVN-Kubernetes network plugin
+
+Before using the live migration method to the OVN-Kubernetes network plugin, cluster administrators should consider the following information:
+
+* The live migration procedure is unsupported for clusters with OpenShift SDN multitenant mode enabled. 
+
+* Egress router pods block the live migration process. They must be removed before beginning the live migration process.
+
+* During the live migration, multicast, egress IP addresses, and egress firewalls are temporarily disabled. They can be migrated from OpenShift SDN to OVN-Kubernetes after the live migration process has finished.
+
+* The migration is intended to be a one-way process. However, for users that want to rollback to OpenShift-SDN, migration from OpenShift-SDN to OVN-Kubernetes must have succeeded. Users can follow the same procedure below to migrate to the OpenShift SDN network plugin from the OVN-Kubernetes network plugin.
+
+* The live migration is not supported on HyperShift clusters.
+
+* OpenShift SDN does not support IPsec. After the migration, cluster administrators can enable IPsec.
+
+* OpenShift SDN does not support IPv6. After the migration, cluster administrators can enable dual-stack.
+
+* The cluster MTU is the MTU value for pod interfaces. It is always less than your hardware MTU to account for the cluster network overlay overhead. The overhead is 100 bytes for OVN-Kubernetes and 50 bytes for OpenShift SDN.
++
+During the live migration, both OVN-Kubernetes and OpenShift SDN run in parallel. OVN-Kubernetes manages the cluster network of some nodes, while OpenShift SDN manages the cluster network of others. To ensure that cross-CNI traffic remains functional, the Cluster Network Operator updates the routable MTU to ensure that both CNIs share the same overlay MTU. As a result, after the migration has completed, the cluster MTU is 50 bytes less.
+
+* Some parameters of OVN-Kubernetes cannot be changed after installation. The following parameters can be set only before starting the live migration:
+
+** `InternalTransitSwitchSubnet`
+** `internalJoinSubnet`
+
+* Unless otherwise configured, OVN-Kubernetes uses the following IP address ranges:
+** `100.64.0.0/1`. This IP address range is used for the `internalJoinSubnet` parameter of OVN-Kubernetes by default. If this IP address range is already in use, enter the following command to update it to `100.63.0.0/16`:
++
+[source,terminal]
+----
+$ oc patch network.operator.openshift.io cluster --type='merge' -p='{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"ipv4":{"internalJoinSubnet": "100.63.0.0/16"}}}}}'
+----
+** `100.88.0.0/16`. This IP address range is used for the `internalTransSwitchSubnet` parameter of OVN-Kubernetes by default. If this IP address range is already in use by another network, enter the following command to update it to `100.99.0.0/16`:
++
+[source,terminal]
+----
+$ oc patch network.operator.openshift.io cluster --type='merge' -p='{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"ipv4":{"internalTransitSwitchSubnet": "100.99.0.0/16"}}}}}'
+----
+
+* In most cases, the live migration is independent of the secondary interfaces of pods created by the Multus CNI plugin. However, if these secondary interfaces were set up on the default network interface controller (NIC) of the host, for example, using MACVLAN, IPVLAN, SR-IOV, or bridge interfaces with the default NIC as the control node, OVN-Kubernetes might encounter malfunctions. Users should remove such configurations before proceeding with the live migration.
+
+* When there are multiple NICs inside of the host, and the default route is not on the interface that has the Kubernetes NodeIP, you must use the offline migration instead.
+
+* All `DaemonSet` objects in the `openshift-sdn` namespace, which are not managed by the Cluster Network Operator (CNO), must be removed before initiating the live migration. These unmanaged daemon sets can cause the migration status to remain incomplete if not properly handled.

--- a/modules/nw-ovn-kubernetes-live-migration.adoc
+++ b/modules/nw-ovn-kubernetes-live-migration.adoc
@@ -1,0 +1,113 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+// * networking/openshift_sdn/rollback-to-ovn-kubernetes.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-ovn-kubernetes-live-migration_{context}"]
+= Migrating to the OVN-Kubernetes network plugin by using the live migration method
+
+The following procedure checks for egress router resources and uses the live migration method to migrate from the OpenShift SDN network plugin to the OVN-Kubernetes network plugin.
+
+.Prerequisites
+
+* A cluster has been configured with the OpenShift SDN CNI network plugin in the network policy isolation mode.
+* You have installed the OpenShift CLI (`oc`).
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have created a recent backup of the etcd database.
+* The cluster is in a known good state without any errors.
+* Before migration to OVN-Kubernetes, a security group rule must be in place to allow UDP packets on port `6081` for all nodes on all cloud platforms.
+* Cluster administrators must remove any egress router pods before beginning the live migration. For more information about egress router pods, see "Deploying an egress router pod in redirect mode".
+* You have reviewed the "Considerations for live migration to the OVN-Kubernetes network plugin" section of this document.
+
+.Procedure
+
+. Before initiating the live migration, you must check for any egress router pods. If there is an egress router pod on the cluster when performing a live migration, the Network Operator blocks the migration and returns the following error: 
++
+[source,text]
+----
+The cluster configuration is invalid (network type live migration is not supported for pods with `pod.network.openshift.io/assign-macvlan` annotation. Please remove all egress router pods). Use `oc edit network.config.openshift.io cluster` to fix.
+----
++
+** Enter the following command to locate egress router pods on your cluster:
++
+[source,terminal]
+----
+$ oc get pods --all-namespaces -o json | jq '.items[] | select(.metadata.annotations."pod.network.openshift.io/assign-macvlan" == "true") | {name: .metadata.name, namespace: .metadata.namespace}'
+----
++
+.Example output
++
+[source,terminal]
+----
+{
+  "name": "egress-multi",
+  "namespace": "egress-router-project"
+}
+----
++
+** Alternatively, you can query metrics on the {product-title} web console or by using the `oc` CLI to check for egress router pods. For more information, see "Checking live migration metrics".
+
+. Enter the following command to remove an egress router pod:
++
+[source,terminal]
+----
+$ oc delete pod <egress_pod_name> -n <egress_router_project>
+----
+
+ifdef::openshift-rosa,openshift-dedicated[]
+. Enter the following command to add the `unsupported-red-hat-internal-testing` annotation to the cluster-level network configuration:
++
+[source,terminal]
+----
+$ oc patch Network.config.openshift.io cluster --type='merge' --patch '{"metadata":{"annotations":{"unsupported-red-hat-internal-testing": "true"}}}'
+----
+endif::[]
+
+. Enter the following command to patch the cluster-level networking configuration and initiate the migration from OpenShift SDN to OVN-Kubernetes:
++
+[source,terminal]
+----
+$ oc patch Network.config.openshift.io cluster --type='merge' --patch '{"metadata":{"annotations":{"network.openshift.io/network-type-migration":""}},"spec":{"networkType":"OVNKubernetes"}}'
+----
++
+After running these commands, the migration process begins. During this process, the Machine Config Operator reboots the nodes in your cluster twice. It is expected that the migration takes approximately twice as long as a cluster upgrade.
+
+. Optional: You can enter the following commands to ensure that the migration process has completed, and to check the status of the `network.config`:
++
+[source,terminal]
+----
+$ oc get network.config.openshift.io cluster -o jsonpath='{.status.networkType}'
+----
++
+[source,terminal]
+----
+$ oc get network.config cluster -o=jsonpath='{.status.conditions}' | jq .
+----
++
+You can check live migration metrics for troubleshooting issues. For more information, see "Checking live migration metrics".
+
+. Complete the following steps only if the migration succeeds and your cluster is in a good state:
+
+.. To remove the migration configuration from the `network.config` custom resource, enter the following command:
++
+[source,terminal]
+----
+$ oc patch Network.operator.openshift.io cluster --type='merge' \
+  --patch '{ "spec": { "migration": null } }'
+----
+
+.. To remove custom configuration for the OpenShift SDN network provider, enter the following command:
++
+[source,terminal]
+----
+$ oc patch Network.operator.openshift.io cluster --type='merge' \
+  --patch '{ "spec": { "defaultNetwork": { "openshiftSDNConfig": null } } }'
+----
+
+.. To remove the OpenShift SDN network provider namespace, enter the following command:
++
+[source,terminal]
+----
+$ oc delete namespace openshift-sdn
+----

--- a/modules/nw-ovn-kubernetes-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-migration-about.adoc
@@ -3,30 +3,45 @@
 // * networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
 
 [id="nw-ovn-kubernetes-migration-about_{context}"]
-= Migration to the OVN-Kubernetes network plugin
+= Offline migration to the OVN-Kubernetes network plugin overview
 
-Migrating to the OVN-Kubernetes network plugin is a manual process that includes some downtime during which your cluster is unreachable. Although a rollback procedure is provided, the migration is intended to be a one-way process.
+The offline migration method is a manual process that includes some downtime, during which your cluster is unreachable. This method is primarily used for self-managed {product-title} deployments. 
 
-A migration to the OVN-Kubernetes network plugin is supported on the following platforms:
+Although a rollback procedure is provided, the offline migration is intended to be a one-way process.
 
-* Bare metal hardware
-* Amazon Web Services (AWS)
-* Google Cloud Platform (GCP)
-* {ibm-cloud-name}
-* Microsoft Azure
-* {rh-openstack-first}
-* VMware vSphere
-* Nutanix
-
+////
 [IMPORTANT]
 ====
 Migrating to or from the OVN-Kubernetes network plugin is not supported for managed OpenShift cloud services such as {product-dedicated}, Azure Red Hat OpenShift(ARO), and Red Hat OpenShift Service on AWS (ROSA).
 ====
-
+////
 include::snippets/sdn-deprecation-statement.adoc[]
 
+The following sections provide more information about the offline migration method.
+
+[id="supported-platforms-offline-migrating-ovn-kubernetes"]
+== Supported platforms when using the offline migration method
+
+The following table provides information about the supported platforms for the offline migration type.
+
+.Supported platforms for the offline migration method
+[cols="1,1", options="header"]
+|===
+| Platform              | Offline Migration
+
+| Bare metal hardware (IPI and UPI)            |&#10003;         
+| Amazon Web Services (AWS) (IPI and UPI)      |&#10003;         
+| Google Cloud Platform (GCP) (IPI and UPI)    |&#10003;         
+| {ibm-cloud-name} (IPI and UPI)               |&#10003;         
+| Microsoft Azure (IPI and UPI)                |&#10003;         
+| {rh-openstack-first} (IPI and UPI)           |&#10003;         
+| VMware vSphere (IPI and UPI)                 |&#10003;        
+| AliCloud (IPI and UPI)                       |&#10003;                  
+| Nutanix (IPI and UPI)                        |&#10003;                  
+|===
+
 [id="considerations-migrating-ovn-kubernetes-network-provider_{context}"]
-== Considerations for migrating to the OVN-Kubernetes network plugin
+== Considerations for offline migration to the OVN-Kubernetes network plugin
 
 If you have more than 150 nodes in your {product-title} cluster, then open a support case for consultation on your migration to the OVN-Kubernetes network plugin.
 

--- a/modules/nw-ovn-kubernetes-migration.adoc
+++ b/modules/nw-ovn-kubernetes-migration.adoc
@@ -5,7 +5,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-ovn-kubernetes-migration_{context}"]
-= Migrating to the OVN-Kubernetes network plugin
+= Migrating to the OVN-Kubernetes network plugin by using the offline migration method
 
 As a cluster administrator, you can change the network plugin for your cluster to OVN-Kubernetes.
 During the migration, you must reboot every node in your cluster.
@@ -24,7 +24,7 @@ Perform the migration only when an interruption in service is acceptable.
 * A recent backup of the etcd database is available.
 * A reboot can be triggered manually for each node.
 * The cluster is in a known good state, without any errors.
-* On all cloud platforms after updating software, a security group rule must be in place to allow UDP packets on port `6081` for all nodes.
+* Before migration to OVN-Kubernetes, a security group rule must be in place to allow UDP packets on port `6081` for all nodes on all cloud platforms.
 
 .Procedure
 

--- a/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
@@ -6,14 +6,19 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can migrate to the OVN-Kubernetes network plugin from the OpenShift SDN network plugin.
+As a cluster administrator, you can migrate to the OVN-Kubernetes network plugin from the OpenShift SDN network plugin using the _offline_ migration method or the _live_ migration method.
 
 To learn more about OVN-Kubernetes, read xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes#about-ovn-kubernetes[About the OVN-Kubernetes network plugin].
 
 include::modules/nw-ovn-kubernetes-migration-about.adoc[leveloffset=+1]
 include::modules/nw-network-plugin-migration-process.adoc[leveloffset=+2]
+include::modules/nw-ovn-kubernetes-migration.adoc[leveloffset=+2]
 
-include::modules/nw-ovn-kubernetes-migration.adoc[leveloffset=+1]
+include::modules/nw-ovn-kubernetes-live-migration-about.adoc[leveloffset=+1]
+include::modules/how-the-live-migration-process-works.adoc[leveloffset=+2]
+include::modules/nw-ovn-kubernetes-live-migration.adoc[leveloffset=+2]
+include::modules/nw-ovn-kubernetes-checking-live-migration-metrics.adoc[leveloffset=+2]
+include::modules/live-migration-metrics-information.adoc[leveloffset=+3]
 
 [role="_additional-resources"]
 [id="migrate-from-openshift-sdn-additional-resources"]
@@ -33,4 +38,5 @@ include::modules/nw-ovn-kubernetes-migration.adoc[leveloffset=+1]
 - xref:../../networking/openshift_sdn/assigning-egress-ips.adoc#assigning-egress-ips[Configuring egress IPs for a project]
 - xref:../../networking/openshift_sdn/configuring-egress-firewall.adoc#configuring-egress-firewall[Configuring an egress firewall for a project]
 - xref:../../networking/openshift_sdn/enabling-multicast.adoc#enabling-multicast[Enabling multicast for a project]
+- xref:../../networking/openshift_sdn/deploying-egress-router-layer3-redirection.adoc#deploying-egress-router-layer3-redirection[Deploying an egress router pod in redirect mode]
 * xref:../../rest_api/operator_apis/network-operator-openshift-io-v1.adoc#network-operator-openshift-io-v1[Network [operator.openshift.io/v1]]

--- a/rest_api/operator_apis/network-operator-openshift-io-v1.adoc
+++ b/rest_api/operator_apis/network-operator-openshift-io-v1.adoc
@@ -760,7 +760,7 @@ Type::
 Description::
 +
 --
-ipv4 allows users to configure IP settings for IPv4 connections. When ommitted, this means no opinions and the default configuration is used. Check individual fields within ipv4 for details of default values.
+ipv4 allows users to configure IP settings for IPv4 connections. When omitted, this means no opinions and the default configuration is used. Check individual fields within ipv4 for details of default values.
 --
 
 Type::


### PR DESCRIPTION
This is PR 1 of 2. The second is https://github.com/openshift/openshift-docs/pull/77067. It needs reviewed separately.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-10662

Link to docs preview:
https://76672--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#nw-ovn-kubernetes-migration-about_migrate-from-openshift-sdn

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
