### PR TITLE
OSDOCS-9825: adds 4.16.0 async relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -56,11 +56,10 @@ See the following list for details:
 
 [id="microshift-4-16-custom-cert-auths"]
 ==== Customizable certificate authorities for the API server are supported
-With this release, you can configure a custom server certificate that has been issued by an external certificate authority (CA). The default API server certificate is issued by an internal {microshift-short} cluster CA. You can now replace this certificate with one that is issued by a CA that clients trust. See xref:../microshift_configuring/microshift-custom-ca.adoc#microshift-custom-ca[Configuring custom certificate authorities] for details.
+With this release, you can configure a custom server certificate that has been issued by an external certificate authority (CA). The default API server certificate is issued by an internal {microshift-short} cluster CA. You can now replace this certificate with one that is issued by a CA that clients trust. See xref:../microshift_configuring/microshift-custom-ca.adoc#microshift-custom-ca[Configuring custom certificate authorities].
 
 [id="microshift-4-16-audit-logging-config"]
 ==== Configurable policies for log file rotation and retention
-
 You can now configure audit logging policies to manage the retention policies for log files, ensuring that edge devices with limited storage capacities are not hampered by accumulated logging data. To configure audit log policies, use settings such as a maximum file size limit and maximum retained files to set a limit on log storage size. You can also choose an audit policy profile to specify the data collected. See xref:../microshift_configuring/microshift-audit-logs-config.adoc#microshift-audit-logs-config[Configuring audit logs].
 
 [id="microshift-4-16-networking"]
@@ -90,10 +89,14 @@ See xref:../microshift_running_apps/microshift-gitops.adoc#microshift-gitops[Aut
 
 [id="microshift-4-16-support-updates"]
 ==== Getting a cluster ID
-With this release, you can get the ID of a {microshift-short} cluster. When opening a support case, you can provide the cluster ID to Red{nbsp}Hat Support to help in identifying issues with your cluster. See xref:../microshift_support/microshift-getting-cluster-id.adoc#microshift-getting-cluster-id[Getting your cluster ID] for more information.
+With this release, you can get the ID of a {microshift-short} cluster. When opening a support case, you can provide the cluster ID to Red{nbsp}Hat Support to help in identifying issues with your cluster. See xref:../microshift_support/microshift-getting-cluster-id.adoc#microshift-getting-cluster-id[Getting your cluster ID].
 
-//[id="microshift-4-16-security"]
-//=== Security and compliance
+[id="microshift-4-16-security"]
+=== Security and compliance
+
+[id="microshift-4-16-ssl-medium-cipher-suites"]
+==== SSL Medium Strength Cipher Suites now supported
+During an SSL handshake between a client and a server, the cipher to use is negotiated between them. With this release, SSL Medium Strength Cipher Suites are now supported for the kube-controller-manager daemon, kube-scheduler control-plane process, and kubelet "node agent." This enhancement to the internal communication between kubernetes components improves control plane communications security. (link:https://issues.redhat.com/browse/OCPBUGS-29037[OCPBUGS-29037])
 
 //[id="microshift-4-16-doc-enhancements"]
 //=== Documentation enhancements
@@ -136,13 +139,17 @@ With this release, you can get the ID of a {microshift-short} cluster. When open
 //[id="microshift-4-16-installation-bug-fixes"]
 //=== Installation
 
-//[discrete]
-//[id="microshift-4-16-networking-bug-fixes"]
-//==== Networking
+[discrete]
+[id="microshift-4-16-networking-bug-fixes"]
+=== Networking
 
-//[discrete]
-//[id="microshift-4-16-support-bug-fixes"]
-//==== Support
+Previously, the {microshift-short} load balancer controller tried to update the IP addresses of every `LoadBalancer` service in the cluster. Some of these services, such as those with a defined `loadBalancerClass`, have their own update procedures for external IPs. This conflicted with the {microshift-short} controller. Now, services that have a `loadBalancerClass` are filtered and IP addresses owned by other load balancer services are ignored by {microshift-short}. (link:https://issues.redhat.com/browse/OCPBUGS-30833[OCPBUGS-30833])
+
+[discrete]
+[id="microshift-4-16-support-bug-fixes"]
+=== Support
+
+Previously, when `microshift-etcd` unexpectedly exited, {microshift-short} tried to restart so that `microshift-etcd` could restart, but there was a lingering unit fragment. Every attempt to restart `microshift-etcd` failed, making the system unusable. The `--collect` flag was added to the `systemd-run` invocation used to start `microshift-etcd`. The additional flag results in systemd cleaning up the unit fragment even if the unit failed. The system now recovers and restarts. (link:https://issues.redhat.com/browse/OCPBUGS-33588[OCPBUGS-33588])
 
 [id="microshift-4-16-asynchronous-errata-updates"]
 == Asynchronous errata updates
@@ -158,11 +165,10 @@ Red Hat Customer Portal user accounts must have systems registered and consuming
 
 This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections.
 
-//TODO verify info prior to merge freeze
 [id="microshift-4-16-0-dp"]
 === RHEA-2024:0043 - {microshift-short} 4.16.0 bug fix and security update advisory
 
-//Issued: 2024-MM-DD
+Issued: 2024-06-25
 
 {product-title} release 4.16.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHEA-2024:0043[RHEA-2024:0043] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHEA-2024:0041[RHEA-2024:0041] advisory.
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-9825](https://issues.redhat.com/browse/OSDOCS-9825)

Link to docs preview:
[Bug fixes](https://77258--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-bug-fixes)
[4.16.0 async relnote](https://77258--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-0-dp)

SME review:
- [x] SMEs have approved this change.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
