### PR TITLE
[OCPBUGS#35419] Remove ShiftStack provider network non-support statements

### DIFF
--- a/installing/installing_openstack/installing-openstack-user-sr-iov.adoc
+++ b/installing/installing_openstack/installing-openstack-user-sr-iov.adoc
@@ -16,7 +16,6 @@ Using your own infrastructure allows you to integrate your cluster with existing
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 * You verified that {product-title} {product-version} is compatible with your {rh-openstack} version by using the xref:../../architecture/architecture-installation.adoc#supported-platforms-for-openshift-clusters_architecture-installation[Supported platforms for OpenShift clusters] section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
-* Your network configuration does not rely on a provider network. Provider networks are not supported.
 * You have an {rh-openstack} account where you want to install {product-title}.
 * You understand performance and scalability practices for cluster scaling, control plane sizing, and etcd. For more information, see xref:../../scalability_and_performance/recommended-performance-scale-practices/recommended-control-plane-practices.adoc#recommended-host-practices[Recommended practices for scaling the cluster].
 * On the machine where you run the installation program, you have:

--- a/modules/installation-osp-deploying-bare-metal-machines.adoc
+++ b/modules/installation-osp-deploying-bare-metal-machines.adoc
@@ -32,8 +32,6 @@ Be sure that your `install-config.yaml` file reflects whether the {rh-openstack}
 
 * The {rh-openstack} network supports both VM and bare metal server attachment.
 
-* Your network configuration does not rely on a provider network. Provider networks are not supported.
-
 * If you want to deploy the machines on a pre-existing network, a {rh-openstack} subnet is provisioned.
 
 * If you want to deploy the machines on an installer-provisioned network, the {rh-openstack} Bare Metal service (Ironic) is able to listen for and interact with Preboot eXecution Environment (PXE) boot machines that run on tenant networks.


### PR DESCRIPTION
Resolves OCPBUGS-35419. Removes non-support statements with respect to provider networks in ShiftStack docs. Provider networks were supported beginning in 4.8, and that support statement is in the release notes.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-35419
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Needs CM.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
