### PR TITLE
OSDOCS-10955-RN Adding warning about lack of CAPI testing with secret regions

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -70,9 +70,14 @@ With this release, you can now install {op-system} to iSCSI boot devices. Multip
 
 [id="ocp-4-16-installation-and-update-aws-capi_{context}"]
 ==== Cluster API replaces Terraform for AWS installations
-In {product-title} {product-version}, the installation program uses Cluster API instead of Terraform to provision cluster infrastructure during installations on AWS. There are several additional required permissions as a result of this change. For more information, see xref:../installing/installing_aws/installing-aws-account.adoc#installation-aws-permissions_installing-aws-account[Required AWS permissions for the IAM user].
+In {product-title} {product-version}, the installation program uses Cluster API (CAPI) instead of Terraform to provision cluster infrastructure during installations on AWS. There are several additional required permissions as a result of this change. For more information, see xref:../installing/installing_aws/installing-aws-account.adoc#installation-aws-permissions_installing-aws-account[Required AWS permissions for the IAM user].
 
 Additionally, SSH access to control plane and compute machines is no longer open to the machine network, but is restricted to the security groups associated with the control plane and compute plane machines.
+
+[WARNING]
+====
+Installing a cluster on AWS into a secret or top-secret region has not been tested with CAPI as of the release of {product-title} {product-version}. This document will be updated when installation into a secret region has been tested. There is a known issue with Network Load Balancers' support for security groups in secret or top secret regions that causes installations to fail. For more information, see link:https://issues.redhat.com/browse/OCPBUGS-33311[*OCPBUGS-33311*].
+====
 
 [id="ocp-4-16-installation-and-update-optional-ccm_{context}"]
 ==== Optional cloud controller manager cluster capability
@@ -1966,6 +1971,8 @@ In the following tables, features are marked with the following statuses:
 * The `oc annotate` command does not work for LDAP group names that contain an equal sign (`=`), because the command uses the equal sign as a delimiter between the annotation name and value. As a workaround, use `oc patch` or `oc edit` to add the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917280[*BZ#1917280*])
 
 * {run-once-operator} (RODOO) cannot be installed on clusters managed by the Hypershift Operator. (link:https://issues.redhat.com/browse/OCPBUGS-17533[*OCPBUGS-17533*])
+
+* {product-title} {product-version} installation on {aws-short} in a secret or top secret region fails due to an issue with Network Load Balancers (NLBs) and security groups in these regions. (link:https://issues.redhat.com/browse/OCPBUGS-33311[*OCPBUGS-33311*])
 
 * When you run Cloud-native Network Functions (CNF) latency tests on an {product-title} cluster, the `oslat` test can sometimes return results greater than 20 microseconds. This results in an `oslat` test failure.
 (link:https://issues.redhat.com/browse/RHEL-9279[*RHEL-9279*])


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-10955

Link to docs preview:
https://77665--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-installation-and-update-aws-capi_release-notes

QE review:
- [x] QE has approved this change.
