### PR TITLE
RHDEVDOCS 6074 change from clustertasks to new cluster resolver tasks- existing docs part

### DIFF
--- a/create/managing-nonversioned-and-versioned-cluster-tasks.adoc
+++ b/create/managing-nonversioned-and-versioned-cluster-tasks.adoc
@@ -12,7 +12,7 @@ Both NVCT and VCT have the same metadata, behavior, and specifications, includin
 
 [IMPORTANT]
 ====
-In {pipelines-title} 1.10, cluster task functionality is deprecated and is planned to be removed in a future release.
+In {pipelines-title} 1.10, `ClusterTask` functionality is deprecated and is planned to be removed in a future release.
 ====
 
 include::modules/op-differences-between-non-versioned-and-versioned-cluster-tasks.adoc[leveloffset=+1]

--- a/create/remote-pipelines-tasks-resolvers.adoc
+++ b/create/remote-pipelines-tasks-resolvers.adoc
@@ -19,6 +19,8 @@ Bundles resolver:: Retrieves a task or pipeline from a Tekton bundle, which is a
 Cluster resolver:: Retrieves a task or pipeline that is already created on the same {OCP} cluster in a specific namespace.
 Git resolver:: Retrieves a task or pipeline binding from a Git repository. You must specify the repository, the branch, and the path.
 
+An {pipelines-shortname} installation includes a set of standard tasks that you can use in your pipelines. These tasks are located in the {pipelines-shortname} installation namespace, which is normally the `openshift-pipelines` namespace. You can use the cluster resolver to access the tasks.
+
 [id="resolver-hub_{context}"]
 == Specifying a remote pipeline or task from a Tekton catalog
 You can use the hub resolver to specify a remote pipeline or task that is defined either in a public Tekton catalog of link:https://artifacthub.io/[{artifact-hub}] or in an instance of {tekton-hub}.
@@ -43,6 +45,8 @@ include::modules/op-resolver-bundle.adoc[leveloffset=+2]
 == Specifying a remote pipeline or task from the same cluster
 
 You can use the cluster resolver to specify a remote pipeline or task that is defined in a namespace on the {OCP} cluster where {pipelines-title} is running.
+
+In particular, you can use the cluster resolver to access tasks that {pipelines-shortname} provides in its installation namespace, which is normally the `openshift-pipelines` namespace.
 
 include::modules/op-resolver-cluster-config.adoc[leveloffset=+2]
 include::modules/op-resolver-cluster.adoc[leveloffset=+2]

--- a/modules/op-about-pipelines.adoc
+++ b/modules/op-about-pipelines.adoc
@@ -8,7 +8,7 @@ A `Pipeline` is a collection of `Task` resources arranged in a specific order of
 
 A `Pipeline` resource definition consists of a number of fields or attributes, which together enable the pipeline to accomplish a specific goal. Each `Pipeline` resource definition must contain at least one `Task` resource, which ingests specific inputs and produces specific outputs. The pipeline definition can also optionally include _Conditions_, _Workspaces_, _Parameters_, or _Resources_ depending on the application requirements.
 
-The following example shows the `build-and-deploy` pipeline, which builds an application image from a Git repository using the `buildah` `ClusterTask` resource:
+The following example shows the `build-and-deploy` pipeline, which builds an application image from a Git repository using the `buildah` task provided in the `openshift-pipelines` namespace:
 
 [source,yaml,subs="attributes+"]
 ----
@@ -36,32 +36,44 @@ spec: <4>
   tasks: <7>
   - name: fetch-repository
     taskRef:
-      name: git-clone
-      kind: ClusterTask
+      resolver: cluster
+      params:
+      - name: kind
+        value: task
+      - name: name
+        value: git-clone
+      - name: namespace
+        value: openshift-pipelines
     workspaces:
     - name: output
       workspace: shared-workspace
     params:
-    - name: url
+    - name: URL
       value: $(params.git-url)
-    - name: subdirectory
+    - name: SUBDIRECTORY
       value: ""
-    - name: deleteExisting
+    - name: DELETE_EXISTING
       value: "true"
-    - name: revision
+    - name: REVISION
       value: $(params.git-revision)
   - name: build-image <8>
     taskRef:
-      name: buildah
-      kind: ClusterTask
+      resolver: cluster
+      params:
+      - name: kind
+        value: task
+      - name: name
+        value: buildah
+      - name: namespace
+        value: openshift-pipelines
+    workspaces:
+    - name: source
+      workspace: shared-workspace
     params:
     - name: TLSVERIFY
       value: "false"
     - name: IMAGE
       value: $(params.IMAGE)
-    workspaces:
-    - name: source
-      workspace: shared-workspace
     runAfter:
     - fetch-repository
   - name: apply-manifests <9>
@@ -93,11 +105,11 @@ spec: <4>
 <5> Workspaces used across all the tasks in the pipeline.
 <6> Parameters used across all the tasks in the pipeline.
 <7> Specifies the list of tasks used in the pipeline.
-<8> Task `build-image`, which uses the `buildah` `ClusterTask` to build application images from a given Git repository.
+<8> Task `build-image`, which uses the `buildah` task provided in the `openshift-pipelines` namespace to build application images from a given Git repository.
 <9> Task `apply-manifests`, which uses a user-defined task with the same name.
 <10> Specifies the sequence in which tasks are run in a pipeline. In this example, the `apply-manifests` task is run only after the `build-image` task is completed.
 
 [NOTE]
 ====
-The {pipelines-title} Operator installs the Buildah cluster task and creates the `pipeline` service account with sufficient permission to build and push an image. The Buildah cluster task can fail when associated with a different service account with insufficient permissions.
+The {pipelines-title} Operator installs the Buildah task in the `openshift-pipelines` namespace and creates the `pipeline` service account with sufficient permission to build and push an image. The Buildah task can fail when associated with a different service account with insufficient permissions.
 ====

--- a/modules/op-about-workspace.adoc
+++ b/modules/op-about-workspace.adoc
@@ -43,16 +43,22 @@ spec:
   tasks: <2>
   - name: build-image
     taskRef:
-      name: buildah
-      kind: ClusterTask
+      resolver: cluster
+      params:
+      - name: kind
+        value: task
+      - name: name
+        value: buildah
+      - name: namespace
+        value: openshift-pipelines
+    workspaces: <3>
+    - name: source <4>
+      workspace: shared-workspace <5>
     params:
     - name: TLSVERIFY
       value: "false"
     - name: IMAGE
       value: $(params.IMAGE)
-    workspaces: <3>
-    - name: source <4>
-      workspace: shared-workspace <5>
     runAfter:
     - fetch-repository
   - name: apply-manifests

--- a/modules/op-assembling-a-pipeline.adoc
+++ b/modules/op-assembling-a-pipeline.adoc
@@ -14,7 +14,7 @@ In this section, you will create a pipeline that takes the source code of the ap
 The pipeline performs the following tasks for the back-end application `pipelines-vote-api` and front-end application `pipelines-vote-ui`:
 
 * Clones the source code of the application from the Git repository by referring to the `git-url` and `git-revision` parameters.
-* Builds the container image using the `buildah` cluster task.
+* Builds the container image using the `buildah` task provided in the `openshift-pipelines` namespace.
 * Pushes the image to the {product-registry} by referring to the `image` parameter.
 * Deploys the new image on {OCP} by using the `apply-manifests` and `update-deployment` tasks.
 
@@ -49,30 +49,42 @@ spec:
   tasks:
   - name: fetch-repository
     taskRef:
-      name: git-clone
-      kind: ClusterTask
+      resolver: cluster
+      params:
+      - name: kind
+        value: task
+      - name: name
+        value: git-clone
+      - name: namespace
+        value: openshift-pipelines
     workspaces:
     - name: output
       workspace: shared-workspace
     params:
-    - name: url
+    - name: URL
       value: $(params.git-url)
-    - name: subdirectory
+    - name: SUBDIRECTORY
       value: ""
-    - name: deleteExisting
+    - name: DELETE_EXISTING
       value: "true"
-    - name: revision
+    - name: REVISION
       value: $(params.git-revision)
   - name: build-image
     taskRef:
-      name: buildah
-      kind: ClusterTask
-    params:
-    - name: IMAGE
-      value: $(params.IMAGE)
+      resolver: cluster
+      params:
+      - name: kind
+        value: task
+      - name: name
+        value: buildah
+      - name: namespace
+        value: openshift-pipelines
     workspaces:
     - name: source
       workspace: shared-workspace
+    params:
+    - name: IMAGE
+      value: $(params.IMAGE)
     runAfter:
     - fetch-repository
   - name: apply-manifests

--- a/modules/op-configuring-buildah-to-use-build-user.adoc
+++ b/modules/op-configuring-buildah-to-use-build-user.adoc
@@ -10,11 +10,11 @@ You can define a Buildah task to use the `build` user with user id `1000`.
 
 .Procedure
 
-. Create a copy of the `buildah` cluster task as an ordinary task.
+. Create a copy of the `buildah` task, which is provided in the `openshift-pipelines` namespace; change the name of the copy to `buildah-as-user`.
 +
 [source,terminal]
 ----
-$ oc get clustertask buildah -o yaml | yq '. |= (del .metadata |= with_entries(select(.key == "name" )))' | yq '.kind="Task"' | yq '.metadata.name="buildah-as-user"' | oc create -f -
+$ oc get task buildah -n openshift-pipelines -o yaml | yq '. |= (del .metadata |= with_entries(select(.key == "name" )))' | yq '.kind="Task"' | yq '.metadata.name="buildah-as-user"' | oc create -f -
 ----
 
 . Edit the copied `buildah` task.

--- a/modules/op-constructing-pipelines-using-pipeline-builder.adoc
+++ b/modules/op-constructing-pipelines-using-pipeline-builder.adoc
@@ -13,7 +13,7 @@ In the *Developer* perspective of the console, you can use the *+Add* -> *Pipeli
 
 [IMPORTANT]
 ====
-In {pipelines-title} 1.10, cluster task functionality is deprecated and is planned to be removed in a future release.
+In {pipelines-title} 1.10, `ClusterTask` functionality is deprecated and is planned to be removed in a future release.
 ====
 
 * Specify the type of resources required for the pipeline run, and if required, add additional parameters to the pipeline.

--- a/modules/op-creating-pipeline-tasks.adoc
+++ b/modules/op-creating-pipeline-tasks.adoc
@@ -57,5 +57,5 @@ tkn                                      1 day ago
 
 [IMPORTANT]
 ====
-In {pipelines-title} 1.10, cluster task functionality is deprecated and is planned to be removed in a future release.
+In {pipelines-title} 1.10, `ClusterTask` functionality is deprecated and is planned to be removed in a future release.
 ====

--- a/modules/op-disabling-cluster-tasks-and-pipeline-templates.adoc
+++ b/modules/op-disabling-cluster-tasks-and-pipeline-templates.adoc
@@ -29,3 +29,7 @@ spec:
         value: 'true'
 ----
 
+[IMPORTANT]
+====
+In {pipelines-title} 1.10, `ClusterTask` functionality is deprecated and is planned to be removed in a future release.
+====

--- a/modules/op-entitlements-manual-copying.adoc
+++ b/modules/op-entitlements-manual-copying.adoc
@@ -24,7 +24,7 @@ $ oc get secret etc-pki-entitlement -n openshift-config-managed -o json | \
 ----
 <1> Replace `<pipeline_namespace>` with the namespace of your pipeline.
 
-. In your Buildah task definition, use the `buildah` cluster task or a copy of this cluster task and define the `rhel-entitlement` workspace, as in the following example.
+. In your Buildah task definition, use the `buildah` task provided in the `openshift-pipelines` namespace or a copy of this task and define the `rhel-entitlement` workspace, as shown in the following example.
 
 . In your task run or pipeline run that runs the Buildah task, assign the `etc-pki-entitlement` secret to the `rhel-entitlement` workspace, as in the following example.
 
@@ -60,8 +60,14 @@ spec:
 # ...
       - name: buildah
         taskRef:
-          name: buildah
-          kind: ClusterTask
+          resolver: cluster
+          params:
+          - name: kind
+            value: task
+          - name: name
+            value: buildah
+          - name: namespace
+            value: openshift-pipelines
         workspaces:
         - name: source
           workspace: shared-workspace

--- a/modules/op-entitlements-shared-csi-driver.adoc
+++ b/modules/op-entitlements-shared-csi-driver.adoc
@@ -67,7 +67,7 @@ $ oc create rolebinding shared-resource-rhel-entitlement --role=shared-shared-re
 If you changed the default service account for {pipelines-shortname} or if you define a custom service account in the pipeline run or task run, assign the role to this account instead of the `pipeline` account.
 ====
 
-. In your Buildah task definition, use the `buildah` cluster task or a copy of this cluster task and define the `rhel-entitlement` workspace, as in the following example.
+. In your Buildah task definition, use the `buildah` task provided in the `openshift-pipelines` namespace or a copy of this task and define the `rhel-entitlement` workspace, as shown in the following example.
 
 . In your task run or pipeline run that runs the Buildah task, assign the shared secret to the `rhel-entitlement` workspace, as in the following example.
 
@@ -84,7 +84,7 @@ spec:
       volumeClaimTemplate:
         spec:
           accessModes:
-            - ReadWriteOnce
+          - ReadWriteOnce
           resources:
             requests:
               storage: 1Gi
@@ -99,25 +99,31 @@ spec:
           sharedSecret: shared-rhel-entitlement
   pipelineSpec:
     workspaces:
-      - name: shared-workspace
-      - name: dockerconfig
-      - name: rhel-entitlement  # <2>
+    - name: shared-workspace
+    - name: dockerconfig
+    - name: rhel-entitlement  # <2>
     tasks:
 # ...
-      - name: buildah
-        taskRef:
-          name: buildah
-          kind: ClusterTask
-        workspaces:
-        - name: source
-          workspace: shared-workspace
-        - name: dockerconfig
-          workspace: dockerconfig
-        - name: rhel-entitlement  # <3>
-          workspace: rhel-entitlement
+    - name: buildah
+      taskRef:
+        resolver: cluster
         params:
-        - name: IMAGE
-          value: <image_where_you_want_to_push>
+        - name: kind
+          value: task
+        - name: name
+          value: buildah
+        - name: namespace
+          value: openshift-pipelines
+      workspaces:
+      - name: source
+        workspace: shared-workspace
+      - name: dockerconfig
+        workspace: dockerconfig
+      - name: rhel-entitlement  # <3>
+        workspace: rhel-entitlement
+      params:
+      - name: IMAGE
+        value: <image_where_you_want_to_push>
 ----
 <1> The definition of the `rhel-entitlement` workspace in the pipeline run, assigning the `shared-rhel-entitlement` CSI shared secret to the workspace
 <2> The definition of the `rhel-entitlement` workspace in the pipeline definition

--- a/modules/op-installing-pipelines-operator-in-web-console.adoc
+++ b/modules/op-installing-pipelines-operator-in-web-console.adoc
@@ -22,7 +22,7 @@ The supported profiles are:
 
 * Lite: This installs only Tekton Pipelines.
 * Basic: This installs Tekton Pipelines, Tekton Triggers, and Tekton Chains.
-* All: This is the default profile used when the `TektonConfig` CR is installed. This profile installs all of the Tekton components, including Tekton Pipelines, Tekton Triggers, Tekton Chains, {pac}, and Tekton Addons. Tekton Addons includes the `ClusterTasks`, `ClusterTriggerBindings`, `ConsoleCLIDownload`, `ConsoleQuickStart`, and `ConsoleYAMLSample` resources.
+* All: This is the default profile used when the `TektonConfig` CR is installed. This profile installs all of the Tekton components, including Tekton Pipelines, Tekton Triggers, Tekton Chains, {pac}, and Tekton Addons. Tekton Addons includes the `ClusterTasks`, `ClusterTriggerBindings`, `ConsoleCLIDownload`, `ConsoleQuickStart`, and `ConsoleYAMLSample` resources, as well as the tasks available using the cluster resolver from the `openshift-pipelines` namespace.
 
 [discrete]
 .Procedure

--- a/modules/op-specifying-pipelines-resource-quota-using-priority-class.adoc
+++ b/modules/op-specifying-pipelines-resource-quota-using-priority-class.adoc
@@ -84,14 +84,20 @@ spec:
   tasks:
   - name: git-clone
     taskRef:
-      kind: ClusterTask
-      name: git-clone
-    params:
-      - name: url
-        value: $(params.GIT_URL)
+      resolver: cluster
+      params:
+      - name: kind
+        value: task
+      - name: name
+        value: git-clone
+      - name: namespace
+        value: openshift-pipelines
     workspaces:
     - name: output
       workspace: source
+    params:
+    - name: URL
+      value: $(params.GIT_URL)
   - name: build
     taskRef:
       name: mvn

--- a/modules/op-starting-a-task-run-pipeline-run-build-user.adoc
+++ b/modules/op-starting-a-task-run-pipeline-run-build-user.adoc
@@ -70,17 +70,23 @@ spec:
   tasks:
   - name: fetch-repository # <1>
     taskRef:
-      name: git-clone
-      kind: ClusterTask
+      resolver: cluster
+      params:
+      - name: kind
+        value: task
+      - name: name
+        value: git-clone
+      - name: namespace
+        value: openshift-pipelines
     workspaces:
     - name: output
       workspace: shared-workspace
     params:
-    - name: url
+    - name: URL
       value: $(params.URL)
-    - name: subdirectory
+    - name: SUBDIRECTORY
       value: ""
-    - name: deleteExisting
+    - name: DELETE_EXISTING
       value: "true"
   - name: buildah
     taskRef:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
please cp to pipelines-docs-1.15

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
RHDEVDOCS 6074

Links to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://77342--ocpdocs-pr.netlify.app/openshift-pipelines/latest/about/understanding-openshift-pipelines.html#about-pipelines_understanding-openshift-pipelines
https://77342--ocpdocs-pr.netlify.app/openshift-pipelines/latest/about/understanding-openshift-pipelines.html#about-workspaces_understanding-openshift-pipelines
https://77342--ocpdocs-pr.netlify.app/openshift-pipelines/latest/create/creating-applications-with-cicd-pipelines.html#assembling-a-pipeline_creating-applications-with-cicd-pipelines
https://77342--ocpdocs-pr.netlify.app/openshift-pipelines/latest/create/remote-pipelines-tasks-resolvers.html
https://77342--ocpdocs-pr.netlify.app/openshift-pipelines/latest/create/using-rh-entitlements-pipelines.html#op-entitlements-manual-copying_using-rh-entitlements-pipelines
https://77342--ocpdocs-pr.netlify.app/openshift-pipelines/latest/create/using-rh-entitlements-pipelines.html#op-entitlements-shared-csi-driver_using-rh-entitlements-pipelines
https://77342--ocpdocs-pr.netlify.app/openshift-pipelines/latest/install_config/customizing-configurations-in-the-tektonconfig-cr.html#op-disabling-cluster-tasks-and-pipeline-templates_customizing-configurations-in-the-tektonconfig-cr
https://77342--ocpdocs-pr.netlify.app/openshift-pipelines/latest/install_config/installing-pipelines.html#op-installing-pipelines-operator-in-web-console_installing-pipelines
https://77342--ocpdocs-pr.netlify.app/openshift-pipelines/latest/resource/setting-compute-resource-quota-for-openshift-pipelines.html#specifying-pipelines-resource-quota-using-priority-class_setting-compute-resource-quota-for-openshift-pipelines
https://77342--ocpdocs-pr.netlify.app/openshift-pipelines/latest/secure/unprivileged-building-of-container-images-using-buildah.html#configuring-builah-to-use-build-user_unprivileged-building-of-container-images-using-buildah

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
