### PR TITLE
PR for SRVCOM-3054: Update the Serverless 1.33 release notes

### DIFF
--- a/about/serverless-release-notes.adoc
+++ b/about/serverless-release-notes.adoc
@@ -28,6 +28,9 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 
 // Release notes included, most to least recent
 // OCP + OSD + ROSA
+include::modules/serverless-rn-1-33-0.adoc[leveloffset=+1]
+
+// OCP + OSD + ROSA
 include::modules/serverless-rn-1-32-0.adoc[leveloffset=+1]
 
 // OCP + OSD + ROSA

--- a/modules/serverless-deprecated-removed-features.adoc
+++ b/modules/serverless-deprecated-removed-features.adoc
@@ -13,7 +13,7 @@ For the most recent list of major functionality deprecated and removed within {S
 .Deprecated and removed features tracker
 [cols="3,1,1,1,1,1,1,1",options="header"]
 |====
-|Feature |1.22 to 1.26|1.27|1.28|1.29|1.30|1.31|1.32
+|Feature |1.27|1.28|1.29|1.30|1.31|1.32|1.33
 
 |Serving TLS for internal traffic
 |-
@@ -21,7 +21,7 @@ For the most recent list of major functionality deprecated and removed within {S
 |-
 |-
 |-
-|-
+|Removed
 |Removed
 
 |EventTypes `v1beta1` API
@@ -30,7 +30,7 @@ For the most recent list of major functionality deprecated and removed within {S
 |-
 |-
 |-
-|-
+|Deprecated
 |Deprecated
 
 |`domain-mapping` and `domain-mapping-webhook` deployments
@@ -39,7 +39,7 @@ For the most recent list of major functionality deprecated and removed within {S
 |-
 |-
 |-
-|-
+|Removed
 |Removed
 
 |{SMProductName} with {ServerlessProductShortName} when Kourier is enabled
@@ -48,21 +48,21 @@ For the most recent list of major functionality deprecated and removed within {S
 |-
 |-
 |-
-|-
+|Deprecated
 |Deprecated
 
 |`NamespacedKafka` annotation
 |-
 |-
 |-
-|-
+|Deprecated
 |Deprecated
 |Deprecated
 |Deprecated
 
 |`enable-secret-informer-filtering` annotation
 |-
-|-
+|Deprecated
 |Deprecated
 |Deprecated
 |Deprecated
@@ -70,9 +70,9 @@ For the most recent list of major functionality deprecated and removed within {S
 |Deprecated
 
 |Serving and Eventing `v1alpha1` API
-|-
 |Deprecated
 |Deprecated
+|Removed
 |Removed
 |Removed
 |Removed

--- a/modules/serverless-rn-1-33-0.adoc
+++ b/modules/serverless-rn-1-33-0.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies
+//
+// * about/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-33-0_{context}"]
+= Red Hat {ServerlessProductName} 1.33
+
+{ServerlessProductName} 1.33 is now available. New features, updates, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes:
+
+[id="new-features-1-33-0_{context}"]
+== New features
+
+* {ServerlessProductName} now uses Knative Serving 1.12.
+* {ServerlessProductName} now uses Knative Eventing 1.12.
+* {ServerlessProductName} now uses Kourier 1.12.
+* {ServerlessProductName} now uses Knative (`kn`) CLI 1.12.
+* {ServerlessProductName} now uses Knative for Apache Kafka 1.12.
+* The `kn func` CLI plugin now uses `func` 1.13.
+
+* OpenShift Serverless on ARM64 is now available as Technology Preview.
+* The `NamespacedKafka` annotation is now deprecated. Use the standard Kafka broker without data plane isolation instead.
+
+* When enabling the automatic `EventType` auto-creation, you can now easily discover events available within the cluster. This functionality is available as a Developer Preview.
+
+* You can now use the Custom Metrics Autoscaler Operator to autoscale Knative Eventing sources for Apache Kafka sources, defined by a `KafkaSource` object. This functionality is available as a Technology Preview feature, offering enhanced scalability and efficiency for Kafka-based event sources within Knative Eventing.
+
+[id="known-issues-1-33-0_{context}"]
+== Known issues
+
+* Due to different mount point permissions, direct upload on a cluster build does not work on {ibmzProductName} (s390x) and {ibmpowerProductName} (ppc64le).
+
+* Building and deploying a function using Podman version 4.6 fails with the `invalid pull policy "1"` error.
++
+To work around this issue, use Podman version 4.5.

--- a/modules/serverless-tech-preview-features.adoc
+++ b/modules/serverless-tech-preview-features.adoc
@@ -13,30 +13,39 @@ The following table provides information about which {ServerlessProductName} fea
 .Generally Available and Technology Preview features tracker
 [cols="2,1,1,1",options="header"]
 |====
-|Feature |1.30|1.31|1.32
+|Feature |1.31|1.32|1.33
 
+|ARM64 support
+|-
+|-
+|TP
+
+|Custom Metrics Autoscaler Operator (KEDA)
+|-
+|-
+|TP
 |Pipelines-as-code
 |-
-|-
+|TP
 |TP
 
 |`new-trigger-filters`
 |-
-|-
+|TP
 |TP
 
 |Go function using S2I builder
 |-
-|-
+|TP
 |TP
 
 |Installing and using {ServerlessProductShortName} on {sno}
-|-
+|GA
 |GA
 |GA
 
 |Using {SMProductShortName} to isolate network traffic with {ServerlessProductShortName}
-|-
+|TP
 |TP
 |TP
 
@@ -76,7 +85,7 @@ The following table provides information about which {ServerlessProductName} fea
 |TP
 
 |Service Mesh mTLS
-|TP
+|GA
 |GA
 |GA
 


### PR DESCRIPTION
**Affected versions:** `serverless-docs-1.33`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVCOM-3054

**Doc preview:** 

- [Serverless 1.33.0 release notes](https://77215--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-rn-1-33-0_serverless-release-notes)

- [Generally Available and Technology Preview features table](https://77215--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-tech-preview-features_serverless-release-notes)

- [Deprecated and removed features table](https://77215--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-deprecated-removed-features_serverless-release-notes)