### PR TITLE
OSDOCS-10752 Added vSphere and Nutanix CAPI release notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -79,6 +79,14 @@ Additionally, SSH access to control plane and compute machines is no longer open
 Installing a cluster on AWS into a secret or top-secret region has not been tested with CAPI as of the release of {product-title} {product-version}. This document will be updated when installation into a secret region has been tested. There is a known issue with Network Load Balancers' support for security groups in secret or top secret regions that causes installations to fail. For more information, see link:https://issues.redhat.com/browse/OCPBUGS-33311[*OCPBUGS-33311*].
 ====
 
+[id="ocp-4-16-installation-and-update-vsphere-capi_{context}"]
+==== Cluster API replaces Terraform for {vmw-first} installations
+In {product-title} {product-version}, the installation program uses Cluster API instead of Terraform to provision cluster infrastructure during installations on {vmw-first}.
+
+[id="ocp-4-16-installation-and-update-nutanix-capi_{context}"]
+==== Cluster API replaces Terraform for Nutanix installations
+In {product-title} {product-version}, the installation program uses Cluster API instead of Terraform to provision cluster infrastructure during installations on Nutanix.
+
 [id="ocp-4-16-installation-and-update-optional-ccm_{context}"]
 ==== Optional cloud controller manager cluster capability
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-10752
https://issues.redhat.com/browse/OSDOCS-10756

Link to docs preview:
[vSphere](https://77754--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-installation-and-update-vsphere-capi_release-notes)
[Nutanix](https://77754--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-installation-and-update-nutanix-capi_release-notes)

QE review:
- [x] QE has approved this change.
