### PR TITLE
OCPBUGS-35361-12: Updated the wait-ip note for bm only

### DIFF
--- a/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
@@ -32,7 +32,7 @@ serviceNetwork:
 
 [IMPORTANT]
 ====
-If you specified an NMState configuration in the `networkConfig` section of your `install-config.yaml` file, ensure you add `interfaces.wait-ip: ipv4+ipv6` to the NMState YAML file to resolve an issue that prevents your cluster from deploying on a dual-stack network.
+On a bare-metal platform, if you specified an NMState configuration in the `networkConfig` section of your `install-config.yaml` file, add `interfaces.wait-ip: ipv4+ipv6` to the NMState YAML file to resolve an issue that prevents your cluster from deploying on a dual-stack network.
 
 .Example NMState YAML configuration file that includes the `wait-ip` parameter
 [source,yaml]


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OCPBUGS-35361](https://issues.redhat.com/browse/OCPBUGS-35361)

Link to docs preview:
[Optional: Deploying with dual-stack networking](https://77430--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#modifying-install-config-for-dual-stack-network_ipi-install-installation-workflow)

- [x] SME has approved this change.
- [x] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
