### PR TITLE
vSphere CPMS RN followup

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -517,9 +517,13 @@ For more information, see xref:../machine_management/applying-autoscaling.adoc#c
 
 This release introduces the ability to manage machines by using the upstream Cluster API, integrated into {product-title}, as a Technology Preview for {vmw-full} clusters.
 This capability is in addition or an alternative to managing machines with the Machine API.
-For more information, see _Managing machines with the Cluster API_.
-
 For more information, see xref:../machine_management/cluster_api_machine_management/cluster-api-about.adoc#cluster-api-about[About the Cluster API].
+
+[id="ocp-4-16-cpms-fd-vmw_{context}"]
+==== Defining a {vmw-short} failure domain for a control plane machine set
+
+With this release, the previously Technology Preview feature of defining a {vmw-short} failure domain for a control plane machine set is Generally Available.
+For more information, see xref:../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.adoc#cpmso-config-options-vsphere[Control plane configuration options for VMware vSphere]
 
 [id="ocp-4-16-nodes_{context}"]
 === Nodes
@@ -1156,6 +1160,13 @@ Kubernetes 1.29 removed the following deprecated APIs, so you must migrate manif
 [discrete]
 [id="ocp-4-16-cloud-compute-bug-fixes_{context}"]
 ==== Cloud Compute
+
+* Previously, the installation program populated the `network.devices`, `template` and `workspace` fields in the `spec.template.spec.providerSpec.value` section of the {vmw-full} control plane machine set custom resource (CR).
+These fields should be set in the {vmw-short} failure domain, and the installation program populating them caused unintended behaviors.
+Updating these fields did not trigger an update to the control plane machines, and these fields were cleared when the control plane machine set was deleted.
+With this release, the installation program is updated to no longer populate values that are included in the failure domain configuration.
+If these values are not defined in a failure domain configuration, for instance on a cluster that is updated to {product-title} {product-version} from an earlier version, the values defined by the installation program are used.
+(link:https://issues.redhat.com/browse/OCPBUGS-32947[*OCPBUGS-32947*])
 
 [discrete]
 [id="ocp-4-16-cloud-cred-operator-bug-fixes_{context}"]
@@ -1891,7 +1902,7 @@ In the following tables, features are marked with the following statuses:
 |Not Available
 |Technology Preview
 
-|Defining a vSphere failure domain for a control plane machine set
+|Defining a {vmw-short} failure domain for a control plane machine set
 |Not Available
 |Technology Preview
 |General Availability


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OCPBUGS-32947](https://issues.redhat.com/browse/OCPBUGS-32947), [OSDOCS-10271](https://issues.redhat.com//browse/OSDOCS-10271)

Link to docs preview:
- [Defining a vSphere failure domain for a control plane machine set](https://77786--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-cpms-fd-vmw_release-notes)
- [bugfix](https://77786--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-cloud-compute-bug-fixes_release-notes)

QE review:
N/A

Additional information:
- adds a blurb to accompany the existing TP > GA table update for vSphere CMPS FD support
- bugfix writeup for related OCPBUGS-32947