### PR TITLE
SD Enhancement: Created a variable for the ROSA classic product

### DIFF
--- a/_attributes/attributes-openshift-dedicated.adoc
+++ b/_attributes/attributes-openshift-dedicated.adoc
@@ -50,4 +50,6 @@
 :hcp: hosted control planes
 :hcp-title: ROSA with HCP
 :hcp-title-first: {product-title} (ROSA) with {hcp} (HCP)
+:rosa-classic: ROSA (classic architecture)
+:rosa-classic-first: {product-title} (ROSA) (classic architecture)
 //ROSA CLI variables


### PR DESCRIPTION
This PR adds a variable for the renamed ROSA classic product.

Example: 
![image](https://github.com/openshift/openshift-docs/assets/16167833/7356f641-1bd0-47d7-8afd-02694361b480)
