### PR TITLE
Add a command for velero backup details

### DIFF
--- a/modules/oadp-backup-restore-cr-issues.adoc
+++ b/modules/oadp-backup-restore-cr-issues.adoc
@@ -48,9 +48,16 @@ $ oc -n {namespace} exec deployment/velero -c velero -- ./velero \
 $ oc delete backup <backup> -n openshift-adp
 ----
 +
-You do not need to clean up the backup location because a `Backup` CR in progress has not uploaded  files to object storage.
+You do not need to clean up the backup location because a `Backup` CR in progress has not uploaded files to object storage.
 
 . Create a new `Backup` CR.
+
+. View the Velero backup details
++
+[source,terminal, subs="+quotes"]
+----
+$ velero backup describe _<backup-name>_ --details
+----
 
 [id="backup-cr-remains-partiallyfailed_{context}"]
 == Backup CR status remains in PartiallyFailed


### PR DESCRIPTION
Version(s):
OADP 1.4.0
OCP 4.12 → OCP 4.16

Issue:
[OADP-1444](https://issues.redhat.com/browse/OADP-1444)

Link to docs preview: https://77086--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting.html#backup-cr-remains-in-progress_oadp-troubleshooting 


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

