### PR TITLE
TELCODOCS#1894: Added "Uninstalling LVM Stroage by using the CLI" proc

### DIFF
--- a/modules/lvms-uninstalling-logical-volume-manager-operator-using-openshift-cli.adoc
+++ b/modules/lvms-uninstalling-logical-volume-manager-operator-using-openshift-cli.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="lvms-unstalling-lvms-using-cli_{context}"]
+= Uninstalling {lvms} by using the CLI
+
+You can uninstall {lvms} by using the {oc-first}.
+
+.Prerequisites
+
+* You have logged in to `oc` as a user with `cluster-admin` permissions.
+* You deleted the persistent volume claims (PVCs), volume snapshots, and volume clones provisioned by {lvms}. You have also deleted the applications that are using these resources.
+* You deleted the `LVMCluster` custom resource (CR).
+
+.Procedure
+
+. Get the `currentCSV` value for the {lvms} Operator by running the following command:
++
+[source,terminal]
+----
+$ oc get subscription.operators.coreos.com lvms-operator -n <namespace> -o yaml | grep currentCSV
+----
++
+.Example output
+[source,terminal]
+----
+currentCSV: lvms-operator.v4.15.3
+----
+
+. Delete the subscription by running the following command:
++
+[source,terminal]
+----
+$ oc delete subscription.operators.coreos.com lvms-operator -n <namespace>
+----
++
+.Example output
+[source,terminal]
+----
+subscription.operators.coreos.com "lvms-operator" deleted
+----
+
+. Delete the CSV for the {lvms} Operator in the target namespace by running the following command:
++
+[source,terminal]
+----
+$ oc delete clusterserviceversion <currentCSV> -n <namespace> <1>
+----
+<1> Replace `<currentCSV>` with the `currentCSV` value for the {lvms} Operator.
++
+.Example output
+[source,terminal]
+----
+clusterserviceversion.operators.coreos.com "lvms-operator.v4.15.3" deleted
+----
+
+.Verification
+
+* To verify that the {lvms} Operator is uninstalled, run the following command:
++
+[source,terminal]
+----
+$ oc get csv -n <namespace>
+----
++
+If the {lvms} Operator was successfully uninstalled, it does not appear in the output of this command.

--- a/modules/lvms-uninstalling-logical-volume-manager-operator-using-openshift-web-console.adoc
+++ b/modules/lvms-uninstalling-logical-volume-manager-operator-using-openshift-web-console.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="lvms-unstalling-lvms-with-web-console_{context}"]
-= Uninstalling {lvms} using the web console
+= Uninstalling {lvms} by using the web console
 
 You can uninstall {lvms} using the {product-title} web console.
 

--- a/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
+++ b/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
@@ -201,6 +201,7 @@ include::modules/lvms-monitoring-logical-volume-manager-operator.adoc[leveloffse
 
 // Uninstalling LVM Storage
 
+include::modules/lvms-uninstalling-logical-volume-manager-operator-using-openshift-cli.adoc[leveloffset=+1]
 include::modules/lvms-uninstalling-logical-volume-manager-operator-using-openshift-web-console.adoc[leveloffset=+1]
 include::modules/lvms-uninstalling-logical-volume-manager-operator-using-rhacm.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
[TELCODOCS-1894](https://issues.redhat.com/browse/TELCODOCS-1894)
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
4.13+
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[Uninstalling LVM Storage by using the CLI](https://77083--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html#lvms-unstalling-lvms-with-cli_logical-volume-manager-storage)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->