### PR TITLE
OSSM-6378 xrefs in ossm-routing-ingress

### DIFF
--- a/modules/ossm-routing-ingress.adoc
+++ b/modules/ossm-routing-ingress.adoc
@@ -24,10 +24,6 @@ That command returns the `NAME`, `TYPE`, `CLUSTER-IP`, `EXTERNAL-IP`, `PORT(S)`,
 If the `EXTERNAL-IP` value is set, your environment has an external load balancer that you can use for the ingress gateway.
 
 If the `EXTERNAL-IP` value is `<none>`, or perpetually `<pending>`, your environment does not provide an external load balancer for the ingress gateway.
-ifdef::openshift-enterprise[]
-You can access the gateway using the service's xref:../../networking/configuring-node-port-service-range.adoc#configuring-node-port-service-range[node port].
-
-endif::[]
 
 ////
 TO DO - remove XREF in this module.

--- a/service_mesh/v2x/ossm-traffic-manage.adoc
+++ b/service_mesh/v2x/ossm-traffic-manage.adoc
@@ -19,6 +19,13 @@ endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/ossm-routing-ingress.adoc[leveloffset=+2]
 
+ifdef::openshift-enterprise[]
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../networking/configuring-node-port-service-range.adoc#configuring-node-port-service-range[Configuring the node port service range]
+endif::[]
+
 include::modules/ossm-routing-gateways.adoc[leveloffset=+2]
 
 [id="ossm-auto-route_{context}"]


### PR DESCRIPTION
[OSSM-6378](https://issues.redhat.com//browse/OSSM-6378) xrefs in ossm-routing-ingress

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSSM-6378

Link to docs preview:
https://76744--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-traffic-manage#ossm-routing-ingress_traffic-management 

QE review:

QE is not required as this is a style fix.

Additional information:
Request from Observability team related to their PR https://github.com/openshift/openshift-docs/pull/74819 and it is also a style fix.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
