### PR TITLE
OSDOCS-10416: Support cluster migration to Entra Workload ID (RNs)

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -634,6 +634,13 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 [id="ocp-4-16-auth_{context}"]
 === Authentication and authorization
 
+[id="ocp-4-16-auth-entra-migration_{context}"]
+==== Enabling {entra-first} on existing clusters
+
+In this release, you can enable {entra-first} to use short-term credentials on an existing {azure-first} {product-title} cluster.
+This functionality is now also supported in versions 4.14 and 4.15 of {product-title}.
+For more information, see xref:../post_installation_configuration/changing-cloud-credentials-configuration.adoc#post-install-enable-token-auth_changing-cloud-credentials-configuration[Enabling token-based authentication].
+
 [id="ocp-4-16-networking_{context}"]
 === Networking
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-10416](https://issues.redhat.com//browse/OSDOCS-10416)

Link to docs preview:
[Enabling Microsoft Entra Workload ID on existing clusters](https://77602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-auth-entra-migration_release-notes)

QE review:
- [x] QE has approved this change.

Additional information: