### PR TITLE
OSDOCS-10526 updated billing into module

### DIFF
--- a/modules/rosa-sdpolicy-am-billing.adoc
+++ b/modules/rosa-sdpolicy-am-billing.adoc
@@ -4,8 +4,11 @@
 // * rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
 :_mod-docs-content-type: CONCEPT
 [id="rosa-sdpolicy-billing_{context}"]
-= Billing
+= Billing and pricing
 
-{product-title} is billed through Amazon Web Services (AWS) based on the usage of AWS components used by the service, such as load balancers, storage, EC2 instances, other components, and Red{nbsp}Hat subscriptions for the OpenShift service.
+{product-title} is billed directly to your {AWS} account. ROSA pricing is consumption based, with annual commitments or three-year commitments for greater discounting. The total cost of ROSA consists of two components:
 
-Any additional Red{nbsp}Hat software must be purchased separately.
+* ROSA service fees
+* AWS infrastructure fees
+
+Visit the link:https://aws.amazon.com/rosa/pricing/[{product-title} Pricing] page on the AWS website for more details.

--- a/rosa_architecture/rosa-understanding.adoc
+++ b/rosa_architecture/rosa-understanding.adoc
@@ -48,15 +48,7 @@ For additional information about ROSA installation, see link:https://www.redhat.
 
 //This mode makes use of a pre-created IAM user with `AdministratorAccess` within the account that has proper permissions to create other roles and resources as needed. Using this account the service creates all the necessary resources that are needed for the cluster.
 
-[id="rosa-understanding-billing-pricing_{context}"]
-== Billing and pricing
-
-ROSA is billed directly to your AWS account. ROSA pricing can be consumption based, with annual commitments or three-year commitments for greater discounting. The total cost of ROSA consists of two components:
-
-* ROSA service fees
-* AWS infrastructure fees
-
-Visit the link:https://aws.amazon.com/rosa/pricing/[AWS pricing page] for more details.
+include::modules/rosa-sdpolicy-am-billing.adoc[leveloffset=+1] 
 
 [id="rosa-understanding-getting-started_{context}"]
 == Getting started


### PR DESCRIPTION
Updated the billing module and made sure it was in the right places. 

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.15+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-10526
Link to docs preview:

https://77443--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html

https://77443--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html

https://77443--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-understanding.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
