### PR TITLE
Removes multi-nic egress IP condition

### DIFF
--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -207,8 +207,6 @@ For users who want an egress IP and traffic to be routed over a particular inter
 
 * If a network interface is removed or if the IP address and subnet mask which allows the egress IP to be hosted on the interface is removed, then the egress IP is reconfigured. Consequently, it could be assigned to another node and interface.
 
-* The Egress IP must be IPv4. IPv6 is currently unsupported.
-
 * IP forwarding must be enabled for the network interface. To enable IP forwarding, you can use the `oc edit network.operator` command and edit the object like the following example:
 +
 [source,yaml]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OCPBUGS-35413

Link to docs preview:
https://77424--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/assigning-egress-ips.html#nw-egress-ips-multi-nic-considerations_egress-ips

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
