### PR TITLE
OSDOCS-10780: Style fix: Sample to example

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-rosa-cloudwatch-sts.adoc
+++ b/cloud_experts_tutorials/cloud-experts-rosa-cloudwatch-sts.adoc
@@ -226,7 +226,7 @@ EOF
 $ aws logs describe-log-groups --log-group-name-prefix rosa-${ROSA_CLUSTER_NAME}
 ----
 +
-.Sample output
+.Example output
 +
 [source,c]
 ----

--- a/cloud_experts_tutorials/rosa-mobb-prerequisites-tutorial.adoc
+++ b/cloud_experts_tutorials/rosa-mobb-prerequisites-tutorial.adoc
@@ -107,7 +107,7 @@ $ aws configure
 $ aws configure
 ----
 +
-.Sample output
+.Example output
 [source,terminal]
 ----
 AWS Access Key ID []:
@@ -127,7 +127,7 @@ $ aws sts get-caller-identity
 +
 You should receive output similar to the following:
 +
-.Sample output
+.Example output
 [source,terminal]
 ----
 {

--- a/modules/rosa-creating-node-tuning.adoc
+++ b/modules/rosa-creating-node-tuning.adoc
@@ -25,7 +25,7 @@ $ rosa create tuning-config -c <cluster_id> --name <name_of_tuning> --spec-path 
 +
 You must supply the path to the `spec.json` file or the command returns an error.
 +
-.Sample output
+.Example output
 [source,terminal]
 ----
 $ I: Tuning config 'sample-tuning' has been created on cluster 'cluster-example'.
@@ -45,7 +45,7 @@ You can specify the type of output you want for the configuration list.
 
 ** Without specifying the output type, you see the ID and name of the tuning configuration:
 +
-.Sample output without specifying output type
+.Example output without specifying output type
 [source,terminal]
 ----
 ID                                    NAME
@@ -59,7 +59,7 @@ ID                                    NAME
 The following JSON output has hard line-returns for the sake of reading clarity. This JSON output is invalid unless you remove the newlines in the JSON strings.
 ====
 +
-.Sample output specifying JSON output
+.Example output specifying JSON output
 [source,terminal]
 ----
 [

--- a/modules/rosa-deleting-node-tuning.adoc
+++ b/modules/rosa-deleting-node-tuning.adoc
@@ -30,7 +30,7 @@ $ rosa delete tuning-config -c <cluster_id> <name_of_tuning>
 +
 The tuning configuration on the cluster is deleted
 +
-.Sample output
+.Example output
 [source,terminal]
 ----
 ? Are you sure you want to delete tuning config sample-tuning on cluster sample-cluster? Yes

--- a/modules/rosa-hcp-vpc-terraform.adoc
+++ b/modules/rosa-hcp-vpc-terraform.adoc
@@ -66,7 +66,7 @@ $ export SUBNET_IDS=$(terraform output -raw cluster-subnets-string)
 $ echo $SUBNET_IDS
 ----
 +
-.Sample output
+.Example output
 +
 [source,terminal]
 ----

--- a/modules/rosa-modifying-node-tuning.adoc
+++ b/modules/rosa-modifying-node-tuning.adoc
@@ -31,7 +31,7 @@ The following items in this spec file are:
 <2> Provide the name of your tuning configuration.
 <3> Optionally, you can provide the output type. If you do not specify any outputs, you only see the ID and name of the tuning configuration.
 +
-.Sample output without specifying output type
+.Example output without specifying output type
 [source,terminal]
 ----
 Name:    sample-tuning
@@ -53,7 +53,7 @@ Spec:    {
 
 ----
 +
-.Sample output specifying JSON output
+.Example output specifying JSON output
 [source,terminal]
 ----
 {
@@ -95,7 +95,7 @@ In this command, you use the `spec.json` file to edit your configurations.
 $ rosa describe tuning-config -c <cluster_id> --name <name_of_tuning>
 ----
 +
-.Sample output
+.Example output
 [source,terminal]
 ----
 Name:  sample-tuning

--- a/modules/rosa-operator-config.adoc
+++ b/modules/rosa-operator-config.adoc
@@ -49,7 +49,7 @@ $ rosa create operator-roles --hosted-cp
 +
 You must include the `--hosted-cp` parameter to create the correct roles for {hcp-title} clusters. This command returns the following information.
 +
-.Sample output
+.Example output
 +
 [source,terminal]
 ----
@@ -90,7 +90,7 @@ The Operator roles are now created and ready to use for creating your {hcp-title
 $ rosa list operator-roles
 ----
 +
-.Sample output
+.Example output
 +
 [source,terminal]
 ----

--- a/modules/rosa-sts-account-roles-terraform.adoc
+++ b/modules/rosa-sts-account-roles-terraform.adoc
@@ -187,7 +187,7 @@ $ terraform init
 $ terraform validate
 ----
 +
-.Sample output
+.Example output
 +
 [source,terminal]
 ----
@@ -219,7 +219,7 @@ If you used the `terraform plan` command first, you can provide your created `ac
 $ rosa list account-roles
 ----
 +
-.Sample output
+.Example output
 
 [source,terminal]
 ----

--- a/modules/rosa-sts-byo-oidc-options.adoc
+++ b/modules/rosa-sts-byo-oidc-options.adoc
@@ -54,7 +54,7 @@ Creates an OIDC configuration that is hosted under Red Hat's AWS account. This c
 $ rosa create oidc-config --managed
 ----
 
-.Sample output
+.Example output
 [source,terminal]
 ----
 W: For a managed OIDC Config only auto mode is supported. However, you may choose the provider creation mode

--- a/modules/rosa-sts-ocm-and-user-role-troubleshooting.adoc
+++ b/modules/rosa-sts-ocm-and-user-role-troubleshooting.adoc
@@ -8,7 +8,7 @@
 
 You may receive an error when trying to create a cluster using the {product-title} (ROSA) CLI, `rosa`.
 
-.Sample output
+.Example output
 [source,terminal]
 ----
 E: Failed to create cluster: The sts_user_role is not linked to account '1oNl'. Please create a user role and link it to the account.
@@ -29,7 +29,7 @@ After any user sets up an `ocm-role` IAM resource linked to a Red Hat account, a
 $ rosa list ocm-role
 ----
 +
-.Sample output
+.Example output
 +
 [source,terminal]
 ----
@@ -43,7 +43,7 @@ ManagedOpenShift-OCM-Role-1158  arn:aws:iam::2066:role/ManagedOpenShift-OCM-Role
 $ rosa list user-role
 ----
 +
-.Sample output
+.Example output
 +
 [source,terminal]
 ----


### PR DESCRIPTION
[OSDOCS-10780](https://issues.redhat.com//browse/OSDOCS-10780): Style fix: Sample to example. Change all instances of .Sample output to .Example output in the ROSA docs

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-10780

Link to docs preview:

- https://76794--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-rosa-cloudwatch-sts.html
- https://76794--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-oidc-overview.html
- https://76794--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-sts-about-iam-resources.html
- https://76794--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-creating-cluster-with-aws-kms-key.html
- https://76794--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html
- https://76794--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-tuning-config.html
- https://76794--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-understanding-terraform.html
- https://76794--ocpdocs-pr.netlify.app/openshift-rosa/latest/support/troubleshooting/rosa-troubleshooting-iam-resources.html

No QE or PM needed.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
