### PR TITLE
osdocs-10375: adding new link to cluster-wide proxy additional resources

### DIFF
--- a/networking/enable-cluster-wide-proxy.adoc
+++ b/networking/enable-cluster-wide-proxy.adoc
@@ -34,3 +34,4 @@ include::modules/nw-proxy-remove.adoc[leveloffset=+1]
 
 * xref:../security/certificates/updating-ca-bundle.adoc#ca-bundle-understanding_updating-ca-bundle[Replacing the CA Bundle certificate]
 * xref:../security/certificate_types_descriptions/proxy-certificates.adoc#customization[Proxy certificate customization]
+* link:https://access.redhat.com/solutions/7065528[How is the cluster-wide proxy setting applied to {product-title} nodes?]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-10375](https://issues.redhat.com//browse/OSDOCS-10375)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://76676--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/enable-cluster-wide-proxy.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
