### PR TITLE
OSDOCS-9608: Adding note about HCP being unsupported

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-update-component-routes.adoc
+++ b/cloud_experts_tutorials/cloud-experts-update-component-routes.adoc
@@ -18,7 +18,13 @@ The changes that we make to the component routes{fn-term-component-routes} in th
 == Prerequisites
 * ROSA CLI (`rosa`) version 1.2.37 or higher
 * AWS CLI (`aws`)
-* A ROSA cluster
+* A ROSA Classic cluster version 4.14 or higher
++
+[NOTE]
+====
+ROSA with HCP is not supported at this time.
+====
++
 * OpenShift CLI (`oc`)
 * `jq` CLI
 * Access to the cluster as a user with the `cluster-admin` role.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): `enterprise-4.15`+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-9608
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://77787--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-update-component-routes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Not required
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Small correction to add a node that says HCP is unsupported at this time
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
