### PR TITLE
[OSDOCS-10961] Using Red Hat subscriptions in builds is missing a module

### DIFF
--- a/cicd/builds/running-entitled-builds.adoc
+++ b/cicd/builds/running-entitled-builds.adoc
@@ -11,9 +11,7 @@ Use the following sections to install Red Hat subscription content within {produ
 
 include::modules/builds-create-imagestreamtag.adoc[leveloffset=+1]
 
-ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/builds-source-secrets-entitlements.adoc[leveloffset=+1]
-endif::openshift-dedicated,openshift-rosa[]
 
 == Running builds with Subscription Manager
 

--- a/modules/builds-source-secrets-entitlements.adoc
+++ b/modules/builds-source-secrets-entitlements.adoc
@@ -10,7 +10,9 @@ Builds that use Red Hat subscriptions to install content must include the entitl
 
 .Prerequisites
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * You must have access to {op-system-base-full} package repositories through your subscription. The entitlement secret to access these repositories is automatically created by the Insights Operator when your cluster is subscribed.
+endif::openshift-dedicated,openshift-rosa[]
 
 * You must have access to the cluster as a user with the `cluster-admin` role or you have permission to access secrets in the `openshift-config-managed` project.
 


### PR DESCRIPTION
Version(s): `enterprise-4.15`+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-10961
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
_Primary changes:_
https://77696--ocpdocs-pr.netlify.app/openshift-dedicated/latest/cicd/builds/running-entitled-builds.html
https://77696--ocpdocs-pr.netlify.app/openshift-rosa/latest/cicd/builds/running-entitled-builds.html
_Secondary changes:_
https://77696--ocpdocs-pr.netlify.app/openshift-enterprise/latest/cicd/builds/running-entitled-builds.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: not required
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This enables the missing module and adds a conditional to remove unnecessary subscription information as all ROSA/OSD customers receive RHEL package entitlements as a part of the service offering. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
