### PR TITLE
OCPBUGS-35498 remove Multi-network policy support stated as Tech Preview

### DIFF
--- a/networking/multiple_networks/configuring-multi-network-policy.adoc
+++ b/networking/multiple_networks/configuring-multi-network-policy.adoc
@@ -8,13 +8,6 @@ toc::[]
 
 As a cluster administrator, you can configure multi-network for additional networks. You can specify multi-network policy for SR-IOV, macvlan, and OVN-Kubernetes additional networks. Macvlan additional networks are fully supported. Other types of additional networks, such as ipvlan, are not supported.
 
-[IMPORTANT]
-====
-Support for configuring multi-network policies for SR-IOV additional networks is a Technology Preview feature and is only supported with kernel network interface cards (NICs). SR-IOV is not supported for Data Plane Development Kit (DPDK) applications.
-
-For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
-====
-
 include::modules/nw-multi-network-policy-differences.adoc[leveloffset=+1]
 include::modules/nw-multi-network-policy-enable.adoc[leveloffset=+1]
 include::modules/nw-multi-network-policy-ipv6-suppport.adoc[leveloffset=+1]


### PR DESCRIPTION
[OCPBUGS-35498]: Remove Multi-network policy support stated as Tech Preview
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15, 4.16 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-35498
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://77630--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-multi-network-policy.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Additional feedback merged in https://github.com/openshift/openshift-docs/pull/77710
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
