### PR TITLE
CNV#29336: Document USB host passthrough (GA)

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -4390,6 +4390,8 @@ Topics:
       File: virt-configuring-pci-passthrough
     - Name: Configuring virtual GPUs
       File: virt-configuring-virtual-gpus
+    - Name: Configuring USB host passthrough
+      File: virt-configuring-usb-host-passthrough
     - Name: Enabling descheduler evictions on virtual machines
       File: virt-enabling-descheduler-evictions
     - Name: About high availability for virtual machines

--- a/modules/virt-configuring-vm-use-usb-device.adoc
+++ b/modules/virt-configuring-vm-use-usb-device.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * virt//virtual_machines/advanced_vm_management/virt-configuring-usb-host-passthrough.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-configuring-vm-use-usb-device_{context}"]
+= Configuring a virtual machine connection to a USB device
+
+You can configure virtual machine (VM) access to a USB device. This configuration allows a guest to connect to actual USB hardware that is attached to an {product-title} node, as if the hardware and VM are physically connected.
+
+.Procedure
+
+. Locate the USB device by running the following command:
++
+[source,terminal]
+----
+$ oc /dev/serial/by-id/usb-VENDOR_device_name
+----
+
+. Open the virtual machine instance custom resource (CR) by running the following commmand:
++
+[source,terminal]
+----
+$ oc edit vmi vmi-usb
+----
+
+. Edit the CR by adding a USB device, as shown in the following example:
++
+.Example configuration
+[source, yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachineInstance
+metadata:
+  labels:
+    special: vmi-usb
+  name: vmi-usb <1>
+spec:
+  domain:
+    devices:
+      hostDevices:
+      - deviceName: kubevirt.io/peripherals
+        name: local-peripherals
+# ...
+----
+<1> The name of the USB device.
+

--- a/modules/virt-enabling-usb-host-passthrough.adoc
+++ b/modules/virt-enabling-usb-host-passthrough.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// * virt/advanced_vm_management/virt-configuring-usb-host-passthrough.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-enabling-usb-host-passthrough_{context}"]
+= Enabling USB host passthrough
+
+You can enable USB host passthrough at the cluster level.
+
+You specify a resource name and USB device name for each device you want first to add and then assign to a virtual machine (VM). You can allocate more than one device, each of which is known as a `selector` in the HyperConverged (HCO) custom resource (CR), to a single resource name. If you have multiple, identical USB devices on the cluster, you can choose to allocate a VM to a specific device.
+
+.Prerequisites
+
+* You have access to an {product-title} cluster as a user who has the `cluster-admin` role.
+
+.Procedure
+
+. Identify the USB device vendor and product by running the following command:
++
+[source,terminal]
+----
+$ lsusb
+----
+
+. Open the HCO CR by running the following commmand:
++
+[source,terminal]
+----
+$ oc edit hyperconverged kubevirt-hyperconverged -n openshift-cnv
+----
+
+. Add a USB device to the `permittedHostDevices` stanza, as shown in the following example:
+
++
+.Example YAML snippet
+[source,yaml]
+----
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+   name: kubevirt-hyperconverged
+   namespace: {CNVNamespace}
+spec:
+  configuration:
+    permittedHostDevices: <1>
+      usbHostDevices: <2>
+        - resourceName: kubevirt.io/peripherals <3>
+          selectors:
+            - vendor: "045e"
+              product: "07a5"
+            - vendor: "062a"
+              product: "4102"
+            - vendor: "072f"
+              product: "b100"
+
+----
+<1> Lists the host devices that have permission to be used in the cluster.
+<2> Lists the available USB devices.
+<3> Uses `resourceName: deviceName` for each device you want to add and assign to the VM. In this example, the resource is bound to three devices, each of which is identified by `vendor` and `product` and is known as a `selector`.

--- a/virt/virtual_machines/advanced_vm_management/virt-configuring-usb-host-passthrough.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-configuring-usb-host-passthrough.adoc
@@ -1,0 +1,14 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="virt-configuring-USB-host-passthrough"]
+= Configuring USB host passthrough
+include::_attributes/common-attributes.adoc[]
+:context: virt-configuring-USB-host-passthrough
+
+toc::[]
+
+As a cluster administrator, you can expose USB devices in a cluster, making them available for virtual machine (VM) owners to assign to VMs. Enabling this passthrough of USB devices allows a guest to connect to actual USB hardware that is attached to an {product-title} node, as if the hardware and the VM are physically connected.
+
+You can expose a USB device by first enabling host passthrough and then configuring the VM to use the USB device.
+
+include::modules/virt-enabling-usb-host-passthrough.adoc[leveloffset=+1]
+include::modules/virt-configuring-vm-use-usb-device.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.17

Issue: [CNV-29336](https://issues.redhat.com/browse/CNV-29336)

Link to docs preview: 
[Configuring USB host passthrough](https://77072--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-configuring-usb-host-passthrough.html)
[Enabling USB host passthrough](https://77072--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-configuring-usb-host-passthrough.html)
[Configuring a virtual machine connection to a USB device](https://77072--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-configuring-usb-host-passthrough.html#virt-configuring-VM-use-usb-device_virt-configuring-USB-host-passthrough)


QE review:
- [x] QE has approved this change.

Additional information:

