### PR TITLE
HCIDOCS-366: Fix "Non-bootable ISO attached to BMH" documentation

### DIFF
--- a/modules/bmo-attaching-a-non-bootable-iso-to-a-bare-metal-node.adoc
+++ b/modules/bmo-attaching-a-non-bootable-iso-to-a-bare-metal-node.adoc
@@ -50,7 +50,7 @@ $ oc apply -f <node_name>-dataimage.yaml -n <node_namespace> <1>
 +
 [NOTE]
 ====
-You can physically reboot the node. You can also attach the `reboot.metal3.io` annotation or reset set the `online` status in the `BareMetalHost` resource. A forced reboot of the bare-metal node will change the state of the node to `NotReady` for awhile. For example, 5 minutes or more.
+To reboot the node, attach the `reboot.metal3.io` annotation, or reset set the `online` status in the `BareMetalHost` resource. A forced reboot of the bare-metal node will change the state of the node to `NotReady` for awhile. For example, 5 minutes or more.
 ====
 
 . View the `DataImage` resource by running the following command:


### PR DESCRIPTION
Incorporated QE feedback for HCIDOCS-72.

Fixes: [HCIDOCS-366](https://issues.redhat.com//browse/HCIDOCS-366)

See https://issues.redhat.com/browse/HCIDOCS-366 for additional details.

Preview URL: https://77821--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/bare-metal-configuration.html#attaching-a-non-bootable-iso-to-a-bare-metal-node_post-install-bare-metal-configuration

For release(s): 4.16
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
