### PR TITLE
OSDOCS-9882 OCP 4.16 Hosted Control Plane bug fix RNs

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -255,7 +255,7 @@ This release introduces a new `--interactive` flag for the `oc delete` command. 
 [id="ocp-4-16-ibm-z_{context}"]
 === {ibm-z-title} and {ibm-linuxone-title}
 
-With this release, {ibm-z-name} and {ibm-linuxone-name} are now compatible with {product-title} {product-version}. You can perform the installation with z/VM, LPAR, or {op-system-base-full} Kernel-based Virtual Machine (KVM). For installation instructions, see 
+With this release, {ibm-z-name} and {ibm-linuxone-name} are now compatible with {product-title} {product-version}. You can perform the installation with z/VM, LPAR, or {op-system-base-full} Kernel-based Virtual Machine (KVM). For installation instructions, see
 xref:../installing/installing_ibm_z/preparing-to-install-on-ibm-z.adoc#preparing-to-install-on-ibm-z[Installing a cluster with on {ibm-z-title} and {ibm-linuxone-title}].
 
 [IMPORTANT]
@@ -1841,6 +1841,34 @@ With this release, the CCO no longer checks for the nonexistent permission.
 [discrete]
 [id="ocp-4-16-hosted-control-plane-bug-fixes_{context}"]
 ==== Hosted Control Plane
+
+* Previously, Multus CNI required CSRs to be approved when you used the `Other` network type in hosted clusters. The proper RBAC rules were set only when the network type was `Other` and was set to Calico. As a consequence, the CSRs were not approved when the network type was `Other` and set to Cilium. With this update, the correct RBAC rules are set for all valid network types, and RBACs are now properly configured when you use the `Other` network type. (link:https://issues.redhat.com/browse/OCPBUGS-26977[*OCPBUGS-26977*])
+
+* Previously, an {aws-first} policy issue prevented the {cap-aws-short} from retrieving the necessary domain information. As a consequence, installing an {aws-short} hosted cluster with a custom domain failed. With this update, the policy issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-29391[*OCPBUGS-29391*])
+
+* Previously, in disconnected environments, the HyperShift Operator ignored registry overrides. As a consequence, changes to node pools were ignored, and node pools encountered errors. With this update, the metadata inspector works as expected during the HyperShift Operator reconciliation, and the override images are properly populated. (link:https://issues.redhat.com/browse/OCPBUGS-34773[*OCPBUGS-34773*])
+
+* Previously, the Hypershift Operator was not using the `RegistryOverrides` mechanism to inspect the image from the internal registry. With this release, the metadata inspector works as expected during the Hypershift Operator reconciliation, and the `OverrideImages` are properly populated. (link:https://issues.redhat.com/browse/OCPBUGS-32220[*OCPBUGS-32220*])
+
+* Previously, the {product-title} Cluster Manager container did not have the correct TLS certificates. As a result, image streams could not be used in disconnected deployments. With this update, the TLS certificates are added as projected volumes. (link:https://issues.redhat.com/browse/OCPBUGS-34390[*OCPBUGS-34390*])
+
+* Previously, the `azure-kms-provider-active` container in the KAS pod used an entrypoint statement in shell form in the Dockerfile. As a consequence, the container failed. To resolve this issue, use the `exec` form for the entrypoint statement. (link:https://issues.redhat.com/browse/OCPBUGS-33940[*OCPBUGS-33940*])
+
+* Previously, the `konnectivity-agent` daemon set used the `ClusterIP` DNS policy. As a result, when CoreDNS was down, the `konnectivity-agent` pods on the data plane could not resolve the proxy server URL, and they could fail to `konnectivity-server` in the control plane. With this update, the `konnectivity-agent` daemon set was modified to use `dnsPolicy: Default`. The `konnectivity-agent` uses the host system DNS service to look up the proxy server address, and it does not depend on CoreDNS anymore. (link:https://issues.redhat.com/browse/OCPBUGS-31444[*OCPBUGS-31444*])
+
+* Previously, the inability to find a resource caused re-creation attempts to fail. As a consequence, many `409` response codes were logged in Hosted Cluster Config Operator logs. With this update, specific resources were added to the cache so that the Hosted Cluster Config Operator does not try to re-create existing resources. (link:https://issues.redhat.com/browse/OCPBUGS-23228[*OCPBUGS-23228*])
+
+* Previously, the pod security violation alert was missing in hosted clusters. With this update, the alert is added to hosted clusters. (link:https://issues.redhat.com/browse/OCPBUGS-31263[*OCPBUGS-31263*])
+
+* Previously, the `recycler-pod` template in hosted clusters in disconnected environments pointed to `quay.io/openshift/origin-tools:latest`. As a consequence, the recycler pods failed to start. With this update, the recycler pod image now points to the {produt-title} payload reference. (link:https://issues.redhat.com/browse/OCPBUGS-31398[*OCPBUGS-31398*])
+
+* With this update, in disconnected deployments, the HyperShift Operator receives the new ICSP/IDMS from the management cluster and adds them to the HyperShift Operator and the Control Plane Operator in every reconciliation loop. The changes to the ICSP/IDMS cause the `control-plane-operator` pod to be restarted. (link:https://issues.redhat.com/browse/OCPBUGS-29110[*OCPBUGS-29110*])
+
+* With this update, the `ControllerAvailabilityPolicy` setting becomes immutable after it is set. Changing between `SingleReplica` and `HighAvailability` is not supported. (link:https://issues.redhat.com/browse/OCPBUGS-27282[*OCPBUGS-27282*])
+
+* With this update, the `machine-config-operator` custom resource definitions (CRDs) are renamed to ensure that resources are being omitted properly in hosted control planes. (link:https://issues.redhat.com/browse/OCPBUGS-34575[*OCPBUGS-34575*])
+
+* With this update, the size is reduced for audit log files that are stored in the `kube-apiserver`, `openshift-apiserver`, and `oauth-apiserver` pods for hosted control planes. (link:https://issues.redhat.com/browse/OCPBUGS-31106[*OCPBUGS-31106*])
 
 [discrete]
 [id="ocp-4-16-image-registry-bug-fixes_{context}"]


### PR DESCRIPTION
Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-9882](https://issues.redhat.com/browse/OSDOCS-9882)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Bug Fixes -> Hosted Control Plane](https://77802--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-bug-fixes_release-notes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Not needed

<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
