### PR TITLE
HCIDOCS-340: Added a release note regarding the new HostFirmwareComponents resource

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -240,6 +240,11 @@ These additions help identify issues that might stem from using a specific versi
 
 For more information, see xref:../support/gathering-cluster-data.adoc#about-must-gather_gathering-cluster-data[About the must-gather tool].
 
+[id="ocp-4-16-upgrading-or-downgrading-host-firmware_{context}"]
+==== Upgrading or downgrading host firmware
+
+Beginning with {product-title} {product-version}, you can upgrade or downgrade the firmware for a bare-metal node to a specific version. Metal^3^ provides the `HostFirmwareComponents` resource, which describes BIOS and baseboard management controller (BMC) firmware versions. Upgrading or downgrading firmware is useful when deploying an {product-title} cluster on bare metal with validated patterns that have been tested against specific firmware versions. See xref:../post_installation_configuration/bare-metal-configuration.adoc#about-the-hostfirmwarecomponents-resource_post-install-bare-metal-configuration[About the HostFirmwareComponents resource] for additional details.
+
 [id="ocp-4-16-monitoring_{context}"]
 === Monitoring
 


### PR DESCRIPTION
Adds a release note about the HostFirmwareComponents resource.

Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/HCIDOCS-340
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://77386--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-upgrading-or-downgrading-host-firmware
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
