### PR TITLE
OCPBUGS-34863: Document 4.16 known issue for bond0 losing DHCP addresses

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -1220,6 +1220,8 @@ In the following tables, features are marked with the following statuses:
 
 * {run-once-operator} (RODOO) cannot be installed on clusters managed by the Hypershift Operator. (link:https://issues.redhat.com/browse/OCPBUGS-17533[*OCPBUGS-17533*])
 
+* For a bonding network interface that holds a `br-ex` bridge device, do not set the `mode=6 balance-alb` bond mode in a node network configuration. This bond mode is not supported on {product-title} and it can cause the Open vSwitch (OVS) bridge device to disconnect from your networking environment. (link:https://issues.redhat.com/browse/OCPBUGS-34430[*OCPBUGS-34430*]).
+
 [id="ocp-telco-ran-4-16-known-issues_{context}"]
 
 [id="ocp-telco-core-4-16-known-issues_{context}"]


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OCPBUGS-34863](https://issues.redhat.com/browse/OCPBUGS-34863)

Link to docs preview:
[Open vSwitch (OVS) bridge device known issue](https://76890--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-known-issues)


- [x] SME has approved this change.
- [x] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
