### PR TITLE
TELCODOCS-1890: Remove H200 from MIG note in GPU enablement

### DIFF
--- a/modules/nvidia-gpu-enablement.adoc
+++ b/modules/nvidia-gpu-enablement.adoc
@@ -14,5 +14,5 @@ image::512_OpenShift_NVIDIA_GPU_enablement_1223.png[NVIDIA GPU enablement]
 
 [NOTE]
 ====
-MIG is only supported with A30, A100, A100X, A800, AX800, H100, H200, and H800.
+MIG is only supported with A30, A100, A100X, A800, AX800, H100, and H800.
 ====


### PR DESCRIPTION
BUG

D/S Docs: [TELCODOCS-1890] Remove H200 from MIG note in GPU enablement

Jira: https://issues.redhat.com/browse/TELCODOCS-1890

Version(s):  openshift-4.16, openshift-4.15.z, openshift-4.14.z, openshift-4.13.z 

Link to docs preview: https://76749--ocpdocs-pr.netlify.app/openshift-enterprise/latest/architecture/nvidia-gpu-architecture-overview.html#nvidia-gpu-enablement_nvidia-gpu-architecture-overview

SME review: @egallen 
QE review: @wabouhamad 
