### PR TITLE
OCPBUGS-34644: Adding IP address to example

### DIFF
--- a/modules/nw-metallb-configure-return-traffic-proc.adoc
+++ b/modules/nw-metallb-configure-return-traffic-proc.adoc
@@ -21,6 +21,8 @@ This example associates a VRF routing table with MetalLB and an egress service t
 
 * Install the OpenShift CLI (`oc`).
 * Log in as a user with `cluster-admin` privileges.
+* Install the Kubernetes NMState Operator.
+* Install the MetalLB Operator.
 
 .Procedure
 
@@ -40,28 +42,37 @@ spec:
   maxUnavailable: 3
   desiredState:
     interfaces:
-      - name: ens4vrf <3>
-        type: vrf <4>
-        state: up
-        vrf:
-          port:
-            - ens4 <5>
-          route-table-id: 2 <6>
-    routes: <7>
+    - name: ens4vrf <3>
+      type: vrf <4>
+      state: up
+      vrf:
+        port:
+        - ens4 <5>
+        route-table-id: 2 <6>
+    - name: ens4 <7>
+      type: ethernet
+      state: up
+      ipv4:
+        address:
+        - ip: 192.168.130.130
+          prefix-length: 24
+        dhcp: false
+        enabled: true
+    routes: <8>
       config:
-        - destination: 0.0.0.0/0
-          metric: 150
-          next-hop-address: 192.168.130.1
-          next-hop-interface: ens4
-          table-id: 2
-    route-rules: <8>
+      - destination: 0.0.0.0/0
+        metric: 150
+        next-hop-address: 192.168.130.1
+        next-hop-interface: ens4
+        table-id: 2
+    route-rules: <9>
       config:
-        - ip-to: 172.30.0.0/16
-          priority: 998
-          route-table: 254
-        - ip-to: 10.132.0.0/14
-          priority: 998
-          route-table: 254
+      - ip-to: 172.30.0.0/16
+        priority: 998
+        route-table: 254 <10>
+      - ip-to: 10.132.0.0/14
+        priority: 998
+        route-table: 254
 ----
 <1> The name of the policy.
 <2> This example applies the policy to all nodes with the label `vrf:true`.
@@ -69,8 +80,10 @@ spec:
 <4> The type of interface. This example creates a VRF instance.
 <5> The node interface that the VRF attaches to.
 <6> The name of the route table ID for the VRF.
-<7> Defines the configuration for network routes. The `next-hop-address` field defines the IP address of the next hop for the route. The `next-hop-interface` field defines the outgoing interface for the route. In this example, the VRF routing table is `2`, which references the ID that you define in the `EgressService` CR.
-<8> Defines additional route rules. The `ip-to` fields must match the `Cluster Network` CIDR and `Service Network` CIDR. You can view the values for these CIDR address specifications by running the following command: `oc describe network.config/cluster`.
+<7> The IPv4 address of the interface associated with the VRF. 
+<8> Defines the configuration for network routes. The `next-hop-address` field defines the IP address of the next hop for the route. The `next-hop-interface` field defines the outgoing interface for the route. In this example, the VRF routing table is `2`, which references the ID that you define in the `EgressService` CR.
+<9> Defines additional route rules. The `ip-to` fields must match the `Cluster Network` CIDR and `Service Network` CIDR. You can view the values for these CIDR address specifications by running the following command: `oc describe network.config/cluster`.
+<10> The main routing table that the Linux kernel uses when calculating routes has the ID `254`.
 
 .. Apply the policy by running the following command:
 +


### PR DESCRIPTION
OCPBUGS-34644: If the IP address for the interface isn't already defined, it will cause issues with the procedure. 

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OCPBUGS-34644

Link to docs preview:
https://76690--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-configure-return-traffic.html#nw-metallb-configure-return-traffic-proc_metallb-configure-return-traffic

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
