### PR TITLE
OSDOCS#10801: Added a known issue for OIDC configurations.

### DIFF
--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -136,6 +136,7 @@ include::snippets/technology-preview.adoc[leveloffset=+1]
 
 [id="rosa-known-issues_{context}"]
 == Known issues
+* If you configure your cluster using external OIDC configuration and set the `--user-auth` flag to `disabled`, the console pods might enter a crash loop. (link:https://issues.redhat.com/browse/OCPBUGS-29510[*OCPBUGS-29510*])
 * The OpenShift Cluster Manager roles (`ocm-role`) and user roles (`user-role`) that are key to the ROSA provisioning wizard might get enabled accidentally in your Red Hat organization by another user. However, this behavior does not affect the usability.
 * The `htpasswd` identity provider does not function as expected in all scenarios against the `rosa create admin` function.
 


### PR DESCRIPTION
Version(s):
`enterprise-4.15+`

Issue:
**[OSDOCS-10801](https://issues.redhat.com/browse/OSDOCS-10801)**

Link to docs preview:
- [What's New in ROSA](https://file.rdu.redhat.com/eponvell/OSDOCS-10801_BugFix-RN/rosa_release_notes/rosa-release-notes.html#rosa-known-issues_rosa-whats-new)
    ![image](https://github.com/openshift/openshift-docs/assets/16167833/450dce79-2f54-4716-b2b5-ea02d85ab0a3)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added a known issue that notes that users should not set a flag to `disabled`.