### PR TITLE
Fix VPA install verify step

### DIFF
--- a/modules/nodes-pods-vertical-autoscaler-install.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-install.adoc
@@ -28,6 +28,8 @@ is automatically created if it does not exist.
 
 . Click *Install*.
 
+.Verifiction
+
 . Verify the installation by listing the VPA Operator components:
 
 .. Navigate to *Workloads* -> *Pods*.
@@ -36,7 +38,7 @@ is automatically created if it does not exist.
 
 .. Navigate to *Workloads* -> *Deployments* to verify that there are four deployments running.
 
-. Verify the installation in the {product-title} CLI using the following command:
+. Optional: Verify the installation in the {product-title} CLI using the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
When working on [PR 75005, I inadvertently deleted](https://github.com/openshift/openshift-docs/pull/75005/files#diff-04d1e46ea49170de63c74991681381b1aad601d0371388ce508694ba0b79d8afR38-R39) an _Optional_ tag before a verification step in main and entetprise-4.16. This PR replaces the _Optional_ tag for consistency across all versions and adds a Verification header to the topic. 

QE review not needed
