### PR TITLE
[OSDOCS9863] Update Multi-architecture and Storage TP tables OCP 4.16 Release Notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -774,8 +774,8 @@ In the following tables, features are marked with the following statuses:
 
 |{ibm-power-server-name} Block CSI Driver Operator
 |Technology Preview
-|Technology Preview
-|Technology Preview
+|General Availability
+|General Availability
 
 |Read Write Once Pod access mod
 |Technology Preview
@@ -889,8 +889,8 @@ In the following tables, features are marked with the following statuses:
 
 |{ibm-power-server-name} using installer-provisioned infrastructure
 |Technology Preview
-|Technology Preview
-|Technology Preview
+|General Availability
+|General Availability
 
 |`kdump` on `arm64` architecture
 |Technology Preview
@@ -1063,9 +1063,9 @@ In the following tables, features are marked with the following statuses:
 |====
 
 [discrete]
-=== Architecture Technology Preview features
+=== Hosted Control Plane Technology Preview features
 
-.Architecture Technology Preview tracker
+.Hosted Control Plane Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
 |Feature |4.14 |4.15 |4.16
@@ -1076,14 +1076,34 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 
 |Hosted control planes for {product-title} on bare metal
-|Technology Preview
+|General Availability
 |General Availability
 |General Availability
 
 |Hosted control planes for {product-title} on {VirtProductName}
+|General Availability
+|General Availability
+|General Availability
+
+|Hosted control planes for {product-title} using non-bare metal agent machines
+|Not Available
 |Technology Preview
-|General Availability
-|General Availability
+|Technology Preview
+
+|Hosted control planes for an ARM64 {product-title} cluster on AWS
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|Hosted control planes for {product-title} on {ibm-power-title}
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|Hosted control planes for {product-title} on {ibm-z-title}
+|Technology Preview
+|Technology Preview
+|Technology Preview
 
 |====
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-9863
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 
https://77097--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-technology-preview-tables
Storage table 14/Multi-Architecture  table 17/Hosted Control Plane table 24
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
