### PR TITLE
OSDOCS-9882-bare-metal-hardware: Documented the 4.16 BM hardware prov bug fixes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -1217,6 +1217,10 @@ Kubernetes 1.29 removed the following deprecated APIs, so you must migrate manif
 [id="ocp-4-16-bare-metal-hardware-bug-fixes_{context}"]
 ==== Bare Metal Hardware Provisioning
 
+* Previously, newer versions of Redfish used Manager resources to deprecate the Uniform Resource Identifier (URI) for the RedFish Virtual Media API. This caused any hardware that used the newer Redfish URI for Virtual Media to not be provisioned. With this release, the Ironic API identifies the correct Redfish URI to deploy for the RedFish Virtual Media API so that hardware relying on either the deprectaed or newer URI could be provisioned. (link:https://issues.redhat.com/browse/OCPBUGS-30171[*OCPBUGS-30171*])
+
+* Previously, the Bare Metal Operator (BMO) was not using a leader lock to control incoming and outgoing Operator pod traffic. After an OpenShift `Deployment` object included a new Operator pod, the new pod competed with system resources, such as the `ClusterOperator` status, and this terminated any outgoing Operator pods. This issue also impacted clusters that do not include any bare-metal nodes. With this release, the BMO includes a leader lock to manage new pod traffic, and this fix resolves the competing pod issue. (link:https://issues.redhat.com/browse/OCPBUGS-25766[*OCPBUGS-25766*])
+
 [discrete]
 [id="ocp-4-16-builds-bug-fixes_{context}"]
 ==== Builds


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-9882](https://issues.redhat.com/browse/OSDOCS-9882)

Link to docs preview:
[Bug fixes - BM Hardware Prov](https://77620--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-bug-fixes_release-notes)

