### PR TITLE
OCPBUGS-33761: Expand the rolling back steps for the SDN network plugin

### DIFF
--- a/modules/nw-ovn-kubernetes-rollback.adoc
+++ b/modules/nw-ovn-kubernetes-rollback.adoc
@@ -8,7 +8,7 @@
 [id="nw-ovn-kubernetes-rollback_{context}"]
 = Using the offline migration method to roll back to the OpenShift SDN network plugin
 
-As a cluster administrator, you can roll back to the OpenShift SDN Container Network Interface (CNI) network plugin by using the offline migration method. During the migration you must manually reboot every node in your cluster. With the offline migration method, there is some downtime, during which your cluster is unreachable. 
+Cluster administrators can roll back to the OpenShift SDN Container Network Interface (CNI) network plugin by using the offline migration method. During the migration you must manually reboot every node in your cluster. With the offline migration method, there is some downtime, during which your cluster is unreachable.
 
 [IMPORTANT]
 ====
@@ -66,42 +66,66 @@ MCO:: Rolls out an update to the systemd configuration necessary for OpenShift S
 
 . Stop all of the machine configuration pools managed by the Machine Config Operator (MCO):
 
-** Stop the master configuration pool:
+** Stop the `master` configuration pool by entering the following command in your CLI:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
 $ oc patch MachineConfigPool master --type='merge' --patch \
   '{ "spec": { "paused": true } }'
 ----
 
-** Stop the worker machine configuration pool:
+** Stop the `worker` machine configuration pool by entering the following command in your CLI:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
 $ oc patch MachineConfigPool worker --type='merge' --patch \
   '{ "spec":{ "paused": true } }'
 ----
 
-. To prepare for the migration, set the migration field to `null` by entering the following command:
+. To prepare for the migration, set the migration field to `null` by entering the following command in your CLI:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
 $ oc patch Network.operator.openshift.io cluster --type='merge' \
   --patch '{ "spec": { "migration": null } }'
 ----
 
-. To start the migration, set the network plugin back to OpenShift SDN by entering the following commands:
+. Check that the migration status is empty for the `Network.config.openshift.io` object by entering the following command in your CLI. Empty command output indicates that the object is not in a migration operation.
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
+----
+$ oc get Network.config cluster -o jsonpath='{.status.migration}'
+----
+
+. Apply the patch to the `Network.operator.openshift.io` object to set the network plugin back to OpenShift SDN by entering the following command in your CLI:
++
+[source,terminal,subs="+quotes"]
 ----
 $ oc patch Network.operator.openshift.io cluster --type='merge' \
   --patch '{ "spec": { "migration": { "networkType": "OpenShiftSDN" } } }'
+----
++
+[IMPORTANT]
+====
+If you applied the patch to the `Network.config.openshift.io` object before the patch operation finalizes on the `Network.operator.openshift.io` object, the Cluster Network Operator (CNO) enters into a degradation state and this causes a slight delay until the CNO recovers from the degraded state.
+====
 
+. Confirm that the migration status of the network plugin for the `Network.config.openshift.io cluster` object is `OpenShiftSDN` by entering the following command in your CLI:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc get Network.config cluster -o jsonpath='{.status.migration.networkType}'
+----
+
+. Apply the patch to the `Network.config.openshift.io` object to set the network plugin back to OpenShift SDN by entering the following command in your CLI:
++
+[source,terminal,subs="+quotes"]
+----
 $ oc patch Network.config.openshift.io cluster --type='merge' \
   --patch '{ "spec": { "networkType": "OpenShiftSDN" } }'
 ----
 
-. Optional: You can disable automatic migration of several OVN-Kubernetes capabilities to the OpenShift SDN equivalents:
+. Optional: Disable automatic migration of several OVN-Kubernetes capabilities to the OpenShift SDN equivalents:
 +
 --
 * Egress IPs
@@ -111,7 +135,7 @@ $ oc patch Network.config.openshift.io cluster --type='merge' \
 +
 To disable automatic migration of the configuration for any of the previously noted OpenShift SDN features, specify the following keys:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
 $ oc patch Network.operator.openshift.io cluster --type='merge' \
   --patch '{
@@ -141,9 +165,9 @@ where:
 * VXLAN port
 --
 +
-To customize either or both of the previously noted settings, customize and enter the following command. If you do not need to change the default value, omit the key from the patch.
+To customize either or both of the previously noted settings, customize and enter the following command in your CLI. If you do not need to change the default value, omit the key from the patch.
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
 $ oc patch Network.operator.openshift.io cluster --type=merge \
   --patch '{
@@ -163,7 +187,7 @@ The UDP port for the VXLAN overlay network. If a value is not specified, the def
 --
 +
 .Example patch command
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
 $ oc patch Network.operator.openshift.io cluster --type=merge \
   --patch '{
@@ -206,7 +230,6 @@ do
 done
 ----
 
-
 . Wait until the Multus daemon set rollout completes. Run the following command to see your rollout status:
 +
 [source,terminal]
@@ -230,7 +253,7 @@ daemon set "multus" successfully rolled out
 --
 * Start the master configuration pool:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
 $ oc patch MachineConfigPool master --type='merge' --patch \
   '{ "spec": { "paused": false } }'
@@ -238,7 +261,7 @@ $ oc patch MachineConfigPool master --type='merge' --patch \
 
 * Start the worker configuration pool:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
 $ oc patch MachineConfigPool worker --type='merge' --patch \
   '{ "spec": { "paused": false } }'
@@ -250,9 +273,9 @@ As the MCO updates machines in each config pool, it reboots each node.
 By default the MCO updates a single machine per pool at a time, so the time that the migration requires to complete grows with the size of the cluster.
 
 . Confirm the status of the new machine configuration on the hosts:
-.. To list the machine configuration state and the name of the applied machine configuration, enter the following command:
+.. To list the machine configuration state and the name of the applied machine configuration, enter the following command in your CLI:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
 $ oc describe node | egrep "hostname|machineconfig"
 ----
@@ -274,7 +297,7 @@ Verify that the following statements are true:
  * The value of the `machineconfiguration.openshift.io/currentConfig` field is equal to the value of the `machineconfiguration.openshift.io/desiredConfig` field.
 --
 
-.. To confirm that the machine config is correct, enter the following command:
+.. To confirm that the machine config is correct, enter the following command in your CLI:
 +
 [source,terminal]
 ----
@@ -285,14 +308,14 @@ where `<config_name>` is the name of the machine config from the `machineconfigu
 
 . Confirm that the migration succeeded:
 
-.. To confirm that the network plugin is OpenShift SDN, enter the following command.  The value of `status.networkType` must be `OpenShiftSDN`.
+.. To confirm that the network plugin is OpenShift SDN, enter the following command in your CLI. The value of `status.networkType` must be `OpenShiftSDN`.
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ oc get network.config/cluster -o jsonpath='{.status.networkType}{"\n"}'
+$ oc get Network.config/cluster -o jsonpath='{.status.networkType}{"\n"}'
 ----
 
-.. To confirm that the cluster nodes are in the `Ready` state, enter the following command:
+.. To confirm that the cluster nodes are in the `Ready` state, enter the following command in your CLI:
 +
 [source,terminal]
 ----
@@ -301,7 +324,7 @@ $ oc get nodes
 
 .. If a node is stuck in the `NotReady` state, investigate the machine config daemon pod logs and resolve any errors.
 
-... To list the pods, enter the following command:
+... To list the pods, enter the following command in your CLI:
 +
 [source,terminal]
 ----
@@ -327,7 +350,7 @@ machine-config-server-k9rtx                  1/1     Running   0          43h
 +
 The names for the config daemon pods are in the following format: `machine-config-daemon-<seq>`. The `<seq>` value is a random five character alphanumeric sequence.
 
-... To display the pod log for each machine config daemon pod shown in the previous output, enter the following command:
+... To display the pod log for each machine config daemon pod shown in the previous output, enter the following command in your CLI:
 +
 [source,terminal]
 ----
@@ -338,9 +361,9 @@ where `pod` is the name of a machine config daemon pod.
 
 ... Resolve any errors in the logs shown by the output from the previous command.
 
-.. To confirm that your pods are not in an error state, enter the following command:
+.. To confirm that your pods are not in an error state, enter the following command in your CLI:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
 $ oc get pods --all-namespaces -o wide --sort-by='{.spec.nodeName}'
 ----
@@ -349,23 +372,23 @@ If pods on a node are in an error state, reboot that node.
 
 . Complete the following steps only if the migration succeeds and your cluster is in a good state:
 
-.. To remove the migration configuration from the Cluster Network Operator configuration object, enter the following command:
+.. To remove the migration configuration from the Cluster Network Operator configuration object, enter the following command in your CLI:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
 $ oc patch Network.operator.openshift.io cluster --type='merge' \
   --patch '{ "spec": { "migration": null } }'
 ----
 
-.. To remove the OVN-Kubernetes configuration, enter the following command:
+.. To remove the OVN-Kubernetes configuration, enter the following command in your CLI:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
 $ oc patch Network.operator.openshift.io cluster --type='merge' \
   --patch '{ "spec": { "defaultNetwork": { "ovnKubernetesConfig":null } } }'
 ----
 
-.. To remove the OVN-Kubernetes network provider namespace, enter the following command:
+.. To remove the OVN-Kubernetes network provider namespace, enter the following command in your CLI:
 +
 [source,terminal]
 ----

--- a/networking/openshift_sdn/migrate-to-openshift-sdn.adoc
+++ b/networking/openshift_sdn/migrate-to-openshift-sdn.adoc
@@ -12,7 +12,10 @@ include::snippets/sdn-deprecation-statement.adoc[]
 
 To learn more about OpenShift SDN, read xref:../../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[About the OpenShift SDN network plugin].
 
+// How the migration process works
 include::modules/nw-network-plugin-migration-process.adoc[leveloffset=+1]
+
+// Migrating to the OpenShift SDN network plugin
 include::modules/nw-ovn-kubernetes-rollback.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-33761](https://issues.redhat.com/browse/OCPBUGS-33761)

Link to docs preview:
* [Migrating to the OpenShift SDN network plugin](https://76876--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/rollback-to-openshift-sdn.html)

- [x] SME has approved this change
- [x] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
