### PR TITLE
OSDOCS-10782: Update ROSA with HCP activation and account linking tutorial

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-rosa-hcp-activation-and-account-linking-tutorial.adoc
+++ b/cloud_experts_tutorials/cloud-experts-rosa-hcp-activation-and-account-linking-tutorial.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id=“cloud-experts-rosa-hcp-activation-and-account-linking-tutorial”]
-= Tutorial: ROSA with HCP activation and account linking
+= Tutorial: {hcp-title} activation and account linking
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-rosa-hcp-activation-and-account-linking-tutorial
 
@@ -25,12 +25,14 @@ If you have received a private offer for the product, make sure to proceed accor
 == Prerequisites
 
 * Make sure to log in to the Red{nbsp}Hat account that you plan to associate with the AWS account where you have activated {hcp-title} in previous steps.
-* Only a single AWS account that will be used for service billing can be associated with a Red{nbsp}Hat account. Typically an organizational AWS account that has other AWS accounts, such as developer accounts, linked would be the one that is to be billed, rather than individual AWS end user accounts.
-* Red{nbsp}Hat accounts belonging to the same Red{nbsp}Hat organization will be linked with the same AWS account. Therefore, you can manage who has access to creating {hcp-title} clusters on the Red{nbsp}Hat organization account level.
+* The AWS account used for service billing can only be associated with a single Red{nbsp}Hat account. Typically an AWS payer account is the one that is used to subscribe to ROSA and used for account linking and billing.
+* All team members belonging to the same Red{nbsp}Hat organization can use the linked AWS account for service billing while creating {hcp-title} clusters.
 
 == Subscription enablement and AWS account setup
 
-. Activate the {hcp-title} product at the AWS console page by clicking the *Get started* button:
+. Activate the {hcp-title} product at the link:https://console.aws.amazon.com/rosa/home[AWS console page] by clicking the *Get started* button:
++
+.Get started 
 +
 image::rosa-get-started.png[]
 +
@@ -38,21 +40,28 @@ If you have activated ROSA before but did not complete the process, you can clic
 
 . Confirm that you want your contact information to be shared with Red{nbsp}Hat and enable the service:
 +
+.Enable ROSA
 image::rosa-enable-2.png[]
 +
 * You will not be charged by enabling the service in this step. The connection is made for billing and metering that will take place only after you deploy your first cluster. This could take a few minutes.
 +
 . After the process is completed, you will see a confirmation:
 +
+.ROSA enablement confirmation
++
 image::rosa-prereq-enable-3.png[]
 +
-. Other sections on this verification page show the status of additional prerequisites. In case any of these prerequisites are not met, a respective message is shown. Here is an example of insufficient quotas in the selected region:
+. Other sections on this verification page show the status of additional prerequisites. In case any of these prerequisites are not met, a corresponding message is shown. Here is an example of insufficient quotas in the selected region:
++
+.Service quotas
 +
 image::rosa-service-quota-4.png[]
 
 .. Click the *Increase service quotas* button or use the *Learn more* link to get more information about the about how to manage service quotas. In the case of insufficient quotas, note that quotas are region-specific. You can use the region switcher in the upper right corner of the web console to re-run the quota check for any region you are interested in and then submit service quota increase requests as needed.
 
 . If all the prerequisites are met, the page will look like this:
++
+.Verify ROSA prerequisites 
 +
 image::rosa-prereq-5.png[]
 +
@@ -62,23 +71,38 @@ The ELB service-linked role is created for you automatically. You can click any 
 
 . Click the orange *Continue to Red{nbsp}Hat* button to proceed with account linking:
 +
+.Continue to Red{nbsp}Hat
++
 image::rosa-continue-rh-6.png[]
 
 . If you are not already logged in to your Red{nbsp}Hat account in your current browser's session, you will be asked to log in to your account:
++
+[NOTE]
+====
+Your AWS account must be linked to a single Red{nbsp}Hat organization. 
+====
++
+.Log in to your Red{nbsp}Hat account
 +
 image::rosa-login-rh-account-7.png[]
 +
 * You can also register for a new Red{nbsp}Hat account or reset your password on this page.
 * Make sure to log in to the Red{nbsp}Hat account that you plan to associate with the AWS account where you have activated {hcp-title} in previous steps.
-* Only a single AWS account that will be used for service billing can be associated with a Red{nbsp}Hat account. Typically an organizational AWS account that has other AWS accounts, such as developer accounts, linked would be the one that is to be billed, rather than individual AWS end user accounts.
-* Red{nbsp}Hat accounts belonging to the same Red{nbsp}Hat organization will be linked with the same AWS account. Therefore, you can manage who has access to creating {hcp-title} clusters on the Red{nbsp}Hat organization account level.
+* The AWS account used for service billing can only be associated with a single Red{nbsp}Hat account. Typically an AWS payer account is the one that is used to subscribe to ROSA and used for account linking and billing.
+* All team members belonging to the same Red{nbsp}Hat organization can use the linked AWS account for service billing while creating {hcp-title} clusters.
 
 . Complete the Red{nbsp}Hat account linking after reviewing the terms and conditions:
 +
 [NOTE]
 ====
-This step is available only if the logged-in Red{nbsp}Hat account, or the Red{nbsp}Hat organization managing the Red{nbsp}Hat account, was not linked to an AWS account before.
+This step is available only if the AWS account was not linked to any Red{nbsp}Hat account before.
+
+This step is skipped if the AWS account is already linked to the user's logged in Red{nbsp}Hat account.
+
+If the AWS account is linked to a different Red{nbsp}Hat account, an error will be displayed. See link:https://access.redhat.com/articles/7066995[Correcting Billing Account Information for HCP clusters] for troubleshooting.
 ====
++
+.Complete your account connection
 +
 image::rosa-rh-account-connection-8.png[]
 +
@@ -88,93 +112,85 @@ Both the Red{nbsp}Hat and AWS account numbers are shown on this screen.
 +
 If this is the first time you are using the {hybrid-console}, you will be asked to agree with the general managed services terms and conditions before being able to create the first ROSA cluster:
 +
+.Terms and conditions
++
 image::rosa-terms-conditions-9.png[]
 +
-Additional terms that need to be reviewed and accepted will be shown after clicking the *View Terms and Conditions* button:
+Additional terms that need to be reviewed and accepted are shown after clicking the *View Terms and Conditions* button:
++
+.Red{nbsp}Hat terms and conditions
 +
 image::rosa-terms-conditions-9-5.png[]
 +
 Submit your agreement once you have reviewed any additional terms when prompted at this time.
 
-. The {hybrid-console-second} provides a confirmation that AWS prerequisites were completed and lists the first steps needed for cluster deployment:
+. The {hybrid-console-second} provides a confirmation that AWS account setup was completed and lists the prerequisites for cluster deployment:
++
+.Complete ROSA prerequisites
 +
 image::rosa-cluster-create-10.png[]
-
-. The following steps pertain to technical deployment of the cluster:
-+
-image::rosa-deploy-11.png[]
-+
-* It is possible that these steps will be performed on a different machine than where the service enablement and account linking were completed.
-* As mentioned previously, any Red{nbsp}Hat account belonging to the Red{nbsp}Hat organization that was linked with the AWS account that activated the ROSA service will have access to creating a cluster and will be able to select the billing AWS account that was linked under this Red{nbsp}Hat organization previously.
 +
 The last section of this page shows cluster deployment options, either using the `rosa` CLI or through the web console:
 +
+.Deploy the cluster and set up access
++
 image::rosa-cli-ui-12.png[]
-+
-* The following steps describe cluster deployment using the `rosa` CLI.
-* If you are interested in deployment using the web console only, you can skip to the _{hcp-title} cluster deployment using the web console_ section. However, note that the `rosa` CLI is required for certain tasks, such as creating the account roles. If you are deploying ROSA for the first time, follow this the CLI steps until running the `rosa whoami` command, before skipping to the web console deployment steps.
 
-== {hcp-title} cluster deployment using the CLI
+== Selecting the AWS billing account for {hcp-title} during cluster deployment using the CLI
 
-. Click the *Download the ROSA CLI* button to download the ROSA command line interface (CLI) for your operating system and set it up as described in the xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-get-started-cli[Help with ROSA CLI setup].
-+
 [IMPORTANT]
 ====
-Make sure that you have the most recent AWS CLI installed. See link:https://aws.amazon.com/cli/[Instructions to install the AWS CLI] for more information.
+Make sure that you have the most recent ROSA command line interface (CLI) and AWS CLI installed and have completed the ROSA prerequisites covered in the previous section. See xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-get-started-cli[Help with ROSA CLI setup] and link:https://aws.amazon.com/cli/[Instructions to install the AWS CLI] for more information.
 ====
+
+. Initiate the cluster deployment using the `rosa create cluster` command. You can click the *copy* button on the link:https://console.redhat.com/openshift/create/rosa/getstarted[Set up Red{nbsp}Hat OpenShift Service on AWS (ROSA) console page] and paste the command in your terminal. This launches the cluster creation process in interactive mode:
 +
-. After the previous steps are completed, you can verify that both CLI are available by running the `rosa version`. This command shows an update notification if you are using an older version and `aws –version` commands in your terminal.
-
-. The prerequisite for creating a {hcp-title} cluster is to log in using the `rosa` cli by the personalized command with your unique token shown under step _2.1. To authenticate, run this command_ on the web console. Use the *copy* button for easy copy and pasting of the command with full token into your terminal:
-+
-image::rosa-token-13.png[]
-+
-Do not share your unique token.
-
-. The final prerequisite before your first cluster deployment is making sure the necessary account-wide roles and policies are created. The `rosa` CLI can help with that by using the command shown under step _2.2. To create the necessary account-wide roles and policies quickly…_ on the web console. The alternative to that is manual creation of these roles and policies.
-
-. After logging in, creating the account roles, and verifying your identity using the `rosa whoami` command, your terminal will look similar to this:
-+
-image::rosa-whoami-14.png[]
-
-
-. Initiate the cluster deployment using the presented command. You can click the *copy* button again and paste the command in your terminal:
+.Deploy the cluster and set up access
 +
 image::rosa-cli-15.png[]
 
 . To use a custom AWS profile, one of the non-default profiles specified in your `~/.aws/credentials`, you can add the `–profile <profile_name>` selector to the rosa create cluster command so that the command looks like rosa create cluster `–profile stage`. If no AWS CLI profile is specified using this option, the default AWS CLI profile will determine the AWS infrastructure profile into which the cluster is deployed. The billing AWS profile is selected in one of the following steps.
 
-. After entering a cluster name, you will be asked whether to use the hosted control plane. Select *yes*:
-//At the time of creating this tutorial, the `rosa` CLI defaults to the “classic” control plane.
-+
-image::rosa-create-cli-16.png[]
-
 . When deploying a {hcp-title} cluster, the billing AWS account needs to be specified:
++
+.Specify the Billing Account
 +
 image::rosa-create-cli-billing-17.png[]
 +
-* Only AWS accounts that were linked to the Red{nbsp}Hat organization that is currently used will be shown.
-* The specified AWS account will be charged for using the ROSA service, regardless of whether the infrastructure AWS account is linked to it in the same AWS organization.
-* You can see an indicator of whether the ROSA contract is enabled for a given AWS billing account or not.
-* To select an AWS account that does not have the contract enabled, refer to the first few steps in this tutorial to enable the contract and allow the service charging, which is required for a successful cluster deployment.
+* Only AWS accounts that are linked to the user's logged in Red{nbsp}Hat account are shown.
+* The specified AWS account is charged for using the ROSA service.
+* An indicator shows if the ROSA contract is enabled or not enabled for a given AWS billing account.
+** If you select an AWS billing account that shows the _Contract enabled_ label, on-demand consumption rates are charged only after the capacity of your pre-paid contract is consumed.
+** AWS accounts without the _Contract enabled_ label are charged the applicable on-demand consumption rates.
 
-. In the following steps, you will specify technical details of the cluster that is to be deployed:
-+
-image::rosa-cli-details-18.png[]
+.Additional resources 
 
-* These steps are beyond the scope of this tutorial. See xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly[Creating ROSA with HCP clusters using the default options] for more details about how to complete the {hcp-title} cluster deployment using the CLI.
+* The detailed cluster deployment steps are beyond the scope of this tutorial. See xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly[Creating {hcp-title} clusters using the default options] for more details about how to complete the {hcp-title} cluster deployment using the CLI.
 
-== {hcp-title} cluster deployment using the web console
+== Selecting the AWS billing account for {hcp-title} during cluster deployment using the web console
 
 . A cluster can be created using the web console by selecting the second option in the bottom section of the introductory *Set up ROSA* page:
 +
+.Deploy with web interface
++
 image::rosa-deploy-ui-19.png[]
++
+[NOTE]
+====
+Complete the prerequisites before starting the web console deployment process. 
+
+The `rosa` CLI is required for certain tasks, such as creating the account roles. If you are deploying ROSA for the first time, follow this the CLI steps until running the `rosa whoami` command, before starting the web console deployment steps.
+====
 
 . The first step when creating a ROSA cluster using the web console is the control plane selection. Make sure the *Hosted* option is selected before clicking the *Next* button:
 +
+.Select hosted option
++
 image::rosa-deploy-ui-hcp-20.png[]
 
-. The next step *Accounts and roles* allows you specifying the infrastructure AWS account, into which the ROSA cluster will be deployed and where the resources will be consumed and managed:
+. The next step *Accounts and roles* allows you specifying the infrastructure AWS account, into which the the ROSA cluster is deployed and where the resources are consumed and managed:
++
+.AWS infrastructure account
 +
 image::rosa-ui-account-21.png[]
 +
@@ -184,16 +200,19 @@ image::rosa-ui-account-21.png[]
 
 . The billing AWS account is selected in the immediately following section:
 +
+.AWS billing account
++
 image::rosa-ui-billing-22.png[]
 +
-* Only AWS accounts that were linked to the Red{nbsp}Hat organization that is currently used will be shown.
-* The specified AWS account will be charged for using the ROSA service, regardless of whether the infrastructure AWS account is linked to it in the same AWS organization.
-* You can see an indicator whether the ROSA contract is enabled for a given AWS billing account or not.
-* In case you would like to use an AWS account that does not have a contract enabled yet, you can either use the _Connect ROSA to a new AWS billing account_ to reach the ROSA AWS console page, where you can activate it after logging in using the respective AWS account by following steps described earlier in this tutorial, or ask the administrator of the AWS account to do that for you.
+* Only AWS accounts that are linked to the user's logged in Red{nbsp}Hat account are shown.
+* The specified AWS account is charged for using the ROSA service.
+* An indicator shows if the ROSA contract is enabled or not enabled for a given AWS billing account.
+** If you select an AWS billing account that shows the _Contract enabled_ label, on-demand consumption rates are charged only after the capacity of your pre-paid contract is consumed.
+** AWS accounts without the _Contract enabled_ label are charged the applicable on-demand consumption rates.
 
 The following steps past the billing AWS account selection are beyond the scope of this tutorial.
 
 .Additional resources
 
-* For information on using the CLI to create a cluster, see xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-cli_rosa-hcp-sts-creating-a-cluster-quickly[Creating a ROSA with HCP cluster using the CLI].
+* For information on using the CLI to create a cluster, see xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-cli_rosa-hcp-sts-creating-a-cluster-quickly[Creating a {hcp-title} cluster using the CLI].
 * See link:https://cloud.redhat.com/learning/learn:getting-started-red-hat-openshift-service-aws-rosa/resource/resources:how-deploy-cluster-red-hat-openshift-service-aws-using-console-ui[this learning path] for more details on how to complete ROSA cluster deployment using the web console.


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-10782

Link to docs preview:
https://77524--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-rosa-hcp-activation-and-account-linking-tutorial.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
