### PR TITLE
OSDOCS-10846 OCP 4.12.59 Release Notes

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -4752,3 +4752,33 @@ $ oc patch console.operator.openshift.io/cluster --type='merge' -p='{"status":{"
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-12-59"]
+=== RHSA-2024:3713 - {product-title} 4.12.59 bug fix and security update
+
+Issued: 2024-06-12
+
+{product-title} release 4.12.59, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:3713[RHSA-2024:3713] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:3715[RHSA-2024:3715] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.59 --pullspecs
+----
+
+[id="ocp-4-12-59-bug-fixes"]
+==== Bug fixes
+
+* Previously, the Ingress Operator would specify the `spec.template.spec.hostNetwork: true` on a router deployment without specifying the `spec.template.spec.containers[*].ports[*].hostPort`. This caused the API server to set a default value for each filed port's `hostPort`, which the Ingress Operator would then detect as an external update and attempt to revert it. Now, the Ingress Operator no longer incorrectly performs these updates. (link:https://issues.redhat.com/browse/OCPBUGS-34888[*OCPBUGS-34888*])
+
+* Previously, the Ingress Operator was leaving the `spec.internalTrafficPolicy`, `spec.ipFamilies`, and `spec.ipFamilyPolicy` fields unspecified for `NodePort` and `ClusterIP` type services. The API would then set default values for these fields, which the Ingress Operator would try to revert. With this update, the Ingress Operator specifies an initial value and fixes the error caused by API default values. (link:https://issues.redhat.com/browse/OCPBUGS-34757[*OCPBUGS-34757*])
+
+* Previously, if you configured an {product-title} cluster with a high number of internal services or user-managed load balancer IP addresses, you experienced a delayed startup time for the OVN-Kubernetes service. This delay occurred when the OVN-Kubernetes service attempted to install `iptables` rules on a node. With this release, the OVN-Kubernetes service can process a large number of services in a few seconds. Additionally, you can access a new log to view the status of installing `iptables` rules on a node. (link:https://issues.redhat.com/browse/OCPBUGS-34273[*OCPBUGS-34273*])
+
+* Previously, the Ingress Operator did not specify `ingressClass.spec.parameters.scope`, while the Ingress Class API object specifies type `cluster` by default. This caused unnecessary updates to all Ingress Classes when the Operator starts. With this update, the Ingress Operator specifies `ingressClass.spec.parameters.scope` of type `cluster`. (link:https://issues.redhat.com/browse/OCPBUGS-34110[*OCPBUGS-34110*])
+
+[id="ocp-4-12-59-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-10846](https://issues.redhat.com/browse/OSDOCS-10846)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

[Link to docs preview](https://77263--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-59)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Not needed

<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Errata links will not work until release day (June 12).
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
