### PR TITLE
OCPBUGS-34127: Updated the isolation modes nodes in OVN K8S docs

### DIFF
--- a/modules/nw-ovn-kubernetes-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-migration-about.adoc
@@ -53,7 +53,7 @@ OVN-Kubernetes supports only the network policy isolation mode.
 
 [IMPORTANT]
 ====
-If your cluster uses OpenShift SDN configured in either the multitenant or subnet isolation modes, you cannot migrate to the OVN-Kubernetes network plugin.
+For a cluster using OpenShift SDN that is configured in either the multitenant or subnet isolation mode, you can still migrate to the OVN-Kubernetes network plugin. Note that after the migration operation, multitenant isolation mode is dropped, so you must manually configure network policies to achieve the same level of project-level isolation for pods and services.
 ====
 
 [discrete]


### PR DESCRIPTION
Version(s):
4.12+ 

Issue:
[OCPBUGS-34127](https://issues.redhat.com/browse/OCPBUGS-34127)

Link to docs preview:
[Namespace isolation](https://77026--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#considerations-migrating-ovn-kubernetes-network-provider_migrate-from-openshift-sdn)

- [x] SME has approved this change
- [x] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
