### PR TITLE
TELCODOCS-1689 - Adding PolicyGenerator release notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -473,6 +473,20 @@ For pre-IceLake processors, the `intel_pstate` is deactivated by default, wherea
 [id="ocp-4-16-edge-computing_{context}"]
 === Edge computing
 
+[id="ocp-4-16-edge-computing_pg-ztp-rhacm_{context}"]
+==== Using {rh-rhacm} PolicyGenerator resources to manage {ztp} cluster policies (Technology Preview)
+
+You can now use `PolicyGenerator` resources and {rh-rhacm-first} to deploy polices for managed clusters with {ztp}.
+The `PolicyGenerator` API is part of the link:https://open-cluster-management.io/[Open Cluster Management] standard and provides a generic way of patching resources which is not possible with the `PolicyGenTemplate` API.
+Using `PolicyGenTemplate` resources to manage and deploy polices will be deprecated in an upcoming OpenShift Container Platform release.
+
+For more information, see xref:../edge_computing/policygenerator_for_ztp/ztp-configuring-managed-clusters-policygenerator.adoc#ztp-configuring-managed-clusters-policygenerator[Configuring managed cluster policies by using PolicyGenerator resources].
+
+[NOTE]
+====
+The `PolicyGenerator` API does not currently support merging patches with custom Kubernetes resources that contain lists of items. For example, in `PtpConfig` CRs.
+====
+
 [id="ocp-4-16-edge-computing-talm-enfore-policies_{context}"]
 ==== {cgu-operator} policy remediation
 
@@ -1455,6 +1469,10 @@ In the following tables, features are marked with the following statuses:
 |Not Available
 |Technology Preview
 
+|Using {rh-rhacm} `PolicyGenerator` resources to manage {ztp} cluster policies
+|Not Available
+|Not Available
+|Technology Preview
 |====
 
 [discrete]


### PR DESCRIPTION
Recommend ACM PolicyGenerator over ztp PolicyGenTemplate for managed cluster polices release notes

Version(s):
enterprise-4.16

Issue:
https://issues.redhat.com/browse/TELCODOCS-1689


Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
