### PR TITLE
ROX-22641: Update policy criteria for k8s resource

### DIFF
--- a/modules/policy-criteria.adoc
+++ b/modules/policy-criteria.adoc
@@ -865,12 +865,18 @@ NOT, +
 | *Runtime* ONLY - Kubernetes Events
 
 | Kubernetes Resource
-| The name of the accessed Kubernetes resource, such as `configmaps` or `secrets`.
+| Type of the accessed Kubernetes resource.
 | Kubernetes Resource
 | One of: +
 
-SECRETS +
-CONFIGMAPS +
+Config maps +
+Secrets +
+ClusterRoles +
+ClusterRoleBindings +
+NetworkPolicies +
+SecurityContextConstraints +
+EgressFirewalls
+
 | ! `OR` only
 | *Runtime* ONLY - Audit Log
 


### PR DESCRIPTION
Version(s):

4.4+

[Issue](https://issues.redhat.com/browse/ROX-22641)

[Link to docs preview
](https://77193--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-security-policies.html#policy-criteria_manage-security-policies)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
