### PR TITLE
OSDOCS#10119: Release note for new interactive flag for deleting reso…

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -102,6 +102,11 @@ With this release, if you query a resource by using its short name, the OpenShif
 Warning: short name "ex" could also match lower priority resource examples.test.com
 ----
 
+[id="ocp-4-16-interactive-flag"]
+==== New flag to require confirmation when deleting resources (Technology Preview)
+
+This release introduces a new `--interactive` flag for the `oc delete` command. When the `--interactive` flag is set to `true`, the resource is deleted only if the user confirms the deletion. This flag is available as a Technology Preview feature.
+
 [id="ocp-4-16-ibm-z"]
 === {ibm-z-title} and {ibm-linuxone-title}
 


### PR DESCRIPTION
…urces

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-10119

Link to docs preview:
https://76896--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-interactive-flag

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
