### PR TITLE
OSDOCS-9882-authentication: Documented the authentication 4.16 bug fi…

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -1083,6 +1083,12 @@ Kubernetes 1.29 removed the following deprecated APIs, so you must migrate manif
 [id="ocp-4-16-api-auth-bug-fixes_{context}"]
 ==== API Server and Authentication
 
+* Previously, `ephemeral` and `csi` volumes were not properly added to security context constraints (SCCs) on upgraded clusters. With this release, SCCs on upgraded clusters are properly updated to have `ephemeral` and `csi` volumes. (link:https://issues.redhat.com/browse/OCPBUGS-33522[*OCPBUGS-33522*])
+
+* Previously, the `ServiceAccounts` resource could not be used with OAuth clients for a cluster with the `ImageRegistry` capability enabled. With this release, this issue is fixed. (link:https://issues.redhat.com/browse/OCPBUGS-30319[*OCPBUGS-30319*])
+
+* Previously, when you created a pod with an empty security context and you have access to all security context constraints (SCCs), the pod would receive the `anyuid` SCC. After the `ovn-controller` component added a label to the pod, the pod would be re-admitted for SCC selection, where the pod received an escalated SCC, such as `privileged`. With this release, this issue is resolved so the pod is not re-admitted for SCC selection. (link:https://issues.redhat.com/browse/OCPBUGS-11933[*OCPBUGS-11933*])
+
 [discrete]
 [id="ocp-4-16-bare-metal-hardware-bug-fixes_{context}"]
 ==== Bare Metal Hardware Provisioning
@@ -1130,7 +1136,7 @@ With this release, the CCO no longer checks for the nonexistent permission.
 
 * This release expands the `ClusterOperatorDown` and `ClusterOperatorDegraded` alerts to cover ClusterVersion conditions and send alerts for `Available=False` (`ClusterOperatorDown`) and `Failing=True` (`ClusterOperatorDegraded`). In previous releases, those alerts only covered ClusterOperator conditions. (link:https://issues.redhat.com/browse/OCPBUGS-9133[*OCPBUGS-9133*])
 
-* Previously, Cluster Version Operator (CVO) changes that were introduced in {product-title} 4.15.0, 4.14.0, 4.13.17, and 4.12.43 caused failing risk evaluations to block the CVO from fetching new update recommendations. When the risk evaluations failed, the bug caused the CVO to overlook the update recommendation service. With this release, the CVO continues to poll the update recommendation service, regardless of whether update risks are being successfully evaluated and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-25708[*OCPBUGS-25708*]) 
+* Previously, Cluster Version Operator (CVO) changes that were introduced in {product-title} 4.15.0, 4.14.0, 4.13.17, and 4.12.43 caused failing risk evaluations to block the CVO from fetching new update recommendations. When the risk evaluations failed, the bug caused the CVO to overlook the update recommendation service. With this release, the CVO continues to poll the update recommendation service, regardless of whether update risks are being successfully evaluated and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-25708[*OCPBUGS-25708*])
 
 [discrete]
 [id="ocp-4-16-dev-console-bug-fixes_{context}"]


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-9882](https://issues.redhat.com/browse/OSDOCS-9882)

Link to docs preview:
[Bug fixes - API Server and Authentication](https://77731--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-bug-fixes_release-notes)

