### PR TITLE
OCPBUGS-34723 OpenShift cluster configuration for vDU application workloads needs update

### DIFF
--- a/modules/ztp-du-host-firmware-requirements.adoc
+++ b/modules/ztp-du-host-firmware-requirements.adoc
@@ -12,14 +12,14 @@ Bare-metal hosts require the firmware to be configured before the host can be pr
 
 . Set the *UEFI/BIOS Boot Mode* to `UEFI`.
 . In the host boot sequence order, set *Hard drive first*.
-. Apply the specific firmware configuration for your hardware. The following table describes a representative firmware configuration for an Intel Xeon Skylake or Intel Cascade Lake server, based on the Intel FlexRAN 4G and 5G baseband PHY reference design.
+. Apply the specific firmware configuration for your hardware. The following table describes a representative firmware configuration for an Intel Xeon Skylake server and later hardware generations, based on the Intel FlexRAN 4G and 5G baseband PHY reference design.
 +
 [IMPORTANT]
 ====
 The exact firmware configuration depends on your specific hardware and network requirements. The following sample configuration is for illustrative purposes only.
 ====
 +
-.Sample firmware configuration for an Intel Xeon Skylake or Cascade Lake server
+.Sample firmware configuration
 [cols=2*, width="90%", options="header"]
 |====
 |Firmware setting

--- a/modules/ztp-sno-du-tuning-the-performance-patch.adoc
+++ b/modules/ztp-sno-du-tuning-the-performance-patch.adoc
@@ -23,6 +23,4 @@ include::snippets/ztp_TunedPerformancePatch.yaml[]
 |`spec.profile.data`
 a|* The `include` line that you set in `spec.profile.data` must match the associated `PerformanceProfile` CR name.
 For example, `include=openshift-node-performance-${PerformanceProfile.metadata.name}`.
-
-* When using the non-realtime kernel, remove the `timer_migration override` line from the `[sysctl]` section.
 |====

--- a/snippets/ztp_99-sync-time-once-master.yaml
+++ b/snippets/ztp_99-sync-time-once-master.yaml
@@ -13,7 +13,8 @@ spec:
         - contents: |
             [Unit]
             Description=Sync time once
-            After=network.service
+            After=network-online.target
+            Wants=network-online.target
             [Service]
             Type=oneshot
             TimeoutStartSec=300

--- a/snippets/ztp_99-sync-time-once-worker.yaml
+++ b/snippets/ztp_99-sync-time-once-worker.yaml
@@ -13,7 +13,7 @@ spec:
         - contents: |
             [Unit]
             Description=Sync time once
-            After=network.service
+            After=network-online.target
             [Service]
             Type=oneshot
             TimeoutStartSec=300

--- a/snippets/ztp_TunedPerformancePatch.yaml
+++ b/snippets/ztp_TunedPerformancePatch.yaml
@@ -3,7 +3,8 @@ kind: Tuned
 metadata:
   name: performance-patch
   namespace: openshift-cluster-node-tuning-operator
-  annotations: {}
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   profile:
     - name: performance-patch
@@ -16,11 +17,10 @@ spec:
         [main]
         summary=Configuration changes profile inherited from performance created tuned
         include=openshift-node-performance-openshift-node-performance-profile
-        [sysctl]
-        kernel.timer_migration=1
         [scheduler]
         group.ice-ptp=0:f:10:*:ice-ptp.*
         group.ice-gnss=0:f:10:*:ice-gnss.*
+        group.ice-dplls=0:f:10:*:ice-dplls.*
         [service]
         service.stalld=start,enable
         service.chronyd=stop,disable


### PR DESCRIPTION
[OCPBUGS-34723]: OpenShift cluster configuration for vDU application workloads needs update


<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-34723
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
* https://76862--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-reference-cluster-configuration-for-vdu.html
* https://76862--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-reference-cluster-configuration-for-vdu.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
