### PR TITLE
OSDOCS#10086 reorganizing AWS UPI pre-install (UPI)

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -196,6 +196,10 @@ Topics:
     Dir: upi
     Distros: openshift-origin,openshift-enterprise
     Topics:
+    - Name: Preparing to install a cluster
+      File: upi-aws-preparing-to-install
+    - Name: Installation requirements
+      File: upi-aws-installation-reqs
     - Name: Installing a cluster using CloudFormation templates
       File: installing-aws-user-infra
     - Name: Installing a cluster in a restricted network with user-provisioned infrastructure

--- a/installing/installing_aws/upi/installing-aws-user-infra.adoc
+++ b/installing/installing_aws/upi/installing-aws-user-infra.adoc
@@ -26,6 +26,7 @@ The steps for performing a user-provisioned infrastructure installation are prov
 ====
 If you have an AWS profile stored on your computer, it must not use a temporary session token that you generated while using a multi-factor authentication device. The cluster continues to use your current AWS credentials to create AWS resources for the entire life of the cluster, so you must use key-based, long-term credentials. To generate appropriate keys, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users] in the AWS documentation. You can supply the keys when you run the installation program.
 ====
+* You xref:../../../installing/installing_aws/upi/upi-aws-installation-reqs#upi-aws-installation-reqs[prepared the user-provisioned infrastructure.]
 * You downloaded the AWS CLI and installed it on your computer. See link:https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html[Install the AWS CLI Using the Bundled Installer (Linux, macOS, or UNIX)] in the AWS documentation.
 * If you use a firewall, you xref:../../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 +
@@ -34,38 +35,6 @@ If you have an AWS profile stored on your computer, it must not use a temporary 
 Be sure to also review this site list if you are configuring a proxy.
 ====
 * If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../../installing/installing_aws/ipi/installing-aws-customizations.adoc#manually-create-iam_installing-aws-customizations[manually create and maintain long-term credentials].
-
-include::modules/cluster-entitlements.adoc[leveloffset=+1]
-
-[id="installation-requirements-user-infra_{context}"]
-== Requirements for a cluster with user-provisioned infrastructure
-
-For a cluster that contains user-provisioned infrastructure, you must deploy all
-of the required machines.
-
-This section describes the requirements for deploying {product-title} on user-provisioned infrastructure.
-
-include::modules/installation-machine-requirements.adoc[leveloffset=+2]
-include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../../scalability_and_performance/optimization/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
-
-include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
-include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
-include::modules/csr-management.adoc[leveloffset=+2]
-
-include::modules/installation-aws-user-infra-requirements.adoc[leveloffset=+1]
-
-include::modules/installation-aws-permissions.adoc[leveloffset=+2]
-
-include::modules/installation-aws-marketplace-subscribe.adoc[leveloffset=+1]
-
-include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
-
-include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-user-infra-generate.adoc[leveloffset=+1]
 
@@ -175,8 +144,6 @@ include::modules/installation-aws-user-infra-bootstrap.adoc[leveloffset=+1]
 
 * You can view details about the running instances that are created by using the link:https://console.aws.amazon.com/ec2[AWS EC2 console].
 
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
-
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
 include::modules/installation-approve-csrs.adoc[leveloffset=+1]
@@ -203,13 +170,6 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 .Additional resources
 
 * See xref:../../../web_console/web-console.adoc#web-console[Accessing the web console] for more details about accessing and understanding the {product-title} web console.
-
-include::modules/cluster-telemetry.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* See xref:../../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service.
 
 [role="_additional-resources"]
 [id="installing-aws-user-infra-additional-resources"]

--- a/installing/installing_aws/upi/installing-restricted-networks-aws.adoc
+++ b/installing/installing_aws/upi/installing-restricted-networks-aws.adoc
@@ -42,6 +42,7 @@ Because the installation media is on the mirror host, you can use that computer 
 ====
 If you have an AWS profile stored on your computer, it must not use a temporary session token that you generated while using a multi-factor authentication device. The cluster continues to use your current AWS credentials to create AWS resources for the entire life of the cluster, so you must use key-based, long-term credentials. To generate appropriate keys, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users] in the AWS documentation. You can supply the keys when you run the installation program.
 ====
+* You xref:../../../installing/installing_aws/upi/upi-aws-installation-reqs#upi-aws-installation-reqs[prepared the user-provisioned infrastructure.]
 * You downloaded the AWS CLI and installed it on your computer. See link:https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html[Install the AWS CLI Using the Bundled Installer (Linux, macOS, or UNIX)] in the AWS documentation.
 * If you use a firewall and plan to use the Telemetry service, you xref:../../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
 +
@@ -53,35 +54,7 @@ Be sure to also review this site list if you are configuring a proxy.
 
 include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 
-include::modules/cluster-entitlements.adoc[leveloffset=+1]
-
-[id="installation-requirements-user-infra_{context}"]
-== Requirements for a cluster with user-provisioned infrastructure
-
-For a cluster that contains user-provisioned infrastructure, you must deploy all
-of the required machines.
-
-This section describes the requirements for deploying {product-title} on user-provisioned infrastructure.
-
-include::modules/installation-machine-requirements.adoc[leveloffset=+2]
-include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../../scalability_and_performance/optimization/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
-
-include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
-include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
-include::modules/csr-management.adoc[leveloffset=+2]
-
-include::modules/installation-aws-user-infra-requirements.adoc[leveloffset=+1]
-
-include::modules/installation-aws-permissions.adoc[leveloffset=+2]
-
 //You extract the installation program from the mirrored content.
-
-include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-user-infra-generate.adoc[leveloffset=+1]
 
@@ -163,8 +136,6 @@ include::modules/installation-aws-user-infra-bootstrap.adoc[leveloffset=+1]
 
 //You can install the CLI on the mirror host.
 
-include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
-
 include::modules/installation-approve-csrs.adoc[leveloffset=+1]
 
 include::modules/installation-operators-config.adoc[leveloffset=+1]
@@ -183,14 +154,14 @@ include::modules/installation-create-ingress-dns-records.adoc[leveloffset=+1]
 
 include::modules/installation-aws-user-infra-installation.adoc[leveloffset=+1]
 
+include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
+
 include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
 * See xref:../../../web_console/web-console.adoc#web-console[Accessing the web console] for more details about accessing and understanding the {product-title} web console.
-
-include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources

--- a/installing/installing_aws/upi/upi-aws-installation-reqs.adoc
+++ b/installing/installing_aws/upi/upi-aws-installation-reqs.adoc
@@ -1,0 +1,32 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="upi-aws-installation-reqs"]
+= Installation requirements for user-provisioned infrastructure on AWS
+include::_attributes/common-attributes.adoc[]
+:context: upi-aws-installation-reqs
+
+toc::[]
+
+Before you begin an installation on infrastructure that you provision, be sure that your AWS environment meets the following installation requirements.
+
+For a cluster that contains user-provisioned infrastructure, you must deploy all
+of the required machines.
+
+
+include::modules/installation-machine-requirements.adoc[leveloffset=+1]
+include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../scalability_and_performance/optimization/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
+include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
+include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
+
+include::modules/csr-management.adoc[leveloffset=+1]
+
+include::modules/installation-aws-user-infra-requirements.adoc[leveloffset=+1]
+
+include::modules/installation-aws-permissions.adoc[leveloffset=+1]
+
+include::modules/installation-aws-marketplace-subscribe.adoc[leveloffset=+1]

--- a/installing/installing_aws/upi/upi-aws-preparing-to-install.adoc
+++ b/installing/installing_aws/upi/upi-aws-preparing-to-install.adoc
@@ -1,0 +1,46 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="upi-aws-preparing-to-install"]
+= Preparing to install a cluster on AWS
+include::_attributes/common-attributes.adoc[]
+:context: upi-aws-preparing-to-install
+
+toc::[]
+
+You prepare to install an {product-title} cluster on AWS by completing the following steps:
+
+* Verifying internet connectivity for your cluster.
+
+* xref:../../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configuring an AWS account].
+
+* Downloading the installation program.
++
+[NOTE]
+====
+If you are installing in a disconnected environment, you extract the installation program from the mirrored content. For more information, see xref:../../../installing/disconnected_install/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Mirroring images for a disconnected installation].
+====
+* Installing the {oc-first}.
++
+[NOTE]
+====
+If you are installing in a disconnected environment, install `oc` to the mirror host.
+====
+* Generating an SSH key pair. You can use this key pair to authenticate into the {product-title} cluster's nodes after it is deployed.
+
+* xref:../../../installing/installing_aws/upi/upi-aws-installation-reqs#upi-aws-installation-reqs[Preparing the user-provisioned infrastructure.]
+
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, xref:../../../installing/installing_aws/ipi/installing-aws-customizations.adoc#manually-create-iam_installing-aws-customizations[manually creating long-term credentials for AWS] or xref:../../../installing/installing_aws/ipi/installing-aws-customizations.adoc#installing-aws-with-short-term-creds_installing-aws-customizations[configuring an AWS cluster to use short-term credentials] with Amazon Web Services Security Token Service (AWS STS).
+
+include::modules/cluster-entitlements.adoc[leveloffset=+1]
+
+include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
+
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
+include::modules/ssh-agent-using.adoc[leveloffset=+1]
+
+include::modules/cluster-telemetry.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* See xref:../../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service.


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-10086

Link to docs preview:
[Preparing to install (UPI)](https://77208--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/upi-aws-preparing-to-install)
[Installation requirements](https://77208--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/upi-aws-installation-reqs)
[Installing using CF templates](https://77208--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra)
[Restricted install (UPI)](https://77208--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws)

QE review:
NA, as these changes are structural only. 

The "Preparing to Install" assembly was copied directly from the IPI Preparing to Install assembly (with one extra prerequisite added).
