### PR TITLE
OCPBUGS-35498-416 remove Multi-network policy support stated as Tech …

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -1175,8 +1175,8 @@ In the following tables, features are marked with the following statuses:
 
 |Multi-network policies for SR-IOV networks
 |Technology Preview
-|Technology Preview
-|Technology Preview
+|General Availability
+|General Availability
 
 |OVN-Kubernetes network plugin as secondary network
 |General Availability


### PR DESCRIPTION
[OCPBUGS-35498]: move Multi-network policy support stated as Tech Preview to GA

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue::https://issues.redhat.com/browse/OCPBUGS-35498
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://77642--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
