### PR TITLE
OSDOCS-10794: Documented the 4.14.28 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3322,6 +3322,39 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.14.28
+[id="ocp-4-14-28"]
+=== RHSA-2024:3523 - {product-title} 4.14.28 bug fix update and security update
+
+Issued: 2024-06-10
+
+{product-title} release 4.14.28, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:3523[RHSA-2024:3523] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:3526[RHBA-2024:3526] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.28 --pullspecs
+----
+
+[id="ocp-4-14-28-bug-fixes"]
+==== Bug fixes
+
+* Previously, the HyperShift Operator was not using the `RegistryOverrides` mechanism to inspect the image from the internal registry. With this release, the metadata inspector works as expected during the HyperShift Operator reconciliation, and the `OverrideImages` are properly populated. (link:https://issues.redhat.com/browse/OCPBUGS-33844[*OCPBUGS-33844*])
+
+* Previously, the recycler pods for Hosted Control Planes (HCPs) were not starting in disconnected environments. With this release, the HCP recycler-pod image now points to the {product-title} payload reference and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-33843[*OCPBUGS-33843*])
+
+* Previously, the information from `imageRegistryOverrides` was only extracted once on the HyperShift Operator initialization and did not refresh. With this release, the HyperShift Operator retrieves the new `ImageContentSourcePolicy` files from the management cluster and adds them to the HyperShift Operator and Control Plane Operator in every reconciliation loop. (link:https://issues.redhat.com/browse/OCPBUGS-33713[*OCPBUGS-33713*])
+
+* Previously, the Helm Plugin index view did not display the same number of charts as the Helm CLI if the chart names varied. With this release, the Helm catalog now looks for `charts.openshift.io/name` and `charts.openshift.io/provider` so that all versions are grouped together in a single catalog title. (link:https://issues.redhat.com/browse/OCPBUGS-33321[*OCPBUGS-33321*])
+
+[id="ocp-4-14-28-updating"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.14.27
 [id="ocp-4-14-27"]
 === RHSA-2024:3331 - {product-title} 4.14.27 bug fix update and security update


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-10794](https://issues.redhat.com/browse/OSDOCS-10794)

Link to docs preview:
[4.14.28](https://76861--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-28)

