### PR TITLE
Adds xref that was blocked earlier to RNs

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -480,8 +480,8 @@ For more information, see xref:../machine_management/applying-autoscaling.adoc#c
 This release introduces the ability to manage machines by using the upstream Cluster API, integrated into {product-title}, as a Technology Preview for {vmw-full} clusters.
 This capability is in addition or an alternative to managing machines with the Machine API.
 For more information, see _Managing machines with the Cluster API_.
-//xref blocked by #72885
-//For more information, see xr3f:../machine_management/cluster_api_machine_management/cluster-api-about.adoc#cluster-api-about[Managing machines with the Cluster API].
+
+For more information, see xref:../machine_management/cluster_api_machine_management/cluster-api-about.adoc#cluster-api-about[About the Cluster API].
 
 [id="ocp-4-16-nodes_{context}"]
 === Nodes


### PR DESCRIPTION
Version(s):
4.16

Issue:
N/A

Link to docs preview:
[Managing machines with the Cluster API for VMware vSphere (Technology Preview)](https://77739--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-capi-tp-vmw_release-notes)

QE review:
N/A

Additional information: