### PR TITLE
HCIDOCS-188: Scaling UPI cluster with BMO doesn't explain host networ…

### DIFF
--- a/installing/installing_bare_metal/upi/scaling-a-user-provisioned-cluster-with-the-bare-metal-operator.adoc
+++ b/installing/installing_bare_metal/upi/scaling-a-user-provisioned-cluster-with-the-bare-metal-operator.adoc
@@ -13,7 +13,15 @@ include::modules/upi-prerequisites-for-scaling-a-upi-cluster.adoc[leveloffset=+2
 include::modules/upi-limitations-for-scaling-a-upi-cluster.adoc[leveloffset=+2]
 include::modules/configuring-a-provisioning-resource-to-scale-user-provisioned-clusters.adoc[leveloffset=+1]
 include::modules/upi-provisioning-new-hosts-in-a-upi-cluster.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing_bare_metal/ipi/ipi-install-expanding-the-cluster.adoc#preparing-the-bare-metal-node_ipi-install-expanding[Preparing the bare metal node]
+
+* xref:../../installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#root-device-hints_ipi-install-installation-workflow[Root device hints]
+
+* xref:../../installing/installing_bare_metal/ipi/ipi-install-expanding-the-cluster.adoc#ipi-install-diagnosing-duplicate-mac-address_ipi-install-expanding[Diagnosing a duplicate MAC address when provisioning a new host in the cluster]
+
 include::modules/upi-managing-existing-hosts-in-a-upi-cluster.adoc[leveloffset=+1]
 include::modules/upi-removing-hosts-from-a-upi-cluster.adoc[leveloffset=+1]
-
-

--- a/modules/upi-provisioning-new-hosts-in-a-upi-cluster.adoc
+++ b/modules/upi-provisioning-new-hosts-in-a-upi-cluster.adoc
@@ -9,7 +9,7 @@ You can use the Bare Metal Operator (BMO) to provision bare-metal hosts in a use
 
 [NOTE]
 ====
-To provision bare-metal hosts to the cluster by using the BMO, you must set the `spec.externallyProvisioned` specification in the `BareMetalHost` custom resource to `false`.
+Provisioning bare-metal hosts to the cluster using the BMO sets the `spec.externallyProvisioned` specification in the `BareMetalHost` custom resource to `false` by default. Do not set the `spec.externallyProvisioned` specification to `true`, as this can result in unexpected behavior.
 ====
 
 .Prerequisites
@@ -20,9 +20,9 @@ To provision bare-metal hosts to the cluster by using the BMO, you must set the 
 
 .Procedure
 
-. Create the `Secret` CR and the `BareMetalHost` CR.
-
-.. Save the following YAML in the `bmh.yaml` file:
+. Create a configuration file for the bare-metal node. Depending on whether you are using a static configuration or a DHCP server, use one of the following example `bmh.yaml` files, replacing values in the YAML to match your environment:
++
+.Static configuration `bmh.yaml`
 +
 [source,yaml]
 ----
@@ -30,35 +30,146 @@ To provision bare-metal hosts to the cluster by using the BMO, you must set the 
 apiVersion: v1
 kind: Secret
 metadata:
-  name: worker1-bmc
+  name: openshift-worker-<num>-network-config-secret # <1>
+  namespace: openshift-machine-api
+type: Opaque
+stringData:
+ nmstate: | # <2>
+  interfaces: # <3>
+  - name: <nic1_name> # <4>
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: <ip_address> # <5>
+        prefix-length: 24
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - <dns_ip_address> # <6>
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: <next_hop_ip_address> # <7>
+      next-hop-interface: <next_hop_nic1_name> # <8>
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openshift-worker-<num>-bmc-secret # <1>
   namespace: openshift-machine-api
 type: Opaque
 data:
-  username: <base64_of_uid>
-  password: <base64_of_pwd>
+  username: <base64_of_uid> # <9>
+  password: <base64_of_pwd> # <9>
 ---
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
-  name: worker1
+  name: <openshift-worker-<num> # <1>
   namespace: openshift-machine-api
 spec:
+  online: true
+  bootMACAddress: <nic1_mac_address> # <10>
   bmc:
-    address: <protocol>://<bmc_url> <1>
-    credentialsName: "worker1-bmc"
-  bootMACAddress: <nic1_mac_address>
-  externallyProvisioned: false <2>
+    address: <protocol>://<bmc_url> # <11>
+    credentialsName: openshift-worker-<num>-bmc-secret # <1>
+    disableCertificateVerification: false
   customDeploy:
     method: install_coreos
-  online: true
   userData:
     name: worker-user-data-managed
     namespace: openshift-machine-api
+  rootDeviceHints:
+    deviceName: <root_device_hint> # <12>
+  preprovisioningNetworkDataName: openshift-worker-<num>-network-config-secret # <1>
 ----
-<1> You can only use bare-metal host drivers that support virtual media networking booting, for example `redfish-virtualmedia` and `idrac-virtualmedia`.
-<2> You must set the `spec.externallyProvisioned` specification in the `BareMetalHost` custom resource to `false`. The default value is `false`.
++
+--
+<1> Replace `<num>` with a unique compute node number for the bare-metal nodes in the `name`, `credentialsName`, and `preprovisioningNetworkDataName` fields.
+<2> Add the NMState YAML syntax to configure the host interfaces. To configure the network interface for a newly created node, specify the name of the secret that has the network configuration. Follow the `nmstate` syntax to define the network configuration for your node. See "Preparing the bare metal node" for details on configuring NMState syntax.
+<3> Optional: If you have configured the network interface with `nmstate`, and you want to disable an interface, set `state: up` with the IP addresses set to `enabled: false` as shown in the following example:
++
+[source,yaml]
+----
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openshift-worker-<num>-network-config-secret
+  namespace: openshift-machine-api
+ # ...
+interfaces:
+  - name: <nic_name>
+    type: ethernet
+    state: up
+    ipv4:
+      enabled: false
+    ipv6:
+      enabled: false
+# ...
+----
++
+<4> Replace `<nic1_name>` with the name of the bare-metal node's first network interface controller (NIC).
+<5> Replace `<ip_address>` with the IP address of the bare-metal node's NIC.
+<6> Replace `<dns_ip_address>` with the IP address of the bare-metal node's DNS resolver.
+<7> Replace `<next_hop_ip_address>` with the IP address of the bare-metal node's external gateway.
+<8> Replace `<next_hop_nic1_name>` with the name of the bare-metal node's external gateway.
+<9> Replace `<base64_of_uid>` and `<base64_of_pwd>` with the base64 string of the user name and password.
+<10> Replace `<nic1_mac_address>` with the MAC address of the bare-metal node's first NIC. See the "BMC addressing" section for additional BMC configuration options.
+<11> Replace `<protocol>` with the BMC protocol, such as IPMI, Redfish, or others. Replace `<bmc_url>` with the URL of the bare-metal node's baseboard management controller.
+<12> Optional: Replace `<root_device_hint>` with a device path when specifying a root device hint. See "Root device hints" for additional details.
+--
++
+.DHCP configuration `bmh.yaml`:
++
+[source,yaml]
+----
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openshift-worker-<num>-bmc-secret # <1>
+  namespace: openshift-machine-api
+type: Opaque
+data:
+  username: <base64_of_uid> # <2>
+  password: <base64_of_pwd> # <2>
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: openshift-worker-<num> # <1>
+  namespace: openshift-machine-api
+spec:
+  online: true
+  bootMACAddress: <nic1_mac_address> # <3>
+  bmc:
+    address: <protocol>://<bmc_url> # <4>
+    credentialsName: openshift-worker-<num>-bmc
+    disableCertificateVerification: false
+  customDeploy:
+    method: install_coreos
+  userData:
+    name: worker-user-data-managed
+    namespace: openshift-machine-api
+  rootDeviceHints:
+    deviceName: <root_device_hint> # <5>
+----
++
+<1> Replace `<num>` with a unique compute node number for the bare-metal nodes in the `name` and `credentialsName` fields.
+<2> Replace `<base64_of_uid>` and `<base64_of_pwd>` with the base64 string of the user name and password.
+<3> Replace `<nic1_mac_address>` with the MAC address of the bare-metal node's first NIC. See the "BMC addressing" section for additional BMC configuration options.
+<4> Replace `<protocol>` with the BMC protocol, such as IPMI, Redfish, or others. Replace `<bmc_url>` with the URL of the bare-metal node's baseboard management controller.
+<5> Optional: Replace `<root_device_hint>` with a device path when specifying a root device hint. See "Root device hints" for additional details.
++
+[IMPORTANT]
+====
+If the MAC address of an existing bare-metal node matches the MAC address of the bare-metal host that you are attempting to provision, then the installation will fail. If the host enrollment, inspection, cleaning, or other steps fail, the Bare Metal Operator retries the installation continuously. See "Diagnosing a duplicate MAC address when provisioning a new host in the cluster" for additional details.
+====
 
-. Create the bare-metal host object by running the following command:
+. Create the bare-metal node by running the following command:
 +
 [source,terminal]
 ----
@@ -68,26 +179,30 @@ $ oc create -f bmh.yaml
 .Example output
 [source,terminal]
 ----
-secret/worker1-bmc created
-baremetalhost.metal3.io/worker1 created
+secret/openshift-worker-<num>-network-config-secret created
+secret/openshift-worker-<num>-bmc-secret created
+baremetalhost.metal3.io/openshift-worker-<num> created
 ----
-
-. Approve all certificate signing requests (CSRs).
-
-.. Verify that the provisioning state of the host is `provisioned` by running the following command:
++
+. Inspect the bare-metal node by running the following command:
 +
 [source,terminal]
 ----
-$ oc get bmh -A
+$ oc -n openshift-machine-api get bmh openshift-worker-<num>
 ----
++
+where:
+
+<num>:: Specifies the compute node number.
 +
 .Example output
 [source,terminal]
 ----
-NAMESPACE               NAME          STATE                    CONSUMER   ONLINE   ERROR   AGE
-openshift-machine-api   controller1   externally provisioned              true             5m25s
-openshift-machine-api   worker1       provisioned                         true             4m45s
+NAME                    STATE       CONSUMER   ONLINE   ERROR
+openshift-worker-<num>  provisioned true
 ----
++
+. Approve all certificate signing requests (CSRs).
 
 .. Get the list of pending CSRs by running the following command:
 +
@@ -133,4 +248,3 @@ NAME        STATUS   ROLES           AGE     VERSION
 app1        Ready    worker          47s     v1.24.0+dc5a2fd
 controller1 Ready    master,worker   2d22h   v1.24.0+dc5a2fd
 ----
-

--- a/modules/upi-removing-hosts-from-a-upi-cluster.adoc
+++ b/modules/upi-removing-hosts-from-a-upi-cluster.adoc
@@ -15,7 +15,7 @@ You can use the Bare Metal Operator (BMO) to remove bare-metal hosts from a user
 
 .Procedure
 
-. Cordon and drain the host by running the following command:
+. Cordon and drain the node by running the following command:
 +
 [source,terminal]
 ----
@@ -43,11 +43,11 @@ node/app1 drained
 
 . Delete the `customDeploy` specification from the `BareMetalHost` CR.
 
-.. Edit the `BareMetalHost` CR for the host by running the following command:
+. Delete the host by running the following command:
 +
 [source,terminal]
 ----
-$ oc edit bmh -n openshift-machine-api <host_name>
+$ oc delete bmh -n openshift-machine-api <bmh_name>
 ----
 
 .. Delete the lines `spec.customDeploy` and `spec.customDeploy.method`:
@@ -73,7 +73,12 @@ NAMESPACE               NAME          STATE                    CONSUMER   ONLINE
 openshift-machine-api   controller1   externally provisioned              true             58m
 openshift-machine-api   worker1       deprovisioning                      true             57m
 ----
-
++
+[NOTE]
+====
+During deletion, the state of the host changes from `deprovisioning` to `available`. The time required for the state change of the host can vary depending on your specific configuration.
+====
++
 . Delete the node by running the following command:
 +
 [source,terminal]
@@ -96,4 +101,3 @@ $ oc get nodes
 NAME          STATUS   ROLES           AGE     VERSION
 controller1   Ready    master,worker   2d23h   v1.24.0+dc5a2fd
 ----
-


### PR DESCRIPTION
**Fixes:** [HCIDOCS-188](https://issues.redhat.com/browse/HCIDOCS-188)

**For:** OCP 4.13+

[**Preview**](https://77264--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/scaling-a-user-provisioned-cluster-with-the-bare-metal-operator.html)
- https://77264--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/scaling-a-user-provisioned-cluster-with-the-bare-metal-operator.htmlr

**Approvals -** `/lgtm`:
- [x] SME
- [x] QE
- [ ] Peer Review