### PR TITLE
Document s390x support for PCI-DSS profiles

### DIFF
--- a/modules/compliance-supported-profiles.adoc
+++ b/modules/compliance-supported-profiles.adoc
@@ -159,6 +159,7 @@ The Compliance Operator provides the following compliance profiles:
 |link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library]
 |`x86_64`
  `ppc64le`
+ `s390x`
 |
 
 |ocp4-pci-dss-node
@@ -168,6 +169,7 @@ The Compliance Operator provides the following compliance profiles:
 |link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library]
 |`x86_64`
  `ppc64le`
+ `s390x`
 |Red Hat OpenShift Service on AWS with hosted control planes (ROSA HCP) - requires 1.5.0+
 
 |ocp4-high


### PR DESCRIPTION
CO 1.5.0 included s390x support for PCI-DSS profiles. Let's update the
support matrix to reflect that information.
