### PR TITLE
OSDOCS#10845: Edit ClusterExtension rename NOTE

### DIFF
--- a/operators/olm_v1/index.adoc
+++ b/operators/olm_v1/index.adoc
@@ -26,8 +26,8 @@ Fully declarative model that supports GitOps workflows::
 ====
 Earlier Technology Preview phases of {olmv1} introduced a new `Operator` API; this API is renamed `ClusterExtension` in {product-title} 4.16 to address the following:
 
-* Signals that {olmv1} encompasses more than only Operators
-* Avoids the issue of the separate `Operator` API available in {olmv0}, which caused user experience conflicts, for example with `oc <verb> operators` commands
+* More accurately reflects the simplified functionality of extending a cluster's capabilities
+* Better represents a more flexible packaging format
 * `Cluster` prefix clearly indicates that `ClusterExtension` objects are cluster-scoped, a change from {olmv0} where Operators could be either namespace-scoped or cluster-scoped
 ====
 * The `Catalog` API, provided by the new catalogd component, serves as the foundation for {olmv1}, unpacking catalogs for on-cluster clients so that users can discover installable content, such as Kubernetes extensions and Operators. This provides increased visibility into all available Operator bundle versions, including their details, channels, and update edges.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-10845

4.16

Follow-up edits to https://github.com/openshift/openshift-docs/pull/76372/files#diff-a58502f68312db24f7cdfdf89fc8d611d60d1d9b97f8b32783796a2a75af9bf8R23-R32 per PM discussion. Updates bullets in the `[NOTE]`.

Preview: https://77312--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/olm_v1/index.html#olmv1-highlights_olmv1-about 