### PR TITLE
OSDOCS-10835: adds certificate cleaning option in relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -62,6 +62,10 @@ With this release, you can configure a custom server certificate that has been i
 ==== Configurable policies for log file rotation and retention
 You can now configure audit logging policies to manage the retention policies for log files, ensuring that edge devices with limited storage capacities are not hampered by accumulated logging data. To configure audit log policies, use settings such as a maximum file size limit and maximum retained files to set a limit on log storage size. You can also choose an audit policy profile to specify the data collected. See xref:../microshift_configuring/microshift-audit-logs-config.adoc#microshift-audit-logs-config[Configuring audit logs].
 
+[id="microshift-4-16-certificates-cleaning"]
+==== Support for cleaning up certificates
+With this release, you can clean up custom certificates. For more information, see xref:../microshift_configuring/microshift-custom-ca.adoc#microshift-custom-ca-certificates-cleaning_microshift-custom-ca[Cleaning up and recreating the custom certificates].
+
 [id="microshift-4-16-networking"]
 === Networking
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-10835](https://issues.redhat.com/browse/OSDOCS-10835)

Link to docs preview:
[Cleaning up the certificates are supported](https://77217--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-configuring)

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.

Additional information:
[Main PR for reference](https://github.com/openshift/openshift-docs/pull/77156)