### PR TITLE
OBSDOCS-1119: Add missing entries to the API support Monitoring table

### DIFF
--- a/modules/api-support-tiers-mapping.adoc
+++ b/modules/api-support-tiers-mapping.adoc
@@ -123,6 +123,12 @@ API groups that end with the suffix `monitoring.coreos.com` have the following m
 |`v1`
 |Tier 1
 
+|`v1alpha1`
+|Tier 1
+
+|`v1beta1`
+|Tier 1
+
 |===
 endif::microshift[]
 


### PR DESCRIPTION
Version(s): `enterprise-4.12` and later

Issue: [OBSDOCS-1119](https://issues.redhat.com/browse/OBSDOCS-1119)

Link to docs preview: https://77553--ocpdocs-pr.netlify.app/openshift-enterprise/latest/rest_api/understanding-api-support-tiers.html#mapping-support-tiers-to-monitoring-api-groups_understanding-api-tiers

QE review:
- [x] QE has approved this change.

**Additional information:**