### PR TITLE
TELCODOCS-1847: Make it possible to unload several kmods

### DIFF
--- a/modules/kmm-replacing-in-tree-modules-with-out-of-tree-modules.adoc
+++ b/modules/kmm-replacing-in-tree-modules-with-out-of-tree-modules.adoc
@@ -10,7 +10,7 @@ You can use Kernel Module Management (KMM) to build kernel modules that can be l
 
 Dynamically loaded modules include in-tree modules and out-of-tree (OOT) modules. In-tree modules are internal to the Linux kernel tree, that is, they are already part of the kernel. Out-of-tree modules are external to the Linux kernel tree. They are generally written for development and testing purposes, such as testing the new version of a kernel module that is shipped in-tree, or to deal with incompatibilities.
 
-Some modules loaded by KMM could replace in-tree modules already loaded on the node. To unload an in-tree module before loading your module, set the `.spec.moduleLoader.container.inTreeModuleToRemove` field. The following is an example for module replacement for all kernel mappings:
+Some modules that are loaded by KMM could replace in-tree modules that are already loaded on the node. To unload in-tree modules before loading your module, set the value of the `.spec.moduleLoader.container.inTreeModulesToRemove` field to the modules that you want to unload. The following example demonstrates module replacement for all kernel mappings:
 
 [source,yaml]
 ----
@@ -21,12 +21,10 @@ spec:
       modprobe:
         moduleName: mod_a
 
-      inTreeModuleToRemove: mod_b
+      inTreeModulesToRemove: [mod_a, mod_b]
 ----
 
-In this example, the `moduleLoader` pod uses `inTreeModuleToRemove` to unload the in-tree `mod_b` before loading `mod_a`
-from the `moduleLoader` image.
-When the `moduleLoader`pod is terminated and `mod_a` is unloaded, `mod_b` is not loaded again.
+In this example, the `moduleLoader` pod uses `inTreeModulesToRemove` to unload the in-tree `mod_a` and `mod_b` before loading `mod_a` from the `moduleLoader` image. When the `moduleLoader`pod is terminated and `mod_a` is unloaded, `mod_b` is not loaded again.
 
 The following is an example for module replacement for specific kernel mappings:
 
@@ -38,6 +36,6 @@ spec:
     container:
       kernelMappings:
         - literal: 6.0.15-300.fc37.x86_64
-          containerImage: some.registry/org/my-kmod:6.0.15-300.fc37.x86_64
-          inTreeModuleToRemove: <module_name>
+          containerImage: "some.registry/org/my-kmod:${KERNEL_FULL_VERSION}"
+          inTreeModulesToRemove: [<module_name>, <module_name>]
 ----


### PR DESCRIPTION
D/S Docs:[MGMT-16638] Make it possible to unload several kmods

Jira: https://issues.redhat.com/browse/TELCODOCS-1847

Version(s): openshift-4.14, openshift-4.15, openshift-4.16

Fix version: KMMO 2.1

Link to docs preview: https://77130--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html#kmm-replacing-in-tree-modules-with-out-of-tree-modules_kernel-module-management-operator

Dev review: @qbarrand
QE review: @cdvultur
