### PR TITLE
CNV#29661: documentation for persistent nvram

### DIFF
--- a/modules/virt-configuring-vm-with-persistent-efi.adoc
+++ b/modules/virt-configuring-vm-with-persistent-efi.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/advanced_vm_management/virt-uefi-mode-for-vms.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-vm-with-persistent-efi_{context}"]
+= Configuring VMs with persistent EFI
+
+You can configure a VM to have EFI persistence enabled by editing its manifest file.
+
+.Prerequisites
+
+* `VMPersistentState` feature gate enabled.
+
+.Procedure
+
+* Edit the VM manifest file and save to apply settings.
++
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: vm
+spec:
+  template:
+    spec:
+      domain:
+        firmware:
+          bootloader:
+            efi:
+              persistent: true
+# ...
+----

--- a/modules/virt-enabling-persistent-efi.adoc
+++ b/modules/virt-enabling-persistent-efi.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/advanced_vm_management/virt-uefi-mode-for-vms.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-enabling-persistent-efi_{context}"]
+= Enabling persistent EFI
+
+You can enable EFI persistence in a VM by configuring an RWX storage class at the cluster level and adjusting the settings in the EFI section of the VM.
+
+.Prerequisites
+
+* You must have cluster administrator privileges.
+* You must have a storage class that supports RWX access mode and FS volume mode.
+
+.Procedure
+
+* Enable the `VMPersistentState` feature gate by running the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
+  --type json -p '[{"op":"replace","path":"/spec/featureGates/VMPersistentState", "value": true}]'
+----

--- a/virt/virtual_machines/advanced_vm_management/virt-uefi-mode-for-vms.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-uefi-mode-for-vms.adoc
@@ -10,3 +10,5 @@ You can boot a virtual machine (VM) in Unified Extensible Firmware Interface (UE
 
 include::modules/virt-about-uefi-mode-for-vms.adoc[leveloffset=+1]
 include::modules/virt-booting-vms-uefi-mode.adoc[leveloffset=+1]
+include::modules/virt-enabling-persistent-efi.adoc[leveloffset=+1]
+include::modules/virt-configuring-vm-with-persistent-efi.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/CNV-29661

Link to docs preview:
https://76833--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/virtual_machines/advanced_vm_management/virt-uefi-mode-for-vms.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
