### PR TITLE
[OSDOCS#10055]: Add relnote for rotation of etcd signer certificates

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -639,6 +639,11 @@ For more information, see xref:../edge_computing/ztp-deploying-far-edge-sites.ad
 [id="ocp-4-16-insights-operator_{context}"]
 === Insights Operator
 
+[id="ocp-4-16-etcd-certificates_{context}"]
+=== Security
+
+A new signer certificate authority (CA), `openshift-etcd`, is now available to sign certificates. It is contained in a trust bundle with the existing CA. Two CA secrets,`etcd-signer` and `etcd-metric-signer`, are also available for rotation. Starting with this release, all certificates will move to a proven library. This change allows for the automatic rotation of all certificates that were not managed by `cluster-etcd-operator`. All node-based certificates will continue with the current update process.
+
 [id="ocp-4-16-notable-technical-changes_{context}"]
 == Notable technical changes
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-10055](https://issues.redhat.com/browse/OSDOCS-10055)  Release notes

Link to docs preview:
[Security](https://77608--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-etcd-certificates_release-notes)  (Updated 6/20/2024)

QE review:
- [x ] QE has approved this change.

Additional information:
n/a
