### PR TITLE
[OSDOCS-10979] updating Dynamic Certificates tutorial to remove references to the CDO

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-dynamic-certificate-custom-domain.adoc
+++ b/cloud_experts_tutorials/cloud-experts-dynamic-certificate-custom-domain.adoc
@@ -24,11 +24,11 @@ Learn how to use the link:https://docs.openshift.com/container-platform/latest/s
 [id="cloud-experts-dynamic-certificate-custom-domain-prerequisites"]
 == Prerequisites
 
-* A ROSA cluster
+* A ROSA cluster (HCP or Classic)
 * A user account with `cluster-admin` privileges
 * The OpenShift CLI (`oc`)
 * The Amazon Web Services (AWS) CLI (`aws`)
-* A unique domain, such as `*.apps.<company_name>.io`
+* A unique domain, such as `*.apps.example.com`
 * An Amazon Route 53 public hosted zone for the above domain
 
 [id="cloud-experts-dynamic-certificate-custom-domain-environment-setup"]
@@ -38,24 +38,35 @@ Learn how to use the link:https://docs.openshift.com/container-platform/latest/s
 +
 [source,terminal]
 ----
-$ export DOMAIN=apps.<company_name>.io <1>
-$ export EMAIL=<youremail@company_name.io> <2>
+$ export DOMAIN=apps.example.com <1>
+$ export EMAIL=email@example.com <2>
 $ export AWS_PAGER=""
-$ export CLUSTER_NAME=$(oc get infrastructure cluster -o=jsonpath="{.status.infrastructureName}"  | sed 's/-[a-z0-9]\{5\}$//')
+$ export CLUSTER=$(oc get infrastructure cluster -o=jsonpath="{.status.infrastructureName}"  | sed 's/-[a-z0-9]\{5\}$//')
 $ export OIDC_ENDPOINT=$(oc get authentication.config.openshift.io cluster -o json | jq -r .spec.serviceAccountIssuer | sed  's|^https://||')
 $ export REGION=$(oc get infrastructure cluster -o=jsonpath="{.status.platformStatus.aws.region}")
 $ export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-$ export SCRATCH="/tmp/${CLUSTER_NAME}/dynamic-certs"
+$ export SCRATCH="/tmp/${CLUSTER}/dynamic-certs"
 $ mkdir -p ${SCRATCH}
 ----
-<1> The custom domain.
-<2> The e-mail Let's Encrypt will use to send notifications about your certificates.
+<1> Replace with the custom domain you want to use for the `IngressController`.
+<2> Replace with the e-mail you want Let's Encrypt to use to send notifications about your certificates.
++
 . Ensure all fields output correctly before moving to the next section:
 +
 [source,terminal]
 ----
-$ echo "Cluster: ${CLUSTER_NAME}, Region: ${REGION}, OIDC Endpoint: ${OIDC_ENDPOINT}, AWS Account ID: ${AWS_ACCOUNT_ID}"
+$ echo "Cluster: ${CLUSTER}, Region: ${REGION}, OIDC Endpoint: ${OIDC_ENDPOINT}, AWS Account ID: ${AWS_ACCOUNT_ID}"
 ----
++
+[NOTE]
+====
+The "Cluster" output from the previous command may be the name of your cluster, the internal ID of your cluster, or the cluster's domain prefix. If you prefer to use another identifier, you can manually set this value by running the following command:
+
+[source,terminal]
+----
+$ export CLUSTER=my-custom-value
+----
+====
 
 [id="cloud-experts-dynamic-certificate-prep-aws"]
 == Preparing your AWS account
@@ -77,7 +88,7 @@ $ export ZONE_ID=$(aws route53 list-hosted-zones-by-name --output json \
   --dns-name "${DOMAIN}." --query 'HostedZones[0]'.Id --out text | sed 's/\/hostedzone\///')
 ----
 +
-. Create an AWS IAM policy document for the `cert-manager` Operator that provides the ability to update _only_ the specified public hosted zone:
+. Create an AWS IAM policy document for the cert-manager Operator that provides the ability to update _only_ the specified public hosted zone:
 +
 [source,terminal]
 ----
@@ -112,11 +123,11 @@ EOF
 +
 [source,terminal]
 ----
-$ POLICY_ARN=$(aws iam create-policy --policy-name "${CLUSTER_NAME}-cert-manager-policy" \
+$ POLICY_ARN=$(aws iam create-policy --policy-name "${CLUSTER}-cert-manager-policy" \
   --policy-document file://${SCRATCH}/cert-manager-policy.json \
   --query 'Policy.Arn' --output text)
 ----
-. Create an AWS IAM trust policy for the `cert-manager` Operator:
+. Create an AWS IAM trust policy for the cert-manager Operator:
 +
 [source,terminal]
 ----
@@ -141,11 +152,11 @@ $ cat <<EOF > "${SCRATCH}/trust-policy.json"
 EOF
 ----
 +
-. Create an IAM role for the `cert-manager` Operator using the trust policy you created in the previous step:
+. Create an IAM role for the cert-manager Operator using the trust policy you created in the previous step:
 +
 [source,terminal]
 ----
-$ ROLE_ARN=$(aws iam create-role --role-name "${CLUSTER_NAME}-cert-manager-operator" \
+$ ROLE_ARN=$(aws iam create-role --role-name "${CLUSTER}-cert-manager-operator" \
    --assume-role-policy-document "file://${SCRATCH}/trust-policy.json" \
    --query Role.Arn --output text)
 ----
@@ -154,14 +165,14 @@ $ ROLE_ARN=$(aws iam create-role --role-name "${CLUSTER_NAME}-cert-manager-opera
 +
 [source,terminal]
 ----
-$ aws iam attach-role-policy --role-name "${CLUSTER_NAME}-cert-manager-operator" \
+$ aws iam attach-role-policy --role-name "${CLUSTER}-cert-manager-operator" \
   --policy-arn ${POLICY_ARN}
 ----
 
 [id="cloud-experts-dynamic-certificate-custom-domain-install-cert-man-op"]
 == Installing the cert-manager Operator
 
-. Create a project to install the `cert-manager` Operator into:
+. Create a project to install the cert-manager Operator into:
 +
 [source,terminal]
 ----
@@ -170,10 +181,10 @@ $ oc new-project cert-manager-operator
 +
 [IMPORTANT]
 ====
-Do not attempt to use more than one `cert-manager` Operator in your cluster. If you have a community `cert-manager` Operator installed in your cluster, you must uninstall it before installing the `cert-manager` Operator for Red{nbsp}Hat OpenShift.
+Do not attempt to use more than one cert-manager Operator in your cluster. If you have a community cert-manager Operator installed in your cluster, you must uninstall it before installing the cert-manager Operator for Red{nbsp}Hat OpenShift.
 ====
 +
-. Install the `cert-manager` Operator for Red{nbsp}Hat OpenShift:
+. Install the cert-manager Operator for Red Hat OpenShift:
 +
 [source,terminal]
 ----
@@ -206,7 +217,7 @@ EOF
 It takes a few minutes for this Operator to install and complete its set up.
 ====
 +
-. Verify that the `cert-manager` Operator is running:
+. Verify that the cert-manager Operator is running:
 +
 [source,terminal]
 ----
@@ -220,14 +231,14 @@ NAME                                                        READY   STATUS    RE
 cert-manager-operator-controller-manager-84b8799db5-gv8mx   2/2     Running   0          12s
 ----
 +
-. Annotate the service account used by the `cert-manager` pods with the AWS IAM role you created earlier:
+. Annotate the service account used by the cert-manager pods with the AWS IAM role you created earlier:
 +
 [source,terminal]
 ----
 $ oc -n cert-manager annotate serviceaccount cert-manager eks.amazonaws.com/role-arn=${ROLE_ARN}
 ----
 +
-. Restart the existing `cert-manager` controller pod by running the following command:
+. Restart the existing cert-manager controller pod by running the following command:
 +
 [source,terminal]
 ----
@@ -286,13 +297,6 @@ letsencrypt-production   True    47s
 [id="cloud-experts-dynamic-certificate-custom-domain-create-cd-ingress-con"]
 == Creating a custom domain Ingress Controller
 
-. Create a new project:
-+
-[source,terminal]
-----
-$ oc new-project custom-domain-ingress
-----
-+
 . Create and configure a certificate resource to provision a certificate for the custom domain Ingress Controller:
 +
 [NOTE]
@@ -307,7 +311,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: custom-domain-ingress-cert
-  namespace: custom-domain-ingress
+  namespace: openshift-ingress
 spec:
   secretName: custom-domain-ingress-cert-tls
   issuerRef:
@@ -323,12 +327,12 @@ EOF
 +
 [NOTE]
 ====
-It takes a few minutes for this certificate to be issued by Let's Encrypt. If it takes longer than 5 minutes, run `oc -n custom-domain-ingress describe certificate.cert-manager.io/custom-domain-ingress-cert` to see any issues reported by cert-manager.
+It takes a few minutes for this certificate to be issued by Let's Encrypt. If it takes longer than 5 minutes, run `oc -n openshift-ingress describe certificate.cert-manager.io/custom-domain-ingress-cert` to see any issues reported by cert-manager.
 ====
 +
 [source,terminal]
 ----
-$ oc -n custom-domain-ingress get certificate.cert-manager.io/custom-domain-ingress-cert
+$ oc -n openshift-ingress get certificate.cert-manager.io/custom-domain-ingress-cert
 ----
 +
 .Example output
@@ -339,43 +343,56 @@ NAME                         READY   SECRET                           AGE
 custom-domain-ingress-cert   True    custom-domain-ingress-cert-tls   9m53s
 ----
 +
-. Create a new `CustomDomain` custom resource (CR):
+. Create a new `IngressController` resource:
 +
 [source,terminal]
 ----
 $ cat << EOF | oc apply -f -
-apiVersion: managed.openshift.io/v1alpha1
-kind: CustomDomain
+apiVersion: operator.openshift.io/v1
+kind: IngressController
 metadata:
   name: custom-domain-ingress
+  namespace: openshift-ingress-operator
 spec:
   domain: ${DOMAIN}
-  scope: External
-  loadBalancerType: NLB
-  certificate:
+  defaultCertificate:
     name: custom-domain-ingress-cert-tls
-    namespace: custom-domain-ingress
+  endpointPublishingStrategy:
+    loadBalancer:
+      dnsManagementPolicy: Unmanaged
+      providerParameters:
+        aws:
+          type: NLB
+        type: AWS
+      scope: External
+    type: LoadBalancerService
 EOF
 ----
-. Verify that your custom domain Ingress Controller has been deployed and has a `Ready` status:
++
+[WARNING]
+====
+This `IngressController` example will create an internet accessible Network Load Balancer (NLB) in your AWS account. To provision an internal NLB instead, set the `.spec.endpointPublishingStrategy.loadBalancer.scope` parameter to `Internal` before creating the `IngressController` resource.
+====
++
+. Verify that your custom domain IngressController has successfully created an external load balancer:
 +
 [source,terminal]
 ----
-$ oc get customdomains
+$ oc -n openshift-ingress get service/router-custom-domain-ingress
 ----
 +
 .Example output
 [source,terminal]
 ----
-NAME                    ENDPOINT                                                               DOMAIN            STATUS
-custom-domain-ingress   tfoxdx.custom-domain-ingress.cluster.1234.p1.openshiftapps.com         example.com       Ready
+NAME                           TYPE           CLUSTER-IP      EXTERNAL-IP                                                                     PORT(S)                      AGE
+router-custom-domain-ingress   LoadBalancer   172.30.174.34   a309962c3bd6e42c08cadb9202eca683-1f5bbb64a1f1ec65.elb.us-east-1.amazonaws.com   80:31342/TCP,443:31821/TCP   7m28s
 ----
 +
 . Prepare a document with the necessary DNS changes to enable DNS resolution for your custom domain Ingress Controller:
 +
 [source,terminal]
 ----
-$ INGRESS=$(oc get customdomain.managed.openshift.io/custom-domain-ingress --template={{.status.endpoint}})
+$ INGRESS=$(oc -n openshift-ingress get service/router-custom-domain-ingress -ojsonpath="{.status.loadBalancer.ingress[0].hostname}")
 $ cat << EOF > "${SCRATCH}/create-cname.json"
 {
   "Comment":"Add CNAME to custom domain endpoint",
@@ -504,7 +521,7 @@ $ oc -n hello-world annotate route hello-openshift-tls cert-manager.io/issuer-ki
 +
 [NOTE]
 ====
-It takes 2-3 minutes for the certificate to be created. The renewal of the certificate will automatically be managed by the `cert-manager` Operator as it approaches expiration.
+It takes 2-3 minutes for the certificate to be created. The renewal of the certificate will automatically be managed by the cert-manager Operator as it approaches expiration.
 ====
 . Verify the certificate for the route is now trusted:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): `enterprise-4.15`+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-10979
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://77785--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-dynamic-certificate-custom-domain.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Not required for tutorials
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
