### PR TITLE
OSDOCS:10625: adds 4.15.16 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -322,3 +322,12 @@ Issued: 2024-05-29
 The {product-title} release 4.15.15 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:3330[RHBA-2024:3330] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:3327[RHSA-2024:3327] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-15-16-dp"]
+=== RHBA-2024:3490 - {microshift-short} 4.15.16 bug fix and update advisory
+
+Issued: 2024-06-05
+
+The {product-title} release 4.15.16 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:3490[RHBA-2024:3490] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:3488[RHBA-2024:3488] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-10625](https://issues.redhat.com/browse/OSDOCS-10625)

Link to docs preview:
[MicroShift 4-15-16 async release note](https://76756--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-16-dp)

QE review:
- N/A stock errata text (no bugs or enhancements, etc.)

Additional info:
Planned release date 6/04/2024. Errata links do not work until the advisories are shipped.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
