### PR TITLE
OSDOCS-7177: add intel vroc RAID procedure

### DIFF
--- a/installing/install_config/installing-customizing.adoc
+++ b/installing/install_config/installing-customizing.adoc
@@ -45,6 +45,7 @@ endif::openshift-webscale[]
 include::modules/installation-special-config-kmod.adoc[leveloffset=+1]
 include::modules/installation-special-config-storage.adoc[leveloffset=+1]
 include::modules/installation-special-config-raid.adoc[leveloffset=+1]
+include::modules/installation-special-config-raid-intel-vroc.adoc[leveloffset=+1]
 include::modules/installation-special-config-chrony.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/modules/installation-special-config-raid-intel-vroc.adoc
+++ b/modules/installation-special-config-raid-intel-vroc.adoc
@@ -1,0 +1,79 @@
+// Module included in the following assemblies:
+//
+// * installing/install_config/installing-customizing.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="installation-special-config-raid-intel-vroc_{context}"]
+== Configuring an Intel(R) Virtual RAID on CPU (VROC) data volume
+
+Intel(R) VROC is a type of hybrid RAID, where some of the maintenance is offloaded to the hardware, but appears as software RAID to the operating system.
+
+The following procedure configures an Intel(R) VROC-enabled RAID1.
+
+.Prerequisites
+
+* You have a system with Intel(R) Volume Management Device (VMD) enabled.
+
+.Procedure
+
+. Create the Intel(R) Matrix Storage Manager (IMSM) RAID container by running the following command:
++
+[source,terminal]
+----
+$ mdadm -CR /dev/md/imsm0 -e \
+  imsm -n2 /dev/nvme0n1 /dev/nvme1n1 <1>
+----
+<1> The RAID device names. In this example, there are two devices listed. If you provide more than two device names, you must adjust the `-n` flag. For example, listing three devices would use the flag `-n3`.
+
+. Create the RAID1 storage inside the container:
+
+.. Create a dummy RAID0 volume in front of the real RAID1 volume by running the following command:
++
+[source,terminal]
+----
+$ mdadm -CR /dev/md/dummy -l0 -n2 /dev/imsm0 -z10m --assume-clean
+----
+
+.. Create the real RAID1 array by running the following command:
++
+[source,terminal]
+----
+$ mdadm -CR /dev/md/coreos -l1 -n2 /dev/imsm0
+----
+
+.. Stop both RAID0 and RAID1 member arrays and delete the dummy RAID0 array with the following commands:
++
+[source,terminal]
+----
+$ mdadm -S /dev/md/dummy \
+  mdadm -S /dev/md/coreos \
+  mdadm --kill-subarray=0 /dev/md/imsm0
+----
+
+.. Restart the RAID1 arrays by running the following command:
++
+[source,terminal]
+----
+$ mdadm -A /dev/md/coreos /dev/md/imsm0
+----
+
+. Install {op-system} on the RAID1 device:
+
+.. Get the UUID of the IMSM container by running the following command:
++
+[source,terminal]
+----
+$ mdadm --details --export /dev/md/imsm0
+----
+
+.. Install {op-system} and include the `rd.md.uuid` kernel argument by running the following command:
++
+[source,terminal]
+----
+$ coreos-installer install /dev/md/coreos \
+  --append-karg rd.md.uuid=<md_UUID> <1>
+  ...
+----
+<1> The UUID of the IMSM container.
++
+Include any additional `coreos-installer` arguments you need to install {op-system}.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-7177
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://77793--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/installing-customizing.html#installation-special-config-raid-intel-vroc_installing-customizing
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
