### PR TITLE
Adds whereabouts multi tenant example to networking docs

### DIFF
--- a/modules/nw-multus-ipam-object.adoc
+++ b/modules/nw-multus-ipam-object.adoc
@@ -192,11 +192,16 @@ spec:
 [id="nw-multus-whereabouts_{context}"]
 == Dynamic IP address assignment configuration with Whereabouts
 
-The Whereabouts CNI plugin allows the dynamic assignment of an IP address to an additional network without the use of a DHCP server.
+The Whereabouts CNI plugin allows the dynamic assignment of an IP address to an additional network without the use of a DHCP server. 
 
-The following table describes the configuration for dynamic IP address assignment with Whereabouts:
+The Whereabouts CNI plugin also supports overlapping IP address ranges and configuration of the same CIDR range multiple times within separate `NetworkAttachmentDefinitions`. This provides greater flexibility and management capabilities in multi-tenant environments.
 
-.`ipam` whereabouts configuration object
+[id="dynamic-ip-address-assignment-configuration-objects"]
+=== Dynamic IP address configuration objects
+
+The following table describes the configuration objects for dynamic IP address assignment with Whereabouts:
+
+.`ipam` Whereabouts configuration object
 [cols=".^2,.^2,.^6",options="header"]
 |====
 |Field|Type|Description
@@ -213,16 +218,17 @@ The following table describes the configuration for dynamic IP address assignmen
 |`array`
 |Optional: A list of zero or more IP addresses and ranges in CIDR notation. IP addresses within an excluded address range are not assigned.
 
+|`network_name`
+|`string`
+| Optional: Helps ensure that each group or domain of pods gets its own set of IP addresses, even if they share the same range of IP addresses. Setting this field is important for keeping networks separate and organized, notably in multi-tenant environments.
+
 |====
 
-////
-[NOTE]
-=====
-Whereabouts can be used for both IPv4 and IPv6 addresses.
-=====
-////
+[id="dynamic-ip-address-assignment-whereabouts"]
+=== Dynamic IP address assignment configuration that uses Whereabouts:
 
-.Dynamic IP address assignment configuration example that uses Whereabouts
+The following example shows a dynamic address assignment configuration that uses Whereabouts:
+
 [source,json]
 ----
 {
@@ -236,6 +242,38 @@ Whereabouts can be used for both IPv4 and IPv6 addresses.
   }
 }
 ----
+
+[id="dynamic-ip-address-assignment-overlapping-ip-ranges"]
+=== Dynamic IP address assignment with Whereabouts
+
+The following example shows a dynamic IP address assignment that uses overlapping IP address ranges for multi-tenant networks:
+
+.NetworkAttachmentDefinition 1
+[source,json]
+----
+{
+  "ipam": {
+    "type": "whereabouts",
+    "range": "192.0.2.192/29",
+    "network_name": "example_net_common", <1>
+  }
+}
+----
+<1> Optional. If set, must match the `network_name` of NetworkAttachmentDefinition 2.
+
+.NetworkAttachmentDefinition 2
+[source,json]
+----
+{
+  "ipam": {
+    "type": "whereabouts",
+    "range": "192.0.2.192/24",
+    "network_name": "example_net_common", <1>
+    "enable_overlapping_ranges": true
+  }
+}
+----
+<1> Optional. If set, must match the `network_name` of NetworkAttachmentDefinition 1. 
 
 ifdef::sr-iov[]
 :!sr-iov:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
