### PR TITLE
OCPBUGS#29306: Agent validation check correction

### DIFF
--- a/modules/validations-before-agent-iso-creation.adoc
+++ b/modules/validations-before-agent-iso-creation.adoc
@@ -12,7 +12,6 @@ is created.
 .`install-config.yaml`
 
 * `baremetal`, `vsphere` and `none` platforms are supported.
-* If `none` is used as a platform, the number of control plane replicas must be `1` and the total number of worker replicas must be `0`.
 * The `networkType` parameter must be `OVNKubernetes` in the case of `none` platform.
 * `apiVIPs` and `ingressVIPs` parameters must be set for bare metal and vSphere platforms.
 * Some host-specific fields in the bare metal platform configuration that have equivalents in `agent-config.yaml` file are ignored. A warning message is logged if these fields are set.


### PR DESCRIPTION
[OCPBUGS-29306](https://issues.redhat.com/browse/OCPBUGS-29306)

Version(s): 4.14+

This PR corrects an Agent Installer validation check that is no longer true as of 4.14+

QE review:
- [x] QE has approved this change.

Preview: [Validation checks before agent ISO creation](https://76750--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#validations-before-agent-iso-creation_preparing-to-install-with-agent-based-installer)