### PR TITLE
TELCODOCS-1484 -  Adding IPsec encryption for managed clusters via GitOps ZTP release note

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -668,7 +668,16 @@ With this release, you can use the {lcao} to orchestrate an image-based upgrade 
 The {lcao} generates an OCI image that matches the configuration of participating clusters.
 In addition to the OCI image, the image-based upgrade uses the `ostree` library and the OADP Operator to reduce upgrade and service outage duration when transitioning between the original and target platform versions.
 
-For more information, see xref:../edge_computing/image_based_upgrade/cnf-understanding-image-based-upgrade.adoc#understanding-image-based-upgrade-for-sno[Understanding the image-based upgrade for single-node OpenShift clusters].
+For more information, see xref:../edge_computing/image_based_upgrade/cnf-understanding-image-based-upgrade.adoc#understanding-image-based-upgrade-for-sno[Understanding the image-based upgrade for {sno} clusters].
+
+[id="ocp-4-16-edge-computing-ipsec-encryption-for-managed-clusters-ztp_{context}"]
+==== Deploying IPsec encryption to managed clusters with {ztp} and {rh-rhacm} (Technology Preview)
+
+You can now enable IPsec encryption in managed {sno} clusters that you deploy with {ztp} and {rh-rhacm-first}.
+You can encrypt external traffic between pods and IPsec endpoints external to the managed cluster.
+All pod-to-pod network traffic between nodes on the OVN-Kubernetes cluster network is encrypted with IPsec in Transport mode.
+
+For more information, see xref:../edge_computing/ztp-deploying-far-edge-sites.adoc#ztp-configuring-ipsec-using-ztp-and-siteconfig_ztp-deploying-far-edge-sites[Configuring IPsec encryption for {sno} clusters using {ztp} and SiteConfig resources].
 
 [id="ocp-4-16-hcp_{context}"]
 === Hosted control planes
@@ -2065,6 +2074,10 @@ In the following tables, features are marked with the following statuses:
 |Not Available
 |Technology Preview
 
+|Deploying IPsec encryption to managed clusters with {ztp} and {rh-rhacm}
+|Not Available
+|Not Available
+|Technology Preview
 |====
 
 [id="ocp-4-16-known-issues_{context}"]


### PR DESCRIPTION
[TELCODOCS-1484](https://issues.redhat.com//browse/TELCODOCS-1484) - IPsec via GitOps ZTP for SNO clusters release note

Version(s):
enterprise-4.16

Issue:
https://issues.redhat.com/browse/TELCODOCS-1484

Link to docs preview:
https://77618--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-edge-computing-ipsec-encryption-for-managed-clusters-ztp_release-notes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
