### PR TITLE
OCPBUGS-35013: Removal of xt_u32 kernel module

### DIFF
--- a/modules/telco-core-kernel.adoc
+++ b/modules/telco-core-kernel.adoc
@@ -28,7 +28,6 @@ The user can install the following kernel modules by using `MachineConfig` to pr
 * xt_REDIRECT
 * xt_statistic
 * xt_TCPMSS
-* xt_u32
 
 Limits and requirements::
 


### PR DESCRIPTION
Since RHEL 9 we do not compile xt_u32 kernel module

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OCPBUGS-35013

```
[root@sno9 ~]# cat /lib/modules/$(uname -r)/config | grep -i xt | grep -i u32
# CONFIG_NETFILTER_XT_MATCH_U32 is not set
```