### PR TITLE
OSDOCS-10491: Split CCO postinstall tasks into new assembly

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -625,6 +625,8 @@ Topics:
   File: storage-configuration
 - Name: Preparing for users
   File: preparing-for-users
+- Name: Changing the cloud provider credentials configuration
+  File: changing-cloud-credentials-configuration
 - Name: Configuring alert notifications
   File: configuring-alert-notifications
 - Name: Converting a connected cluster to a disconnected cluster

--- a/authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc
@@ -17,7 +17,7 @@ With mint mode, each cluster component has only the specific permissions it requ
 
 [NOTE]
 ====
-By default, mint mode requires storing the `admin` credential in the cluster `kube-system` namespace. If this approach does not meet the security requirements of your organization, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove the credential after installing the cluster].
+By default, mint mode requires storing the `admin` credential in the cluster `kube-system` namespace. If this approach does not meet the security requirements of your organization, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove the credential after installing the cluster].
 ====
 
 [id="mint-mode-permissions"]
@@ -72,4 +72,4 @@ include::modules/manually-rotating-cloud-creds.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 == Additional resources
-* xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[Removing cloud provider credentials]
+* xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[Removing cloud provider credentials]

--- a/installing/installing_alibaba/installing-alibaba-customizations.adoc
+++ b/installing/installing_alibaba/installing-alibaba-customizations.adoc
@@ -69,4 +69,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
 //Given that manual mode is required to install on Alibaba Cloud, I do not believe this xref is necessary.
-//* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+//* If necessary, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_alibaba/installing-alibaba-default.adoc
+++ b/installing/installing_alibaba/installing-alibaba-default.adoc
@@ -57,4 +57,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
 //Given that manual mode is required to install on Alibaba Cloud, I do not believe this xref is necessary.
-//* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials]
+//* If necessary, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials]

--- a/installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+++ b/installing/installing_alibaba/installing-alibaba-network-customizations.adoc
@@ -79,4 +79,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
 //Given that manual mode is required to install on Alibaba Cloud, I do not believe this xref is necessary.
-//* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+//* If necessary, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_alibaba/installing-alibaba-vpc.adoc
+++ b/installing/installing_alibaba/installing-alibaba-vpc.adoc
@@ -70,4 +70,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
 //Given that manual mode is required to install on Alibaba Cloud, I do not believe this xref is necessary.
-//* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+//* If necessary, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_aws/ipi/installing-aws-china.adoc
+++ b/installing/installing_aws/ipi/installing-aws-china.adoc
@@ -111,4 +111,4 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 * xref:../../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, you can xref:../../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+* If necessary, you can xref:../../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_aws/ipi/installing-aws-customizations.adoc
+++ b/installing/installing_aws/ipi/installing-aws-customizations.adoc
@@ -108,4 +108,4 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 * xref:../../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, you can xref:../../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+* If necessary, you can xref:../../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_aws/ipi/installing-aws-default.adoc
+++ b/installing/installing_aws/ipi/installing-aws-default.adoc
@@ -42,4 +42,4 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 * xref:../../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, you can xref:../../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+* If necessary, you can xref:../../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_aws/ipi/installing-aws-government-region.adoc
+++ b/installing/installing_aws/ipi/installing-aws-government-region.adoc
@@ -112,4 +112,4 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 * xref:../../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, you can xref:../../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+* If necessary, you can xref:../../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_aws/ipi/installing-aws-network-customizations.adoc
+++ b/installing/installing_aws/ipi/installing-aws-network-customizations.adoc
@@ -126,4 +126,4 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 * xref:../../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, you can xref:../../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+* If necessary, you can xref:../../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_aws/ipi/installing-aws-private.adoc
+++ b/installing/installing_aws/ipi/installing-aws-private.adoc
@@ -106,4 +106,4 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 * xref:../../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, you can xref:../../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+* If necessary, you can xref:../../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_aws/ipi/installing-aws-secret-region.adoc
+++ b/installing/installing_aws/ipi/installing-aws-secret-region.adoc
@@ -105,4 +105,4 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 * xref:../../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, you can xref:../../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+* If necessary, you can xref:../../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_aws/ipi/installing-aws-vpc.adoc
+++ b/installing/installing_aws/ipi/installing-aws-vpc.adoc
@@ -104,5 +104,5 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 * xref:../../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, you can xref:../../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+* If necessary, you can xref:../../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].
 * After installing a cluster on AWS into an existing VPC, you can xref:../../../post_installation_configuration/configuring-aws-outposts.adoc#configuring-aws-outposts[extend the AWS VPC cluster into an AWS Outpost].

--- a/installing/installing_aws/upi/installing-aws-user-infra.adoc
+++ b/installing/installing_aws/upi/installing-aws-user-infra.adoc
@@ -223,4 +223,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * xref:../../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, you can xref:../../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+* If necessary, you can xref:../../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_aws/upi/installing-restricted-networks-aws.adoc
+++ b/installing/installing_aws/upi/installing-restricted-networks-aws.adoc
@@ -213,4 +213,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can xref:../../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
 * If necessary, see xref:../../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]
-* If necessary, you can xref:../../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+* If necessary, you can xref:../../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_azure_stack_hub/installing-azure-stack-hub-default.adoc
+++ b/installing/installing_azure_stack_hub/installing-azure-stack-hub-default.adoc
@@ -73,4 +73,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+* If necessary, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
+++ b/installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
@@ -89,4 +89,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+* If necessary, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc
+++ b/installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc
@@ -20,7 +20,7 @@ include::modules/cco-ccoctl-configuring.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources_configuring-iam-ibm-cloud-refreshing-ids"]
 .Additional resources
-* xref:../../post_installation_configuration/cluster-tasks.adoc#refreshing-service-ids-ibm-cloud_post-install-cluster-tasks[Rotating API keys for {ibm-cloud-name}]
+* xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#refreshing-service-ids-ibm-cloud_changing-cloud-credentials-configuration[Rotating API keys for {ibm-cloud-name}]
 
 [id="next-steps_configuring-iam-ibm-cloud"]
 == Next steps

--- a/installing/installing_ibm_powervs/preparing-to-install-on-ibm-power-vs.adoc
+++ b/installing/installing_ibm_powervs/preparing-to-install-on-ibm-power-vs.adoc
@@ -48,7 +48,7 @@ include::modules/cco-ccoctl-configuring.adoc[leveloffset=+1]
 [id="additional-resources_configuring-ibm-cloud-refreshing-ids"]
 
 .Additional resources
-* xref:../../post_installation_configuration/cluster-tasks.adoc#refreshing-service-ids-ibm-cloud_post-install-cluster-tasks[Rotating API keys]
+* xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#refreshing-service-ids-ibm-cloud_changing-cloud-credentials-configuration[Rotating API keys]
 
 [id="next-steps_preparing-to-install-on-ibm-power-vs"]
 == Next steps

--- a/post_installation_configuration/changing-cloud-credentials-configuration.adoc
+++ b/post_installation_configuration/changing-cloud-credentials-configuration.adoc
@@ -1,0 +1,67 @@
+:_mod-docs-content-type: ASSEMBLY
+:context: changing-cloud-credentials-configuration
+[id="changing-cloud-credentials-configuration"]
+= Changing the cloud provider credentials configuration
+include::_attributes/common-attributes.adoc[]
+
+toc::[]
+
+For supported configurations, you can change how {product-title} authenticates with your cloud provider.
+
+To determine which cloud credentials strategy your cluster uses, see xref:../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc#cco-determine-mode_about-cloud-credential-operator[Determining the Cloud Credential Operator mode].
+
+[id="post-install-rotate-remove-cloud-creds_{context}"]
+== Rotating or removing cloud provider credentials
+
+After installing {product-title}, some organizations require the rotation or removal of the cloud provider credentials that were used during the initial installation.
+
+To allow the cluster to use the new credentials, you must update the secrets that the xref:../operators/operator-reference.adoc#cloud-credential-operator_cluster-operators-ref[Cloud Credential Operator (CCO)] uses to manage cloud provider credentials.
+
+[id="ccoctl-rotate-remove-cloud-creds_{context}"]
+=== Rotating cloud provider credentials with the Cloud Credential Operator utility
+
+// Right now only IBM can do this, but it makes sense to set this up so that other clouds can be added.
+The Cloud Credential Operator (CCO) utility `ccoctl` supports updating secrets for clusters installed on {ibm-cloud-name}.
+
+//Rotating IBM Cloud credentials with ccoctl
+include::modules/refreshing-service-ids-ibm-cloud.adoc[leveloffset=+3]
+
+//Rotating cloud provider credentials manually
+include::modules/manually-rotating-cloud-creds.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere[vSphere CSI Driver Operator]
+
+//Removing cloud provider credentials manually
+include::modules/manually-removing-cloud-creds.adoc[leveloffset=+2]
+
+//These additional resources are for the "Rotating or removing cloud provider credentials" section, do not separate them from that content.
+[role="_additional-resources"]
+.Additional resources
+* xref:../authentication/managing_cloud_provider_credentials/cco-mode-passthrough.adoc#admin-credentials-root-secret-formats_cco-mode-passthrough[Admin credentials root secret format]
+
+[id="post-install-enable-token-auth_{context}"]
+== Enabling token-based authentication
+//Today, just Entra. But this should be a section that anticipates the addition of AWS STS and GCP WID.
+
+After installing an {azure-first} {product-title} cluster, you can enable {entra-first} to use short-term credentials.
+
+//Configuring the Cloud Credential Operator utility
+include::modules/cco-ccoctl-configuring.adoc[leveloffset=+2]
+
+//Enabling {entra-first} on an existing cluster
+include::modules/enabling-entra-workload-id-existing-cluster.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc#cco-short-term-creds-azure_cco-short-term-creds[Microsoft Entra Workload ID]
+* xref:../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-with-short-term-creds_installing-azure-customizations[Configuring an Azure cluster to use short-term credentials]
+
+//Verifying the credentials configuration
+include::modules/cco-ccoctl-install-verifying.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc#about-cloud-credential-operator[About the Cloud Credential Operator]

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -685,60 +685,6 @@ include::modules/pod-disruption-eviction-policy.adoc[leveloffset=+2]
 * xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
 * link:https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy[Unhealthy Pod Eviction Policy] in the Kubernetes documentation
 
-[id="post-install-rotate-remove-cloud-creds"]
-== Rotating or removing cloud provider credentials
-
-After installing {product-title}, some organizations require the rotation or removal of the cloud provider credentials that were used during the initial installation.
-
-To allow the cluster to use the new credentials, you must update the secrets that the xref:../operators/operator-reference.adoc#cloud-credential-operator_cluster-operators-ref[Cloud Credential Operator (CCO)] uses to manage cloud provider credentials.
-
-[id="ccoctl-rotate-remove-cloud-creds"]
-=== Rotating cloud provider credentials with the Cloud Credential Operator utility
-
-// Right now only IBM can do this, but it makes sense to set this up so that other clouds can be added.
-The Cloud Credential Operator (CCO) utility `ccoctl` supports updating secrets for clusters installed on {ibm-cloud-name}.
-
-//Rotating IBM Cloud credentials with ccoctl
-include::modules/refreshing-service-ids-ibm-cloud.adoc[leveloffset=+3]
-
-//Rotating cloud provider credentials manually
-include::modules/manually-rotating-cloud-creds.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-* xref:../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc[vSphere CSI Driver Operator]
-
-//Removing cloud provider credentials manually
-include::modules/manually-removing-cloud-creds.adoc[leveloffset=+2]
-
-//These additional resources are for the "Rotating or removing cloud provider credentials" section, do not separate them from that content.
-[role="_additional-resources"]
-.Additional resources
-* xref:../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc#about-cloud-credential-operator[About the Cloud Credential Operator]
-* xref:../authentication/managing_cloud_provider_credentials/cco-mode-passthrough.adoc#admin-credentials-root-secret-formats_cco-mode-passthrough[Admin credentials root secret format]
-
-[id="post-install-enable-token-auth"]
-== Enabling token-based authentication
-//Today, just Entra. But this should be a section that anticipates the addition of AWS STS and GCP WID.
-
-After installing an {azure-first} {product-title} cluster, you can enable {entra-first} to use short-term credentials.
-
-To determine which cloud credentials strategy your cluster uses, see xref:../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc#cco-determine-mode_about-cloud-credential-operator[Determining the Cloud Credential Operator mode].
-
-//Configuring the Cloud Credential Operator utility
-include::modules/cco-ccoctl-configuring.adoc[leveloffset=+2]
-
-//Enabling {entra-first} on an existing cluster
-include::modules/enabling-entra-workload-id-existing-cluster.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-* xref:../authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc#cco-short-term-creds-azure_cco-short-term-creds[Microsoft Entra Workload ID]
-* xref:../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-with-short-term-creds_installing-azure-customizations[Configuring an Azure cluster to use short-term credentials]
-
-//Verifying the credentials configuration
-include::modules/cco-ccoctl-install-verifying.adoc[leveloffset=+2]
-
 [id="post-install-must-gather-disconnected"]
 == Configuring image streams for a disconnected cluster
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-10491](https://issues.redhat.com//browse/OSDOCS-10491)

Link to docs preview:
[Changing the cloud provider credentials configuration](https://77450--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/changing-cloud-credentials-configuration.html)

QE review:
N/A

Additional information:
CP to 4.16 should be simple, 4.12-4.15 will require care.
4.16: https://github.com/openshift/openshift-docs/pull/77599
4.15: https://github.com/openshift/openshift-docs/pull/77647
4.14: https://github.com/openshift/openshift-docs/pull/77659
4.13:
4.12: