### PR TITLE
OSDOCS-10834: adds 4.15.8 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -340,3 +340,12 @@ Issued: 2024-06-11
 The {product-title} release 4.15.17 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:3675[RHBA-2024:3675] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:3673[RHBA-2024:3673] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-15-18-dp"]
+=== RHBA-2024:3891 - {microshift-short} 4.15.18 bug fix and security update advisory
+
+Issued: 2024-06-18
+
+The {product-title} release 4.15.18 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:3891[RHBA-2024:3891] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:3889[RHSA-2024:3889] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-10834](https://issues.redhat.com/browse/OSDOCS-10834)

Link to docs preview:
[4.15.18 relnote](https://77419--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-18-dp)

QE review:
- N/A stock text

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
