### PR TITLE
[OCPBUGS#35415]Updated default CIDR which are needed for OVN

### DIFF
--- a/modules/nw-ovn-kubernetes-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-migration-about.adoc
@@ -41,7 +41,7 @@ While the OVN-Kubernetes network plugin implements many of the capabilities pres
 * Egress router pods
 --
 
-* If your cluster or surrounding network uses any part of the `100.64.0.0/16` address range, you must choose another unused IP range by specifying the `v4InternalSubnet` spec under the `spec.defaultNetwork.ovnKubernetesConfig` object definition. OVN-Kubernetes uses the IP range `100.64.0.0/16` internally by default.
+* If your cluster or surrounding network uses any part of the `100.64.0.0/16`, `169.254.169.0/29`, `100.88.0.0/16`, `fd98::/64`, `fd69::/125`, and the `fd97::/64` address ranges, you must choose another unused IP address range by specifying the `v4InternalSubnet` spec under the `spec.defaultNetwork.ovnKubernetesConfig` object definition. OVN-Kubernetes uses the IP address range `100.64.0.0/16` internally by default.
 
 The following sections highlight the differences in configuration between the aforementioned capabilities in OVN-Kubernetes and OpenShift SDN network plugins.
 


### PR DESCRIPTION
Added all the other needed OVN CIDR ranges that are missing in SDN to the OVN migration doc

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. --> 4.12, 4.13, 4.14, 4.15 and coming versions

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. ---> https://issues.redhat.com/browse/OCPBUGS-35415

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. ---> https://77622--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
