### PR TITLE
Move Specialized Hardware and Driver content from dep/rem table to tech preview table

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -806,26 +806,6 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.14 |4.15 |4.16
 
-|Driver Toolkit
-|General Availability
-|General Availability
-|General Availability
-
-|Kernel Module Management Operator
-|General Availability
-|General Availability
-|General Availability
-
-|Kernel Module Management Operator - Hub and spoke cluster support
-|General Availability
-|General Availability
-|General Availability
-
-|Node Feature Discovery
-|General Availability
-|General Availability
-|General Availability
-
 |====
 
 [discrete]
@@ -1516,7 +1496,27 @@ In the following tables, features are marked with the following statuses:
 .Specialized hardware and driver enablement Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.14 |4.15 |4.1
+|Feature |4.14 |4.15 |4.16
+
+|Driver Toolkit
+|General Availability
+|General Availability
+|General Availability
+
+|Kernel Module Management Operator
+|General Availability
+|General Availability
+|General Availability
+
+|Kernel Module Management Operator - Hub and spoke cluster support
+|General Availability
+|General Availability
+|General Availability
+
+|Node Feature Discovery
+|General Availability
+|General Availability
+|General Availability
 
 |====
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: This content got put in the dep/rem table when it belongs in the tech preview table (feature table). There were no dep/rem items for Specialized Hardware and Driver enablement
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://77693--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: No qe is required for this PR, it simply moves content from a less appropriate place to a more appropriate place.
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Original [PR 77405 ](https://github.com/openshift/openshift-docs/pull/77405)was merged and is complete, with all peer, merge and qe review done.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
