### PR TITLE
[enterprise-4.12] OSSM-6420 OSSM 2.5.2, 2.4.8, and 2.3.12: [DOC] Release Notes, Known I…

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -148,7 +148,7 @@ endif::[]
 :product-rosa: Red Hat OpenShift Service on AWS
 :SMProductName: Red Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 2.5.1
+:SMProductVersion: 2.5.2
 :MaistraVersion: 2.5
 :KialiProduct: Kiali Operator provided by Red Hat
 :SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin

--- a/modules/ossm-rn-fixed-issues.adoc
+++ b/modules/ossm-rn-fixed-issues.adoc
@@ -15,7 +15,21 @@ Provide the following info for each issue if possible:
 ////
 
 The following issues have been resolved in the current release:
-//current release is 2.5.1/2.4.7/2.3.11 scheduled for April 18, 2024
+
+//current release is 2.5.2/2.4.8/2.3.12 scheduled for May 22, 2024
+
+* https://issues.redhat.com/browse/OSSM-6331[OSSM-6331] Previously, the `smcp.general.logging.componentLevels` spec accepted invalid `LogLevel` values, and the `ServiceMeshControlPlane` resource was still created. Now, the terminal shows an error message if an invalid value is used, and the control plane is not created.
+
+* https://issues.redhat.com/browse/OSSM-6290[OSSM-6290] Previously, the **Project** filter of the **Istio Config** list page did not work correctly. All `istio config` items were displayed from all namespaces even if you selected a specific project from the drop-down menu. Now, only the `istio config` items that belong to the selected project in the filter dropdown are displayed.
+
+* https://issues.redhat.com/browse/OSSM-6298[OSSM-6298] Previously, when you clicked an item reference within the {SMPlugin}, the console sometimes performed multiple redirects before opening the desired page. As a result, navigating back to the previous page that was open in the console caused your web browser to open the wrong page. Now, these redirects do not occur, and clicking *Back* in a web browser brings you to the correct page.
+
+* https://issues.redhat.com/browse/OSSM-6299[OSSM-6299] Previously, in {product-title} 4.15, when you clicked the **Node graph** menu option of any node menu within the traffic graph, the node graph was not displayed. Instead, the page refreshed with the same traffic graph. Now, clicking the **Node graph** menu option correctly displays the node graph.
+
+The following issues have been resolved in previous releases:
+
+[id="ossm-rn-fixed-issues-ossm_{context}"]
+== {SMProductShortName} fixed issues
 
 * https://issues.redhat.com/browse/OSSM-6177[OSSM-6177] Previously, when validation messages were enabled in the `ServiceMeshControlPlane` (SMCP), the `istiod` crashed continuously unless `GatewayAPI` support was enabled. Now, when validation messages are enabled but `GatewayAPI` support is not, the `istiod` does not continuously crash.
 
@@ -36,11 +50,6 @@ The following issues have been resolved in the current release:
 * https://issues.redhat.com/browse/OSSM-5902[OSSM-5902] Previously, the {SMPlugin} redirected to a "Not Found Page" error when the user clicked the **Istio config** health symbol on the **Overview** page. Now, the plugin redirects to the correct **Istio config** details page.
 
 * https://issues.redhat.com/browse/OSSM-5541[OSSM-5541] Previously, an Istio operator pod might keep waiting for the leader lease in some restart conditions. Now, the leader election implementation has been enhanced to avoid this issue.
-
-The following issues have been resolved in previous releases:
-
-[id="ossm-rn-fixed-issues-ossm_{context}"]
-== {SMProductShortName} fixed issues
 
 * https://issues.redhat.com/browse/OSSM-1397[OSSM-1397] Previously, if you removed the `maistra.io/member-of` label from a namespace, the {SMProductShortName} Operator did not automatically reapply the label to the namespace. As a result, sidecar injection did not work in the namespace.
 +

--- a/modules/ossm-rn-known-issues.adoc
+++ b/modules/ossm-rn-known-issues.adoc
@@ -201,14 +201,6 @@ New issues for Kiali should be created in the link:https://issues.redhat.com/pro
 
 These are the known issues in Kiali:
 
-// Separate PR since only applies to 4.15 * https://issues.redhat.com/browse/OSSM-6299[OSSM-6299] In {product-title} 4.15, when you click the **Node graph** menu option of any node menu within the traffic graph, the node graph is not displayed. Instead, the page is refreshed with the same traffic graph. Currently, no workaround exists for this issue.
-
-* https://issues.redhat.com/browse/OSSM-6298[OSSM-6298] When you click an item reference within the {SMPlugin}, such as a workload link related to a specific service, the console sometimes performs multiple redirections before opening the desired page. If you click *Back* in a web browser, a different page of the console opens instead of the previous page.
-+
-Workaround: In the web browser, click *Back* twice to navigate to the previous page.
-
-// Separate PR since only applies to 4.15 * https://issues.redhat.com/browse/OSSM-6290[OSSM-6290] For {product-title} 4.15, the **Project** filter of the **Istio Config** list page does not work correctly. All `istio` items are displayed even if you select a specific project from the dropdown. Currently, no workaround exists for this issue.
-
 //Keep KIALI-2206 in RN as this is for information purposes.
 * link:https://issues.jboss.org/browse/KIALI-2206[KIALI-2206] When you are accessing the Kiali console for the first time, and there is no cached browser data for Kiali, the “View in Grafana” link on the Metrics tab of the Kiali Service Details page redirects to the wrong location. The only way you would encounter this issue is if you are accessing Kiali for the first time.
 //Keep KIALI-507 in RN as this is for information purposes.

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -15,6 +15,34 @@ Module included in the following assemblies:
 
 This release adds improvements related to the following components and concepts.
 
+[id="new-features-ossm-2-5-2"]
+== New features {SMProductName} version 2.5.2
+
+//Release is scheduled for May 22, 2024.
+//As of May 8, there are no new features so the phrase "new features" has been removed. This is a z-stream release to update containers before they are Grade B or C on May 28.
+//Includes 2.5.2, 2.4.8, 2.3.12
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.12 and later.
+
+The most current version of the {SMProductName} Operator can be used with all supported versions of {SMProductShortName}. The version of {SMProductShortName} is specified using the `ServiceMeshControlPlane`.
+
+=== Component versions for {SMProductName} version 2.5.2
+
+// Release is scheduled for May 22, 2024. Code and Doc Freeze is scheduled for May 10, 2024. Component versions should be available after May 10.
+
+|===
+|Component |Version
+
+|Istio
+|1.18.5
+
+|Envoy Proxy
+|1.26.8
+
+|Kiali
+|1.73.8
+|===
+
 [id="new-features-ossm-2-5-1"]
 == New features {SMProductName} version 2.5.1
 
@@ -148,6 +176,34 @@ A new version of the Gateway API custom resource definition (CRD) is now availab
 |1.16.x
 |0.5.1
 |For multitenant mesh deployment, all Gateway API CRDs must be present. Use the experimental branch.
+|===
+
+[id="new-features-ossm-2-4-8"]
+== New features {SMProductName} version 2.4.8
+
+//Release is scheduled for May 22, 2024.
+//As of May 8, there are no new features so the phrase "new features" has been removed. This is a z-stream release to update containers before they are Grade B or C on May 28.
+//Includes 2.5.2, 2.4.8, 2.3.12
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.12 and later.
+
+The most current version of the {SMProductName} Operator can be used with all supported versions of {SMProductShortName}. The version of {SMProductShortName} is specified using the `ServiceMeshControlPlane`.
+
+=== Component versions for {SMProductName} version 2.4.8
+
+// Release is scheduled for May 22, 2024. Code and Doc Freeze is scheduled for May 10, 2024. Component versions should be available after May 10.
+
+|===
+|Component |Version
+
+|Istio
+|1.16.7
+
+|Envoy Proxy
+|1.24.12
+
+|Kiali
+|1.65.11
 |===
 
 [id="new-features-ossm-2-4-7"]
@@ -460,6 +516,34 @@ spec:
 * HBONE protocol for sidecars is an experimental feature that is not supported.
 * {SMProductShortName} on ARM64 architecture is not supported.
 * OpenTelemetry API remains a Technology Preview feature.
+
+[id="new-features-ossm-2-3-12"]
+== New features {SMProductName} version 2.3.12
+
+//Release is scheduled for May 22, 2024.
+//As of May 8, there are no new features so the phrase "new features" has been removed. This is a z-stream release to update containers before they are Grade B or C on May 28.
+//Includes 2.5.2, 2.4.8, 2.3.12
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.12 and later.
+
+The most current version of the {SMProductName} Operator can be used with all supported versions of {SMProductShortName}. The version of {SMProductShortName} is specified using the `ServiceMeshControlPlane`.
+
+=== Component versions for {SMProductName} version 2.3.12
+
+// Release is scheduled for May 22, 2024. Code and Doc Freeze is scheduled for May 10, 2024. Component versions should be available after May 10.
+
+|===
+|Component |Version
+
+|Istio
+|1.14.5
+
+|Envoy Proxy
+|1.22.11
+
+|Kiali
+|1.57.14
+|===
 
 [id="new-features-ossm-2-3-11"]
 == New features {SMProductName} version 2.3.11


### PR DESCRIPTION
[enterprise-4.12] [OSSM-6420](https://issues.redhat.com//browse/OSSM-6420) OSSM 2.5.2, 2.4.8, and 2.3.12: [DOC] Release Notes, Known Issues and Bug Fixes

Cherry Picked from 0a72caf82dc52c1eb3d91bf3ae77e09513e65eef xref: https://github.com/openshift/openshift-docs/pull/75663. 


<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12

Issue:
https://issues.redhat.com//browse/OSSM-6420

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->



Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
