### PR TITLE
[SRVKE-1155] Add the KEDA autoscaling for KafkaSource docs

### DIFF
--- a/eventing/event-sources/serverless-kafka-developer-source.adoc
+++ b/eventing/event-sources/serverless-kafka-developer-source.adoc
@@ -23,3 +23,5 @@ include::modules/specifying-sink-flag-kn.adoc[leveloffset=+2]
 include::modules/serverless-kafka-source-yaml.adoc[leveloffset=+1]
 
 include::modules/serverless-kafka-sasl-source.adoc[leveloffset=+1]
+
+include::modules/serverless-kafka-source-autoscale-keda.adoc[leveloffset=+1]

--- a/modules/serverless-kafka-source-autoscale-keda.adoc
+++ b/modules/serverless-kafka-source-autoscale-keda.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * eventing/event-sources/serverless-kafka-developer-source.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-kafka-source-autoscale-keda_{context}"]
+= Configuring KEDA autoscaling for KafkaSource
+
+You can configure Knative Eventing sources for Apache Kafka (KafkaSource) to be autoscaled using the Custom Metrics Autoscaler Operator, which is based on the Kubernetes Event Driven Autoscaler (KEDA).
+
+:FeatureName: Configuring KEDA autoscaling for KafkaSource
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+.Prerequisites
+
+* The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource are installed on your cluster.
+
+.Procedure
+
+. In the `KnativeKafka` custom resource, enable KEDA scaling:
++
+.Example YAML
+[source,yaml]
+----
+apiVersion: operator.serverless.openshift.io/v1alpha1
+kind: KnativeKafka
+metadata:
+  name: knative-kafka
+  namespace: knative-eventing
+spec:
+  config:
+    kafka-features:
+      controller-autoscaler-keda: enabled
+----
+
+. Apply the `KnativeKafka` YAML file:
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----


### PR DESCRIPTION
Version(s):
`serverless-docs-1.33`+

Issue:
https://issues.redhat.com/browse/SRVKE-1155

Link to docs preview:
https://77485--ocpdocs-pr.netlify.app/openshift-serverless/latest/eventing/event-sources/serverless-kafka-developer-source.html#serverless-kafka-source-autoscale-keda_serverless-kafka-developer-source

QE review:
- [x] QE has approved this change.