### PR TITLE
HCIDOCS-72: DS & RN: METAL-650 Attach non-bootable ISO to BMH

### DIFF
--- a/modules/bmo-attaching-a-non-bootable-iso-to-a-bare-metal-node.adoc
+++ b/modules/bmo-attaching-a-non-bootable-iso-to-a-bare-metal-node.adoc
@@ -1,0 +1,98 @@
+// This module is included in the following assemblies: 
+//
+// * post_installation_configuration/bare-metal-configuration.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="attaching-a-non-bootable-iso-to-a-bare-metal-node_{context}"]
+= Attaching a non-bootable ISO to a bare-metal node
+
+You can attach a generic, non-bootable ISO virtual media image to a provisioned node by using the `DataImage` resource. After you apply the resource, the ISO image becomes accessible to the operating system after it has booted. This is useful for configuring a node after provisioning the operating system and before the node boots for the first time.
+
+.Prerequisites
+
+* The node must use Redfish or drivers derived from it to support this feature.
+* The node must be in the `Provisioned` or `ExternallyProvisioned` state.
+* The `name` must be the same as the name of the node defined in its `BareMetalHost` resource.
+* You have a valid `url` to the ISO image.
+
+.Procedure
+
+. Create a `DataImage` resource:
++
+[source,yaml]
+----
+apiVersion: metal3.io/v1alpha1
+kind: DataImage
+metadata:
+  name: <node_name> # <1>
+spec:
+  url: "http://dataimage.example.com/non-bootable.iso" # <2>
+----
+<1> Specify the name of the node as defined in its `BareMetalHost` resource.
+<2> Specify the URL and path to the ISO image.
+
+. Save the `DataImage` resource to a file by running the following command:
++
+[source,terminal]
+----
+$ vim <node_name>-dataimage.yaml
+----
+
+. Apply the `DataImage` resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <node_name>-dataimage.yaml -n <node_namespace> <1>
+----
+<1> Replace `<node_namespace>` so that the namespace matches the namespace for the `BareMetalHost` resource. For example, `openshift-machine-api`.
+
+. Reboot the node. 
++
+[NOTE]
+====
+You can physically reboot the node. You can also attach the `reboot.metal3.io` annotation or reset set the `online` status in the `BareMetalHost` resource. A forced reboot of the bare-metal node will change the state of the node to `NotReady` for awhile. For example, 5 minutes or more.
+====
+
+. View the `DataImage` resource by running the following command:
++
+[source,terminal]
+----
+$ oc get dataimage <node_name> -n openshift-machine-api -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+apiVersion: v1
+items:
+- apiVersion: metal3.io/v1alpha1
+  kind: DataImage
+  metadata:
+    annotations:
+      kubectl.kubernetes.io/last-applied-configuration: |
+        {"apiVersion":"metal3.io/v1alpha1","kind":"DataImage","metadata":{"annotations":{},"name":"bmh-node-1","namespace":"openshift-machine-api"},"spec":{"url":"http://dataimage.example.com/non-bootable.iso"}}
+    creationTimestamp: "2024-06-10T12:00:00Z"
+    finalizers:
+    - dataimage.metal3.io
+    generation: 1
+    name: bmh-node-1
+    namespace: openshift-machine-api
+    ownerReferences:
+    - apiVersion: metal3.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: BareMetalHost
+      name: bmh-node-1
+      uid: 046cdf8e-0e97-485a-8866-e62d20e0f0b3
+    resourceVersion: "21695581"
+    uid: c5718f50-44b6-4a22-a6b7-71197e4b7b69
+  spec:
+    url: http://dataimage.example.com/non-bootable.iso
+  status:
+    attachedImage:
+      url: http://dataimage.example.com/non-bootable.iso
+    error:
+      count: 0
+      message: ""
+    lastReconciled: "2024-06-10T12:05:00Z"
+----

--- a/post_installation_configuration/bare-metal-configuration.adoc
+++ b/post_installation_configuration/bare-metal-configuration.adoc
@@ -14,6 +14,8 @@ include::modules/bmo-about-the-baremetalhost-resource.adoc[leveloffset=+1]
 include::modules/bmo-getting-the-baremetalhost-resource.adoc[leveloffset=+1]
 include::modules/bmo-editing-a-baremetalhost-resource.adoc[leveloffset=+1]
 
+include::modules/bmo-attaching-a-non-bootable-iso-to-a-bare-metal-node.adoc[leveloffset=+1]
+
 include::modules/bmo-about-the-hostfirmwaresettings-resource.adoc[leveloffset=+1]
 include::modules/bmo-getting-the-hostfirmwaresettings-resource.adoc[leveloffset=+1]
 include::modules/bmo-editing-the-hostfirmwaresettings-resource.adoc[leveloffset=+1]


### PR DESCRIPTION
Added a module for attaching a non-bootable ISO after provisioning a node.

Fixes: [HCIDOCS-72](https://issues.redhat.com//browse/HCIDOCS-72)

See https://issues.redhat.com/browse/HCIDOCS-72 for additional details.

Preview URL: https://77467--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/bare-metal-configuration.html#attaching-a-non-bootable-iso-to-a-bare-metal-node_post-install-bare-metal-configuration

For release(s): 4.16
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
