### PR TITLE
OCPBUGS-31019: Compute Node to Nodes (Typo Fix)

### DIFF
--- a/modules/update-duration-mco.adoc
+++ b/modules/update-duration-mco.adoc
@@ -50,4 +50,4 @@ ip-10-0-207-224.us-east-2.compute.internal  Ready                       worker  
 +
 If the status of the node is `NotReady` or `SchedulingDisabled`, then the node is not available and this impacts the update duration.
 +
-You can check the status of nodes from the *Administrator* perspective in the web console by expanding **Compute** → **Node**.
+You can check the status of nodes from the *Administrator* perspective in the web console by expanding **Compute** → **Nodes**.


### PR DESCRIPTION
Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OCPBUGS-31019

Link to docs preview:
https://76816--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/understanding-openshift-update-duration.html#machine-config-operator-node-updates_openshift-update-duration

QE review:
N/A

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
