### PR TITLE
OSDOCS-10649: Adding update steps for Entra cluster

### DIFF
--- a/modules/cco-ccoctl-upgrading.adoc
+++ b/modules/cco-ccoctl-upgrading.adoc
@@ -44,7 +44,7 @@ $ ccoctl aws create-all \// <1>
 <6> Optional: By default, the `ccoctl` utility stores the OpenID Connect (OIDC) configuration files in a public S3 bucket and uses the S3 URL as the public OIDC endpoint. To store the OIDC configuration in a private S3 bucket that is accessed by the IAM identity provider through a public CloudFront distribution URL instead, use the `--create-private-s3-bucket` parameter.
 ====
 +
-.Google Cloud Platform (GCP)
+.{gcp-first}
 [%collapsible]
 ====
 [source,terminal]
@@ -78,6 +78,46 @@ $ ccoctl ibmcloud create-service-id \
 <2> Specify the name of the {product-title} cluster.
 <3> Optional: Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
 <4> Optional: Specify the name of the resource group used for scoping the access policies.
+====
++
+.{azure-first}
+[%collapsible]
+====
+[source,terminal]
+----
+$ ccoctl azure create-managed-identities \
+  --name <azure_infra_name> \// <1>
+  --output-dir ./output_dir \
+  --region <azure_region> \// <2>
+  --subscription-id <azure_subscription_id> \// <3>
+  --credentials-requests-dir <path_to_directory_for_credentials_requests> \
+  --issuer-url "${OIDC_ISSUER_URL}" \// <4>
+  --dnszone-resource-group-name <azure_dns_zone_resourcegroup_name> \// <5>
+  --installation-resource-group-name "${AZURE_INSTALL_RG}" <6>
+----
+<1> The value of the `name` parameter is used to create an Azure resource group.
+To use an existing Azure resource group instead of creating a new one, specify the `--oidc-resource-group-name` argument with the existing group name as its value.
+<2> Specify the region of the existing cluster.
+<3> Specify the subscription ID of the existing cluster.
+<4> Specify the OIDC issuer URL from the existing cluster.
+You can obtain this value by running the following command:
++
+[source,terminal]
+----
+$ oc get authentication cluster \
+  -o jsonpath \
+  --template='{ .spec.serviceAccountIssuer }'
+----
+<5> Specify the name of the resource group that contains the DNS zone.
+<6> Specify the {azure-short} resource group name.
+You can obtain this value by running the following command:
++
+[source,terminal]
+----
+$ oc get infrastructure cluster \
+  -o jsonpath \
+  --template '{ .status.platformStatus.azure.resourceGroupName }'
+----
 ====
 +
 .Nutanix


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-10649](https://issues.redhat.com//browse/OSDOCS-10649)

Link to docs preview:
[Updating cloud provider resources with the Cloud Credential Operator utility](https://77460--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/preparing-manual-creds-update.html#cco-ccoctl-upgrading_preparing-manual-creds-update)

QE review:
- [x] QE has approved this change.

Additional information: