### PR TITLE
Changing FlowMetrics to FlowMetric

### DIFF
--- a/modules/network-observability-configuring-custom-metrics.adoc
+++ b/modules/network-observability-configuring-custom-metrics.adoc
@@ -4,16 +4,16 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-configuring-custom-metrics_{context}"]
-= Configuring custom metrics by using FlowMetrics API
-You can configure the `FlowMetrics` API to create custom metrics by using flowlogs data fields as Prometheus labels. You can add multiple `FlowMetrics` resources to a project to see multiple dashboard views.
+= Configuring custom metrics by using FlowMetric API
+You can configure the `FlowMetric` API to create custom metrics by using flowlogs data fields as Prometheus labels. You can add multiple `FlowMetric` resources to a project to see multiple dashboard views.
 
 .Procedure
 
 . In the web console, navigate to *Operators* -> *Installed Operators*.
-. In the *Provided APIs* heading for the *NetObserv Operator*, select *FlowMetrics*.
+. In the *Provided APIs* heading for the *NetObserv Operator*, select *FlowMetric*.
 . In the *Project:*  dropdown list, select the project of the Network Observability Operator instance. 
 . Click *Create FlowMetric*.
-. Configure the `FlowMetrics` resource, similar to the following sample configurations:
+. Configure the `FlowMetric` resource, similar to the following sample configurations:
 +
 .Generate a metric that tracks ingress bytes received from cluster external sources
 [%collapsible]

--- a/modules/network-observability-custom-metrics.adoc
+++ b/modules/network-observability-custom-metrics.adoc
@@ -5,4 +5,4 @@
 :_mod-docs-content-type: CONCEPT
 [id="network-observability-custom-metrics_{context}"]
 = Custom metrics
-You can create custom metrics out of the flowlogs data using the `FlowMetrics` API. In every flowlogs data that is collected, there are a number of fields labeled per log, such as source name and destination name. These fields can be leveraged as Prometheus labels to enable the customization of cluster information on your dashboard. 
+You can create custom metrics out of the flowlogs data using the `FlowMetric` API. In every flowlogs data that is collected, there are a number of fields labeled per log, such as source name and destination name. These fields can be leveraged as Prometheus labels to enable the customization of cluster information on your dashboard. 

--- a/modules/network-observability-flowmetrics-charts.adoc
+++ b/modules/network-observability-flowmetrics-charts.adoc
@@ -4,12 +4,12 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-custom-charts-flowmetrics_{context}"]
-= Configuring custom charts using FlowMetrics API
+= Configuring custom charts using FlowMetric API
 You can generate charts for dashboards in the {product-title} web console, which you can view as an administrator in the *Dashboard* menu by defining the `charts` section of the `FlowMetric` resource.
 
 .Procedure
 . In the web console, navigate to *Operators* -> *Installed Operators*.
-. In the *Provided APIs* heading for the *NetObserv Operator*, select *FlowMetrics*.
+. In the *Provided APIs* heading for the *NetObserv Operator*, select *FlowMetric*.
 . In the *Project:*  dropdown list, select the project of the Network Observability Operator instance. 
 . Click *Create FlowMetric*.
 . Configure the `FlowMetric` resource, similar to the following sample configurations: 

--- a/modules/network-observability-flows-format.adoc
+++ b/modules/network-observability-flows-format.adoc
@@ -9,8 +9,7 @@ The "Filter ID" column shows which related name to use when defining Quick Filte
 
 The "Loki label" column is useful when querying Loki directly: label fields need to be selected using link:https://grafana.com/docs/loki/latest/logql/log_queries/#log-stream-selector[stream selectors].
 
-The "Cardinality" column gives information about the implied metric cardinality if this field was to be used as a Prometheus label with the `FlowMetrics` API. Refer to the `FlowMetrics` documentation for more information on using this API.
-
+The "Cardinality" column gives information about the implied metric cardinality if this field was to be used as a Prometheus label with the `FlowMetric` API. For more information, see the "FlowMetric API reference". 
 
 [cols="1,1,3,1,1,1",options="header"]
 |===


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
Only merge to no-1.6
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
in technical review, it came up that `FlowMetric` and `FlowMetrics` can be used interchangably, but we decided to take `FlowMetric`. In the already merged feature doc, `FlowMetrics` was used, so I'm changing it to `FlowMetric`. See tech review comment here: https://github.com/openshift/openshift-docs/pull/76753#discussion_r1626513229

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

- https://76902--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/metrics-alerts-dashboards#network-observability-configuring-custom-metrics_metrics-dashboards-alerts
- https://76902--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/json-flows-format-reference

QE review:
QE review not required since technically FlowMetrics is OK to use, this is just a matter of making it consistent throughout the documentation. 


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
