### PR TITLE
TELCODOCS-1480 - Removing out of date Tech Preview note for PTP Dual NIC T-BC

### DIFF
--- a/modules/ptp-configuring-linuxptp-services-as-boundary-clock-dual-nic.adoc
+++ b/modules/ptp-configuring-linuxptp-services-as-boundary-clock-dual-nic.adoc
@@ -6,9 +6,6 @@
 [id="ptp-configuring-linuxptp-services-as-bc-for-dual-nic_{context}"]
 = Configuring linuxptp services as boundary clocks for dual-NIC hardware
 
-:FeatureName: Precision Time Protocol (PTP) hardware with dual-NIC configured as boundary clocks
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 You can configure the `linuxptp` services (`ptp4l`, `phc2sys`) as boundary clocks for dual-NIC hardware by creating a `PtpConfig` custom resource (CR) object for each NIC.
 
 Dual NIC hardware allows you to connect each NIC to the same upstream leader clock with separate `ptp4l` instances for each NIC feeding the downstream clocks.


### PR DESCRIPTION
PTP Dual NIC T-BC went GA in 4.13.

Version(s):
enterprise-4.13+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1480

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
