### PR TITLE
RHDEVDOCS 6058 Pipelines main page redirect for 1.15 and a few versions after that

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -386,7 +386,7 @@ AddType text/vtt                            vtt
     RewriteRule ^container-platform/(4\.10|4\.11|4\.12|4\.13|4\.14)/cicd/pipelines/securing-webhooks-with-event-listeners.html /pipelines/latest/secure/securing-webhooks-with-event-listeners.html [L,R=302]
 
     # redirect top-level without filespec to the about file
-    RewriteRule ^pipelines/(1\.10|1\.11|1\.12|1\.13|1\.14)/?$ /pipelines/$1/about/understanding-openshift-pipelines.html [L,R=302]
+    RewriteRule ^pipelines/(1\.10|1\.11|1\.12|1\.13|1\.14|1\.15|1\.16|1\.17|1\.18)/?$ /pipelines/$1/about/understanding-openshift-pipelines.html [L,R=302]
 
 
     # OSD redirects for new content


### PR DESCRIPTION

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
main only

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
RHDEVDOCS 6058

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
NA

QE review:
NA
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

This is a small technical change to ensure that in Pipelines 1.15 and future versions the link to "version only" redirects to the about page. No doc change is involved.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
