### PR TITLE
HCIDOCS-244: Added a release note for editing the BareMetalHost resource.

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -250,6 +250,11 @@ For more information, see xref:../support/gathering-cluster-data.adoc#about-must
 
 Beginning with {product-title} {product-version}, you can upgrade or downgrade the firmware for a bare-metal node to a specific version. Metal^3^ provides the `HostFirmwareComponents` resource, which describes BIOS and baseboard management controller (BMC) firmware versions. Upgrading or downgrading firmware is useful when deploying an {product-title} cluster on bare metal with validated patterns that have been tested against specific firmware versions. See xref:../post_installation_configuration/bare-metal-configuration.adoc#about-the-hostfirmwarecomponents-resource_post-install-bare-metal-configuration[About the HostFirmwareComponents resource] for additional details.
 
+[id="ocp-4-16-editing-the-baremetalhost-resource_{context}"]
+==== Editing the BareMetalHost resource
+
+In {product-title} {product-version} and later, you can edit the baseboard management controller (BMC) address in the `BareMetalHost` resource of a bare-metal node. The node must be in the `Provisioned`, `ExternallyProvisioned`, `Registering`, or `Available` state. Editing the BMC address in the `BareMetalHost` resource will not result in deprovisioning the node. See xref:../post_installation_configuration/bare-metal-configuration.adoc#editing-a-baremetalhost-resource_post-install-bare-metal-configuration[Editing a BareMetalHost resource] for additional details.
+
 [id="ocp-4-16-monitoring_{context}"]
 === Monitoring
 


### PR DESCRIPTION
This PR adds a release note for editing a BareMetalHost resource.

Version(s): 4.16

Issue: https://issues.redhat.com/browse/HCIDOCS-244

Link to docs preview: https://77403--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-editing-the-baremetalhost-resource_release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
