### PR TITLE
[enterprise-4.13] OSDOCS#9399: Added NTP/UDP 123 port in network connectivity requirements

### DIFF
--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -217,7 +217,7 @@ the Cluster Version Operator on port `9099`.
 |`10256`
 |openshift-sdn
 
-.5+|UDP
+.6+|UDP
 |`4789`
 |VXLAN
 
@@ -232,6 +232,11 @@ the Cluster Version Operator on port `9099`.
 
 |`4500`
 |IPsec NAT-T packets
+
+|`123`
+|Network Time Protocol (NTP) on UDP port `123`
+
+If an external NTP time server is configured, you must open UDP port `123`.
 
 |TCP/UDP
 |`30000`-`32767`


### PR DESCRIPTION
Version(s):
4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Cherry-picked from: 9efd4421d662d536509d10ccbe76d8b1de894570

xref: https://github.com/openshift/openshift-docs/pull/75863