### PR TITLE
TELCODOCS-1707: Preparing configmap objects GitOps

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3107,8 +3107,8 @@ Topics:
       File: cnf-image-based-upgrade-generate-seed
     - Name: Creating ConfigMap objects for the image-based upgrade with Lifecycle Agent
       File: cnf-image-based-upgrade-prep-resources
-#    - Name: Creating ConfigMap objects for the image-based upgrade with Lifecycle Agent using GitOps ZTP
-#      File: ztp-image-based-upgrade-prep-resources
+    - Name: Creating ConfigMap objects for the image-based upgrade with Lifecycle Agent using GitOps ZTP
+      File: ztp-image-based-upgrade-prep-resources
 #  - Name: Performing an image-based upgrade for single-node OpenShift clusters
 #    File: cnf-image-based-upgrade-base
 #  - Name: Performing an image-based upgrade for single-node OpenShift clusters using GitOps ZTP

--- a/edge_computing/image_based_upgrade/cnf-understanding-image-based-upgrade.adoc
+++ b/edge_computing/image_based_upgrade/cnf-understanding-image-based-upgrade.adoc
@@ -6,8 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: The Lifecycle Agent
-
 From {product-title} 4.14.13, the {lcao} provides you with an alternative way to upgrade the platform version of a {sno} cluster.
 The image-based upgrade is faster than the standard upgrade method and allows you to directly upgrade from {product-title} <4.y> to <4.y+2>, and <4.y.z> to <4.y.z+n>.
 

--- a/edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/ztp-image-based-upgrade-prep-resources.adoc
+++ b/edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/ztp-image-based-upgrade-prep-resources.adoc
@@ -1,0 +1,25 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="ztp-image-based-upgrade-prep-resources"]
+= Creating ConfigMap objects for the image-based upgrade with {lcao} using {ztp}
+include::_attributes/common-attributes.adoc[]
+:context: ztp-gitops
+
+toc::[]
+
+Create your OADP resources, extra manifests, and custom catalog sources wrapped in a `ConfigMap` object to prepare for the image-based upgrade.
+
+include::modules/ztp-image-based-upgrade-prep-oadp.adoc[leveloffset=+1]
+
+
+include::modules/ztp-image-based-upgrade-prep-label-extramanifests.adoc[leveloffset=+1]
+
+////
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/cnf-image-based-upgrade-shared-container-image.adoc#ztp-image-based-upgrade-shared-container-directory_shared-container-directory[Configuring a shared container directory between ostree stateroots when using GitOps ZTP]
+
+* xref:../../../edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/cnf-image-based-upgrade-install-operators#zp-image-based-upgrade-installing-oadp-with-gitops_install-operators[Installing and configuring the OADP Operator with GitOps ZTP]
+
+* xref:../../../edge_computing/image_based_upgrade/ztp-image-based-upgrade.adoc#ztp-image-based-upgrade-for-sno[Performing an image-based upgrade with Lifecycle Agent and GitOps ZTP]
+////

--- a/modules/ztp-image-based-upgrade-prep-label-extramanifests.adoc
+++ b/modules/ztp-image-based-upgrade-prep-label-extramanifests.adoc
@@ -1,0 +1,94 @@
+// Module included in the following assemblies:
+// * edge_computing/image-based-upgrade/cnf-preparing-for-image-based-upgrade.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ztp-image-based-upgrade-prep-label-extramanifests_{context}"]
+= Labeling extra manifests for the image-based upgrade with {ztp}
+
+Label your extra manifests so that the {lcao} can extract resources that are labeled with the `lca.openshift.io/target-ocp-version: <target_version>` label.
+
+.Prerequisites
+
+* Provision one or more managed clusters with {ztp}.
+* Log in as a user with `cluster-admin` privileges.
+* Generate a seed image from a compatible seed cluster.
+* Create a separate partition on the target cluster for the container images that is shared between stateroots. For more information, see "Configuring a shared container directory between ostree stateroots when using {ztp}".
+* Deploy a version of {lcao} that is compatible with the version used with the seed image.
+
+.Procedure
+
+. Label your required extra manifests with the `lca.openshift.io/target-ocp-version: <target_version>` label in your existing `PolicyGenTemplate` CR:
++
+[source,yaml]
+----
+apiVersion: ran.openshift.io/v1
+kind: PolicyGenTemplate
+metadata:
+  name: example-sno
+spec:
+  bindingRules:
+    sites: "example-sno"
+    du-profile: "4.15"
+  mcp: "master"
+  sourceFiles:
+    - fileName: SriovNetwork.yaml
+      policyName: "config-policy"
+      metadata:
+        name: "sriov-nw-du-fh"
+        labels:
+          lca.openshift.io/target-ocp-version: "4.15" <1>
+      spec:
+        resourceName: du_fh
+        vlan: 140
+    - fileName: SriovNetworkNodePolicy.yaml
+      policyName: "config-policy"
+      metadata:
+        name: "sriov-nnp-du-fh"
+        labels:
+          lca.openshift.io/target-ocp-version: "4.15"
+      spec:
+        deviceType: netdevice
+        isRdma: false
+        nicSelector:
+          pfNames: ["ens5f0"]
+        numVfs: 8
+        priority: 10
+        resourceName: du_fh
+    - fileName: SriovNetwork.yaml
+      policyName: "config-policy"
+      metadata:
+        name: "sriov-nw-du-mh"
+        labels:
+          lca.openshift.io/target-ocp-version: "4.15"
+      spec:
+        resourceName: du_mh
+        vlan: 150
+    - fileName: SriovNetworkNodePolicy.yaml
+      policyName: "config-policy"
+      metadata:
+        name: "sriov-nnp-du-mh"
+        labels:
+          lca.openshift.io/target-ocp-version: "4.15"
+      spec:
+        deviceType: vfio-pci
+        isRdma: false
+        nicSelector:
+          pfNames: ["ens7f0"]
+        numVfs: 8
+        priority: 10
+        resourceName: du_mh
+    - fileName: DefaultCatsrc.yaml <2>
+      policyName: "config-policy"
+      metadata:
+        name: default-cat-source
+        namespace: openshift-marketplace
+        labels:
+            lca.openshift.io/target-ocp-version: "4.15"
+      spec:
+          displayName: default-cat-source
+          image: quay.io/example-org/example-catalog:v1
+----
+<1> Ensure that the `lca.openshift.io/target-ocp-version` label matches either the y-stream or the z-stream of the target {product-title} version that is specified in the `spec.seedImageRef.version` field of the `ImageBasedUpgrade` CR. The {lcao} only applies the CRs that match the specified version.
+<2> If you do not want to use custom catalog sources, remove this entry.
+
+. Push the changes to your Git repository.

--- a/modules/ztp-image-based-upgrade-prep-oadp.adoc
+++ b/modules/ztp-image-based-upgrade-prep-oadp.adoc
@@ -1,0 +1,136 @@
+// Module included in the following assemblies:
+// * edge_computing/image-based-upgrade/cnf-preparing-for-image-based-upgrade.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="zztp-image-based-upgrade-prep-oadp_{context}"]
+= Creating OADP resources for the image-based upgrade with {ztp}
+
+Prepare your OADP resources to restore your application after an upgrade.
+
+.Prerequisites
+
+* Provision one or more managed clusters with {ztp}.
+* Log in as a user with `cluster-admin` privileges.
+* Generate a seed image from a compatible seed cluster.
+* Create a separate partition on the target cluster for the container images that is shared between stateroots. For more information, see "Configuring a shared container directory between ostree stateroots when using {ztp}".
+* Deploy a version of {lcao} that is compatible with the version used with the seed image.
+* Install the OADP Operator, the `DataProtectionApplication` CR, and its secret on the target cluster.
+* Create an S3-compatible storage solution and a ready-to-use bucket with proper credentials configured. For more information, see "Installing and configuring the OADP Operator with {ztp}".
+
+.Procedure
+
+. Ensure that your Git repository that you use with the ArgoCD policies application contains the following directory structure:
++
+--
+[source,terminal]
+----
+├── source-crs/
+│   ├── ibu/
+│   │    ├── ImageBasedUpgrade.yaml
+│   │    ├── PlatformBackupRestore.yaml
+│   │    ├── PlatformBackupRestoreLvms.yaml
+├── ...
+├── ibu-upgrade-ranGen.yaml
+├── kustomization.yaml
+----
+
+[IMPORTANT]
+====
+The `kustomization.yaml` file must be located in the same directory structure as previously shown to reference the `ibu-upgrade-ranGen.yaml` manifest.
+====
+
+The `source-crs/ibu/PlatformBackupRestore.yaml` file is provided in the ZTP container image.
+
+.PlatformBackupRestore.yaml
+include::snippets/ibu-PlatformBackupRestore.adoc[]
+
+If you use {lvms} to create persistent volumes, you can use the `source-crs/ibu/PlatformBackupRestoreLvms.yaml` provided in the ZTP container image to back up your {lvms} resources.
+
+.PlatformBackupRestoreLvms.yaml
+include::snippets/ibu-PlatformBackupRestoreLvms.adoc[]
+--
+
+. Optional: If you need to restore applications after the upgrade, create the OADP `Backup` and `Restore` CRs for your application in the `openshift-adp` namespace:
+
+.. Create the OADP CRs for cluster-scoped application artifacts in the `openshift-adp` namespace:
++
+.Example OADP CRs for cluster-scoped application artifacts for LSO and {LVMS}
+include::snippets/ibu-ApplicationClusterScopedBackupRestore.adoc[]
+
+.. Create the OADP CRs for your namespace-scoped application artifacts in the `source-crs/custom-crs` directory:
++
+--
+.Example OADP CRs namespace-scoped application artifacts when LSO is used
+include::snippets/ibu-ApplicationBackupRestoreLso.adoc[]
+
+.Example OADP CRs namespace-scoped application artifacts when {lvms} is used
+include::snippets/ibu-ApplicationBackupRestoreLvms.adoc[]
+
+[IMPORTANT]
+====
+The same version of the applications must function on both the current and the target release of {product-title}.
+====
+--
+
+. Create the `oadp-cm` `ConfigMap` object through the `oadp-cm-policy` in a new `PolicyGenTemplate` called `ibu-upgrade-ranGen.yaml`:
++
+[source,yaml]
+----
+apiVersion: ran.openshift.io/v1
+kind: PolicyGenTemplate
+metadata:
+  name: example-group-ibu
+  namespace: "ztp-group"
+spec:
+  bindingRules:
+    group-du-sno: ""
+  mcp: "master"
+  evaluationInterval: 
+    compliant: 10s
+    noncompliant: 10s
+  sourceFiles:
+  - fileName: ConfigMapGeneric.yaml
+    complianceType: mustonlyhave
+    policyName: "oadp-cm-policy"
+    metadata:
+      name: oadp-cm
+      namespace: openshift-adp
+----
+
+. Create a `kustomization.yaml` with the following content:
++
+[source,yaml]
+----
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generators: <1>
+- ibu-upgrade-ranGen.yaml
+
+configMapGenerator: <2>
+- files:
+  - source-crs/ibu/PlatformBackupRestore.yaml
+  #- source-crs/custom-crs/ApplicationClusterScopedBackupRestore.yaml
+  #- source-crs/custom-crs/ApplicationApplicationBackupRestoreLso.yaml
+  name: oadp-cm
+  namespace: ztp-group
+generatorOptions:
+  disableNameSuffixHash: true 
+
+
+patches: <3>
+- target:
+    group: policy.open-cluster-management.io
+    version: v1
+    kind: Policy
+    name: group-ibu-oadp-cm-policy
+  patch: |-
+    - op: replace
+      path: /spec/policy-templates/0/objectDefinition/spec/object-templates/0/objectDefinition/data
+      value: '{{hub copyConfigMapData "ztp-group" "oadp-cm" hub}}'
+----
+<1> Generates the `oadp-cm-policy`.
+<2> Creates the `oadp-cm` `ConfigMap` object on the hub cluster with `Backup` and `Restore` CRs.
+<3> Overrides the data field of `ConfigMap` added in `oadp-cm-policy`. A hub template is used to propagate the `oadp-cm` `ConfigMap` to all target clusters.
+
+. Push the changes to your Git repository.


### PR DESCRIPTION
Version(s): 4.16+

Issue: https://issues.redhat.com/browse/TELCODOCS-1707

Docs preview: https://77475--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/ztp-image-based-upgrade-prep-resources

Additional information:
Dividing the original https://github.com/openshift/openshift-docs/pull/74025 to smaller chunks. This is PR#6 from [commit#7](https://github.com/openshift/openshift-docs/pull/74025/commits/e10f8c91ba523894fe82b6b818d5305e14d800a1)

- [PR#1](https://github.com/openshift/openshift-docs/pull/76871) 
- [PR#2](https://github.com/openshift/openshift-docs/pull/77078) 
- [PR#3](https://github.com/openshift/openshift-docs/pull/77256)
- [PR#4](https://github.com/openshift/openshift-docs/pull/77256)
- [PR#5](https://github.com/openshift/openshift-docs/pull/77308)
- [PR#6](https://github.com/openshift/openshift-docs/pull/77379)

Only relevant topicmap content is added. See thread in review channel on Slack.
Xrefs are pointing to non-existent sections at the moment, so they are commented out until added.

This PR contains 3 commits. You only need to review content in [commit 3, Add Preparing/ConfigMap objects GitOps](https://github.com/openshift/openshift-docs/pull/77475/commits/37224ec1918db16a4fdd91333ca870065ec7ef11), which is the assembly linked in the docs preview. I had to include the other 2 commits to make the build work. I didn't squash them as I thought this way might be might clearer. 