### PR TITLE
[enterprise-4.16] OSDOCS#10501: Add ClusterExtension API rename 4.16 RN

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -321,12 +321,25 @@ With this release, the etcd tuning parameters can be set to values that optimize
 
 With this release, `dasd` image artifacts for the `s390x` architecture are removed from the {product-title} image building pipeline. You can still use the `metal4k` image artifact, which is identical and contains the same functionality.
 
+[discrete]
 [id="egress-ip-etp-local-support_{context}"]
 === Support for EgressIP with ExternalTrafficPolicy=Local services
 
 Previously, it was unsupported for EgressIP selected pods to also serve as backends for services with `externalTrafficPolicy` set to `Local`. When attempting this configuration, service ingress traffic reaching the pods was incorrectly rerouted to the egress node hosting the EgressIP. This affected how responses to incoming service traffic connections were handled and led to non-functional services when `externalTrafficPolicy` was set to `Local`, as connections were dropped and the service became unavailable.
 
 With {product-title} {product-version}, OVN-Kubernetes now supports the use of `ExternalTrafficPolicy=Local` services and EgressIP configurations at the same time on the same set of selected pods. OVN-Kubernetes now only reroutes the traffic originating from the EgressIP pods towards the egress node while routing the responses to ingress service traffic from the EgressIP pods via the same node where the pod is located.
+
+[discrete]
+[id="ocp-4-16-olm-ce-rename_{context}"]
+=== Operator API renamed to ClusterExtension
+
+Earlier Technology Preview phases of {olmv1-first} introduced a new `Operator` API, provided as `operator.operators.operatorframework.io` by the Operator Controller component. In {product-title} 4.16, this API is renamed `ClusterExtension`, provided as `clusterextension.olm.operatorframework.io`, for this Technology Preview phase of {olmv1}.
+
+This API still streamlines management of installed extensions, which includes Operators via the `registry+v1` bundle format, by consolidating user-facing APIs into a single object. The rename to `ClusterExtension` addresses the following:
+
+* More accurately reflects the simplified functionality of extending a cluster's capabilities
+* Better represents a more flexible packaging format
+* `Cluster` prefix clearly indicates that `ClusterExtension` objects are cluster-scoped, a change from {olmv0} where Operators could be either namespace-scoped or cluster-scoped
 
 [id="ocp-4-16-deprecated-removed-features_{context}"]
 == Deprecated and removed features


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-10501

4.16

Related to https://github.com/openshift/openshift-docs/pull/76372/files#diff-a58502f68312db24f7cdfdf89fc8d611d60d1d9b97f8b32783796a2a75af9bf8R23-R32 and its follow-up https://github.com/openshift/openshift-docs/pull/77312.

Preview: https://77315--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-olm-ce-rename_release-notes