### PR TITLE
OBSDOCS-1088-Logging 5.9.3 Release Notes

### DIFF
--- a/modules/logging-release-notes-5-9-2.adoc
+++ b/modules/logging-release-notes-5-9-2.adoc
@@ -1,4 +1,4 @@
-/module included in logging-5-9-release-notes.adoc
+// module included in logging-5-9-release-notes.adoc
 :_mod-docs-content-type: REFERENCE
 [id="logging-release-notes-5-9-2_{context}"]
 = Logging 5.9.2

--- a/modules/logging-release-notes-5-9-3.adoc
+++ b/modules/logging-release-notes-5-9-3.adoc
@@ -1,0 +1,21 @@
+// module included in logging-5-9-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-5-9-3_{context}"]
+= Logging 5.9.3
+This release includes link:https://access.redhat.com/errata/RHBA-2024:3736[OpenShift Logging Bug Fix Release 5.9.3]
+
+[id="logging-release-notes-5-9-3-bug-fixes"]
+== Bug Fixes
+
+* Before this update, there was a delay in restarting Ingesters when configuring `LokiStack`, because the {loki-op} sets the write-ahead log `replay_memory_ceiling` to zero bytes for the `1x.demo` size. With this update, the minimum value used for the `replay_memory_ceiling` has been increased to avoid delays. (link:https://issues.redhat.com/browse/LOG-5614[LOG-5614])
+
+* Before this update, monitoring the Vector collector output buffer state was not possible. With this update, monitoring and alerting the Vector collector output buffer size is possible that improves observability capabilities and helps keep the system running optimally. (link:https://issues.redhat.com/browse/LOG-5586[LOG-5586])
+
+[id="logging-release-notes-5-9-3-CVEs"]
+== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2024-2961[CVE-2024-2961]
+* link:https://access.redhat.com/security/cve/CVE-2024-28182[CVE-2024-28182]
+* link:https://access.redhat.com/security/cve/CVE-2024-33599[CVE-2024-33599]
+* link:https://access.redhat.com/security/cve/CVE-2024-33600[CVE-2024-33600]
+* link:https://access.redhat.com/security/cve/CVE-2024-33601[CVE-2024-33601]
+* link:https://access.redhat.com/security/cve/CVE-2024-33602[CVE-2024-33602]

--- a/observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-9-3.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-9-2.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-9-1.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Logging Z-Stream Release Notes - 5.9.3
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1088

Fix Version: 4.13+

Doc Preview: https://77211--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/logging_release_notes/logging-5-9-release-notes.html#logging-release-notes-5-9-3_logging-5-9-release-notes

SME Review: @periklis 
QE Review: @anpingli 
Peer Review: @mletalie 