### PR TITLE
[MULTIARCH-4220] Updating agent-based installer documentation for IBM Z

### DIFF
--- a/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
@@ -25,7 +25,7 @@ The following procedures deploy a single-node {product-title} in a disconnected 
 // Downloading the Agent-based Installer
 include::modules/installing-ocp-agent-download.adoc[leveloffset=+2]
 
-//Verifying architectures 
+//Verifying architectures
 include::modules/agent-installer-architectures.adoc[leveloffset=+2]
 
 // Creating the preferred configuration inputs
@@ -70,6 +70,9 @@ include::modules/installing-ocp-agent-encrypt.adoc[leveloffset=+2]
 
 // Creating and booting the agent image
 include::modules/installing-ocp-agent-boot.adoc[leveloffset=+2]
+
+// Adding {ibm-z-name} agents with {op-system-base} KVM
+include::modules/installing-ocp-agent-ibm-z-kvm.adoc[leveloffset=+2]
 
 // Verifying that the current installation host can pull release images
 include::modules/installing-ocp-agent-tui.adoc[leveloffset=+2]

--- a/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
@@ -18,27 +18,23 @@ The Agent-based Installer can also optionally generate or accept Zero Touch Prov
 
 .Agent-based Installer supported architectures
 |===
-|CPU architecture |Connected installation |Disconnected installation |Comments
+|CPU architecture |Connected installation |Disconnected installation
 
 |`64-bit x86`
 |&#10003;
 |&#10003;
-|
 
 |`64-bit ARM`
 |&#10003;
 |&#10003;
-|
 
 |`ppc64le`
 |&#10003;
 |&#10003;
-|
 
 |`s390x`
 |&#10003;
 |&#10003;
-|ISO boot is not supported. Instead, use PXE assets.
 |===
 
 //Understanding Agent-based Installer

--- a/modules/installing-ocp-agent-boot.adoc
+++ b/modules/installing-ocp-agent-boot.adoc
@@ -19,4 +19,4 @@ $ openshift-install --dir <install_directory> agent create image
 +
 NOTE: Red Hat Enterprise Linux CoreOS (RHCOS) supports multipathing on the primary disk, allowing stronger resilience to hardware failure to achieve higher host availability. Multipathing is enabled by default in the agent ISO image, with a default `/etc/multipath.conf` configuration.
 
-. Boot the `agent.x86_64.iso` or `agent.aarch64.iso` image on the bare metal machines.
+. Boot the `agent.x86_64.iso`, `agent.aarch64.iso`, or `agent.s390x.iso` image on the bare metal machines.

--- a/modules/installing-ocp-agent-download.adoc
+++ b/modules/installing-ocp-agent-download.adoc
@@ -9,11 +9,6 @@
 
 Use this procedure to download the Agent-based Installer and the CLI needed for your installation.
 
-[NOTE]
-====
-Currently, downloading the Agent-based Installer is not supported on the {ibm-z-name} (`s390x`) architecture. The recommended method is by creating PXE assets.
-====
-
 .Procedure
 
 . Log in to the {product-title} web console using your login credentials.

--- a/modules/installing-ocp-agent-ibm-z-kvm.adoc
+++ b/modules/installing-ocp-agent-ibm-z-kvm.adoc
@@ -1,6 +1,11 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_with_agent_based_installer/prepare-pxe-infra-agent.adoc
+// * installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
+
+ifeval::["{context}" == "prepare-pxe-assets-agent"]
+:pxe-boot:
+endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="installing-ocp-agent-ibm-z-kvm_{context}"]
@@ -8,11 +13,18 @@
 
 Use the following procedure to manually add {ibm-z-name} agents with {op-system-base} KVM.
 
+[NOTE]
+====
+Currently, ISO boot support on {ibm-z-name} (`s390x`) is available only for {op-system-base} KVM, which provides the flexibility to choose either PXE or ISO-based installation.
+For installations with z/VM, only PXE boot is supported.
+====
 .Procedure
 
 . Boot your {op-system-base} KVM machine.
 
 . To deploy the virtual server, run the `virt-install` command with the following parameters:
+
+ifdef::pxe-boot[]
 +
 [source,terminal]
 ----
@@ -38,3 +50,29 @@ $ virt-install \
    --osinfo detect=on,require=off
 ----
 <1> For the `--location` parameter, specify the location of the kernel/initrd on the HTTP or HTTPS server.
+endif::pxe-boot[]
+
+ifndef::pxe-boot[]
++
+[source,terminal]
+----
+$ virt-install
+    --name <vm_name> \
+    --autostart \
+    --memory=<memory> \
+    --cpu host \
+    --vcpus=<vcpus> \
+    --cdrom <agent.iso_image> \ <1>
+    --disk pool=default,size=<disk_pool_size> \
+    --network network:default,mac=<mac_address> \
+    --graphics none \
+    --noautoconsole \
+    --os-variant rhel9.0 \
+    --wait=-1
+----
+<1> For the `--cdrom` parameter, specify the location of the ISO image on the HTTP or HTTPS server.
+endif::pxe-boot[]
+
+ifeval::["{context}" == "prepare-pxe-assets-agent"]
+:!pxe-boot:
+endif::[]

--- a/modules/installing-ocp-agent-ibm-z.adoc
+++ b/modules/installing-ocp-agent-ibm-z.adoc
@@ -8,11 +8,6 @@
 
 After creating the PXE assets, you can add {ibm-z-name} agents.
 
-[NOTE]
-====
-Currently ISO boot is not supported on {ibm-z-name} (`s390x`) architecture. Therefore, manually adding {ibm-z-name} agents is required for Agent-based installations on {ibm-z-name}.
-====
-
 Depending on your {ibm-z-name} environment, you can choose from the following options:
 
 * Adding {ibm-z-name} agents with z/VM

--- a/modules/understanding-agent-install.adoc
+++ b/modules/understanding-agent-install.adoc
@@ -9,19 +9,12 @@ As an {product-title} user, you can leverage the advantages of the Assisted Inst
 
 The Agent-based installation comprises a bootable ISO that contains the Assisted discovery agent and the Assisted Service. Both are required to perform the cluster installation, but the latter runs on only one of the hosts.
 
-[NOTE]
-====
-Currently, ISO boot is not supported on {ibm-z-name} (`s390x`) architecture. The recommended method is by using PXE assets, which requires specifying additional kernel arguments.
-====
-
 The `openshift-install agent create image` subcommand generates an ephemeral ISO based on the inputs that you provide. You can choose to provide inputs through the following manifests:
 
 Preferred:
 
 * `install-config.yaml`
 * `agent-config.yaml`
-
-or
 
 Optional: ZTP manifests
 


### PR DESCRIPTION
Version(s): 4.16+

Issues:
https://issues.redhat.com/browse/MULTIARCH-4220 
https://jsw.ibm.com/browse/OCPONZ-3707 

Links to docs preview:
https://77278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html

https://77278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer#installing-ocp-agent-boot_installing-with-agent-based-installer 

https://77278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html

https://77278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent#installing-ocp-agent-ibm-z-kvm-iso-boot_prepare-pxe-assets-agent 


QE review:
 

 

- [x] QE has approved this change.



Additional information:
Link to doc inputs provided by Neeraj on Box notes: https://ibm.ent.box.com/notes/1533268146935