### PR TITLE
OSDOCS#10451: Expanded information about SRE access

### DIFF
--- a/modules/sre-cluster-access.adoc
+++ b/modules/sre-cluster-access.adoc
@@ -64,7 +64,9 @@ Each of these access types have different levels of access to components:
 == SRE access to AWS accounts
 Red Hat personnel do not access AWS accounts in the course of routine {product-title} operations. For emergency troubleshooting purposes, the SREs have well-defined and auditable procedures to access cloud infrastructure accounts.
 
-SREs generate a short-lived AWS access token for a reserved role using the AWS Security Token Service (STS). Access to the STS token is audit-logged and traceable back to individual users. Both STS and non-STS clusters use the AWS STS service for SRE access. For non-STS clusters, the `BYOCAdminAccess` role has the `AdministratorAccess` IAM policy attached, and this role is used for administration. For STS clusters, the `ManagedOpenShift-Support-Role` has the `ManagedOpenShift-Support-Access` policy attached, and this role is used for administration.
+In the isolated backplane flow, SREs request access to a customer's support role. This request is just-in-time (JIT) processed by the backplane API which dynamically updates the organization role's permissions to a specific SRE personnel's account. This SRE's account is given access to a specific Red Hat customer's environment. SRE access to a Red Hat customer's environment is a temporary, short-lived access that is only established at the time of the access request. 
+
+Access to the STS token is audit-logged and traceable back to individual users. Both STS and non-STS clusters use the AWS STS service for SRE access. Access control uses the unified backplane flow when the `ManagedOpenShift-Technical-Support-Role` has the `ManagedOpenShift-Support-Access` policy attached, and this role is used for administration. Access control uses the isolated backplane flow when the `ManagedOpenShift-Support-Role` has the `ManagedOpenShift-Technical-Support-<org_id>` policy attached. See the KCS article link:https://access.redhat.com/solutions/7045629[Updating Trust Policies for ROSA clusters] for more information.
 
 [id="rosa-sre-sts-view-aws-account_{context}"]
 == SRE STS view of AWS accounts


### PR DESCRIPTION
Version(s):
`enterprise-4.15+`

Issue:
**[OSDOCS-10451](https://issues.redhat.com/browse/OSDOCS-10451)**

Link to docs preview:
- [SRE Access](https://76805--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-sre-access.html) - ROSA
  - [Updated section](https://76805--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-sre-access.html#rosa-policy-sre-aws-infra-access_rosa-sre-access) + graphic
    ![image](https://github.com/openshift/openshift-docs/assets/16167833/536c8543-d04b-4410-ab15-2e8ecd0131a2)
- [SRE Access](https://76805--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-sre-access.html) - OSD - unchanged
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Expanded the existing content that covers SRE's access on clusters.