### PR TITLE
OBSDOCS-1131: Update the upstream OTEL version in the downstream OTEL 3.2 release notes

### DIFF
--- a/observability/otel/otel_rn/otel-rn-3-2.adoc
+++ b/observability/otel/otel_rn/otel-rn-3-2.adoc
@@ -43,7 +43,7 @@ include::snippets/technology-preview.adoc[leveloffset=+1]
 
 This update introduces the following enhancement:
 
-* {OTELName} 3.2 is based on the open source link:https://opentelemetry.io/[OpenTelemetry] release 0.99.0.
+* {OTELName} 3.2 is based on the open source link:https://opentelemetry.io/[OpenTelemetry] release 0.100.0.
 
 [id="otel-rn_3-2_jaeger-release-notes_deprecated-functionality"]
 == Deprecated functionality


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12, 4.13, 4.14, 4.15, 4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OBSDOCS-1131

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
