### PR TITLE
OSDOCS-10554: edits command for update to 4.16.0

### DIFF
--- a/modules/microshift-updating-rpms-y.adoc
+++ b/modules/microshift-updating-rpms-y.adoc
@@ -40,8 +40,9 @@ $ sudo subscription-manager repos \
 +
 [source,terminal]
 ----
-$ sudo dnf update microshift
+$ sudo dnf update microshift --allowerasing
 ----
+//Q: or should this be $ sudo dnf install -y --allowerasing 'microshift-${version}'
 
 . Reboot the host to apply updates by running the following command:
 +


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-10554](https://issues.redhat.com/browse/OSDOCS-10554)

Link to docs preview:
[Update RPMa manually, step 2](https://77262--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-rpms-manually.html#microshift-updating-rpms_microshift-update-rpms-manually)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
