### PR TITLE
ocpbugs18514: fixing procedure in the machine-management Infrastructure machine section

### DIFF
--- a/machine_management/creating-infrastructure-machinesets.adoc
+++ b/machine_management/creating-infrastructure-machinesets.adoc
@@ -97,6 +97,7 @@ include::modules/binding-infra-node-workloads-using-taints-tolerations.adoc[leve
 
 * See xref:../nodes/scheduling/nodes-scheduler-about.adoc#nodes-scheduler-about[Controlling pod placement using the scheduler] for general information on scheduling a pod to a node.
 * See xref:moving-resources-to-infrastructure-machinesets[Moving resources to infrastructure machine sets] for instructions on scheduling pods to infra nodes.
+* See xref:../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-about_nodes-scheduler-taints-tolerations[Understanding taints and tolerations] for more details about different effects of taints.
 
 [id="moving-resources-to-infrastructure-machinesets"]
 == Moving resources to infrastructure machine sets

--- a/modules/binding-infra-node-workloads-using-taints-tolerations.adoc
+++ b/modules/binding-infra-node-workloads-using-taints-tolerations.adoc
@@ -53,6 +53,48 @@ For example:
 +
 [source,terminal]
 ----
+$ oc adm taint nodes node1 node-role.kubernetes.io/infra=reserved:NoSchedule
+----
++
+[TIP]
+====
+You can alternatively apply the following YAML to add the taint:
+
+[source,yaml]
+----
+kind: Node
+apiVersion: v1
+metadata:
+  name: <node_name>
+  labels:
+    ...
+spec:
+  taints:
+    - key: node-role.kubernetes.io/infra
+      effect: NoSchedule
+      value: reserved
+  ...
+----
+====
++
+This example places a taint on `node1` that has key `node-role.kubernetes.io/infra` and taint effect `NoSchedule`. Nodes with the `NoSchedule` effect schedule only pods that tolerate the taint, but allow existing pods to remain scheduled on the node. 
++
+[NOTE]
+====
+If a descheduler is used, pods violating node taints could be evicted from the cluster.
+====
+
+.. Add the taint with NoExecute Effect along with the above taint with NoSchedule Effect:
++
+[source,terminal]
+----
+$ oc adm taint nodes <node_name> <key>=<value>:<effect>
+----
++
+For example:
++
+[source,terminal]
+----
 $ oc adm taint nodes node1 node-role.kubernetes.io/infra=reserved:NoExecute
 ----
 +
@@ -77,27 +119,30 @@ spec:
 ----
 ====
 +
-This example places a taint on `node1` that has key `node-role.kubernetes.io/infra` and taint effect `NoSchedule`. Nodes with the `NoSchedule` effect schedule only pods that tolerate the taint, but allow existing pods to remain scheduled on the node.
+This example places a taint on `node1` that has the key `node-role.kubernetes.io/infra` and taint effect `NoExecute`. Nodes with the `NoExecute` effect schedule only pods that tolerate the taint. The effect will remove any existing pods from the node that do not have a matching toleration. 
 +
-[NOTE]
-====
-If a descheduler is used, pods violating node taints could be evicted from the cluster.
-====
+
 
 . Add tolerations for the pod configurations you want to schedule on the infra node, like router, registry, and monitoring workloads. Add the following code to the `Pod` object specification:
 +
 [source,yaml]
 ----
 tolerations:
-  - effect: NoExecute <1>
+  - effect: NoSchedule <1>
     key: node-role.kubernetes.io/infra <2>
-    operator: Exists <3>
-    value: reserved <4>
+    value: reserved <3>
+  - effect: NoExecute <4>
+    key: node-role.kubernetes.io/infra <5>
+    operator: Exists <6>
+    value: reserved <7>
 ----
 <1> Specify the effect that you added to the node.
 <2> Specify the key that you added to the node.
-<3> Specify the `Exists` Operator to require a taint with the key `node-role.kubernetes.io/infra` to be present on the node.
-<4> Specify the value of the key-value pair taint that you added to the node.
+<3> Specify the value of the key-value pair taint that you added to the node.
+<4> Specify the effect that you added to the node.
+<5> Specify the key that you added to the node.
+<6> Specify the `Exists` Operator to require a taint with the key `node-role.kubernetes.io/infra` to be present on the node.
+<7> Specify the value of the key-value pair taint that you added to the node.
 +
 This toleration matches the taint created by the `oc adm taint` command. A pod with this toleration can be scheduled onto the infra node.
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: OCPBUGS-18514
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://76903--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#binding-infra-node-workloads-using-taints-tolerations_creating-infrastructure-machinesets
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
