### PR TITLE
CMP-2583: Update CO supported profiles to include supported platforms

### DIFF
--- a/modules/compliance-supported-profiles.adoc
+++ b/modules/compliance-supported-profiles.adoc
@@ -9,7 +9,7 @@
 The Compliance Operator provides the following compliance profiles:
 
 .Supported compliance profiles
-[cols="10%,40%,10%,10%,40%,10%", options="header"]
+[cols="10%,40%,10%,10%,40%,10%,40%", options="header"]
 
 |===
 |Profile
@@ -18,6 +18,7 @@ The Compliance Operator provides the following compliance profiles:
 |Compliance Operator version
 |Industry compliance benchmark
 |Supported architectures
+|Supported platforms
 
 |rhcos4-stig
 |Defense Information Systems Agency Security Technical Implementation Guide (DISA STIG) for Red Hat Openshift
@@ -25,6 +26,7 @@ The Compliance Operator provides the following compliance profiles:
 |1.3.0+
 |link:https://public.cyber.mil/stigs/downloads/[DISA-STIG] ^[1]^
 |`x86_64`
+|Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 
 |ocp4-stig-node
 |Defense Information Systems Agency Security Technical Implementation Guide (DISA STIG) for Red Hat Openshift
@@ -32,6 +34,7 @@ The Compliance Operator provides the following compliance profiles:
 |1.3.0+
 |link:https://public.cyber.mil/stigs/downloads/[DISA-STIG] ^[1]^
 |`x86_64`
+|Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 
 |ocp4-stig
 |Defense Information Systems Agency Security Technical Implementation Guide (DISA STIG) for Red Hat Openshift
@@ -39,6 +42,7 @@ The Compliance Operator provides the following compliance profiles:
 |1.3.0+
 |link:https://public.cyber.mil/stigs/downloads/[DISA-STIG] ^[1]^
 |`x86_64`
+|
 
 |ocp4-cis-1-4
 |CIS Red Hat OpenShift Container Platform 4 Benchmark v1.4.0
@@ -48,6 +52,7 @@ The Compliance Operator provides the following compliance profiles:
 |`x86_64`
  `ppc64le`
  `s390x`
+|
 
 |ocp4-cis-node-1-4
 |CIS Red Hat OpenShift Container Platform 4 Benchmark v1.4.0
@@ -57,6 +62,7 @@ The Compliance Operator provides the following compliance profiles:
 |`x86_64`
  `ppc64le`
  `s390x`
+|Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 
 |ocp4-cis
 |CIS Red Hat OpenShift Container Platform 4 Benchmark v1.5.0
@@ -66,6 +72,7 @@ The Compliance Operator provides the following compliance profiles:
 |`x86_64`
  `ppc64le`
  `s390x`
+|
 
 |ocp4-cis-node
 |CIS Red Hat OpenShift Container Platform 4 Benchmark v1.5.0
@@ -75,6 +82,7 @@ The Compliance Operator provides the following compliance profiles:
 |`x86_64`
  `ppc64le`
  `s390x`
+|Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 
 |ocp4-e8
 |Australian Cyber Security Centre (ACSC) Essential Eight
@@ -82,6 +90,7 @@ The Compliance Operator provides the following compliance profiles:
 |0.1.39+
 |link:https://www.cyber.gov.au/acsc/view-all-content/publications/hardening-linux-workstations-and-servers[ACSC Hardening Linux Workstations and Servers]
 |`x86_64`
+|
 
 |ocp4-moderate
 |NIST 800-53 Moderate-Impact Baseline for Red Hat OpenShift - Platform level
@@ -91,6 +100,7 @@ The Compliance Operator provides the following compliance profiles:
 |`x86_64`
  `ppc64le`
  `s390x`
+|
 
 |rhcos4-e8
 |Australian Cyber Security Centre (ACSC) Essential Eight
@@ -98,6 +108,7 @@ The Compliance Operator provides the following compliance profiles:
 |0.1.39+
 |link:https://www.cyber.gov.au/acsc/view-all-content/publications/hardening-linux-workstations-and-servers[ACSC Hardening Linux Workstations and Servers]
 |`x86_64`
+|Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 
 |rhcos4-moderate
 |NIST 800-53 Moderate-Impact Baseline for Red Hat Enterprise Linux CoreOS
@@ -105,6 +116,7 @@ The Compliance Operator provides the following compliance profiles:
 |0.1.39+
 |link:https://nvd.nist.gov/800-53/Rev4/impact/moderate[NIST SP-800-53 Release Search]
 |`x86_64`
+|Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 
 |ocp4-moderate-node
 |NIST 800-53 Moderate-Impact Baseline for Red Hat OpenShift - Node level
@@ -114,6 +126,7 @@ The Compliance Operator provides the following compliance profiles:
 |`x86_64`
  `ppc64le`
  `s390x`
+|Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 
 |ocp4-nerc-cip
 |North American Electric Reliability Corporation (NERC) Critical Infrastructure Protection (CIP) cybersecurity standards profile for the Red Hat OpenShift Container Platform - Platform level
@@ -121,6 +134,7 @@ The Compliance Operator provides the following compliance profiles:
 |0.1.44+
 |link:https://www.nerc.com/pa/Stand/Pages/USRelStand.aspx[NERC CIP Standards]
 |`x86_64`
+|
 
 |ocp4-nerc-cip-node
 |North American Electric Reliability Corporation (NERC) Critical Infrastructure Protection (CIP) cybersecurity standards profile for the Red Hat OpenShift Container Platform - Node level
@@ -128,6 +142,7 @@ The Compliance Operator provides the following compliance profiles:
 |0.1.44+
 |link:https://www.nerc.com/pa/Stand/Pages/USRelStand.aspx[NERC CIP Standards]
 |`x86_64`
+|Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 
 |rhcos4-nerc-cip
 |North American Electric Reliability Corporation (NERC) Critical Infrastructure Protection (CIP) cybersecurity standards profile for Red Hat Enterprise Linux CoreOS
@@ -135,6 +150,7 @@ The Compliance Operator provides the following compliance profiles:
 |0.1.44+
 |link:https://www.nerc.com/pa/Stand/Pages/USRelStand.aspx[NERC CIP Standards]
 |`x86_64`
+|Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 
 |ocp4-pci-dss
 |PCI-DSS v3.2.1 Control Baseline for Red Hat OpenShift Container Platform 4
@@ -143,6 +159,7 @@ The Compliance Operator provides the following compliance profiles:
 |link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library]
 |`x86_64`
  `ppc64le`
+|
 
 |ocp4-pci-dss-node
 |PCI-DSS v3.2.1 Control Baseline for Red Hat OpenShift Container Platform 4
@@ -151,6 +168,7 @@ The Compliance Operator provides the following compliance profiles:
 |link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library]
 |`x86_64`
  `ppc64le`
+|Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 
 |ocp4-high
 |NIST 800-53 High-Impact Baseline for Red Hat OpenShift - Platform level
@@ -158,6 +176,7 @@ The Compliance Operator provides the following compliance profiles:
 |0.1.52+
 |link:https://csrc.nist.gov/Projects/risk-management/sp800-53-controls/release-search#!/800-53[NIST SP-800-53 Release Search]
 |`x86_64`
+|
 
 |ocp4-high-node
 |NIST 800-53 High-Impact Baseline for Red Hat OpenShift - Node level
@@ -165,6 +184,7 @@ The Compliance Operator provides the following compliance profiles:
 |0.1.52+
 |link:https://csrc.nist.gov/Projects/risk-management/sp800-53-controls/release-search#!/800-53[NIST SP-800-53 Release Search]
 |`x86_64`
+|Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 
 |rhcos4-high
 |NIST 800-53 High-Impact Baseline for Red Hat Enterprise Linux CoreOS
@@ -172,6 +192,7 @@ The Compliance Operator provides the following compliance profiles:
 |0.1.52+
 |link:https://csrc.nist.gov/Projects/risk-management/sp800-53-controls/release-search#!/800-53[NIST SP-800-53 Release Search]
 |`x86_64`
+|Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 |===
 [.small]
 1. To locate the CIS {product-title} v4 Benchmark, go to  link:https://www.cisecurity.org/benchmark/kubernetes[CIS Benchmarks] and click *Download Latest CIS Benchmark*, where you can then register to download the benchmark.

--- a/security/compliance_operator/co-scans/compliance-operator-supported-profiles.adoc
+++ b/security/compliance_operator/co-scans/compliance-operator-supported-profiles.adoc
@@ -18,7 +18,7 @@ authorized auditor to achieve compliance with a standard.
 
 [IMPORTANT]
 ====
-The Compliance Operator might report incorrect results on managed platforms, such as OpenShift Dedicated, Red Hat OpenShift Service on AWS, and Azure Red Hat OpenShift. For more information, see the link:https://access.redhat.com/solutions/6983418[Red Hat Knowledgebase Solution #6983418].
+The Compliance Operator might report incorrect results on some managed platforms, such as OpenShift Dedicated and Azure Red Hat OpenShift. For more information, see the link:https://access.redhat.com/solutions/6983418[Red Hat Knowledgebase Solution #6983418].
 ====
 
 include::modules/compliance-supported-profiles.adoc[leveloffset=+1]


### PR DESCRIPTION
With Compliance Operator 1.5.0, users can deploy the Compliance Operator on ROSA HCP. Let's update the documentation to advertise that functionality for profiles that are tested on ROSA HCP.

Version(s):
4.12+

Issue:
Jira noted in the PR title.

Link to docs preview:
https://76945--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/co-scans/compliance-operator-supported-profiles.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
