### PR TITLE
OSDOCS: CNV-38825 - Correcting bridge NAD CLI doc

### DIFF
--- a/modules/virt-creating-linux-bridge-nad-cli.adoc
+++ b/modules/virt-creating-linux-bridge-nad-cli.adoc
@@ -35,7 +35,7 @@ spec:
   config: '{
     "cniVersion": "0.3.1",
     "name": "bridge-network", <3>
-    "type": "cnv-bridge", <4>
+    "type": "bridge", <4>
     "bridge": "bridge-interface", <5>
     "macspoofchk": true, <6>
     "vlan": 100, <7>

--- a/modules/virt-pxe-booting-with-mac-address.adoc
+++ b/modules/virt-pxe-booting-with-mac-address.adoc
@@ -35,7 +35,7 @@ spec:
     "name": "pxe-net-conf",
     "plugins": [
       {
-        "type": "cnv-bridge",
+        "type": "bridge",
         "bridge": "br1",
         "vlan": 1 <1>
       },


### PR DESCRIPTION
Version: 
4.14

Issue:
https://issues.redhat.com/browse/CNV-38825

Link to docs preview:
https://76877--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-configuring-pxe-booting.html
https://76877--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-linux-bridge.html

QE review:
- [x] QE has approved this change.
