### PR TITLE
[interna-fix] on-premise-accept-text-file

### DIFF
--- a/.vale/styles/config/vocabularies/OpenShiftDocs/accept.txt
+++ b/.vale/styles/config/vocabularies/OpenShiftDocs/accept.txt
@@ -1,11 +1,13 @@
 # Regex terms added to accept.txt are ignored by the Vale linter and override RedHat Vale rules.
 # Add terms that have a corresponding incorrectly capitalized form to reject.txt.
 [Ff]ronthaul
+[Mm][Bb]ps
 [Mm]idhaul
 [Pp]assthrough
 [Pp]ostinstall
 [Pp]recaching
 [Pp]reinstall
+[Oo]n-premise
 [Rr]ealtime
 [Tt]elco
 Assisted Installer
@@ -17,7 +19,6 @@ gpspipe
 hyperthreads?
 KPIs?
 linuxptp
-[Mm][Bb]ps
 Mellanox
 MetalLB
 NICs?


### PR DESCRIPTION
"On-premise" in the context of bundling bare-metal, vSphere, Nutanix, and OpenStack platforms is a valid term. [Example](https://docs.openshift.com/container-platform/4.15/architecture/architecture.html#architecture-platform-introduction_architecture). 


See the following PRs for why this exception is needed:

* RH SSG repo: [487](https://github.com/redhat-documentation/supplementary-style-guide/pull/487)
* Vale repo: [798](https://github.com/redhat-documentation/vale-at-red-hat/pull/798)