### PR TITLE
OSDOCS9493: Updated release notes to include cert-manager 1.14.

### DIFF
--- a/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
@@ -12,6 +12,42 @@ These release notes track the development of {cert-manager-operator}.
 
 For more information, see xref:../../security/cert_manager_operator/index.adoc#cert-manager-operator-about[About the {cert-manager-operator}].
 
+[id="cert-manager-operator-release-notes-1-14-0"]
+== {cert-manager-operator} 1.14.0
+
+Issued: 2024-07-08
+
+The following advisory is available for the {cert-manager-operator} 1.14.0:
+
+* link:https://access.redhat.com/errata/RHEA-2024:4360[RHEA-2024:4360]
+
+Version `1.14.0` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.14.5`. For more information, see the link:https://cert-manager.io/docs/releases/release-notes/release-notes-1.14/#v1145[cert-manager project release notes for v1.14.5].
+
+[id="cert-manager-operator-new-features-1-14-0"]
+=== New features and enhancements
+
+*FIPS compliance support*
+
+With this release, FIPS mode is now automatically enabled for {cert-manager-operator}. When installed on an {product-title} cluster in FIPS mode, {cert-manager-operator} ensures compatibility without affecting the cluster's FIPS support status.
+
+*NCM issuer*
+
+The {cert-manager-operator} now supports the Nokia NetGuard Certificate Manager (NCM) issuer. The `ncm-issuer` is a cert-manager external issuer that integrates with the NCM PKI system using a Kubernetes controller to sign certificate requests. This integration streamlines the process of obtaining non-self-signed certificates for applications, ensuring their validity and keeping them updated.
+
+[NOTE]
+====
+The NCM issuer is validated only with version 1.1.1 and the {cert-manager-operator} version 1.14.0. This version handles tasks such as issuance, renewal, and managing certificates for the API server and ingress controller of {product-title} clusters.
+====
+
+[id="cert-manager-operator-1-14-0-CVEs"]
+=== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2023-45288[CVE-2023-45288]
+* link:https://access.redhat.com/security/cve/CVE-2024-28180[CVE-2024-28180]
+* link:https://access.redhat.com/security/cve/CVE-2020-8559[CVE-2020-8559]
+* link:https://access.redhat.com/security/cve/CVE-2024-26147[CVE-2024-26147]
+* link:https://access.redhat.com/security/cve/CVE-2024-24783[CVE-2024-24783]
+
 [id="cert-manager-operator-release-notes-1-13-1"]
 == {cert-manager-operator} 1.13.1
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14 - 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-9493
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://76692--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-operator-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
