### PR TITLE
OSDOCS-10754: Optional vSphere tags (RNs)

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -68,6 +68,18 @@ This release adds improvements related to the following components and concepts.
 In {product-title} {product-version}, you can disable the cloud controller manager capability during installation.
 For more information, see xref:../installing/cluster-capabilities.adoc#cluster-cloud-controller-manager-operator_cluster-capabilities[Cloud controller manager capability].
 
+[id="ocp-4-16-installation-and-update-vsphere-tagging_{context}"]
+==== Optional additional tags for {vmw-first}
+
+In {product-title} {product-version}, you can add up to ten tags to attach to the VMs provisioned by a {vmw-first} cluster.
+These tags are in addition to the unique cluster-specific tag that the installation program uses to identify and remove associated VMs when a cluster is decommissioned.
+
+You can define the tags on the {vmw-first} VMs in the `install-config.yaml` file during cluster creation.
+For more information, see xref:../installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc#installation-installer-provisioned-vsphere-config-yaml_installing-restricted-networks-installer-provisioned-vsphere[Sample `install-config.yaml` file for an installer-provisioned {vmw-first} cluster].
+
+You can define tags for compute or control plane machines on an existing cluster by using machine sets.
+For more information, see "Adding tags to machines by using machine sets" for xref:../machine_management/creating_machinesets/creating-machineset-vsphere.adoc#machine-api-vmw-add-tags_creating-machineset-vsphere[compute] or xref:../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.adoc#machine-api-vmw-add-tags_cpmso-config-options-vsphere[control plane] machine sets.
+
 [id="ocp-4-16-web-console_{context}"]
 === Web console
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-10754](https://issues.redhat.com//browse/OSDOCS-10754)

Link to docs preview:
[Optional additional tags for VMware vSphere](https://77389--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-installation-and-update-vsphere-tagging_release-notes)

QE review:
- [x] QE has approved this change.

Additional information: