### PR TITLE
OSDOCS-10097: MCO release note updated boot images

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -399,6 +399,11 @@ By default, when you make certain changes to the parameters in a `MachineConfig`
 
 With {op-system-first} image layering, you can now automatically build the custom layered image directly in your cluster, as a Technology Preview feature. Previously, you needed to build the custom layered image outside of the cluster, then pull the image into the cluster. The image layering feature allows you to extend the functionality of your base {op-system} image by layering additional images onto the base image. For more information, see xref:../post_installation_configuration/coreos-layering.adoc#coreos-layering[RHCOS image layering].
 
+[id="ocp-4-16-machine-config-operator-boot-image_{context}"]
+==== Updating boot images
+
+By default, the MCO does not delete the boot image it uses to bring up a {op-system-first} node. This means that the boot image in your cluster is not updated along with your cluster. You can now configure your cluster to update the boot image whenever you update your cluster. For more information, see xref:../post_installation_configuration/machine-configuration-tasks.adoc#mco-update-boot-images_post-install-machine-configuration-tasks[Updating boot images].
+
 [id="ocp-4-16-machine-management_{context}"]
 === Machine management
 


### PR DESCRIPTION
Version 4.16+

Issue
Release note for [Updated boot images: Phase 1](https://issues.redhat.com/browse/OSDOCS-10097) 

Preview:
[Updating boot images](https://77686--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-machine-config-operator-boot-image_release-notes)

QE review:
N/A, release note