### PR TITLE
OSDOCS-10745: adds 4.15.17 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -331,3 +331,12 @@ Issued: 2024-06-05
 The {product-title} release 4.15.16 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:3490[RHBA-2024:3490] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:3488[RHBA-2024:3488] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-15-17-dp"]
+=== RHBA-2024:3675 - {microshift-short} 4.15.17 bug fix and update advisory
+
+Issued: 2024-06-11
+
+The {product-title} release 4.15.17 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:3675[RHBA-2024:3675] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:3673[RHBA-2024:3673] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-10745](https://issues.redhat.com/browse/OSDOCS-10745)

Link to docs preview:
[4.15.17 async release note](https://77150--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-17-dp)

QE review:
- N/A stock text, no other release notes