### PR TITLE
[enterprise-4.15] Fix azure/entra attr in 4.15 RN

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -201,9 +201,9 @@ For more information, see xref:../web_console/dynamic-plugin/dynamic-plugins-ref
 For more information about `console.resource/details-item`, see xref:../web_console/dynamic-plugin/dynamic-plugins-reference.adoc#dynamic-plugin-sdk-extensions_dynamic-plugins-reference[{product-title} console API].
 
 [id="ocp-4-15-console-supports-azure-sts-detection"]
-===== OperatorHub support for {azure-id}
+===== OperatorHub support for {entra-first}
 
-With this release, OperatorHub detects when a {product-title} cluster running on Azure is configured for {azure-id}. When detected, a "Cluster in Workload Identity / Federated Identity Mode" notification is displayed with additional instructions before installing an Operator to ensure it runs correctly. The *Operator Installation* page is also modified to add fields for the required Azure credentials information.
+With this release, OperatorHub detects when a {product-title} cluster running on Azure is configured for {entra-first}. When detected, a "Cluster in Workload Identity / Federated Identity Mode" notification is displayed with additional instructions before installing an Operator to ensure it runs correctly. The *Operator Installation* page is also modified to add fields for the required Azure credentials information.
 
 For the updated step for the *Install Operator* page, see xref:../operators/admin/olm-adding-operators-to-cluster.adoc#olm-installing-from-operatorhub-using-web-console_olm-adding-operators-to-a-cluster[Installing from OperatorHub using the web console].
 
@@ -609,9 +609,9 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 === Authentication and authorization
 
 [id="ocp-4-15-auth-olm-azure-sts"]
-==== OLM-based Operator support for {azure-id}
+==== OLM-based Operator support for {entra-first}
 
-With this release, some Operators managed by Operator Lifecycle Manager (OLM) on Azure clusters can use the Cloud Credential Operator (CCO) in manual mode with {azure-id}. These Operators authenticate with short-term credentials that are managed outside the cluster.
+With this release, some Operators managed by Operator Lifecycle Manager (OLM) on Azure clusters can use the Cloud Credential Operator (CCO) in manual mode with {entra-first}. These Operators authenticate with short-term credentials that are managed outside the cluster.
 
 For more information, see xref:../operators/operator_sdk/token_auth/osdk-cco-azure.adoc#osdk-cco-azure[CCO-based workflow for OLM-managed Operators with Azure AD Workload Identity].
 
@@ -872,9 +872,9 @@ For information on the `olm.deprecations` schema, see xref:../operators/understa
 === Operator development
 
 [id="ocp-4-15-osdk-cco-azure"]
-==== Token authentication for Operators on cloud providers: {azure-id}
+==== Token authentication for Operators on cloud providers: {entra-first}
 
-With this release, Operators managed by Operator Lifecycle Manager (OLM) can support token authentication when running on Azure clusters configured for {azure-id}. Updates to the Cloud Credential Operator (CCO) enable semi-automated provisioning of certain short-term credentials, provided that the Operator author has enabled their Operator to support {azure-id}.
+With this release, Operators managed by Operator Lifecycle Manager (OLM) can support token authentication when running on Azure clusters configured for {entra-first}. Updates to the Cloud Credential Operator (CCO) enable semi-automated provisioning of certain short-term credentials, provided that the Operator author has enabled their Operator to support {entra-first}.
 
 For more information, see xref:../operators/operator_sdk/token_auth/osdk-cco-azure.adoc#osdk-cco-azure[CCO-based workflow for OLM-managed Operators with Azure AD Workload Identity].
 


### PR DESCRIPTION
4.15-release-notes-only follow-up for [OSDOCS-10415](https://issues.redhat.com//browse/OSDOCS-10415)

* [OperatorHub support for Microsoft Entra Workload ID](https://76839--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-console-supports-azure-sts-detection)
* [OLM-based Operator support for Microsoft Entra Workload ID](https://76839--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-auth-olm-azure-sts) 
* [Token authentication for Operators on cloud providers: Microsoft Entra Workload ID](https://76839--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-osdk-cco-azure)