### PR TITLE
[SRVOCF-513] Add primitve types returning to Node.js function docs

### DIFF
--- a/modules/serverless-nodejs-function-return-values.adoc
+++ b/modules/serverless-nodejs-function-return-values.adoc
@@ -22,6 +22,98 @@ function handle(context, customer) {
 }
 ----
 
+[id="serverless-nodejs-function-return-values-primitive-types_{context}"]
+== Returning primitive types
+
+Functions can return any valid JavaScript type, including primitives such as strings, numbers, and booleans:
+
+.Example function returning a string
+[source,javascript]
+----
+function handle(context) {
+  return "This function Works!"
+}
+----
+
+Calling this function returns the following string:
+
+[source,terminal]
+----
+$ curl https://myfunction.example.com
+----
+
+[source,terminal]
+----
+This function Works!
+----
+
+.Example function returning a number
+[source,javascript]
+----
+function handle(context) {
+  let somenumber = 100
+  return { body: somenumber }
+}
+----
+
+Calling this function returns the following number:
+
+[source,terminal]
+----
+$ curl https://myfunction.example.com
+----
+
+[source,terminal]
+----
+100
+----
+
+.Example function returning a boolean
+[source,javascript]
+----
+function handle(context) {
+  let someboolean = false
+  return { body: someboolean }
+}
+----
+
+Calling this function returns the following boolean:
+
+[source,terminal]
+----
+$ curl https://myfunction.example.com
+----
+
+[source,terminal]
+----
+false
+----
+
+Returning primitives directly without wrapping them in an object results in a `204 No Content` status code with an empty body:
+
+.Example function returning a primitive directly
+[source,javascript]
+----
+function handle(context) {
+  let someboolean = false
+  return someboolean
+}
+----
+
+Calling this function returns the following:
+
+[source,terminal]
+----
+$ http :8080
+----
+
+[source,terminal]
+----
+HTTP/1.1 204 No Content
+Connection: keep-alive
+...
+----
+
 [id="serverless-nodejs-function-return-values-headers_{context}"]
 == Returning headers
 


### PR DESCRIPTION
Version(s):
`serverless-docs-1.33`+

Issue:
https://issues.redhat.com/browse/SRVOCF-513

Link to docs preview:
https://77506--ocpdocs-pr.netlify.app/openshift-serverless/latest/functions/reference/serverless-developing-nodejs-functions.html#serverless-nodejs-function-return-values_serverless-developing-nodejs-functions

QE review:
- [ ] QE has approved this change.