### PR TITLE
OSDOCS-9882 4.16 bug fix RNs for Node, Builds, and Kube Controller Ma…

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -1811,6 +1811,10 @@ Kubernetes 1.29 removed the following deprecated APIs, so you must migrate manif
 [id="ocp-4-16-builds-bug-fixes_{context}"]
 ==== Builds
 
+* Previously, clusters that updated from earlier versions to 4.16 continued to allow builds to be triggered by unauthenticated webhooks. With this release, new clusters require build webhooks to be authenticated. Builds are not triggered by unauthenticated webhooks unless a cluster administrator allows unauthenticated webhooks in the namespace or cluster. (link:https://issues.redhat.com/browse/OCPBUGS-33378[*OCPBUGS-33378*])
+
+* Previously, if the developer or cluster administrator used lowercase environment variable names for proxy information, these environment variables were carried into the build output container image. At runtime, the proxy settings were active and had to be unset. With this release, lowercase versions of the `++*++_PROXY` environment variables are prevented from leaking into built container images. Now, `buildDefaults` are only kept during the build and settings created for the build process only are removed before pushing the image in the registry. (link:https://issues.redhat.com/browse/OCPBUGS-34825[*OCPBUGS-34825*])
+
 [discrete]
 [id="ocp-4-16-cloud-compute-bug-fixes_{context}"]
 ==== Cloud Compute
@@ -2078,6 +2082,8 @@ With this release, the CCO no longer checks for the nonexistent permission.
 [id="ocp-4-16-kube-controller-bug-fixes_{context}"]
 ==== Kubernetes Controller Manager
 
+* Previously, when deleting a `ClusterResourceQuota` resource using the foreground deletion cascading strategy, the removal failed to complete. With this release, `ClusterResourceQuota` resources are deleted properly when using the foreground cascading strategy. (link:https://issues.redhat.com/browse/OCPBUGS-22301[*OCPBUGS-22301*])
+
 [discrete]
 [id="ocp-4-16-kube-scheduler-bug-fixes_{context}"]
 ==== Kubernetes Scheduler
@@ -2244,6 +2250,10 @@ With this release, session affinity without a timeout is possible by setting the
 [discrete]
 [id="ocp-4-16-node-bug-fixes_{context}"]
 ==== Node
+
+* Previously, {product-title} upgrades for Ansible caused an error as the IPsec configuration was not idempotent. With this update, the issue is resolved. Now, all IPsec configurations for OpenShift Ansible playbooks are idempotent. (link:https://issues.redhat.com/browse/OCPBUGS-30802[*OCPBUGS-30802*])
+
+* Previously, the CRI-O removed all of the images installed between minor version upgrades of {product-title} to ensure stale payload images did not take up space on the node. However, it was decided this was a performance penalty, and this functionality was removed. With this fix, the kubelet will still garbage collect stale images after disk usage hits a certain level. As a result, {product-title} no longer removes all images after an upgrade between minor versions. (link:https://issues.redhat.com/browse/OCPBUGS-24743[*OCPBUGS-24743*])
 
 [discrete]
 [id="ocp-4-16-node-tuning-operator-bug-fixes_{context}"]


### PR DESCRIPTION
…nager

Version(s): 4.16 
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-9882](https://issues.redhat.com/browse/OSDOCS-9882)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Bug Fixes, scroll to the Builds, Kubernetes Controller Manager, and Node sections.](https://77815--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-bug-fixes_release-notes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
Not needed
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
