### PR TITLE
OSDOCS-10597: adds 4.14.28 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -531,3 +531,12 @@ Issued: 2024-05-30
 {product-title} release 4.14.27 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:3334[RHBA-2024:3334] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:3331[RHSA-2024:3331] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-14-28-dp"]
+=== RHBA-2024:3525 - {microshift-short} 4.14.28 bug fix and security update advisory
+
+Issued: 2024-06-10
+
+{product-title} release 4.14.28 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:3525[RHBA-2024:3525] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:3523[RHSA-2024:3523] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-10597](https://issues.redhat.com/browse/OSDOCS-10597)

Link to docs preview:
[4.14.28 async release note](https://76804--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes.html#microshift-4-14-28-dp)


QE review:
- N/A stock text, no other release notes