### PR TITLE
Fix comma typo modules/ztp-comparing-pgt-and-rhacm-pg-patching-strategies.adoc

### DIFF
--- a/modules/ztp-comparing-pgt-and-rhacm-pg-patching-strategies.adoc
+++ b/modules/ztp-comparing-pgt-and-rhacm-pg-patching-strategies.adoc
@@ -38,7 +38,7 @@ Replacing a list in a merge patch is supported.
 |Merging and replacing lists is supported in a limited fashion - you can only merge one object in the list.
 
 |Does not currently support the link:https://spec.openapis.org/oas/latest.html[OpenAPI specification] for resource patching.
-This means that additional directives are required in the patch to merge content that does not follow a schema, for example `PtpConfig` resources.
+This means that additional directives are required in the patch to merge content that does not follow a schema, for example, `PtpConfig` resources.
 |Works by replacing fields and values with values as defined by the patch.
 
 |Requires additional directives, for example, `$patch: replace` in the patch to merge content that does not follow a schema.


### PR DESCRIPTION
Version(s):
enterprise-4.16

QE review:
- [x] QE not required.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

