### PR TITLE
ROX-23494: Add responsibility matrix for ACS

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -42,6 +42,8 @@ Distros: openshift-acs
 Topics:
 - Name: Service description
   File: rhacs-cloud-service-service-description
+- Name: Overview of responsibilities for RHACS Cloud Service
+  File: acs-cloud-responsibility-matrix
 - Name: RHACS Cloud Service architecture
   File: acscs-architecture
 - Name: Getting started with RHACS Cloud Service

--- a/cloud_service/acs-cloud-responsibility-matrix.adoc
+++ b/cloud_service/acs-cloud-responsibility-matrix.adoc
@@ -1,0 +1,11 @@
+[id="acs-cloud-policy-responsibility-matrix"]
+:_mod-docs-content-type: ASSEMBLY
+include::modules/common-attributes.adoc[]
+:context: acs-cloud-responsibility-matrix
+= Overview of responsibilities for Red Hat Advanced Cluster Security Cloud Service
+
+toc::[]
+
+This documentation outlines Red Hat and customer responsibilities for the {product-title-managed-short} managed service.
+
+include::modules/acs-cloud-responsibilities.adoc[leveloffset=+1]

--- a/modules/acs-cloud-responsibilities.adoc
+++ b/modules/acs-cloud-responsibilities.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * cloud_service/acs-cloud-responsibility-matrix.adoc
+:_mod-docs-content-type: CONCEPT
+[id="acs-cloud-responsibilities_{context}"]
+= Shared responsibilities for {product-title-managed-short}
+
+While Red Hat manages the {product-title-managed-short} services, also referred to as _Central services_, the customer has certain responsibilities.
+
+[cols="2,1,1",options="header"]
+|===
+
+|Resource or action
+|Red Hat responsibility
+|Customer responsibility
+
+
+|Hosted components, also called Central components
+a|* Platform monitoring
+* Software updates
+* High availability
+* Backup and restore
+* Security
+* Infrastructure configuration
+* Scaling
+* Maintenance
+* Vulnerability management
+a| * Access and identity authorization
+
+|Secured clusters (on-premise or cloud)
+|
+a| * Software updates
+* Backup and restore
+* Security
+* Infrastructure configuration
+* Scaling
+* Maintenance
+* Access and identity authorization
+* Vulnerability management
+
+|===


### PR DESCRIPTION
Version(s):

RHACS 4.4+

[Issue
](https://issues.redhat.com/browse/ROX-23494)

[Link to docs preview
](https://77107--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/acs-cloud-responsibility-matrix.html)

QE review: (**ACS has no QE, reviewed/ack'd by SME**)
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Modeled on the [ROSA matrix](https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.html), should we have more rows/columns, and if so, what should be in here?
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
