### PR TITLE
OBSDOCS-1087-Logging 5.8.8 Release Notes

### DIFF
--- a/modules/logging-release-notes-5-8-8.adoc
+++ b/modules/logging-release-notes-5-8-8.adoc
@@ -1,0 +1,36 @@
+// module included in /logging/logging-5-8-release-notes
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-5-8-8_{context}"]
+= Logging 5.8.8
+This release includes link:https://access.redhat.com/errata/RHBA-2024:3737[OpenShift Logging Bug Fix Release 5.8.8] and link:https://access.redhat.com/errata/RHBA-2024:3738[OpenShift Logging Bug Fix Release 5.8.8].
+
+[id="logging-release-notes-5-8-8-bug-fixes"]
+== Bug fixes
+
+* Before this update, there was a delay in restarting Ingesters when configuring `LokiStack`, because the {loki-op} sets the write-ahead log `replay_memory_ceiling` to zero bytes for the `1x.demo` size. With this update, the minimum value used for the `replay_memory_ceiling` has been increased to avoid delays. (link:https://issues.redhat.com/browse/LOG-5615[LOG-5615])
+
+[id="logging-release-notes-5-8-8-CVEs"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2020-15778[CVE-2020-15778]
+* link:https://access.redhat.com/security/cve/CVE-2021-43618[CVE-2021-43618]
+* link:https://access.redhat.com/security/cve/CVE-2023-6004[CVE-2023-6004]
+* link:https://access.redhat.com/security/cve/CVE-2023-6597[CVE-2023-6597]
+* link:https://access.redhat.com/security/cve/CVE-2023-6918[CVE-2023-6918]
+* link:https://access.redhat.com/security/cve/CVE-2023-7008[CVE-2023-7008]
+* link:https://access.redhat.com/security/cve/CVE-2024-0450[CVE-2024-0450]
+* link:https://access.redhat.com/security/cve/CVE-2024-2961[CVE-2024-2961]
+* link:https://access.redhat.com/security/cve/CVE-2024-22365[CVE-2024-22365]
+* link:https://access.redhat.com/security/cve/CVE-2024-25062[CVE-2024-25062]
+* link:https://access.redhat.com/security/cve/CVE-2024-26458[CVE-2024-26458]
+* link:https://access.redhat.com/security/cve/CVE-2024-26461[CVE-2024-26461]
+* link:https://access.redhat.com/security/cve/CVE-2024-26642[CVE-2024-26642]
+* link:https://access.redhat.com/security/cve/CVE-2024-26643[CVE-2024-26643]
+* link:https://access.redhat.com/security/cve/CVE-2024-26673[CVE-2024-26673]
+* link:https://access.redhat.com/security/cve/CVE-2024-26804[CVE-2024-26804]
+* link:https://access.redhat.com/security/cve/CVE-2024-28182[CVE-2024-28182]
+* link:https://access.redhat.com/security/cve/CVE-2024-32487[CVE-2024-32487]
+* link:https://access.redhat.com/security/cve/CVE-2024-33599[CVE-2024-33599]
+* link:https://access.redhat.com/security/cve/CVE-2024-33600[CVE-2024-33600]
+* link:https://access.redhat.com/security/cve/CVE-2024-33601[CVE-2024-33601]
+* link:https://access.redhat.com/security/cve/CVE-2024-33602[CVE-2024-33602]

--- a/observability/logging/logging_release_notes/logging-5-8-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-8-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-8-8.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-8-7.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-8-6.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Logging Z-Stream Release Notes - 5.8.8
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1087

Fix Version: 4.12, 4.13, 4.14, 4.15

Doc Preview: https://77212--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/logging_release_notes/logging-5-8-release-notes.html#logging-release-notes-5-8-8_logging-5-8-release-notes

SME Review: @periklis 
QE Review: @anpingli 
Peer Review: 