### PR TITLE
HCIDOCS-307: Added a release note for Dell iDRAC.

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -540,6 +540,11 @@ The Cluster Samples Operator is deprecated with the {product-title} 4.16 release
 
 //|===
 
+[id="ocp-4-16-dell-idrac-removed"]
+==== Dell iDRAC driver for BMC addressing removed
+
+{product-title} {product-version} supports basebard management controller (BMC) addressing with Dell servers as documented in xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#bmc-addressing-for-dell-idrac_ipi-install-installation-workflow[BMC addressing for Dell iDRAC]. Specifically, it supports `idrac-virtualmedia`, `redfish`, and `ipmi`. In previous versions, `idrac` was included, but not documented or supported. In {product-title} {product-version}, `idrac` has been removed.
+
 [id="ocp-4-16-metallb-addresspool-removed"]
 ==== MetalLB AddressPool custom resource definition (CRD) removed
 


### PR DESCRIPTION
This PR adds a release note that the `idrac` driver for Dell was removed.


Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/HCIDOCS-307

Link to docs preview: https://77074--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-dell-idrac-removed
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
