### PR TITLE
TELCODOCS-1670: RN for network flow matrix

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -172,9 +172,14 @@ With this release, if you have pods in your cluster using `iptables` rules the f
 
 For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_firewalls_and_packet_filters/getting-started-with-nftables_firewall-packet-filters#doc-wrapper[Getting started with nftables]. If you are running third-party software, check with your vendor to ensure they will have an `nftables` based version available soon.
 
+[id="ocp-4-16-networking-ingress-network-flow_{context}"]
+==== Ingress network flows for {product-title} services
+
+With this release, you can view the ingress network flows for {product-title} services. You can use this information to manage ingress traffic for your network and improve network security.
+
+For more information, see xref:../installing/install_config/configuring-firewall.html#network-flow-matrix_configuring-firewall[{product-title} network flow matrix].
 
 [id="ocp-4-16-registry_{context}"]
-[id="ocp-4-16-registry"]
 === Registry
 
 [id="ocp-4-16-storage_{context}"]


### PR DESCRIPTION
[TELCODOCS-1670](https://issues.redhat.com//browse/TELCODOCS-1670): RN for network flow matrix story.

Version(s):
4.16

Issue:
https://issues.redhat.com/browse/TELCODOCS-1670

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

CNF QE has [commented](https://github.com/openshift/openshift-docs/pull/69720#issuecomment-2158666343) that the related story for this RN does not need QE review. Same goes for this RN. It has SME approval.