### PR TITLE
Update boot images for GCP (tech preview)

### DIFF
--- a/modules/mco-update-boot-images-disable.adoc
+++ b/modules/mco-update-boot-images-disable.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/machine-configuration-tasks.adoc
+// * nodes/nodes-nodes-managing.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="mco-update-boot-images-disable_{context}"]
+= Disabling updated boot images
+
+To disable the updated boot image feature, edit the `MachineConfiguration` object to remove the `managedBootImages` stanza.
+
+If you disable this feature after some nodes have been created with the new boot image version, any existing nodes retain their current boot image. Turning off this feature does not rollback the nodes or machine sets to the originally-installed boot image. The machine sets retain the boot image version that was present when the feature was enabled and is not updated again when the cluster is upgraded to a new {product-title} version in the future.
+
+.Procedure
+
+. Disable updated boot images by editing the `MachineConfiguration` object:
++
+[source,terminal]
+----
+$ oc edit MachineConfiguration cluster
+----
+
+. Remove the `managedBootImages` stanza:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: MachineConfiguration
+metadata:
+  name: cluster
+  namespace: openshift-machine-config-operator
+spec:
+# ...
+  managedBootImages: <1>
+    machineManagers:
+    - resource: machinesets
+      apiGroup: machine.openshift.io
+      selection:
+        mode: All
+----
+<1> Remove the entire stanza to disable updated boot images.

--- a/modules/mco-update-boot-images.adoc
+++ b/modules/mco-update-boot-images.adoc
@@ -1,0 +1,159 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/machine-configuration-tasks.adoc
+// * nodes/nodes-nodes-managing.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="mco-update-boot-images_{context}"]
+= Updating boot images
+
+The Machine Config Operator (MCO) uses a boot image to bring up a {op-system-first} node. By default, {product-title} does not manage the boot image.
+
+This means that the boot image in your cluster is not updated along with your cluster. For example, if your cluster was originally created with {product-title} 4.12, the boot image that the cluster uses to create nodes is the same 4.12 version, even if your cluster is at a later version. If the cluster is later upgraded to 4.13 or later, new nodes continue to scale with the same 4.12 image.
+
+This process could cause the following issues:
+
+* Extra time to start up nodes
+* Certificate expiration issues
+* Version skew issues
+
+To avoid these issues, you can configure your cluster to update the boot image whenever you update your cluster. By modifying the `MachineConfiguration` object, you can enable this feature. Currently, the ability to update the boot image is available for only Google Cloud Platform (GCP) clusters and is not supported for Cluster CAPI Operator managed clusters.
+
+:FeatureName: The updating boot image feature
+include::snippets/technology-preview.adoc[]
+
+To view the current boot image used in your cluster, examine a machine set:
+
+.Example machine set with the boot image reference
+
+[source,yaml]
+----
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  name: ci-ln-hmy310k-72292-5f87z-worker-a
+  namespace: openshift-machine-api
+spec:
+# ...
+  template:
+# ...
+    spec:
+# ...
+      providerSpec:
+# ...
+        value:
+          disks:
+          - autoDelete: true
+            boot: true
+            image: projects/rhcos-cloud/global/images/rhcos-412-85-202203181601-0-gcp-x86-64 <1>
+# ...
+----
+<1> This boot image is the same as the originally-installed {product-title} version, in this example {product-title} 4.12, regardless of the current version of the cluster. The way that the boot image is represented in the machine set depends on the platform, as the structure of the `providerSpec` field differs from platform to platform.
+
+If you configure your cluster to update your boot images, the boot image referenced in your machine sets matches the current version of the cluster.
+
+.Prerequisites
+
+* You have enabled the `TechPreviewNoUpgrade` feature set by using the feature gates. For more information, see "Enabling features using feature gates" in the "Additional resources"  section.
+
+.Procedure
+
+. Edit the `MachineConfiguration` object, named `cluster`, to enable the updating of boot images by running the following command:
++
+[source,terminal]
+----
+$ oc edit MachineConfiguration cluster
+----
+
+.. Optional: Configure the boot image update feature for all the machine sets:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: MachineConfiguration
+metadata:
+  name: cluster
+  namespace: openshift-machine-config-operator
+spec:
+# ...
+  managedBootImages: <1>
+    machineManagers:
+    - resource: machinesets
+      apiGroup: machine.openshift.io
+      selection:
+        mode: All <2>
+----
+<1> Activates the boot image update feature.
+<2> Specifies that all the machine sets in the cluster are to be updated.
+
+.. Optional: Configure the boot image update feature for specific machine sets:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: MachineConfiguration
+metadata:
+  name: cluster
+  namespace: openshift-machine-config-operator
+spec:
+# ...
+  managedBootImages: <1>
+    machineManagers:
+    - resource: machinesets
+      apiGroup: machine.openshift.io
+      selection:
+        mode: Partial
+          partial:
+            machineResourceSelector:
+              matchLabels:
+                update-boot-image: "true" <2>
+----
+<1> Activates the boot image update feature.
+<2> Specifies that any machine set with this label is to be updated.
++
+[TIP]
+====
+If an appropriate label is not present on the machine set, add a key/value pair by running a command similar to following:
+
+----
+$ oc label machineset.machine ci-ln-hmy310k-72292-5f87z-worker-a update-boot-image=true -n openshift-machine-api
+----
+====
+
+.Verification
+
+. Get the boot image version by running the following command:
++
+[source,terminal]
+----
+$ oc get machinesets <machineset_name> -n openshift-machine-api -o yaml
+----
++
+.Example machine set with the boot image reference
++
+[source,yaml]
+----
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster: ci-ln-77hmkpt-72292-d4pxp
+    update-boot-image: "true"
+  name: ci-ln-77hmkpt-72292-d4pxp-worker-a
+  namespace: openshift-machine-api
+spec:
+# ...
+  template:
+# ...
+    spec:
+# ...
+      providerSpec:
+# ...
+        value:
+          disks:
+          - autoDelete: true
+            boot: true
+            image: projects/rhcos-cloud/global/images/rhcos-416-92-202402201450-0-gcp-x86-64 <1>
+# ...
+----
+<1> This boot image is the same as the current {product-title} version.

--- a/nodes/nodes/nodes-nodes-managing.adoc
+++ b/nodes/nodes/nodes-nodes-managing.adoc
@@ -21,6 +21,15 @@ configuration of nodes. By creating an instance of a `KubeletConfig` object, a m
 // assemblies.
 
 include::modules/nodes-nodes-managing-about.adoc[leveloffset=+1]
+include::modules/mco-update-boot-images.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+
+include::modules/mco-update-boot-images-disable.adoc[leveloffset=+2]
+
 include::modules/nodes-nodes-working-master-schedulable.adoc[leveloffset=+1]
 include::modules/nodes-nodes-working-setting-booleans.adoc[leveloffset=+1]
 include::modules/nodes-nodes-kernel-arguments.adoc[leveloffset=+1]

--- a/post_installation_configuration/machine-configuration-tasks.adoc
+++ b/post_installation_configuration/machine-configuration-tasks.adoc
@@ -29,6 +29,15 @@ include::modules/checking-mco-status.adoc[leveloffset=+2]
 include::modules/checking-mco-node-status.adoc[leveloffset=+2]
 include::modules/checking-mco-status-certs.adoc[leveloffset=+2]
 
+include::modules/mco-update-boot-images.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+
+include::modules/mco-update-boot-images-disable.adoc[leveloffset=+2]
+
 [id="using-machineconfigs-to-change-machines"]
 == Using MachineConfig objects to configure nodes
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-8177

Previews
Nodes -> Working with nodes ->  Managing nodes -> [Updating boot images](https://76910--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-managing.html#mco-update-boot-images_nodes-nodes-managing) - New module. Link to Enabling features using feature gates in Additional refs. 
Nodes -> Working with nodes ->  Managing nodes -> [Disabling boot images](https://76910--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-managing.html#mco-update-boot-images-disable_nodes-nodes-managing) -- New module
Postinstallation configuration -> Machine configuration tasks -> [Updating boot images](https://76910--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#mco-update-boot-images_post-install-machine-configuration-tasks) - Same new module, no differences.  Link to Enabling features using feature gates in Additional refs. 
Postinstallation configuration -> Machine configuration tasks -> [Disabling boot images](https://76910--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#mco-update-boot-images-disable_post-install-machine-configuration-tasks) - Same new module, no differences.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

