### PR TITLE
TELCODOCS-1682 - RN - Telco RAN 4.16 - MetalLB - FRRK8s integration

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -208,6 +208,14 @@ If you have already upgraded your cluster to {product-title} {product-version} a
 * An IPv6 network for API and Ingress services on the second `machineNetwork` configuration.
 
 For more information, see xref:../networking/ovn_kubernetes_network_provider/converting-to-dual-stack.html#nw-dual-stack-convert_converting-to-dual-stack[Converting to a dual-stack cluster network] in _Converting to IPv4/IPv6 dual-stack networking_.
+[id="ocp-4-16-networking-metallb-frr-k8s_{context}"]
+==== Integration of MetalLB and FRR-K8s (Technology Preview)
+
+This release introduces `FRR-K8s`, a Kubernetes based `DaemonSet` that exposes a subset of the `FRR` API in a Kubernetes-compliant manner.
+As a cluster administrator, you can use the `FRRConfiguration` custom resource (CR) to configure the MetalLB Operator to use the `FRR-K8s` daemon set as the backend.
+You can use this to operate FRR services, such as receiving routes.
+
+For more information, see xref:../networking/metallb/metallb-frr-k8s.adoc#metallb-configure-frr-k8s[Configuring the integration of MetalLB and FRR-K8s].
 
 [id="ocp-4-16-registry_{context}"]
 === Registry
@@ -1003,6 +1011,11 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |General Availability
 |General Availability
+
+|Integration of MetalLB and FRR-K8s
+|Not Available
+|Not Available
+|Technology Preview
 
 |====
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->Release Note for [TELCODOCS-1736](https://issues.redhat.com//browse/TELCODOCS-1736) - Telco RAN 4.16 - MetalLB - FRRK8s integration - [TELCODOCS-1682](https://issues.redhat.com//browse/TELCODOCS-1682) 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->


Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
RN for Telco RAN 4.16 - https://issues.redhat.com/browse/TELCODOCS-1736
Integration of MetalLB and FRR-K8s - https://issues.redhat.com/browse/TELCODOCS-1682
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Networking](https://77411--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-networking_release-notes)
- Integration of MetalLB and FRR-K8s (Technology Preview)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
