### PR TITLE
OCPBUGS#35537: Updated a command in the installation proc

### DIFF
--- a/modules/multi-arch-installing-using-cli.adoc
+++ b/modules/multi-arch-installing-using-cli.adoc
@@ -19,7 +19,7 @@ You can install the Multiarch Tuning Operator by using the {oc-first}.
 +
 [source,terminal]
 ----
-$ oc new-project openshift-multiarch-tuning-operator
+$ oc create ns openshift-multiarch-tuning-operator
 ----
 
 . Create an `OperatorGroup` object:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OCPBUGS-35537](https://issues.redhat.com/browse/OCPBUGS-35537)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[Installing the Multiarch Tuning Operator using the CLI](https://77533--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.html#multi-architecture-installing-using-cli_multiarch-tuning-operator)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->