### PR TITLE
TELCODOCS-1833 Adding deprecation notice for diskPartition

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -588,6 +588,15 @@ The Cluster Samples Operator is deprecated with the {product-title} 4.16 release
 [id="ocp-4-16-removed-features_{context}"]
 === Removed features
 
+[id="ocp-4-16-nodes-diskpartition-deprecated_{context}"]
+==== Deprecated disk partition configuration method
+
+The `nodes.diskPartition` section in the `SiteConfig` custom resource (CR) is deprecated with the {product-title} 4.16 release. It has been replaced with the `ignitionConfigOverride` method, which provides a more flexible way of creating a disk partition for any use case.
+
+For more information, see xref:../edge_computing/ztp-advanced-policy-config.adoc#ztp-configuring-disk-partitioning_ztp-advanced-policy-config[Configuring disk partitioning with SiteConfig].
+
+
+
 [id="ocp-4-16-removed-features-platform-operators_{context}"]
 ==== Removal of platform Operators and plain bundles (Technology Preview)
 


### PR DESCRIPTION
[TELCODOCS-1833]:Deprecate diskPartition in SiteConfig

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16 RN 
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-1833 
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://76757--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-nodes.diskPartition-deprecated
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
