### PR TITLE
OSDOCS-9882-manage-console: Bug batched the 4.16 management console bugs

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -291,7 +291,7 @@ With this release, OVN-Kubernetes uses a new `DNSNameResolver` custom resource t
 [id="ocp-4-16-networking-sriov-draining_{context}"]
 ==== Parallel node draining during SR-IOV network policy updates
 
-With this update, you can configure the SR-IOV Network Operator to drain nodes in parallel during network policy updates. The option to drain nodes in parallel enables faster rollouts of SR-IOV network configurations. You can use the `SriovNetworkPoolConfig` custom resource to configure parallel node draining and define the maximum number of nodes in the pool that the Operator can drain in parallel.
+With this release, you can configure the SR-IOV Network Operator to drain nodes in parallel during network policy updates. The option to drain nodes in parallel enables faster rollouts of SR-IOV network configurations. You can use the `SriovNetworkPoolConfig` custom resource to configure parallel node draining and define the maximum number of nodes in the pool that the Operator can drain in parallel.
 
 For further information, see xref:../networking/hardware_networks/configuring-sriov-device.adoc#configure-sr-iov-operator-parallel-nodes_configuring-sriov-device[Configuring parallel node draining during SR-IOV network policy updates].
 
@@ -1489,6 +1489,84 @@ With this release, the CCO no longer checks for the nonexistent permission.
 [id="ocp-4-16-management-console-bug-fixes_{context}"]
 ==== Management Console
 
+* Previously, the *Debug container* link was not shown for pods with a `Completed` status. With this release, the link shows as expected. (link:https://issues.redhat.com/browse/OCPBUGS-34711[*OCPBUGS-34711*])
+
+* Previously, due to an issue in PatternFly 5, text boxes in the web console were no longer resizable. With this release, text boxes are again resizable. (link:https://issues.redhat.com/browse/OCPBUGS-34393[*OCPBUGS-34393*])
+
+* Previously, French and Spanish were not available in the web console. With this release, translations for French and Spanish are now available. (link:https://issues.redhat.com/browse/OCPBUGS-33965[*OCPBUGS-33965*])
+
+* Previously, the masthead logo was not restricted to a `max-height` of 60px. As a result, logos that are larger than 60px high display at their native size and cause the masthead size too to be too large. With this release, the masthead logo is restricted to a max-height of 60px. (link:https://issues.redhat.com/browse/OCPBUGS-33523[*OCPBUGS-33523*])
+
+* Previously, there was a missing return statement in the `HealthCheck` controller causing it to panic under certain circumstances. With this release, the proper return statement was added to the `HealthCheck` controller so it no longer panics. (link:https://issues.redhat.com/browse/OCPBUGS-33505[*OCPBUGS-33505*]
+
+* Previously, an incorrect field was sent to the API server that was not noticeable. With the implementation of Admission Webhook display warning the same action would return a warning notification. A fix was provided to resolve the issue. (link:https://issues.redhat.com/browse/OCPBUGS-33222[*OCPBUGS-33222*])
+
+* Previously, the message text of a `StatusItem` might have been vertically misaligned with the icon when a timestamp was not present. With this release, the message text is correctly aligned. (link:https://issues.redhat.com/browse/OCPBUGS-33219[*OCPBUGS-33219*])
+
+* Previously, the creator field was autopopulated and not mandatory. Updates to the API made the field empty from {product-title} 4.15 and higher. With this release, the field is marked as mandatory for correct validation. (link:https://issues.redhat.com/browse/OCPBUGS-31931[*OCPBUGS-31931*])
+
+* Previously, the YAML editor in the web console did not have the *Create* button and samples did not show on the web console. With this release, you can now see the *Create* button and the samples. (link:https://issues.redhat.com/browse/OCPBUGS-31703[*OCPBUGS-31703*])
+
+* Previously, changes to the bridge server flags on an external OpenID Connect (OIDC) feature caused the bridge server fail to start in local development. With this release, the flags usage are updated and the bridge server starts. (link:https://issues.redhat.com/browse/OCPBUGS-31695[*OCPBUGS-31695*])
+
+* Previously, when editing a {vmw-full} connection, the form could be submitted even if no values were actually changed. This resulted in unnecessary node reboots. With this release, the console now detects the form changes, and does not allow submission if no value was changed. (link:https://issues.redhat.com/browse/OCPBUGS-31613[*OCPBUGS-31613*])
+
+* Previously, the `NetworkAttachmentDefinition` was always created in the default namespace if the form method `from the console` was used. The selected name is also not honored, and creates the `NetworkAttachmentDefinition` object with the selected name and a random suffix. With this release, the `NetworkAttachmentDefinition` object is created in the current project. (link:https://issues.redhat.com/browse/OCPBUGS-31558[*OCPBUGS-31558*])
+
+* Previously, when clicking the *Configure* button by the `AlertmanagerRecieversNotConfigured` alert, the *Configuration* page did not show. With this release, the link in the `AlertmanagerRecieversNotConfigured` alert is fixed and directs you to the *Configuration* page. (link:https://issues.redhat.com/browse/OCPBUGS-30805[*OCPBUGS-30805*])
+
+* Previously, plugins using `ListPageFilters` were only using two filters: label and name. With this release, a parameter was added that enables plugins to configure multiple text-based search filters. (link:https://issues.redhat.com/browse/OCPBUGS-30077[*OCPBUGS-30077*])
+
+* Previously, there was no response when clicking on quick start items. With this release, the quick start window shows when clicking on the quick start selections. (link:https://issues.redhat.com/browse/OCPBUGS-29992[*OCPBUGS-29992*])
+
+* Previously, the {product-title} web console terminated unexpectedly if authentication discovery failed on the first attempt. With this release, authentication initialization was updated to retry up to 5 minutes before failing. (link:https://issues.redhat.com/browse/OCPBUGS-29479[*OCPBUGS-29479*])
+
+* Previously there was an issue causing an error message on the *Image Manifest Vulnerability* page after an Image Manifest Vulnerability (IMV) was created in the CLI. With this release, the error message no longer shows. (link:https://issues.redhat.com/browse/OCPBUGS-28967[*OCPBUGS-28967*])
+
+* Previously, when using the modal dialog in a hook as part of the actions hook, an error occured because the console framework passed null objects as part of the render cycle. With this release, `getGroupVersionKindForResource` is now null-safe and will return `undefined` if the `apiVersion` or `kind` are undefined. Additionally, the run time error for `useDeleteModal` no longer occurs, but note that it will not work with an `undefined` resource. (link:https://issues.redhat.com/browse/OCPBUGS-28856[*OCPBUGS-28856*])
+
+* Previously, the *Expand PersistentVolumeClaim* modal assumes the `pvc.spec.resources.requests.stroage` value includes a unit. With this release, the size is updated to 2GiB and you can change the value of the persistent volume claim (PVC). (link:https://issues.redhat.com/browse/OCPBUGS-27779[*OCPBUGS-27779*])
+
+* Previously, the value of image vulnerabilities reported in the {product-title} web console were inconsistent. With this release, the image vulnerabilities on the *Overview* page were removed. (link:https://issues.redhat.com/browse/OCPBUGS-27455[*OCPBUGS-27455*])
+
+* Previously, a certificate signing request (CSR) could show for a recently approved Node. With this release, the duplication is detected and does not show CSRs for approved Nodes. (link:https://issues.redhat.com/browse/OCPBUGS-27399[*OCPBUGS-27399*])
+
+* Previously, the *Type* column was not first on the condition table on the *MachineHealthCheck detail* page. With this release, the *Type* is now listed first on the condition table. (link:https://issues.redhat.com/browse/OCPBUGS-27246[*OCPBUGS-27246*])
+
+* Previously, the console plugin proxy was not copying the status code from plugin service responses. This caused all responses from the plugin service to have a `200` status, causing unexpected behavior, especially around browser caching. With this release, the console proxy logic was updated to forward the plugin service proxy response status code. Proxied plugin requests now behave as expected. (link:https://issues.redhat.com/browse/OCPBUGS-26933[*OCPBUGS-26933*])
+
+* Previously, when cloning a persistent volume claim (PVC), the modal assumes `pvc.spec.resources.requests.storage` value includes a unit. With this release, `pvc.spec.resources.requests.storage` includes a unit suffix and the *Clone PVC* modal works as expected. (link: https://issues.redhat.com/browse/OCPBUGS-26772[*OCPBUGS-26772*])
+
+* Previously, escaped strings were not handled properly when editing {vmw-full} connection, causing broken {vmw-full} configuration. With this release, the escape strings work as expected and the {vmw-full} configuration no longer breaks. (link:https://issues.redhat.com/browse/OCPBUGS-25942[*OCPBUGS-25942*])
+
+* Previously, when configuring a {vmw-full} connection,  the `resourcepool-path` key was not added to the {vmw-full} config map which might have caused issues connecting to {vmw-full}. With this release, there are no longer issues connecting to {vmw-full}. (link:https://issues.redhat.com/browse/OCPBUGS-25927[*OCPBUGS-25927*])
+
+* Previously, there was missing text in the *Customer feedback* modal. With this release, the link text is restored and the correct Red Hat image is displayed. (link:https://issues.redhat.com/browse/OCPBUGS-25843[*OCPBUGS-25843*])
+
+* Previously, the *Update cluster* modal would not open when clicking *Select a version* from the *Cluster Settings* page. With this release, the *Update cluster* modal shows when clicking *Select a version*. (link:https://issues.redhat.com/browse/OCPBUGS-25780[*OCPBUGS-25780*])
+
+* Previously, on a mobile device, the filter part in the resource section of the *Search* page did not work on a mobile device. With this release, filtering now works as expected ona mobile device. (link:https://issues.redhat.com/browse/OCPBUGS-25530[*OCPBUGS-25530*])
+
+* Previously, the console Operator was using a client instead of listeners for fetching a cluster resource. This caused the Operator to do operations on resources with an older revision. With this release, the console Operator uses list to fetch data from cluster instead of clients. (link:https://issues.redhat.com/browse/OCPBUGS-25484[*OCPBUGS-25484*])
+
+* Previously, the console was incorrectly parsing restore size values from volume snapshots in the restore as new persistent volume claims  (PVC) modal. With this release, the modal parses the restore size correctly. (link:https://issues.redhat.com/browse/OCPBUGS-24637[*OCPBUGS-24637*])
+
+* Previously, the *Alerting*, *Metrics*, and *Target* pages were not available in the console due to a change on the routing library. With this release, routes load correctly. (link:https://issues.redhat.com/browse/OCPBUGS-24515[*OCPBUGS-24515*])
+
+* Previously, there was a runtime error on the *Node details* page when a `MachineHealthCheck` without conditions existed. With this release, the *Node details* page loads as expected. (link:https://issues.redhat.com/browse/OCPBUGS-24408[*OCPBUGS-24408*])
+
+* Previously, the console backend would proxy operand list requests to the public API server endpoint, which caused CA certificate issues under some circumstances. With this release, the proxy configuration was updated to point to the internal API server endpoint which fixed this issue. (link:https://issues.redhat.com/browse/OCPBUGS-22487[*OCPBUGS-22487*])
+
+* Previously, a deployment could not be scaled up or down when a `HorizontalPodAutoscaler` was present. With this release, when a deployment with an `HorizontalPodAutoscaler` is scaled down to `zero`, an *Enable Autoscale* button is displayed so you can enable pod autoscaling. (link:https://issues.redhat.com/browse/OCPBUGS-22405[*OCPBUGS-22405*])
+
+* Previously, when editing a file, the `Info alert:Non-printable file detected. File contains non-printable characters. Preview is not available.` error was presented. With this release, a check was added to determine if a file is binary, and you are able to edit the file as expected. (link:https://issues.redhat.com/browse/OCPBUGS-18699[*OCPBUGS-18699*])
+
+* Previously, the console API conversion webhook server could not update serving certificates at runtime, and would fail if these certificates were updated by deleting the signing key. This would cause the console to not recover when CA certs were rotated. With this release, console conversion webhook server was updated to detect CA certificate changes, and handle them at runtime. The server now remains available and the console recovers as expected after CA certificates are rotated. (link:https://issues.redhat.com/browse/OCPBUGS-15827[*OCPBUGS-15827*])
+
+* Previously, production builds of the console front-end bundle have historically had source maps disabled. As a consequence, browser tools for analyzing source code could not be used on production builds. With this release, the console Webpack configuration is updated to enable source maps on production builds. Browser tools will now work as expected for both dev and production builds. (link:https://issues.redhat.com/browse/OCPBUGS-10851[*OCPBUGS-10851*])
+
+* Previously, the console redirect service had the same service Certificate Authority (CA) controller annotation as the console service. This caused the service CA controller to sometimes incorrectly sync CA certs for these services, and the console would not function correctly after removing and reinstalling. With this release, the console Operator was updated to remove this service CA annotation from the console redirect service. The console services and CA certs now function as expected when the Operator transitions from a removed to a managed state. (link:https://issues.redhat.com/browse/OCPBUGS-7656[*OCPBUGS-7656*])
+
 [discrete]
 [id="ocp-4-16-monitoring-bug-fixes_{context}"]
 ==== Monitoring
@@ -1522,6 +1600,17 @@ With this release, the CCO no longer checks for the nonexistent permission.
 * Previously, when a MAC address changed on the physical interface being used by OVN-Kubernetes, it would not be updated correctly within OVN-Kubernetes and could cause traffic disruption and Kube API outages from the node for a prolonged period of time. This was most common when a bond interface was being used, where the MAC address of the bond might swap depending on which device was the first to come up. With this release, the issues if fixed so that OVN-Kubernetes dynamically detects MAC address changes and updates it correctly. (link:https://issues.redhat.com/browse/OCPBUGS-18716[*OCPBUGS-18716*])
 
 * Previously, the global navigation satellite system (GNSS) module was capable of reporting both the GPS `fix` position and the GNSS `offset` position, which represents the offset between the GNSS module and the constellations. The previous T-GM did not use the `ubloxtool` CLI tool to probe the `ublox` module for reading `offset` and `fix` positions. Instead, it could only read the GPS `fix` information via GPSD. The reason for this was that the previous implementation of the `ubloxtool` CLI tool took 2 seconds to receive a response, and with every call it increased CPU usage by threefold. With this release, the `ubloxtool` request is now optimized, and the GPS `offset` position is now available. (link:https://issues.redhat.com/browse/OCPBUGS-17422[*OCPBUGS-17422*])
+* Previously, `EgressIP` pods hosted by a secondary interface would not failover because of a race condition. Users would receive an error message indicating that the `EgressIP` pod could not be assigned because it conflicted with an existing IP address. With this release, the `EgressIP` pod moves to an egress node. (https://issues.redhat.com/browse/OCPBUGS-20209[*OCPBUGS-20209*])
+
+* Previously, when a MAC address changed on the physical interface being used by OVN-Kubernetes, it would not be updated correctly within OVN-Kubernetes and could cause traffic disruption and Kube API outages from the node for a prolonged period of time. This was most common when a bond interface was being used, where the MAC address of the bond might swap depending on which device was the first to come up. With this release, the issues if fixed so that OVN-Kubernetes dynamically detects MAC address changes and updates it correctly. (link:https://issues.redhat.com/browse/OCPBUGS-18716[*OCPBUGS-18716*])
+
+* Previously, the global navigation satellite system (GNSS) module was capable of reporting both the GPS `fix` position and the GNSS `offset` position, which represents the offset between the GNSS module and the constellations. The previous T-GM did not use the `ubloxtool` CLI tool to probe the `ublox` module for reading `offset` and `fix` positions. Instead, it could only read the GPS `fix` information via GPSD. The reason for this was that the previous implementation of the `ubloxtool` CLI tool took two seconds to receive a response, and with every call it increased CPU usage by threefold. With this release, the `ubloxtool` request is now optimized, and the GPS `offset` position is now available. (link:https://issues.redhat.com/browse/OCPBUGS-17422[*OCPBUGS-17422*])
+
+////
+* Previously for {product-title} clusters on {azure-full} that used OVN-Kubernetes as the Container Network Interface (CNI), an issue existed where the source IP recognized by the pod was the OVN gateway router of the node when the load balancer service with `externalTrafficPolicy: Local` was used. This occurred due to a Source Network Address Translation (SNAT) being applied to UDP packets.
++
+With this release, session affinity without a timeout is possible by setting the affinity timeout to a higher value, for example, `86400` seconds, or 24 hours. As a result, the affinity is treated as permanent unless there are network disruptions such as endpoints or nodes going down. As a result, session affinity is more persistent. (link:https://issues.redhat.com/browse/OCPBUGS-24219[*OCPBUGS-24219*])
+////
 
 * Previously, IPv6 was unsupported when assigning an egress IP to a network interface that was not the primary network interface. This issue has been resolved, and the egress IP can be IPv6. (https://issues.redhat.com/browse/OCPBUGS-24271[*OCPBUGS-24271*])
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-9882](https://issues.redhat.com/browse/OSDOCS-9882)

Link to docs preview:
[Bug fixes - Management Console](https://77706--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-bug-fixes_release-notes)

