### PR TITLE
OSDOCS-5779: vSphere CAPI TP

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2335,6 +2335,8 @@ Topics:
       File: cluster-api-config-options-aws
     - Name: Cluster API configuration options for Google Cloud Platform
       File: cluster-api-config-options-gcp
+    - Name: Cluster API configuration options for VMware vSphere
+      File: cluster-api-config-options-vsphere
 #  - Name: Cluster API resiliency and recovery
 #    File: cluster-api-resiliency
   - Name: Troubleshooting Cluster API clusters

--- a/machine_management/cluster_api_machine_management/cluster-api-about.adoc
+++ b/machine_management/cluster_api_machine_management/cluster-api-about.adoc
@@ -9,7 +9,7 @@ toc::[]
 :FeatureName: Managing machines with the Cluster API
 include::snippets/technology-preview.adoc[]
 
-The link:https://cluster-api.sigs.k8s.io/[Cluster API] is an upstream project that is integrated into {product-title} as a Technology Preview for Amazon Web Services (AWS) and Google Cloud Platform (GCP).
+The link:https://cluster-api.sigs.k8s.io/[Cluster API] is an upstream project that is integrated into {product-title} as a Technology Preview for {aws-first}, {gcp-first}, and {vmw-first}.
 
 //Cluster API overview
 include::modules/capi-overview.adoc[leveloffset=+1]

--- a/machine_management/cluster_api_machine_management/cluster-api-configuration.adoc
+++ b/machine_management/cluster_api_machine_management/cluster-api-configuration.adoc
@@ -23,3 +23,5 @@ For provider-specific configuration options for your cluster, see the following 
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc#cluster-api-config-options-aws[Cluster API configuration options for {aws-full}]
 
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-gcp.adoc#cluster-api-config-options-gcp[Cluster API configuration options for {gcp-full}]
+
+* xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-vsphere.adoc#cluster-api-config-options-vsphere[Cluster API configuration options for {vmw-full}]

--- a/machine_management/cluster_api_machine_management/cluster-api-getting-started.adoc
+++ b/machine_management/cluster_api_machine_management/cluster-api-getting-started.adoc
@@ -33,6 +33,7 @@ include::modules/capi-creating-infrastructure-resource.adoc[leveloffset=+2]
 .Additional resources
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc#capi-yaml-infrastructure-aws_cluster-api-config-options-aws[Sample YAML for a Cluster API infrastructure resource on {aws-full}]
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-gcp.adoc#capi-yaml-infrastructure-gcp_cluster-api-config-options-gcp[Sample YAML for a Cluster API infrastructure resource on {gcp-full}]
+* xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-vsphere.adoc#capi-yaml-infrastructure-vsphere_cluster-api-config-options-vsphere[Sample YAML for a Cluster API infrastructure resource on {vmw-full}]
 
 //Creating a Cluster API machine template
 include::modules/capi-creating-machine-template.adoc[leveloffset=+2]
@@ -40,6 +41,7 @@ include::modules/capi-creating-machine-template.adoc[leveloffset=+2]
 .Additional resources
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc#capi-yaml-machine-template-aws_cluster-api-config-options-aws[Sample YAML for a Cluster API machine template resource on {aws-full}]
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-gcp.adoc#capi-yaml-machine-template-gcp_cluster-api-config-options-gcp[Sample YAML for a Cluster API machine template resource on {gcp-full}]
+* xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-vsphere.adoc#capi-yaml-machine-template-vsphere_cluster-api-config-options-vsphere[Sample YAML for a Cluster API machine template resource on {vmw-full}]
 
 //Creating a Cluster API compute machine set
 include::modules/capi-creating-machine-set.adoc[leveloffset=+2]
@@ -47,3 +49,4 @@ include::modules/capi-creating-machine-set.adoc[leveloffset=+2]
 .Additional resources
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc#capi-yaml-machine-set-aws_cluster-api-config-options-aws[Sample YAML for a Cluster API compute machine set resource on {aws-full}]
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-gcp.adoc#capi-yaml-machine-set-gcp_cluster-api-config-options-gcp[Sample YAML for a Cluster API compute machine set resource on {gcp-full}]
+* xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-vsphere.adoc#capi-yaml-machine-set-vsphere_cluster-api-config-options-vsphere[Sample YAML for a Cluster API compute machine set resource on {vmw-full}]

--- a/machine_management/cluster_api_machine_management/cluster-api-managing-machines.adoc
+++ b/machine_management/cluster_api_machine_management/cluster-api-managing-machines.adoc
@@ -15,6 +15,7 @@ include::modules/capi-modifying-machine-template.adoc[leveloffset=+1]
 .Additional resources
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc#capi-yaml-machine-template-aws_cluster-api-config-options-aws[Sample YAML for a Cluster API machine template resource on {aws-full}]
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-gcp.adoc#capi-yaml-machine-template-gcp_cluster-api-config-options-gcp[Sample YAML for a Cluster API machine template resource on {gcp-full}]
+* xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-vsphere.adoc#capi-yaml-machine-template-vsphere_cluster-api-config-options-vsphere[Sample YAML for a Cluster API machine template resource on {vmw-full}]
 * xref:../../machine_management/cluster_api_machine_management/cluster-api-managing-machines.adoc#machineset-modifying_cluster-api-managing-machines[Modifying a compute machine set by using the CLI]
 
 //Modifying a compute machine set by using the CLI
@@ -24,3 +25,4 @@ include::modules/machineset-modifying.adoc[leveloffset=+1,tag=!MAPI]
 .Additional resources
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc#capi-yaml-machine-set-aws_cluster-api-config-options-aws[Sample YAML for a Cluster API compute machine set resource on {aws-full}]
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-gcp.adoc#capi-yaml-machine-set-gcp_cluster-api-config-options-gcp[Sample YAML for a Cluster API compute machine set resource on {gcp-full}]
+* xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-vsphere.adoc#capi-yaml-machine-set-vsphere_cluster-api-config-options-vsphere[Sample YAML for a Cluster API compute machine set resource on {vmw-full}]

--- a/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-vsphere.adoc
+++ b/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-vsphere.adoc
@@ -1,0 +1,37 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="cluster-api-config-options-vsphere"]
+= Cluster API configuration options for VMware vSphere
+include::_attributes/common-attributes.adoc[]
+:context: cluster-api-config-options-vsphere
+
+toc::[]
+
+:FeatureName: Managing machines with the Cluster API
+include::snippets/technology-preview.adoc[]
+
+You can change the configuration of your {vmw-first} Cluster API machines by updating values in the Cluster API custom resource manifests.
+
+[id="cluster-api-sample-yaml-vsphere_{context}"]
+== Sample YAML for configuring {vmw-full} clusters
+
+The following example YAML files show configurations for a {vmw-full} cluster.
+
+//Sample YAML for a CAPI vSphere infrastructure resource
+include::modules/capi-yaml-infrastructure-vsphere.adoc[leveloffset=+2]
+
+//Sample YAML for CAPI vSphere machine template resource
+include::modules/capi-yaml-machine-template-vsphere.adoc[leveloffset=+2]
+
+//Sample YAML for a CAPI vSphere compute machine set resource
+include::modules/capi-yaml-machine-set-vsphere.adoc[leveloffset=+2]
+// This additional resources section can be added if this configuration is validated. (see also: callout in capi-yaml-machine-set-vsphere.adoc)
+// [role="_additional-resources"]
+// .Additional resources
+// * xref:../../../post_installation_configuration/post-install-vsphere-zones-regions-configuration.adoc#post-install-vsphere-zones-regions-configuration[Multiple regions and zones configuration for a cluster on {vmw-full}]
+
+// [id="cluster-api-supported-features-vsphere_{context}"]
+// == Enabling {vmw-full} features with the Cluster API
+
+// You can enable the following features by updating values in the Cluster API custom resource manifests.
+
+//Not sure what, if anything, we can add here at this time.

--- a/modules/capi-creating-cluster-resource.adoc
+++ b/modules/capi-creating-cluster-resource.adoc
@@ -45,6 +45,7 @@ The following values are valid:
 +
 * `AWSCluster`: The cluster is running on {aws-first}.
 * `GCPCluster`: The cluster is running on {gcp-first}.
+* `VSphereCluster`: The cluster is running on {vmw-first}.
 --
 
 . Create the cluster CR by running the following command:

--- a/modules/capi-creating-infrastructure-resource.adoc
+++ b/modules/capi-creating-infrastructure-resource.adoc
@@ -39,13 +39,14 @@ spec: # <4>
 <1> The `apiVersion` varies by platform.
 For more information, see the sample Cluster API infrastructure resource YAML for your provider.
 The following values are valid:
-* `infrastructure.cluster.x-k8s.io/v1beta1`: The version that {gcp-first} clusters use.
 * `infrastructure.cluster.x-k8s.io/v1beta2`: The version that {aws-first} clusters use.
+* `infrastructure.cluster.x-k8s.io/v1beta1`: The version that {gcp-first} and {vmw-first} clusters use.
 <2> Specify the infrastructure kind for the cluster.
 This value must match the value for your platform.
 The following values are valid:
 * `AWSCluster`: The cluster is running on {aws-short}.
 * `GCPCluster`: The cluster is running on {gcp-short}.
+* `VSphereCluster`: The cluster is running on {vmw-short}.
 <3> Specify the name of the cluster.
 <4> Specify the details for your environment.
 These parameters are provider specific.

--- a/modules/capi-creating-machine-template.adoc
+++ b/modules/capi-creating-machine-template.adoc
@@ -39,6 +39,7 @@ spec:
 <1> Specify the machine template kind. This value must match the value for your platform. The following values are valid:
 * `AWSMachineTemplate`: The cluster is running on {aws-first}.
 * `GCPMachineTemplate`: The cluster is running on {gcp-first}.
+* `VSphereMachineTemplate`: The cluster is running on {vmw-first}.
 <2> Specify a name for the machine template.
 <3> Specify the details for your environment. These parameters are provider specific. For more information, see the sample Cluster API machine template YAML for your provider.
 --

--- a/modules/capi-limitations.adoc
+++ b/modules/capi-limitations.adoc
@@ -15,7 +15,7 @@ Using the Cluster API to manage machines is a Technology Preview feature and has
 Enabling this feature set cannot be undone and prevents minor version updates.
 ====
 
-* Only {aws-short} and {gcp-short} clusters can use the Cluster API.
+* Only {aws-first}, {gcp-first}, and {vmw-first} clusters can use the Cluster API.
 
 * You must manually create the primary resources that the Cluster API requires.
 For more information, see "Getting started with the Cluster API".

--- a/modules/capi-modifying-machine-template.adoc
+++ b/modules/capi-modifying-machine-template.adoc
@@ -28,6 +28,7 @@ $ oc get <machine_template_kind> <1>
 <1> Specify the value that corresponds to your platform. The following values are valid:
 * `AWSMachineTemplate`: The cluster is running on {aws-first}.
 * `GCPMachineTemplate`: The cluster is running on {gcp-first}.
+* `VSphereMachineTemplate`: The cluster is running on {vmw-first}.
 --
 +
 .Example output

--- a/modules/capi-yaml-cluster.adoc
+++ b/modules/capi-yaml-cluster.adoc
@@ -6,7 +6,8 @@
 [id="capi-yaml-cluster_{context}"]
 = Sample YAML for a Cluster API cluster resource
 
-The cluster resource defines the name and infrastructure provider for the cluster and is managed by the Cluster API. This resource has the same structure for all providers.
+The cluster resource defines the name and infrastructure provider for the cluster and is managed by the Cluster API.
+This resource has the same structure for all providers.
 
 [source,yaml]
 ----
@@ -16,16 +17,22 @@ metadata:
   name: <cluster_name> # <1>
   namespace: openshift-cluster-api
 spec:
+  controlPlaneEndpoint: # <2>
+    host: <control_plane_endpoint_address>
+    port: 6443
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: <infrastructure_kind> # <2>
+    kind: <infrastructure_kind> # <3>
     name: <cluster_name>
     namespace: openshift-cluster-api
 ----
 <1> Specify the name of the cluster.
-<2> Specify the infrastructure kind for the cluster. Valid values are:
+<2> Specify the IP address of the control plane endpoint and the port used to access it.
+<3> Specify the infrastructure kind for the cluster.
+Valid values are:
 +
 --
-* `AWSCluster`: The cluster is running on Amazon Web Services (AWS).
-* `GCPCluster`: The cluster is running on Google Cloud Platform (GCP).
+* `AWSCluster`: The cluster is running on {aws-full}.
+* `GCPCluster`: The cluster is running on {gcp-full}.
+* `VSphereCluster`: The cluster is running on {vmw-full}.
 --

--- a/modules/capi-yaml-infrastructure-aws.adoc
+++ b/modules/capi-yaml-infrastructure-aws.adoc
@@ -1,12 +1,13 @@
 // Module included in the following assemblies:
 //
-// * machine_management/cluster_api_machine_management/cluster-api-configuration.adoc
+// * machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="capi-yaml-infrastructure-aws_{context}"]
-= Sample YAML for a Cluster API infrastructure resource on Amazon Web Services
+= Sample YAML for a Cluster API infrastructure resource on {aws-full}
 
-The infrastructure resource is provider-specific and defines properties that are shared by all the compute machine sets in the cluster, such as the region and subnets. The compute machine set references this resource when creating machines.
+The infrastructure resource is provider-specific and defines properties that are shared by all the compute machine sets in the cluster, such as the region and subnets.
+The compute machine set references this resource when creating machines.
 
 [source,yaml]
 ----

--- a/modules/capi-yaml-infrastructure-vsphere.adoc
+++ b/modules/capi-yaml-infrastructure-vsphere.adoc
@@ -1,10 +1,10 @@
 // Module included in the following assemblies:
 //
-// * machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-gcp.adoc
+// * machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-vsphere.adoc
 
 :_mod-docs-content-type: REFERENCE
-[id="capi-yaml-infrastructure-gcp_{context}"]
-= Sample YAML for a Cluster API infrastructure resource on {gcp-full}
+[id="capi-yaml-infrastructure-vsphere_{context}"]
+= Sample YAML for a Cluster API infrastructure resource on {vmw-full}
 
 The infrastructure resource is provider-specific and defines properties that are shared by all the compute machine sets in the cluster, such as the region and subnets.
 The compute machine set references this resource when creating machines.
@@ -12,21 +12,27 @@ The compute machine set references this resource when creating machines.
 [source,yaml]
 ----
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: GCPCluster # <1>
+kind: VSphereCluster # <1>
 metadata:
   name: <cluster_name> # <2>
 spec:
   controlPlaneEndpoint: # <3>
     host: <control_plane_endpoint_address>
     port: 6443
-  network:
-    name: <cluster_name>-network
-  project: <project> # <4>
-  region: <region> # <5>
+  identityRef:
+    kind: Secret
+    name: <cluster_name>
+  server: <vsphere_server> # <4>
 ----
 <1> Specify the infrastructure kind for the cluster.
 This value must match the value for your platform.
 <2> Specify the cluster ID as the name of the cluster.
 <3> Specify the IP address of the control plane endpoint and the port used to access it.
-<4> Specify the {gcp-short} project name.
-<5> Specify the {gcp-short} region.
+<4> Specify the {vmw-short} server for the cluster.
+You can find this value on an existing {vmw-short} cluster by running the following command:
++
+[source,terminal]
+----
+$ oc get infrastructure cluster \
+  -o jsonpath="{.spec.platformSpec.vsphere.vcenters[0].server}"
+----

--- a/modules/capi-yaml-machine-set-aws.adoc
+++ b/modules/capi-yaml-machine-set-aws.adoc
@@ -1,12 +1,13 @@
 // Module included in the following assemblies:
 //
-// * machine_management/cluster_api_machine_management/cluster-api-configuration.adoc
+// * machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="capi-yaml-machine-set-aws_{context}"]
-= Sample YAML for a Cluster API compute machine set resource on Amazon Web Services
+= Sample YAML for a Cluster API compute machine set resource on {aws-full}
 
-The compute machine set resource defines additional properties of the machines that it creates. The compute machine set also references the infrastructure resource and machine template when creating machines.
+The compute machine set resource defines additional properties of the machines that it creates.
+The compute machine set also references the infrastructure resource and machine template when creating machines.
 
 [source,yaml]
 ----

--- a/modules/capi-yaml-machine-set-gcp.adoc
+++ b/modules/capi-yaml-machine-set-gcp.adoc
@@ -1,12 +1,13 @@
 // Module included in the following assemblies:
 //
-// * machine_management/cluster_api_machine_management/cluster-api-configuration.adoc
+// * machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-gcp.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="capi-yaml-machine-set-gcp_{context}"]
-= Sample YAML for a Cluster API compute machine set resource on Google Cloud Platform
+= Sample YAML for a Cluster API compute machine set resource on {gcp-full}
 
-The compute machine set resource defines additional properties of the machines that it creates. The compute machine set also references the infrastructure resource and machine template when creating machines.
+The compute machine set resource defines additional properties of the machines that it creates.
+The compute machine set also references the infrastructure resource and machine template when creating machines.
 
 [source,yaml]
 ----

--- a/modules/capi-yaml-machine-set-vsphere.adoc
+++ b/modules/capi-yaml-machine-set-vsphere.adoc
@@ -1,0 +1,64 @@
+// Module included in the following assemblies:
+//
+// * machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-vsphere.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="capi-yaml-machine-set-vsphere_{context}"]
+= Sample YAML for a Cluster API compute machine set resource on {vmw-full}
+
+The compute machine set resource defines additional properties of the machines that it creates.
+The compute machine set also references the infrastructure resource and machine template when creating machines.
+
+[source,yaml]
+----
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineSet
+metadata:
+  name: <machine_set_name> # <1>
+  namespace: openshift-cluster-api
+spec:
+  clusterName: <cluster_name> # <2>
+  replicas: 1
+  selector:
+    matchLabels:
+      test: example
+  template:
+    metadata:
+      labels:
+        test: example
+    spec:
+      bootstrap:
+         dataSecretName: worker-user-data # <3>
+      clusterName: <cluster_name>
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate # <4>
+        name: <template_name> # <5>
+      failureDomain: # <6>
+        - name: <failure_domain_name>
+          region: <region_a>
+          zone: <zone_a>
+          server: <vcenter_server_name>
+          topology:
+            datacenter: <region_a_datacenter>
+            computeCluster: "</region_a_datacenter/host/zone_a_cluster>"
+            resourcePool: "</region_a_datacenter/host/zone_a_cluster/Resources/resource_pool>"
+            datastore: "</region_a_datacenter/datastore/datastore_a>"
+            networks:
+            - port-group
+----
+<1> Specify a name for the compute machine set.
+<2> Specify the cluster ID as the name of the cluster.
+<3> For the Cluster API Technology Preview, the Operator can use the worker user data secret from the `openshift-machine-api` namespace.
+<4> Specify the machine template kind.
+This value must match the value for your platform.
+<5> Specify the machine template name.
+<6> Specify the failure domain configuration details.
++
+[NOTE]
+====
+Using multiple regions and zones on a {vmw-short} cluster that uses the Cluster API is not a validated configuration.
+====
+// This callout section can be updated if this configuration is validated. (see also: additional resources in cluster-api-config-options-vsphere.adoc)
+// <6> Specify one or more failure domains.
+// For more information about specifying multiple regions and zones on a {vmw-short} cluster, see "Multiple regions and zones configuration for a cluster on {vmw-full}."

--- a/modules/capi-yaml-machine-template-aws.adoc
+++ b/modules/capi-yaml-machine-template-aws.adoc
@@ -1,12 +1,13 @@
 // Module included in the following assemblies:
 //
-// * machine_management/cluster_api_machine_management/cluster-api-configuration.adoc
+// * machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="capi-yaml-machine-template-aws_{context}"]
-= Sample YAML for a Cluster API machine template resource on Amazon Web Services
+= Sample YAML for a Cluster API machine template resource on {aws-full}
 
-The machine template resource is provider-specific and defines the basic properties of the machines that a compute machine set creates. The compute machine set references this template when creating machines.
+The machine template resource is provider-specific and defines the basic properties of the machines that a compute machine set creates.
+The compute machine set references this template when creating machines.
 
 [source,yaml]
 ----
@@ -37,6 +38,8 @@ spec:
           values:
           - # ...
 ----
-<1> Specify the machine template kind. This value must match the value for your platform.
+<1> Specify the machine template kind.
+This value must match the value for your platform.
 <2> Specify a name for the machine template.
-<3> Specify the details for your environment. The values here are examples.
+<3> Specify the details for your environment.
+The values here are examples.

--- a/modules/capi-yaml-machine-template-gcp.adoc
+++ b/modules/capi-yaml-machine-template-gcp.adoc
@@ -1,12 +1,13 @@
 // Module included in the following assemblies:
 //
-// * machine_management/cluster_api_machine_management/cluster-api-configuration.adoc
+// * machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-gcp.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="capi-yaml-machine-template-gcp_{context}"]
-= Sample YAML for a Cluster API machine template resource on Google Cloud Platform
+= Sample YAML for a Cluster API machine template resource on {gcp-full}
 
-The machine template resource is provider-specific and defines the basic properties of the machines that a compute machine set creates. The compute machine set references this template when creating machines.
+The machine template resource is provider-specific and defines the basic properties of the machines that a compute machine set creates.
+The compute machine set references this template when creating machines.
 
 [source,yaml]
 ----
@@ -33,6 +34,8 @@ spec:
         - <cluster_name>-worker
       ipForwarding: Disabled
 ----
-<1> Specify the machine template kind. This value must match the value for your platform.
+<1> Specify the machine template kind.
+This value must match the value for your platform.
 <2> Specify a name for the machine template.
-<3> Specify the details for your environment. The values here are examples.
+<3> Specify the details for your environment.
+The values here are examples.

--- a/modules/capi-yaml-machine-template-vsphere.adoc
+++ b/modules/capi-yaml-machine-template-vsphere.adoc
@@ -1,0 +1,59 @@
+// Module included in the following assemblies:
+//
+// * machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-vsphere.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="capi-yaml-machine-template-vsphere_{context}"]
+= Sample YAML for a Cluster API machine template resource on {vmw-full}
+
+The machine template resource is provider-specific and defines the basic properties of the machines that a compute machine set creates.
+The compute machine set references this template when creating machines.
+
+[source,yaml]
+----
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereMachineTemplate # <1>
+metadata:
+  name: <template_name> # <2>
+  namespace: openshift-cluster-api
+spec:
+  template:
+    spec: # <3>
+      template: <vm_template_name> # <4>
+      server: <vcenter_server_ip> # <5>
+      diskGiB: 128
+      cloneMode: linkedClone # <6>
+      datacenter: <vcenter_datacenter_name> # <7>
+      datastore: <vcenter_datastore_name> # <8>
+      folder: <vcenter_vm_folder_path> # <9>
+      resourcePool: <vsphere_resource_pool> # <10>
+      numCPUs: 4
+      memoryMiB: 16384
+      network:
+        devices:
+        - dhcp4: true
+          networkName: "<vm_network_name>" # <11>
+----
+<1> Specify the machine template kind.
+This value must match the value for your platform.
+<2> Specify a name for the machine template.
+<3> Specify the details for your environment.
+The values here are examples.
+<4> Specify the vSphere VM template to use, such as `user-5ddjd-rhcos`.
+<5> Specify the vCenter server IP or fully qualified domain name.
+<6> Specify the type of VM clone to use.
+The following values are valid:
++
+--
+* `fullClone`
+* `linkedClone`
+--
++
+When using the `linkedClone` type, the disk size matches the clone source instead of using the `diskGiB` value.
+For more information, see the {vmw-short} documentation about VM clone types.
+<7> Specify the vCenter Datacenter to deploy the compute machine set on.
+<8> Specify the vCenter Datastore to deploy the compute machine set on.
+<9> Specify the path to the vSphere VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
+<10> Specify the vSphere resource pool for your VMs.
+<11> Specify the vSphere VM network to deploy the compute machine set to.
+This VM network must be where other compute machines reside in the cluster.

--- a/modules/cluster-capi-operator.adoc
+++ b/modules/cluster-capi-operator.adoc
@@ -7,7 +7,7 @@
 
 [NOTE]
 ====
-This Operator is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Amazon Web Services (AWS) and Google Cloud Platform (GCP) clusters.
+This Operator is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for {aws-first}, {gcp-first}, and {vmw-first} clusters.
 ====
 
 [discrete]
@@ -33,6 +33,11 @@ link:https://github.com/openshift/cluster-capi-operator[cluster-capi-operator]
 ** CR: `gcpmachine`
 ** Validation: No
 
+*  `vspheremachines.infrastructure.cluster.x-k8s.io`
+** Scope: Namespaced
+** CR: `vspheremachine`
+** Validation: No
+
 * `awsmachinetemplates.infrastructure.cluster.x-k8s.io`
 ** Scope: Namespaced
 ** CR: `awsmachinetemplate`
@@ -41,4 +46,9 @@ link:https://github.com/openshift/cluster-capi-operator[cluster-capi-operator]
 *  `gcpmachinetemplates.infrastructure.cluster.x-k8s.io`
 ** Scope: Namespaced
 ** CR: `gcpmachinetemplate`
+** Validation: No
+
+*  `vspheremachinetemplates.infrastructure.cluster.x-k8s.io`
+** Scope: Namespaced
+** CR: `vspheremachinetemplate`
 ** Validation: No

--- a/post_installation_configuration/post-install-vsphere-zones-regions-configuration.adoc
+++ b/post_installation_configuration/post-install-vsphere-zones-regions-configuration.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 :context: post-install-vsphere-zones-regions-configuration
 [id="post-install-vsphere-zones-regions-configuration"]
-=  Multiple regions and zones configuration for a cluster on {vmw-short}
+=  Multiple regions and zones configuration for a cluster on VMware vSphere
 include::_attributes/common-attributes.adoc[]
 
 toc::[]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-5779](https://issues.redhat.com//browse/OSDOCS-5779)

Link to docs preview:
* [About the Cluster API](https://76742--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster-api-about)
* [Getting started with the Cluster API](https://76742--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster-api-getting-started)
* [Managing machines with the Cluster API](https://76742--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster-api-managing-machines)
* [Cluster API configuration](https://76742--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster-api-configuration)
* [Cluster API configuration options for VMware vSphere](https://76742--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-vsphere) 
* [Cluster CAPI Operator](https://76742--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator-reference#cluster-capi-operator_cluster-operators-ref)

QE review:
- [x] QE has approved this change.

Additional information: