### PR TITLE
RHDEVDOCS-6064: Sizing requirements for argocd-redis

### DIFF
--- a/modules/sizing-requirements-for-gitops.adoc
+++ b/modules/sizing-requirements-for-gitops.adoc
@@ -28,3 +28,47 @@ Optionally, you can also use the ArgoCD custom resource with the `oc` command to
 ----
 oc edit argocd <name of argo cd> -n namespace
 ----
+
+[id="sizing-requirements-for-argocd-redis_{context}"]
+== Sizing requirements for argocd-redis
+
+During the capacity planning stage for your application in the {gitops-title} Operator, you must ensure that an adequate amount of resources, such as memory, CPU, and storage, are allocated for the `argocd-redis` pod.
+
+The default memory limit for the Redis pod might not be enough to manage a large number of resources. In these instances, you must increase the memory limit, monitor the memory metrics, and change the memory configuration while the application deployment scales up.
+
+The following command shows the example of the memory configuration for a Redis pod in the `openshift-gitops` namespace:
+[source,terminal]
+----
+$ oc get argocd -n openshift-gitops openshift-gitops -o json | jq '.spec.redis.resources'
+----
+
+.Example Output
+[source,terminal]
+----
+{
+    "limits": { #<1>
+        "cpu": "500m",
+        "memory": "256Mi"
+  },
+  "requests": { #<2>
+    "cpu": "250m",
+    "memory": "128Mi"
+  }
+}
+----
+<1> The highest resource limit threshold allocated to the pod.
+<2> The lowest resource limit threshold allocated to the pod.
+
+The following example command changes the memory configuration for a Redis pod. The highest resource limit threshold is set to 8 GiB and the lowest is set to 256 MiB.
+[source,terminal]
+----
+$ oc patch argocd -n openshift-gitops openshift-gitops --type json -p '[{"op": "replace", "path":  \
+  "/spec/redis/resources/limits/memory", "value": "8Gi"}, {"op": "replace", "path": \
+  "/spec/redis/resources/requests/memory", "value": "256Mi"}]'
+----
+
+.Example Output
+[source,terminal]
+----
+argocd.argoproj.io/openshift-gitops patched
+----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

GitOps 1.13

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/RHDEVDOCS-6064

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Sizing requirements for argocd-redis](https://77736--ocpdocs-pr.netlify.app/openshift-gitops/latest/installing_gitops/preparing-gitops-install.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: cfang@redhat.com
QE review: @varshab1210 
Internal peer review: @eromanova97 
Peer review:

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
