### PR TITLE
OCPBUGS-33330: Removed remote shell into a pod command from OVN-KBS a…

### DIFF
--- a/modules/nw-ovn-kubernetes-running-network-tools.adoc
+++ b/modules/nw-ovn-kubernetes-running-network-tools.adoc
@@ -16,13 +16,6 @@ Get information about the logical switches and routers by running `network-tools
 
 .Procedure
 
-. Open a remote shell into a pod by running the following command:
-+
-[source,terminal]
-----
-$ oc rsh -n openshift-ovn-kubernetes ovnkube-node-2hsbt
-----
-
 . List the routers by running the following command:
 +
 [source,terminal]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OCPBUGS-33330](https://issues.redhat.com/browse/OCPBUGS-33330)

Link to docs preview:
[Running network-tools](https://77257--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/ovn-kubernetes-architecture-assembly.html#nw-ovn-kubernetes-running-network-tools_ovn-kubernetes-architecture)

- [x] SME has approved this change.
- [x] QE has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
