### PR TITLE
OSDOCS-9895 updating AWS AMI list

### DIFF
--- a/modules/installation-aws-user-infra-rhcos-ami.adoc
+++ b/modules/installation-aws-user-infra-rhcos-ami.adoc
@@ -23,94 +23,97 @@ ifndef::openshift-origin[]
 |AWS AMI
 
 |`af-south-1`
-|`ami-0493ec0f0a451f83b`
+|`ami-018de6b1be470b7e6`
 
 |`ap-east-1`
-|`ami-050a6d164705e7f62`
+|`ami-092f09a4c8aacf56a`
 
 |`ap-northeast-1`
-|`ami-00910c337e0f52cff`
+|`ami-001c9fc85b77505f4`
 
 |`ap-northeast-2`
-|`ami-07e98d33de2b93ac0`
+|`ami-0a5d7f1966d88fba3`
 
 |`ap-northeast-3`
-|`ami-09bc0a599f4b3c483`
+|`ami-085a2726ceb4f5eeb`
 
 |`ap-south-1`
-|`ami-0ba603a7f9d41228e`
+|`ami-03f2c19071fb6eab3`
 
 |`ap-south-2`
-|`ami-03130aecb5d7459cc`
+|`ami-0c82522890979d94b`
 
 |`ap-southeast-1`
-|`ami-026c056e0a25e5a04`
+|`ami-06e5b9d16ead6c55c`
 
 |`ap-southeast-2`
-|`ami-0d471f504ff6d9a0f`
+|`ami-0ccd429129fbf6bc0`
 
 |`ap-southeast-3`
-|`ami-0c1b9a0721cbb3291`
+|`ami-096f9b4d41116d95c`
 
 |`ap-southeast-4`
-|`ami-0ef23bfe787efe11e`
+|`ami-0b511ab55f9f7d052`
 
 |`ca-central-1`
-|`ami-0163965a05b75f976`
+|`ami-0e357287c651be1f2`
+
+|`ca-west-1`
+|`ami-0b1692e5776740901`
 
 |`eu-central-1`
-|`ami-01edb54011f870f0c`
+|`ami-08b13fb388ba5610d`
 
 |`eu-central-2`
-|`ami-0bc500d6056a3b104`
+|`ami-04777298b55045ea9`
 
 |`eu-north-1`
-|`ami-0ab155e935177f16a`
+|`ami-05421993a4ee567b9`
 
 |`eu-south-1`
-|`ami-051b4c06b21f5a328`
+|`ami-00959341869d34746`
 
 |`eu-south-2`
-|`ami-096644e5555c23b19`
+|`ami-0a745b610522a87cc`
 
 |`eu-west-1`
-|`ami-0faeeeb3d2b1aa07c`
+|`ami-0e48f85ec57bd7baa`
 
 |`eu-west-2`
-|`ami-00bb1522dc71b604f`
+|`ami-0c015b1387acddc5e`
 
 |`eu-west-3`
-|`ami-01e5397bd2b795bd3`
+|`ami-01e466af77a95b93d`
 
 |`il-central-1`
-|`ami-0b32feb5d77c64e61`
+|`ami-0a1b706793b54d087`
 
 |`me-central-1`
-|`ami-0a5158a3e68ab7e88`
+|`ami-09d58e8b2099ae5bc`
 
 |`me-south-1`
-|`ami-024864ad1b799dbba`
+|`ami-0f9c259bc4346599c`
 
 |`sa-east-1`
-|`ami-0c402ffb0c4b7edc0`
+|`ami-06277517d966881a3`
 
 |`us-east-1`
-|`ami-057df4d0cb8cbae0d`
+|`ami-05483066c3caaccf5`
 
 |`us-east-2`
-|`ami-07566e5da1fd297f8`
+|`ami-0c704ce516493a479`
 
 |`us-gov-east-1`
-|`ami-0fe03a7e289354670`
+|`ami-0695b2cbdd1ec4d48`
 
 |`us-gov-west-1`
-|`ami-06b7cc6445c5da732`
+|`ami-004404a0eaa427b39`
 
 |`us-west-1`
-|`ami-02d20001c5b9df1e9`
+|`ami-0aaa56637063be772`
 
 |`us-west-2`
-|`ami-0dfba457127fba98c`
+|`ami-0870c7a3d5ef4d2b3`
 
 |===
 
@@ -123,94 +126,97 @@ ifndef::openshift-origin[]
 |AWS AMI
 
 |`af-south-1`
-|`ami-06c7b4e42179544df`
+|`ami-0d96d447d3df14f4e`
 
 |`ap-east-1`
-|`ami-07b6a37fa6d2d2e99`
+|`ami-010236402dfba1717`
 
 |`ap-northeast-1`
-|`ami-056d2eef4a3638246`
+|`ami-08feeb6d9068bb12e`
 
 |`ap-northeast-2`
-|`ami-0bd5a7684f0ff4e02`
+|`ami-0772082c119147205`
 
 |`ap-northeast-3`
-|`ami-0fd08063da50de1da`
+|`ami-05bcbb13493d0516f`
 
 |`ap-south-1`
-|`ami-08f1ae2cef8f9690e`
+|`ami-0034a539e8adcb817`
 
 |`ap-south-2`
-|`ami-020ba25cc1ec53b1c`
+|`ami-0fc56b7c53c38ff70`
 
 |`ap-southeast-1`
-|`ami-0020a1c0964ac8e48`
+|`ami-0b50a0e92a58f3ad8`
 
 |`ap-southeast-2`
-|`ami-07013a63289350c3c`
+|`ami-0697a9174ae206182`
 
 |`ap-southeast-3`
-|`ami-041d6ca1d57e3190f`
+|`ami-05ae309319a7ad504`
 
 |`ap-southeast-4`
-|`ami-06539e9cbefc28702`
+|`ami-00500414843baa657`
 
 |`ca-central-1`
-|`ami-0bb3991641f2b40f6`
+|`ami-05e76bf99d3b0d4c8`
+
+|`ca-west-1`
+|`ami-099fc953c221ec590`
 
 |`eu-central-1`
-|`ami-0908d117c26059e39`
+|`ami-0d2e2698884020b71`
 
 |`eu-central-2`
-|`ami-0e48c82ffbde67ed2`
+|`ami-0a96ba21ddee01719`
 
 |`eu-north-1`
-|`ami-016614599b38d515e`
+|`ami-0ab8a1070d0b1d9a5`
 
 |`eu-south-1`
-|`ami-01b6cc1f0fd7b431f`
+|`ami-0d0465299a8b196c1`
 
 |`eu-south-2`
-|`ami-0687e1d98e55e402d`
+|`ami-07d5aa3c6d468c738`
 
 |`eu-west-1`
-|`ami-0bf0b7b1cb052d68d`
+|`ami-08e7d209f26c09c80`
 
 |`eu-west-2`
-|`ami-0ba0bf567caa63731`
+|`ami-0c8336d4e2c1f13cb`
 
 |`eu-west-3`
-|`ami-0eab6a7956a66deda`
+|`ami-085d804b98acf0648`
 
 |`il-central-1`
-|`ami-03b3cb1f4869bf21d`
+|`ami-02ce030e36aeb7643`
 
 |`me-central-1`
-|`ami-0a6e1ade3c9e206a1`
+|`ami-0dea3ac466040b77f`
 
 |`me-south-1`
-|`ami-0aa0775c68eac9f6f`
+|`ami-02ef2a46887b9786d`
 
 |`sa-east-1`
-|`ami-07235eee0bb930c78`
+|`ami-0d19817d31b2399f9`
 
 |`us-east-1`
-|`ami-005808ca73e7b36ff`
+|`ami-04859c888566a2c2f`
 
 |`us-east-2`
-|`ami-0c5c9420f6b992e9e`
+|`ami-02f7e4a5dc66361bb`
 
 |`us-gov-east-1`
-|`ami-08c9b2b8d578caf92`
+|`ami-067ef782980ea96ad`
 
 |`us-gov-west-1`
-|`ami-0bdff65422ba7d95d`
+|`ami-0ce67540c1bb2319d`
 
 |`us-west-1`
-|`ami-017ad4dd030a04233`
+|`ami-0a09c5d2f287718a3`
 
 |`us-west-2`
-|`ami-068d0af5e3c08e618`
+|`ami-06b94e64e595f6cee`
 
 |===
 endif::openshift-origin[]


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-9895

Link to docs preview:
https://77689--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-aws-user-infra-rhcos-ami_installing-aws-user-infra

QE review:
- [x] QE has approved this change.

Updating AMI list and adding ca-west-1 region