### PR TITLE
TELCODOCS-1747: updating variable for 2.11 RHACM release

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -46,7 +46,7 @@ endif::[]
 :rh-storage: OpenShift Data Foundation
 :rh-rhacm-first: Red Hat Advanced Cluster Management (RHACM)
 :rh-rhacm: RHACM
-:rh-rhacm-version: 2.10
+:rh-rhacm-version: 2.11
 :sandboxed-containers-first: OpenShift sandboxed containers
 :sandboxed-containers-operator: OpenShift sandboxed containers Operator
 :sandboxed-containers-version: 1.5


### PR DESCRIPTION
[TELCODOCS-1747](https://issues.redhat.com//browse/TELCODOCS-1747): updating variable for [4.11](https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.11) RHACM release

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1747

Updating variable only, no QE required.