### PR TITLE
TELCODOCS-1707: Add performing upgrade non-GitOps

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3109,8 +3109,8 @@ Topics:
       File: cnf-image-based-upgrade-prep-resources
     - Name: Creating ConfigMap objects for the image-based upgrade with Lifecycle Agent using GitOps ZTP
       File: ztp-image-based-upgrade-prep-resources
-#  - Name: Performing an image-based upgrade for single-node OpenShift clusters
-#    File: cnf-image-based-upgrade-base
+  - Name: Performing an image-based upgrade for single-node OpenShift clusters
+    File: cnf-image-based-upgrade-base
 #  - Name: Performing an image-based upgrade for single-node OpenShift clusters using GitOps ZTP
 #    File: ztp-image-based-upgrade
 ---

--- a/edge_computing/image_based_upgrade/cnf-image-based-upgrade-base.adoc
+++ b/edge_computing/image_based_upgrade/cnf-image-based-upgrade-base.adoc
@@ -1,0 +1,27 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="cnf-image-based-upgrade-for-sno"]
+= Performing an image-based upgrade for {sno} clusters
+include::_attributes/common-attributes.adoc[]
+:context: cnf-image-based-upgrade
+
+toc::[]
+
+You can use the {lcao} to do a manual image-based upgrade of a {sno} cluster.
+
+When you deploy the {lcao} on a cluster, an `ImageBasedUpgrade` CR is automatically created.
+You update this CR to specify the image repository of the seed image and to move through the different stages.
+
+include::modules/cnf-image-based-upgrade-prep.adoc[leveloffset=+1]
+
+////
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/ztp-image-based-upgrade-prep-resources.adoc#ztp-image-based-upgrade-creating-backup-resources-with-ztp_ztp-gitops[Creating ConfigMap objects for the image-based upgrade with Lifecycle Agent]
+////
+
+include::modules/cnf-image-based-upgrade-with-backup.adoc[leveloffset=+1]
+
+include::modules/cnf-image-based-upgrade-rollback.adoc[leveloffset=+1]
+
+include::modules/cnf-image-based-upgrade-troubleshooting.adoc[leveloffset=+1]

--- a/modules/cnf-image-based-upgrade-prep.adoc
+++ b/modules/cnf-image-based-upgrade-prep.adoc
@@ -1,0 +1,121 @@
+// Module included in the following assemblies:
+// * edge_computing/image-based-upgrade/cnf-image-based-upgrade-base.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ztp-image-based-upgrade-prep_{context}"]
+= Moving to the Prep stage of the image-based upgrade with {lcao}
+
+When you deploy the {lcao} on a cluster, an `ImageBasedUpgrade` custom resource (CR) is automatically created.
+
+After you created all the resources that you need during the upgrade, you can move on to the `Prep` stage.
+For more information, see the "Creating ConfigMap objects for the image-based upgrade with {lcao}" section.
+
+.Prerequisites
+
+* You have created resources to back up and restore your clusters.
+
+.Procedure
+
+. Check that you have patched your `ImageBasedUpgrade` CR:
++
+[source,yaml]
+----
+apiVersion: lca.openshift.io/v1
+kind: ImageBasedUpgrade
+metadata:
+  name: upgrade
+spec:
+  stage: Idle
+  seedImageRef:
+    version: 4.15.2 <1>
+    image: <seed_container_image> <2>
+    pullSecretRef: <seed_pull_secret> <3>
+  autoRollbackOnFailure: {}
+#    initMonitorTimeoutSeconds: 1800 <4>
+  extraManifests: <5>
+  - name: example-extra-manifests-cm
+    namespace: openshift-lifecycle-agent
+  - name: example-catalogsources-cm
+    namespace: openshift-lifecycle-agent
+  oadpContent: <6>
+  - name: oadp-cm-example
+    namespace: openshift-adp
+----
+<1> Specify the target platform version. The value must match the version of the seed image.
+<2> Specify the repository where the target cluster can pull the seed image from.
+<3> Specify the reference to a secret with credentials to pull container images if the images are in a private registry.
+<4> (Optional) Specify the time frame in seconds to roll back if the upgrade does not complete within that time frame after the first reboot. If not defined or set to `0`, the default value of `1800` seconds (30 minutes) is used.
+<5> (Optional) Specify the list of `ConfigMap` resources that contain your custom catalog sources to retain after the upgrade and your extra manifests to apply to the target cluster that are not part of the seed image.
+<6> Add the `oadpContent` section with the OADP `ConfigMap` information.
+
+. To start the `Prep` stage, change the value of the `stage` field to `Prep` in the `ImageBasedUpgrade` CR by running the following command:
++
+--
+[source,terminal]
+----
+$ oc patch imagebasedupgrades.lca.openshift.io upgrade -p='{"spec": {"stage": "Prep"}}' --type=merge -n openshift-lifecycle-agent
+----
+
+If you provide `ConfigMap` objects for OADP resources and extra manifests, {lcao} validates the specified `ConfigMap` objects during the `Prep` stage.
+You might encounter the following issues: 
+
+* Validation warnings or errors if the {lcao} detects any issues with the `extraManifests` parameters.
+* Validation errors if the {lcao} detects any issues with the `oadpContent` parameters.
+
+Validation warnings do not block the `Upgrade` stage but you must decide if it is safe to proceed with the upgrade.
+These warnings, for example missing CRDs, namespaces, or dry run failures, update the `status.conditions` for the `Prep` stage and `annotation` fields in the `ImageBasedUpgrade` CR with details about the warning.
+
+.Example validation warning
+[source,yaml]
+----
+[...]
+metadata:
+annotations:
+  extra-manifest.lca.openshift.io/validation-warning: '...'
+[...]
+----
+
+However, validation errors, such as adding `MachineConfig` or Operator manifests to extra manifests, cause the `Prep` stage to fail and block the `Upgrade` stage.
+
+When the validations pass, the cluster creates a new `ostree` stateroot, which involves pulling and unpacking the seed image, and running host-level commands.
+Finally, all the required images are precached on the target cluster.
+--
+
+.Verification
+
+* Check the status of the `ImageBasedUpgrade` CR by running the following command:
++
+--
+[source,terminal]
+----
+$ oc get ibu -o yaml
+----
+
+.Example output
+[source,yaml]
+----
+  conditions:
+  - lastTransitionTime: "2024-01-01T09:00:00Z"
+    message: In progress
+    observedGeneration: 13
+    reason: InProgress
+    status: "False"
+    type: Idle
+  - lastTransitionTime: "2024-01-01T09:00:00Z"
+    message: Prep completed
+    observedGeneration: 13
+    reason: Completed
+    status: "False"
+    type: PrepInProgress
+  - lastTransitionTime: "2024-01-01T09:00:00Z"
+    message: Prep stage completed successfully
+    observedGeneration: 13
+    reason: Completed
+    status: "True"
+    type: PrepCompleted
+  observedGeneration: 13
+  validNextStages:
+  - Idle
+  - Upgrade
+----
+--

--- a/modules/cnf-image-based-upgrade-rollback.adoc
+++ b/modules/cnf-image-based-upgrade-rollback.adoc
@@ -1,0 +1,59 @@
+// Module included in the following assemblies:
+// * edge_computing/image-based-upgrade/cnf-image-based-upgrade-base.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ztp-image-based-upgrade-rollback_{context}"]
+= (Optional) Moving to the Rollback stage of the image-based upgrade with {lcao}
+
+An automatic rollback is initiated if the upgrade does not complete within the time frame specified in the `initMonitorTimeoutSeconds` field after rebooting.
+
+.Example ImageBasedUpgrade CR
+[source,yaml]
+----
+apiVersion: lca.openshift.io/v1
+kind: ImageBasedUpgrade
+metadata:
+  name: upgrade
+spec:
+  stage: Idle
+  seedImageRef:
+    version: 4.15.2
+    image: <seed_container_image>
+  autoRollbackOnFailure: {}
+#    initMonitorTimeoutSeconds: 1800 <1>
+[...]
+----
+<1> (Optional) Specify the time frame in seconds to roll back if the upgrade does not complete within that time frame after the first reboot. If not defined or set to `0`, the default value of `1800` seconds (30 minutes) is used.
+
+You can manually roll back the changes if you encounter unresolvable issues after an upgrade.
+
+.Prerequisites
+
+* Log in to the hub cluster as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. To move to the rollback stage, patch the value of the `stage` field to `Rollback` in the `ImageBasedUpgrade` CR by running the following command:
++
+--
+[source,terminal]
+----
+$ oc patch imagebasedupgrades.lca.openshift.io upgrade -p='{"spec": {"stage": "Rollback"}}' --type=merge
+----
+
+The {lcao} reboots the cluster with the previously installed version of {product-title} and restores the applications.
+--
+
+. If you are satisfied with the changes, finalize the the rollback by patching the value of the `stage` field to `Idle` in the `ImageBasedUpgrade` CR by running the following command:
++
+--
+[source,terminal]
+----
+$ oc patch imagebasedupgrades.lca.openshift.io upgrade -p='{"spec": {"stage": "Idle"}}' --type=merge -n openshift-lifecycle-agent
+----
+
+[WARNING]
+====
+If you move to the `Idle` stage after a rollback, the {lcao} cleans up resources that can be used to troubleshoot a failed upgrade.
+====
+--

--- a/modules/cnf-image-based-upgrade-troubleshooting.adoc
+++ b/modules/cnf-image-based-upgrade-troubleshooting.adoc
@@ -1,0 +1,303 @@
+// Module included in the following assemblies:
+// * edge_computing/image-based-upgrade/cnf-image-based-upgrade-base.adoc
+// * edge_computing/image-based-upgrade/ztp-image-based-upgrade.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ztp-image-based-upgrade-troubleshooting_{context}"]
+= Troubleshooting image-based upgrades with {lcao}
+
+You can encounter issues during the image-based upgrade.
+
+[id="ztp-image-based-upgrade-troubleshooting-must-gather_{context}"]
+== Collecting logs
+
+You can use the `oc adm must-gather` CLI to collect information for debugging and troubleshooting.
+
+.Procedure
+
+* Collect data about the Operators by running the following command:
++
+[source,terminal]
+----
+$  oc adm must-gather \
+--dest-dir=must-gather/tmp \
+--image=$(oc -n openshift-lifecycle-agent get deployment.apps/lifecycle-agent-controller-manager -o jsonpath='{.spec.template.spec.containers[?(@.name == "manager")].image}') \
+--image=quay.io/konveyor/oadp-must-gather:latest \// <1>
+--image=quay.io/openshift/origin-must-gather:latest <2>
+----
+<1> (Optional) You can add this options if you need to gather more information from the OADP Operator.
+<2> (Optional) You can add this options if you need to gather more information from the SR-IOV Operator.
+
+[id="ztp-image-based-upgrade-troubleshooting-manual-cleanup_{context}"]
+== AbortFailed or FinalizeFailed error
+
+Issue::
++
+--
+During the finalize stage or when you stop the process at the `Prep` stage, {lcao} cleans up the following resources:
+
+* Stateroot that is no longer required
+* Precaching resources
+* OADP CRs
+* `ImageBasedUpgrade` CR
+
+If the {lcao} fails to perform the above steps, it transitions to the `AbortFailed` or `FinalizeFailed` states.
+The condition message and log show which steps failed.
+
+.Example error message
+[source,yaml]
+----
+message: failed to delete all the backup CRs. Perform cleanup manually then add 'lca.openshift.io/manual-cleanup-done' annotation to ibu CR to transition back to Idle
+      observedGeneration: 5
+      reason: AbortFailed
+      status: "False"
+      type: Idle
+----
+--
+
+Resolution::
+
+. Inspect the logs to determine why the failure occurred.
+
+. To prompt {lcao} to retry the cleanup, add the `lca.openshift.io/manual-cleanup-done` annotation to the `ImageBasedUpgrade` CR.
+
+After observing this annotation, {lcao} retries the cleanup and, if it is successful, the `ImageBasedUpgrade` stage transitions to `Idle`.
+
+If the cleanup fails again, you can manually clean up the resources.
+
+[id="ztp-image-based-upgrade-troubleshooting-stateroot_{context}"]
+=== Cleaning up stateroot manually
+
+Issue::
+
+Stopping at the `Prep` stage, {lcao} cleans up the new stateroot. When finalizing after a successful upgrade or a rollback, {lcao} cleans up the old stateroot.
+If this step fails, it is recommended that you inspect the logs to determine why the failure occurred. 
+
+Resolution::
+--
+. Check if there are any existing deployments in the stateroot by running the following command:
++
+[source,terminal]
+----
+$ ostree admin status
+----
+
+. If there are any, clean up the existing deployment by running the following command:
++
+[source,terminal]
+----
+$ ostree admin undeploy <index_of_deployment> 
+----
+
+. After cleaning up all the deployments of the stateroot, wipe the stateroot directory by running the following commands:
+
+[WARNING]
+====
+Ensure that the booted deployment is not in this stateroot.
+====
+
+[source,terminal]
+----
+$ stateroot="<stateroot_to_delete>"
+----
+
+[source,terminal]
+----
+$ unshare -m /bin/sh -c "mount -o remount,rw /sysroot && rm -rf /sysroot/ostree/deploy/${stateroot}"
+----
+--
+
+[id="ztp-image-based-upgrade-troubleshooting-oadp-resources_{context}"]
+=== Cleaning up OADP resources manually
+
+Issue::
+
+Automatic cleanup of OADP resources can fail due to connection issues between {lcao} and the S3 backend. By restoring the connection and adding the `lca.openshift.io/manual-cleanup-done` annotation, the {lcao} can successfully cleanup backup resources.
+
+Resolution::
+--
+. Check the backend connectivity by running the following command:
++
+[source,terminal]
+----
+$ oc get backupstoragelocations.velero.io -n openshift-adp
+----
+
++
+.Example output
+[source,terminal]
+----
+NAME                          PHASE       LAST VALIDATED   AGE   DEFAULT
+dataprotectionapplication-1   Available   33s              8d    true
+----
+
+. Remove all backup resources and then add the `lca.openshift.io/manual-cleanup-done` annotation to the `ImageBasedUpgrade` CR.
+--
+
+[id="ztp-image-based-upgrade-troubleshooting-lvms_{context}"]
+== {lvms} volume contents not restored
+
+When {lvms} is used to provide dynamic persistent volume storage, {lvms} might not restore the persistent volume contents if it is configured incorrectly.
+
+[id="ztp-image-based-upgrade-troubleshooting-lvms-backup_{context}"]
+=== Missing {lvms}-related fields in Backup CR
+
+Issue::
+Your `Backup` CRs might be missing fields that are needed to restore your persistent volumes.
+You can check for events in your application pod to determine if you have this issue by running the following:
++
+--
+[source,terminal]
+----
+$ oc describe pod <your_app_name>
+----
+
+.Example output showing missing {lvms}-related fields in Backup CR
+[source,terminal]
+----
+Events:
+  Type     Reason            Age                From               Message
+  ----     ------            ----               ----               -------
+  Warning  FailedScheduling  58s (x2 over 66s)  default-scheduler  0/1 nodes are available: pod has unbound immediate PersistentVolumeClaims. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling..
+  Normal   Scheduled         56s                default-scheduler  Successfully assigned default/db-1234 to sno1.example.lab
+  Warning  FailedMount       24s (x7 over 55s)  kubelet            MountVolume.SetUp failed for volume "pvc-1234" : rpc error: code = Unknown desc = VolumeID is not found
+----
+--
+
+Resolution::
+You must include `logicalvolumes.topolvm.io` in the application `Backup` CR.
+Without this resource, the application restores its persistent volume claims and persistent volume manifests correctly, however, the `logicalvolume` associated with this persistent volume is not restored properly after pivot.
++
+.Example Backup CR
+[source,yaml]
+----
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  labels:
+    velero.io/storage-location: default
+  name: small-app
+  namespace: openshift-adp
+spec:
+  includedNamespaces:
+  - test
+  includedNamespaceScopedResources:
+  - secrets
+  - persistentvolumeclaims
+  - deployments
+  - statefulsets
+  includedClusterScopedResources: <1>
+  - persistentVolumes
+  - volumesnapshotcontents
+  - logicalvolumes.topolvm.io
+----
+<1> To restore the persistent volumes for your application, you must configure this section as shown.
+
+[id="ztp-image-based-upgrade-troubleshooting-lvms-restore_{context}"]
+=== Missing {lvms}-related fields in Restore CR
+
+Issue::
+The expected resources for the applications are restored but the persistent volume contents are not preserved after upgrading.
+
+. List the persistent volumes for you applications by running the following command before pivot:
++
+--
+[source,terminal]
+----
+$ oc get pv,pvc,logicalvolumes.topolvm.io -A
+----
+
+.Example output before pivot
+[source,terminal]
+----
+NAME                        CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM            STORAGECLASS   REASON   AGE
+persistentvolume/pvc-1234   1Gi        RWO            Retain           Bound    default/pvc-db   lvms-vg1                4h45m
+
+NAMESPACE   NAME                           STATUS   VOLUME     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+default     persistentvolumeclaim/pvc-db   Bound    pvc-1234   1Gi        RWO            lvms-vg1       4h45m
+
+NAMESPACE   NAME                                AGE
+            logicalvolume.topolvm.io/pvc-1234   4h45m
+----
+--
+
+. List the persistent volumes for you applications by running the following command after pivot:
++
+--
+[source,terminal]
+----
+$ oc get pv,pvc,logicalvolumes.topolvm.io -A
+----
+
+.Example output after pivot
+[source,terminal]
+----
+NAME                        CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM            STORAGECLASS   REASON   AGE
+persistentvolume/pvc-1234   1Gi        RWO            Delete           Bound    default/pvc-db   lvms-vg1                19s
+
+NAMESPACE   NAME                           STATUS   VOLUME     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+default     persistentvolumeclaim/pvc-db   Bound    pvc-1234   1Gi        RWO            lvms-vg1       19s
+
+NAMESPACE   NAME                                AGE
+            logicalvolume.topolvm.io/pvc-1234   18s
+----
+--
+
+Resolution::
+The reason for this issue is that the `logicalvolume` status is not preserved in the `Restore` CR.
+This status is important because it is required for Velero to reference the volumes that must be preserved after pivoting.
+You must include the following fields in the application `Restore` CR:
++
+.Example Restore CR
+[source,yaml]
+----
+apiVersion: velero.io/v1
+kind: Restore
+metadata:
+  name: sample-vote-app
+  namespace: openshift-adp
+  labels:
+    velero.io/storage-location: default
+  annotations:
+    lca.openshift.io/apply-wave: "3"
+spec:
+  backupName:
+    sample-vote-app
+  restorePVs: true <1>
+  restoreStatus: <2>
+    includedResources:
+      - logicalvolumes
+----
+<1> To preserve the persistent volumes for your application, you must set `restorePVs` to `true`.
+<2> To preserve the persistent volumes for your application, you must configure this section as shown.
+
+[id="ztp-image-based-upgrade-troubleshooting-debugging-oadp-crs_{context}"]
+== Debugging failed Backup and Restore CRs
+
+Issue::
+The backup or restoration of artifacts failed.
+
+Resolution::
+You can debug `Backup` and `Restore` CRs and retrieve logs with the Velero CLI tool.
+The Velero CLI tool provides more detailed information than the OpenShift CLI tool.
+
+. Describe the `Backup` CR that contains errors by running the following command:
++
+[source,terminal]
+----
+$ oc exec -n openshift-adp velero-7c87d58c7b-sw6fc -c velero -- ./velero describe backup -n openshift-adp backup-acm-klusterlet --details
+----
+
+. Describe the `Restore` CR that contains errors by running the following command:
++
+[source,terminal]
+----
+$ oc exec -n openshift-adp velero-7c87d58c7b-sw6fc -c velero -- ./velero describe restore -n openshift-adp restore-acm-klusterlet --details
+----
+
+. Download the backed up resources to a local directory by running the following command:
++
+[source,terminal]
+----
+$ oc exec -n openshift-adp velero-7c87d58c7b-sw6fc -c velero -- ./velero backup download -n openshift-adp backup-acm-klusterlet -o ~/backup-acm-klusterlet.tar.gz
+----

--- a/modules/cnf-image-based-upgrade-with-backup.adoc
+++ b/modules/cnf-image-based-upgrade-with-backup.adoc
@@ -1,0 +1,171 @@
+// Module included in the following assemblies:
+// * edge_computing/image-based-upgrade/cnf-image-based-upgrade-base.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ztp-image-based-upgrading-with-backup_{context}"]
+= Moving to the Upgrade stage of the image-based upgrade with {lcao}
+
+After you generate the seed image and complete the `Prep` stage, you can upgrade the target cluster.
+During the upgrade process, the OADP Operator creates a backup of the artifacts specified in the OADP custom resources (CRs), then the {lcao} upgrades the cluster.
+
+If the upgrade fails or stops, an automatic rollback is initiated.
+If you have an issue after the upgrade, you can initiate a manual rollback.
+For more information about manual rollback, see "(Optional) Initiating a rollback with {lcao}".
+
+.Prerequisites
+
+* Complete the `Prep` stage.
+
+.Procedure
+
+. To move to the `Upgrade` stage, change the value of the `stage` field to `Upgrade` in the `ImageBasedUpgrade` CR by running the following command:
++
+[source,terminal]
+----
+$ oc patch imagebasedupgrades.lca.openshift.io upgrade -p='{"spec": {"stage": "Upgrade"}}' --type=merge
+----
+
+. Check the status of the `ImageBasedUpgrade` CR by running the following command:
++
+--
+[source,terminal]
+----
+$ oc get ibu -o yaml
+----
+
+.Example output
+[source,yaml]
+----
+status:
+  conditions:
+  - lastTransitionTime: "2024-01-01T09:00:00Z"
+    message: In progress
+    observedGeneration: 5
+    reason: InProgress
+    status: "False"
+    type: Idle
+  - lastTransitionTime: "2024-01-01T09:00:00Z"
+    message: Prep completed
+    observedGeneration: 5
+    reason: Completed
+    status: "False"
+    type: PrepInProgress
+  - lastTransitionTime: "2024-01-01T09:00:00Z"
+    message: Prep completed successfully
+    observedGeneration: 5
+    reason: Completed
+    status: "True"
+    type: PrepCompleted
+  - lastTransitionTime: "2024-01-01T09:00:00Z"
+    message: |-
+      Waiting for system to stabilize: one or more health checks failed
+        - one or more ClusterOperators not yet ready: authentication
+        - one or more MachineConfigPools not yet ready: master
+        - one or more ClusterServiceVersions not yet ready: sriov-fec.v2.8.0
+    observedGeneration: 1
+    reason: InProgress
+    status: "True"
+    type: UpgradeInProgress
+  observedGeneration: 1
+  rollbackAvailabilityExpiration: "2024-05-19T14:01:52Z"
+  validNextStages:
+  - Rollback
+----
+
+The OADP Operator creates a backup of the data specified in the OADP `Backup` and `Restore` CRs and the target cluster reboots.
+--
+
+. Monitor the status of the CR by running the following command:
++
+[source,terminal]
+----
+$ oc get ibu -o yaml
+----
+
+. If you are satisfied with the upgrade, finalize the changes by patching the value of the `stage` field to `Idle` in the `ImageBasedUpgrade` CR by running the following command:
++
+--
+[source,terminal]
+----
+$ oc patch imagebasedupgrades.lca.openshift.io upgrade -p='{"spec": {"stage": "Idle"}}' --type=merge
+----
+
+[IMPORTANT]
+====
+You cannot roll back the changes once you move to the `Idle` stage after an upgrade.
+====
+
+The {lcao} deletes all resources created during the upgrade process.
+--
+
+.Verification
+
+. Check the status of the `ImageBasedUpgrade` CR by running the following command:
++
+--
+[source,terminal]
+----
+$ oc get ibu -o yaml
+----
+
+.Example output
+[source,yaml]
+----
+status:
+  conditions:
+  - lastTransitionTime: "2024-01-01T09:00:00Z"
+    message: In progress
+    observedGeneration: 5
+    reason: InProgress
+    status: "False"
+    type: Idle
+  - lastTransitionTime: "2024-01-01T09:00:00Z"
+    message: Prep completed
+    observedGeneration: 5
+    reason: Completed
+    status: "False"
+    type: PrepInProgress
+  - lastTransitionTime: "2024-01-01T09:00:00Z"
+    message: Prep completed successfully
+    observedGeneration: 5
+    reason: Completed
+    status: "True"
+    type: PrepCompleted
+  - lastTransitionTime: "2024-01-01T09:00:00Z"
+    message: Upgrade completed
+    observedGeneration: 1
+    reason: Completed
+    status: "False"
+    type: UpgradeInProgress
+  - lastTransitionTime: "2024-01-01T09:00:00Z"
+    message: Upgrade completed
+    observedGeneration: 1
+    reason: Completed
+    status: "True"
+    type: UpgradeCompleted
+  observedGeneration: 1
+  rollbackAvailabilityExpiration: "2024-01-01T09:00:00Z"
+  validNextStages:
+  - Idle
+  - Rollback
+----
+--
+
+. Check the status of the cluster restoration by running the following command:
++
+--
+[source,terminal]
+----
+$ oc get restores -n openshift-adp -o custom-columns=NAME:.metadata.name,Status:.status.phase,Reason:.status.failureReason
+----
+
+.Example output
+[source,terminal]
+----
+NAME             Status      Reason
+acm-klusterlet   Completed   <none> <1>
+apache-app       Completed   <none>
+localvolume      Completed   <none>
+----
+<1> The `acm-klusterlet` is specific to {rh-rhacm} environments only.
+--


### PR DESCRIPTION
Version(s): 4.16+

Issue: https://issues.redhat.com/browse/TELCODOCS-1707

Docs preview: https://77477--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_based_upgrade/cnf-image-based-upgrade-base

Additional information:
Dividing the original https://github.com/openshift/openshift-docs/pull/74025 to smaller chunks. This is PR#8 from [commit#8](https://github.com/openshift/openshift-docs/pull/74025/commits/4b889f5759ca748bfea494c3b8d4682738d0817b)

- [PR#1](https://github.com/openshift/openshift-docs/pull/76871) 
- [PR#2](https://github.com/openshift/openshift-docs/pull/77078) 
- [PR#3](https://github.com/openshift/openshift-docs/pull/77256)
- [PR#4](https://github.com/openshift/openshift-docs/pull/77256)
- [PR#5](https://github.com/openshift/openshift-docs/pull/77308)
- [PR#6](https://github.com/openshift/openshift-docs/pull/77379)
- [PR#7](https://github.com/openshift/openshift-docs/pull/77475)

Only relevant topicmap content is added. See thread in review channel on Slack.
Xrefs are pointing to non-existent sections at the moment, so they are commented out until added.

This PR contains 2 commits. The first commit is from PR#1. This contains attributes, directory structure etc. and is required to make the build work for this PR. I also added placeholder files to make the build work, these will be removed at merge review. I know we should squash commits but leaving it for now in case it makes it easier to understand what needs to be reviewed.