### PR TITLE
OSDOCS-9882-networking: bug batch the networking 4.16 bugs

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -1095,6 +1095,38 @@ With this release, the CCO no longer checks for the nonexistent permission.
 [id="ocp-4-16-networking-bug-fixes_{context}"]
 ==== Networking
 
+* Previously, the API documentation for the `status.componentRoutes.currentHostnames` field in the Ingress API included developer notes. After you entered the `oc explain ingresses.status.componentRoutes.currentHostnames --api-version=config.openshift.io/v1` command, developer notes would show in the output along with the intended information. With this release, the developer notes are removed from the `status.componentRoutes.currentHostnames` field, so that after you enter the command, the output lists current hostnames used by the route. (link:https://issues.redhat.com/browse/OCPBUGS-31058[*OCPBUGS-31058*])
+
+* Previously, the load balancing algorithm did not differentiate between active and inactive services when determining weights, and it employed a random algorithm excessively in environments with many inactive services or environments routing backends with weight `0`. This led to increased memory usage and a higher risk of excessive memory consumption. With this release, changes optimize traffic direction towards active services only and prevent unnecessary use of a random algorithm with higher weights, reducing the potential for excessive memory consumption. (link:https://issues.redhat.com/browse/OCPBUGS-29690[*OCPBUGS-29690*])
+
+* Previously, if multiple routes were specified in the same certificate or if a route specified the default certificate as a custom certificate, and HTTP/2 was enabled on the router, an HTTP/2 client could perform connection coalescing on routes. Clients, such as a web browser, could re-use connections and potentially connect to the wrong backend server. With this release, the {product-title} router now checks when the same certificate is specified on more than one route or when a route specifies the default certificate as a custom certificate. When either one of these conditions is detected, the router configures the HAProxy load balancer so to not allow HTTP/2 client connections to any routes that use these certificate.(link:https://issues.redhat.com/browse/OCPBUGS-29373[*OCPBUGS-29373*])
+
+* Previously, if you configured a deployment with the `routingViaHost` parameter set to `true`, traffic failed to reach the IPv6 `ExternalTrafficPolicy=Local` load balancer service. With this release, the issue is fixed. (link:https://issues.redhat.com/browse/OCPBUGS-27211[*OCPBUGS-27211*])
+
+* Previously, a pod selected by an `EgressIp` object that was hosted on a secondary network interface controller (NIC) caused connections to node IP addresses to timeout. With this release, the issue is fixed. (link:https://issues.redhat.com/browse/OCPBUGS-26979[*OCPBUGS-26979*])
+
+* Previously, a leap file package that the {product-title} Precision Time Protocol (PTP) Operator installed could not be used by the `ts2phc` process because the package expired. With this release, the leap file package is updated to read leap events from Global Positioning System (GPS) signals and update the offset dynamically so that the expired package situation no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-25939[*OCPBUGS-25939*])
+
+* Previously, pods assigned an IP from the pool created by the Whereabouts CNI plugin were getting stuck in the `ContainerCreating` state after a node forced a reboot. With this release, the Whereabouts CNI plugin issue associated with the IP allocation after a node force reboot is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-24608[*OCPBUGS-24608*])
+
+* Previously, there was a conflict between two scripts on {product-title} in IPv6, including single and dual-stack, deployments. One script set the hostname to a fully qualified domain name (FQDN) but the other script might set it to a short name too early. This conflict happened because the event that triggered setting the hostname to FQDN might run after the script that set it to a short name. This occurred due to asynchronous network events. With this release, new code has been added to ensure that the FQDN is set properly. This new code ensures that there is a wait for a specific network event before allowing the hostname to be set. (link:https://issues.redhat.com/browse/OCPBUGS-22324[*OCPBUGS-22324*])
+
+* Previously, if a pod selected by an `EgressIP` through a secondary interface had its label removed, another pod in the same namespace would also lose its `EgressIP` assignment, breaking its connection to the external host. With this release, the issue is fixed, so that when a pod label is removed and it stops using the `EgressIP`, other pods with the matching label continue to use the `EgressIP` without interruption. (link:https://issues.redhat.com/browse/OCPBUGS-20220[*OCPBUGS-20220*])
+
+* Previously, `EgressIP` pods hosted by a secondary interface would not failover because of a race condition. Users would receive an error message indicating that the `EgressIP` pod could not be assigned because it conflicted with an existing IP address. With this update, the `EgressIP` pod moves to an egress node. (https://issues.redhat.com/browse/OCPBUGS-20209[*OCPBUGS-20209*])
+
+* Previously, when a MAC address changed on the physical interface being used by OVN-Kubernetes, it would not be updated correctly within OVN-Kubernetes and could cause traffic disruption and Kube API outages from the node for a prolonged period of time. This was most common when a bond interface was being used, where the MAC address of the bond might swap depending on which device was the first to come up. With this release, the issues if fixed so that OVN-Kubernetes dynamically detects MAC address changes and updates it correctly. (link:https://issues.redhat.com/browse/OCPBUGS-18716[*OCPBUGS-18716*])
+
+* Previously, the global navigation satellite system (GNSS) module was capable of reporting both the GPS `fix` position and the GNSS `offset` position, which represents the offset between the GNSS module and the constellations. The previous T-GM did not use the `ubloxtool` CLI tool to probe the `ublox` module for reading `offset` and `fix` positions. Instead, it could only read the GPS `fix` information via GPSD. The reason for this was that the previous implementation of the `ubloxtool` CLI tool took two seconds to receive a response, and with every call it increased CPU usage by threefold. With this update, the `ubloxtool` request is now optimized, and the GPS `offset` position is now available. (link:https://issues.redhat.com/browse/OCPBUGS-17422[*OCPBUGS-17422*])
+
+////
+* Previously for {product-title} clusters on {azure-full} that used OVN-Kubernetes as the Container Network Interface (CNI), an issue existed where the source IP recognized by the pod was the OVN gateway router of the node when the load balancer service with `externalTrafficPolicy: Local` was used. This occurred due to a Source Network Address Translation (SNAT) being applied to UDP packets.
++
+With this release, session affinity without a timeout is possible by setting the affinity timeout to a higher value, for example, `86400` seconds, or 24 hours. As a result, the affinity is treated as permanent unless there are network disruptions such as endpoints or nodes going down. As a result, session affinity is more persistent. (link:https://issues.redhat.com/browse/OCPBUGS-24219[*OCPBUGS-24219*])
+////
+
+* Previously, IPv6 was unsupported when assigning an egress IP to a network interface that was not the primary network interface. This issue has been resolved, and the egress IP can be IPv6. (https://issues.redhat.com/browse/OCPBUGS-24271[*OCPBUGS-24271*])
+
 [discrete]
 [id="ocp-4-16-node-bug-fixes_{context}"]
 ==== Node


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-9882](https://issues.redhat.com/browse/OSDOCS-9882)

Link to docs preview:
[Bug fixes - Networking](https://77620--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-bug-fixes_release-notes)

