### PR TITLE
OCPBUGS#35807: Doc improvements in "Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator" chapter

### DIFF
--- a/modules/multi-arch-creating-podplacment-config-using-cli.adoc
+++ b/modules/multi-arch-creating-podplacment-config-using-cli.adoc
@@ -6,7 +6,7 @@
 [id="multi-architecture-creating-podplacement-config-using-cli_{context}"]
 = Creating the ClusterPodPlacementConfig object by using the CLI
 
-You can create the `ClusterPodPlacementConfig` object by using the {oc-first}.
+To deploy the pod placement operand that enables architecture-aware workload scheduling, you can create the `ClusterPodPlacementConfig` object by using the {oc-first}.
 
 .Prerequisites
 

--- a/modules/multi-arch-creating-podplacment-config-using-web-console.adoc
+++ b/modules/multi-arch-creating-podplacment-config-using-web-console.adoc
@@ -7,7 +7,7 @@
 
 = Creating the ClusterPodPlacementConfig object by using the web console
 
-You can create the `ClusterPodPlacementConfig` object by using the {product-title} web console.
+To deploy the pod placement operand that enables architecture-aware workload scheduling, you can create the `ClusterPodPlacementConfig` object by using the {product-title} web console.
 
 .Prerequisites
 
@@ -19,7 +19,7 @@ You can create the `ClusterPodPlacementConfig` object by using the {product-titl
 
 . Log in to the {product-title} web console.
 
-. Click *Operators* → *Installed Operators*.
+. Navigate to *Operators* → *Installed Operators*.
 
 . On the *Installed Operators* page, click *Multiarch Tuning Operator*. 
 

--- a/modules/multi-arch-creating-podplacment-config.adoc
+++ b/modules/multi-arch-creating-podplacment-config.adoc
@@ -6,14 +6,12 @@
 [id="multi-architecture-creating-podplacement-config_{context}"]
 = Creating the ClusterPodPlacementConfig object
 
-After installing the Multiarch Tuning Operator, you must create the `ClusterPodPlacementConfig` object.
+After installing the Multiarch Tuning Operator, you must create the `ClusterPodPlacementConfig` object. When you create this object, the Multiarch Tuning Operator deploys an operand that enables architecture-aware workload scheduling.
 
 [NOTE]
 ====
-You can create only a single instance of the `ClusterPodPlacementConfig` object.
-====
-
-The `ClusterPodPlacementConfig` object is used to enable or disable the pod placement operand of the Multiarch Tuning Operator. 
+You can create only one instance of the `ClusterPodPlacementConfig` object.
+==== 
 
 .Example `ClusterPodPlacementConfig` object configuration
 [source,yaml]

--- a/modules/multi-arch-deleting-podplacment-config-using-cli.adoc
+++ b/modules/multi-arch-deleting-podplacment-config-using-cli.adoc
@@ -6,7 +6,9 @@
 [id="multi-architecture-deleting-podplacement-config-using-cli_{context}"]
 = Deleting the ClusterPodPlacementConfig object by using the CLI
 
-You can delete the `ClusterPodPlacementConfig` object by using the {oc-first}.
+You can create only one instance of the `ClusterPodPlacementConfig` object. If you want to re-create this object, you must first delete the existing instance.
+
+You can delete this object by using the {oc-first}.
 
 .Prerequisites
 

--- a/modules/multi-arch-deleting-podplacment-config-using-web-console.adoc
+++ b/modules/multi-arch-deleting-podplacment-config-using-web-console.adoc
@@ -7,7 +7,9 @@
 
 = Deleting the ClusterPodPlacementConfig object by using the web console
 
-You can delete the `ClusterPodPlacementConfig` object by using the {product-title} web console.
+You can create only one instance of the `ClusterPodPlacementConfig` object. If you want to re-create this object, you must first delete the existing instance.
+
+You can delete this object by using the {product-title} web console.
 
 .Prerequisites
 
@@ -19,7 +21,7 @@ You can delete the `ClusterPodPlacementConfig` object by using the {product-titl
 
 . Log in to the {product-title} web console.
 
-. Click *Operators* → *Installed Operators*.
+. Navigate to *Operators* → *Installed Operators*.
 
 . On the *Installed Operators* page, click *Multiarch Tuning Operator*. 
 

--- a/modules/multi-arch-deleting-podplacment-config.adoc
+++ b/modules/multi-arch-deleting-podplacment-config.adoc
@@ -1,9 +1,0 @@
-//Module included in the following assemblies
-//
-//post_installation_configuration/multiarch-tuning-operator.adoc
-
-:_mod-docs-content-type: CONCEPT
-[id="multi-architecture-deleting-podplacement-config_{context}"]
-= Deleting the ClusterPodPlacementConfig object
-
-You can delete the `ClusterPodPlacementConfig` object by using the {product-title} CLI or the {product-title} web console.

--- a/modules/multi-arch-installing-using-cli.adoc
+++ b/modules/multi-arch-installing-using-cli.adoc
@@ -94,6 +94,8 @@ $ oc get csv -n openshift-multiarch-tuning-operator
 NAME                               DISPLAY                     VERSION   REPLACES   PHASE
 multiarch-tuning-operator.v0.9.0   Multiarch Tuning Operator   0.9.0                Succeeded
 ----
++
+The installation is successful if the Operator is in `Succeeded` phase.
 
 . Optional: To verify that the `OperatorGroup` object is created, run the following command:
 +

--- a/modules/multi-arch-installing-using-web-console.adoc
+++ b/modules/multi-arch-installing-using-web-console.adoc
@@ -17,28 +17,26 @@ You can install the Multiarch Tuning Operator by using the {product-title} web c
 .Procedure
 
 . Log in to the {product-title} web console.
-. Click *Operators -> OperatorHub*.
+. Navigate to *Operators -> OperatorHub*.
 . Enter *Multiarch Tuning Operator* in the search field.
 . Click *Multiarch Tuning Operator*.
 . Select the *Multiarch Tuning Operator* version from the *Version* list.
 . Click *Install*
 . Set the following options on the *Operator Installation* page:
-.. *Update Channel* as *tech-preview*.
-.. *Installation Mode* as *All namespaces on the cluster*.
-.. *Installed Namespace* as *Operator recommended Namespace* or *Select a Namespace*.
+.. Set *Update Channel* to *tech-preview*.
+.. Set *Installation Mode* to *All namespaces on the cluster*.
+.. Set *Installed Namespace* to *Operator recommended Namespace* or *Select a Namespace*.
 +
 The recommended Operator namespace is `openshift-multiarch-tuning-operator`. If the `openshift-multiarch-tuning-operator` namespace does not exist, it is created during the operator installation.
 +
 If you select *Select a namespace*, you must select a namespace for the Operator from the *Select Project* list.
 .. *Update approval* as *Automatic* or *Manual*.
 +
-[NOTE]
-====
 If you select *Automatic* updates, Operator Lifecycle Manager (OLM) automatically updates the running instance of the Multiarch Tuning Operator without any intervention.
-
++
 If you select *Manual* updates, OLM creates an update request.
 As a cluster administrator, you must manually approve the update request to update the Multiarch Tuning Operator to a newer version.
-====
+
 . Optional: Select the *Enable Operator recommended cluster monitoring on this Namespace* checkbox.
 . Click *Install*.
 

--- a/modules/multi-arch-uninstalling-using-cli.adoc
+++ b/modules/multi-arch-uninstalling-using-cli.adoc
@@ -4,8 +4,8 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="multi-architecture-uninstalling-using-cli_{context}"]
-
 = Uninstalling the Multiarch Tuning Operator by using the CLI
+
 You can uninstall the Multiarch Tuning Operator by using the {oc-first}.
 
 .Prerequisites

--- a/modules/multi-arch-uninstalling-using-web-console.adoc
+++ b/modules/multi-arch-uninstalling-using-web-console.adoc
@@ -21,7 +21,7 @@ You must delete the `ClusterPodPlacementConfig` object before uninstalling the M
 .Procedure
 
 . Log in to the {product-title} web console.
-. Click *Operators -> OperatorHub*.
+. Navigate to *Operators -> OperatorHub*.
 . Enter *Multiarch Tuning Operator* in the search field.
 . Click *Multiarch Tuning Operator*.
 . Click the *Details* tab. 

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc
@@ -12,21 +12,20 @@ The Multiarch Tuning Operator is a Technology Preview feature only. Technology P
 For more information about the support scope of Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 ====
 
-The Multiarch Tuning Operator enhances the operational experience within multi-architecture clusters, and single-architecture clusters that are migrating to a multi-architecture compute configuration. 
+The Multiarch Tuning Operator enhances the operational experience within multi-architecture clusters, and single-architecture clusters that are migrating to a multi-architecture compute configuration.
 
-This Operator implements the `ClusterPodPlacementConfig` object to support architecture-aware workload scheduling.
+This Operator implements the `clusterpodplacementconfigs` custom resource (CR) to support architecture-aware workload scheduling.
 
-When you create the `ClusterPodPlacementConfig` object, the Multiarch Tuning Operator deploys an operand. This operand automates the configuration of scheduling predicates for the workloads based on their supported architectures. It uses the `kubernetes.io/arch` label set by the kubelet in the node objects.
+To enable architecture-aware workload scheduling, you must create the `ClusterPodPlacementConfig` object. When you create the `ClusterPodPlacementConfig` object, this Operator deploys an operand.
 
-When a pod is created, the operand configures the `nodeAffinity` field in the pod specification by computing the subset of architectures that the pod can support.
+When a pod is created, the operand performs the following actions: 
 
-Before a pod enters the scheduling cycle, the operand adds the `multiarch.openshift.io/scheduling-gate` scheduling gate that prevents the scheduling of the pod until the operand completes the following actions:
+. Add the `multiarch.openshift.io/scheduling-gate` scheduling gate that prevents the scheduling of the pod.
+. Compute a scheduling predicate that includes the supported architecture values for the `kubernetes.io/arch` label. 
+. Integrate the scheduling predicate as a `nodeAffinity` requirement in the pod specification.
+. Remove the scheduling gate from the pod.
 
-. Compute a predicate for the `kubernetes.io/arch` label. 
-. Integrate the predicate as a `nodeAffinity` requirement in the pod specification.
-. Remove the scheduling gate.
-
-These operand actions restrict the scheduling of workloads to those nodes that have the supported architectures.
+When the operand removes the scheduling gate, the pod enters the scheduling cycle. The workload is then scheduled on nodes based on the supported architectures.
 
 [IMPORTANT]
 ====
@@ -51,11 +50,10 @@ include::modules/multi-arch-creating-podplacment-config-using-cli.adoc[leveloffs
 include::modules/multi-arch-creating-podplacment-config-using-web-console.adoc[leveloffset=+2]
 
 //Deleting the pod placement config object
-include::modules/multi-arch-deleting-podplacment-config.adoc[leveloffset=+1]
 
-include::modules/multi-arch-deleting-podplacment-config-using-cli.adoc[leveloffset=+2]
+include::modules/multi-arch-deleting-podplacment-config-using-cli.adoc[leveloffset=+1]
 
-include::modules/multi-arch-deleting-podplacment-config-using-web-console.adoc[leveloffset=+2]
+include::modules/multi-arch-deleting-podplacment-config-using-web-console.adoc[leveloffset=+1]
 
 //Uninstalling Multiarch Tuning Operator
 include::modules/multi-arch-uninstalling-using-cli.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OCPBUGS-35807](https://issues.redhat.com/browse/OCPBUGS-35807)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator](https://77701--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->