### PR TITLE
MIG-1287: Adding scanning for deprecated images to the 'Updating deprecated internal images' troubleshooting procedure

### DIFF
--- a/modules/migration-updating-deprecated-internal-images.adoc
+++ b/modules/migration-updating-deprecated-internal-images.adoc
@@ -25,28 +25,39 @@ If an {product-title} 3 image is deprecated in {product-title} {product-version}
 The {product-registry} is exposed by default on {product-title} 4.
 
 . If you are using insecure registries, add your registry host values to the `[registries.insecure]` section of `/etc/container/registries.conf` to ensure that `podman` does not encounter a TLS verification error.
-. Log in to the {product-title} 3 registry:
+. Log in to the {product-title} 3 registry by running the following command:
 +
 [source,terminal]
 ----
 $ podman login -u $(oc whoami) -p $(oc whoami -t) --tls-verify=false <registry_url>:<port>
 ----
 
-. Log in to the {product-title} 4 registry:
+. Log in to the {product-title} 4 registry by running the following command:
 +
 [source,terminal]
 ----
 $ podman login -u $(oc whoami) -p $(oc whoami -t) --tls-verify=false <registry_url>:<port>
 ----
 
-. Pull the {product-title} 3 image:
+. Pull the {product-title} 3 image by running the following command:
 +
 [source,terminal]
 ----
 $ podman pull <registry_url>:<port>/openshift/<image>
 ----
 
-. Tag the {product-title} 3 image for the {product-title} 4 registry:
+. Scan the {product-title} 3 image for deprecated namespaces by running the following command:
++
+[source,terminal]
+----
+$ oc get bc --all-namespaces --template='range .items
+"BuildConfig:" .metadata.namespace/.metadata.name =>
+"\t""ImageStream(FROM):" .spec.strategy.sourceStrategy.from.namespace/.spec.strategy.sourceStrategy.from.name
+"\t""ImageStream(TO):" .spec.output.to.namespace/.spec.output.to.name
+end'
+----
+
+. Tag the {product-title} 3 image for the {product-title} 4 registry by running the following command:
 +
 [source,terminal]
 ----
@@ -56,7 +67,7 @@ $ podman tag <registry_url>:<port>/openshift/<image> \ <1>
 <1> Specify the registry URL and port for the {product-title} 3 cluster.
 <2> Specify the registry URL and port for the {product-title} 4 cluster.
 
-. Push the image to the {product-title} 4 registry:
+. Push the image to the {product-title} 4 registry by running the following command:
 +
 [source,terminal]
 ----
@@ -64,7 +75,7 @@ $ podman push <registry_url>:<port>/openshift/<image> <1>
 ----
 <1> Specify the {product-title} 4 cluster.
 
-. Verify that the image has a valid image stream:
+. Verify that the image has a valid image stream by running the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
MTC 1.8, OCP 4.12+ 

Resolves https://issues.redhat.com/browse/MIG-1287 by adding a step to the "Updating deprecated internal images" sub-section of the "Troubleshooting" section of MTC OCP 3 -> OCP 4 guide.

Preview: https://76796--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/troubleshooting-3-4.html#migration-updating-deprecated-internal-images_troubleshooting-3-4 [Step 6 of the procedure]