### PR TITLE
OSSM-6302 [DOC] Tempo + OTEL configuration

### DIFF
--- a/modules/ossm-configuring-distr-tracing-tempo.adoc
+++ b/modules/ossm-configuring-distr-tracing-tempo.adoc
@@ -5,21 +5,76 @@ This module is included in the following assemblies:
 
 :_mod-docs-content-type: PROCEDURE
 [id="ossm-configuring-distr-tracing-tempo_{context}"]
-= Configuring the distributed tracing platform (Tempo)
+= Configuring the {TempoName} and the {OTELName}
 
-You can expose tracing data to the {TempoName} stack by appending a named element and the `zipkin` provider to the `spec.meshConfig.extensionProviders` specification in the `ServiceMehControlPlane`, as shown in the following example. Then, a telemetry custom resource configures Istio proxies to collect trace spans and send them to the Tempo distributor service endpoint.
+You can expose tracing data to the {TempoName} by appending a named element and the `opentelemetry` provider to the `spec.meshConfig.extensionProviders` specification in the `ServiceMeshControlPlane`. Then, a telemetry custom resource configures Istio proxies to collect trace spans and send them to the OpenTelemetry Collector endpoint.
 
-You can create a TempoStack instance in the `tracing-system` namespace _after_ creating the `ServiceMeshControlPlane` and the `ServiceMeshMemberRoll` resources.
+//As of July 2, 2024, there is no common attribute for OpenTelemetry Collector.
+
+You can create a {OTELName} instance in a mesh namespace and configure it to send tracing data to a tracing platform backend service.
 
 .Prerequisites
 
-* You have installed the {TempoOperator} and {SMProductName} Operator in the `openshift-operators` namespace.
-* You have created namespaces such as `istio-system` and `tracing-system`.
+* You created a TempoStack instance using the Red Hat {TempoOperator} in the `tracing-system` namespace. For more information, see "Installing {TempoName}" in the "Additional resources" section.
+
+* You installed the {OTELOperator} in either the recommended namespace or the `openshift-operators` namespace. For more information, see "Installing the {OTELName}" in the "Additional resources" section.
+
+* If using {SMProductName} 2.5 or earlier, set the `spec.tracing.type` parameter of the `ServiceMeshControlPlane` resource to `None` so tracing data can be sent to the OpenTelemetry Collector.
 
 .Procedure
 
-. Configure the `ServiceMeshControlPlane` resource to define an extension provider:
+. Create an OpenTelemetry Collector instance in a mesh namespace. This example uses the `bookinfo` namespace:
 +
+.Example OpenTelemetry Collector configuration
+[source, yaml]
+----
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel
+  namespace: bookinfo  # <1>
+  annotations:
+    sidecar.istio.io/inject: 'true' # <2>
+spec:
+  mode: deployment
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+    exporters:
+      otlp:
+        endpoint: "tempo-sample-distributor.tracing-system.svc.cluster.local:4317" # <3>
+        tls:
+          insecure: true
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: []
+          exporters: [otlp]
+----
+<1> Include the namespace in the `ServiceMeshMemberRoll` member list.
+<2> The sidecar injection annotation is only required when you enable the `spec.security.dataPlane` parameter for mTLS encryption in the `ServiceMeshControlPlane` resource.
+<3> In this example, a TempoStack instance is running in the `tracing-system` namespace. You do not have to include the TempoStack namespace, such as`tracing-system`, in the `ServiceMeshMemberRoll` member list.
++
+[NOTE]
+====
+You only need to create one instance of the OpenTelemetry Collector in one of the `ServiceMeshMemberRoll` member namespaces.
+====
+
+. Check the `otel-collector` pod log and verify that the pod is running.
++
+.Example `otel-collector` pod log check
+[source,terminal]
+----
+$ oc logs -n bookinfo  -l app.kubernetes.io/name=otel-collector
+----
++
+. Create or update an existing `ServiceMeshControlPlane` custom resource (CR) in the `istio-system` namespace:
++
+.Example SMCP custom resource
 [source,yaml]
 ----
 kind: ServiceMeshControlPlane
@@ -28,61 +83,42 @@ metadata:
   name: basic
   namespace: istio-system
 spec:
-# ...
+  addons:
+    grafana:
+      enabled: false
+    kiali:
+      enabled: true
+    prometheus:
+      enabled: true
   meshConfig:
     extensionProviders:
-      - name: tempo
-        zipkin:
-          service: tempo-sample-distributor.tracing-system.svc.cluster.local
-          port: 9411
-  tracing:
-    sampling: 10000
-    type: None <1>
-  version: v2.5
----
-kind: ServiceMeshMemberRoll
-apiVersion: maistra.io/v1
-metadata:
-  name: default
-  namespace: istio-system
-spec:
-  members:
-    - tracing-system
+      - name: otel
+        opentelemetry:
+          port: 4317
+          service: otel-collector.bookinfo.svc.cluster.local
+  policy:
+    type: Istiod
+  telemetry:
+    type: Istiod
+  version: v2.6
 ----
-<1> The `spec.tracing.type` setting defines a deprecated distributed tracing Jaeger instance. Set `spec.tracing.type` to `None` when connecting to a TempoStack using an `extensionProvider` setting.
 +
 [NOTE]
 ====
-Create a TempoStack instance _after_ creating the `ServiceMeshControlPlane` and the `ServiceMeshMemberRoll` resources.
-====
+When upgrading from SMCP 2.5 to 2.6, set the `spec.tracing.type` parameter to `None`:
 
-. Configure the Kiali resource specification to enable a Kiali workload traces dashboard. You can use the dashboard to view tracing query results.
-+
+.Example SMCP `spec.tracing.type` parameter
 [source,yaml]
 ----
-apiVersion: kiali.io/v1alpha1
-kind: Kiali
-# ...
 spec:
-  external_services:
-    tracing:
-      query_timeout: 30
-      enabled: true
-      in_cluster_url: 'http://tempo-sample-query-frontend.tracing-system.svc.cluster.local:16685'
-      url: '[Tempo query frontend Route url]'
-      use_grpc: true # <1>
+  tracing:
+    type: None
 ----
-<1> If you are not using the default HTTP or gRPC port for Jaeger or Tempo, replace the `in_cluster_url:` port with your custom port.
-+
-[NOTE]
-====
-Kiali 1.73 uses the Jaeger Query API, which causes a longer response time depending on Tempo resource limits. If you see a `Could not fetch spans` error message in the Kiali UI, then check your Tempo configuration or reduce the limit per query in Kiali.
 ====
 
-. Create a TempoStack instance using the Red Hat {TempoOperator} in the `tracing-system` namespace. For more information, see "Installing the distributed tracing platform (Tempo)" in the "Additional resources" section.
-
-. Apply a Telemetry custom resource for {SMProductShortName} to start the Tempo provider setting.
+. Create a Telemetry resource in the `istio-system` namespace:
 +
+.Example Telemetry resource
 [source,yaml]
 ----
 apiVersion: telemetry.istio.io/v1alpha1
@@ -93,8 +129,79 @@ metadata:
 spec:
   tracing:
   - providers:
-    - name: tempo
+    - name: otel
     randomSamplingPercentage: 100
 ----
 
-You can also create an Istio gateway and virtual service resources to expose an {product-title} route for accessing the Tempo Jaeger Query console.
+. Verify the `istiod` log.
+
+. Configure the Kiali resource specification to enable a Kiali workload traces dashboard. You can use the dashboard to view tracing query results.
++
+.Example Kiali resource
+[source,yaml]
+----
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+# ...
+spec:
+  external_services:
+    tracing:
+      query_timeout: 30 #<1>
+      enabled: true
+      in_cluster_url: 'http://tempo-sample-query-frontend.tracing-system.svc.cluster.local:16685'
+      url: '[Tempo query frontend Route url]'
+      use_grpc: true # <2>
+----
+<1> The default `query_timeout` integer value is 30 seconds. If you set the value to greater than 30 seconds, you must update `.spec.server.write_timeout` in the Kiali CR and add the annotation `haproxy.router.openshift.io/timeout=50s` to the Kiali route. Both `.spec.server.write_timeout` and `haproxy.router.openshift.io/timeout=` must be greater than `query_timeout`.
+<2> If you are not using the default HTTP or gRPC port, replace the `in_cluster_url:` port with your custom port.
++
+[NOTE]
+====
+Kiali 1.73 uses the Jaeger Query API, which causes a longer response time depending on Tempo resource limits. If you see a `Could not fetch spans` error message in the Kiali UI, then check your Tempo configuration or reduce the limit per query in Kiali.
+====
+
+. Send requests to your application.
+
+. Verify the `istiod` pod logs and the `otel-collector` pod logs.
+
+[id="configuring-distr-tracing-tempo-mtls-encrypted-namespace_{context}"]
+== Configuring the {TempoName} in a mTLS encrypted Service Mesh member namespace
+
+[NOTE]
+====
+You don't need this additional `DestinationRule` configuration if you created a TempoStack instance in a namespace that is not a Service Mesh member namespace.
+====
+
+All traffic is TLS encrypted when you enable Service Mesh `dataPlane` mTLS encryption and you create a TempoStack instance in a Service Mesh member namespace such as `tracing-system-mtls`. This encryption is not expected from the Tempo distributed service and returns a TLS error.
+
+To fix the TLS error, disable the TLS `trafficPolicy` by applying a `DestinationRule` for Tempo and Kiali:
+
+.Example `DestinationRule` Tempo
+[source,yaml]
+----
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: tempo
+  namespace: tracing-system-mtls
+spec:
+  host: "*.tracing-system-mtls.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+----
+
+.Example `DestinationRule` Kiali
+[source,yaml]
+----
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: kiali
+  namespace: istio-system
+spec:
+  host: kiali.istio-system.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+----

--- a/modules/ossm-enabling-jaeger.adoc
+++ b/modules/ossm-enabling-jaeger.adoc
@@ -22,9 +22,9 @@ spec:
     type: Jaeger
 ----
 
-Currently, the only tracing type that is supported is `Jaeger`.
+In {SMProductName} 2.6, the tracing type `Jaeger` is deprecated and disabled by default.
 
-Jaeger is enabled by default. To disable tracing, set `type` to `None`.
+In {SMProductName} 2.5 and earlier, the tracing type `Jaeger` is enabled by default. To disable `Jaeger` tracing, set the `spec.tracing.type` parameter of the `ServiceMeshControlPlane` resource to `None`.
 
 The sampling rate determines how often the Envoy proxy generates a trace. You can use the sampling rate option to control what percentage of requests get reported to your tracing system. You can configure this setting based upon your traffic in the mesh and the amount of tracing data you want to collect. You configure `sampling` as a scaled integer representing 0.01% increments. For example, setting the value to `10` samples 0.1% of traces, setting the value to `500` samples 5% of traces, and a setting of `10000` samples 100% of traces.
 

--- a/service_mesh/v2x/ossm-observability.adoc
+++ b/service_mesh/v2x/ossm-observability.adoc
@@ -22,12 +22,6 @@ include::modules/ossm-distr-tracing.adoc[leveloffset=+1]
 
 include::modules/ossm-configuring-distr-tracing-tempo.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
-.Additional resources
-ifndef::openshift-rosa,openshift-dedicated[]
-xref:../../observability/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-installing.adoc[Installing the distributed tracing platform (Tempo)].
-endif::openshift-rosa,openshift-dedicated[]
-
 include::modules/ossm-config-external-jaeger.adoc[leveloffset=+2]
 
 include::modules/ossm-config-sampling.adoc[leveloffset=+2]


### PR DESCRIPTION
**OSSM 2.6**

[OSSM-6302](https://issues.redhat.com//browse/OSSM-6302) [DOC] Tempo + OTEL configuration

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Given the consistent cherry-pick failures of Service Mesh docs (esp Release Notes) to 4.12, 4.13, and sometimes 4.14, it might be better to create separate PRs for 4.12, 4.13, and 4.14. 

Separate PRs may be created after this PR has passed Dev, QE, and Doc Peer Review.

Issue:
https://issues.redhat.com/browse/OSSM-6302

Link to docs preview:

Distributed Tracing (Tempo): https://77583--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-observability.html#ossm-configuring-distr-tracing-tempo_observability

Jaeger Reference: https://77583--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-reference-jaeger 

Reviews:
- [x] Dev has approved this change. 
- [x] QE has approved this change. 
- [x] OCP Doc Peer Review 
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Reviews and dates added for quick reference of what PRs are where for OSSM 2.6.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
