### PR TITLE
OSDOCS-10407 clarified cluster creation vCPU requirement

### DIFF
--- a/modules/rosa-required-aws-service-quotas.adoc
+++ b/modules/rosa-required-aws-service-quotas.adoc
@@ -8,7 +8,7 @@
 
 The table below describes the AWS service quotas and levels required to create and run one {product-title} cluster. Although most default values are suitable for most workloads, you might need to request additional quota for the following cases:
 
-* ROSA clusters require at least 100 vCPUs, but the default maximum value for vCPUs assigned to Running On-Demand Standard Amazon EC2 instances is `5`. Therefore if you have not created a ROSA cluster using the same AWS account previously, you must request additional EC2 quota for `Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances`.
+* ROSA (classic architecture) clusters require a minimum AWS EC2 service quota of 100 vCPUs to provide for cluster creation, availability, and upgrades. The default maximum value for vCPUs assigned to Running On-Demand Standard Amazon EC2 instances is `5`. Therefore if you have not created a ROSA cluster using the same AWS account previously, you must request additional EC2 quota for `Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances`.
 
 * Some optional cluster configuration features, such as custom security groups, might require you to request additional quota. For example, because ROSA associates 1 security group with network interfaces in worker machine pools by default, and the default quota for `Security groups per network interface` is `5`, if you want to add 5 custom security groups, you must request additional quota, because this would bring the total number of security groups on worker network interfaces to 6.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.15+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-10407

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://77096--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-required-aws-service-quotas.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
