### PR TITLE
[enterprise-4.15] OBSDOCS-1084: Update Default monitoring targets section with missing …

### DIFF
--- a/modules/monitoring-default-monitoring-targets.adoc
+++ b/modules/monitoring-default-monitoring-targets.adoc
@@ -7,33 +7,43 @@
 = Default monitoring targets
 
 ifndef::openshift-dedicated,openshift-rosa[]
-In addition to the components of the stack itself, the default monitoring stack monitors:
+In addition to the components of the stack itself, the default monitoring stack monitors additional platform components.
+
+The following are examples of monitoring targets:
 endif::openshift-dedicated,openshift-rosa[]
 
 ifdef::openshift-dedicated,openshift-rosa[]
-Red Hat Site Reliability Engineers (SRE) monitor the following platform targets in your {product-title} cluster:
+The following are examples of targets monitored by Red{nbsp}Hat Site Reliability Engineers (SRE) in your {product-title} cluster:
 endif::openshift-dedicated,openshift-rosa[]
 
 * CoreDNS
-* Elasticsearch (if Logging is installed)
 * etcd
-* Fluentd (if Logging is installed)
 * HAProxy
 * Image registry
 * Kubelets
 * Kubernetes API server
 * Kubernetes controller manager
 * Kubernetes scheduler
+ifndef::openshift-rosa[]
 * OpenShift API server
 * OpenShift Controller Manager
 * Operator Lifecycle Manager (OLM)
-* Vector (if Logging is installed)
+endif::openshift-rosa[]
+
+ifdef::openshift-dedicated,openshift-rosa[]
+[NOTE]
+====
+The exact list of targets can vary depending on your cluster capabilities and installed components.
+====
+endif::openshift-dedicated,openshift-rosa[]
 
 ifndef::openshift-dedicated,openshift-rosa[]
 [NOTE]
 ====
-Each {product-title} component is responsible for its monitoring configuration. For problems with the monitoring of an {product-title} component, open a
-link:https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12332330&summary=Monitoring_issue&issuetype=1&priority=10200&versions=12391126[Jira issue] against that component, not against the general monitoring component.
+* The exact list of targets can vary depending on your cluster capabilities and installed components.
+
+* Each {product-title} component is responsible for its monitoring configuration. For problems with the monitoring of an {product-title} component, open a
+link:https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12332330&summary=Monitoring_issue&issuetype=1&priority=10200&versions=12407352[Jira issue] against that component, not against the general monitoring component.
 ====
 
 Other {product-title} framework components might be exposing metrics as well. For details, see their respective documentation.

--- a/observability/monitoring/monitoring-overview.adoc
+++ b/observability/monitoring/monitoring-overview.adoc
@@ -33,6 +33,10 @@ ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/monitoring-default-monitoring-components.adoc[leveloffset=+2]
 endif::openshift-dedicated,openshift-rosa[]
 include::modules/monitoring-default-monitoring-targets.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../observability/monitoring/managing-metrics.adoc#getting-detailed-information-about-a-target_managing-metrics[Getting detailed information about a metrics target]
+
 include::modules/monitoring-components-for-monitoring-user-defined-projects.adoc[leveloffset=+2]
 include::modules/monitoring-targets-for-user-defined-projects.adoc[leveloffset=+2]
 include::modules/monitoring-common-terms.adoc[leveloffset=+1]


### PR DESCRIPTION
Manual CP from https://github.com/openshift/openshift-docs/pull/77351 to 4.15