### PR TITLE
CCO bug fix text for 4.16 RNs

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -969,6 +969,31 @@ Kubernetes 1.29 removed the following deprecated APIs, so you must migrate manif
 [id="ocp-4-16-cloud-cred-operator-bug-fixes_{context}"]
 ==== Cloud Credential Operator
 
+* Previously, the Cloud Credential Operator was missing some permissions required to create a private cluster on {azure-first}.
+These missing permissions prevented installation of an {azure-short} private cluster using {entra-first}.
+This release includes the missing permissions and enables installation of an {azure-short} private cluster using {entra-short}.
+(link:https://issues.redhat.com/browse/OCPBUGS-25193[*OCPBUGS-25193*])
+
+* Previously, a bug caused the Cloud Credential Operator (CCO) to report an incorrect mode in the metrics. Even though the cluster was in the default mode, the metrics reported that it was in the credentials removed mode. This update uses a live client in place of a cached client so that it is able to obtain the root credentials, and the CCO no longer reports an incorrect mode in the metrics. (link:https://issues.redhat.com/browse/OCPBUGS-26488[*OCPBUGS-26488*])
+
+* Previously, the Cloud Credential Operator credentials mode metric on an {product-title} cluster that uses {entra-first} reported using manual mode.
+With this release, clusters that use {entra-short} are updated to report that they are using manual mode with pod identity.
+(link:https://issues.redhat.com/browse/OCPBUGS-27446[*OCPBUGS-27446*])
+
+* Previously, creating an {aws-first} root secret on a bare metal cluster caused the Cloud Credential Operator (CCO) pod to crash.
+The issue is resolved in this release.
+(link:https://issues.redhat.com/browse/OCPBUGS-28535[*OCPBUGS-28535*])
+
+* Previously, removing the root credential from a {gcp-first} cluster that used the Cloud Credential Operator (CCO) in mint mode caused the CCO to become degraded after approximately one hour.
+In a degraded state, the CCO cannot manage the component credential secrets on a cluster.
+The issue is resolved in this release.
+(link:https://issues.redhat.com/browse/OCPBUGS-28787[*OCPBUGS-28787*])
+
+* Previously, the Cloud Credential Operator (CCO) checked for a nonexistent `s3:HeadBucket` permission during installation on {aws-first}.
+When the CCO failed to find this permission, it considered the provided credentials insufficient for mint mode.
+With this release, the CCO no longer checks for the nonexistent permission.
+(link:https://issues.redhat.com/browse/OCPBUGS-31678[*OCPBUGS-31678*])
+
 [discrete]
 [id="ocp-4-16-cluster-version-operator-bug-fixes_{context}"]
 ==== Cluster Version Operator


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-9882](https://issues.redhat.com//browse/OSDOCS-9882)

Link to docs preview:
[Cloud Credential Operator](https://77520--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-cloud-cred-operator-bug-fixes_release-notes)

QE review:
- [x] QE has approved this change.

Additional information: