### PR TITLE
OSDOCS-10955 Adding warning for AWS CAPI secret regions

### DIFF
--- a/installing/installing_aws/ipi/installing-aws-secret-region.adoc
+++ b/installing/installing_aws/ipi/installing-aws-secret-region.adoc
@@ -13,6 +13,13 @@ In {product-title} version {product-version}, you can install a cluster on Amazo
 
 To configure a cluster in either region, you change parameters in the `install config.yaml` file before you install the cluster.
 
+[WARNING]
+====
+In {product-title} {product-version}, the installation program uses Cluster API (CAPI) instead of Terraform to provision cluster infrastructure during installations on AWS. Installing a cluster on AWS into a secret or top-secret region has not been tested with CAPI as of the release of {product-title} {product-version}. This document will be updated when installation into a secret region has been tested.
+
+There is a known issue with Network Load Balancers' support for security groups in secret or top secret regions that causes installations in these regions to fail. For more information, see link:https://issues.redhat.com/browse/OCPBUGS-33311[OCPBUGS-33311].
+====
+
 [id="prerequisites_installing-aws-secret-region"]
 == Prerequisites
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-10955

Link to docs preview:
https://77667--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-secret-region.html

QE review:
- [x] QE has approved this change.
