### PR TITLE
HCIDOCS-187: Document procedure for changing BMC address after installation

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -59,6 +59,14 @@ include::modules/ipi-install-additional-install-config-parameters.adoc[leveloffs
 // BMC addressing
 include::modules/ipi-install-bmc-addressing.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../post_installation_configuration/bare-metal-configuration.adoc#editing-a-baremetalhost-resource_post-install-bare-metal-configuration[Editing a BareMetalHost resource]
+
+// Verifying support for the Redfish API
+include::modules/ipi-install-verifying-support-for-redfish-apis.adoc[leveloffset=+2]
+
 // BMC addressing for Dell iDRAC
 include::modules/ipi-install-bmc-addressing-for-dell-idrac.adoc[leveloffset=+2]
 

--- a/modules/bmo-editing-a-baremetalhost-resource.adoc
+++ b/modules/bmo-editing-a-baremetalhost-resource.adoc
@@ -1,0 +1,47 @@
+// This module is included in the following assemblies: 
+//
+// post_installation_configuration/bare-metal-configuration.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="editing-a-baremetalhost-resource_{context}"]
+= Editing a BareMetalHost resource
+
+After you deploy an {product-title} cluster on bare metal, you might need to edit a node's `BareMetalHost` resource. Consider the following examples:
+
+* You deploy a cluster with the {ai-full} and need to add or edit the baseboard management controller (BMC) host name or IP address.
+* You want to move a node from one cluster to another without deprovisioning it.
+
+.Prerequisites
+
+* Ensure the node is in the `Provisioned`, `ExternallyProvisioned`, or `Available` state.
+
+.Procedure
+
+. Get the list of nodes:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc get bmh -n openshift-machine-api
+----
+
+. Before editing the node's `BareMetalHost` resource, detach the node from Ironic by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc annotate baremetalhost <node_name> -n openshift-machine-api 'baremetalhost.metal3.io/detached=true' <1>
+----
+<1> Replace `<node_name>` with the name of the node.
+
+. Edit the  `BareMetalHost` resource by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc edit bmh <node_name> -n openshift-machine-api
+----
+
+. Reattach the node to Ironic by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc annotate baremetalhost <node_name> -n openshift-machine-api 'baremetalhost.metal3.io/detached'-
+----

--- a/modules/ipi-install-bmc-addressing.adoc
+++ b/modules/ipi-install-bmc-addressing.adoc
@@ -8,6 +8,8 @@
 
 Most vendors support Baseboard Management Controller (BMC) addressing with the Intelligent Platform Management Interface (IPMI). IPMI does not encrypt communications. It is suitable for use within a data center over a secured or dedicated management network. Check with your vendor to see if they support Redfish network boot. Redfish delivers simple and secure management for converged, hybrid IT and the Software Defined Data Center (SDDC). Redfish is human readable and machine capable, and leverages common internet and web services standards to expose information directly to the modern tool chain. If your hardware does not support Redfish network boot, use IPMI.
 
+You can modify the BMC address during installation while the node is in the `Registering` state. If you need to modify the BMC address after the node leaves the `Registering` state, you must disconnect the node from Ironic, edit the `BareMetalHost` resource, and reconnect the node to Ironic. See the _Editing a BareMetalHost resource_ section for details.
+
 [discrete]
 == IPMI
 
@@ -64,62 +66,4 @@ platform:
           password: <password>
           disableCertificateVerification: True
 ----
-[discrete]
-== Redfish APIs
 
-Several redfish API endpoints are called onto your BCM when using the bare-metal installer-provisioned infrastructure.
-
-[IMPORTANT]
-====
-You need to ensure that your BMC supports all of the redfish APIs before installation.
-====
-
-List of redfish APIs::
-* Power on
-+
-[source,terminal]
-----
-curl -u $USER:$PASS -X POST -H'Content-Type: application/json' -H'Accept: application/json' -d '{"ResetType": "On"}' https://$SERVER/redfish/v1/Systems/$SystemID/Actions/ComputerSystem.Reset
-----
-* Power off
-+
-[source,terminal]
-----
-curl -u $USER:$PASS -X POST -H'Content-Type: application/json' -H'Accept: application/json' -d '{"ResetType": "ForceOff"}' https://$SERVER/redfish/v1/Systems/$SystemID/Actions/ComputerSystem.Reset
-----
-* Temporary boot using `pxe`
-+
-[source,terminal]
-----
-curl -u $USER:$PASS -X PATCH -H "Content-Type: application/json"  https://$Server/redfish/v1/Systems/$SystemID/ -d '{"Boot": {"BootSourceOverrideTarget": "pxe", "BootSourceOverrideEnabled": "Once"}}
-----
-* Set BIOS boot mode using `Legacy` or `UEFI`
-+
-[source,terminal]
-----
-curl -u $USER:$PASS -X PATCH -H "Content-Type: application/json"  https://$Server/redfish/v1/Systems/$SystemID/ -d '{"Boot": {"BootSourceOverrideMode":"UEFI"}}
-----
-
-List of redfish-virtualmedia APIs::
-* Set temporary boot device using `cd` or `dvd`
-+
-[source,terminal]
-----
-curl -u $USER:$PASS -X PATCH -H "Content-Type: application/json" https://$Server/redfish/v1/Systems/$SystemID/ -d '{"Boot": {"BootSourceOverrideTarget": "cd", "BootSourceOverrideEnabled": "Once"}}'
-----
-* Mount virtual media
-+
-[source,terminal]
-----
-curl -u $USER:$PASS -X PATCH -H "Content-Type: application/json" -H "If-Match: *" https://$Server/redfish/v1/Managers/$ManagerID/VirtualMedia/$VmediaId -d '{"Image": "https://example.com/test.iso", "TransferProtocolType": "HTTPS", "UserName": "", "Password":""}'
-----
-
-[NOTE]
-====
-The `PowerOn` and `PowerOff` commands for redfish APIs are the same for the redfish-virtualmedia APIs.
-====
-
-[IMPORTANT]
-====
-`HTTPS` and `HTTP` are the only supported parameter types for `TransferProtocolTypes`.
-====

--- a/modules/ipi-install-verifying-support-for-redfish-apis.adoc
+++ b/modules/ipi-install-verifying-support-for-redfish-apis.adoc
@@ -1,0 +1,84 @@
+// This is included in the following assemblies:
+//
+// installing/installing_bare_metal_ipi/ipi-install-configuration-files.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id='verifying-support-for-redfish-apis_{context}']
+
+= Verifying support for Redfish APIs
+
+When installing using the Redfish API, the installation program calls several Redfish endpoints on the baseboard management controller (BMC) when using installer-provisioned infrastructure on bare metal. If you use Redfish, ensure that your BMC supports all of the Redfish APIs before installation.
+
+.Procedure
+
+. Set the IP address or hostname of the BMC by running the following command:
++
+[source,terminal]
+----
+$ export SERVER=<ip_address> <1>
+----
+<1> Replace `<ip_address>` with the IP address or hostname of the BMC.
+
+. Set the ID of the system by running the following command:
++
+[source,terminal]
+----
+$ export SystemID=<system_id> <1>
+----
+<1> Replace `<system_id>` with the system ID. For example, `System.Embedded.1` or `1`. See the following vendor-specific BMC sections for details.
+
+.List of Redfish APIs:
+
+. Check `power on` support by running the following command:
++
+[source,terminal]
+----
+$ curl -u $USER:$PASS -X POST -H'Content-Type: application/json' -H'Accept: application/json' -d '{"ResetType": "On"}' https://$SERVER/redfish/v1/Systems/$SystemID/Actions/ComputerSystem.Reset
+----
+
+. Check `power off` support by running the following command:
++
+[source,terminal]
+----
+$ curl -u $USER:$PASS -X POST -H'Content-Type: application/json' -H'Accept: application/json' -d '{"ResetType": "ForceOff"}' https://$SERVER/redfish/v1/Systems/$SystemID/Actions/ComputerSystem.Reset
+----
+
+. Check the temporary boot implementation that uses `pxe` by running the following command:
++
+[source,terminal]
+----
+$ curl -u $USER:$PASS -X PATCH -H "Content-Type: application/json"  https://$Server/redfish/v1/Systems/$SystemID/ -d '{"Boot": {"BootSourceOverrideTarget": "pxe", "BootSourceOverrideEnabled": "Once"}}
+----
+
+. Check the status of setting the BIOS boot mode that uses `Legacy` or `UEFI` by running the following command:
++
+[source,terminal]
+----
+$ curl -u $USER:$PASS -X PATCH -H "Content-Type: application/json"  https://$Server/redfish/v1/Systems/$SystemID/ -d '{"Boot": {"BootSourceOverrideMode":"UEFI"}}
+----
+
+.List of Redfish virtual media APIs:
+
+. Check the ability to set the temporary boot device that uses `cd` or `dvd` by running the following command:
++
+[source,terminal]
+----
+$ curl -u $USER:$PASS -X PATCH -H "Content-Type: application/json" https://$Server/redfish/v1/Systems/$SystemID/ -d '{"Boot": {"BootSourceOverrideTarget": "cd", "BootSourceOverrideEnabled": "Once"}}'
+----
+
+. Check the ability to mount virtual media by running the following command:
++
+[source,terminal]
+----
+$ curl -u $USER:$PASS -X PATCH -H "Content-Type: application/json" -H "If-Match: *" https://$Server/redfish/v1/Managers/$ManagerID/VirtualMedia/$VmediaId -d '{"Image": "https://example.com/test.iso", "TransferProtocolType": "HTTPS", "UserName": "", "Password":""}'
+----
+
+[NOTE]
+====
+The `PowerOn` and `PowerOff` commands for Redfish APIs are the same for the Redfish virtual media APIs.
+====
+
+[IMPORTANT]
+====
+`HTTPS` and `HTTP` are the only supported parameter types for `TransferProtocolTypes`.
+====

--- a/post_installation_configuration/bare-metal-configuration.adoc
+++ b/post_installation_configuration/bare-metal-configuration.adoc
@@ -12,6 +12,7 @@ include::modules/bmo-about-the-bare-metal-operator.adoc[leveloffset=+1]
 include::modules/con_bmo-bare-metal-operator-architecture.adoc[leveloffset=+2]
 include::modules/bmo-about-the-baremetalhost-resource.adoc[leveloffset=+1]
 include::modules/bmo-getting-the-baremetalhost-resource.adoc[leveloffset=+1]
+include::modules/bmo-editing-a-baremetalhost-resource.adoc[leveloffset=+1]
 
 include::modules/bmo-about-the-hostfirmwaresettings-resource.adoc[leveloffset=+1]
 include::modules/bmo-getting-the-hostfirmwaresettings-resource.adoc[leveloffset=+1]


### PR DESCRIPTION
Added "Editing a BareMetalHost resource" module. This PR replaces https://github.com/openshift/openshift-docs/pull/77276/ and https://github.com/openshift/openshift-docs/pull/76624, which were conflicting with the PR for HCIDOCS-201, which is now successfully merged. Hopefully, this PR resolves that issue. It has been SME, QE, and peer reviewed.

Fixes: [HCIDOCS-187](https://issues.redhat.com//browse/HCIDOCS-187)

See https://issues.redhat.com/browse/HCIDOCS-187 for additional details.

Preview URL: https://77380--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#bmc-addressing_ipi-install-installation-workflow and https://77380--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/bare-metal-configuration.html#editing-a-baremetalhost-resource_post-install-bare-metal-configuration

For release(s): 4.16
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
