### PR TITLE
ROX-9308: Add documentation to remove the admin user

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -250,6 +250,8 @@ Topics:
       File: configure-ocp-oauth
     - Name: Connecting Azure AD to RHACS using SSO configuration
       File: connecting-azure-ad-to-rhacs-using-sso-configuration
+  - Name: Remove the admin user
+    File: remove-admin-user
   - Name: Configuring short-lived access
     File: configure-short-lived-access
 - Name: Using the system health dashboard

--- a/modules/remove-admin-user.adoc
+++ b/modules/remove-admin-user.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * operating/manage-user-access/remove-admin-user.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="remove_admin-user_{context}"]
+= Remove the admin user
+
+After an authentication provider has been successfully created, it is strongly recommended to remove the `admin` user.
+
+Removing the `admin` user is dependent on the installation method of the {product-title-short} portal.
+Perform one of the following procedures:
+
+* For operator installations, set `central.adminPasswordGenerationDisabled` to `true` in your `Central` custom resource.
+
+* For helm installations:
+** In your `Central` helm configuration set `central.adminPassword.generate` to `false`.
+** Follow the steps xref:./change-config-options-after-deployment-central-service.adoc[Change config options after deployment] to update the configuration.
+
+* For roxctl installations:
+** When generating the manifest, set `Disable password generation` to `false`.
+** Follow the steps xref:./install-central-roxctl.adoc[Install Central roxctl] to apply the changes.

--- a/operating/manage-user-access/remove-admin-user.adoc
+++ b/operating/manage-user-access/remove-admin-user.adoc
@@ -1,0 +1,25 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="remove-admin-user"]
+= Remove the admin user
+include::modules/common-attributes.adoc[]
+:context: remove-admin-user
+
+toc::[]
+
+[role="_abstract"]
+
+{rh-rhacs-first} creates an administrator account, `admin`, during the installation process which can be used to login via username and password.
+The password is dynamically generated (unless specifically overridden) and unique to your ACS instance.
+
+In production environments, it is highly recommended to create an authentication provider and remove the `admin` user.
+
+include::modules/remove-admin-user.adoc[leveloffset=+1]
+
+After applying the configuration changes, you will not be able to login as an `admin` user.
+
+ [NOTE]
+ ====
+ It is possible to add the `admin` user again as a fallback by reverting the configuration changes.
+
+ When enabling the `admin` user again, a new password will be generated.
+ ====


### PR DESCRIPTION
Add documentation on how to remove the `admin` user after adding an authentication provider.
This is somewhat similar (at the very least the basics of it) as removing the `kubeadmin` user from OCP: https://docs.openshift.com/container-platform/4.15/authentication/remove-kubeadmin.html

Version(s):
Latest ACS version (4.5)

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/ROX-9308

Link to docs preview:
https://77226--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-user-access/remove-admin-user.html

QE review:
- [x] QE has approved this change.

