### PR TITLE
OSDOCS-10491: Split CCO postinstall tasks into new assembly

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -610,6 +610,8 @@ Topics:
   File: storage-configuration
 - Name: Preparing for users
   File: preparing-for-users
+- Name: Changing the cloud provider credentials configuration
+  File: changing-cloud-credentials-configuration
 - Name: Configuring alert notifications
   File: configuring-alert-notifications
 - Name: Converting a connected cluster to a disconnected cluster

--- a/authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc
@@ -17,7 +17,7 @@ With mint mode, each cluster component has only the specific permissions it requ
 
 [NOTE]
 ====
-By default, mint mode requires storing the `admin` credential in the cluster `kube-system` namespace. If this approach does not meet the security requirements of your organization, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove the credential after installing the cluster].
+By default, mint mode requires storing the `admin` credential in the cluster `kube-system` namespace. If this approach does not meet the security requirements of your organization, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove the credential after installing the cluster].
 ====
 
 [id="mint-mode-permissions"]
@@ -72,4 +72,4 @@ include::modules/manually-rotating-cloud-creds.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 == Additional resources
-* xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[Removing cloud provider credentials]
+* xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[Removing cloud provider credentials]

--- a/installing/installing_alibaba/installing-alibaba-customizations.adoc
+++ b/installing/installing_alibaba/installing-alibaba-customizations.adoc
@@ -69,4 +69,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
 //Given that manual mode is required to install on Alibaba Cloud, I do not believe this xref is necessary.
-//* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+//* If necessary, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_alibaba/installing-alibaba-default.adoc
+++ b/installing/installing_alibaba/installing-alibaba-default.adoc
@@ -57,4 +57,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
 //Given that manual mode is required to install on Alibaba Cloud, I do not believe this xref is necessary.
-//* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials]
+//* If necessary, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials]

--- a/installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+++ b/installing/installing_alibaba/installing-alibaba-network-customizations.adoc
@@ -79,4 +79,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
 //Given that manual mode is required to install on Alibaba Cloud, I do not believe this xref is necessary.
-//* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+//* If necessary, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_alibaba/installing-alibaba-vpc.adoc
+++ b/installing/installing_alibaba/installing-alibaba-vpc.adoc
@@ -70,4 +70,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
 //Given that manual mode is required to install on Alibaba Cloud, I do not believe this xref is necessary.
-//* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+//* If necessary, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_aws/installing-aws-china.adoc
+++ b/installing/installing_aws/installing-aws-china.adoc
@@ -123,4 +123,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+* If necessary, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_aws/installing-aws-customizations.adoc
+++ b/installing/installing_aws/installing-aws-customizations.adoc
@@ -124,4 +124,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+* If necessary, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_aws/installing-aws-government-region.adoc
+++ b/installing/installing_aws/installing-aws-government-region.adoc
@@ -128,4 +128,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+* If necessary, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_aws/installing-aws-network-customizations.adoc
+++ b/installing/installing_aws/installing-aws-network-customizations.adoc
@@ -145,4 +145,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+* If necessary, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_aws/installing-aws-private.adoc
+++ b/installing/installing_aws/installing-aws-private.adoc
@@ -122,4 +122,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+* If necessary, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_aws/installing-aws-secret-region.adoc
+++ b/installing/installing_aws/installing-aws-secret-region.adoc
@@ -121,4 +121,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+* If necessary, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_aws/installing-aws-user-infra.adoc
+++ b/installing/installing_aws/installing-aws-user-infra.adoc
@@ -223,4 +223,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+* If necessary, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_aws/installing-aws-vpc.adoc
+++ b/installing/installing_aws/installing-aws-vpc.adoc
@@ -120,5 +120,5 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+* If necessary, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].
 * After installing a cluster on AWS into an existing VPC, you can xref:../../post_installation_configuration/configuring-aws-outposts.adoc#configuring-aws-outposts[extend the AWS VPC cluster into an AWS Outpost].

--- a/installing/installing_aws/installing-restricted-networks-aws.adoc
+++ b/installing/installing_aws/installing-restricted-networks-aws.adoc
@@ -213,4 +213,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
 * If necessary, see xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]
-* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+* If necessary, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_azure_stack_hub/installing-azure-stack-hub-default.adoc
+++ b/installing/installing_azure_stack_hub/installing-azure-stack-hub-default.adoc
@@ -73,4 +73,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+* If necessary, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
+++ b/installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
@@ -89,4 +89,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].
+* If necessary, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc
+++ b/installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc
@@ -20,7 +20,7 @@ include::modules/cco-ccoctl-configuring.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources_configuring-iam-ibm-cloud-refreshing-ids"]
 .Additional resources
-* xref:../../post_installation_configuration/cluster-tasks.adoc#refreshing-service-ids-ibm-cloud_post-install-cluster-tasks[Rotating API keys for {ibm-cloud-name}]
+* xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#refreshing-service-ids-ibm-cloud_changing-cloud-credentials-configuration[Rotating API keys for {ibm-cloud-name}]
 
 [id="next-steps_configuring-iam-ibm-cloud"]
 == Next steps

--- a/installing/installing_ibm_powervs/preparing-to-install-on-ibm-power-vs.adoc
+++ b/installing/installing_ibm_powervs/preparing-to-install-on-ibm-power-vs.adoc
@@ -48,7 +48,7 @@ include::modules/cco-ccoctl-configuring.adoc[leveloffset=+1]
 [id="additional-resources_configuring-ibm-cloud-refreshing-ids"]
 
 .Additional resources
-* xref:../../post_installation_configuration/cluster-tasks.adoc#refreshing-service-ids-ibm-cloud_post-install-cluster-tasks[Rotating API keys]
+* xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#refreshing-service-ids-ibm-cloud_changing-cloud-credentials-configuration[Rotating API keys]
 
 [id="next-steps_preparing-to-install-on-ibm-power-vs"]
 == Next steps

--- a/modules/enabling-entra-workload-id-existing-cluster.adoc
+++ b/modules/enabling-entra-workload-id-existing-cluster.adoc
@@ -1,0 +1,249 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="enabling-entra-workload-id-existing-cluster_{context}"]
+= Enabling {entra-first} on an existing cluster
+
+If you did not configure your {azure-first} {product-title} cluster to use {entra-first} during installation, you can enable this authentication method on an existing cluster.
+
+[IMPORTANT]
+====
+The process to enable {entra-short} on an existing cluster is disruptive and takes a significant amount of time.
+Before proceeding, observe the following considerations:
+
+* Read the following steps and ensure that you understand and accept the time requirement.
+The exact time requirement varies depending on the individual cluster, but it is likely to require at least one hour.
+
+* During this process, you must refresh all service accounts and restart all pods on the cluster.
+These actions are disruptive to workloads.
+To mitigate this impact, you can temporarily halt these services and then redeploy them when the cluster is ready.
+
+* After starting this process, do not attempt to update the cluster until it is complete.
+If an update is triggered, the process to enable {entra-short} on an existing cluster fails.
+====
+
+.Prerequisites
+
+* You have installed an {product-title} cluster on {azure-first}.
+* You have access to the cluster using an account with `cluster-admin` permissions.
+* You have installed the {oc-first}.
+* You have extracted and prepared the Cloud Credential Operator utility (`ccoctl`) binary.
+* You have access to your {azure-short} account by using the {azure-short} CLI (`az`).
+
+.Procedure
+
+. Create an output directory for the manifests that the `ccoctl` utility generates.
+This procedure uses `./output_dir` as an example.
+
+. Extract the service account public signing key for the cluster to the output directory by running the following command:
++
+[source,terminal]
+----
+$ oc get configmap \
+  --namespace openshift-kube-apiserver bound-sa-token-signing-certs \
+  --output 'go-template={{index .data "service-account-001.pub"}}' > ./output_dir/serviceaccount-signer.public <1>
+----
+<1> This procedure uses a file named `serviceaccount-signer.public` as an example.
+
+. Use the extracted service account public signing key to create an OpenID Connect (OIDC) issuer and {azure-short} blob storage container with OIDC configuration files by running the following command:
++
+[source,terminal]
+----
+$ ./ccoctl azure create-oidc-issuer \
+  --name <azure_infra_name> \// <1>
+  --output-dir ./output_dir \
+  --region <azure_region> \// <2>
+  --subscription-id <azure_subscription_id> \// <3>
+  --tenant-id <azure_tenant_id> \
+  --public-key-file ./output_dir/serviceaccount-signer.public <4>
+----
+<1> The value of the `name` parameter is used to create an Azure resource group.
+To use an existing Azure resource group instead of creating a new one, specify the `--oidc-resource-group-name` argument with the existing group name as its value.
+<2> Specify the region of the existing cluster.
+<3> Specify the subscription ID of the existing cluster.
+<4> Specify the file that contains the service account public signing key for the cluster.
+
+. Verify that the configuration file for the Azure pod identity webhook was created by running the following command:
++
+[source,terminal]
+----
+$ ll ./output_dir/manifests
+----
++
+.Example output
++
+[source,text]
+----
+total 8
+-rw-------. 1 cloud-user cloud-user 193 May 22 02:29 azure-ad-pod-identity-webhook-config.yaml <1>
+-rw-------. 1 cloud-user cloud-user 165 May 22 02:29 cluster-authentication-02-config.yaml
+----
+<1> The file `azure-ad-pod-identity-webhook-config.yaml` contains the Azure pod identity webhook configuration.
+
+. Set an `OIDC_ISSUER_URL` variable with the OIDC issuer URL from the generated manifests in the output directory by running the following command:
++
+[source,terminal]
+----
+$ OIDC_ISSUER_URL=`awk '/serviceAccountIssuer/ { print $2 }' ./output_dir/manifests/cluster-authentication-02-config.yaml`
+----
+
+. Update the `spec.serviceAccountIssuer` parameter of the cluster `authentication` configuration by running the following command:
++
+[source,terminal]
+----
+$ oc patch authentication cluster \
+  --type=merge \
+  -p "{\"spec\":{\"serviceAccountIssuer\":\"${OIDC_ISSUER_URL}\"}}"
+----
+
+. Monitor the configuration update progress by running the following command:
++
+[source,terminal]
+----
+$ oc adm wait-for-stable-cluster
+----
++
+This process might take 15 minutes or longer.
+The following output indicates that the process is complete:
++
+[source,text]
+----
+All clusteroperators are stable
+----
+
+. Restart all of the pods in the cluster by running the following command:
++
+[source,terminal]
+----
+$ oc adm reboot-machine-config-pool mcp/worker mcp/master
+----
++
+Restarting a pod updates the `serviceAccountIssuer` field and refreshes the service account public signing key.
+
+. Monitor the restart and update process by running the following command:
++
+[source,terminal]
+----
+$ oc adm wait-for-node-reboot nodes --all
+----
++
+This process might take 15 minutes or longer.
+The following output indicates that the process is complete:
++
+[source,text]
+----
+All nodes rebooted
+----
+
+. Update the Cloud Credential Operator `spec.credentialsMode` parameter to `Manual` by running the following command:
++
+[source,terminal]
+----
+$ oc patch cloudcredential cluster \
+  --type=merge \
+  --patch '{"spec":{"credentialsMode":"Manual"}}'
+----
+
+. Extract the list of `CredentialsRequest` objects from the {product-title} release image by running the following command:
++
+[source,terminal]
+----
+$ oc adm release extract \
+  --credentials-requests \
+  --included \
+  --to <path_to_directory_for_credentials_requests> \
+  --registry-config ~/.pull-secret
+----
++
+[NOTE]
+====
+This command might take a few moments to run.
+====
+
+. Set an `AZURE_INSTALL_RG` variable with the {azure-short} resource group name by running the following command:
++
+[source,terminal]
+----
+$ AZURE_INSTALL_RG=`oc get infrastructure cluster -o jsonpath --template '{ .status.platformStatus.azure.resourceGroupName }'`
+----
+
+. Use the `ccoctl` utility to create managed identities for all `CredentialsRequest` objects by running the following command:
++
+[source,terminal]
+----
+$ ccoctl azure create-managed-identities \
+  --name <azure_infra_name> \
+  --output-dir ./output_dir \
+  --region <azure_region> \
+  --subscription-id <azure_subscription_id> \
+  --credentials-requests-dir <path_to_directory_for_credentials_requests> \
+  --issuer-url "${OIDC_ISSUER_URL}" \
+  --dnszone-resource-group-name <azure_dns_zone_resourcegroup_name> \// <1>
+  --installation-resource-group-name "${AZURE_INSTALL_RG}"
+----
+<1> Specify the name of the resource group that contains the DNS zone.
+
+. Apply the {azure-short} pod identity webhook configuration for {entra-short} by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f ./output_dir/manifests/azure-ad-pod-identity-webhook-config.yaml
+----
+
+. Apply the secrets generated by the `ccoctl` utility by running the following command:
++
+[source,terminal]
+----
+$ find ./output_dir/manifests -iname "openshift*yaml" -print0 | xargs -I {} -0 -t oc replace -f {}
+----
++
+This process might take several minutes.
+
+
+. Restart all of the pods in the cluster by running the following command:
++
+[source,terminal]
+----
+$ oc adm reboot-machine-config-pool mcp/worker mcp/master
+----
++
+Restarting a pod updates the `serviceAccountIssuer` field and refreshes the service account public signing key.
+
+. Monitor the restart and update process by running the following command:
++
+[source,terminal]
+----
+$ oc adm wait-for-node-reboot nodes --all
+----
++
+This process might take 15 minutes or longer.
+The following output indicates that the process is complete:
++
+[source,text]
+----
+All nodes rebooted
+----
+
+. Monitor the configuration update progress by running the following command:
++
+[source,terminal]
+----
+$ oc adm wait-for-stable-cluster
+----
++
+This process might take 15 minutes or longer.
+The following output indicates that the process is complete:
++
+[source,text]
+----
+All clusteroperators are stable
+----
+
+. Optional: Remove the {azure-short} root credentials secret by running the following command:
++
+[source,terminal]
+----
+$ oc delete secret -n kube-system azure-credentials
+----

--- a/post_installation_configuration/changing-cloud-credentials-configuration.adoc
+++ b/post_installation_configuration/changing-cloud-credentials-configuration.adoc
@@ -1,0 +1,67 @@
+:_mod-docs-content-type: ASSEMBLY
+:context: changing-cloud-credentials-configuration
+[id="changing-cloud-credentials-configuration"]
+= Changing the cloud provider credentials configuration
+include::_attributes/common-attributes.adoc[]
+
+toc::[]
+
+For supported configurations, you can change how {product-title} authenticates with your cloud provider.
+
+To determine which cloud credentials strategy your cluster uses, see xref:../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc#cco-determine-mode_about-cloud-credential-operator[Determining the Cloud Credential Operator mode].
+
+[id="post-install-rotate-remove-cloud-creds_{context}"]
+== Rotating or removing cloud provider credentials
+
+After installing {product-title}, some organizations require the rotation or removal of the cloud provider credentials that were used during the initial installation.
+
+To allow the cluster to use the new credentials, you must update the secrets that the xref:../operators/operator-reference.adoc#cloud-credential-operator_cluster-operators-ref[Cloud Credential Operator (CCO)] uses to manage cloud provider credentials.
+
+[id="ccoctl-rotate-remove-cloud-creds_{context}"]
+=== Rotating cloud provider credentials with the Cloud Credential Operator utility
+
+// Right now only IBM can do this, but it makes sense to set this up so that other clouds can be added.
+The Cloud Credential Operator (CCO) utility `ccoctl` supports updating secrets for clusters installed on {ibm-cloud-name}.
+
+//Rotating IBM Cloud credentials with ccoctl
+include::modules/refreshing-service-ids-ibm-cloud.adoc[leveloffset=+3]
+
+//Rotating cloud provider credentials manually
+include::modules/manually-rotating-cloud-creds.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere[vSphere CSI Driver Operator]
+
+//Removing cloud provider credentials manually
+include::modules/manually-removing-cloud-creds.adoc[leveloffset=+2]
+
+//These additional resources are for the "Rotating or removing cloud provider credentials" section, do not separate them from that content.
+[role="_additional-resources"]
+.Additional resources
+* xref:../authentication/managing_cloud_provider_credentials/cco-mode-passthrough.adoc#admin-credentials-root-secret-formats_cco-mode-passthrough[Admin credentials root secret format]
+
+[id="post-install-enable-token-auth_{context}"]
+== Enabling token-based authentication
+//Today, just Entra. But this should be a section that anticipates the addition of AWS STS and GCP WID.
+
+After installing an {azure-first} {product-title} cluster, you can enable {entra-first} to use short-term credentials.
+
+//Configuring the Cloud Credential Operator utility
+include::modules/cco-ccoctl-configuring.adoc[leveloffset=+2]
+
+//Enabling {entra-first} on an existing cluster
+include::modules/enabling-entra-workload-id-existing-cluster.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc#cco-short-term-creds-azure_cco-short-term-creds[Microsoft Entra Workload ID]
+* xref:../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-with-short-term-creds_installing-azure-customizations[Configuring an Azure cluster to use short-term credentials]
+
+//Verifying the credentials configuration
+include::modules/cco-ccoctl-install-verifying.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc#about-cloud-credential-operator[About the Cloud Credential Operator]

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -685,38 +685,6 @@ include::modules/pod-disruption-eviction-policy.adoc[leveloffset=+2]
 * xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
 * link:https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy[Unhealthy Pod Eviction Policy] in the Kubernetes documentation
 
-[id="post-install-rotate-remove-cloud-creds"]
-== Rotating or removing cloud provider credentials
-
-After installing {product-title}, some organizations require the rotation or removal of the cloud provider credentials that were used during the initial installation.
-
-To allow the cluster to use the new credentials, you must update the secrets that the xref:../operators/operator-reference.adoc#cloud-credential-operator_cluster-operators-ref[Cloud Credential Operator (CCO)] uses to manage cloud provider credentials.
-
-[id="ccoctl-rotate-remove-cloud-creds"]
-=== Rotating cloud provider credentials with the Cloud Credential Operator utility
-
-// Right now only IBM can do this, but it makes sense to set this up so that other clouds can be added.
-The Cloud Credential Operator (CCO) utility `ccoctl` supports updating secrets for clusters installed on {ibm-cloud-name}.
-
-//Rotating IBM Cloud credentials with ccoctl
-include::modules/refreshing-service-ids-ibm-cloud.adoc[leveloffset=+3]
-
-//Rotating cloud provider credentials manually
-include::modules/manually-rotating-cloud-creds.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-* xref:../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc[vSphere CSI Driver Operator]
-
-//Removing cloud provider credentials manually
-include::modules/manually-removing-cloud-creds.adoc[leveloffset=+2]
-
-//These additional resources are for the "Rotating or removing cloud provider credentials" section, do not separate them from that content.
-[role="_additional-resources"]
-.Additional resources
-* xref:../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc#about-cloud-credential-operator[About the Cloud Credential Operator]
-* xref:../authentication/managing_cloud_provider_credentials/cco-mode-passthrough.adoc#admin-credentials-root-secret-formats_cco-mode-passthrough[Admin credentials root secret format]
-
 [id="post-install-must-gather-disconnected"]
 == Configuring image streams for a disconnected cluster
 


### PR DESCRIPTION
Cherrypicked from eb0e333cb29942f9592fb56ee82c10ca993b6ebc xref: #77450
- requires change management for Entra steps
- should CP cleanly into 4.14 (also needs change management for Entra steps)