### PR TITLE
OSDOCS-10898: RHEL-versioned ccoctl

### DIFF
--- a/modules/cco-ccoctl-configuring.adoc
+++ b/modules/cco-ccoctl-configuring.adoc
@@ -360,14 +360,22 @@ Ensure that the architecture of the `$RELEASE_IMAGE` matches the architecture of
 +
 [source,terminal]
 ----
-$ oc image extract $CCO_IMAGE --file="/usr/bin/ccoctl" -a ~/.pull-secret
+$ oc image extract $CCO_IMAGE \
+  --file="/usr/bin/ccoctl.<rhel_version>" \// <1>
+  -a ~/.pull-secret
 ----
+<1> For `<rhel_version>`, specify the value that corresponds to the version of {op-system-base-full} that the host uses.
+If no value is specified, `ccoctl.rhel8` is used by default.
+The following values are valid:
++
+* `rhel8`: Specify this value for hosts that use {op-system-base} 8.
+* `rhel9`: Specify this value for hosts that use {op-system-base} 9.
 
 . Change the permissions to make `ccoctl` executable by running the following command:
 +
 [source,terminal]
 ----
-$ chmod 775 ccoctl
+$ chmod 775 ccoctl.<rhel_version>
 ----
 
 .Verification


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-10898](https://issues.redhat.com//browse/OSDOCS-10898) for OCPBUGS-31290

Link to docs preview:
[Configuring the Cloud Credential Operator utility for a cluster update](https://77512--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/preparing-manual-creds-update.html#cco-ccoctl-configuring_preparing-manual-creds-update)

QE review:
- [x] QE has approved this change.

Additional information: