### PR TITLE
rearranging the capabilities table

### DIFF
--- a/snippets/capabilities-table.adoc
+++ b/snippets/capabilities-table.adoc
@@ -3,32 +3,65 @@
 The following table describes the `baselineCapabilitySet` values.
 
 .Cluster capabilities `baselineCapabilitySet` values description
-[cols=".^4,.^6a",options="header"]
+[cols=".^1,.^5a,.^4a",options="header"]
 |===
-|Value|Description
+|Value|Description|Default capabilities
 
 |`vCurrent`
-|Specify this option when you want to automatically add new, default capabilities that are introduced in new releases.
+|Specify this option when you want to automatically add the new, default capabilities that are introduced in new releases.
+|See the capabilities for each release.
 
 |`v4.11`
-|Specify this option when you want to enable the default capabilities for {product-title} 4.11. By specifying `v4.11`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.11 are `baremetal`, `MachineAPI`, `marketplace`, and `openshift-samples`.
+|Specify this option when you want to enable the default capabilities for {product-title} 4.11.
+By specifying `v4.11`, capabilities that are introduced in newer versions of {product-title} are not enabled.
+|* `baremetal`
+* `MachineAPI`
+* `marketplace`
+* `openshift-samples`
 
 |`v4.12`
-|Specify this option when you want to enable the default capabilities for {product-title} 4.12. By specifying `v4.12`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.12 are `baremetal`, `MachineAPI`, `marketplace`, `openshift-samples`, `Console`, `Insights`, `Storage`, and `CSISnapshot`.
+|Specify this option when you want to enable the default capabilities for {product-title} 4.12.
+By specifying `v4.12`, capabilities that are introduced in newer versions of {product-title} are not enabled.
+|All capabilities that are enabled for {product-title} 4.11 as well as the following:
+
+* `Console`
+* `CSISnapshot`
+* `Insights`
+* `Storage`
 
 |`v4.13`
-|Specify this option when you want to enable the default capabilities for {product-title} 4.13. By specifying `v4.13`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.13 are `baremetal`, `MachineAPI`, `marketplace`, `openshift-samples`, `Console`, `Insights`, `Storage`, `CSISnapshot`, and `NodeTuning`.
+|Specify this option when you want to enable the default capabilities for {product-title} 4.13.
+By specifying `v4.13`, capabilities that are introduced in newer versions of {product-title} are not enabled.
+|All capabilities that are enabled for {product-title} 4.12 as well as the following:
+
+* `NodeTuning`
 
 |`v4.14`
-|Specify this option when you want to enable the default capabilities for {product-title} 4.14. By specifying `v4.14`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.14 are `baremetal`, `MachineAPI`, `marketplace`, `openshift-samples`, `Console`, `Insights`, `Storage`, `CSISnapshot`, `NodeTuning`, `ImageRegistry`, `Build`, and `DeploymentConfig`.
+|Specify this option when you want to enable the default capabilities for {product-title} 4.14.
+By specifying `v4.14`, capabilities that are introduced in newer versions of {product-title} are not enabled.
+|All capabilities that are enabled for {product-title} 4.13 as well as the following:
+
+* `Build`
+* `DeploymentConfig`
+* `ImageRegistry`
 
 |`v4.15`
-|Specify this option when you want to enable the default capabilities for {product-title} 4.15. By specifying `v4.15`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.15 are `baremetal`, `MachineAPI`, `marketplace`, `OperatorLifecycleManager`, `openshift-samples`, `Console`, `Insights`, `Storage`, `CSISnapshot`, `NodeTuning`, `ImageRegistry`, `Build`, `CloudCredential`, and `DeploymentConfig`.
+|Specify this option when you want to enable the default capabilities for {product-title} 4.15.
+By specifying `v4.15`, capabilities that are introduced in newer versions of {product-title} are not enabled.
+|All capabilities that are enabled for {product-title} 4.14 as well as the following:
+
+* `CloudCredential`
+* `OperatorLifecycleManager`
 
 |`v4.16`
-|Specify this option when you want to enable the default capabilities for {product-title} 4.16. By specifying `v4.16`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.16 are `baremetal`, `MachineAPI`, `marketplace`, `OperatorLifecycleManager`, `openshift-samples`, `Console`, `Insights`, `Storage`, `CSISnapshot`, `NodeTuning`, `ImageRegistry`, `Build`, `CloudCredential`, `DeploymentConfig`, and `CloudControllerManager`.
+|Specify this option when you want to enable the default capabilities for {product-title} 4.16.
+By specifying `v4.16`, capabilities that are introduced in newer versions of {product-title} are not enabled.
+|All capabilities that are enabled for {product-title} 4.15 as well as the following:
+
+* `CloudControllerManager`
 
 |`None`
-|Specify when the other sets are too large, and you do not need any capabilities or want to fine-tune via `additionalEnabledCapabilities`.
+|Specify when the other sets are too large, and you do not need any capabilities or want to fine-tune via the `additionalEnabledCapabilities` parameter.
+|Not applicable.
 
 |===


### PR DESCRIPTION
Version(s):
4.16+

Issue:
N/A

Link to docs preview:
[Selecting cluster capabilities](https://76781--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/cluster-capabilities.html#selecting-cluster-capabilities_cluster-capabilities)

QE review:
- [ ] QE has approved this change.

Additional information:
Not 4.16 release specific, but every version is different