### PR TITLE
TELCODOCS-1852-updates extra field in installConfigOverrides

### DIFF
--- a/modules/ztp-configuring-disk-partitioning.adoc
+++ b/modules/ztp-configuring-disk-partitioning.adoc
@@ -144,7 +144,6 @@ $ oc get bmh -n my-sno-ns my-sno -ojson | jq '.metadata.annotations["bmac.agent-
 
 .. Enter into a debug session on the {sno} node by running the following command. This step instantiates a debug pod called `<node_name>-debug`:
 +
---
 [source,terminal]
 ----
 $ oc debug node/my-sno-node
@@ -201,4 +200,3 @@ tmpfs           126G  4.0K  126G   1% /tmp
 /dev/sda3       350M  110M  218M  34% /boot
 tmpfs            26G     0   26G   0% /run/user/1000
 ----
---

--- a/snippets/ztp_example-sno.yaml
+++ b/snippets/ztp_example-sno.yaml
@@ -22,6 +22,7 @@ spec:
     # Notes:
     # - OperatorLifecycleManager is needed for 4.15 and later
     # - NodeTuning is needed for 4.13 and later, not for 4.12 and earlier
+    # - Ingress is needed for 4.16 and later
     installConfigOverrides: | 
       {
         "capabilities": {
@@ -29,6 +30,7 @@ spec:
           "additionalEnabledCapabilities": [
             "NodeTuning",
             "OperatorLifecycleManager"
+            "Ingress"
           ]
         }
       }


### PR DESCRIPTION
[TELCODOCS-1852]: Doc updates for GitOps ZTP solution maintenance 4.16
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-1852
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://77272--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-deploying-far-edge-sites#ztp-deploying-a-site_ztp-deploying-far-edge-sites


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->