### PR TITLE
OBSDOCS-835: Monitoring 4.16 Release Notes for Monitoring - new features and removed issues

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -404,6 +404,53 @@ In {product-title} {product-version} and later, you can edit the baseboard manag
 [id="ocp-4-16-monitoring_{context}"]
 === Monitoring
 
+The in-cluster monitoring stack for this release includes the following new and modified features.
+
+[id="ocp-4-16-monitoring-updates-to-monitoring-stack-components-and-dependencies"]
+==== Updates to monitoring stack components and dependencies
+This release includes the following version updates for in-cluster monitoring stack components and dependencies:
+
+* kube-state-metrics to 2.12.0
+* Metrics Server to 0.7.1
+* node-exporter to 1.8.0
+* Prometheus to 2.52.0
+* Prometheus Operator to 0.73.2
+* Thanos to 0.35.0
+
+[id="ocp-4-16-monitoring-changes-to-alerting-rules"]
+==== Changes to alerting rules
+
+[NOTE]
+====
+Red{nbsp}Hat does not guarantee backward compatibility for recording rules or alerting rules.
+====
+
+* Added the `ClusterMonitoringOperatorDeprecatedConfig` alert to monitor when the Cluster Monitoring Operator configuration uses a deprecated field.
+* Added the `PrometheusOperatorStatusUpdateErrors` alert to monitor when the Prometheus Operator fails to update object status.
+
+[id="ocp-4-16-monitoring-metrics-server-to-access-metrics-api-ga"]
+==== Metrics Server component to access the Metrics API general availability (GA)
+
+Metrics Server component is now generally available and automatically installed instead of the deprecated Prometheus Adapter. Metrics Server collects resource metrics and exposes them in the `metrics.k8s.io` Metrics API service for use by other tools and APIs, which frees the core platform Prometheus stack from handling this functionality. For more information, see xref:../observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc#metricsserverconfig[MetricsServerConfig] in the config map API reference for the Cluster Monitoring Operator.
+
+[id="ocp-4-16-monitoring-new-role-to-allow-read-only-access-to-alertmanager-api"]
+==== New monitoring role to allow read-only access to the Alertmanager API
+
+This release introduces a new `monitoring-alertmanager-view` role to allow read-only access to the Alertmanager API in the `openshift-monitoring` project.
+
+[id="ocp-4-16-monitoring-vpa-metrics-available-in-kube-state-metrics-agent"]
+==== VPA metrics are available in the kube-state-metrics agent
+
+Vertical Pod Autoscaler (VPA) metrics are now available through the `kube-state-metrics` agent. VPA metrics follow a similar exposition format like they did before being deprecated and removed from native support upstream.
+
+[id="ocp-4-16-monitoring-change-in-proxy-service-for-monitoring-components"]
+==== Change in proxy service for monitoring components
+With this release, the proxy service in front of Prometheus, Alertmanager, and Thanos Ruler has been updated from OAuth to `kube-rbac-proxy`. This change might affect service accounts and users accessing these API endpoints without the appropriate roles and cluster roles.
+
+[id="ocp-4-16-monitoring-change-in-how-prometheus-handles-duplicate-samples"]
+==== Change in how Prometheus handles duplicate samples
+With this release, when Prometheus scrapes a target, duplicate samples are no longer silently ignored, even if they have the same value. The first sample is accepted and the `prometheus_target_scrapes_sample_duplicate_timestamp_total` counter is incremented, which might trigger the `PrometheusDuplicateTimestamps` alert.
+
 [id="ocp-4-16-network-observability-1-5_{context}"]
 === Network Observability Operator
 The Network Observability Operator releases updates independently from the {product-title} minor version release stream. Updates are available through a single, Rolling Stream which is supported on all currently supported versions of {product-title} 4. Information regarding new features, enhancements, and bug fixes for the Network Observability Operator is found in the xref:../observability/network_observability/network-observability-operator-release-notes.adoc#network-observability-rn[Network Observability release notes].
@@ -630,7 +677,12 @@ In the following tables, features are marked with the following statuses:
 |`dedicatedServiceMonitors` setting that enables dedicated service monitors for core platform monitoring
 |General Availability
 |Deprecated
+|Removed
+
+|`prometheus-adapter` component that queries resource metrics from Prometheus and exposes them in the metrics API.
+|General Availability
 |Deprecated
+|Removed
 
 |====
 
@@ -908,6 +960,16 @@ For more information, see xref:../edge_computing/ztp-advanced-policy-config.adoc
 ==== Dell iDRAC driver for BMC addressing removed
 
 {product-title} {product-version} supports baseboard management controller (BMC) addressing with Dell servers as documented in xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#bmc-addressing-for-dell-idrac_ipi-install-installation-workflow[BMC addressing for Dell iDRAC]. Specifically, it supports `idrac-virtualmedia`, `redfish`, and `ipmi`. In previous versions, `idrac` was included, but not documented or supported. In {product-title} {product-version}, `idrac` has been removed.
+
+[id="ocp-4-16-dedicated-service-monitors-removed"]
+==== Dedicated service monitors for core platform monitoring
+
+With this release, the dedicated service monitors feature for core platform monitoring has been removed. You can no longer enable this feature in the `cluster-monitoring-config` config map object in the `openshift-monitoring` namespace. To replace this feature, Prometheus functionality has been improved to ensure that alerts and time aggregations are accurate. This improved functionality is active by default and makes the dedicated service monitors feature obsolete.
+
+[id="ocp-4-16-prometheus-adapter-removed"]
+==== Prometheus Adapter for core platform monitoring
+
+With this release, the Prometheus Adapter component for core platform monitoring has been removed. It has been replaced by the new Metrics Server component.
 
 [id="ocp-4-16-metallb-addresspool-removed_{context}"]
 ==== MetalLB AddressPool custom resource definition (CRD) removed


### PR DESCRIPTION
Version(s): `enterprise-4.16` only

Issues: 
[OBSDOCS-836](https://issues.redhat.com/browse/OBSDOCS-836)
[OBSDOCS-838](https://issues.redhat.com/browse/OBSDOCS-838)

Links to docs preview: 
https://76755--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-monitoring
https://76755--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-removed-features

QE review:
- [x] QE has approved this change.

**Additional information:**