### PR TITLE
[enterprise-4.16] OSDOCS#10503: Add legacy OLM support 4.16 RN

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -242,7 +242,7 @@ The following are the key enhancements and features in oc-mirror plugin v2:
 +
 oc-mirror plugin v2 automatically generates a comprehensive list of `ImageDigestMirrorSet` (IDMS) and `ImageTagMirrorSet` (ITMS) objects after each run. These objects replace the `ImageContentSourcePolicy` (ICSP) used in oc-mirror plugin v1. This enhancement eliminates the need for manual merging and cleanup of operator images and ensures all necessary images are included.
 
-* *CatalogSource objects*: 
+* *CatalogSource objects*:
 +
 CatalogSource objects creation, where the plugin now generates CatalogSource objects for all relevant catalog indexes to enhance the application of oc-mirror's output artifacts to disconnected clusters.
 
@@ -250,11 +250,11 @@ CatalogSource objects creation, where the plugin now generates CatalogSource obj
 +
 oc-mirror plugin v2 verifies that the complete image set specified in the image set config is mirrored to the registry, regardless of whether the images were previously mirrored or not. This ensures comprehensive and reliable mirroring.
 
-* *Cache system*: 
+* *Cache system*:
 +
 The new cache system replaces metadata, maintaining minimal archive sizes by incorporating only new images into the archive. This optimizes storage and improves performance.
 
-* *Selective mirroring by date*: 
+* *Selective mirroring by date*:
 +
 Users can now generate mirroring archives based on the mirroring date, allowing for the selective inclusion of new images.
 
@@ -262,7 +262,7 @@ Users can now generate mirroring archives based on the mirroring date, allowing 
 +
 The introduction of a `Delete` feature replaces automatic pruning, providing users with greater control over image deletion.
 
-* *Support for `registries.conf`*: 
+* *Support for `registries.conf`*:
 +
 oc-mirror plugin v2 supports the `registries.conf` file that facilitates mirroring to multiple enclaves using the same cache. This enhances flexibility and efficiency in managing mirrored images.
 
@@ -275,9 +275,9 @@ Users can filter Operator versions by bundle name, offering more precise control
 While oc-mirror plugin v2 brings numerous enhancements, some features from oc-mirror plugin v1 are not yet present in oc-mirror plugin v2:
 
 * Helm Charts: Helm charts are not present in oc-mirror plugin v2.
-    
+
 * `ImageSetConfig v1alpha2`: The api version `v1alpha2` is not available, users must update to `v2alpha1`.
-    
+
 * Storage Metadata (`storageConfig`): Storage metadata is not used in oc-mirror plugin v2 `ImageSetConfiguration`.
 
 * Automatic Pruning: Replaced by the new `Delete` feature in oc-mirror plugin v2.
@@ -947,6 +947,19 @@ For more information about adding devices to a volume group, see xref:../storage
 [id="ocp-4-16-olm_{context}"]
 === Operator lifecycle
 
+[id="ocp-4-16-olmv1-ce-rename_{context}"]
+==== Operator API renamed to ClusterExtension (Technology Preview)
+
+Earlier Technology Preview phases of {olmv1-first} introduced a new `Operator` API, provided as `operator.operators.operatorframework.io` by the Operator Controller component. In {product-title} 4.16, this API is renamed `ClusterExtension`, provided as `clusterextension.olm.operatorframework.io`, for this Technology Preview phase of {olmv1}.
+
+This API still streamlines management of installed extensions, which includes Operators via the `registry+v1` bundle format, by consolidating user-facing APIs into a single object. The rename to `ClusterExtension` addresses the following:
+
+* More accurately reflects the simplified functionality of extending a cluster's capabilities
+* Better represents a more flexible packaging format
+* `Cluster` prefix clearly indicates that `ClusterExtension` objects are cluster-scoped, a change from {olmv0} where Operators could be either namespace-scoped or cluster-scoped
+
+For more information, see xref:../operators/olm_v1/arch/olmv1-operator-controller.adoc#olmv1-operator-controller[Operator Controller].
+
 [id="ocp-4-16-olm-improved-status-conditions_{context}"]
 ==== Improved status condition messages and deprecation notices for cluster extensions in {olmv1-first} (Technology Preview)
 
@@ -956,6 +969,20 @@ With this release, {olmv1} displays the following status condition messages for 
 * Installed version
 * Improved health reporting
 * Deprecation notices for packages, channels, and bundles
+
+[id="ocp-4-16-olmv1-legacy-olm-upgrade-edges_{context}"]
+==== Support for {olmv0} upgrade edges in {olmv1} (Technology Preview)
+
+When determining upgrade edges for an installed cluster extension, {olmv1-first} supports {olmv0} semantics starting in {product-title} 4.16. This support follows the behavior from {olmv0}, including `replaces`, `skips`, and `skipRange` directives, with a few noted differences.
+
+By supporting {olmv0} semantics, {olmv1} now honors the upgrade graph from catalogs accurately.
+
+[NOTE]
+====
+Support for semantic versioning (semver) upgrade constraints was introduced in {product-title} 4.15 but disabled in 4.16 in favor of {olmv0} semantics during this Technology Preview phase.
+====
+
+For more information, see xref:../operators/olm_v1/olmv1-installing-an-operator-from-a-catalog.adoc#upgrade-constraint-semantics_olmv1-installing-operator[Upgrade constraint semantics].
 
 [id="ocp-4-16-osdk_{context}"]
 === Operator development
@@ -1255,18 +1282,6 @@ Previously, it was unsupported for EgressIP selected pods to also serve as backe
 With {product-title} {product-version}, OVN-Kubernetes now supports the use of `ExternalTrafficPolicy=Local` services and EgressIP configurations at the same time on the same set of selected pods. OVN-Kubernetes now only reroutes the traffic originating from the EgressIP pods towards the egress node while routing the responses to ingress service traffic from the EgressIP pods via the same node where the pod is located.
 
 [discrete]
-[id="ocp-4-16-olm-ce-rename_{context}"]
-=== Operator API renamed to ClusterExtension
-
-Earlier Technology Preview phases of {olmv1-first} introduced a new `Operator` API, provided as `operator.operators.operatorframework.io` by the Operator Controller component. In {product-title} 4.16, this API is renamed `ClusterExtension`, provided as `clusterextension.olm.operatorframework.io`, for this Technology Preview phase of {olmv1}.
-
-This API still streamlines management of installed extensions, which includes Operators via the `registry+v1` bundle format, by consolidating user-facing APIs into a single object. The rename to `ClusterExtension` addresses the following:
-
-* More accurately reflects the simplified functionality of extending a cluster's capabilities
-* Better represents a more flexible packaging format
-* `Cluster` prefix clearly indicates that `ClusterExtension` objects are cluster-scoped, a change from {olmv0} where Operators could be either namespace-scoped or cluster-scoped
-
-[discrete]
 [id="ocp-4-16-legacy-sa-tokens_{context}"]
 === Legacy service account API token secrets are no longer generated for each service account
 
@@ -1284,6 +1299,14 @@ For information about detecting legacy service account API token secrets that ar
 
 In this release, the functionality to authenticate to private registries on {aws-first}, {gcp-first}, and {azure-first} clusters is moved from the in-tree provider to binaries that ship with {product-title}.
 This change supports the default external cloud authentication provider behavior that is introduced in Kubernetes 1.29.
+
+[discrete]
+[id="ocp-4-16-olmv1-default-upgrade-constraints_{context}"]
+=== Default {olmv1} upgrade constraints changed to {olmv0} semantics (Technology Preview)
+
+In {product-title} 4.16, {olmv1-first} changes its default upgrade constraints from semantic versioning (semver) to {olmv0} semantics.
+
+For more information, see xref:../release_notes/ocp-4-16-release-notes.adoc#ocp-4-16-olmv1-legacy-olm-upgrade-edges_release-notes[Support for {olmv0} upgrade edges in {olmv1} (Technology Preview)].
 
 [id="ocp-4-16-deprecated-removed-features_{context}"]
 == Deprecated and removed features


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-10503

4.16

* Release note for https://github.com/openshift/openshift-docs/pull/77338.
* Also moving "Operator API renamed to ClusterExtension" from "Notable technical changes" up to "New features and enhancements" per PM discussion.

Preview:

* New features -> Operator lifecycle -> [Support for legacy OLM upgrade edges in OLM 1.0](https://77344--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-olmv1-legacy-olm-upgrade-edges_release-notes)
* Notable technical changes -> [Default OLM 1.0 upgrade constraints changed to legacy OLM semantics](https://77344--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-olmv1-default-upgrade-constraints_release-notes)