### PR TITLE
OCPBUGS#10586: Removed TP reference for installing on OCI

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -820,15 +820,16 @@ If the following conditions are true, the feature is enabled by default:
 === Oracle(R) Cloud Infrastructure
 
 [id="ocp-4-15-installation-oci-assisted-installer-vm"]
-==== Using the Assisted Installer to install a cluster on {oci} (Technology Preview)
+==== Using the Assisted Installer to install a cluster on {oci}
 
 You can run cluster workloads on {oci-first} infrastructure that supports dedicated, hybrid, public, and multiple cloud environments. Both Red Hat and Oracle test, validate, and support running {oci} in an {product-title} cluster on {oci}.
 
 {oci} provides services that can meet your needs for regulatory compliance, performance, and cost-effectiveness. You can access {oci} Resource Manager configurations to provision and configure {oci} resources.
 
 For more information, see xref:../installing/installing_oci/installing-oci-assisted-installer.adoc[Using the Assisted Installer to install a cluster on {oci}].
+
 [id="ocp-4-15-installation-oci-agent-based-installer-vm"]
-==== Using the Agent-based Installer to install a cluster on {oci} (Technology Preview)
+==== Using the Agent-based Installer to install a cluster on {oci}
 
 You can use the Agent-based Installer to install a cluster on {oci-first}, so that you can run cluster workloads on infrastructure that supports dedicated, hybrid, public, and multiple cloud environments.
 
@@ -2139,8 +2140,8 @@ In the following tables, features are marked with the following statuses:
 
 |Installing {product-title} on {oci-first} with VMs
 |N/A
-|Developer Preview
-|Technology Preview
+|General Availability
+|General Availability
 
 |Installing {product-title} on {oci-first} on bare metal
 |N/A
@@ -2180,11 +2181,6 @@ In the following tables, features are marked with the following statuses:
 |Mount shared entitlements in BuildConfigs in RHEL
 |Technology Preview
 |Technology Preview
-|Technology Preview
-
-|{product-title} on Oracle Cloud Infrastructure (OCI)
-|Not Available
-|Developer Preview
 |Technology Preview
 
 |Selectable Cluster Inventory


### PR DESCRIPTION
Version(s): 4.15

Issue: https://issues.redhat.com/browse/OSDOCS-10586

Link to docs preview: https://76853--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-oci

Review:
- [x] QE has approved this change.
- [x]  PM has approved this change.
- [x]  SME has approved this change.
