### PR TITLE
OCPBUGS-31819: Documented a non-existent AWS HeadBucket permission fo…

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -1956,6 +1956,8 @@ Users who want to upgrade from earlier {product-title} versions and who operate 
 [id="ocp-4-14-installer-bug-fixes"]
 ==== Installer
 
+* Previously, the installation program required the `s3:HeadBucket` permission for AWS, even though it does not exist. The correct permission for the `HeadBucket` action is `s3:ListBucket`. With this release, `s3:HeadBucket` is removed from the list of required permissions and only `s3:ListBucket` is required, as expected. (link:https://issues.redhat.com/browse/OCPBUGS-31819[*OCPBUGS-31819*])
+
 * Previously, if you did not specify a custom {op-system-first} Amazon Machine Image (AMI) when installing an AWS cluster to a supported secret partition, the installation failed. With this update, the installation program validates that you have specified the ID of an {op-system} AMI in the installation configuration file before deploying the cluster. (link:https://issues.redhat.com/browse/OCPBUGS-13636[*OCPBUGS-13636*])
 
 * Previously, the {product-title} installation program did not find private hosted zones in the host project during installations on Google Cloud Platform (GCP) by using a shared VPC. With this update, the installation program checks for an existing private hosted zone in the host project and uses the private hosted zone if it exists. (link:https://issues.redhat.com/browse/OCPBUGS-11736[*OCPBUGS-11736*])


### PR DESCRIPTION
Change management sent. The note was published in 4.15 but 4.14 is where the fix first occured, so it should be documented in 4.14. See https://issues.redhat.com/browse/OCPBUGS-32690 for 4.15 approved now. 

Version(s):
4.14

Issue:
[OCPBUGS-31819](https://issues.redhat.com/browse/OCPBUGS-31819)

Link to docs preview:
[Installer bug fix OCPBGUS-31819](https://77225--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-installation-and-update:~:text=Previously%2C%20the%20installation%20program%20required%20the%20s3%3AHeadBucket%20permission%20for%20AWS)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
