### PR TITLE
OSDOCS-10977: move GA date back MicroShift 4.16

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -11,7 +11,7 @@ toc::[]
 {microshift-short} is designed to make control plane restarts economical and be lifecycle-managed as a single unit by the operating system. Updates, roll-backs, and configuration changes consist of simply staging another version in parallel and then - without relying on a network - flipping to and from that version and restarting.
 
 //TODO verify K8s version and another other relevant notes
-[id="microshift-4-16-about-this-release"]
+[id="microshift-4-16-about-this-release_{context}"]
 == About this release
 Version 4.16 of {product-title} includes new features and enhancements. {microshift-short} was introduced as Generally Available with {microshift-short} 4.14. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. {microshift-short} is derived from {OCP} {OCP-version} and uses the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
 
@@ -22,21 +22,21 @@ You can deploy {microshift-short} clusters to on-premise, cloud, disconnected, a
 
 For lifecycle information, see the link:https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{product-title} Life Cycle Policy].
 
-[id="microshift-4-16-new-features-and-enhancements"]
+[id="microshift-4-16-new-features-and-enhancements_{context}"]
 == New features and enhancements
 
 This release adds improvements related to the following components and concepts.
 
 //L3 major categories with features in each as L4s
-[id="microshift-4-16-rhel"]
+[id="microshift-4-16-rhel_{context}"]
 === {op-system-base-full}
 * {microshift-short} {product-version} runs on {op-system-base-full} 9.4.
 
-[id="microshift-4-16-updating"]
+[id="microshift-4-16-updating_{context}"]
 === Updating
 Updating two minor versions in a single step is now supported. Updates for both single-version minor releases and patch releases are still supported.
 
-[id="microshift-4-16-updates-supported"]
+[id="microshift-4-16-updates-supported_{context}"]
 ==== Update two minor versions in a single step
 See the following list for details:
 
@@ -51,64 +51,67 @@ See the following list for details:
 //[id="microshift-4-16-installation"]
 //=== Installation
 
-[id="microshift-4-16-configuring"]
+[id="microshift-4-16-configuring_{context}"]
 === Configuring
 
-[id="microshift-4-16-custom-cert-auths"]
+[id="microshift-4-16-custom-cert-auths_{context}"]
 ==== Customizable certificate authorities for the API server are supported
 With this release, you can configure a custom server certificate that has been issued by an external certificate authority (CA). The default API server certificate is issued by an internal {microshift-short} cluster CA. You can now replace this certificate with one that is issued by a CA that clients trust. See xref:../microshift_configuring/microshift-custom-ca.adoc#microshift-custom-ca[Configuring custom certificate authorities].
 
-[id="microshift-4-16-audit-logging-config"]
+[id="microshift-4-16-audit-logging-config_{context}"]
 ==== Configurable policies for log file rotation and retention
 You can now configure audit logging policies to manage the retention policies for log files, ensuring that edge devices with limited storage capacities are not hampered by accumulated logging data. To configure audit log policies, use settings such as a maximum file size limit and maximum retained files to set a limit on log storage size. You can also choose an audit policy profile to specify the data collected. See xref:../microshift_configuring/microshift-audit-logs-config.adoc#microshift-audit-logs-config[Configuring audit logs].
 
-[id="microshift-4-16-certificates-cleaning"]
+[id="microshift-4-16-certificates-cleaning_{context}"]
 ==== Support for cleaning up certificates
 With this release, you can clean up custom certificates. For more information, see xref:../microshift_configuring/microshift-custom-ca.adoc#microshift-custom-ca-certificates-cleaning_microshift-custom-ca[Cleaning up and recreating the custom certificates].
 
-[id="microshift-4-16-networking"]
+[id="microshift-4-16-networking_{context}"]
 === Networking
 
-[id="microshift-4-16-multus"]
+[id="microshift-4-16-multus_{context}"]
 ==== Multiple networks capability now available
 With this release, using multiple networks is supported with the {microshift-short} Multus plugin. If you have advanced networking requirements, you can attach additional networks to a pod for high-performance network configurations. After installing the {microshift-short} Multus RPM package, you can use the Bridge, MACVLAN, or IPVLAN plugins to create additional networks. See xref:../microshift_networking/microshift_multiple_networks/microshift-cni-multus.adoc#microshift-multus-intro_microshift-cni-multus[Additional networks in {microshift-short}].
 
-[id="microshift-4-16-configure-ingress-router"]
+[id="microshift-4-16-configure-ingress-router_{context}"]
 ==== Custom configurations for the ingress router are supported
 You can now configure ingress routes to create access to multiple services inside your {microshift-short} cluster. You can use a variety of combinations to customize the endpoint configuration for your use case. See xref:../microshift_networking/microshift-nw-router.adoc#microshift-nw-router-con_microshift-nw-router[About configuring the router].
 
-[id="microshift-4-16-configure-route-admission-policy"]
+[id="microshift-4-16-configure-route-admission-policy_{context}"]
 ==== Configuring the route admission policy now available
 You can now configure the route admission policy to allow routes to claim different paths of the same hostname across namespaces. See xref:../microshift_networking/microshift-nw-router.adoc#microshift-configuring-route-admission_microshift-nw-router[Configuring the route admission policy].
 
 //[id="microshift-4-16-storage"]
 //=== Storage
 
-[id="microshift-4-16-running-apps"]
+[id="microshift-4-16-running-apps_{context}"]
 === Running applications
 
-[id="microshift-4-16-gitops"]
+[id="microshift-4-16-gitops_{context}"]
 ==== GitOps with Argo CD now available
 With this release, you can use the GitOps with Argo CD agent derived from GitOps 1.12 with {microshift-short}. Using GitOps means you can update a single Git repository and automate the deployment of new applications or updates to existing ones. You can also use your Git repository as an audit trail of changes so that you can create processes such as review and approval for merging pull requests that implement configuration changes.
 See xref:../microshift_running_apps/microshift-gitops.adoc#microshift-gitops[Automating application management with the GitOps controller].
 
-[id="microshift-4-16-support"]
+[id="microshift-4-16-support_{context}"]
 === Support
 
-[id="microshift-4-16-support-updates"]
+[id="microshift-4-16-support-updates_{context}"]
 ==== Getting a cluster ID
 With this release, you can get the ID of a {microshift-short} cluster. When opening a support case, you can provide the cluster ID to Red{nbsp}Hat Support to help in identifying issues with your cluster. See xref:../microshift_support/microshift-getting-cluster-id.adoc#microshift-getting-cluster-id[Getting your cluster ID].
 
-[id="microshift-4-16-security"]
+[id="microshift-4-16-security_{context}"]
 === Security and compliance
 
-[id="microshift-4-16-ssl-medium-cipher-suites"]
+[id="microshift-4-16-ssl-medium-cipher-suites_{context}"]
 ==== SSL Medium Strength Cipher Suites now supported
 During an SSL handshake between a client and a server, the cipher to use is negotiated between them. With this release, SSL Medium Strength Cipher Suites are now supported for the kube-controller-manager daemon, kube-scheduler control-plane process, and kubelet "node agent." This enhancement to the internal communication between kubernetes components improves control plane communications security. (link:https://issues.redhat.com/browse/OCPBUGS-29037[OCPBUGS-29037])
 
-//[id="microshift-4-16-doc-enhancements"]
-//=== Documentation enhancements
-//Doc enhancements include additions for RFEs and other continuous improvement items that are substantial and are not tied to new features or bug fixes already listed here. These can also go under the relevant section as applicable.
+[id="microshift-4-16-doc-enhancements_{context}"]
+=== Documentation enhancements
+
+[id="microshift-4-16-route-config_{context}"]
+==== Route configuration now documented
+With this release, specific details for creating and managing supported route configurations are documented, see xref:../microshift_networking/microshift-configuring-routes.adoc#microshift-configuring-routes[Configuring routes].
 
 //[id="microshift-4-16-deprecated-and-removed"]
 //== Deprecated and removed features
@@ -140,7 +143,7 @@ During an SSL handshake between a client and a server, the cipher to use is nego
 //|====
 
 //NOTE: Do NOT repeat bug fixes already noted in previous version z-streams
-[id="microshift-4-16-bug-fixes"]
+[id="microshift-4-16-bug-fixes_{context}"]
 == Bug fixes
 
 //[discrete]
@@ -176,8 +179,8 @@ This section is updated over time to provide notes on enhancements and bug fixes
 [id="microshift-4-16-0-dp"]
 === RHEA-2024:0043 - {microshift-short} 4.16.0 bug fix and security update advisory
 
-Issued: 2024-06-25
+Issued: 2024-06-27
 
-{product-title} release 4.16.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHEA-2024:0043[RHEA-2024:0043] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHEA-2024:0041[RHEA-2024:0041] advisory.
+{product-title} release 4.16.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:0043[RHSA-2024:0043] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0041[RHSA-2024:0041] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-10977](https://issues.redhat.com/browse/OSDOCS-10977)

Link to docs preview:
[4.16.0 async relnote date change only](https://77762--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-0-dp)

QE review:
- N/A date change comes from OCP release program call

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
