### PR TITLE
OSDOCS-9882-image-registry: Documented the Image Registry 4.16 bug fixes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -1327,6 +1327,10 @@ With this release, the CCO no longer checks for the nonexistent permission.
 
 * Previously, the `oc tag` command did not validate tag names when the command created new tags. After images were created from tags with invalid names, the `podman pull` command would fail. With this release, a validation step checks new tags for invalid names and you can now delete existing tags that have invalid names, so that this issue no longer exists. (link:https://issues.redhat.com/browse/OCPBUGS-25703[*OCPBUGS-25703*])
 
+* Previously, the Image Registry Operator had maintained its own list of {ibm-power-server-name} regions, so any new regions were not added to the list. With this release, the Operator relies on an external library for accessing regions so that it can support new regions. (link:https://issues.redhat.com/browse/OCPBUGS-26767[*OCPBUGS-26767*])
+
+* Previously, the image registry Azure path-fix job incorrectly required the presence of `AZURE_CLIENT_ID` and `TENANT_CLIENT_ID` parameters to function. This caused a valid configuration to throw an error message. With this release, a check is added to the Identity and Access Management (IAM) service account key to validate if these parameters are needed, so that a cluster upgrade operation no longer fails. (link:https://issues.redhat.com/browse/OCPBUGS-32328[*OCPBUGS-32328*])
+
 [discrete]
 [id="ocp-4-16-installer-bug-fixes_{context}"]
 ==== Installer


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-9882](https://issues.redhat.com/browse/OSDOCS-9882)

Link to docs preview:
[Bug fixes - Image Registry](https://77713--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-bug-fixes_release-notes)

