### PR TITLE
coreos-layering-configuring: Remove cliwrap from the example

### DIFF
--- a/modules/coreos-layering-configuring.adoc
+++ b/modules/coreos-layering-configuring.adoc
@@ -32,14 +32,12 @@ For example, the following Containerfile creates a custom layered image from an 
 # Using a {product-version}.0 image
 FROM quay.io/openshift-release/ocp-release@sha256... <1>
 #Install hotfix rpm
-RUN rpm-ostree cliwrap install-to-root / && \ <2>
-    rpm-ostree override replace http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/kernel-{,core-,modules-,modules-core-,modules-extra-}5.14.0-295.el9.x86_64.rpm && \ <3>
+RUN rpm-ostree override replace http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/kernel-{,core-,modules-,modules-core-,modules-extra-}5.14.0-295.el9.x86_64.rpm && \ <2>
     rpm-ostree cleanup -m && \
     ostree container commit
 ----
 <1> Specifies the {op-system} base image of your cluster.
-<2> Enables `cliwrap`. This is currently required to intercept some command invocations made from kernel scripts.
-<3> Replaces the kernel packages.
+<2> Replaces the kernel packages.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Doc update for OCPBUGS-33483

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16 and up

Issue:
OCPBUGS-33483

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://77066--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/coreos-layering.html
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
This is required along with changes to rpm-ostree for OCP 4.16 and up, if the cliwrap is left in the docs users will encounter: https://issues.redhat.com/browse/OCPBUGS-30149
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
