### PR TITLE
OSDOCS-10746: adds 4.14.29 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -539,4 +539,11 @@ Issued: 2024-06-10
 
 {product-title} release 4.14.28 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:3525[RHBA-2024:3525] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:3523[RHSA-2024:3523] advisory.
 
+[id="microshift-4-14-29-dp"]
+=== RHBA-2024:3699 - {microshift-short} 4.14.29 bug fix and enhancement advisory
+
+Issued: 2024-06-13
+
+{product-title} release 4.14.29 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:3699[RHBA-2024:3699] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:3697[RHBA-2024:3697] advisory.
+
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-10746](https://issues.redhat.com/browse/OSDOCS-10746)

Link to docs preview:
[4.14.29 relnote](https://77155--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes.html#microshift-4-14-29-dp)

QE review:
- N/A stock text

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
