### PR TITLE
OSDOCS#10137: Adding RNs for descheduler 5.0.1

### DIFF
--- a/nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
+++ b/nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
@@ -12,6 +12,35 @@ These release notes track the development of the {descheduler-operator}.
 
 For more information, see xref:../../../nodes/scheduling/descheduler/index.adoc#nodes-descheduler-about_nodes-descheduler-about[About the descheduler].
 
+[id="descheduler-operator-release-notes-5.0.1"]
+== Release notes for {descheduler-operator} 5.0.1
+
+Issued: 2024-07-01
+
+The following advisory is available for the {descheduler-operator} 5.0.1:
+
+* link:https://access.redhat.com/errata/RHSA-2024:3617[RHSA-2024:3617]
+
+[id="descheduler-operator-5.0.1-notable-changes"]
+=== New features and enhancements
+
+* You can now install and use the {descheduler-operator} in an {product-title} cluster running in FIPS mode.
++
+--
+include::snippets/fips-snippet.adoc[]
+--
+
+[id="descheduler-operator-5.0.1-bug-fixes"]
+=== Bug fixes
+
+* This release of the {descheduler-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
+
+// No known issues to list
+// [id="descheduler-operator-5.0.1-known-issues"]
+// === Known issues
+//
+// * TODO
+
 [id="descheduler-operator-release-notes-5.0.0"]
 == Release notes for {descheduler-operator} 5.0.0
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15 and 4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-10137

Link to docs preview:
https://76905--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/descheduler/nodes-descheduler-release-notes.html#descheduler-operator-release-notes-5.0.1

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
**Not to be merged until after 4.16 GA, on July 1**
