### PR TITLE
WIP vSphere CPMS params ignored in 4.15

### DIFF
--- a/modules/cpmso-yaml-failure-domain-vsphere.adoc
+++ b/modules/cpmso-yaml-failure-domain-vsphere.adoc
@@ -38,10 +38,18 @@ spec:
         - name: <failure_domain_name2>
 # ...
 ----
-<1> A failure domain defines the vCenter location for {product-title} cluster nodes.
-<2> Defines failure domains by name for the control plane machine set.
-
+<1> Specifies the vCenter location for {product-title} cluster nodes.
+<2> Specifies failure domains by name for the control plane machine set.
++
 [IMPORTANT]
 ====
-Each `failureDomains.platform.vsphere.name` field value in the `ControlPlaneMachineSet` CR must match the corresponding value defined in the `failureDomains.name` field of the cluster-wide infrastructure CRD. Currently, the `vsphere.name` field is the only supported failure domain field that you can specify in the `ControlPlaneMachineSet` CR.
+Each `name` field value in this section must match the corresponding value in the `failureDomains.name` field of the cluster-wide infrastructure CRD.
+You can find the value of the `failureDomains.name` field by running the following command:
+
+[source,terminal]
+----
+$ oc get infrastructure cluster -o=jsonpath={.spec.platformSpec.vsphere.failureDomains[0].name
+----
+
+The `name` field is the only supported failure domain field that you can specify in the `ControlPlaneMachineSet` CR.
 ====

--- a/modules/cpmso-yaml-provider-spec-vsphere.adoc
+++ b/modules/cpmso-yaml-provider-spec-vsphere.adoc
@@ -40,24 +40,37 @@ spec:
             template: <vm_template_name> <8>
             userDataSecret:
               name: master-user-data <9>
-            workspace:
-              datacenter: <vcenter_datacenter_name> <10>
-              datastore: <vcenter_datastore_name> <11>
-              folder: <path_to_vcenter_vm_folder> <12>
-              resourcePool: <vsphere_resource_pool> <13>
-              server: <vcenter_server_ip> <14>
+            workspace: <10>
+              datacenter: <vcenter_datacenter_name> <11>
+              datastore: <vcenter_datastore_name> <12>
+              folder: <path_to_vcenter_vm_folder> <13>
+              resourcePool: <vsphere_resource_pool> <14>
+              server: <vcenter_server_ip> <15>
 ----
 <1> Specifies the secret name for the cluster. Do not change this value.
 <2> Specifies the VM disk size for the control plane machines.
 <3> Specifies the cloud provider platform type. Do not change this value.
 <4> Specifies the memory allocated for the control plane machines.
 <5> Specifies the network on which the control plane is deployed.
++
+[NOTE]
+====
+If the cluster is configured to use a failure domain, this parameter is configured in the failure domain.
+If you specify this value in the provider specification, the Control Plane Machine Set Operator ignores it.
+====
 <6> Specifies the number of CPUs allocated for the control plane machines.
 <7> Specifies the number of cores for each control plane CPU.
 <8> Specifies the vSphere VM template to use, such as `user-5ddjd-rhcos`.
 <9> Specifies the control plane user data secret. Do not change this value.
-<10> Specifies the vCenter Datacenter for the control plane.
-<11> Specifies the vCenter Datastore for the control plane.
-<12> Specifies the path to the vSphere VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
-<13> Specifies the vSphere resource pool for your VMs.
-<14> Specifies the vCenter server IP or fully qualified domain name.
+<10> Specifies the workspace details for the control plane.
++
+[NOTE]
+====
+If the cluster is configured to use a failure domain, these parameters are configured in the failure domain.
+If you specify these values in the provider specification, the Control Plane Machine Set Operator ignores them.
+====
+<11> Specifies the vCenter Datacenter for the control plane.
+<12> Specifies the vCenter Datastore for the control plane.
+<13> Specifies the path to the vSphere VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
+<14> Specifies the vSphere resource pool for your VMs.
+<15> Specifies the vCenter server IP or fully qualified domain name.


### PR DESCRIPTION
Version(s):
4.15

Issue:
N/A, via Slack DM

Link to docs preview:
- [Sample VMware vSphere provider specification](https://77797--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.html#cpmso-yaml-provider-spec-vsphere_cpmso-config-options-vsphere)
- [Sample VMware vSphere failure domain configuration](https://77797--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.html#cpmso-yaml-failure-domain-vsphere_cpmso-config-options-vsphere) (not updated yet but needs work too)

QE review:
- [ ] QE has approved this change.

Additional information: