### PR TITLE
OSDOCS-10958: removing 60 day update requirement from EUS doc

### DIFF
--- a/updating/updating_a_cluster/eus-eus-update.adoc
+++ b/updating/updating_a_cluster/eus-eus-update.adoc
@@ -26,7 +26,6 @@ There are a number of caveats to consider when attempting an EUS-to-EUS update.
 * EUS-to-EUS updates are only offered after updates between all versions involved have been made available in `stable` channels.
 * If you encounter issues during or after updating to the odd-numbered minor version but before updating to the next even-numbered version, then remediation of those issues may require that non-control plane hosts complete the update to the odd-numbered version before moving forward.
 * You can do a partial update by updating the worker or custom pool nodes to accommodate the time it takes for maintenance.
-* You can complete the update process during multiple maintenance windows by pausing at intermediate steps. However, plan to complete the entire update within 60 days. This is critical to ensure that normal cluster automation processes are completed.
 
 * Until the machine config pools are unpaused and the update is complete, some features and bugs fixes in <4.y+1> and <4.y+2> of {product-title} are not available.
 


### PR DESCRIPTION
[OSDOCS-10958](https://issues.redhat.com/browse/OSDOCS-10958)

Versions: 4.16+

Context given to me from PM for removing the 60 day EUS update requirement:

> 60d Context: Certificates rotate at 80% of 365d which is 72d, 60d is a nice round number that's < 72d and provides some buffer if something goes wrong and they need to talk to support before their cluster blows up.
4.14 and later we can assume that certificate rotation happens out of band from MachineConfig updates which is where the previous constraint came from.

QE review:
- [x] QE has approved this change.

Preview: 