### PR TITLE
OSDOCS-9882-cloud-compute: Bug batched the cloud compute bugs

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -1225,12 +1225,49 @@ Kubernetes 1.29 removed the following deprecated APIs, so you must migrate manif
 [id="ocp-4-16-cloud-compute-bug-fixes_{context}"]
 ==== Cloud Compute
 
-* Previously, the installation program populated the `network.devices`, `template` and `workspace` fields in the `spec.template.spec.providerSpec.value` section of the {vmw-full} control plane machine set custom resource (CR).
-These fields should be set in the {vmw-short} failure domain, and the installation program populating them caused unintended behaviors.
-Updating these fields did not trigger an update to the control plane machines, and these fields were cleared when the control plane machine set was deleted.
+* Previously, the installation program populated the `network.devices`, `template` and `workspace` fields in the `spec.template.spec.providerSpec.value` section of the {vmw-full} control plane machine set custom resource (CR). These fields should be set in the {vmw-short} failure domain, and the installation program populating them caused unintended behaviors. Updating these fields did not trigger an update to the control plane machines, and these fields were cleared when the control plane machine set was deleted.
++
 With this release, the installation program is updated to no longer populate values that are included in the failure domain configuration.
 If these values are not defined in a failure domain configuration, for instance on a cluster that is updated to {product-title} {product-version} from an earlier version, the values defined by the installation program are used.
 (link:https://issues.redhat.com/browse/OCPBUGS-32947[*OCPBUGS-32947*])
+
+* Previously, a node associated with a rebooting machine briefly having a status of `Ready=Unknown` triggered the `UnavailableReplicas` condition in the Control Plane Machine Set Operator. This condition caused the Operator to enter the `Available=False` state and trigger alerts because that state indicates a nonfunctional component that requires immediate administrator intervention. This alert should not have been triggered for the brief and expected unavailabilty while rebooting. With this release, a grace period for node unreadiness is added to avoid triggering unnecessary alerts. (link:https://issues.redhat.com/browse/OCPBUGS-34970[*OCPBUGS-34970*])
+
+* Previously, a transient failure to fetch bootstrap data during machine creation, such as a transient failure to connect to the API server, caused the machine to enter a terminal failed state. With this release, failure to fetch bootstrap data during machine creation is retried indefinitely until it eventually succeeds. (link:https://issues.redhat.com/browse/OCPBUGS-34158[*OCPBUGS-34158*])
+
+* Previously, the Machine API Operator operator panicked when deleting a server in an error state because it was not passed a port list. With this release, deleting a machine stuck in an `ERROR` state does not crash the controller. (link:https://issues.redhat.com/browse/OCPBUGS-34155[*OCPBUGS-34155*])
+
+* Previously, an optional internal function of the cluster autoscaler caused repeated log entries when it was not implemented. The issue is resolved in this release. (link:https://issues.redhat.com/browse/OCPBUGS-33932[*OCPBUGS-33932*])
+
+* Previously, if the control plane machine set was created with a template without a path during installation on a {vmw-first} cluster, the Control Plane Machine Set Operator rejected modification or deletion of the control plane machine set custom resource (CR). With this release, the Operator allows template names for {vmw-short} in the control plane machine set definition. (link:https://issues.redhat.com/browse/OCPBUGS-32295[*OCPBUGS-32295*])
+
+* Previously, the Control Plane Machine Set Operator crashed when attempting to update a {vmw-first} cluster because the infrastructure resource was not configured. With this release, the Operator can handle this scenario so that the cluster update is able to proceed. (link:https://issues.redhat.com/browse/OCPBUGS-31808[*OCPBUGS-31808*])
+
+* Previously, when a user created a compute machine set with taints, they could choose to not specify the `Value` field. Failure to specify this field caused the cluster autoscaler to crash. With this release, the cluster autoscaler is updated to handle an empty `Value` field. (link:https://issues.redhat.com/browse/OCPBUGS-31421[*OCPBUGS-31421*])
+
+* Previously, IPv6 services were wrongly marked as internal on the {rh-openstack} cloud provider, making it impossible to share IPv6 load balancers between {product-title} services. With this release, IPv6 services are not marked as internal, allowing IPv6 load balancers to be shared between services that use stateful IPv6 addresses. This fix allows load balancers to use stateful IPv6 addresses that are defined in the `loadBalancerIP` property of the service. (link:https://issues.redhat.com/browse/OCPBUGS-29605[*OCPBUGS-29605*])
+
+* Previously, when a control plane machine was marked as unready and a change was initiated by the modifying the control plane machine set, the unready machine was removed prematurely. This premature action caused multiple indexes to be replaced simultaneously. With this release, the control plane machine set no longer deletes a machine when only a single machine exists within the index. This change prevents premature roll-out of changes and prevents more than one index from being replaced at a time. (link:https://issues.redhat.com/browse/OCPBUGS-29249[*OCPBUGS-29249*])
+
+* Previously, connections to the {azure-short} API sometimes hung for up to 16 minutes. With this release, a timeout is introduced to prevent hanging API calls. (link:https://issues.redhat.com/browse/OCPBUGS-29012[*OCPBUGS-29012*])
+
+* Previously, the Machine API {ibm-cloud-title} controller did not integrate the full logging options from the `klogr` package. As a result, the controller crashed in Kubernetes version 1.29 and later. With this release, the missing options are included and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-28965[*OCPBUGS-28965*])
+
+* Previously, the Cluster API {ibm-power-server-title} controller pod would start on the unsupported {ibm-cloud-title} platform. This caused the controller pod to get stuck in the creation phase. With this release, the cluster detects the difference between {ibm-power-server-title} and {ibm-cloud-title}. The cluster then only starts on the supported platform. (link:https://issues.redhat.com/browse/OCPBUGS-28539[*OCPBUGS-28539*])
+
+* Previously, the machine autoscaler could not account for any taint set directly on the compute machine set spec due to a parsing error. This could cause undesired scaling behavior when relying on a compute machine set taint to scale from zero. The issue is resolved in this release and the machine autoscaler can now scale up correctly and identify taints that prevent workloads from scheduling. (link:https://issues.redhat.com/browse/OCPBUGS-27509[*OCPBUGS-27509*])
+
+* Previously, machine sets that ran on {azure-first} regions with no availability zone support always created `AvailabilitySets` objects for Spot instances. This operation caused Spot instances to fail because the instances did not support availability sets. With this release, machine sets do not create `AvailabilitySets` objects for Spot instances that operate in non-zonal configured regions. (link:https://issues.redhat.com/browse/OCPBUGS-25940[*OCPBUGS-25940*])
+
+* Previously, the removal of code that provided image credentials from the kubelet in {product-title} 4.14 caused pulling images from the Amazon Elastic Container Registry (ECR) to fail without a specified pull secret. This release includes a separate credential provider that provides ECR credentials for the kubelet. (link:https://issues.redhat.com/browse/OCPBUGS-25662[*OCPBUGS-25662*])
+
+* Previously, the default VM type for the {azure-short} load balancer was changed from `Standard` to `VMSS`, but the service type load balancer code could not attach standard VMs to load balancers. With this release, the default VM type is reverted to remain compatible with {product-title} deployments. (link:https://issues.redhat.com/browse/OCPBUGS-25483[*OCPBUGS-25483*])
+
+* Previously, {product-title} did not include the cluster name in the names of the {rh-openstack} load balancer resources that were created by the OpenStack Cloud Controller Manager. This behavior caused issues when `LoadBalancer` services had the same name in multiple clusters that ran in a single {rh-openstack} project. With this release, the cluster name is included in the names of Octavia resources. When upgrading from a previous cluster version, the load balancers are renamed. The new names follow the pattern `kube_service_<cluster-name>_<namespace>_<service-name>` instead of `kube_service_kubernetes_<namespace>_<service-name>`. (link:https://issues.redhat.com/browse/OCPBUGS-13680[*OCPBUGS-13680*])
+
+* Previously, when you created or deleted large volumes of service objects simultaneously, service controller ability to process each service sequentially would slow down. This caused short timeout issues for the service controller and backlog issues for the objects. With this release, the service controller can now process up to 10 service objects simultaneously to reduce the backlog and timeout issues. (link:https://issues.redhat.com/browse/OCPBUGS-13106[*OCPBUGS-13106*])
+
+* Previously, the logic that fetches the name of a node did not account for the possibility of multiple values for the returned hostname from the {aws-short} metadata service. When multiple domains are configured for a VPC  Dynamic Host Configuration Protocol (DHCP) option, this hostname might return multiple values. The space between multiple values caused the logic to crash. With this release, the logic is updated to use only the first returned hostname as the node name. (link:https://issues.redhat.com/browse/OCPBUGS-10498[*OCPBUGS-10498*])
 
 [discrete]
 [id="ocp-4-16-cloud-cred-operator-bug-fixes_{context}"]
@@ -1390,6 +1427,8 @@ With this release, the CCO no longer checks for the nonexistent permission.
 * Previously, the global navigation satellite system (GNSS) module was capable of reporting both the GPS `fix` position and the GNSS `offset` position, which represents the offset between the GNSS module and the constellations. The previous T-GM did not use the `ubloxtool` CLI tool to probe the `ublox` module for reading `offset` and `fix` positions. Instead, it could only read the GPS `fix` information via GPSD. The reason for this was that the previous implementation of the `ubloxtool` CLI tool took two seconds to receive a response, and with every call it increased CPU usage by threefold. With this update, the `ubloxtool` request is now optimized, and the GPS `offset` position is now available. (link:https://issues.redhat.com/browse/OCPBUGS-17422[*OCPBUGS-17422*])
 
 * Previously, IPv6 was unsupported when assigning an egress IP to a network interface that was not the primary network interface. This issue has been resolved, and the egress IP can be IPv6. (https://issues.redhat.com/browse/OCPBUGS-24271[*OCPBUGS-24271*])
+
+* Previously, the `network-tools` image, which is a debugging tool, included the Wireshark network protocol analyzer. Wireshark had a dependency on the `gstreamer1` package, and this package has specific licensing requirements. With this release, the `gstreamer1` package is removed from the network-tools image and the image now includes the `wireshark-cli` package.(link:https://issues.redhat.com/browse/OCPBUGS-31699[*OCPBUGS-31699*])
 
 [discrete]
 [id="ocp-4-16-node-bug-fixes_{context}"]


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-9882](https://issues.redhat.com/browse/OSDOCS-9882)

Link to docs preview:
[Bug fixes - Cloud Compute](https://77709--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-bug-fixes_release-notes)

