### PR TITLE
[OCPBUGS#35239]: Update the compatibility matrix

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -37,11 +37,33 @@
 :ocp: OpenShift Container Platform
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:ocp-supported-version: 4.15
-:rhacs-version: 4.4
-:quay-version: 3.11
-:rhacm-version: 2.10
-:odf-version: 4.15
+// These variable are the current product release versions for the OPP products
+:ocp-supported-version: 4.16
+:rhacs-version: 4.5
+:quay-version: 3.12
+:rhacm-version: 2.11
+:odf-version: 4.16
+// These variables are for the immediate past 4 OPP product versions that are in the compatibility table
+:ocp-supported-version-1: 4.15
+:rhacs-version-1: 4.4
+:quay-version-1: 3.11
+:rhacm-version-1: 2.10
+:odf-version-1: 4.15
+:ocp-supported-version-2: 4.14
+:rhacs-version-2: 4.3
+:quay-version-2: 3.10
+:rhacm-version-2: 2.9
+:odf-version-2: 4.14
+:ocp-supported-version-3: 4.13
+:rhacs-version-3: 4.0
+:quay-version-3: 3.8
+:rhacm-version-3: 2.8
+:odf-version-3: 4.12
+:ocp-supported-version-4: 4.12
+:rhacs-version-4: 3.7.4
+:quay-version-4: 3.8
+:rhacm-version-4: 2.7
+:odf-version-4: 4.12
 // Following variables are required for publishing using PV2
 :product-title: OpenShift Platform Plus
 :product-version: .1

--- a/modules/opp-architecture-compatibility-matrix.adoc
+++ b/modules/opp-architecture-compatibility-matrix.adoc
@@ -8,15 +8,41 @@
 
 {product-title} is based on {ocp} {ocp-supported-version}. To find the verified release number for each {product-title} product, see the following information:
 
-[cols="1,1,1,1"]
+[cols="1,1,1,1,1"]
 |===
+|{ocp}
 |{rh-rhacm}
 |{acs}
 |{quay}
 |{rh-storage-essentials-first}
 
+|{ocp-supported-version}
 |{rhacm-version}
 |{rhacs-version}
 |{quay-version}
 |{odf-version}
+
+|{ocp-supported-version-1}
+|{rhacm-version-1}
+|{rhacs-version-1}
+|{quay-version-1}
+|{odf-version-1}
+
+|{ocp-supported-version-2}
+|{rhacm-version-2}
+|{rhacs-version-2}
+|{quay-version-2}
+|{odf-version-2}
+
+|{ocp-supported-version-3}
+|{rhacm-version-3}
+|{rhacs-version-3}
+|{quay-version-3}
+|{odf-version-3}
+
+|{ocp-supported-version-4}
+|{rhacm-version-4}
+|{rhacs-version-4}
+|{quay-version-4}
+|{odf-version-4}
 |===


### PR DESCRIPTION
Jira: [OCPBUGS-35239](https://issues.redhat.com/browse/OCPBUGS-35239)

Version(s):
This PR is based on the ‘opp-docs-main’ repo and when merged, it should be in that branch only. The OPP doc is not versioned. Add this PR to the ‘Continuous Release’ milestone.

Link to docs preview:
[Architecture](https://77314--ocpdocs-pr.netlify.app/openshift-opp/latest/architecture/opp-architecture.html) Updated 6/26/2024)

QE review:
- [x ] QE has approved this change. (Oded R.)

Additional information:
The product versions that are listed might not be the latest available version for the product. The versions listed in the compatibility matrix are the latest verified versions for OPP.