### PR TITLE
OSDOCS#10421 updating Azure Marketplace doc to mention control plane machines

### DIFF
--- a/modules/installation-azure-marketplace-subscribe.adoc
+++ b/modules/installation-azure-marketplace-subscribe.adoc
@@ -31,7 +31,7 @@ endif::[]
 ifndef::mapi[]
 Using the Azure Marketplace offering lets you deploy an {product-title} cluster, which is billed on pay-per-use basis (hourly, per core) through Azure, while still being supported directly by Red{nbsp}Hat.
 
-To deploy an {product-title} cluster using the Azure Marketplace offering, you must first obtain the Azure Marketplace image. The installation program uses this image to deploy worker nodes. When obtaining your image, consider the following:
+To deploy an {product-title} cluster using the Azure Marketplace offering, you must first obtain the Azure Marketplace image. The installation program uses this image to deploy worker or control plane nodes. When obtaining your image, consider the following:
 endif::mapi[]
 ifdef::mapi[]
 You can create a machine set running on Azure that deploys machines that use the Azure Marketplace offering. To use this offering, you must first obtain the Azure Marketplace image. When obtaining your image, consider the following:
@@ -90,7 +90,7 @@ rh-ocp-worker  redhat-limited  rh-ocp-worker-gen1  redhat-limited:rh-ocp-worker:
 +
 [NOTE]
 ====
-Regardless of the version of {product-title} that you install, the correct version of the Azure Marketplace image to use is 4.13. If required, your VMs are automatically upgraded as part of the installation process.
+Use the latest image that is available for compute and control plane nodes. If required, your VMs are automatically upgraded as part of the installation process.
 ====
 . Inspect the image for your offer by running one of the following commands:
 ** North America:
@@ -132,10 +132,10 @@ $ az vm image terms accept --urn redhat:rh-ocp-worker:rh-ocp-worker:<version>
 $ az vm image terms accept --urn redhat-limited:rh-ocp-worker:rh-ocp-worker:<version>
 ----
 ifdef::ipi[]
-. Record the image details of your offer. You must update the `compute` section in the `install-config.yaml` file with values for `publisher`, `offer`, `sku`, and `version` before deploying the cluster.
+. Record the image details of your offer. You must update the `compute` section in the `install-config.yaml` file with values for `publisher`, `offer`, `sku`, and `version` before deploying the cluster. You may also update the `controlPlane` section to deploy control plane machines with the specified image details, or the `defaultMachinePlatform` section to deploy both control plane and compute machines with the specified image details. Use the latest available image for control plane and compute nodes.
 endif::ipi[]
 ifdef::upi[]
-. Record the image details of your offer. If you use the Azure Resource Manager (ARM) template to deploy your worker nodes:
+. Record the image details of your offer. If you use the Azure Resource Manager (ARM) template to deploy your compute nodes:
 +
 .. Update `storageProfile.imageReference` by deleting the `id` parameter and adding the `offer`, `publisher`, `sku`, and `version` parameters by using the values from your offer.
 .. Specify a `plan` for the virtual machines (VMs).
@@ -174,7 +174,7 @@ ifdef::mapi[]
 endif::mapi[]
 
 ifdef::ipi[]
-.Sample `install-config.yaml` file with the Azure Marketplace worker nodes
+.Sample `install-config.yaml` file with the Azure Marketplace compute nodes
 
 [source,yaml]
 ----


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-10421

Link to docs preview:
https://77207--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-customizations.html#installation-azure-marketplace-subscribe_installing-azure-customizations

QE review:
- [x] QE has approved this change.
