### PR TITLE
OSDOCS-10716: updates audit log default values

### DIFF
--- a/modules/microshift-audit-logs-config-intro.adoc
+++ b/modules/microshift-audit-logs-config-intro.adoc
@@ -20,11 +20,18 @@ You can set fields in combination to define a maximum storage limit for retained
 
 {microshift-short} includes the following default audit log rotation values:
 
-* `maxFileSize`: 200Mb
-* `maxFiles`: 10 files
-* `maxFileAge`: 0, This value means that no default age limit is set.
-* `profile`: Default, This profile logs only metadata for read and write requests.
+.{microshift-short} default audit log values
+[cols="20%,20%,50%",options="header"]
+|===
 
-The maximum default storage usage for audit log retention is 2000Mb, provided that there are 10 or fewer files.
+|Audit log parameter|Default setting|Definition
+|`maxFileAge`:|`0`|How long log files are retained before automatic deletion. The default value means that a log file is never deleted based on age. This value can be configured.
+|`maxFiles`:|`10`|The total number of log files retained. By default, {microshift-short} retains 10 log files. The oldest is deleted when an excess file is created. This value can be configured.
+|`maxFileSize`:|`200`|By default, when the `audit.log` file reaches the `maxFileSize` limit, the `audit.log` file is rotated and {microshift-short} begins writing to a new `audit.log` file. This value in in megabytes and can be configured.
+|`profile`:|`Default`|The `Default` profile setting only logs metadata for read and write requests; request bodies are not logged except for OAuth access token requests. If you do not specify this field, the `Default` profile is used.
+
+|===
+
+The maximum default storage usage for audit log retention is 2000Mb if there are 10 or fewer files.
 
 If you do not specify a value for a field, the default value is used. If you remove a previously set field value, the default value is restored after the next {microshift-short} service restart.

--- a/modules/microshift-audit-logs-config-proc.adoc
+++ b/modules/microshift-audit-logs-config-proc.adoc
@@ -20,16 +20,16 @@ You can configure audit log settings by using the {microshift-short} service con
 apiServer:
 # ....
   auditLog:
-    maxFileSize: 200 # <1>
-    maxFiles: 1 # <2>
-    maxFileAge: 7 # <3>
+    maxFileAge: 7 # <1>
+    maxFileSize: 200 # <2>
+    maxFiles: 1 # <3>
     profile: Default # <4>
 # ....
 ----
-<1> The maximum audit log file size in megabytes. If the value is 0, the limit is disabled.  In this example, the file is rotated as soon as the live log reaches the 200 MB limit.
-<2> The maximum number of rotated audit log files retained. After the limit is reached, the log files in order from oldest to newest are deleted. When the value is 0, the limit is disabled. In this example, the value `1` results in only 1 file of size `maxFileSize` being retained in addition to the current active log.
-<3> Specifies the maximum time in days that log files are kept. Files older than this limit are deleted. If the value is 0, the limit is disabled. In this example, after a log file is more than 7 days old, it is deleted. The files are deleted regardless of whether or not the live log has reached the maximum file size specified in the `maxFileSize` field. File age is determined by the timestamp written in the name of the rotated log file, for example, `audit-2024-05-16T17-03-59.994.log`.
-<4> Logs only metadata for read and write requests; does not log request bodies except for OAuth access token requests. If you do not specify this field, the Default profile is used.
+<1> Specifies the maximum time in days that log files are kept. Files older than this limit are deleted. In this example, after a log file is more than 7 days old, it is deleted. The files are deleted regardless of whether or not the live log has reached the maximum file size specified in the `maxFileSize` field. File age is determined by the timestamp written in the name of the rotated log file, for example, `audit-2024-05-16T17-03-59.994.log`. When the value is `0`, the limit is disabled.
+<2> The maximum audit log file size in megabytes. In this example, the file is rotated as soon as the live log reaches the 200 MB limit. When the value is set to `0`, the limit is disabled.
+<3> The maximum number of rotated audit log files retained. After the limit is reached, the log files are deleted in order from oldest to newest. In this example, the value `1` results in only 1 file of size `maxFileSize` being retained in addition to the current active log. When the value is set to `0`, the limit is disabled.
+<4> Logs only metadata for read and write requests; does not log request bodies except for OAuth access token requests. If you do not specify this field, the `Default` profile is used.
 
 . Optional: To specify a new directory for logs, you can stop {microshift-short}, and then move the `/var/log/kube-apiserver` directory to your desired location:
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-10716](https://issues.redhat.com/browse/OSDOCS-10716)

Link to docs preview:
[Configuring audit logs](https://76743--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-audit-logs-config.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review:
- [x] SME has approved this change.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
