### PR TITLE
[SRVOCF-416] Add func docs on automatic build & deploy on GitHub updates

### DIFF
--- a/functions/serverless-functions-on-cluster-builds.adoc
+++ b/functions/serverless-functions-on-cluster-builds.adoc
@@ -11,4 +11,5 @@ Instead of building a function locally, you can build a function directly on the
 include::modules/serverless-functions-creating-on-cluster-builds.adoc[leveloffset=+1]
 include::modules/serverless-functions-specifying-function-revision.adoc[leveloffset=+1]
 include::modules/serverless-functions-setting-custom-volume-size.adoc[leveloffset=+1]
+include::modules/serverless-functions-automatic-build-deploy.adoc[leveloffset=+1]
 include::modules/odc-invoke-serverless-function.adoc[leveloffset=+1]

--- a/modules/serverless-functions-automatic-build-deploy.adoc
+++ b/modules/serverless-functions-automatic-build-deploy.adoc
@@ -1,0 +1,92 @@
+// Module included in the following assemblies:
+//
+// * functions/serverless-functions-on-cluster-builds.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-functions-automatic-build-deploy_{context}"]
+= Configuring automatic building and deployment on GitHub Updates
+
+You can use the Shipwright framework to configure a function to be automatically built and deployed on the cluster whenever the source code in its GitHub repository is updated.
+
+.Prerequisites
+
+* {pipelines-title} must be installed on your cluster.
+
+* You have installed the OpenShift CLI (`oc`).
+
+* You have installed the Knative CLI (`kn`).
+
+* Access to the GitHub repository containing your function's source code.
+
+.Procedure
+
+. Update the `func.yaml` file in your function project to include the GitHub repository URL and the branch to watch for updates:
++
+[source,yaml]
+----
+name: my-function
+namespace: ""
+runtime: node
+...
+repository: https://github.com/john-smith/my-repository.git <1>
+branch: main <2>
+----
+<1> Repository URL
+<2> Branch to monitor
+
+. To define the build configuration using Shipwright, create a `build.yaml` file in your project:
++
+[source,yaml]
+----
+apiVersion: shipwright.io/v1alpha1
+kind: Build
+metadata:
+  name: my-function-build
+spec:
+  source:
+    url: https://github.com/john-smith/my-repository.git <1>
+  strategy:
+    name: buildpacks-v3
+    kind: ClusterBuildStrategy
+  builder:
+    image: paketobuildpacks/builder:base
+  output:
+    image: image-registry.openshift-image-registry.svc:5000/my-project/my-function <2>
+----
+<1> Repository URL
+<2> Function image output
+
+. Apply the configuration to the {ocp-product-title} cluster:
++
+[source,terminal]
+----
+$ oc apply -f build.yaml
+----
+
+. Create a `buildrun.yaml` file to trigger the build whenever there are changes in the specified GitHub repository:
++
+[source,yaml]
+----
+apiVersion: shipwright.io/v1alpha1
+kind: BuildRun
+metadata:
+  name: my-function-buildrun
+spec:
+  buildRef:
+    name: my-function-build
+----
+
+. Apply the configuration to the {ocp-product-title} cluster:
++
+[source,terminal]
+----
+$ oc apply -f buildrun.yaml
+----
+
+. In your repository on GitHub, navigate to *Settings* > *Webhooks* > *Add webhook*.
+
+. Set the **Payload URL** to the endpoint of your {ocp-product-title} cluster's webhook receiver.
+
+. Choose **application/json** as the **Content type**.
+
+. Select the events you want to trigger the webhook. For many use cases, **Push events** are sufficient.


### PR DESCRIPTION
Version(s):
`serverless-docs-1.33`+

Issue:
https://issues.redhat.com/browse/SRVOCF-416

Link to docs preview:
https://77500--ocpdocs-pr.netlify.app/openshift-serverless/latest/functions/serverless-functions-on-cluster-builds.html#serverless-functions-automatic-build-deploy_serverless-functions-on-cluster-builds

QE review:
- [ ] QE has approved this change.