### PR TITLE
[SRVKS-1220] Readiness and liveness probing on a multi-container service

### DIFF
--- a/knative-serving/config-applications/multi-container-support-for-serving.adoc
+++ b/knative-serving/config-applications/multi-container-support-for-serving.adoc
@@ -8,3 +8,6 @@ You can deploy a multi-container pod by using a single Knative service. This met
 
 // Multi-container support
 include::modules/serverless-configuring-multi-container-service.adoc[leveloffset=+1]
+
+// Probing a multi-container service
+include::modules/serverless-probing-multi-container-service.adoc[leveloffset=+1]

--- a/modules/serverless-probing-multi-container-service.adoc
+++ b/modules/serverless-probing-multi-container-service.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// * serverless/knative-serving/config-applications/multi-container-support-for-serving.adoc
+
+
+:_content-type: PROCEDURE
+[id="serverless-probing-multi-container-service_{context}"]
+= Probing a multi-container service
+
+
+You can specify readiness and liveness probes for multiple containers. This feature is not enabled by default and you must configure it using the `KnativeServing` custom resource (CR).
+
+
+.Procedure
+
+
+. Configure multi-container probing for your service by enabling the `multi-container-probing` feature in the `KnativeServing` CR.
++
+.Multi-container probing configuration
+[source,yaml]
+----
+...
+spec:
+  config:
+    features:
+      "multi-container-probing": enabled <1>
+...
+----
+<1> Enabled multi-container-probing feature 
+
+. Apply the updated `KnativeServing` CR.
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----
+. Modify your multi-container service to include the specified probes.
++
+.Multi-container probing
+[source,yaml]
+----
+apiVersion: serving.knative.dev/v1
+kind: Service
+...
+spec:
+ template:
+   spec:
+     containers:
+       - name: first-container
+         image: ghcr.io/knative/helloworld-go:latest
+         ports:
+           - containerPort: 8080
+         readinessProbe: <1>
+           httpGet:
+             port: 8080
+       - name: second-container
+         image: gcr.io/knative-samples/helloworld-java
+         readinessProbe: <2>
+           httpGet:
+             port: 8090
+----
+<1> Readiness probe of the first container
+<2> Readiness probe of the second container
+
+== Additional resources
+* link:https://knative.dev/docs/serving/services/configure-probing/#general-understanding-of-knative-probing[General understanding of Knative Probing]
+


### PR DESCRIPTION
Version(s):
 serverless-docs-1.32+

Issue:
https://issues.redhat.com/browse/SRVKS-1220

Link to docs preview:
https://76863--ocpdocs-pr.netlify.app/openshift-serverless/latest/knative-serving/config-applications/multi-container-support-for-serving.html

QE review:
- [x] QE has approved this change.
