### PR TITLE
OSDOCS-10838-new: Documented the 4.14.29 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3322,6 +3322,35 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.14.29
+[id="ocp-4-14-29"]
+=== RHBA-2024:3697 - {product-title} 4.14.29 bug fix and security updates
+
+Issued: 2024-06-13
+
+{product-title} release 4.14.29, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:3697[RHBA-2024:3697] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:3700[RHSA-2024:3700] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.29 --pullspecs
+----
+
+[id="ocp-4-14-29-bug-fixes"]
+==== Bug fixes
+
+* Previously, for {product-title} deployments on {rh-openstack-first}, the `MachineSet` object did not correctly apply the value for the `Port Security` parameter. This meant that the `port_security_enabled` parameter in the {rh-openstack} server's port had an unexpected value. With this release, the `MachineSet` object applies the `port_security_enabled` flag as expected. (link:https://issues.redhat.com/browse/OCPBUGS-32428[*OCPBUGS-32428*])
+
+* Previously, when an `IngressController` object was configured with client SSL/TLS, but did not have the `clientca-configmap` finalizer, the Ingress Operator tried to add the finalizer without checking whether the `IngressController` object was marked for deletion. Consequently, if an `IngressController` was configured with client SSL/TLS and was subsequently deleted, the Operator would correctly remove the finalizer. The Operator would then repeatedly, and erroneously, try and fail to update the `IngressController` object to add the finalizer back, resulting in error messages in the Operator's logs. With this update, the Ingress Operator no longer adds the `clientca-configmap` finalizer to an `IngressController` object that is marked for deletion. As a result, the Ingress Operator no longer tries to perform erroneous updates and no longer logs the associated errors. (link:https://issues.redhat.com/browse/OCPBUGS-34410[*OCPBUGS-34410*])
+
+[id="ocp-4-14-29-updating"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.14.28
 [id="ocp-4-14-28"]
 === RHSA-2024:3523 - {product-title} 4.14.28 bug fix update and security update


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-10838](https://issues.redhat.com/browse/OSDOCS-10838)

Link to docs preview:
[4.14.29 release notes](https://77296--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-29)
