### PR TITLE
HCIDOCS-128-revert: vCPU mismatch request not relevant to OCP

### DIFF
--- a/modules/lvms-about-lvm-storage-installation.adoc
+++ b/modules/lvms-about-lvm-storage-installation.adoc
@@ -22,8 +22,6 @@ The prerequisites to install {lvms} are as follows:
 
 * Ensure that you have a minimum of 10 milliCPU and 100 MiB of RAM.
 
-* Ensure that you have a minimum of 9 vCPU cores.
-
 * Ensure that every managed cluster has dedicated disks that are used to provision storage. {lvms} uses only those disks that are empty and do not contain file system signatures. To ensure that the disks are empty and do not contain file system signatures, wipe the disks before using them.
 
 * Before installing {lvms} in a private CI environment where you can reuse the storage devices that you configured in the previous {lvms} installation, ensure that you have wiped the disks that are not in use. If you do not wipe the disks before installing {lvms}, you cannot reuse the disks without manual intervention.


### PR DESCRIPTION
Description:
Reverts [HCIDOCS-128](https://issues.redhat.com//browse/HCIDOCS-128) following project request.

Version(s):
main, 4.16, 4.15, 4.14, 4,13, 4.12

Issue:
https://issues.redhat.com/browse/HCIDOCS-128

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Contacts: 
Reporter: AJ van Woensel
QE: Alexander Chuzoy
Contributer: Jakob Moller
OCP technical writer: Shrikanth R.


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


