### PR TITLE
OBSDOCS-844: update CMO config map ref 4.16 [manual CP to main]

### DIFF
--- a/observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+++ b/observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
@@ -142,8 +142,6 @@ The `ClusterMonitoringConfiguration` resource defines settings that customize th
 
 |enableUserWorkload|*bool|`UserWorkloadEnabled` is a Boolean flag that enables monitoring for user-defined projects.
 
-|k8sPrometheusAdapter|*link:#k8sprometheusadapter[K8sPrometheusAdapter]|`K8sPrometheusAdapter` defines settings for the Prometheus Adapter component.
-
 |kubeStateMetrics|*link:#kubestatemetricsconfig[KubeStateMetricsConfig]|`KubeStateMetricsConfig` defines settings for the `kube-state-metrics` agent.
 
 |metricsServer|*link:#metricsserverconfig[MetricsServerConfig]|`MetricsServer` defines settings for the Metrics Server component.
@@ -163,52 +161,6 @@ The `ClusterMonitoringConfiguration` resource defines settings that customize th
 |nodeExporter|link:#nodeexporterconfig[NodeExporterConfig]|`NodeExporterConfig` defines settings for the `node-exporter` agent.
 
 |monitoringPlugin|*link:#monitoringpluginconfig[MonitoringPluginConfig]|`MonitoringPluginConfig` defines settings for the monitoring `console-plugin` component.
-
-|===
-
-== DedicatedServiceMonitors
-
-=== Description
-
-[IMPORTANT]
-====
-This setting is deprecated and is planned to be removed in a future {product-title} version.
-In the current version, this setting still exists but has no effect.
-====
-
-You can use the `DedicatedServiceMonitors` resource to configure dedicated Service Monitors for the Prometheus Adapter
-
-Appears in: link:#k8sprometheusadapter[K8sPrometheusAdapter]
-
-[options="header"]
-|===
-| Property | Type | Description
-|enabled|bool|When `enabled` is set to `true`, the Cluster Monitoring Operator (CMO) deploys a dedicated Service Monitor that exposes the kubelet `/metrics/resource` endpoint. This Service Monitor sets `honorTimestamps: true` and only keeps metrics that are relevant for the pod resource queries of Prometheus Adapter. Additionally, Prometheus Adapter is configured to use these dedicated metrics. Overall, this feature improves the consistency of Prometheus Adapter-based CPU usage measurements used by, for example, the `oc adm top pod` command or the Horizontal Pod Autoscaler.
-
-|===
-
-== K8sPrometheusAdapter
-
-=== Description
-
-The `K8sPrometheusAdapter` resource defines settings for the Prometheus Adapter component.
-
-Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
-
-[options="header"]
-|===
-| Property | Type | Description
-|audit|*Audit|Defines the audit configuration used by the Prometheus Adapter instance. Possible profile values are: `metadata`, `request`, `requestresponse`, and `none`. The default value is `metadata`.
-
-|nodeSelector|map[string]string|Defines the nodes on which the pods are scheduled.
-
-|resources|*v1.ResourceRequirements|Defines resource requests and limits for the `PrometheusAdapter` container.
-
-|tolerations|[]v1.Toleration|Defines tolerations for the pods.
-
-|topologySpreadConstraints|[]v1.TopologySpreadConstraint|Defines a pod's topology spread constraints.
-
-|dedicatedServiceMonitors|*link:#dedicatedservicemonitors[DedicatedServiceMonitors]|Defines dedicated service monitors.
 
 |===
 
@@ -237,39 +189,20 @@ Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 
 === Description
 
-:FeatureName: Metrics Server
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
-The `MetricsServerConfig` resource defines settings for the Metrics Server component. Note that this setting only applies when the `TechPreviewNoUpgrade` feature gate is enabled.
+The `MetricsServerConfig` resource defines settings for the Metrics Server component.
 
 Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 
 [options="header"]
 |===
 | Property | Type | Description
+|audit|*Audit|Defines the audit configuration used by the Metrics Server instance. Possible profile values are `Metadata`, `Request`, `RequestResponse`, and `None`. The default value is `Metadata`.
+
 |nodeSelector|map[string]string|Defines the nodes on which the pods are scheduled.
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
 
 |resources|*v1.ResourceRequirements|Defines resource requests and limits for the Metrics Server container.
-
-|topologySpreadConstraints|[]v1.TopologySpreadConstraint|Defines a pod's topology spread constraints.
-
-|===
-
-== PrometheusOperatorAdmissionWebhookConfig
-
-=== Description
-
-The `PrometheusOperatorAdmissionWebhookConfig` resource defines settings for the admission webhook workload for Prometheus Operator.
-
-Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
-
-[options="header"]
-|===
-| Property | Type | Description
-
-|resources|*v1.ResourceRequirements|Defines resource requests and limits for the `prometheus-operator-admission-webhook` container.
 
 |topologySpreadConstraints|[]v1.TopologySpreadConstraint|Defines a pod's topology spread constraints.
 
@@ -570,6 +503,24 @@ link:#userworkloadconfiguration[UserWorkloadConfiguration]
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
 
 |topologySpreadConstraints|[]v1.TopologySpreadConstraint|Defines the pod's topology spread constraints.
+
+|===
+
+== PrometheusOperatorAdmissionWebhookConfig
+
+=== Description
+
+The `PrometheusOperatorAdmissionWebhookConfig` resource defines settings for the admission webhook workload for Prometheus Operator.
+
+Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
+
+[options="header"]
+|===
+| Property | Type | Description
+
+|resources|*v1.ResourceRequirements|Defines resource requests and limits for the `prometheus-operator-admission-webhook` container.
+
+|topologySpreadConstraints|[]v1.TopologySpreadConstraint|Defines a pod's topology spread constraints.
 
 |===
 


### PR DESCRIPTION
Manual cherry-pick of #76589 content to `main` to rectify a mistake I made with creating the original PR only against the `enterprise-4.16` branch when I should've created it against `main` and CP'ed it to `enterprise-4.16`.