### PR TITLE
OSDOCS-10467: Update AWS EFS for ROSA/OSD

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -624,7 +624,7 @@ Topics:
   - Name: AWS Elastic Block Store CSI Driver Operator
     File: persistent-storage-csi-ebs
   - Name: AWS Elastic File Service CSI Driver Operator
-    File: osd-persistent-storage-aws-efs-csi
+    File: persistent-storage-csi-aws-efs
   - Name: GCP PD CSI Driver Operator
     File: persistent-storage-csi-gcp-pd
   - Name: GCP Filestore CSI Driver Operator

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -862,7 +862,7 @@ Topics:
   - Name: AWS Elastic Block Store CSI Driver Operator
     File: persistent-storage-csi-ebs
   - Name: AWS Elastic File Service CSI Driver Operator
-    File: osd-persistent-storage-aws-efs-csi
+    File: persistent-storage-csi-aws-efs
 - Name: Generic ephemeral volumes
   File: generic-ephemeral-vols
 - Name: Dynamic provisioning

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -835,7 +835,7 @@ Topics:
   - Name: AWS Elastic Block Store CSI Driver Operator
     File: persistent-storage-csi-ebs
   - Name: AWS Elastic File Service CSI Driver Operator
-    File: osd-persistent-storage-aws-efs-csi
+    File: persistent-storage-csi-aws-efs
 - Name: Generic ephemeral volumes
   File: generic-ephemeral-vols
 - Name: Dynamic provisioning

--- a/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-what-is-rosa.adoc
+++ b/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-what-is-rosa.adoc
@@ -144,7 +144,7 @@ Check for a newer version of the ROSA CLI. Every release of the ROSA CLI is loca
 == Storage
 Refer to the xref:../../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-storage_rosa-service-definition[storage] section of the service definition.
 
-OpenShift includes the CSI driver for AWS EFS. For more information, see xref:../../storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.adoc#osd-persistent-storage-aws-efs-csi[Setting up AWS EFS for Red{nbsp}Hat OpenShift Service on AWS].
+OpenShift includes the CSI driver for AWS EFS. For more information, see xref:../../storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc#persistent-storage-csi-aws-efs[Setting up AWS EFS for Red{nbsp}Hat OpenShift Service on AWS].
 
 == Using a VPC
 At installation you can select to deploy to an existing VPC or bring your own VPC. You can then select the required subnets and provide a valid CIDR range that encompasses the subnets for the installation program when using those subnets.

--- a/modules/persistent-storage-csi-about.adoc
+++ b/modules/persistent-storage-csi-about.adoc
@@ -3,7 +3,6 @@
 // * storage/container_storage_interface/persistent-storage-csi-ebs.adoc
 // * storage/container_storage_interface/persistent-storage-csi-manila.adoc
 // * storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
-// * storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="csi-about_{context}"]

--- a/modules/persistent-storage-csi-efs-driver-install.adoc
+++ b/modules/persistent-storage-csi-efs-driver-install.adoc
@@ -1,18 +1,12 @@
 // Module included in the following assemblies:
 //
 // * storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
-// * storage/container_storage_interface/osd-persistent-storage-csi-aws-efs.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="persistent-storage-csi-efs-driver-install_{context}"]
 = Installing the {FeatureName} CSI Driver
 
-ifdef::openshift-rosa[]
-After installing the link:https://github.com/openshift/aws-efs-csi-driver-operator[{FeatureName} CSI Driver Operator] (a Red Hat operator) and configuring it with STS, you install the link:https://github.com/openshift/aws-efs-csi-driver[{FeatureName} CSI driver].
-endif::openshift-rosa[]
-ifdef::openshift-dedicated[]
-After installing the {FeatureName} CSI Driver Operator, you install the {FeatureName} CSI Driver.
-endif::openshift-dedicated[]
+After installing the link:https://github.com/openshift/aws-efs-csi-driver-operator[{FeatureName} CSI Driver Operator] (a Red Hat operator), you install the link:https://github.com/openshift/aws-efs-csi-driver[{FeatureName} CSI driver].
 
 .Prerequisites
 * Access to the {product-title} web console.

--- a/modules/persistent-storage-csi-olm-operator-install.adoc
+++ b/modules/persistent-storage-csi-olm-operator-install.adoc
@@ -55,7 +55,7 @@ endif::restricted[]
 .. On the *Install Operator* page, ensure that:
 +
 ifdef::restricted[]
-ifdef::openshift-rosa,openshift-enterprise[]
+ifdef::openshift-enterprise,openshift-dedicated,openshift-rosa[]
 * If you are using {FeatureName} with AWS Secure Token Service (STS), in the *role ARN* field, enter the ARN role copied from the last step of the _Obtaining a role Amazon Resource Name for Security Token Service_ procedure.
 endif::[]
 endif::restricted[]

--- a/modules/persistent-storage-efs-csi-driver-operator-setup.adoc
+++ b/modules/persistent-storage-efs-csi-driver-operator-setup.adoc
@@ -1,19 +1,12 @@
 // Module included in the following assemblies:
 //
 // * storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
-// * storage/container_storage_interface/osd-persistent-storage-csi-aws-efs.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="persistent-storage-efs-csi-driver-operator-setup_{context}"]
 = Setting up the {FeatureName} CSI Driver Operator
 
-ifdef::openshift-rosa[]
-. If you are using Amazon Elastic File Storage (Amazon EFS) with AWS Secure Token Service (STS), configure the https://github.com/openshift/aws-efs-csi-driver[{FeatureName} CSI driver] with STS.
-endif::openshift-rosa[]
-
-ifdef::openshift-rosa,openshift-enterprise[]
 . If you are using {FeatureName} with AWS Secure Token Service (STS), obtain a role Amazon Resource Name (ARN) for STS. This is required for installing the {FeatureName} CSI Driver Operator.
-endif::[]
 
 . Install the {FeatureName} CSI Driver Operator.
 

--- a/modules/sd-persistent-storage-csi-efs-sts.adoc
+++ b/modules/sd-persistent-storage-csi-efs-sts.adoc
@@ -1,0 +1,185 @@
+// Module included in the following assemblies:
+//
+// * storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="efs-sts_{context}"]
+= Obtaining a role Amazon Resource Name for Security Token Service
+
+This procedure explains how to obtain a role Amazon Resource Name (ARN) to configure the AWS EFS CSI Driver Operator with {product-title} on AWS Security Token Service (STS).
+
+[IMPORTANT]
+====
+Perform this procedure before you install the AWS EFS CSI Driver Operator (see _Installing the AWS EFS CSI Driver Operator_ procedure).
+====
+
+.Prerequisites
+
+* Access to the cluster as a user with the cluster-admin role.
+* AWS account credentials
+
+.Procedure
+
+. Create an IAM policy JSON file with the following content:
++
+[source,json]
+----
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticfilesystem:DescribeAccessPoints",
+        "elasticfilesystem:DescribeFileSystems",
+        "elasticfilesystem:DescribeMountTargets",
+        "ec2:DescribeAvailabilityZones",
+        "elasticfilesystem:TagResource"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticfilesystem:CreateAccessPoint"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "aws:RequestTag/efs.csi.aws.com/cluster": "true"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": "elasticfilesystem:DeleteAccessPoint",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/efs.csi.aws.com/cluster": "true"
+        }
+      }
+    }
+  ]
+}
+----
+
+. Create an IAM trust JSON file with the following content:
++
+--
+[source,json]
+----
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::<your_aws_account_ID>:oidc-provider/<openshift_oidc_provider>"  <1>
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "<openshift_oidc_provider>:sub": [  <2>
+            "system:serviceaccount:openshift-cluster-csi-drivers:aws-efs-csi-driver-operator",
+            "system:serviceaccount:openshift-cluster-csi-drivers:aws-efs-csi-driver-controller-sa"
+          ]
+        }
+      }
+    }
+  ]
+}
+----
+<1> Specify your AWS account ID and the OpenShift OIDC provider endpoint. 
++
+Obtain your AWS account ID by running the following command:
++
+[source,terminal]
+----
+$ aws sts get-caller-identity --query Account --output text
+----
+ifdef::openshift-rosa[]
++
+Obtain the OpenShift OIDC endpoint by running the following command:
++
+[source,terminal]
+----
+$ rosa describe cluster \
+  -c $(oc get clusterversion -o jsonpath='{.items[].spec.clusterID}{"\n"}') \
+  -o yaml | awk '/oidc_endpoint_url/ {print $2}' | cut -d '/' -f 3,4
+----
+endif::openshift-rosa[]
+ifdef::openshift-dedicated[]
++
+Obtain the OpenShift OIDC endpoint by running the following command:
++
+[source,terminal]
+----
+$ openshift_oidc_provider=`oc get authentication.config.openshift.io cluster \
+  -o json | jq -r .spec.serviceAccountIssuer | sed -e "s/^https:\/\///"`; \
+  echo $openshift_oidc_provider
+----
+endif::openshift-dedicated[]
+
+<2> Specify the OpenShift OIDC endpoint again.
+--
+
+. Create the IAM role:
++
+[source,terminal]
+----
+ROLE_ARN=$(aws iam create-role \
+  --role-name "<your_cluster_name>-aws-efs-csi-operator" \
+  --assume-role-policy-document file://<your_trust_file_name>.json \
+  --query "Role.Arn" --output text); echo $ROLE_ARN
+----
++
+Copy the role ARN. You will need it when you install the AWS EFS CSI Driver Operator.
+
+. Create the IAM policy:
++
+[source,terminal]
+----
+POLICY_ARN=$(aws iam create-policy \
+  --policy-name "<your_cluster_name>-aws-efs-csi" \
+  --policy-document file://<your_policy_file_name>.json \
+  --query 'Policy.Arn' --output text); echo $POLICY_ARN
+----
+
+. Attach the IAM policy to the IAM role:
++
+[source,terminal]
+----
+$ aws iam attach-role-policy \
+  --role-name "<your_cluster_name>-aws-efs-csi-operator" \
+  --policy-arn $POLICY_ARN
+----
+
+////
+. Create a `Secret` YAML file for the driver operator:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+ name: aws-efs-cloud-credentials
+ namespace: openshift-cluster-csi-drivers
+stringData:
+  credentials: |-
+    [default]
+    sts_regional_endpoints = regional
+    role_arn = <role_ARN> <1>
+    web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
+----
+<1> Replace `role_ARN` with the output you saved while creating the role.
+
+. Create the secret:
++
+[source,terminal]
+----
+$ oc apply -f aws-efs-cloud-credentials.yaml
+----
++
+You are now ready to install the AWS EFS CSI driver.
+////

--- a/storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
@@ -6,7 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-// Content similar to osd-persistent-storage-csi-aws-efs.adoc and rosa-persistent-storage-aws-efs-csi.adoc. Modules are reused.
+ifdef::openshift-dedicated,openshift-rosa[]
+[IMPORTANT]
+====
+This procedure is specific to the link:https://github.com/openshift/aws-efs-csi-driver-operator[AWS EFS CSI Driver Operator] (a Red Hat Operator), which is only applicable for {product-title} 4.10 and later versions.
+====
+endif::openshift-dedicated,openshift-rosa[]
 
 == Overview
 
@@ -32,19 +37,30 @@ include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
 :FeatureName: AWS EFS
 include::modules/persistent-storage-efs-csi-driver-operator-setup.adoc[leveloffset=+1]
 
-ifdef::openshift-rosa,openshift-enterprise[]
+// Obtaining a role ARN (OCP)
+ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/persistent-storage-csi-efs-sts.adoc[leveloffset=+2]
+endif::openshift-dedicated,openshift-rosa[]
 
+// Obtaining a role ARN (OSD and ROSA)
+ifdef::openshift-dedicated,openshift-rosa[]
+include::modules/sd-persistent-storage-csi-efs-sts.adoc[leveloffset=+2]
+endif::openshift-dedicated,openshift-rosa[]
+
+.Next steps
 xref:../../storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc#persistent-storage-csi-olm-operator-install_persistent-storage-csi-aws-efs[Install the AWS EFS CSI Driver Operator].
+
 [role="_additional-resources"]
 .Additional resources
 * xref:../../storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc#persistent-storage-csi-olm-operator-install_persistent-storage-csi-aws-efs[Installing the AWS EFS CSI Driver Operator]
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../installing/installing_aws/ipi/installing-aws-customizations.adoc#cco-ccoctl-configuring_installing-aws-customizations[Configuring the Cloud Credential Operator utility]
+endif::openshift-dedicated,openshift-rosa[]
 * xref:../../storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc#persistent-storage-csi-efs-driver-install_persistent-storage-csi-aws-efs[Installing the {FeatureName} CSI Driver]
-endif::[]
 
 include::modules/persistent-storage-csi-olm-operator-install.adoc[leveloffset=+2]
 
+.Next steps
 xref:../../storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc#persistent-storage-csi-efs-driver-install_persistent-storage-csi-aws-efs[Install the AWS EFS CSI Driver].
 
 include::modules/persistent-storage-csi-efs-driver-install.adoc[leveloffset=+2]
@@ -55,7 +71,9 @@ include::modules/storage-create-storage-class.adoc[leveloffset=+1]
 include::modules/storage-create-storage-class-console.adoc[leveloffset=+2]
 include::modules/storage-create-storage-class-cli.adoc[leveloffset=+2]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/persistent-storage-csi-efs-cross-account.adoc[leveloffset=+1]
+endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/persistent-storage-csi-efs-create-volume.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Originally, the OSD and ROSA docs used a different assembly than OCP to document the AWS EFS Operator. This led to some discrepancies when the OCP assembly was updated, but the OSD/ROSA assembly was not. This PR reuses the OCP assembly so that OCP, OSD, and ROSA all use the same assembly for this content.

Version(s):
* enterprise-4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-10467

Link to docs preview:
* OCP (no changes): https://77073--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-aws-efs
* OSD: https://77073--ocpdocs-pr.netlify.app/openshift-dedicated/latest/storage/container_storage_interface/persistent-storage-csi-aws-efs
* ROSA: https://77073--ocpdocs-pr.netlify.app/openshift-rosa/latest/storage/container_storage_interface/persistent-storage-csi-aws-efs 

QE review:
- [x] QE has approved this change.

Additional information:
This PR does not change any content in the OCP docs. The changes for OSD and ROSA are largely due to conditionalization.