### PR TITLE
OSDOCS-10799: update LVMS min storage sizes for file types

### DIFF
--- a/microshift_storage/microshift-storage-plugin-overview.adoc
+++ b/microshift_storage/microshift-storage-plugin-overview.adoc
@@ -2,6 +2,7 @@
 [id="microshift-storage-plugin-overview"]
 = Dynamic storage using the LVMS plugin
 include::_attributes/attributes-microshift.adoc[]
+include::_attributes/common-attributes.adoc[]
 :context: microshift-storage-plugin-overview
 
 toc::[]
@@ -13,6 +14,9 @@ LVMS provisions new LVM logical volumes for container workloads with appropriate
 include::modules/microshift-lvms-system-requirements.adoc[leveloffset=+1]
 
 include::modules/microshift-lvms-deployment.adoc[leveloffset=+1]
+
+//OCP module with edits
+include::modules/lvms-limitations-to-configure-size-of-devices.adoc[leveloffset=+1]
 
 include::modules/microshift-lvmd-yaml-creating.adoc[leveloffset=+1]
 

--- a/modules/lvms-limitations-to-configure-size-of-devices.adoc
+++ b/modules/lvms-limitations-to-configure-size-of-devices.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
+// * microshift_storage/microshift-storage-plugin-overview.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="limitations-to-configure-size-of-devices_{context}"]
@@ -13,7 +14,15 @@ The limitations to configure the size of the devices that you can use to provisi
 ** You can define the size of PE and LE during the physical and logical device creation.
 ** The default PE and LE size is 4 MB.
 ** If the size of the PE is increased, the maximum size of the LVM is determined by the kernel limits and your disk space.
+ifdef::microshift[]
+** The size limit for {op-system-base-full} 9 using the default PE and LE size is 8 EB.
+** The following are the minimum storage sizes that you can request for each file system type:
+*** `block`: 8 MiB
+*** `xfs`: 300 MiB
+*** `ext4`: 32 MiB
+endif::microshift[]
 
+ifndef::microshift[]
 .Size limits for different architectures using the default PE and LE size
 [cols="1,1,1,1,1", width="100%", options="header"]
 |====
@@ -46,3 +55,4 @@ The limitations to configure the size of the devices that you can use to provisi
 1. Theoretical size.
 2. Tested size.
 --
+endif::microshift[]


### PR DESCRIPTION
Version(s):
4.15+

Issue:
[OSDOCS-10799](https://issues.redhat.com/browse/OSDOCS-10799)

Link to docs preview:
[Limitations plus min sizes LVMS MicroShift](https://76867--ocpdocs-pr.netlify.app/microshift/latest/microshift_storage/microshift-storage-plugin-overview.html#limitations-to-configure-size-of-devices_microshift-storage-plugin-overview)
[OpenShift content](https://76867--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html#limitations-to-configure-size-of-devices_logical-volume-manager-storage)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review:
- [x] SME has approved this change.


Additional information:
Adds update from https://github.com/openshift/openshift-docs/pull/75016/files#diff-0f6119d423328e7bef66e6a4dfef86a3832ba2ef00cfea629c9c1ad528629218R44.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
