### PR TITLE
[TELCODOCS-1480, TELCODOCS-1676] - Adding PTP 4.16 dual NIC GA release notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -152,8 +152,22 @@ If you attempt an upgrade, the Cluster Network Operator reports the following st
     to OVN-Kubernetes in order to be able to upgrade. https://docs.openshift.com/container-platform/4.16/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html
   reason: OpenShiftSDNConfigured
   status: "False"
-  type: Upgradeable 
+  type: Upgradeable
 ----
+
+[id="ocp-4-16-ptp-dual-nic-gm-ga_{context}"]
+==== Dual-NIC Intel E810 Westport Channel as PTP grandmaster clock (Generally Available)
+
+Configuring linuxptp services as grandmaster clock (T-GM) for dual Intel E810 Westport Channel NICs is now a generally available feature in {product-title}.
+The host system clock is synchronized from the NIC that is connected to the Global Navigation Satellite Systems (GNSS) time source. The second NIC is synced to the 1PPS timing output provided by the NIC that is connected to GNSS.
+For more information see xref:../networking/ptp/configuring-ptp.adoc#configuring-linuxptp-services-as-grandmaster-clock-dual-nic_configuring-ptp[Configuring linuxptp services as a grandmaster clock for dual E810 Westport Channel NICs].
+
+[id="ocp-4-16-ptp-dual-nic-tbc-ha_{context}"]
+==== Dual-NIC Intel E810 PTP boundary clock with highly available system clock (Generally Available)
+
+You can configure the `linuxptp` services `ptp4l` and `phc2sys` as a highly available (HA) system clock for dual PTP boundary clocks (T-BC).
+
+For more information, see xref:../networking/ptp/configuring-ptp.adoc#ptp-configuring-linuxptp-services-as-ha-bc-for-dual-nic_configuring-ptp[Configuring linuxptp as a highly available system clock for dual-NIC Intel E810 PTP boundary clocks]
 
 [id="ocp-4-16-networking-multiple-cidr_{context}"]
 ==== Define multiple CIDR blocks for one network security group (NSG) rule
@@ -277,7 +291,7 @@ For more information, see xref:../storage/container_storage_interface/persistent
 
 [id="ocp-4-16-storage-rwop-selinux-context-mode"]
 ==== RWOP with SELinux context mount is generally available
-{product-title} 4.14 introduced a new access mode with Technical Preview status for persistent volumes (PVs) and persistent volume claims (PVCs) called ReadWriteOncePod (RWOP). RWOP can be used only in a single pod on a single node compared to the existing ReadWriteOnce access mode where a PV or PVC can be used on a single node by many pods. If the driver enables it, RWOP uses the SELinux context mount set in the `PodSpec` or container, which allows the driver to mount the volume directly with the correct SELinux labels. This eliminates the need to recursively relabel the volume, and pod startup can be significantly faster. 
+{product-title} 4.14 introduced a new access mode with Technical Preview status for persistent volumes (PVs) and persistent volume claims (PVCs) called ReadWriteOncePod (RWOP). RWOP can be used only in a single pod on a single node compared to the existing ReadWriteOnce access mode where a PV or PVC can be used on a single node by many pods. If the driver enables it, RWOP uses the SELinux context mount set in the `PodSpec` or container, which allows the driver to mount the volume directly with the correct SELinux labels. This eliminates the need to recursively relabel the volume, and pod startup can be significantly faster.
 
 In {product-title} 4.16, this feature is generally available.
 
@@ -391,19 +405,19 @@ With this release, you can increase the disk quota in etcd. This is a Technology
 ====  Reserved core frequency tuning
 
 With this release, the Node Tuning Operator supports setting CPU frequencies in the `PerformanceProfile` for reserved and isolated core CPUs.
-This is an optional feature that you can use to define specific frequencies. 
+This is an optional feature that you can use to define specific frequencies.
 The Node Tuning Operator then sets those frequencies by enabling the `intel_pstate` CPUFreq driver in the Intel hardware.
 You must follow Intel's recommendations on frequencies for FlexRAN-like applications, which require the default CPU frequency to be set to a lower value than the default running frequency.
 
 [id="ocp-4-16-node-tuning-operator-intel_{context}"]
 ====  Node Tuning Operator intel_pstate driver default setting
 
-Previously, for the RAN DU-profile, setting the `realTime` workload hint to `true` in the `PerformanceProfile` always disabled the `intel_pstate`. 
-With this release, the Node Tuning Operator detects the underlying Intel hardware using `TuneD` and appropriately sets the `intel_pstate` kernel parameter based on the processor’s generation. 
-This decouples the `intel_pstate` from the `realTime` and `highPowerConsumption` workload hints. 
+Previously, for the RAN DU-profile, setting the `realTime` workload hint to `true` in the `PerformanceProfile` always disabled the `intel_pstate`.
+With this release, the Node Tuning Operator detects the underlying Intel hardware using `TuneD` and appropriately sets the `intel_pstate` kernel parameter based on the processor’s generation.
+This decouples the `intel_pstate` from the `realTime` and `highPowerConsumption` workload hints.
 The `intel_pstate` now depends only on the underlying processor generation.
 
-For pre-IceLake processors, the `intel_pstate` is deactivated by default, whereas for IceLake and later generation processors, the `intel_pstate` is set to `active`. 
+For pre-IceLake processors, the `intel_pstate` is deactivated by default, whereas for IceLake and later generation processors, the `intel_pstate` is set to `active`.
 
 [id="ocp-4-16-edge-computing_{context}"]
 === Edge computing
@@ -1058,6 +1072,25 @@ In the following tables, features are marked with the following statuses:
 |Not Available
 |Technology Preview
 
+|Dual-NIC hardware as PTP boundary clock
+|General Availability
+|General Availability
+|General Availability
+
+|Dual-NIC Intel E810 PTP boundary clock with highly available system clock
+|Not Available
+|Not Available
+|General Availability
+
+|Intel E810 Westport Channel NIC as PTP grandmaster clock
+|Technology Preview
+|Technology Preview
+|General Availability
+
+|Dual-NIC Intel E810 Westport Channel as PTP grandmaster clock
+|Not Available
+|Technology Preview
+|General Availability
 |====
 
 [discrete]
@@ -1268,7 +1301,7 @@ In the following tables, features are marked with the following statuses:
 |HTTP transport replaces AMQP for PTP and bare-metal events
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|General Availability
 
 |Mount namespace encapsulation
 |Technology Preview
@@ -1509,6 +1542,11 @@ In the following tables, features are marked with the following statuses:
 * For a bonding network interface that holds a `br-ex` bridge device, do not set the `mode=6 balance-alb` bond mode in a node network configuration. This bond mode is not supported on {product-title} and it can cause the Open vSwitch (OVS) bridge device to disconnect from your networking environment. (link:https://issues.redhat.com/browse/OCPBUGS-34430[*OCPBUGS-34430*]).
 
 [id="ocp-telco-ran-4-16-known-issues_{context}"]
+* The current PTP grandmaster clock (T-GM) implementation has a single National Marine Electronics Association (NMEA) sentence generator sourced from the GNSS without a backup NMEA sentence generator.
+If NMEA sentences are lost before reaching the e810 NIC, the T-GM cannot synchronize the devices in the network synchronization chain and the PTP Operator reports an error.
+A proposed fix is to report a `FREERUN` event when the NMEA string is lost.
+Until this limitation is addressed, T-GM does not support PTP clock holdover state.
+(link:https://issues.redhat.com/browse/OCPBUGS-19838[*OCPBUGS-19838*])
 
 [id="ocp-telco-core-4-16-known-issues_{context}"]
 


### PR DESCRIPTION
Version(s):
enterprise-4.16

Issues:
* https://issues.redhat.com/browse/TELCODOCS-1480
* https://issues.redhat.com/browse/TELCODOCS-1676

Link to docs preview:
https://77350--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-ptp-dual-nic-gm-ga_release-notes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->