### PR TITLE
TELCODOCS-1893-RN creating RN

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -143,6 +143,11 @@ With this update, you can configure the SR-IOV Network Operator to drain nodes i
 
 For further information, see xref:../networking/hardware_networks/configuring-sriov-device.adoc#configure-sr-iov-operator-parallel-nodes_configuring-sriov-device[Configuring parallel node draining during SR-IOV network policy updates].
 
+[id="ocp-4-16-networking-create-sriovoperatorconfig_{context}"]
+==== SR-IOV Network Operator no longer automatically creates the SriovOperatorConfig CR
+
+As of {product-title} 4.16, the SR-IOV Network Operator no longer automatically creates a `SriovOperatorConfig` custom resource (CR). Create the `SriovOperatorConfig` CR using the procedure described in xref:../networking/hardware_networks/configuring-sriov-operator.adoc#nw-sriov-configuring-operator_configuring-sriov-operator[Configuring the SR-IOV Network Operator].
+
 [id="ocp-4-16-q-in-q-support_{context}"]
 [id="ocp-4-16-q-in-q-support"]
 ==== Supporting double-tagged packets (QinQ)


### PR DESCRIPTION
[TELCODOCS-1893]: SriovOperatorConfig will no longer be created by the Operator in 4.16 and onwards
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-1893
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://77280--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-networking-create-sriovoperatorconfig_release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
