### PR TITLE
CNV-34643-01: RN for Downward Metrics and CPU Hotplug

### DIFF
--- a/virt/release_notes/virt-4-16-release-notes.adoc
+++ b/virt/release_notes/virt-4-16-release-notes.adoc
@@ -83,6 +83,16 @@ This release adds new features and enhancements related to the following compone
 [id="virt-4-16-web"]
 === Web console
 
+//CNV-34687 Release note: Generally available (GA) CPU Hotplug
+* Hot plugging virtual machines is now generally available. If a virtual machine cannot be hot plugged, the condition `RestartRequired` is applied to the VM. You can view this condition in the *Diagnostics* tab of the web console.
+
+[id="virt-4-16-monitoring"]
+=== Monitoring
+
+//CNV-41655 Release note: NEW Downward Metrics 4.16
+* As an administrator, you can now xref:../../virt/monitoring/virt-exposing-downward-metrics.adoc#virt-exposing-downward-metrics[expose a limited set of host and virtual machine (VM) metrics to a guest VM through a virtio-serial port] for {VirtProductName} by enabling a `downwardMetrics` feature gate and configuring a `downwardMetrics` device. Users retrieve the metrics by using the `vm-dump-metrics` tool or from the command line.
++
+On {op-system-base-full} 9, xref:../../virt/monitoring/virt-exposing-downward-metrics.adoc#virt-viewing-downward-metrics-cli_virt-exposing-downward-metrics[use the command line] to view downward metrics. The `vm-dump-metrics` tool is not supported on the {op-system-base-full} 9 platform.
 
 [id="virt-4-16-deprecated-removed"]
 == Deprecated and removed features


### PR DESCRIPTION
Version(s):
4.16

Issue:
* https://issues.redhat.com/browse/CNV-41655
* https://issues.redhat.com/browse/CNV-34687

Link to docs preview:
https://77327--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-16-release-notes.html#virt-4-16-web

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
