### PR TITLE
Tuning log payloads and delivery section || Corrected tuning implementation YAML

### DIFF
--- a/modules/logging-delivery-tuning.adoc
+++ b/modules/logging-delivery-tuning.adoc
@@ -25,12 +25,16 @@ kind: ClusterLogForwarder
 metadata:
 # ...
 spec:
-  tuning:
-    delivery: AtLeastOnce # <1>
-    compression: none # <2>
-    maxWrite: <integer> # <3>
-    minRetryDuration: 1s # <4>
-    maxRetryDuration: 1s # <5>
+  outputs:
+    - name: tuned-example-output
+      tuning:
+        delivery: AtLeastOnce # <1>
+        compression: none # <2>
+        maxWrite: <integer> # <3>
+        minRetryDuration: 1s # <4>
+        maxRetryDuration: 1s # <5>
+      type: http
+      url: http://example.http.com:8080
 # ...
 ----
 <1> Specify the delivery mode for log forwarding.


### PR DESCRIPTION
clf.spec.tuning doesn't exist in the product but the correct way of defining the tuning config is clf.spec.outputs.tuning 

```
 $ oc explain clusterlogforwarder.spec.tuning
GROUP:      logging.openshift.io
KIND:       ClusterLogForwarder
VERSION:    v1error: field "tuning" does not exist
```

```
 $ oc explain clusterlogforwarder.spec.outputs.tuning
GROUP:      logging.openshift.io
KIND:       ClusterLogForwarder
VERSION:    v1FIELD: tuning <Object>DESCRIPTION:
    Tuning parameters for the output.  Specifying these parameters will alter
    the characteristics of log forwarder which may be different from its
    behavior without the tuning.
```

Same has been corrected in this PR.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): RHOCP 4.13, RHOCP 4.14 and RHOCP 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:  https://issues.redhat.com/browse/OBSDOCS-1049
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. ---> 


Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
