### PR TITLE
OSDOCS#10644: update 'local' wording in disconnected update docs

### DIFF
--- a/modules/disconnected-osus-overview.adoc
+++ b/modules/disconnected-osus-overview.adoc
@@ -7,16 +7,16 @@
 
 = Using the OpenShift Update Service in a disconnected environment
 
-The OpenShift Update Service (OSUS) provides update recommendations to {product-title} clusters. Red Hat publicly hosts the OpenShift Update Service, and clusters in a connected environment can connect to the service through public APIs to retrieve update recommendations.
+The OpenShift Update Service (OSUS) provides update recommendations to {product-title} clusters. Red{nbsp}Hat publicly hosts the OpenShift Update Service, and clusters in a connected environment can connect to the service through public APIs to retrieve update recommendations.
 
-However, clusters in a disconnected environment cannot access these public APIs to retrieve update information. To have a similar update experience in a disconnected environment, you can install and configure the OpenShift Update Service locally so that it is available within the disconnected environment.
+However, clusters in a disconnected environment cannot access these public APIs to retrieve update information. To have a similar update experience in a disconnected environment, you can install and configure the OpenShift Update Service so that it is available within the disconnected environment.
 
 A single OSUS instance is capable of serving recommendations to thousands of clusters.
 OSUS can be scaled horizontally to cater to more clusters by changing the replica value.
 So for most disconnected use cases, one OSUS instance is enough.
-For example, Red Hat hosts just one OSUS instance for the entire fleet of connected clusters.
+For example, Red{nbsp}Hat hosts just one OSUS instance for the entire fleet of connected clusters.
 
 If you want to keep update recommendations separate in different environments, you can run one OSUS instance for each environment.
 For example, in a case where you have separate test and stage environments, you might not want a cluster in a stage environment to receive update recommendations to version A if that version has not been tested in the test environment yet.
 
-The following sections describe how to install a local OSUS instance and configure it to provide update recommendations to a cluster.
+The following sections describe how to install an OSUS instance and configure it to provide update recommendations to a cluster.

--- a/modules/update-service-configure-cvo.adoc
+++ b/modules/update-service-configure-cvo.adoc
@@ -5,13 +5,13 @@
 [id="update-service-configure-cvo"]
 = Configuring the Cluster Version Operator (CVO)
 
-After the OpenShift Update Service Operator has been installed and the OpenShift Update Service application has been created, the Cluster Version Operator (CVO) can be updated to pull graph data from the locally installed OpenShift Update Service.
+After the OpenShift Update Service Operator has been installed and the OpenShift Update Service application has been created, the Cluster Version Operator (CVO) can be updated to pull graph data from the OpenShift Update Service installed in your environment.
 
 .Prerequisites
 
 * The OpenShift Update Service Operator has been installed.
 * The OpenShift Update Service graph data container image has been created and pushed to a repository that is accessible to the OpenShift Update Service.
-* The current release and update target releases have been mirrored to a locally accessible registry.
+* The current release and update target releases have been mirrored to a registry in the disconnected environment.
 * The OpenShift Update Service application has been created.
 
 .Procedure
@@ -44,7 +44,7 @@ $ POLICY_ENGINE_GRAPH_URI="$(oc -n "${NAMESPACE}" get -o jsonpath='{.status.poli
 $ PATCH="{\"spec\":{\"upstream\":\"${POLICY_ENGINE_GRAPH_URI}\"}}"
 ----
 +
-. Patch the CVO to use the local OpenShift Update Service:
+. Patch the CVO to use the OpenShift Update Service in your environment:
 +
 [source,terminal]
 ----

--- a/modules/update-service-create-service-cli.adoc
+++ b/modules/update-service-create-service-cli.adoc
@@ -11,7 +11,7 @@ You can use the OpenShift CLI (`oc`) to create an OpenShift Update Service appli
 
 * The OpenShift Update Service Operator has been installed.
 * The OpenShift Update Service graph data container image has been created and pushed to a repository that is accessible to the OpenShift Update Service.
-* The current release and update target releases have been mirrored to a locally accessible registry.
+* The current release and update target releases have been mirrored to a registry in the disconnected environment.
 
 .Procedure
 
@@ -31,7 +31,7 @@ The namespace must match the `targetNamespaces` value from the operator group.
 $ NAME=service
 ----
 
-. Configure the local registry and repository for the release images as configured in "Mirroring the {product-title} image repository", for example, `registry.example.com/ocp4/openshift4-release-images`:
+. Configure the registry and repository for the release images as configured in "Mirroring the {product-title} image repository", for example, `registry.example.com/ocp4/openshift4-release-images`:
 //TODO: Add xref to the preceding step when allowed.
 +
 [source,terminal]

--- a/modules/update-service-create-service-web-console.adoc
+++ b/modules/update-service-create-service-web-console.adoc
@@ -11,7 +11,7 @@ You can use the {product-title} web console to create an OpenShift Update Servic
 
 * The OpenShift Update Service Operator has been installed.
 * The OpenShift Update Service graph data container image has been created and pushed to a repository that is accessible to the OpenShift Update Service.
-* The current release and update target releases have been mirrored to a locally accessible registry.
+* The current release and update target releases have been mirrored to a registry in the disconnected environment.
 
 .Procedure
 
@@ -28,7 +28,7 @@ You can use the {product-title} web console to create an OpenShift Update Servic
 . Enter the local pullspec in the *Graph Data Image* field to the graph data container image created in "Creating the OpenShift Update Service graph data container image", for example, `registry.example.com/openshift/graph-data:latest`.
 //TODO: Add xref to preceding step when allowed.
 
-. In the *Releases* field, enter the local registry and repository created to contain the release images in "Mirroring the OpenShift Container Platform image repository", for example, `registry.example.com/ocp4/openshift4-release-images`.
+. In the *Releases* field, enter the registry and repository created to contain the release images in "Mirroring the OpenShift Container Platform image repository", for example, `registry.example.com/ocp4/openshift4-release-images`.
 //TODO: Add xref to preceding step when allowed.
 
 . Enter `2` in the *Replicas* field.

--- a/modules/update-service-graph-data.adoc
+++ b/modules/update-service-graph-data.adoc
@@ -43,5 +43,5 @@ $ podman push registry.example.com/openshift/graph-data:latest
 +
 [NOTE]
 ====
-To push a graph data image to a local registry in a disconnected environment, copy the graph data container image created in the previous step to a repository that is accessible to the OpenShift Update Service. Run `oc image mirror --help` for available options.
+To push a graph data image to a registry in a disconnected environment, copy the graph data container image created in the previous step to a repository that is accessible to the OpenShift Update Service. Run `oc image mirror --help` for available options.
 ====

--- a/updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update-osus.adoc
+++ b/updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update-osus.adoc
@@ -24,7 +24,7 @@ The following steps outline the high-level workflow on how to update a cluster i
 
 . Create a graph data container image for the OpenShift Update Service.
 
-. Install the OSUS application and configure your clusters to use the local OpenShift Update Service.
+. Install the OSUS application and configure your clusters to use the OpenShift Update Service in your environment.
 
 . Perform a supported update procedure from the documentation as you would with a connected cluster.
 
@@ -40,7 +40,7 @@ include::modules/disconnected-osus-overview.adoc[leveloffset=+1]
 == Prerequisites
 
 * You must have the `oc` command-line interface (CLI) tool installed.
-* You must provision a local container image registry with the container images for your update, as described in xref:../../../updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc#mirroring-ocp-image-repository[Mirroring {product-title} images].
+* You must provision a container image registry in your environment with the container images for your update, as described in xref:../../../updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc#mirroring-ocp-image-repository[Mirroring {product-title} images].
 
 [id="registry-configuration-for-update-service"]
 == Configuring access to a secured registry for the OpenShift Update Service
@@ -66,7 +66,7 @@ data:
     ...
     -----END CERTIFICATE-----
 ----
-<1> The OpenShift Update Service Operator requires the config map key name updateservice-registry in the registry CA cert.
+<1> The OpenShift Update Service Operator requires the config map key name `updateservice-registry` in the registry CA cert.
 <2> If the registry has the port, such as `registry-with-port.example.com:5000`, `:` should be replaced with `..`.
 
 // Updating the global cluster pull secret
@@ -114,7 +114,7 @@ and must be no more than 63 characters`, try creating the Update Service with a 
 ====
 
 // Configuring the Cluster Version Operator (CVO)
-include::modules/update-service-configure-cvo.adoc[leveloffset=+3]
+include::modules/update-service-configure-cvo.adoc[leveloffset=+1]
 
 [NOTE]
 ====
@@ -126,15 +126,15 @@ See xref:../../../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-
 
 Before updating your cluster, confirm that the following conditions are met:
 
-* The Cluster Version Operator (CVO) is configured to use your locally-installed OpenShift Update Service application.
+* The Cluster Version Operator (CVO) is configured to use your installed OpenShift Update Service application.
 * The release image signature config map for the new release is applied to your cluster.
 +
 [NOTE]
 ====
-The release image signature config map allows the Cluster Version Operator (CVO) to ensure the integrity of release images by verifying that the actual image signatures match the expected signatures.
+The Cluster Version Operator (CVO) uses release image signatures to ensure that release images have not been modified, by verifying that the release image signatures match the expected result.
 ====
-* The current release and update target release images are mirrored to a locally accessible registry.
-* A recent graph data container image has been mirrored to your local registry.
+* The current release and update target release images are mirrored to a registry in the disconnected environment.
+* A recent graph data container image has been mirrored to your registry.
 * A recent version of the OpenShift Update Service Operator is installed.
 +
 [NOTE]
@@ -143,7 +143,7 @@ If you have not recently installed or updated the OpenShift Update Service Opera
 See xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks] for more information about how to update your OLM catalog in a disconnected environment.
 ====
 
-After you configure your cluster to use the locally-installed OpenShift Update Service and local mirror registry, you can use any of the following update methods:
+After you configure your cluster to use the installed OpenShift Update Service and local mirror registry, you can use any of the following update methods:
 
 ** xref:../../../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[Updating a cluster using the web console]
 ** xref:../../../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI]


### PR DESCRIPTION
[OSDOCS-10644](https://issues.redhat.com/browse/OSDOCS-10644)

Version(s): 4.14+

This PR updates wording to avoid the phrase "local OSUS" in the docs for disconnected updates with OSUS, since this might incorrectly imply to users that they would need to install an OSUS instance on every single disconnected cluster.

QE review:
- [x] QE has approved this change.

Preview: [Updating a cluster in a disconnected environment using OSUS](https://76673--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update-osus)
