### PR TITLE
CNV#42655: Reversing about-virt placeholder

### DIFF
--- a/virt/about_virt/about-virt.adoc
+++ b/virt/about_virt/about-virt.adoc
@@ -7,18 +7,17 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 //To prepare to release asynchronously, uncomment the text below and (if necessary) update the version numbers. Then, comment out the rest of the module.
-Documentation for {VirtProductName} will be available for {product-title} {product-version} in the near future.
+//Documentation for {VirtProductName} will be available for {product-title} {product-version} in the near future.
 
-ifdef::openshift-origin[]
-In the meantime, the link:https://docs.okd.io/4.15/virt/about_virt/about-virt.html[{VirtProductName} 4.15 documentation] is available as part of the {product-title} 4.15 documentation.
-endif::[]
+//ifdef::openshift-origin[]
+//In the meantime, the link:https://docs.okd.io/4.15/virt/about_virt/about-virt.html[{VirtProductName} 4.15 documentation] is available as part of the {product-title} 4.15 documentation.
+//endif::[]
 
-ifdef::openshift-enterprise[]
-In the meantime, the link:https://docs.openshift.com/container-platform/4.15/virt/about_virt/about-virt.html[{VirtProductName} 4.15 documentation] is available as part of the {product-title} 4.15 documentation.
-endif::[]
+//ifdef::openshift-enterprise[]
+//In the meantime, the link:https://docs.openshift.com/container-platform/4.15/virt/about_virt/about-virt.html[{VirtProductName} 4.15 documentation] is available as part of the {product-title} 4.15 documentation.
+//endif::[]
 
 
-////
 Learn about {VirtProductName}'s capabilities and support scope.
 
 include::modules/virt-what-you-can-do-with-virt.adoc[leveloffset=+1]
@@ -66,4 +65,3 @@ endif::openshift-rosa,openshift-dedicated[]
 * xref:../../virt/nodes/virt-node-maintenance.adoc#eviction-strategies[Eviction strategies]
 * link:https://access.redhat.com/articles/6994974[Tuning & Scaling Guide]
 * link:https://access.redhat.com/articles/6571671[Supported limits for OpenShift Virtualization 4.x]
-////


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/CNV-42655

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
N/A

Additional information:
reverting about-virt assembly to its previous state (to be merged after CNV 4.16 GA)
