### PR TITLE
OSDOCS-10889 OCP 4.14.30 Release Notes

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3322,7 +3322,61 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
-// 4.14.29
+[id="ocp-4-14-30"]
+=== RHSA-2024:3881 - {product-title} 4.14.30 bug fix and security updates
+
+Issued: 2024-06-19
+
+{product-title} release 4.14.30, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:3881[RHSA-2024:3881] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:3918[RHSA-2024:3918] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.30 --pullspecs
+----
+
+[id="ocp-4-14-30-enhancements"]
+==== Enhancements
+
+The following enhancements are included in this z-stream release:
+
+[id="ocp-4-15-30-password-colon-character"]
+===== Allowing a colon character in pull secret passwords
+
+This release adds the ability to include a colon character in your pull secret password for the {product-title} {ai-full}. (link:https://issues.redhat.com/browse/OCPBUGS-35034[*OCPBUGS-35034*])
+
+[id="ocp-4-15-30-csi-topology-awareness"]
+===== Configuring the topology feature for the Cinder CSI Driver
+
+Previously, the topology feature for the Cinder CSI Driver was always active, because you could not disable the topology feature. With this release, the topology feature is based on the compute and storage availability zones and you can disable the topology feature. (link:https://issues.redhat.com/browse/OCPBUGS-34792[*OCPBUGS-34792*])
+
+[id="ocp-4-14-30-bug-fixes"]
+==== Bug fixes
+
+* Previously, the {product-title} {ai-full} reported installed SATA SDDs as removable and did not use any of them as installation targets. With this release, removable disks are eligible for installation and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-35085[*OCPBUGS-35085*])
+
+* Previously, an {aws-first} policy issue prevented the {cap-aws-short} from retrieving the necessary domain information. As a consequence, installing an {aws-short} hosted cluster with a custom domain failed. With this update, the policy issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-34856[*OCPBUGS-34856*])
+
+* Previously, when you deleted a cluster or BareMetal Host (BMH), a `PreprovImage` image was created during cluster deletion. As a result, the cluster resources were stuck. With this release, an exception is created for the powering off before the delete stage and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-34814[*OCPBUGS-34814*]).
+
+* Previously, when you enabled the `virtualHostedStyle` parameter with `regionEndpoint` in the Image Registry Operator configuration, the image registry ignored `virtualHostedStyle` and failed to start. This release drops the use of `virtualHostedStyle` and uses `ForcePathStyle` instead which fixes the issue. (link:https://issues.redhat.com/browse/OCPBUGS-34668[*OCPBUGS-34668*])
+
+* Previously, when upgrading to {product-title} 4.15.11 from 4.15.8, the `metal3-ironic` and `metal3-ironic-inspector` pods would fail due to an installation failure related to FIPS mode enablement. With this release, the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-34657[*OCPBUGS-34657*]).
+
+* Previously, the OVN-Kubernetes network plugin could not send gratuitous Address Resolution Protocol (ARP) requests to peers to inform them about the medium access control (MAC) address of a new node, because some situations caused the transfer of the Egress IP address from one node to another to fail.  This resulted in failover issues. With this release, the OVN-Kubernetes network plugin correctly informs peers about the medium access control (MAC) address of a new node, without causing a failover issue. (link:https://issues.redhat.com/browse/OCPBUGS-34570[*OCPBUGS-34570*])
+
+* Previously, if you used the `wait-for-ceo` command during the bootstrapping process, the command would not report the error messages in case of a failure. With this release,  the command reports the error messages in the `bootkube` script for you to view. (link:https://issues.redhat.com/browse/OCPBUGS-34495[*OCPBUGS-34495*])
+
+* Previously, the installation program did not support the `ca-west-1` {aws-first} region. With this release, the `ca-west-1` region is supported and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-34024[*OCPBUGS-34024*])
+
+[id="ocp-4-14-30-updating"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 [id="ocp-4-14-29"]
 === RHBA-2024:3697 - {product-title} 4.14.29 bug fix and security updates
 


### PR DESCRIPTION
Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-10889](https://issues.redhat.com/browse/OSDOCS-10889)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
[Link to docs preview](https://77589--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-30)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Not needed
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This release ships June 19th, errata links will not work until then.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
