### PR TITLE
TELCODOCS#1895: Updating Recovering from a missing storage class proc

### DIFF
--- a/modules/lvms-troubleshooting-recovering-from-missing-lvms-or-operator-components.adoc
+++ b/modules/lvms-troubleshooting-recovering-from-missing-lvms-or-operator-components.adoc
@@ -52,10 +52,8 @@ The output of this command must contain a running instance of the following pods
 
 * `lvms-operator`
 * `vg-manager`
-* `topolvm-controller`
-* `topolvm-node`
 +
-If the `topolvm-node` pod is stuck in the `Init` state, it is due to a failure to locate an available disk for {lvms} to use. To retrieve the necessary information to troubleshoot this issue, review the logs of the `vg-manager` pod by running the following command:
+If the `vg-manager` pod is stuck while loading a configuration file, it is due to a failure to locate an available disk for {lvms} to use. To retrieve the necessary information to troubleshoot this issue, review the logs of the `vg-manager` pod by running the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[TELCODOCS-1895](https://issues.redhat.com/browse/TELCODOCS-1895)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[Recovering from a missing storage class](https://77210--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html#recovering-from-missing-lvms-or-operator-components_logical-volume-manager-storage)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->