### PR TITLE
OSDOCS#10684: Release notes for kubeadmin password no longer exposed

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -97,6 +97,11 @@ All {product-title} 4.15 clusters require this administrator acknowledgment befo
 
 For more information, see xref:../updating/preparing_for_updates/updating-cluster-prepare.adoc#updating-cluster-prepare[Preparing to update to {product-title} 4.16].
 
+[id="ocp-4-16-installation-and-update-kubeadmin_{context}"]
+==== Secure kubeadmin password from being displayed in the console
+
+With this release, you can prevent the `kubeadmin` password from being displayed in the console after the installation by using the `--skip-password-print` flag during cluster creation. The password remains accessible in the `auth` directory.
+
 [id="ocp-4-16-web-console_{context}"]
 === Web console
 


### PR DESCRIPTION
Version(s): 4.16

Issue: https://issues.redhat.com/browse/OSDOCS-10684

Link to docs preview:  https://77472--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#the-kubeadmin-password-no-longer-displayed-in-the-console

QE review:
- [x] QE has approved this change. @jianli-wei 