### PR TITLE
OSDOCS#10136: Release note for HashiCorp Vault support for the secret…

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -175,6 +175,15 @@ For more information, see link:https://access.redhat.com/documentation/en-us/red
 [id="ocp-4-16-storage_{context}"]
 === Storage
 
+[id="ocp-4-16-storage-secrets-store-csi-driver-vault_{context}"]
+==== HashiCorp Vault is now available for the {secrets-store-operator} (Technology Preview)
+
+You can now use the {secrets-store-operator} to mount secrets from HashiCorp Vault to a CSI volume in {product-title}. The {secrets-store-operator} is available as a Technology Preview feature.
+
+For the full list of available secrets store providers, see xref:../nodes/pods/nodes-pods-secrets-store.adoc#secrets-store-providers_nodes-pods-secrets-store[Secrets store providers].
+
+For information about using the {secrets-store-operator} to mount secrets from HashiCorp Vault, see xref:../nodes/pods/nodes-pods-secrets-store.adoc#secrets-store-vault_nodes-pods-secrets-store[Mounting secrets from HashiCorp Vault].
+
 [id="ocp-4-16-oci_{context}"]
 === Oracle(R) Cloud Infrastructure
 


### PR DESCRIPTION
…s store operator

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-10136

Link to docs preview:
https://76719--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-storage-secrets-store-csi-driver-vault

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

The second xref depends on #76657 being merged first to jump to proper section.