### PR TITLE
osdocs9673: hiding sigstore section until 4.17

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2608,8 +2608,9 @@ Topics:
     File: nodes-sno-worker-nodes
 - Name: Node metrics dashboard
   File: nodes-dashboard-using
-- Name: Manage secure signatures with sigstore
-  File: nodes-sigstore-using
+# Hiding this section until 4.17.
+#- Name: Manage secure signatures with sigstore
+#  File: nodes-sigstore-using
 ---
 Name: Windows Container Support for OpenShift
 Dir: windows_containers


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-9673](https://issues.redhat.com//browse/OSDOCS-9673)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Additional information: Sigstore features will not be available until 4.17. I'm commenting out this section of the topic map until then.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
