### PR TITLE
OSDOCS-9882-monitoring-oc: Documented the oc and monitoring 4.16 rele…

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -1176,7 +1176,7 @@ With this release, the CCO no longer checks for the nonexistent permission.
 
 * This release expands the `ClusterOperatorDown` and `ClusterOperatorDegraded` alerts to cover ClusterVersion conditions and send alerts for `Available=False` (`ClusterOperatorDown`) and `Failing=True` (`ClusterOperatorDegraded`). In previous releases, those alerts only covered ClusterOperator conditions. (link:https://issues.redhat.com/browse/OCPBUGS-9133[*OCPBUGS-9133*])
 
-* Previously, Cluster Version Operator (CVO) changes that were introduced in {product-title} 4.15.0, 4.14.0, 4.13.17, and 4.12.43 caused failing risk evaluations to block the CVO from fetching new update recommendations. When the risk evaluations failed, the bug caused the CVO to overlook the update recommendation service. With this release, the CVO continues to poll the update recommendation service, regardless of whether update risks are being successfully evaluated and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-25708[*OCPBUGS-25708*]) 
+* Previously, Cluster Version Operator (CVO) changes that were introduced in {product-title} 4.15.0, 4.14.0, 4.13.17, and 4.12.43 caused failing risk evaluations to block the CVO from fetching new update recommendations. When the risk evaluations failed, the bug caused the CVO to overlook the update recommendation service. With this release, the CVO continues to poll the update recommendation service, regardless of whether update risks are being successfully evaluated and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-25708[*OCPBUGS-25708*])
 
 [discrete]
 [id="ocp-4-16-dev-console-bug-fixes_{context}"]
@@ -1217,6 +1217,8 @@ With this release, the CCO no longer checks for the nonexistent permission.
 [discrete]
 [id="ocp-4-16-monitoring-bug-fixes_{context}"]
 ==== Monitoring
+
+* Previously, setting an invalid `.spec.endpoints.proxyUrl` attribute in the `ServiceMonitor` resource would result in breaking, reloading, and restarting Prometheus. This update fixes the issue by validating the `proxyUrl` attribute against invalid syntax. (link:https://issues.redhat.com/browse/OCPBUGS-30989[*OCPBUGS-30989*])
 
 [discrete]
 [id="ocp-4-16-networking-bug-fixes_{context}"]
@@ -1266,6 +1268,38 @@ With this release, session affinity without a timeout is possible by setting the
 [id="ocp-4-16-openshift-cli-bug-fixes_{context}"]
 ==== OpenShift CLI (oc)
 
+* Previously, during the disk-to-mirror process for fully disconnected environments, the oc-mirror plugin v1 failed to mirror the catalog image when access to Red{nbsp}Hat registries was blocked. Additionally, if the `ImageSetConfiguration` used a `targetCatalog` for the mirrored catalog, mirroring would fail due to incorrect catalog image references regardless of the workflow. This issue has been resolved by updating the catalog image source for mirroring to the mirror registry. (link:https://issues.redhat.com/browse/OCPBUGS-31536[*OCPBUGS-31536*])
+
+* Previously, when mirroring operator images with incompatible semantic versioning, oc-mirror plugin v2 (Technology Preview) would fail and exit. This fix ensures that a warning appears in the console, indicating the skipped image and allowing the mirroring process to continue without interruption. (link:https://issues.redhat.com/browse/OCPBUGS-34587[*OCPBUGS-34587*])
+
+* Previously, oc-mirror plugin v2 (Technology Preview) failed to mirror certain Operator catalogs that included image references with both `tag` and `digest` formats. This issue prevented the creation of cluster resources, such as `ImageDigestMirrorSource` (IDMS) and `ImageTagMirrorSource` (ITMS). With this update, oc-mirror resolves the issue by skipping images that have both `tag` and `digest` references, while displaying an appropriate warning message in the console output. (link:https://issues.redhat.com/browse/OCPBUGS-33196[*OCPBUGS-33196*])
+
+* Previously, with oc-mirror plugin v2 (Technology Preview), mirroring errors were only displayed in the console output, making it difficult for users to analyze and troubleshoot other issues. For example, an unstable network might require a rerun, while a manifest unknown error might need further analysis to skip an image or Operator. With this update, a file is generated that contains all errors in the workspace `working-dir/logs` folder. And all the errors that occur during the mirroring process are now logged in `mirroring_errors_YYYYMMdd.txt`. (link:https://issues.redhat.com/browse/OCPBUGS-33098[*OCPBUGS-33098*])
+
+* Previously, the Cloud Credential Operator utility (`ccoctl`) could not run on a {op-system-base} 9 host with FIPS enabled. With this release, a user can run a version of the `ccoctl` utility that is compatible with the {op-system-base} version of their host, including {op-system-base} 9. (link:https://issues.redhat.com/browse/OCPBUGS-32080[*OCPBUGS-32080*])
+
+* Previously, when mirroring operator catalogs, `oc-mirror` would rebuild the catalogs and regenerate their internal cache based on `imagesetconfig` catalog filtering specifications. This process required the `opm` binary from within the catalogs. Starting with version 4.15, operator catalogs include the `opm` {op-system-base} 9 binary, which caused the mirroring process to fail when executed on {op-system-base} 8 systems. With this release, `oc-mirror` no longer rebuilds catalogs by default; instead, it simply mirrors them to their destination registries.
++
+To retain the catalog rebuilding functionality, use `--rebuild-catalog`. However, note that no changes were made to the current implementation, so using this flag might result in the cache not being generated or the catalog not being deployed to the cluster. If you use this command, you can export `OPM_BINARY` to specify a custom `opm` binary that corresponds to the catalog versions and platform found in {product-title}. Mirroring of catalog images is now done without signature verification. Use `--enable-operator-secure-policy` to enable signature verification during mirroring.
+(link:https://issues.redhat.com/browse/OCPBUGS-31536[*OCPBUGS-31536*])
+
+* Previously, some credentials requests were not extracted properly when running the `oc adm release extract --credentials-requests` command with an `install-config.yaml` file that included the `CloudCredential` cluster capability. With this release, the `CloudCredential` capability is correctly included in the OpenShift CLI (`oc`) so that this command extracts credentials requests properly. (link:https://issues.redhat.com/browse/OCPBUGS-24834[*OCPBUGS-24834*])
+
+* Previously, users encountered sequence errors when using the `tar.gz` artifact with the oc-mirror plugin. To resolve this, the oc-mirror plugin now ignores these errors when executed with the `--skip-pruning` flag. This update ensures that the sequence error, which no longer affects the order of `tar.gz` usage in mirroring, is effectively handled. (link:https://issues.redhat.com/browse/OCPBUGS-23496[*OCPBUGS-23496*])
+
+* Previously, when using the oc-mirror plugin to mirror local Open Container Initiative Operator catalogs located in hidden folders, oc-mirror previously failed with an error: ".hidden_folder/data/publish/latest/catalog-oci/manifest-list/kubebuilder/kube-rbac-proxy@sha256:db06cc4c084dd0253134f156dddaaf53ef1c3fb3cc809e5d81711baa4029ea4c is not a valid image reference: invalid reference format “. With this release, oc-mirror now calculates references to images within local Open Container Initiative catalogs differently, ensuring that the paths to hidden catalogs no longer disrupt the mirroring process.
+(link:https://issues.redhat.com/browse/OCPBUGS-23327[*OCPBUGS-23327*])
+
+* Previously, oc-mirror would not stop and return a valid error code when mirroring failed. With this release, oc-mirror now exits with the correct error code when encountering “operator not found”, unless the `--continue-on-error` flag is used. (link:https://issues.redhat.com/browse/OCPBUGS-23003[*OCPBUGS-23003*])
+
+* Previously, when mirroring operators, oc-mirror would ignore the `maxVersion` constraint in `imageSetConfig` if both `minVersion` and `maxVersion` were specified. This resulted in mirroring all bundles up to the channel head. With this release, oc-mirror now considers the `maxVersion` constraint as specified in `imageSetConfig`.
+(link:https://issues.redhat.com/browse/OCPBUGS-21865[*OCPBUGS-21865*])
+
+* Previously, oc-mirror failed to mirror releases using `eus-\*` channels, as it did not recognize that `eus-\*` channels are designated for even-numbered releases only. With this release, oc-mirror plugin now properly acknowledges that `eus-\*` channels are intended for even-numbered releases, enabling users to successfully mirror releases using these channels.
+(link:https://issues.redhat.com/browse/OCPBUGS-19429[*OCPBUGS-19429*])
+
+* Previously, the addition of the `defaultChannel` field in the `mirror.operators.catalog.packages` file enabled users to specify their preferred channel, overriding the `defaultChannel` set in the operator. With this release, oc-mirror plugin now enforces an initial check if the `defaultChannel` field is set, users must also define it in the channels section of the `ImageSetConfig`. This update ensures that the specified `defaultChannel` is properly configured and applied during operator mirroring. (link:https://issues.redhat.com/browse/OCPBUGS-385[*OCPBUGS-385*])
+
 [discrete]
 [id="ocp-4-16-olm-bug-fixes_{context}"]
 ==== Operator Lifecycle Manager (OLM)
@@ -1278,9 +1312,9 @@ With this release, session affinity without a timeout is possible by setting the
 
 * Previously, installing an Operator could sometimes fail if the same Operator had been previously installed and uninstalled. This was due to a caching issue. This bug fix updates {olm} to correctly install the Operator in this scenario, and as a result this issue no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-31073[*OCPBUGS-31073*])
 
-* Previously, the catalogd component could crash loop after an etcd restore. This was due to the garbage collection process causing a looping failure state when the API server was unreachable. This bug fix updates catalogd to add a retry loop, and as a result catalogd no longer crashes in this scenario. (link:https://issues.redhat.com/browse/OCPBUGS-29453[*OCPBUGS-29453*])
+* Previously, the `catalogd` component could crash loop after an etcd restore. This was due to the garbage collection process causing a looping failure state when the API server was unreachable. This bug fix updates `catalogd` to add a retry loop, and as a result `catalogd` no longer crashes in this scenario. (link:https://issues.redhat.com/browse/OCPBUGS-29453[*OCPBUGS-29453*])
 
-* Previously, the default catalog source pod would not receive updates, requiring users to manually recreate it to get updates. This was caused by image IDs for catalog pods not getting detected correctly. This bug fix updates {olm} to correctly detect catalog pod image IDs, and as a result, default catalog sources are updated as expected. (link:https://issues.redhat.com/browse/OCPBUGS-31438[*OCPBUGS-31438*])
+* Previously, the default catalog source pod would not receive updates, requiring users to manually re-create it to get updates. This was caused by image IDs for catalog pods not getting detected correctly. This bug fix updates {olm} to correctly detect catalog pod image IDs, and as a result, default catalog sources are updated as expected. (link:https://issues.redhat.com/browse/OCPBUGS-31438[*OCPBUGS-31438*])
 
 * Previously, users could experience Operator installation errors due to {olm} not being able to find existing `ClusterRoleBinding` or `Service` resources and creating them a second time. This bug fix updates {olm} to pre-create these objects, and as a result these installation errors no longer occur. (link:https://issues.redhat.com/browse/OCPBUGS-24009[*OCPBUGS-24009*])
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-9882](https://issues.redhat.com/browse/OSDOCS-9882)

Link to docs preview:
[Bug fixes](https://77735--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-bug-fixes_release-notes)