### PR TITLE
RHDEVDOCS-6033: Document the changes in the TLS termination policy for the default and user-defined Argo CD instances

### DIFF
--- a/argocd_instance/argo-cd-cr-component-properties.adoc
+++ b/argocd_instance/argo-cd-cr-component-properties.adoc
@@ -28,4 +28,5 @@ include::modules/proc_configuring-notificationsconfiguration-crd-by-using-the-oc
 
 [role="_additional-resources"]
 == Additional resources
-* xref:../argocd_instance/argo-cd-cr-component-properties#gitops-argo-cd-notification_argo-cd-cr-component-properties[Enabling notifications with an Argo CD instance].
+* xref:../argocd_instance/setting-up-argocd-instance.adoc#gitops-argo-cd-installation_setting-up-argocd-instance[Installing a user-defined Argo CD instance]
+

--- a/argocd_instance/setting-up-argocd-instance.adoc
+++ b/argocd_instance/setting-up-argocd-instance.adoc
@@ -6,10 +6,25 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-By default, the {gitops-title} installs an instance of Argo CD in the `openshift-gitops` namespace with additional permissions for managing certain cluster-scoped resources. To manage cluster configurations or deploy applications, you can install and deploy a new Argo CD instance. By default, any new instance has permissions to manage resources only in the namespace where it is deployed.
+By default, {gitops-title} installs an instance of Argo CD in the `openshift-gitops` namespace with additional permissions for managing certain cluster-scoped resources. This default Argo CD instance is also called as the default cluster-scoped instance.
+
+[NOTE]
+====
+For {gitops-shortname} version 1.13 and later, the route TLS termination is set as default to the `reencrypt` mode for both the default and user-defined Argo CD instances. TLS connections to the Argo CD instances now receive the default ingress certificate that is set in {OCP}, instead of the self-signed Argo CD certificate.
+
+You can modify the route TLS termination policy by configuring the `.spec.server.route.tls` field of the Argo CD CR.
+====
+
+To manage cluster configurations or deploy applications, you can install and deploy a new user-defined Argo CD instance. By default, any new user-defined instance has permissions to manage resources only in the namespace where it is deployed.
 
 // Installing an Argo CD instance
 include::modules/gitops-argo-cd-installation.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources 
+* link:https://argocd-operator.readthedocs.io/en/latest/usage/routes/#setting-tls-modes-for-routes[Configuring the route TLS termination]
+* xref:../argocd_instance/argo-cd-cr-component-properties.adoc#argo-cd-properties_argo-cd-cr-component-properties[Argo CD custom resource properties]
+* link:https://docs.openshift.com/container-platform/latest/rest_api/network_apis/route-route-openshift-io-v1.html#spec-tls[Specification for TLS termination configuration]
 
 // Enabling replicas for Argo CD server and repo server
 include::modules/gitops-enable-replicas-for-argo-cd-server.adoc[leveloffset=+1]

--- a/modules/gitops-argo-cd-installation.adoc
+++ b/modules/gitops-argo-cd-installation.adoc
@@ -4,9 +4,9 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="gitops-argo-cd-installation_{context}"]
-= Installing an Argo CD instance 
+= Installing a user-defined Argo CD instance 
 
-To manage cluster configurations or deploy applications, you can install and deploy a new Argo CD instance.
+To manage cluster configurations or deploy applications, you can install and deploy a new user-defined Argo CD instance.
 
 .Prerequisites
 
@@ -19,7 +19,7 @@ To manage cluster configurations or deploy applications, you can install and dep
 
 . In the *Administrator* perspective of the web console, click *Operators* -> *Installed Operators*.
 
-. Create or select the project where you want to install the Argo CD instance from the *Project* drop-down menu.
+. Create or select the project where you want to install the user-defined Argo CD instance from the *Project* drop-down menu.
 
 . Select *OpenShift GitOps Operator* from the installed operators list and click the *Argo CD* tab.
 
@@ -27,7 +27,12 @@ To manage cluster configurations or deploy applications, you can install and dep
 
 .. Enter the *Name* of the instance. By default, the *Name* is set to `example`. 
 
-.. Create an external OS Route to access Argo CD server. Click *Server* -> *Route* and check *Enabled*.  
+.. Create an external OS Route to access Argo CD server. Click *Server* -> *Route* and check *Enabled*. 
++
+[NOTE]
+====
+You can modify the route TLS termination policy by configuring the `.spec.server.route.tls` field of the Argo CD CR.
+==== 
 
 .. Optional: You can also configure YAML for creating an external OS Route by adding the following configuration:
 +
@@ -45,7 +50,7 @@ spec:
       enabled: true
 ----
 
-. Go to *Networking* -> *Routes* -> *<instance_name>-server* in the project where the Argo CD instance is installed.
+. Go to *Networking* -> *Routes* -> *<instance_name>-server* in the project where the user-defined Argo CD instance is installed.
 
 . On the *Details* tab, click the Argo CD web UI link under *Route details* -> *Location*. The Argo CD web UI opens in a separate browser window.
 
@@ -55,9 +60,9 @@ spec:
 ====
 To be a user of the `cluster-admins` group, use the `oc adm groups new cluster-admins <user>` command, where `<user>` is the default cluster role that you can bind to users and groups cluster-wide or locally.
 ====
-. Obtain the password for the Argo CD instance:
+. Obtain the password for the user-defined Argo CD instance:
 .. Use the navigation panel to go to the *Workloads* -> *Secrets* page.
-.. Use the *Project* drop-down list and select the namespace where the Argo CD instance is created.
+.. Use the *Project* drop-down list and select the namespace where the user-defined Argo CD instance is created.
 .. Select the *<argo_CD_instance_name>-cluster* instance to display the password.
 .. On the *Details* tab, copy the password under *Data* -> *admin.password*.
 . Use `admin` as the *Username* and the copied password as the *Password* to log in to the Argo CD UI in the new window.


### PR DESCRIPTION
Jira issue: [RHDEVDOCS-6033](https://issues.redhat.com/browse/RHDEVDOCS-6033) and [RHDEVDOCS-6076](https://issues.redhat.com/browse/RHDEVDOCS-6076)

Aligned team: DevTools 
Cherry-pick to versions: `gitops-docs-1.13`

Docs preview:

- [Setting up an Argo CD instance](https://77298--ocpdocs-pr.netlify.app/openshift-gitops/latest/argocd_instance/setting-up-argocd-instance.html)
- [Installing an Argo CD instance](https://77298--ocpdocs-pr.netlify.app/openshift-gitops/latest/argocd_instance/setting-up-argocd-instance.html#gitops-argo-cd-installation_setting-up-argocd-instance)
- [Argo CD custom resource and component properties](https://77298--ocpdocs-pr.netlify.app/openshift-gitops/latest/argocd_instance/argo-cd-cr-component-properties)

SME review: @chetan-rns, @jgwest 

QE review: @varshab1210, @mehabhalodiya, @trdoyle81 (any one of them)

Peer review:  @stevsmit and @jneczypor 

Additional information: This PR also resolves [RHDEVDOCS-6076](https://issues.redhat.com/browse/RHDEVDOCS-6076).
