### PR TITLE
OSDOCS#10143: Release note for no longer generating legacy SA token s…

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -307,7 +307,7 @@ For more information, see xref:../edge_computing/cnf-talm-for-cluster-upgrades.a
 
 [discrete]
 [id="ocp-4-16-HAProxy-version_{context}"]
-===  HAProxy version 2.8
+=== HAProxy version 2.8
 
 {product-title} {product-version} uses HAProxy 2.8.
 
@@ -352,6 +352,18 @@ This API still streamlines management of installed extensions, which includes Op
 * More accurately reflects the simplified functionality of extending a cluster's capabilities
 * Better represents a more flexible packaging format
 * `Cluster` prefix clearly indicates that `ClusterExtension` objects are cluster-scoped, a change from {olmv0} where Operators could be either namespace-scoped or cluster-scoped
+
+[discrete]
+[id="ocp-4-16-legacy-sa-tokens_{context}"]
+=== Legacy service account API token secrets are no longer generated for each service account
+
+Prior to {product-title} 4.16, when the integrated {product-registry} was enabled, a legacy service account API token secret was generated for every service account in the cluster. Starting with {product-title} 4.16, when the integrated {product-registry} is enabled, the legacy service account API token secret is no longer generated for each service account.
+
+Additionally, when the integrated {product-registry} is enabled, the image pull secret generated for every service account no longer uses a legacy service account API token. Instead, the image pull secret now uses a bound service account token that is automatically refreshed before it expires.
+
+For more information, see xref:../nodes/pods/nodes-pods-secrets.adoc#auto-generated-sa-token-secrets_nodes-pods-secrets[Automatically generated image pull secrets].
+
+For information about detecting legacy service account API token secrets that are in use in your cluster or deleting them if they are not needed, see the Red Hat Knowledgebase article link:https://access.redhat.com/articles/7058801[Long-lived service account API tokens in OpenShift Container Platform].
 
 [id="ocp-4-16-deprecated-removed-features_{context}"]
 == Deprecated and removed features


### PR DESCRIPTION
…ecrets

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-10143

Link to docs preview:
https://76844--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-legacy-sa-tokens_release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
