### PR TITLE
MGMT-16631: {base,unsigned}ImageRegistryTLS have no effect on OpenShift

### DIFF
--- a/hardware_enablement/kmm-kernel-module-management.adoc
+++ b/hardware_enablement/kmm-kernel-module-management.adoc
@@ -51,10 +51,13 @@ include::modules/kmm-replacing-in-tree-modules-with-out-of-tree-modules.adoc[lev
 
 [role="_additional-resources"]
 .Additional resources
-
 * link:https://fastbitlab.com/building-a-linux-kernel-module/[Building a linux kernel module]
 
 include::modules/kmm-example-module-cr.adoc[leveloffset=+2]
+// Added for MGMT-16631
+[role="_additional-resources"]
+.Additional resources
+* xref:../security/certificates/updating-ca-bundle.adoc#ca-bundle-replacing_updating-ca-bundle[Replacing the CA Bundle certificate]
 
 // Added for TELCODOCS-1827
 include::modules/kmm-symbolic-links-for-in-tree-dependencies.adoc[leveloffset=+1]
@@ -64,7 +67,6 @@ include::modules/kmm-running-depmod.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-
 * xref:../hardware_enablement/psap-driver-toolkit.adoc#driver-toolkit[Driver Toolkit]
 
 include::modules/kmm-building-in-cluster.adoc[leveloffset=+2]

--- a/modules/kmm-example-module-cr.adoc
+++ b/modules/kmm-example-module-cr.adoc
@@ -81,7 +81,12 @@ spec:
 <7> For any other kernel, build the image using the Dockerfile in the `my-kmod` ConfigMap.
 <8> Optional.
 <9> Optional: A value for `some-kubernetes-secret` can be obtained from the build environment at `/run/secrets/some-kubernetes-secret`.
-<10> Optional: Avoid using this parameter. If set to `true`, the build is allowed to pull the image in the Dockerfile `FROM` instruction using plain HTTP.
+<10> This field has no effect. When building kmod images or signing kmods within a kmod image,
+you might sometimes need to pull base images from a registry that serves a certificate signed by an
+untrusted Certificate Authority (CA). In order for KMM to trust that CA, it must also trust the new CA
+by replacing the cluster's CA bundle.
++
+See "Additional resources" to learn how to replace the cluster's CA bundle.
 <11> Optional: Avoid using this parameter. If set to `true`, the build will skip any TLS server certificate validation when pulling the image in the Dockerfile `FROM` instruction using plain HTTP.
 <12> Required.
 <13> Required: A secret holding the public secureboot key with the key 'cert'.


### PR DESCRIPTION

D/S Docs: [MGMT-16631] Document that {base,unsigned}ImageRegistryTLS have no effect on OpenShift

Jira: https://issues.redhat.com/browse/MGMT-16631

Version(s): openshift-4.16.0, openshift-4.15.0, openshift-4.14.0, openshift-4.13.0, openshift-4.12.0

Link to docs preview: https://76705--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html#kmm-example-cr_kernel-module-management-operator

SME review: @qbarrand
QE review: @cdvultur

