### PR TITLE
OSDOCS-1005:removes limitation of InFW on ROSA and AWS

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1088,6 +1088,8 @@ Topics:
       File: default-network-policy
     - Name: Configuring multitenant isolation with network policy
       File: multitenant-network-policy
+  - Name: Understanding the Ingress Node Firewall Operator
+    File: ingress-node-firewall-operator
 - Name: OVN-Kubernetes network plugin
   Dir: ovn_kubernetes_network_provider
   Topics:

--- a/modules/nw-infw-operator-cr.adoc
+++ b/modules/nw-infw-operator-cr.adoc
@@ -17,6 +17,4 @@ The Ingress Node Firewall Operator supports only stateless firewall rules.
 Network interface controllers (NICs) that do not support native XDP drivers will run at a lower performance.
 
 For {product-title} 4.14 or later, you must run Ingress Node Firewall Operator on {op-system-base} 9.0 or later.
-
-Ingress Node Firewall Operator is not supported on {aws-first} with the default OpenShift installation or on {product-rosa} (ROSA). For more information on {product-rosa} support and ingress, see link:https://docs.openshift.com/rosa/networking/ingress-operator.html[Ingress Operator in Red Hat OpenShift Service on AWS].
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-10005
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
InFW [OCP](https://76900--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/openshift_network_security/ingress-node-firewall-operator.html)
[ROSA](https://76900--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/openshift_network_security/ingress-node-firewall-operator.html)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
