### PR TITLE
CNV#42655: Adding placeholder text for CNV asynchronous release

### DIFF
--- a/virt/about_virt/about-virt.adoc
+++ b/virt/about_virt/about-virt.adoc
@@ -10,11 +10,11 @@ toc::[]
 Documentation for {VirtProductName} will be available for {product-title} {product-version} in the near future.
 
 ifdef::openshift-origin[]
-In the meantime, the link:https://docs.okd.io/4.14/virt/about_virt/about-virt.html[{VirtProductName} 4.14 documentation] is available as part of the {product-title} 4.14 documentation.
+In the meantime, the link:https://docs.okd.io/4.15/virt/about_virt/about-virt.html[{VirtProductName} 4.15 documentation] is available as part of the {product-title} 4.15 documentation.
 endif::[]
 
 ifdef::openshift-enterprise[]
-In the meantime, the link:https://docs.openshift.com/container-platform/4.14/virt/about_virt/about-virt.html[{VirtProductName} 4.14 documentation] is available as part of the {product-title} 4.14 documentation.
+In the meantime, the link:https://docs.openshift.com/container-platform/4.15/virt/about_virt/about-virt.html[{VirtProductName} 4.15 documentation] is available as part of the {product-title} 4.15 documentation.
 endif::[]
 
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/CNV-42655

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
N/A

Additional information:
OpenShift Virtualization GA has been delayed. This PR adds placeholder text to the about-virt.adoc file to prepare for CNV asynchronous release from OCP.
