### PR TITLE
[RHACS] fixed the scripts download link

### DIFF
--- a/modules/configure-additional-cas.adoc
+++ b/modules/configure-additional-cas.adoc
@@ -9,7 +9,7 @@ To add custom CAs:
 
 .Procedure
 
-. Download the link:https://raw.githubusercontent.com/openshift/openshift-docs/rhacs-docs/files/ca-setup.sh[`ca-setup.sh`] script.
+. Download the link:https://raw.githubusercontent.com/openshift/openshift-docs/rhacs-docs-main/files/ca-setup.sh[`ca-setup.sh`] script.
 +
 [NOTE]
 ====

--- a/modules/helm-generate-root-certificates.adoc
+++ b/modules/helm-generate-root-certificates.adoc
@@ -17,7 +17,7 @@ The generated `values-private.yaml` file has sensitive configuration options. En
 
 .Procedure
 
-. Download the link:https://raw.githubusercontent.com/openshift/openshift-docs/rhacs-docs/files/create_certificate_values_file.sh[`create_certificate_values_file.sh`] script.
+. Download the link:https://raw.githubusercontent.com/openshift/openshift-docs/rhacs-docs-main/files/create_certificate_values_file.sh[`create_certificate_values_file.sh`] script.
 . Make the `create_certificate_values_file.sh` script executable:
 +
 [source,terminal]


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-24556

Preview:
- https://77138--ocpdocs-pr.netlify.app/openshift-acs/latest/configuration/add-trusted-ca.html
- https://77138--ocpdocs-pr.netlify.app/openshift-acs/latest/upgrading/upgrade-helm.html

Fixed the broken link to download the following scripts:
- `ca-setup.sh`
- `create_certificate_values_file.sh`

cherrypick into:
- `rhacs-docs-4.5`
- `rhacs-docs-4.4`
- `rhacs-docs-4.3`
- `rhacs-docs-4.2`


---

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.
