### PR TITLE
OSDOCS-10866 Remove non-4.16 lifecycle information

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -24,16 +24,13 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 You must use {op-system} machines for the control plane, and you can use either {op-system} or {op-system-base} for compute machines.
 //Removed the note per https://issues.redhat.com/browse/GRPA-3517
 
-For {product-title} 4.12 on `x86_64` architecture, Red Hat has added a 6-month Extended Update Support (EUS) phase that extends the total available lifecycle from 18 months to 24 months. For {product-title} 4.12 running on 64-bit ARM (`aarch64`), {ibm-power-name} (`ppc64le`), and {ibm-z-name} (`s390x`) architectures, the EUS lifecycle remains at 18 months.
+//Even-numbered release lifecycle verbiage
+Starting from {product-title} 4.14, the Extended Update Support (EUS) phase for even-numbered releases increases the total available lifecycle to 24 months on all supported architectures, including `x86_64`, 64-bit ARM (`aarch64`), {ibm-power-name} (`ppc64le`), and {ibm-z-name} (`s390x`) architectures.
+Beyond this, Red{nbsp}Hat also offers a 12-month additional EUS add-on, denoted as _Additional EUS Term 2_, that extends the total available lifecycle from 24 months to 36 months. The Additional EUS Term 2 is available on all architecture variants of {product-title}.
 
-Starting with {product-title} 4.14, each EUS phase for even numbered releases on all supported architectures, including `x86_64`, 64-bit ARM (`aarch64`), {ibm-power-name} (`ppc64le`), and {ibm-z-name} (`s390x`) architectures, has a total available lifecycle of 24 months.
-
-Starting with {product-title} 4.14, Red Hat offers a 12-month additional EUS add-on, denoted as _Additional EUS Term 2_, that extends the total available lifecycle from 24 months to 36 months. The Additional EUS Term 2 is available on all architecture variants of {product-title}.
-
-For more information about this support, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
-
-//TODO: The line below should be used when it is next appropriate. Revisit in August 2023 time frame.
-Maintenance support ends for version 4.12 on 25 January 2025 and goes to extended life phase. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
+//Odd-numbered release lifecycle verbiage
+//The support lifecycle for odd-numbered releases, such as {product-title} 4.15, on all supported architectures, including `x86_64`, 64-bit ARM (`aarch64`), {ibm-power-name} (`ppc64le`), and {ibm-z-name} (`s390x`) architectures is 18 months.
+For more information about support for all versions, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
 
 Commencing with the {product-version} release, Red Hat is simplifying the administration and management of Red Hat shipped cluster Operators with the introduction of three new life cycle classifications; Platform Aligned, Platform Agnostic, and Rolling Stream. These life cycle classifications provide additional ease and transparency for cluster administrators to understand the life cycle policies of each Operator and form cluster maintenance and upgrade plans with predictable support boundaries. For more information, see link:https://access.redhat.com/webassets/avalon/j/includes/session/scribe/?redirectTo=https%3A%2F%2Faccess.redhat.com%2Fsupport%2Fpolicy%2Fupdates%2Fopenshift_operators[OpenShift Operator Life Cycles].
 


### PR DESCRIPTION
Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-10866](https://issues.redhat.com/browse/OSDOCS-10866)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

[Link to docs preview](https://77337--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-about-this-release_release-notes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Change based on stakeholder feedback. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
