### PR TITLE
OSDOCS#10138: Adding FIPS snippet for easier reuse

### DIFF
--- a/modules/agent-installer-fips-compliance.adoc
+++ b/modules/agent-installer-fips-compliance.adoc
@@ -10,7 +10,4 @@
 For many {product-title} customers, regulatory readiness, or compliance, on some level is required before any systems can be put into production. That regulatory readiness can be imposed by national standards, industry standards or the organization's corporate governance framework.
 Federal Information Processing Standards (FIPS) compliance is one of the most critical components required in highly secure environments to ensure that only supported cryptographic technologies are allowed on nodes.
 
-[IMPORTANT]
-====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
-====
+include::snippets/fips-snippet.adoc[]

--- a/modules/installation-aws-config-yaml.adoc
+++ b/modules/installation-aws-config-yaml.adoc
@@ -358,10 +358,9 @@ host must trust the certificate.
 ifndef::openshift-origin[]
 <13> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
-[IMPORTANT]
-====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
-====
+--
+include::snippets/fips-snippet.adoc[]
+--
 <14> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
@@ -374,10 +373,9 @@ ifndef::vpc,restricted,aws-outposts[]
 ifndef::openshift-origin[]
 <11> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
-[IMPORTANT]
-====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
-====
+--
+include::snippets/fips-snippet.adoc[]
+--
 <12> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]

--- a/modules/installation-azure-config-yaml.adoc
+++ b/modules/installation-azure-config-yaml.adoc
@@ -252,20 +252,18 @@ ifdef::restricted[]
 <15> When using Azure Firewall to restrict Internet access, you must configure outbound routing to send traffic through the Azure Firewall. Configuring user-defined routing prevents exposing external endpoints in your cluster.
 <16> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
-[IMPORTANT]
-====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64`, `ppc64le`, and `s390x` architectures.
-====
+--
+include::snippets/fips-snippet.adoc[]
+--
 <17> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::restricted[]
 ifdef::vnet[]
 ifndef::openshift-origin[]
 <15> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
-[IMPORTANT]
-====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
-====
+--
+include::snippets/fips-snippet.adoc[]
+--
 <16> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
@@ -276,10 +274,9 @@ ifdef::private[]
 ifndef::openshift-origin[]
 <16> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
-[IMPORTANT]
-====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
-====
+--
+include::snippets/fips-snippet.adoc[]
+--
 <17> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
@@ -290,10 +287,9 @@ ifdef::gov[]
 ifndef::openshift-origin[]
 <17> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
-[IMPORTANT]
-====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
-====
+--
+include::snippets/fips-snippet.adoc[]
+--
 <18> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
@@ -304,10 +300,9 @@ ifndef::vnet,private,gov,restricted[]
 ifndef::openshift-origin[]
 <11> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
-[IMPORTANT]
-====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
-====
+--
+include::snippets/fips-snippet.adoc[]
+--
 <12> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]

--- a/modules/installation-azure-stack-hub-config-yaml.adoc
+++ b/modules/installation-azure-stack-hub-config-yaml.adoc
@@ -93,10 +93,9 @@ endif::openshift-origin[]
 ifndef::openshift-origin[]
 <11> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
-[IMPORTANT]
-====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
-====
+--
+include::snippets/fips-snippet.adoc[]
+--
 <12> If your Azure Stack Hub environment uses an internal certificate authority (CA), add the necessary certificate bundle in `.pem` format.
 <13> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]

--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -243,10 +243,10 @@ Clusters that are installed with the platform type `none` are unable to use some
 ifndef::openshift-origin[]
 <12> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
-[IMPORTANT]
-====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
-====
+--
+include::snippets/fips-snippet.adoc[]
+--
+
 endif::openshift-origin[]
 ifndef::restricted[]
 ifndef::openshift-origin[]

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -640,10 +640,9 @@ endif::agent[]
 ifndef::openshift-origin,ibm-power-vs[]
 |fips:
 |Enable or disable FIPS mode. The default is `false` (disabled). If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
-[IMPORTANT]
-====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
-====
+
+include::snippets/fips-snippet.adoc[]
+
 [NOTE]
 ====
 If you are using Azure File storage, you cannot enable FIPS mode.

--- a/modules/installation-gcp-config-yaml.adoc
+++ b/modules/installation-gcp-config-yaml.adoc
@@ -216,10 +216,9 @@ ifdef::vpc[]
 ifndef::openshift-origin[]
 <13> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
-[IMPORTANT]
-====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
-====
+--
+include::snippets/fips-snippet.adoc[]
+--
 <14> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]

--- a/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
+++ b/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
@@ -88,10 +88,9 @@ If you disable simultaneous multithreading, ensure that your capacity planning a
 ifndef::openshift-origin[]
 <9> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
-[IMPORTANT]
-====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
-====
+--
+include::snippets/fips-snippet.adoc[]
+--
 <10> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]

--- a/modules/installation-ibm-cloud-config-yaml.adoc
+++ b/modules/installation-ibm-cloud-config-yaml.adoc
@@ -93,10 +93,9 @@ If you disable simultaneous multithreading, ensure that your capacity planning a
 ifndef::openshift-origin[]
 <6> Enables or disables FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
-[IMPORTANT]
-====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
-====
+--
+include::snippets/fips-snippet.adoc[]
+--
 <7> Optional: provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]

--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -156,10 +156,9 @@ The Cloud Controller Manager Operator performs a connectivity check on a provide
 ifndef::openshift-origin[]
 <14> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
-[IMPORTANT]
-====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
-====
+--
+include::snippets/fips-snippet.adoc[]
+--
 endif::openshift-origin[]
 ifndef::restricted[]
 ifndef::openshift-origin[]

--- a/modules/machine-config-overview.adoc
+++ b/modules/machine-config-overview.adoc
@@ -59,11 +59,11 @@ The kinds of components that MCO can change include:
 * **kernelType**: Optionally identify a non-standard kernel to use instead of the standard kernel. Use `realtime` to use the RT kernel (for RAN). This is only supported on select platforms. Use the `64k-pages` parameter to enable the 64k page size kernel. This setting is exclusive to machines with 64-bit ARM architectures.
 ifndef::openshift-origin[]
 * **fips**: Enable link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/security_hardening/index#using-the-system-wide-cryptographic-policies_security-hardening[FIPS] mode. FIPS should be set at installation-time setting and not a postinstallation procedure.
++
+--
+include::snippets/fips-snippet.adoc[]
+--
 
-[IMPORTANT]
-====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
-====
 endif::openshift-origin[]
 * **extensions**: Extend {op-system} features by adding selected pre-packaged software. For this feature, available extensions include link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/security_hardening/index#protecting-systems-against-intrusive-usb-devices_security-hardening[usbguard] and kernel modules.
 * **Custom resources (for `ContainerRuntime` and `Kubelet`)**: Outside of machine configs, MCO manages two special custom resources for modifying CRI-O container runtime settings (`ContainerRuntime` CR) and the Kubelet service (`Kubelet` CR).

--- a/modules/rhel-compute-requirements.adoc
+++ b/modules/rhel-compute-requirements.adoc
@@ -30,11 +30,11 @@ If you have {op-system-base} 7 compute machines that were previously supported i
 For the most recent list of major functionality that has been deprecated or removed within {product-title}, refer to the _Deprecated and removed features_ section of the {product-title} release notes.
 ====
 ** If you deployed {product-title} in FIPS mode, you must enable FIPS on the {op-system-base} machine before you boot it. See link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/assembly_installing-a-rhel-8-system-with-fips-mode-enabled_security-hardening[Installing a RHEL 8 system with FIPS mode enabled] in the {op-system-base} 8 documentation.
++
+--
+include::snippets/fips-snippet.adoc[]
+--
 
-[IMPORTANT]
-====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
-====
 endif::[]
 ** NetworkManager 1.0 or later.
 ** 1 vCPU.

--- a/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
+++ b/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
@@ -115,10 +115,8 @@ Tags that are added by Red Hat are required for clusters to stay in compliance w
 
 |`Enable FIPS support (optional)`
 |Enable or disable FIPS mode. The default is `false` (disabled). If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with RHCOS instead.
-[IMPORTANT]
-====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
-====
+
+include::snippets/fips-snippet.adoc[]
 
 |`Encrypt etcd data (optional)`
 |In {product-title}, the control plane storage is encrypted at rest by default and this includes encryption of the etcd volumes. You can additionally enable the `Encrypt etcd data` option to encrypt the key values for some resources in etcd, but not the keys.

--- a/modules/security-compliance-nist.adoc
+++ b/modules/security-compliance-nist.adoc
@@ -18,10 +18,7 @@ FIPS compliance is one of the most critical components required in
 highly secure environments, to ensure that only supported cryptographic
 technologies are allowed on nodes.
 
-[IMPORTANT]
-====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
-====
+include::snippets/fips-snippet.adoc[]
 endif::openshift-origin[]
 
 To understand Red Hat's view of {product-title} compliance frameworks, refer

--- a/security/compliance_operator/compliance-operator-release-notes.adoc
+++ b/security/compliance_operator/compliance-operator-release-notes.adoc
@@ -108,10 +108,9 @@ This update addresses a CVE in an underlying dependency.
 
 * You can install and use the Compliance Operator in an {product-title} cluster running in FIPS mode.
 +
-[IMPORTANT]
-====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode].
-====
+--
+include::snippets/fips-snippet.adoc[]
+--
 
 [id="compliance-operator-1-3-1-known-issue"]
 === Known issue

--- a/security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+++ b/security/file_integrity_operator/file-integrity-operator-release-notes.adoc
@@ -40,11 +40,10 @@ This update addresses a CVE in an underlying dependency.
 === New features and enhancements
 
 * You can install and use the File Integrity Operator in an {product-title} cluster running in FIPS mode.
-
-[IMPORTANT]
-====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see (link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode])
-====
++
+--
+include::snippets/fips-snippet.adoc[]
+--
 
 [id="file-integrity-operator-1-3-3-bug-fixes"]
 === Bug fixes

--- a/snippets/fips-snippet.adoc
+++ b/snippets/fips-snippet.adoc
@@ -1,0 +1,34 @@
+// Text snippet included in the following modules:
+//
+// * modules/agent-installer-fips-compliance.adoc
+// * modules/installation-aws-config-yaml.adoc
+// * modules/installation-aws-config-yaml.adoc
+// * modules/installation-azure-config-yaml.adoc
+// * modules/installation-azure-config-yaml.adoc
+// * modules/installation-azure-config-yaml.adoc
+// * modules/installation-azure-config-yaml.adoc
+// * modules/installation-azure-stack-hub-config-yaml.adoc
+// * modules/installation-bare-metal-config-yaml.adoc
+// * modules/installation-configuration-parameters.adoc
+// * modules/installation-gcp-config-yaml.adoc
+// * modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
+// * modules/installation-ibm-cloud-config-yaml.adoc
+// * modules/installation-vsphere-config-yaml.adoc
+// * modules/machine-config-overview.adoc
+// * modules/rhel-compute-requirements.adoc
+// * modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
+// * modules/security-compliance-nist.adoc
+//
+// Text snippet included in the following assemblies:
+//
+// * security/compliance_operator/compliance-operator-release-notes.adoc
+// * security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+[IMPORTANT]
+====
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode].
+
+When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-10138

Link to docs preview:

https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_alibaba/installation-config-parameters-alibaba.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installation-config-parameters-aws.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-china.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-customizations.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-government-region.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-network-customizations.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-private.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-secret-region.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-vpc.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/installation-config-parameters-azure.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-customizations.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-government-region.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-network-customizations.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-private.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-vnet.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-restricted-networks-azure-installer-provisioned.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installation-config-parameters-ash.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installation-config-parameters-bare-metal.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal-network-customizations.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-restricted-networks-bare-metal.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installation-config-parameters-gcp.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-private.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-vpc.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installation-config-parameters-ibm-cloud-vpc.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_power/installation-config-parameters-ibm-power.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_power/installing-ibm-power.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_power/installing-restricted-networks-ibm-power.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installation-config-parameters-ibm-z.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z-kvm.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z-lpar.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-restricted-networks-ibm-z.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-restricted-networks-ibm-z-lpar.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installation-config-parameters-nutanix.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installation-config-parameters-openstack.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_platform_agnostic/installing-platform-agnostic.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/installing-restricted-networks-vsphere.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/installing-vsphere.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/installing-vsphere-network-customizations.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installation-config-parameters-agent.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/adding-rhel-compute.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/more-rhel-compute.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-release-notes.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/container_security/security-compliance.html
https://77098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/file_integrity_operator/file-integrity-operator-release-notes.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

**Adding this snippet for repetitive FIPS notes, so that I can use them in two future async operator release notes.**

There are only a few differences visually after this PR:
* File integrity operator and compliance operator release notes have the additional sentence "
When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures."
** Confirm with whoever is maintaining these operators these days that this is okay
* Fixed bullet indentation in modules/machine-config-overview.adoc and modules/rhel-compute-requirements.adoc because they were incorrect in the live docs. Confirm with Ben if this is okay.
