### PR TITLE
RHDEVDOCS 5953 remove the note about OCP 4.12 and 4.13 from Pipelines 1.15 doc as support for these versions is not in 1.15

### DIFF
--- a/create/working-with-pipelines-web-console.adoc
+++ b/create/working-with-pipelines-web-console.adoc
@@ -9,11 +9,6 @@ toc::[]
 You can use the *Administrator* or *Developer* perspective to create and modify `Pipeline`, `PipelineRun`, and `Repository` objects from the *Pipelines* page in the {OCP} web console.
 You can also use the *+Add* page in the *Developer* perspective of the web console to create CI/CD pipelines for your software delivery process.
 
-[IMPORTANT]
-====
-In {OCP} versions 4.12 and 4.13, the `tekton.dev/v1` API version is not supported when using the web console to enter YAML manifests for {openshift-pipelines}. For example, when creating pipelines and tasks using the YAML view in the web console, the `API version in the data does not match the expected API version` error message displays. Use the `apiVersion: tekton.dev/v1beta1` setting instead. {OCP} versions 4.14 and later support the `tekton.dev/v1` API version when using the web console to enter YAML manifests.
-====
-
 // Dev console
 include::modules/op-odc-pipelines-abstract.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
please cp to pipelines-docs-1.15

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
RHDEVDOCS 5953

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://77470--ocpdocs-pr.netlify.app/openshift-pipelines/latest/create/working-with-pipelines-web-console.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
Removing a note that no longer applies in 1.15 as the OCP versions it covers are no longer supported

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
