### PR TITLE
CNV#42655: Redirect CNV docs to previous version to support async release

### DIFF
--- a/virt/about-virt.adoc
+++ b/virt/about-virt.adoc
@@ -1,0 +1,9 @@
+include::modules/virt-document-attributes.adoc[]
+[id="about-virt"]
+= About {VirtProductName}
+:context: about-virt
+toc::[]
+
+Documentation for OpenShift Virtualization will be available for {product-title} 4.16 in the near future.
+
+In the meantime, the https://docs.openshift.com/container-platform/4.15/virt/about-virt.html[OpenShift Virtualization 4.15 documentation] is available as part of the {product-title} 4.15 documentation.


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/CNV-42655

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
