### PR TITLE
OCPBUGS-35361: Updated the wait-ip note for bm only

### DIFF
--- a/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
@@ -28,9 +28,10 @@ serviceNetwork:
 - fd03::/112
 ----
 
+ifndef::vsphere[]
 [IMPORTANT]
 ====
-If you specified an NMState configuration in the `networkConfig` section of your `install-config.yaml` file, ensure you add `interfaces.wait-ip: ipv4+ipv6` to the NMState YAML file to resolve an issue that prevents your cluster from deploying on a dual-stack network.
+On a bare-metal platform, if you specified an NMState configuration in the `networkConfig` section of your `install-config.yaml` file, add `interfaces.wait-ip: ipv4+ipv6` to the NMState YAML file to resolve an issue that prevents your cluster from deploying on a dual-stack network.
 
 .Example NMState YAML configuration file that includes the `wait-ip` parameter
 [source,yaml]
@@ -44,6 +45,7 @@ networkConfig:
 # ...
 ----
 ====
+endif::vsphere[]
 
 To provide an interface to the cluster for applications that use IPv4 and IPv6 addresses, configure IPv4 and IPv6 virtual IP (VIP) address endpoints for the Ingress VIP and API VIP services. To configure IPv4 and IPv6 address endpoints, edit the `apiVIPs` and `ingressVIPs` configuration settings in the `install-config.yaml` file . The `apiVIPs` and `ingressVIPs` configuration settings use a list format. The order of the list indicates the primary and secondary VIP address for each service.
 


### PR DESCRIPTION
Version(s):
4.13+

Issue:
[OCPBUGS-35361](https://issues.redhat.com/browse/OCPBUGS-35361)

Link to docs preview:
* [bare metal](https://77429--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#modifying-install-config-for-dual-stack-network_ipi-install-installation-workflow)
* [vsphere](https://77429--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations.html#modifying-install-config-for-dual-stack-network_installing-vsphere-installer-provisioned-network-customizations)

- [x] SME has approved this change.
- [x] QE has approved this change.

