### PR TITLE
TELCODOCS-1893 SriovOperatorConfig will no longer be created by the Operator in 4.16 and onwards

### DIFF
--- a/modules/nw-sriov-configuring-operator.adoc
+++ b/modules/nw-sriov-configuring-operator.adoc
@@ -6,21 +6,35 @@
 [id="nw-sriov-configuring-operator_{context}"]
 = Configuring the SR-IOV Network Operator
 
-[IMPORTANT]
-====
-Modifying the SR-IOV Network Operator configuration is not normally necessary.
-The default configuration is recommended for most use cases.
-Complete the steps to modify the relevant configuration only if the default behavior of the Operator is not compatible with your use case.
-====
+* Create a `SriovOperatorConfig` custom resource (CR) to deploy all the SR-IOV Operator components:
 
-The SR-IOV Network Operator adds the `SriovOperatorConfig.sriovnetwork.openshift.io` CustomResourceDefinition resource.
-The Operator automatically creates a SriovOperatorConfig custom resource (CR) named `default` in the `openshift-sriov-network-operator` namespace.
-
+.. Create a file named `sriovOperatorConfig.yaml` using the following YAML:
++
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovOperatorConfig
+metadata:
+  name: default 
+  namespace: openshift-sriov-network-operator 
+spec:
+  disableDrain: false
+  enableInjector: true
+  enableOperatorWebhook: true
+  logLevel: 2
+----
++
 [NOTE]
-=====
-The `default` CR contains the SR-IOV Network Operator configuration for your cluster.
-To change the Operator configuration, you must modify this CR.
-=====
+====
+The only valid name for the `SriovOperatorConfig` resource is `default` and it must be in the namespace where the Operator is deployed. 
+====
+
+.. Create the resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f sriovOperatorConfig.yaml
+----
 
 [id="nw-sriov-operator-cr_{context}"]
 == SR-IOV Network Operator config custom resource
@@ -284,13 +298,11 @@ After performing the following procedure to disable draining workloads, you must
 
 .Procedure
 
-- To set the `disableDrain` field to `true`, enter the following command:
+- To set the `disableDrain` field to `true` and the `configDaemonNodeSelector` field to `node-role.kubernetes.io/master: ""` , enter the following command:
 +
 [source,terminal]
 ----
-$ oc patch sriovoperatorconfig default --type=merge \
-  -n openshift-sriov-network-operator \
-  --patch '{ "spec": { "disableDrain": true } }'
+$ oc patch sriovoperatorconfig default --type=merge -n openshift-sriov-network-operator --patch '{ "spec": { "disableDrain": true, "configDaemonNodeSelector": { "node-role.kubernetes.io/master": "" } } }'
 ----
 +
 [TIP]
@@ -306,5 +318,7 @@ metadata:
   namespace: openshift-sriov-network-operator
 spec:
   disableDrain: true
+  configDaemonNodeSelector:
+   node-role.kubernetes.io/master: ""
 ----
 ====

--- a/networking/hardware_networks/installing-sriov-operator.adoc
+++ b/networking/hardware_networks/installing-sriov-operator.adoc
@@ -13,4 +13,4 @@ include::modules/nw-sriov-installing-operator.adoc[leveloffset=+1]
 [id="installing-sriov-operator-next-steps"]
 == Next steps
 
-* Optional: xref:../../networking/hardware_networks/configuring-sriov-operator.adoc#configuring-sriov-operator[Configuring the SR-IOV Network Operator]
+* xref:../../networking/hardware_networks/configuring-sriov-operator.adoc#configuring-sriov-operator[Configuring the SR-IOV Network Operator]


### PR DESCRIPTION
[TELCODOCS-1893]: SriovOperatorConfig will no longer be created by the Operator in 4.16 and onwards
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-1893
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

- https://77080--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-operator.html
- https://77080--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/installing-sriov-operator.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
