### PR TITLE
OSDOCS#10935: Release notes for BYOIP

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -117,6 +117,12 @@ It is a container-based utility that builds a disk image that includes the Agent
 
 For more information, see the link:https://access.redhat.com/articles/7065136[OpenShift-based Appliance Builder User Guide].
 
+[id="ocp-4-16-installation-and-update-byoip_{context}"]
+==== Bring your own IPv4 (BYOIP) feature enabled for installation on AWS
+
+With this release, you can enable bring your own public IPv4 addresses (BYOIP) feature when installing on AWS by using the `publicIpv4Pool` field to allocate Elastic IP addresses (EIPs). You must ensure that you have the xref:../installing/installing_aws/installing-aws-account.adoc#installation-aws-permissions_installing-aws-account[required permissions] to enable BYOIP. For more information, see xref:../installing/installing_aws/installation-config-parameters-aws.adoc#installation-configuration-parameters-optional-aws_installation-config-parameters-aws[Optional AWS configuration parameters].
+
+
 [id="ocp-4-16-web-console_{context}"]
 === Web console
 


### PR DESCRIPTION
Version(s):416

Issue: https://issues.redhat.com/browse/OSDOCS-10935

Link to docs preview:  https://77609--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-installation-and-update-byoip_release-notes

Review:
- [x] QE has approved this change.
- [x] SME has approved this change.