### PR TITLE
OSDOCS-10553: Adds release notes for both perspectives of web console

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -155,17 +155,45 @@ This feature provides support for installing an Agent-based Installer cluster wi
 [id="ocp-4-16-web-console_{context}"]
 === Web console
 
+[id="ocp-4-16-web-console-language"]
+==== Language support for French and Spansih
+With this release, French and Spanish are suported in the web console. You can update the language in the web console from the *Language* list on the *User Preferences* page.
+
+[id="ocp-4-16-patternfly4-deprecated"]
+==== Patternfly 4 is now deprecated with {product-version}
+With this release, Patternfly 4 and React Router 5 are deprecated in the web console. All plugins should migrate to Patternfly 5 and React Router 6 as soon as possible.
+
 [id="ocp-4-16-administrator-perspective_{context}"]
 ==== Administrator perspective
 
 This release introduces the following updates to the *Administrator* perspective of the web console:
-//Are there any for 4.16
+
+* A {gcp-first} token authorization, `Auth Token GCP`, and a `Configurable TLS ciphers` filter was added to the *Infrastructure features* filter in the OperatorHub.
+* A new quick start, *Impersonating the system:admin user*, is available with information on impersonating the `system:admin` user.
+* A pod's last termination state is now available to view on the *Container list* and *Container details* pages.
+* An `Impersonate Group` action is now available from the *Groups* and *Group details* pages without having to search for the appropriate `RoleBinding`.
+
+[id="ocp-4-16-node-csr-handling"]
+===== Node CSR handling in the {product-title} web console
+With this release, the {product-title} web console supports node certificate signing requests (CSRs).
+
+[id="ocp-4-16-cross-storage-class-clone-restore"]
+===== Cross Storage Class clone and restore
+
+With this release, you can choose a storage class from the same provider when completing clone or restore operations. This flexibility allows seamless transitions between storage classes with different replica counts. For example, moving from a storage class with 3 replicas to 2/1 replicas.
 
 [id="ocp-4-16-developer-perspective_{context}"]
 ==== Developer Perspective
 
 This release introduces the following updates to the *Developer* perspective of the web console:
-//* are there any for 4.16?
+
+* When searching, a new section was added to the list of *Resources* on the *Search* page to display the recently searched items in the order they were searched.
+* With this release, you can collapse and expand the *Getting started* section.
+
+[id="ocp-4-16-console-telemetry"]
+===== Console Telemetry
+
+With this release, anonymized user analytics were enabled if cluster telemetry is also enabled. This is the default for most of the cluster and provides Red Hat with metrics for how the web console is used. Cluster administrators can update this in each cluster and opt-in, opt-out, or disable frontend telemetry.
 
 [id="ocp-4-16-openshift-cli_{context}"]
 === OpenShift CLI (oc)
@@ -891,6 +919,16 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.14 |4.15 |4.16
 
+|Patternfly 4
+|General Availability
+|Deprecated
+|Deprecated
+
+|React Router 5
+|General Availability
+|Deprecated
+|Deprecated
+
 |====
 
 [discrete]
@@ -1577,21 +1615,7 @@ In the following tables, features are marked with the following statuses:
 
 |====
 
-[discrete]
-=== Web console Technology Preview features
-
-.Web console Technology Preview tracker
-[cols="4,1,1,1",options="header"]
-|====
-|Feature |4.14 |4.15 |4.16
-
-|Multicluster console
-|Technology Preview
-|Technology Preview
-|Technology Preview
-
-|====
-
+//Removed multicluster console. It has not been in development for the past few releases.
 
 [discrete]
 [id="ocp-4-16-scalability-tech-preview_{context}"]


### PR DESCRIPTION
[OSDOCS-10553](https://issues.redhat.com//browse/OSDOCS-10553): Adds release notes for both perspectives of web console

Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-10553

Link to docs preview:
https://76907--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-web-console

Dep and rem tracker table
https://76907--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-deprecated-features:~:text=Web%20console%20deprecated%20and%20removed%20features

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
