### PR TITLE
OSDOCS-9885: updated the TechPreviewNoUpgrade list

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -31,7 +31,6 @@ The following Technology Preview features are enabled by this feature set:
 ** StatefulSet pod availability upgrading limits. Enables users to define the maximum number of statefulset pods unavailable during updates which reduces application downtime. (`MaxUnavailableStatefulSet`)
 ** Admin Network Policy and Baseline Admin Network Policy. Enables `AdminNetworkPolicy` and `BaselineAdminNetworkPolicy` resources, which are part of the Network Policy V2 API, in clusters running the OVN-Kubernetes CNI plugin. Cluster administrators can apply cluster-scoped policies and safeguards for an entire cluster before namespaces are created. Network administrators can secure clusters by enforcing network traffic controls that cannot be overridden by users. Network administrators can enforce optional baseline network traffic controls that can be overridden by users in the cluster, if necessary. Currently, these APIs support only expressing policies for intra-cluster traffic. (`AdminNetworkPolicy`)
 ** `MatchConditions` is a list of conditions that must be met for a request to be sent to this webhook. Match conditions filter requests that have already been matched by the rules, namespaceSelector, and objectSelector. An empty list of `matchConditions` matches all requests. (`admissionWebhookMatchConditions`)
-** Gateway API. To enable the {product-title} Gateway API, set the value of the `enabled` field to `true` in the `techPreview.gatewayAPI` specification of the `ServiceMeshControlPlane` resource.(`gateGatewayAPI`)
 ** `gcpLabelsTags`
 ** `vSphereStaticIPs`
 ** `routeExternalCertificate`
@@ -47,6 +46,38 @@ The following Technology Preview features are enabled by this feature set:
 ** `managedBootImages`
 ** `onClusterBuild`
 ** `signatureStores`
+** `DisableKubeletCloudCredentialProviders`
+** `BareMetalLoadBalancer`
+** `ClusterAPIInstallAWS`
+** `ClusterAPIInstallNutanix`
+** `ClusterAPIInstallOpenStack`
+** `ClusterAPIInstallVSphere`
+** `HardwareSpeed`
+** `KMSv1`
+** `NetworkDiagnosticsConfig`
+** `VSphereDriverConfiguration`
+** `ExternalOIDC`
+** `ChunkSizeMiB`
+** `ClusterAPIInstallGCP`
+** `ClusterAPIInstallPowerVS`
+** `EtcdBackendQuota`
+** `Example`
+** `ExternalRouteCertificate`
+** `ImagePolicy`
+** `InsightsConfig`
+** `InsightsOnDemandDataGather`
+** `MetricsCollectionProfiles`
+** `NewOLM`
+** `NodeDisruptionPolicy`
+** `PinnedImages`
+** `PlatformOperators`
+** `ServiceAccountTokenNodeBinding`
+** `ServiceAccountTokenNodeBindingValidation`
+** `ServiceAccountTokenPodNodeInfo`
+** `TranslateStreamCloseWebsocketRequests`
+** `UpgradeStatus`
+** `VSphereMultiVCenters`
+** `VolumeGroupSnapshot`
 --
 
 ////


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-9885

Link to docs preview:
https://77619--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html

QE review:
- [ ] QE has approved this change.

Additional information:
None
