### PR TITLE
OSDOCS-10681: adds host restart to manual restore

### DIFF
--- a/microshift_backup_and_restore/microshift-backup-and-restore.adoc
+++ b/microshift_backup_and_restore/microshift-backup-and-restore.adoc
@@ -29,7 +29,7 @@ include::modules/microshift-backing-up-manually.adoc[leveloffset=+1]
 
 include::modules/microshift-restoring-data-backups.adoc[leveloffset=+1]
 
-include::modules/microshift-service-starting.adoc[leveloffset=+1]
+//include::modules/microshift-service-starting.adoc[leveloffset=+1]
 
 //additional resources for restoring-data module
 [role="_additional-resources"]

--- a/modules/microshift-restoring-data-backups.adoc
+++ b/modules/microshift-restoring-data-backups.adoc
@@ -17,7 +17,7 @@ On an `rpm-ostree` system, {microshift-short} backs up and restores data automat
 
 * Root access to the host.
 * Full path of the data backup file.
-* {microshift-short} is stopped.
+* The {microshift-short} service is stopped.
 
 .Procedure
 
@@ -48,6 +48,8 @@ Replace `<my_manual_backup>` with the backup name that you used. Optional: You c
 $ sudo microshift restore /<mnt>/<other_backups_location>/<another_manual_backup>
 ----
 Replace `<other_backups_location>` with the directory you used and `<my_manual_backup>` with the backup name you used when creating the backup you are restoring.
-+
+
+. Restart the host. Restarting the host enables all workloads and pods to restart.
+
 .Verification
-* Verify that your backup is restored by restarting {microshift-short} and checking the data.
+* Use the `oc get pods -A` command to verify that the cluster is running, then check the restored data.


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-10681](https://issues.redhat.com/browse/OSDOCS-10681)

Link to docs preview:
[Restoring MicroShift; add _restart the host_ to verification steps](https://76886--ocpdocs-pr.netlify.app/microshift/latest/microshift_backup_and_restore/microshift-backup-and-restore.html#microshift-restoring-data-backups-manually_microshift-backup-and-restore)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
