### PR TITLE
CMP-2582: Update CO install documentation to include ROSA support

### DIFF
--- a/modules/compliance-operator-rosa-installation.adoc
+++ b/modules/compliance-operator-rosa-installation.adoc
@@ -3,13 +3,18 @@
 // * security/compliance_operator/co-management/compliance-operator-installation.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="installing-compliance-operator-hcp_{context}"]
-= Installing the Compliance Operator on Hypershift {hcp}
+[id="installing-compliance-operator-rosa_{context}"]
+= Installing the Compliance Operator on ROSA hosted control planes (HCP)
 
-The Compliance Operator can be installed in {hcp} using the OperatorHub by creating a `Subscription` file.
+As of the Compliance Operator 1.5.0 release, the operator is tested against Red Hat
+OpenShift Service on AWS (ROSA) using hosted control plane topologies (HCP).
 
-:FeatureName: {hcp-capital}
-include::snippets/technology-preview.adoc[]
+ROSA HCP clusters have restricted access to the control plane, which is managed
+by Red Hat. By default, the Compliance Operator will schedule to nodes within
+the `master` node pool, which isn't available in ROSA HCP installations. This
+requires you to configure the `Subscription` object in a way that allows the
+operator to schedule on available node pools. This step is necessary for a
+successful installation on ROSA HCP clusters.
 
 .Prerequisites
 
@@ -17,7 +22,7 @@ include::snippets/technology-preview.adoc[]
 
 .Procedure
 
-. Define a `Namespace` object similar to the following:
+. Define a `Namespace` object:
 +
 .Example `namespace-object.yaml`
 [source,yaml]
@@ -30,9 +35,9 @@ metadata:
     pod-security.kubernetes.io/enforce: privileged <1>
   name: openshift-compliance
 ----
-<1> In {product-title} {product-version}, the pod security label must be set to `privileged` at the namespace level.
+<1> in {product-title} {product-version}, the pod security label must be set to `privileged` at the namespace level.
 
-. Create the `Namespace` object by running the following command:
+. Create the `Namespace` object:
 +
 [source,terminal]
 ----
@@ -54,7 +59,7 @@ spec:
   - openshift-compliance
 ----
 
-. Create the `OperatorGroup` object by running the following command:
+. Create the `OperatorGroup` object:
 +
 [source,terminal]
 ----
@@ -79,13 +84,11 @@ spec:
   sourceNamespace: openshift-marketplace
   config:
     nodeSelector:
-      node-role.kubernetes.io/worker: ""
-    env:
-    - name: PLATFORM
-      value: "HyperShift"
+      node-role.kubernetes.io/worker: "" <1>
 ----
+<1> update the operator deployment to deploy on `worker` nodes.
 
-. Create the `Subscription` object by running the following command:
+. Create the `Subscription` object:
 +
 [source,terminal]
 ----
@@ -94,14 +97,14 @@ $ oc create -f subscription-object.yaml
 
 .Verification
 
-. Verify the installation succeeded by inspecting the CSV file by running the following command:
+. Verify the installation succeeded by inspecting the CSV file:
 +
 [source,terminal]
 ----
 $ oc get csv -n openshift-compliance
 ----
 
-. Verify that the Compliance Operator is up and running by running the following command:
+. Verify that the Compliance Operator is up and running:
 +
 [source,terminal]
 ----

--- a/security/compliance_operator/co-management/compliance-operator-installation.adoc
+++ b/security/compliance_operator/co-management/compliance-operator-installation.adoc
@@ -10,7 +10,7 @@ Before you can use the Compliance Operator, you must ensure it is deployed in th
 
 [IMPORTANT]
 ====
-The Compliance Operator might report incorrect results on managed platforms, such as OpenShift Dedicated, Red Hat OpenShift Service on AWS, and Microsoft Azure Red Hat OpenShift. For more information, see the link:https://access.redhat.com/solutions/6983418[Red Hat Knowledgebase Solution #6983418].
+The Compliance Operator might report incorrect results on managed platforms, such as OpenShift Dedicated, Red Hat OpenShift Service on AWS Classic, and Microsoft Azure Red Hat OpenShift. For more information, see the link:https://access.redhat.com/solutions/6983418[Red Hat Knowledgebase Solution #6983418].
 ====
 
 include::modules/compliance-operator-console-installation.adoc[leveloffset=+1]
@@ -23,6 +23,8 @@ You can create a custom SCC for the Compliance Operator scanner pod service acco
 ====
 
 include::modules/compliance-operator-cli-installation.adoc[leveloffset=+1]
+
+include::modules/compliance-operator-rosa-installation.adoc[leveloffset=+1]
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
The next Compliance Operator release (1.5.0) will include ROSA HCP support.

This commit updates the installation documentation show users how they can install the operator if they're running ROSA HCP clusters.

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
