### PR TITLE
OCPBUGS-31103 update SriovOperatorConfig for Telco DU profile

### DIFF
--- a/snippets/ztp_SriovOperatorConfig.yaml
+++ b/snippets/ztp_SriovOperatorConfig.yaml
@@ -3,7 +3,8 @@ kind: SriovOperatorConfig
 metadata:
   name: default
   namespace: openshift-sriov-network-operator
-  annotations: {}
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
 spec:
   configDaemonNodeSelector:
     "node-role.kubernetes.io/$mcp": ""
@@ -20,6 +21,8 @@ spec:
   #          openshift.io/<resource_name>:  "1"
   #        requests:
   #          openshift.io/<resource_name>:  "1"
-  enableInjector: true
-  enableOperatorWebhook: true
+  enableInjector: false
+  enableOperatorWebhook: false
+  # Disable drain is needed for single-node OpenShift.
+  disableDrain: true
   logLevel: 0


### PR DESCRIPTION
[OCPBUGS-31103]: On an SNO node with Telco DU profile SriovOperatorConfig doesn't get disableDrain set to true

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-31103
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://77149--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-reference-cluster-configuration-for-vdu.html#ztp-sno-du-configuring-sriov_sno-configure-for-vdu
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
