### PR TITLE
OSDOCS-10818: Introducing oc adm upgrade status (tech preview)

### DIFF
--- a/modules/update-upgrading-oc-adm-upgrade-status.adoc
+++ b/modules/update-upgrading-oc-adm-upgrade-status.adoc
@@ -1,0 +1,85 @@
+// Module included in the following assemblies:
+//
+// * updating/updating_a_cluster/updating-cluster-cli.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="update-upgrading-oc-adm-upgrade-status_{context}"]
+= Retrieving information about a cluster update using oc adm upgrade status (Technology Preview)
+
+When updating your cluster, it is useful to understand how your update is progressing. While the `oc adm upgrade` command returns limited information about the status of your update, this release introduces the `oc adm upgrade status` command as a Technology Preview feature. This command decouples status information from the `oc adm upgrade` command and provides specific information regarding a cluster update, including the status of the control plane and worker node updates.
+
+The `oc adm upgrade status` command is read-only and will never alter any state in your cluster. 
+
+:FeatureName: The `oc adm upgrade status` command
+include::snippets/technology-preview.adoc[]
+
+The `oc adm upgrade status` command can be used for clusters from version 4.12 up to the latest supported release. 
+
+[IMPORTANT]
+====
+While your cluster does not need to be a Technology Preview-enabled cluster, you must enable the `OC_ENABLE_CMD_UPGRADE_STATUS` Technology Preview environment variable, otherwise the {oc-first} will not recognize the command and you will not be able to use the feature. 
+====
+
+.Procedure 
+
+. Set the `OC_ENABLE_CMD_UPGRADE_STATUS` environmental variable to `true` by running the following command:
++
+[source,terminal]
+----
+$ export OC_ENABLE_CMD_UPGRADE_STATUS=true
+----
+. Run the `oc adm upgrade status` command:
++
+[source,terminal]
+----
+$ oc adm upgrade status
+----
++
+.Example output for an update progressing successfully
+[%collapsible]
+====
+[source,terminal]
+----
+= Control Plane =
+Assessment:      Progressing
+Target Version:  4.14.1 (from 4.14.0)
+Completion:      97%
+Duration:        54m
+Operator Status: 32 Healthy, 1 Unavailable
+
+Control Plane Nodes
+NAME                                        ASSESSMENT    PHASE      VERSION   EST    MESSAGE
+ip-10-0-53-40.us-east-2.compute.internal    Progressing   Draining   4.14.0    +10m
+ip-10-0-30-217.us-east-2.compute.internal   Outdated      Pending    4.14.0    ?
+ip-10-0-92-180.us-east-2.compute.internal   Outdated      Pending    4.14.0    ?
+
+= Worker Upgrade =
+
+= Worker Pool =
+Worker Pool:     worker
+Assessment:      Progressing
+Completion:      0%
+Worker Status:   3 Total, 2 Available, 1 Progressing, 3 Outdated, 1 Draining, 0 Excluded, 0 Degraded
+
+Worker Pool Nodes
+NAME                                        ASSESSMENT    PHASE      VERSION   EST    MESSAGE
+ip-10-0-4-159.us-east-2.compute.internal    Progressing   Draining   4.14.0    +10m
+ip-10-0-20-162.us-east-2.compute.internal   Outdated      Pending    4.14.0    ?
+ip-10-0-99-40.us-east-2.compute.internal    Outdated      Pending    4.14.0    ?
+
+= Worker Pool =
+Worker Pool:     infra
+Assessment:      Progressing
+Completion:      0%
+Worker Status:   1 Total, 0 Available, 1 Progressing, 1 Outdated, 1 Draining, 0 Excluded, 0 Degraded
+
+Worker Pool Node
+NAME                                             ASSESSMENT    PHASE      VERSION   EST    MESSAGE
+ip-10-0-4-159-infra.us-east-2.compute.internal   Progressing   Draining   4.14.0    +10m
+
+= Update Health =
+SINCE   LEVEL   IMPACT   MESSAGE
+14m4s   Info    None     Update is proceeding well
+----
+====
+With this information, you can make informed decisions on how to proceed with your update.

--- a/updating/updating_a_cluster/updating-cluster-cli.adoc
+++ b/updating/updating_a_cluster/updating-cluster-cli.adoc
@@ -57,6 +57,9 @@ include::modules/updating-sno.adoc[leveloffset=+1]
 // Updating a cluster by using the CLI
 include::modules/update-upgrading-cli.adoc[leveloffset=+1]
 
+//Introducing oc adm upgrade status - Tech Preview
+include::modules/update-upgrading-oc-adm-upgrade-status.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 .Additional resources
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-10818](https://issues.redhat.com/browse/OSDOCS-10818)

Link to docs preview:
https://77273--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-cluster-cli.html#update-upgrading-oc-adm-upgrade-status_updating-cluster-cli

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
