### PR TITLE
OSDOCS-8015: Adding a total resource usage table

### DIFF
--- a/modules/network-observability-total-resource-usage.adoc
+++ b/modules/network-observability-total-resource-usage.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+// * network_observability/configuring_operator.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-total-resource-usage-table_{context}"]
+= Total average memory and CPU usage
+
+The following table outlines averages of total resource usage for clusters with a sampling value of 1, 50, and 400 for 3 different tests: `Test 1`, `Test 2`, and `Test 3`. The tests differ in the following ways:
+
+- `Test 1` takes into account the total number of namespace, pods and services in an {product-title} cluster, places load on the eBPF agent, and represents use cases with a high number of workloads for a given cluster size. For example, `Test 1` consists of 76 Namespaces, 5153 Pods, and 2305 Services.
+- `Test 2` takes into account a high ingress traffic volume.
+- `Test 3` takes into account the total number of namespace, pods and services in an {product-title} cluster, places load on the eBPF agent on a larger scale than `Test 1`, and represents use cases with a high number of workloads for a given cluster size. For example, `Test 3` consists of 553 Namespaces, 6998 Pods, and 2508 Services.
+
+Since different types of cluster use cases are exemplified in the different tests, the numbers in this table cannot be linearly compared side-by-side, but instead are intended to be used as a benchmark for evaluating your personal cluster usage. The examples outlined in the table demonstrate scenarios that are tailored to specific workloads. Consider each example only as a baseline from which adjustments can be made to accommodate your workload needs.
+
+[NOTE]
+====
+Metrics exported to Prometheus can impact the resource usage. Cardinality values for the metrics can help determine how much resources are impacted. For more information, see "Network Flows format" in the Additional resources section.
+====
+
+.Total average resource usage
+[%autowidth, options="header"]
+|===
+| Sampling value | Parameters | Test 1 (25 nodes) | Test 2 (65 nodes) | Test 3 (120 nodes)
+.6+| *Sampling = 1* | *With Loki* 3+|
+| Total NetObserv CPU Usage | 3.24 | 3.42 | 7.30
+| Total NetObserv RSS (Memory) Usage | 14.09 GB | 22.56 GB | 36.46 GB
+| *Without Loki* 3+|
+| Total NetObserv CPU Usage | 2.40 | 2.43 | 5.59
+| Total NetObserv RSS (Memory) Usage | 6.85 GB | 10.39 GB | 13.92 GB
+.6+| *Sampling = 50* | *With Loki* 3+|
+| Total NetObserv CPU Usage | 2.04 | 2.36 | 3.31
+| Total NetObserv RSS (Memory) Usage | 8.79 GB | 19.14 GB | 21.07 GB
+| *Without Loki* 3+|
+| Total NetObserv CPU Usage | 1.55 | 1.64 | 2.70
+| Total NetObserv RSS (Memory) Usage | 6.71 GB | 10.15 GB | 14.82 GB
+.6+| *Sampling = 400* | *With Loki* 3+|
+| Total NetObserv CPU Usage | 1.71 | 1.44 | 2.36
+| Total NetObserv RSS (Memory) Usage | 8.21 GB | 16.02 GB | 17.44 GB
+| *Without Loki* 3+|
+| Total NetObserv CPU Usage | 1.31 | 1.06 | 1.83
+| Total NetObserv RSS (Memory) Usage | 7.01 GB | 10.70 GB | 13.26 GB
+|===
+
+
+Summary: This table shows average total resource usage of Network Observability (Agents+FLP+Kafka+Loki).

--- a/observability/network_observability/configuring-operator.adoc
+++ b/observability/network_observability/configuring-operator.adoc
@@ -31,3 +31,8 @@ For more information about creating the `SriovNetwork` custom resource, see xref
 
 include::modules/network-observability-resource-recommendations.adoc[leveloffset=+1]
 include::modules/network-observability-resources-table.adoc[leveloffset=+2]
+include::modules/network-observability-total-resource-usage.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../observability/network_observability/json-flows-format-reference.adoc#network-observability-flows-format_json_reference[Network Flows format reference].


### PR DESCRIPTION
[OSDOCS#8015]: Adding a total resource usage table

Version(s): 

Issue: https://issues.redhat.com/browse/OSDOCS-8015

Link to docs preview:
https://77127--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/configuring-operator.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Table mockup: https://docs.google.com/document/d/1xyBeIehZwyV_p7GkP9uJbr1ay5vFFcWsZwi3SENtB70/edit?usp=sharing
