### PR TITLE
[enterprise-4.14] TELCODOCS-1187: Day 2 operations for VFs with NMState

### DIFF
--- a/modules/nw-sriov-dual-nic-con.adoc
+++ b/modules/nw-sriov-dual-nic-con.adoc
@@ -9,11 +9,6 @@
 {product-title} can be deployed on a server with a dual port network interface card (NIC).
 You can partition a single, high-speed dual port NIC into multiple virtual functions (VFs) and enable SR-IOV.
 
-[NOTE]
-====
-Currently, it is not possible to assign virtual functions (VF) for system services such as OVN-Kubernetes and assign other VFs created from the same physical function (PF) to pods connected to the SR-IOV Network Operator.
-====
-
 This feature supports the use of bonds for high availability with the Link Aggregation Control Protocol (LACP).
 
 [NOTE]

--- a/modules/virt-example-vf-host-services.adoc
+++ b/modules/virt-example-vf-host-services.adoc
@@ -1,0 +1,113 @@
+// Module included in the following assemblies:
+//
+// * networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="virt-example-vf-host-services_{context}"]
+= Example: Node network configuration policy for virtual functions (Technology Preview)
+
+Update host network settings for Single Root I/O Virtualization (SR-IOV) network virtual functions (VF) in an existing cluster by applying a `NodeNetworkConfigurationPolicy` manifest.
+
+:FeatureName: Updating host network settings for SR-IOV network VFs
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+You can apply a `NodeNetworkConfigurationPolicy` manifest to an existing cluster to complete the following tasks:
+
+* Configure QoS or MTU host network settings for VFs to optimize performance.
+* Add, remove, or update VFs for a network interface.
+* Manage VF bonding configurations.
+
+[NOTE]
+====
+To update host network settings for SR-IOV VFs by using NMState on physical functions that are also managed through the SR-IOV Network Operator, you must set the `externallyManaged` parameter in the relevant `SriovNetworkNodePolicy` resource to `true`. For more information, see the _Additional resources_ section.
+====
+
+The following YAML file is an example of a manifest that defines QoS policies for a VF.
+This file includes samples values that you must replace with your own information.
+
+[source,yaml]
+----
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: qos <1>
+spec:
+  nodeSelector: <2>
+    node-role.kubernetes.io/worker: "" <3>
+  desiredState:
+    interfaces:
+      - name: ens1f0 <4>
+        description: Change QOS on VF0 <5>
+        type: ethernet <6>
+        state: up <7>
+        ethernet:
+         sr-iov:
+           total-vfs: 3 <8>
+           vfs:
+           - id: 0 <9>
+             max-tx-rate: 200 <10>
+----
+
+<1> Name of the policy.
+<2> Optional: If you do not include the `nodeSelector` parameter, the policy applies to all nodes in the cluster.
+<3> This example applies to all nodes with the `worker` role.
+<4> Name of the physical function (PF) network interface.
+<5> Optional: Human-readable description of the interface.
+<6> The type of interface.
+<7> The requested state for the interface after configuration.
+<8> The total number of VFs.
+<9> Identifies the VF with an ID of `0`.
+<10> Sets a maximum transmission rate, in Mbps, for the VF. This sample value sets a rate of 200 Mbps.
+
+The following YAML file is an example of a manifest that creates a VLAN interface on top of a VF and adds it to a bonded network interface.
+It includes samples values that you must replace with your own information.
+
+[source,yaml]
+----
+
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: addvf <1>
+spec:
+  nodeSelector: <2>
+    node-role.kubernetes.io/worker: "" <3>
+  maxUnavailable: 3
+  desiredState:
+    interfaces:
+      - name: ens1f0v1 <4>
+        type: ethernet
+        state: up
+      - name: ens1f0v1.477 <5>
+        type: vlan
+        state: up
+        vlan:
+          base-iface: ens1f0v1 <6>
+          id: 477
+      - name: bond0 <7>
+        description: Add vf <8>
+        type: bond <9>
+        state: up <10>
+        link-aggregation:
+          mode: active-backup <11>
+          options:
+            primary: ens1f1v0.477 <12>
+          port: <13>
+            - ens1f1v0.477
+            - ens1f0v0.477
+            - ens1f0v1.477 <14>
+----
+<1> Name of the policy.
+<2> Optional: If you do not include the `nodeSelector` parameter, the policy applies to all nodes in the cluster.
+<3> This example applies to all nodes with the `worker` role.
+<4> Name of the VF network interface.
+<5> Name of the VLAN network interface.
+<6> The VF network interface to which the VLAN interface is attached.
+<7> Name of the bonding network interface.
+<8> Optional: Human-readable description of the interface.
+<9> The type of interface.
+<10> The requested state for the interface after configuration.
+<11> The bonding policy for the bond.
+<12> The primary attached bonding port.
+<13> The ports for the bonded network interface.
+<14> In this example, this VLAN network interface is added as an additional interface to the bonded network interface.

--- a/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
@@ -54,6 +54,12 @@ include::modules/virt-example-bridge-nncp.adoc[leveloffset=+2]
 
 include::modules/virt-example-vlan-nncp.adoc[leveloffset=+2]
 
+include::modules/virt-example-vf-host-services.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../networking/hardware_networks/configuring-sriov-device.adoc#configuring-sriov-device[Configuring an SR-IOV network device]
+
 include::modules/virt-example-bond-nncp.adoc[leveloffset=+2]
 
 include::modules/virt-example-ethernet-nncp.adoc[leveloffset=+2]


### PR DESCRIPTION
[TELCODOCS-1187](https://issues.redhat.com//browse/TELCODOCS-1187): CP of #63405 to 4.14

Version(s):
4.14

Issue:
https://issues.redhat.com//browse/TELCODOCS-1187

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This cherry-pick has been delayed for long time, the parent PR is already merged to main, 4.15+, with a peer review and merge review completed. So I believe a merge review is all that is need for this cherry-pick, which is finally getting backported to 4.14.
