### PR TITLE
[WIP] Telcodocs 1848: Add PreflightValidation v1beta2

### DIFF
--- a/modules/kmm-build-validation-stage.adoc
+++ b/modules/kmm-build-validation-stage.adoc
@@ -6,20 +6,11 @@
 [id="kmm-build-validation-stage_{context}"]
 = Build validation stage
 
-Build validation is executed only when image validation has failed and there is a `build` section in the `Module` that is relevant for the upgraded kernel. Build validation attempts to run the build job and validate that it finishes successfully.
+Build validation is executed only when image validation has failed and there is a `build` section in the `Module` that is relevant for the upgraded kernel. Build validation attempts to run the build job and validate that it finishes successfully. If the `PushBuiltImage` flag is defined in the `PreflightValidation` custom resource (CR), it also tries to push the resulting image into its repository. The resulting image name is taken from the definition of the `containerImage` field of the `Module` CR.
 
 [NOTE]
 ====
-You must specify the kernel version when running `depmod`, as shown here:
-[source,terminal]
-----
-$ RUN depmod -b /opt ${KERNEL_VERSION}
-----
-====
-
-If the `PushBuiltImage` flag is defined in the `PreflightValidationOCP` custom resource (CR), it will also try to push the resulting image into its repository. The resulting image name is taken from the definition of the `containerImage` field of the `Module` CR.
-
-[NOTE]
-====
-If the `sign` section is defined for the upgraded kernel, then the resulting image will not be the `containerImage` field of the `Module` CR, but a temporary image name, because the resulting image should be the product of Sign flow.
+If the `sign` section is defined for the upgraded kernel, then the resulting image will not be the
+`containerImage` field of the `Module` CR, but a temporary image name, because the resulting image
+should be the product of Sign flow.
 ====

--- a/modules/kmm-example-cr.adoc
+++ b/modules/kmm-example-cr.adoc
@@ -4,26 +4,22 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="kmm-example-cr_{context}"]
-= Example PreflightValidationOCP resource
+= Example PreflightValidation resource
 
-This section shows an example of the `PreflightValidationOCP` resource in the YAML format.
+This section shows an example of the `PreflightValidation` resource in
+the YAML format.
 
-The example verifies all the currently present modules against the upcoming kernel version included in the {product-title} release 4.11.18, which the following release image points to:
-
-[source,terminal]
-----
-quay.io/openshift-release-dev/ocp-release@sha256:22e149142517dfccb47be828f012659b1ccf71d26620e6f62468c264a7ce7863
-----
-
-Because `.spec.pushBuiltImage` is set to `true`, KMM pushes the resulting images of Build/Sign into the defined repositories.
+The example verifies all the currently present modules against the upcoming
+`5.8.18-101.fc31.x86_64` kernel, and push the resulting images of
+Build/Sign into the defined repositories.
 
 [source,yaml]
 ----
-apiVersion: kmm.sigs.x-k8s.io/v1beta1
-kind: PreflightValidationOCP
+apiVersion: kmm.sigs.x-k8s.io/v1beta2
+kind: PreflightValidation
 metadata:
- name: preflight
+  name: preflight
 spec:
- releaseImage: quay.io/openshift-release-dev/ocp-release@sha256:22e149142517dfccb47be828f012659b1ccf71d26620e6f62468c264a7ce7863
- pushBuiltImage: true
+  kernelVersion: 5.8.18-101.fc31.x86_64
+  pushBuiltImage: true
 ----

--- a/modules/kmm-image-validation-stage.adoc
+++ b/modules/kmm-image-validation-stage.adoc
@@ -12,6 +12,4 @@ Image validation consists of two stages:
 
 . Image existence and accessibility. The code tries to access the image defined for the upgraded kernel in the module and get its manifests.
 
-. Verify the presence of the kernel module defined in the `Module` in the correct path for future `modprobe` execution. The correct path is `<dirname>/lib/modules/<upgraded_kernel>/`.
-
-If this validation is successful, it probably means that the kernel module was compiled with the correct Linux headers.
+. Verify the presence of the kernel module defined in the `Module` in the correct path for future `modprobe` execution. If this validation is successful, it probably means that the kernel module was compiled with the correct Linux headers. The correct path is `<dirname>/lib/modules/<upgraded_kernel>/`.

--- a/modules/kmm-replacing-in-tree-modules-with-out-of-tree-modules.adoc
+++ b/modules/kmm-replacing-in-tree-modules-with-out-of-tree-modules.adoc
@@ -10,7 +10,8 @@ You can use Kernel Module Management (KMM) to build kernel modules that can be l
 
 Dynamically loaded modules include in-tree modules and out-of-tree (OOT) modules. In-tree modules are internal to the Linux kernel tree, that is, they are already part of the kernel. Out-of-tree modules are external to the Linux kernel tree. They are generally written for development and testing purposes, such as testing the new version of a kernel module that is shipped in-tree, or to deal with incompatibilities.
 
-Some modules loaded by KMM could replace in-tree modules already loaded on the node. To unload an in-tree module before loading your module, set the `.spec.moduleLoader.container.inTreeModuleToRemove` field. The following is an example for module replacement for all kernel mappings:
+Some modules loaded by KMM could replace in-tree modules already loaded on the node. To unload in-tree modules before loading your module, set `.spec.moduleLoader.container.inTreeModulesToRemove`.
+The following is an example for module replacement for all kernel mappings:
 
 [source,yaml]
 ----
@@ -21,12 +22,10 @@ spec:
       modprobe:
         moduleName: mod_a
 
-      inTreeModuleToRemove: mod_b
+      inTreeModulesToRemove: mod_a, mod_b
 ----
 
-In this example, the `moduleLoader` pod uses `inTreeModuleToRemove` to unload the in-tree `mod_b` before loading `mod_a`
-from the `moduleLoader` image.
-When the `moduleLoader`pod is terminated and `mod_a` is unloaded, `mod_b` is not loaded again.
+In this example, the `moduleLoader` pod uses `inTreeModulesToRemove` to unload the in-tree `mod_b` before loading `mod_a` from the `moduleLoader` image. When the `moduleLoader`pod is terminated and `mod_a` is unloaded, `mod_b` is not loaded again.
 
 The following is an example for module replacement for specific kernel mappings:
 
@@ -38,6 +37,6 @@ spec:
     container:
       kernelMappings:
         - literal: 6.0.15-300.fc37.x86_64
-          containerImage: some.registry/org/my-kmod:6.0.15-300.fc37.x86_64
-          inTreeModuleToRemove: <module_name>
+          containerImage: "some.registry/org/my-kmod:${KERNEL_FULL_VERSION}"
+          inTreeModulesToRemove: <module_name>, <module_name>
 ----

--- a/modules/kmm-sign-validation-stage.adoc
+++ b/modules/kmm-sign-validation-stage.adoc
@@ -6,13 +6,11 @@
 [id="kmm-sign-validation-stage_{context}"]
 = Sign validation stage
 
-Sign validation is executed only when image validation has failed, there is a `sign` section in the `Module` that is relevant for the upgrade kernel, and build validation finished successfully in the event there was a `build` section in the `Module` relevant for the upgraded kernel. Sign validation will try to run the sign job and validate that it finishes successfully.
+Sign validation is executed only when image validation has failed. There is a `sign` section in the `Module` resource that is relevant for the upgrade kernel, and build validation finishes successfully in the event there was a `build` section in the `Module` relevant for the upgraded kernel. Sign validation attempts to run the sign job and validate that it finishes successfully.
 
-If the `PushBuiltImage` flag is defined in the `PreflightValidationOCP` CR, sign validation will also try to push the resulting image to its registry.
-
-The resulting image is always the image defined in the `containerImage` field of the `Module`. The input image is either the output of the Build stage, or an image defined in the `UnsignedImage` field.
+If the `PushBuiltImage` flag is defined in the `PreflightValidation` CR, sign validation will also try to push the resulting image to its registry. The resulting image is always the image defined in the `ContainerImage` field of the `Module`. The input image is either the output of the Build stage, or an image defined in the `UnsignedImage` field.
 
 [NOTE]
 ====
-If a `build` section exists, the `sign` section input image is the `build` section's output image. Therefore, in order for the input image to be available for the `sign` section, the `PushBuiltImage` flag must be defined in the `PreflightValidationOCP` CR.
+If a `build` section exists, the `sign` section input image is the `build` section's output image. Therefore, in order for the input image to be available for the `sign` section, the `PushBuiltImage` flag must be defined in the `PreflightValidation` CR.
 ====

--- a/modules/kmm-validation-kickoff.adoc
+++ b/modules/kmm-validation-kickoff.adoc
@@ -6,21 +6,10 @@
 [id="kmm-validation-kickoff_{context}"]
 = Validation kickoff
 
-Preflight validation is triggered by creating a `PreflightValidationOCP` resource in the cluster. This spec contains two fields:
+Preflight validation is triggered by creating a `PreflightValidation` resource in the cluster.
+This spec contains two fields:
 
-[source,terminal]
-----
-type PreflightValidationOCPSpec struct {
-	// releaseImage describes the OCP release image that all Modules need to be checked against.
-	// +kubebuilder:validation:Required
-	ReleaseImage string `json:"releaseImage"` <1>
-	// Boolean flag that determines whether images build during preflight must also
-	// be pushed to a defined repository
-	// +optional
-	PushBuiltImage bool `json:"pushBuiltImage"` <2>
-}
-----
+`kernelVersion`:: The version of the kernel that the cluster is upgraded to. This field is required.
 
-<1> `ReleaseImage` - Mandatory field that provides the name of the release image for the {product-title} version the cluster is upgraded to.
-
-<2> `PushBuiltImage` - If `true`, then the images created during the Build and Sign validation are pushed to their repositories (`false` by default).
+`pushBuiltImage`:: If `true`, then the images created during the Build and Sign validation are
+pushed to their repositories. This field is `false` by default.

--- a/modules/kmm-validation-lifecycle.adoc
+++ b/modules/kmm-validation-lifecycle.adoc
@@ -6,6 +6,6 @@
 [id="kmm-validation-lifecycle_{context}"]
 = Validation lifecycle
 
-Preflight validation attempts to validate every module loaded in the cluster. Preflight will stop running validation on a `Module` resource after the validation is successful. In case module validation has failed, you can change the module definitions and Preflight will try to validate the module again in the next loop.
+Preflight validation attempts to validate every module loaded in the cluster. Preflight stops running validation on a `Module` resource after the validation is successful. If case module validation fails, you can change the module definitions and Preflight will try to validate the module again in the next loop.
 
-If you want to run Preflight validation for an additional kernel, then you should create another `PreflightValidationOCP` resource for that kernel. After all the modules have been validated, it is recommended to delete the `PreflightValidationOCP` resource.
+If you want to run Preflight validation for an additional kernel, then you should create another `PreflightValidation` resource for that kernel. After all the modules have been validated, it is recommended to delete the `PreflightValidation` resource.

--- a/modules/kmm-validation-status.adoc
+++ b/modules/kmm-validation-status.adoc
@@ -6,43 +6,23 @@
 [id="kmm-validation-status_{context}"]
 = Validation status
 
-Preflight reports the status and progress of each module in the cluster that it attempts to
-validate.
+A `PreflightValidation` resource reports the status and progress of each module in the cluster that it attempts or has attempted to validate in its `.status.modules` list. Elements of that list contain the following fields:
 
-[source,terminal]
-----
-type CRStatus struct {
-	// Status of Module CR verification: true (verified), false (verification failed),
-	// error (error during verification process), unknown (verification has not started yet)
-	// +required
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=True;False
-	VerificationStatus string `json:"verificationStatus"` <1>
-	// StatusReason contains a string describing the status source.
-	// +optional
-	StatusReason string `json:"statusReason,omitempty"` <2>
-	// Current stage of the verification process:
-	// image (image existence verification), build(build process verification)
-	// +required
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=Image;Build;Sign;Requeued;Done
-	VerificationStage string `json:"verificationStage"` <3>
-	// LastTransitionTime is the last time the CR status transitioned from one status to another.
-	// This should be when the underlying status changed.  If that is not known, then using the time when the API field changed is acceptable.
-	// +required
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Format=date-time
-	LastTransitionTime metav1.Time `json:"lastTransitionTime" protobuf:"bytes,4,opt,name=lastTransitionTime"` <4>
-}
-----
+`lastTransitionTime`:: The last time the `Module` resource status transitioned from one status to another. This should be when the underlying status has changed. If that is not known, then using the time when the API field changed is acceptable.
 
-The following fields apply to each module:
+`name`:: The name of the `Module` resource.
 
-<1> `VerificationStatus` - `true` or `false`, validated or not.
+`namespace`:: The namespace of the `Module` resource.
 
-<2> `StatusReason` - Verbal explanation regarding the status.
+`statusReason`:: Verbal explanation regarding the status.
 
-<3> `VerificationStage` - Describes the validation stage being executed (Image, Build, Sign).
+`verificationStage`:: Describes the validation stage being executed: +
+* `image`: Image existence verification
+* `build`: Build process verification
+* `sign`: Sign process verification
 
-<4> `LastTransitionTime` - The time of the last update to the status.
+`verificationStatus`:: The status of the Module verification: +
+* `true`: Verified
+* `false`: Verification failed
+* `error`: Error during the verification process
+* `unknown`: Verfication has not started

--- a/updating/preparing_for_updates/kmm-preflight-validation.adoc
+++ b/updating/preparing_for_updates/kmm-preflight-validation.adoc
@@ -11,8 +11,9 @@ WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to 
 
 To do: Remove this comment once 4.13 docs are EOL.
 ////
+// Updated for TELCODOCS-1848
 
-Before performing an upgrade on the cluster with applied KMM modules, the administrator must verify that kernel modules installed using KMM are able to be installed on the nodes after the cluster upgrade and possible kernel upgrade. Preflight attempts to validate every `Module` loaded in the cluster, in parallel. Preflight does not wait for validation of one `Module` to complete before starting validation of another `Module`.
+Before performing an upgrade on the cluster with applied KMM modules, you must verify that kernel modules installed using KMM are able to be installed on the nodes after the cluster upgrade and possible kernel upgrade. Preflight attempts to validate every `Module` loaded in the cluster, in parallel. Preflight does not wait for validation of one `Module` to complete before starting validation of another `Module`.
 
 :FeatureName: Kernel Module Management Operator Preflight validation
 


### PR DESCRIPTION
D/S Docs:[MGMT-17268] Add PreflightValidation v1beta2

Jira: https://issues.redhat.com/browse/TELCODOCS-1848?src=confmacro
Version(s): openshift-4.14, openshift-4.15, openshift-4.16

Fix version: KMMO 2.1

Link to docs preview: https://77173--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/kmm-preflight-validation.html

Dev review: @qbarrand
QE review: @cdvultur
