### PR TITLE
CNV#42655: Adding redirect rule for CNV asynchronous release

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -502,15 +502,15 @@ AddType text/vtt                            vtt
     RewriteRule ^container-platform/(4\.4|4\.5)/authentication/(allowing-javascript-access-api-server|encrypting-etcd|certificate-types-descriptions)\.html$ /container-platform/$1/security/$2\.html [NE,R=301]
 
 
-    # The following rule prevents an infinite redirect loop when browsing to /container-platform/4.15/virt/about_virt/about-virt.html
-    # RewriteRule ^container-platform/4\.15/virt/about_virt/about-virt.html$ - [L]
+    # The following rule prevents an infinite redirect loop when browsing to /container-platform/4.16/virt/about_virt/about-virt.html
+    RewriteRule ^container-platform/4\.16/virt/about_virt/about-virt.html$ - [L]
 
     # OpenShift Virtualization (CNV) catchall redirect; use when CNV releases asynchronously from OCP. Do not change the 302 to a 301.
     # When uncommented, this redirects all `virt` directory traffic to the about-virt page.
     # Pay mind to the redirect directly above this which prevents redirect loops.
     # To activate the redirects, uncomment the next and previous lines and update the version number to the pending release.
 
-    # RewriteRule container-platform/4\.15/virt/(?!about-virt\.html)(.+)$ /container-platform/4.15/virt/about_virt/about-virt.html [NE,R=302]
+    RewriteRule container-platform/4\.16/virt/(?!about-virt\.html)(.+)$ /container-platform/4.16/virt/about_virt/about-virt.html [NE,R=302]
 
 
     # Red Hat OpenShift support for Windows Containers (WMCO) catchall redirect; use when WMCO releases asynchronously from OCP. Do not change the 302 to a 301.

--- a/.s2i/httpd-cfg/01-community.conf
+++ b/.s2i/httpd-cfg/01-community.conf
@@ -159,14 +159,14 @@ AddType text/vtt                            vtt
     RewriteRule ^latest/install_config/upgrades\.html(.*)$ /latest/install_config/upgrading/index.html$1 [NE,R=301]
     RewriteRule ^latest/install_config/upgrading/(.*)$ /latest/upgrading/$1 [NE,R=301]
 
-    # The following rule prevents an infinite redirect loop when browsing to /(latest|4\.15)/virt/about_virt/about-virt.html
-    # RewriteRule ^(latest|4\.15)/virt/about_virt/about-virt.html$ - [L]
+    # The following rule prevents an infinite redirect loop when browsing to /(latest|4\.16)/virt/about_virt/about-virt.html
+    RewriteRule ^(latest|4\.16)/virt/about_virt/about-virt.html$ - [L]
 
     # OpenShift Virtualization (CNV) catchall redirect; use when CNV releases asynchronously from OCP. Do not change the 302 to a 301.
     # When uncommented, this redirects all `virt` directory traffic to the about-virt page.
     # Pay mind to the redirect directly above this which prevents redirect loops.
     # To activate the redirects, uncomment the next and previous lines and update the version number to the pending release.
-    # RewriteRule ^(latest|4\.15)/virt/(?!about-virt\.html)(.+)$ /$1/virt/about_virt/about-virt.html [NE,R=302]
+    RewriteRule ^(latest|4\.16)/virt/(?!about-virt\.html)(.+)$ /$1/virt/about_virt/about-virt.html [NE,R=302]
 
     # Red Hat OpenShift support for Windows Containers (WMCO) catchall redirect; use when WMCO releases asynchronously from OCP. Do not change the 302 to a 301.
     # When uncommented, this redirects all `windows_containers` directory traffic to the /windows_containers/index.html page.


### PR DESCRIPTION
Version(s):
No CP

Issue:
https://issues.redhat.com/browse/CNV-42655

Link to docs preview:
N/A

QE review:
N/A

Additional information:
* Activated rule to redirect all /virt/* content to the about-virt.adoc assembly to support asynchronous release from OCP
* To be reversed when CNV 4.16 GAs (after merging placeholder reversal)
* No CP

