### PR TITLE
RN for OCPCLOUD-2379

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -134,7 +134,7 @@ If you attempt an upgrade, the Cluster Network Operator reports the following st
     to OVN-Kubernetes in order to be able to upgrade. https://docs.openshift.com/container-platform/4.16/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html
   reason: OpenShiftSDNConfigured
   status: "False"
-  type: Upgradeable 
+  type: Upgradeable
 ----
 
 [id="ocp-4-16-networking-multiple-cidr_{context}"]
@@ -251,7 +251,7 @@ For more information, see xref:../storage/container_storage_interface/persistent
 
 [id="ocp-4-16-storage-rwop-selinux-context-mode"]
 ==== RWOP with SELinux context mount is generally available
-{product-title} 4.14 introduced a new access mode with Technical Preview status for persistent volumes (PVs) and persistent volume claims (PVCs) called ReadWriteOncePod (RWOP). RWOP can be used only in a single pod on a single node compared to the existing ReadWriteOnce access mode where a PV or PVC can be used on a single node by many pods. If the driver enables it, RWOP uses the SELinux context mount set in the `PodSpec` or container, which allows the driver to mount the volume directly with the correct SELinux labels. This eliminates the need to recursively relabel the volume, and pod startup can be significantly faster. 
+{product-title} 4.14 introduced a new access mode with Technical Preview status for persistent volumes (PVs) and persistent volume claims (PVCs) called ReadWriteOncePod (RWOP). RWOP can be used only in a single pod on a single node compared to the existing ReadWriteOnce access mode where a PV or PVC can be used on a single node by many pods. If the driver enables it, RWOP uses the SELinux context mount set in the `PodSpec` or container, which allows the driver to mount the volume directly with the correct SELinux labels. This eliminates the need to recursively relabel the volume, and pod startup can be significantly faster.
 
 In {product-title} 4.16, this feature is generally available.
 
@@ -453,7 +453,7 @@ For information about detecting legacy service account API token secrets that ar
 [id="ocp-4-16-support-ext-cloud-auth_{context}"]
 === Support for external cloud authentication providers
 
-In this release, the functionality to authenticate to private registries is moved from the in-tree provider to binaries that ship with {product-title}.
+In this release, the functionality to authenticate to private registries on {aws-first}, {gcp-first}, and {azure-first} clusters is moved from the in-tree provider to binaries that ship with {product-title}.
 This change supports the default external cloud authentication provider behavior that is introduced in Kubernetes 1.29.
 
 [id="ocp-4-16-deprecated-removed-features_{context}"]

--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -449,6 +449,13 @@ For more information, see xref:../nodes/pods/nodes-pods-secrets.adoc#auto-genera
 
 For information about detecting legacy service account API token secrets that are in use in your cluster or deleting them if they are not needed, see the Red Hat Knowledgebase article link:https://access.redhat.com/articles/7058801[Long-lived service account API tokens in OpenShift Container Platform].
 
+[discrete]
+[id="ocp-4-16-support-ext-cloud-auth_{context}"]
+=== Support for external cloud authentication providers
+
+In this release, the functionality to authenticate to private registries is moved from the in-tree provider to binaries that ship with {product-title}.
+This change supports the default external cloud authentication provider behavior that is introduced in Kubernetes 1.29.
+
 [id="ocp-4-16-deprecated-removed-features_{context}"]
 == Deprecated and removed features
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-10880](https://issues.redhat.com//browse/OSDOCS-10880) for [OCPCLOUD-2379](https://issues.redhat.com//browse/OCPCLOUD-2379)

Link to docs preview:
[Support for external cloud authentication providers](https://77402--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-support-ext-cloud-auth_release-notes)

QE review:
- [x] QE has approved this change.

Additional information: