### PR TITLE
Note added regarding collector dependency for 'drop' filter

### DIFF
--- a/modules/logging-content-filter-drop-records.adoc
+++ b/modules/logging-content-filter-drop-records.adoc
@@ -8,8 +8,14 @@
 
 When the `drop` filter is configured, the log collector evaluates log streams according to the filters before forwarding. The collector drops unwanted log records that match the specified configuration.
 
+[NOTE]
+====
+The `Fluentd` log collector does not support the `drop` filter. Please choose the `Vector` collector to make use of this feature.
+====
+
 .Prerequisites
 
+* You are using `Vector` as your log collector.
 * You have installed the {clo}.
 * You have administrator permissions.
 * You have created a `ClusterLogForwarder` custom resource (CR).


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: The documentation regarding the 'drop' content filter is missing the note that it is supported only by the 'Vector' log collector and not by 'Fluentd'.
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://github.com/bitgully/openshift-docs/blob/main/modules/logging-content-filter-drop-records.adoc
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
