### PR TITLE
WMCO: 240.0.0.0 should not be used for clusters that will enable Windows workload

### DIFF
--- a/modules/windows-containers-release-notes-limitations.adoc
+++ b/modules/windows-containers-release-notes-limitations.adoc
@@ -31,6 +31,8 @@ Note the following limitations when working with Windows nodes managed by the WM
 
 * {productwinc} does not support any Windows operating system language other than English (United States). 
 
+* Due to a limitation within the Windows operating system, `clusterNetwork` CIDR addresses of class E, such as `240.0.0.0`, are not compatible with Windows nodes.
+
 * Kubernetes has identified the following link:https://kubernetes.io/docs/concepts/windows/intro/#limitations[node feature limitations] :
 ** Huge pages are not supported for Windows containers.
 ** Privileged containers are not supported for Windows containers.

--- a/windows_containers/enabling-windows-container-workloads.adoc
+++ b/windows_containers/enabling-windows-container-workloads.adoc
@@ -40,6 +40,11 @@ Windows instances deployed by the WMCO are configured with the containerd contai
 
 You can install the Windows Machine Config Operator using either the web console or OpenShift CLI (`oc`).
 
+[NOTE]
+====
+Due to a limitation within the Windows operating system, `clusterNetwork` CIDR addresses of class E, such as `240.0.0.0`, are not compatible with Windows nodes.
+====
+
 include::modules/installing-wmco-using-web-console.adoc[leveloffset=+2]
 
 include::modules/installing-wmco-using-cli.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-34614

Link to docs preview:
WMCO release notes ->[Known limitations](https://77452--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-6-x#windows-containers-release-notes-limitations_windows-containers-release-notes) -- 8th bullet is new
Enabling Windows containers -> [Installing the Windows Machine Config Operator](https://77452--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/enabling-windows-container-workloads#installing-the-wmco) -- New note.

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
https://issues.redhat.com/browse/OCPBUGS-32256