### PR TITLE
Make CPMS feature shortdesc numerically agnostic

### DIFF
--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-aws.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-aws.adoc
@@ -23,7 +23,7 @@ include::modules/cpmso-yaml-failure-domain-aws.adoc[leveloffset=+2]
 [id="cpmso-supported-features-aws_{context}"]
 == Enabling {aws-full} features for control plane machines
 
-You can enable the following features by updating values in the control plane machine set.
+You can enable features by updating values in the control plane machine set.
 
 //Restricting the API server to private (AWS control plane machine set version)
 include::modules/private-clusters-setting-api-private.adoc[leveloffset=+2]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc
@@ -23,7 +23,7 @@ include::modules/cpmso-yaml-failure-domain-azure.adoc[leveloffset=+2]
 [id="cpmso-supported-features-azure_{context}"]
 == Enabling {azure-full} features for control plane machines
 
-You can enable the following features by updating values in the control plane machine set.
+You can enable features by updating values in the control plane machine set.
 
 include::modules/private-clusters-setting-api-private.adoc[leveloffset=+2]
 [role="_additional-resources"]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-gcp.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-gcp.adoc
@@ -23,7 +23,7 @@ include::modules/cpmso-yaml-failure-domain-gcp.adoc[leveloffset=+2]
 [id="cpmso-supported-features-gcp_{context}"]
 == Enabling {gcp-full} features for control plane machines
 
-You can enable the following features by updating values in the control plane machine set.
+You can enable features by updating values in the control plane machine set.
 
 //Note: GCP GPU features should be compatible with CPMS, but dev cannot think of a use case. Leaving them out to keep things less cluttered. If a customer use case emerges, we can just add the necessary modules in here.
 

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-openstack.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-openstack.adoc
@@ -23,7 +23,7 @@ include::modules/cpmso-yaml-failure-domain-openstack.adoc[leveloffset=+2]
 [id="cpmso-supported-features-openstack_{context}"]
 == Enabling {rh-openstack-first} features for control plane machines
 
-You can enable the following features by updating values in the control plane machine set.
+You can enable features by updating values in the control plane machine set.
 
 //Changing the OpenStack Nova flavor by using a control plane machine set
 include::modules/cpms-changing-openstack-flavor-type.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.15

Issue:
N/A

Link to docs preview:

- https://77392--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-aws.html#cpmso-supported-features-aws_cpmso-config-options-aws
- https://77392--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.html#cpmso-supported-features-azure_cpmso-config-options-azure
- https://77392--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-gcp.html#cpmso-supported-features-gcp_cpmso-config-options-gcp
- https://77392--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-openstack.html#cpmso-supported-features-openstack_cpmso-config-options-openstack

QE review:
N/A

Additional information:
Follow-on to enhancement from #75811 (`main` + 4.16) for 4.15