### PR TITLE
OSDOCS#10717 adding ca-west-1 region to AWS docs

### DIFF
--- a/modules/installation-aws-regions.adoc
+++ b/modules/installation-aws-regions.adoc
@@ -29,6 +29,7 @@ The following AWS public regions are supported:
 * `ap-southeast-3` (Jakarta)
 * `ap-southeast-4` (Melbourne)
 * `ca-central-1` (Central)
+* `ca-west-1` (Calgary)
 * `eu-central-1` (Frankfurt)
 * `eu-central-2` (Zurich)
 * `eu-north-1` (Stockholm)


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-10717

Link to docs preview:
https://77185--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#installation-aws-public_installing-aws-account

QE review:
- [ ] QE has approved this change.
