### PR TITLE
Remove packet drop from 4.12 cli doc

### DIFF
--- a/modules/network-observability-netobserv-cli-reference.adoc
+++ b/modules/network-observability-netobserv-cli-reference.adoc
@@ -3,7 +3,7 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="network-observability-netobserv-cli-reference_{context}"]
-= oc netobserv CLI reference 
+= oc netobserv CLI reference
 The Network Observability CLI (`oc netobserv`) is a CLI tool for capturing flow data and packet data for further analysis.
 
 .`oc netobserv` syntax
@@ -19,7 +19,7 @@ $ oc netobserv [<command>] [<feature_option>] [<command_options>] <1>
 |Command| Description
 
 | `flows`
-| Capture flows information. For subcommands, see the "Flow capture subcommands" table. 
+| Capture flows information. For subcommands, see the "Flow capture subcommands" table.
 
 | `packets`
 | Capture packets from a specific protocol or port pair, such as `netobserv packets --filter=tcp,80`. For more information about packet capture, see the "Packet capture subcommand" table.
@@ -36,7 +36,7 @@ $ oc netobserv [<command>] [<feature_option>] [<command_options>] <1>
 
 [id="network-observability-cli-enrichment_{context}"]
 == Network Observability enrichment
-The Network Observability enrichment to display zone, node, owner and resource names including optional features about packet drops, DNS latencies and Round-trip time can only be enabled when capturing flows. These do not appear in packet capture pcap output file.
+The Network Observability enrichment to display zone, node, owner and resource names including optional features about DNS latencies and Round-trip time can only be enabled when capturing flows. These do not appear in packet capture pcap output file.
 
 .Network Observability enrichment syntax
 [source,terminal]
@@ -48,19 +48,14 @@ $ oc netobserv flows [<enrichment_options>] [<subcommands>]
 |===
 |Option| Description| Possible values| Default
 
-| `--enable_pktdrop` 	
-| Enable packet drop.
+| `--enable_rtt`
+| Enable round trip time.
 | `true`, `false`
 | `false`
 
-| `--enable_rtt`
-| Enable round trip time. 	
-| `true`, `false` 	
-| `false`
-
 | `--enable_dns`
-| Enable DNS tracking. 	
-| `true`, `false` 	
+| Enable DNS tracking.
+| `true`, `false`
 | `false`
 
 | `--help`
@@ -76,7 +71,7 @@ $ oc netobserv flows [<enrichment_options>] [<subcommands>]
 
 [id="cli-reference-flow-capture-options_{context}"]
 == Flow capture options
-Flow capture has mandatory commands as well as additional options, such as enabling extra features about packet drops, DNS latencies, Round-trip time, and filtering.
+Flow capture has mandatory commands as well as additional options, such as enabling extra features about DNS latencies, Round-trip time, and filtering.
 
 .`oc netobserv flows` syntax
 [source,terminal]
@@ -90,8 +85,8 @@ $ oc netobserv flows [<feature_option>] [<command_options>]
 
 | `--enable_filter`
 | Enable flow filter.
-| `true`, `false` 	
-| Yes 
+| `true`, `false`
+| Yes
 | `false`
 
 | `--action`
@@ -101,14 +96,14 @@ $ oc netobserv flows [<feature_option>] [<command_options>]
 | `Accept`
 
 | `--cidr`
-| CIDR to match on the flow. 
+| CIDR to match on the flow.
 | `1.1.1.0/24`, `1::100/64`, or `0.0.0.0/0`
 | Yes
 | `0.0.0.0/0`
 
 | `--protocol`
 | Protocol to match on the flow
-| `TCP`, `UDP`, `SCTP`, `ICMP`, or `ICMPv6` 	
+| `TCP`, `UDP`, `SCTP`, `ICMP`, or `ICMPv6`
 | No
 | -
 
@@ -133,16 +128,16 @@ $ oc netobserv flows [<feature_option>] [<command_options>]
 | `--port`
 | Port to match on the flow.
 | `80`, `443`, or `49051`
-| No 
+| No
 | -
 
 | `--sport_range`
 | Source port range to match on the flow.
 | `80-100` or `443-445`
-| No 	
+| No
 | -
 
-| `--dport_range` 	
+| `--dport_range`
 | Destination port range to match on the flow.
 | `80-100`
 | No
@@ -164,18 +159,18 @@ $ oc netobserv flows [<feature_option>] [<command_options>]
 | ICMP code to match on the flow.
 | `0` or `1`
 | No
-| - 	
+| -
 
 | `--peer_ip`
 | Peer IP to match on the flow.
 | `1.1.1.1` or `1::1`
-| No 	
+| No
 | -
 |===
 
 [id="cli-reference-packet-capture-options_{context}"]
 == Packet capture options
-You can filter on port and protocol for packet capture data. 
+You can filter on port and protocol for packet capture data.
 
 .`oc netobserv packets` syntax
 [source,terminal]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12 only
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
Note no mention of packet drops in the enhancements table: https://77518--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/netobserv_cli/netobserv-cli-reference#network-observability-cli-enrichment_netobserv-cli-reference

packet capture is a cli feature, different from packet drops :)
QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
