### PR TITLE
Adds two commands for procedure accuracy

### DIFF
--- a/modules/installation-adding-registry-pull-secret.adoc
+++ b/modules/installation-adding-registry-pull-secret.adoc
@@ -99,18 +99,50 @@ The contents of the file resemble the following example:
 ----
 // An additional step for following this procedure when using oc-mirror as part of the disconnected install process.
 ifdef::oc-mirror[]
-. Save the file either as `~/.docker/config.json` or `$XDG_RUNTIME_DIR/containers/auth.json`.
-endif::[]
-
-ifdef::oc-mirror-v2[]
-. Save the file as `$XDG_RUNTIME_DIR/containers/auth.json`.
+. Save the file as either `~/.docker/config.json` or `$XDG_RUNTIME_DIR/containers/auth.json`:
+.. If the `.docker` or `$XDG_RUNTIME_DIR/containers` directories do not exist, create one by entering the following command:
++
+[source,terminal]
+----
+$ mkdir -p <directory_name>
+----
++
+Where `<directory_name>` is either `~/.docker` or `$XDG_RUNTIME_DIR/containers`.
+.. Copy the pull secret to the appropriate directory by entering the following command:
++
+[source,terminal]
+----
+$ cp <path>/<pull_secret_file_in_json> <directory_name>/<auth_file>
+----
++
+Where `<directory_name>` is either `~/.docker` or `$XDG_RUNTIME_DIR/containers`, and `<auth_file>` is either `config.json` or `auth.json`.
 endif::[]
 // Similar to the additional step above, except it is framed as optional because it is included in a disconnected update page (where users may or may not use oc-mirror for their process)
 ifdef::update-oc-mirror[]
-. Optional: If using the oc-mirror plugin, save the file either as `~/.docker/config.json` or `$XDG_RUNTIME_DIR/containers/auth.json`.
+. Optional: If using the oc-mirror plugin, save the file as either `~/.docker/config.json` or `$XDG_RUNTIME_DIR/containers/auth.json`:
+.. If the `.docker` or `$XDG_RUNTIME_DIR/containers` directories do not exist, create one by entering the following command:
++
+[source,terminal]
+----
+$ mkdir -p <directory_name>
+----
++
+Where `<directory_name>` is either `~/.docker` or `$XDG_RUNTIME_DIR/containers`.
+.. Copy the pull secret to the appropriate directory by entering the following command:
++
+[source,terminal]
+----
+$ cp <path>/<pull_secret_file_in_json> <directory_name>/<auth_file>
+----
++
+Where `<directory_name>` is either `~/.docker` or `$XDG_RUNTIME_DIR/containers`, and `<auth_file>` is either `config.json` or `auth.json`.
+endif::[]
+// Additional step for allowing this procedure for oc-mirror-v2
+ifdef::oc-mirror-v2[]
+. Save the file as `$XDG_RUNTIME_DIR/containers/auth.json`.
 endif::[]
 endif::[]
-
+ 
 . Generate the base64-encoded user name and password or token for your mirror registry:
 +
 [source,terminal]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-29703

Link to docs preview:
https://77767--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-disconnected.html#installation-adding-registry-pull-secret_installing-mirroring-disconnected

https://77767--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.html#installation-adding-registry-pull-secret_mirroring-ocp-image-repository

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
