### PR TITLE
OSDOCS-8806: cleaning and recreating custom certificates

### DIFF
--- a/microshift_configuring/microshift-custom-ca.adoc
+++ b/microshift_configuring/microshift-custom-ca.adoc
@@ -16,6 +16,8 @@ include::modules/microshift-custom-ca-reserved-names.adoc[leveloffset=+1]
 
 include::modules/microshift-custom-ca-troubleshooting.adoc[leveloffset=+1]
 
+include::modules/microshift-custom-ca-cert-cleaning.adoc[leveloffset=+1]
+
 [id="Additional-resources_microshift-custom-ca_{context}"]
 == Additional resources
 * link:https://docs.openshift.com/container-platform/{ocp-version}/security/certificates/api-server.html#customize-certificates-api-add-named_api-server-certificates[OpenShift: Add an API server named certificate]

--- a/modules/microshift-custom-ca-cert-cleaning.adoc
+++ b/modules/microshift-custom-ca-cert-cleaning.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * microshift_security_compliance/microshift-custom-ca.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-custom-ca-certificates-cleaning_{context}"]
+= Cleaning up and recreating the custom certificates
+
+To stop the {microshift-short} services, clean up the custom certificates and recreate the custom certificates, use the following steps.
+
+.Procedure
+
+. Stop the {microshift-short} services and clean up the custom certificates by running the following command:
++
+[source,terminal]
+----
+$ sudo microshift-cleanup-data --cert
+----
++
+.Example output
+[source,terminal]
+----
+Stopping MicroShift services
+Removing MicroShift certificates
+MicroShift service was stopped
+Cleanup succeeded
+----
+
+. Restart the {microshift-short} services to recreate the custom certificates by running the following command:
++
+[source,terminal]
+----
+$ sudo systemctl start microshift
+----


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-8806](https://issues.redhat.com/browse/OSDOCS-8806)

Link to docs preview:
[Cleaning up and recreating the custom certificates](https://77156--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-custom-ca.html#microshift-custom-ca-certificates-cleaning_microshift-custom-ca)

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.

Additional information:
[Release notes PR](https://github.com/openshift/openshift-docs/pull/77217)
