### PR TITLE
OSDOCS#10956: Removing note about being unsupported in Hypershift

### DIFF
--- a/modules/secrets-store-aws.adoc
+++ b/modules/secrets-store-aws.adoc
@@ -17,11 +17,6 @@ endif::[]
 
 You can use the {secrets-store-operator} to mount secrets from {secrets-store-provider} to a CSI volume in {product-title}. To mount secrets from {secrets-store-provider}, your cluster must be installed on AWS and use AWS Security Token Service (STS).
 
-[IMPORTANT]
-====
-It is not supported to use the {secrets-store-operator} with {secrets-store-provider} in a hosted control plane cluster.
-====
-
 .Prerequisites
 
 * Your cluster is installed on AWS and uses AWS Security Token Service (STS).


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-10956

Link to docs preview:

* https://77666--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets-store.html#secrets-store-aws_nodes-pods-secrets-store
* https://77666--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets-store.html#secrets-store-aws_nodes-pods-secrets-store-parameter-store

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
