### PR TITLE
CNV-37038-37057: Accessing VM using headless services

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -4189,6 +4189,8 @@ Topics:
     File: virt-connecting-vm-to-default-pod-network
   - Name: Exposing a VM by using a service
     File: virt-exposing-vm-with-service
+  - Name: Accessing a VM by using its internal FQDN
+    File: virt-accessing-vm-internal-fqdn
   - Name: Connecting a VM to a Linux bridge network
     File: virt-connecting-vm-to-linux-bridge
   - Name: Connecting a VM to an SR-IOV network
@@ -4205,7 +4207,7 @@ Topics:
     File: virt-dedicated-network-live-migration
   - Name: Configuring and viewing IP addresses
     File: virt-configuring-viewing-ips-for-vms
-  - Name: Accessing a VM by using the cluster FQDN
+  - Name: Accessing a VM by using its external FQDN
     File: virt-accessing-vm-secondary-network-fqdn
   - Name: Managing MAC address pools for network interfaces
     File: virt-using-mac-address-pool-for-vms

--- a/modules/virt-connecting-vm-internal-fqdn.adoc
+++ b/modules/virt-connecting-vm-internal-fqdn.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_networking/virt-accessing-vm-internal-fqdn.adoc              
+
+:_mod-docs-content-type: PROCEDURE                                   
+[id="virt-connecting-vm-internal-fqdn_{context}"]
+= Connecting to a virtual machine by using its internal FQDN
+
+You can connect to a virtual machine (VM) by using its internal fully qualified domain name (FQDN).
+
+.Prerequisites
+* You have installed the `virtctl` tool.
+* You have identified the internal FQDN of the VM from the web console or by mapping the VM to a headless service. The internal FQDN has the format `<vm.spec.hostname>.<vm.spec.subdomain>.<vm.metadata.namespace>.svc.cluster.local`.
+
+
+.Procedure
+
+. Connect to the VM console by entering the following command:
++
+[source,terminal]
+----
+$ virtctl console vm-fedora
+----
+
+. To connect to the VM by using the requested FQDN, run the following command:
++
+[source,terminal]
+----
+$ ping myvm.mysubdomain.<namespace>.svc.cluster.local
+----
++
+.Example output
+[source,terminal]
+----
+PING myvm.mysubdomain.default.svc.cluster.local (10.244.0.57) 56(84) bytes of data.
+64 bytes from myvm.mysubdomain.default.svc.cluster.local (10.244.0.57): icmp_seq=1 ttl=64 time=0.029 ms
+----
++
+In the preceding example, the DNS entry for `myvm.mysubdomain.default.svc.cluster.local` points to `10.244.0.57`, which is the cluster IP address that is currently assigned to the VM.
+

--- a/modules/virt-creating-headless-services.adoc
+++ b/modules/virt-creating-headless-services.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_networking/virt-accessing-vm-internal-fqdn.adoc              
+
+:_mod-docs-content-type: PROCEDURE                                   
+[id="virt-creating-headless-services_{context}"]
+= Creating a headless service in a project by using the CLI
+
+To create a headless service in a namespace, add the `clusterIP: None` parameter to the service YAML definition.
+
+.Prerequisites
+* You have installed the OpenShift CLI (`oc`).
+
+.Procedure
+
+. Create a `Service` manifest to expose the VM, such as the following example:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysubdomain # <1>
+spec:
+  selector:
+    expose: me # <2>
+  clusterIP: None # <3>
+  ports: # <4>
+  - protocol: TCP 
+    port: 1234
+    targetPort: 1234
+----
+<1> The name of the service. This must match the `spec.subdomain` attribute in the `VirtualMachine` manifest file.
+<2> This service selector must match the `expose:me` label in the `VirtualMachine` manifest file.
+<3> Specifies a headless service.
+<4> The list of ports that are exposed by the service. You must define at least one port. This can be any arbitrary value as it does not affect the headless service.
+
+. Save the `Service` manifest file.
+
+. Create the service by running the following command:
++
+[source,terminal]
+----
+$ oc create -f headless_service.yaml
+----

--- a/modules/virt-discovering-vm-internal-fqdn.adoc
+++ b/modules/virt-discovering-vm-internal-fqdn.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_networking/virt-accessing-vm-internal-fqdn.adoc              
+
+:_mod-docs-content-type: PROCEDURE                                   
+[id="virt-discovering-vm-internal-fqdn_{context}"]
+= Mapping a virtual machine to a headless service by using the CLI
+
+To connect to a virtual machine (VM) from within the cluster by using its internal fully qualified domain name (FQDN), you must first map the VM to a headless service. Set the `spec.hostname` and `spec.subdomain` parameters in the VM configuration file.
+
+If a headless service exists with a name that matches the subdomain, a unique DNS A record is created for the VM in the form of `<vm.spec.hostname>.<vm.spec.subdomain>.<vm.metadata.namespace>.svc.cluster.local`.
+
+.Procedure
+
+. Edit the `VirtualMachine` manifest to add the service selector label and subdomain by running the following command:
++
+[source,terminal]
+----
+$ oc edit vm <vm_name>
+----
++
+.Example `VirtualMachine` manifest file
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: vm-fedora
+spec:
+  template:
+    metadata:
+      labels:
+        expose: me # <1>
+    spec:
+      hostname: "myvm" # <2>
+      subdomain: "mysubdomain" # <3>
+# ...
+----
+<1> The `expose:me` label must match the `spec.selector` attribute of the `Service` manifest that you previously created.
+<2> If this attribute is not specified, the resulting DNS A record takes the form of `<vm.metadata.name>.<vm.spec.subdomain>.<vm.metadata.namespace>.svc.cluster.local`.
+<3> The `spec.subdomain` attribute must match the `metadata.name` value of the `Service` object.
+
+. Save your changes and exit the editor.
+
+. Restart the VM to apply the changes.

--- a/virt/vm_networking/virt-accessing-vm-internal-fqdn.adoc
+++ b/virt/vm_networking/virt-accessing-vm-internal-fqdn.adoc
@@ -1,0 +1,29 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="virt-accessing-vm-internal-fqdn"]                            
+= Accessing a virtual machine  by using its internal FQDN                                             
+include::_attributes/common-attributes.adoc[]                   
+:context: virt-accessing-vm-internal-fqdn                        
+                                                                
+toc::[]         
+
+You can access a virtual machine (VM) that is connected to the default internal pod network on a stable fully qualified domain name (FQDN) by using headless services.
+
+A Kubernetes _headless service_ is a form of service that does not allocate a cluster IP address to represent a set of pods. Instead of providing a single virtual IP address for the service, a headless service creates a DNS record for each pod associated with the service. You can expose a VM through its FQDN without having to expose a specific TCP or UDP port. 
+ 
+[IMPORTANT]
+====
+If you created a VM by using the {product-title} web console, you can find its internal FQDN listed in the *Network* tile on the *Overview* tab of the *VirtualMachine details* page. For more information about connecting to the VM, see xref:../../virt/vm_networking/virt-accessing-vm-internal-fqdn.adoc#virt-connecting-vm-internal-fqdn_virt-accessing-vm-internal-fqdn[Connecting to a virtual machine by using its internal FQDN].
+====
+
+
+include::modules/virt-creating-headless-services.adoc[leveloffset=+1]
+
+include::modules/virt-discovering-vm-internal-fqdn.adoc[leveloffset=+1]
+
+include::modules/virt-connecting-vm-internal-fqdn.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_virt-accesing-vm-internal-fqdn"]
+== Additional resources
+
+* xref:../../virt/vm_networking/virt-exposing-vm-with-service.adoc#virt-exposing-vm-with-service[Exposing a VM by using a service]

--- a/virt/vm_networking/virt-accessing-vm-secondary-network-fqdn.adoc
+++ b/virt/vm_networking/virt-accessing-vm-secondary-network-fqdn.adoc
@@ -1,14 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="virt-accessing-vm-secondary-network-fqdn"]
-= Accessing a virtual machine by using the cluster FQDN
+= Accessing a virtual machine by using its external FQDN
 include::_attributes/common-attributes.adoc[]
 :context: virt-accessing-vm-secondary-network-fqdn
 
 toc::[]
 
-You can access a virtual machine (VM) that is attached to a secondary network interface from outside the cluster by using the fully qualified domain name (FQDN) of the cluster.
+You can access a virtual machine (VM) that is attached to a secondary network interface from outside the cluster by using its fully qualified domain name (FQDN).
 
-:FeatureName: Accessing VMs by using the cluster FQDN
+:FeatureName: Accessing a VM from outside the cluster by using its FQDN
 include::snippets/technology-preview.adoc[]
 
 include::modules/virt-configuring-secondary-dns-server.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-37038](https://issues.redhat.com//browse/CNV-37038)
[CNV-37057](https://issues.redhat.com//browse/CNV-37057)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 

- https://76911--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-accessing-vm-internal-fqdn.html
- https://76911--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-accessing-vm-secondary-network-fqdn.html

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
