### PR TITLE
OCPBUGS#3574: Add `spec.installNamespace` field to example CRs

### DIFF
--- a/modules/olmv1-about-target-versions.adoc
+++ b/modules/olmv1-about-target-versions.adoc
@@ -27,6 +27,7 @@ metadata:
   name: pipelines-operator
 spec:
   packageName: openshift-pipelines-operator-rh
+  installNamespace: <namespace_name>
   channel: latest <1>
 ----
 <1> Installs the latest release that can be resolved from the specified channel. Updates to the channel are automatically installed.
@@ -44,7 +45,8 @@ metadata:
   name: pipelines-operator
 spec:
   packageName: openshift-pipelines-operator-rh
-  version: 1.11.1 <1>
+  installNamespace: <namespace_name>
+  version: "1.11.1" <1>
 ----
 <1> Specifies the target version. If you want to update the version of the Operator or extension that is installed, you must manually update this field the CR to the desired target version.
 
@@ -59,7 +61,8 @@ metadata:
   name: pipelines-operator
 spec:
   packageName: openshift-pipelines-operator-rh
-  version: >1.11.1 <1>
+  installNamespace: <namespace_name>
+  version: ">1.11.1" <1>
 ----
 <1> Specifies that the desired version range is greater than version `1.11.1`. For more information, see "Support for version ranges".
 

--- a/modules/olmv1-clusterextension-api.adoc
+++ b/modules/olmv1-clusterextension-api.adoc
@@ -25,6 +25,7 @@ metadata:
   name: <operator_name>
 spec:
   packageName: <package_name>
+  installNamespace: <namespace_name>
   channel: <channel_name>
   version: <version_number>
 ----

--- a/modules/olmv1-forcing-an-update-or-rollback.adoc
+++ b/modules/olmv1-forcing-an-update-or-rollback.adoc
@@ -32,6 +32,7 @@ metadata:
   name: <operator_name> <1>
 spec:
   packageName: <package_name> <2>
+  installNamespace: <namespace_name>
   version: <version> <3>
   upgradeConstraintPolicy: Ignore <4>
 ----

--- a/modules/olmv1-version-range-comparisons.adoc
+++ b/modules/olmv1-version-range-comparisons.adoc
@@ -46,6 +46,7 @@ metadata:
   name: pipelines-operator
 spec:
   packageName: openshift-pipelines-operator-rh
+  installNamespace: <namespace_name>
   version: ">=1.11, <1.13"
 ----
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUGS-35724](https://issues.redhat.com/browse/OCPBUGS-35724)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
* https://77639--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/olm_v1/arch/olmv1-operator-controller.html#olmv1-clusterextension-api
* https://77639--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/olm_v1/arch/olmv1-operator-controller.html#olmv1-about-target-versions_olmv1-operator-controller
* https://77639--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/olm_v1/olmv1-installing-an-operator-from-a-catalog.html#olmv1-version-range-comparisons_olmv1-installing-operator
* https://77639--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/olm_v1/olmv1-installing-an-operator-from-a-catalog.html#olmv1-about-target-versions_olmv1-installing-operator
* https://77639--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/olm_v1/olmv1-installing-an-operator-from-a-catalog.html#olmv1-forcing-an-update-or-rollback_olmv1-installing-operator

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

*NOTE*: This PR does not add the `spec.installNamespace` field to the modules for installing and updating cluster extensions. That content is fixed in #77274

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
