### PR TITLE
OCPBUGS#23348 Adding VRRP to vSphere firewall docs

### DIFF
--- a/modules/installation-vsphere-installer-network-requirements.adoc
+++ b/modules/installation-vsphere-installer-network-requirements.adoc
@@ -18,6 +18,10 @@ Review the following details about the required network ports.
 |Port
 |Description
 
+|VRRP
+|N/A
+|Required for keepalived
+
 |ICMP
 |N/A
 |Network reachability tests


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-23348

Link to docs preview:
https://76962--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs#installation-vsphere-installer-network-requirements_ipi-vsphere-installation-reqs
This module was relocated from the "Installing on vSphere with network customizations" assembly to a dedicated "vSphere installation requirements" assembly in 4.15. However, the content is the same for 4.12+.

QE review:
- [x] QE has approved this change.

