### PR TITLE
OSDOCS#10138:Removing unsupported versions of OSSO and adding note ab…

### DIFF
--- a/nodes/scheduling/secondary_scheduler/index.adoc
+++ b/nodes/scheduling/secondary_scheduler/index.adoc
@@ -8,5 +8,8 @@ toc::[]
 
 You can install the {secondary-scheduler-operator} to run a custom secondary scheduler alongside the default scheduler to schedule pods.
 
+:operator-name: The {secondary-scheduler-operator}
+include::snippets/operator-not-available.adoc[]
+
 // About the {secondary-scheduler-operator}
 include::modules/nodes-secondary-scheduler-about.adoc[leveloffset=+1]

--- a/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.adoc
+++ b/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.adoc
@@ -4,9 +4,13 @@
 include::_attributes/common-attributes.adoc[]
 :context: secondary-scheduler-configuring
 
+toc::[]
+
 You can run a custom secondary scheduler in {product-title} by installing the {secondary-scheduler-operator}, deploying the secondary scheduler, and setting the secondary scheduler in the pod definition.
 
-toc::[]
+:operator-name: The {secondary-scheduler-operator}
+include::snippets/operator-not-available.adoc[]
+
 
 // Installing the {secondary-scheduler-operator}
 include::modules/nodes-secondary-scheduler-install-console.adoc[leveloffset=+1]

--- a/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
+++ b/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
@@ -10,57 +10,7 @@ The {secondary-scheduler-operator-full} allows you to deploy a custom secondary 
 
 These release notes track the development of the {secondary-scheduler-operator-full}.
 
+:operator-name: The {secondary-scheduler-operator}
+include::snippets/operator-not-available.adoc[]
+
 For more information, see xref:../../../nodes/scheduling/secondary_scheduler/index.adoc#nodes-secondary-scheduler-about_nodes-secondary-scheduler-about[About the {secondary-scheduler-operator}].
-
-[id="secondary-scheduler-operator-release-notes-1.2.1"]
-== Release notes for {secondary-scheduler-operator-full} 1.2.1
-
-Issued: 2024-03-06
-
-The following advisory is available for the {secondary-scheduler-operator-full} 1.2.1:
-
-* link:https://access.redhat.com/errata/RHSA-2024:0281[RHSA-2024:0281]
-
-[id="secondary-scheduler-operator-1.2.1-new-features-and-enhancements"]
-=== New features and enhancements
-
-[discrete]
-==== Resource limits removed to support large clusters
-
-With this release, resource limits were removed to allow you to use the {secondary-scheduler-operator} for large clusters with many nodes and pods without failing due to out-of-memory errors.
-
-[id="secondary-scheduler-1.2.1-bug-fixes"]
-=== Bug fixes
-
-* This release of the {secondary-scheduler-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
-
-[id="secondary-scheduler-operator-1.2.1-known-issues"]
-=== Known issues
-
-* Currently, you cannot deploy additional resources, such as config maps, CRDs, or RBAC policies through the {secondary-scheduler-operator}. Any resources other than roles and role bindings that are required by your custom secondary scheduler must be applied externally. (link:https://issues.redhat.com/browse/WRKLDS-645[*WRKLDS-645*])
-
-[id="secondary-scheduler-operator-release-notes-1.2.0"]
-== Release notes for {secondary-scheduler-operator-full} 1.2.0
-
-Issued: 2023-11-01
-
-The following advisory is available for the {secondary-scheduler-operator-full} 1.2.0:
-
-* link:https://access.redhat.com/errata/RHSA-2023:6154[RHSA-2023:6154]
-
-////
-// No enhancements in this release
-[id="secondary-scheduler-operator-1.2.0-new-features-and-enhancements"]
-=== New features and enhancements
-* None
-////
-
-[id="secondary-scheduler-1.2.0-bug-fixes"]
-=== Bug fixes
-
-* This release of the {secondary-scheduler-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
-
-[id="secondary-scheduler-operator-1.2.0-known-issues"]
-=== Known issues
-
-* Currently, you cannot deploy additional resources, such as config maps, CRDs, or RBAC policies through the {secondary-scheduler-operator}. Any resources other than roles and role bindings that are required by your custom secondary scheduler must be applied externally. (link:https://issues.redhat.com/browse/WRKLDS-645[*WRKLDS-645*])

--- a/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-uninstalling.adoc
+++ b/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-uninstalling.adoc
@@ -8,6 +8,9 @@ toc::[]
 
 You can remove the {secondary-scheduler-operator-full} from {product-title} by uninstalling the Operator and removing its related resources.
 
+:operator-name: The {secondary-scheduler-operator}
+include::snippets/operator-not-available.adoc[]
+
 // Uninstalling the {secondary-scheduler-operator}
 include::modules/nodes-secondary-scheduler-uninstall-console.adoc[leveloffset=+1]
 


### PR DESCRIPTION
…out no version available at GA

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-10138

Link to docs preview:

https://77126--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/index.html
https://77126--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.html
https://77126--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.html
https://77126--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-uninstalling.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
