### PR TITLE
HCIDOCS-72: Added a release note

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -570,6 +570,12 @@ Beginning with {product-title} {product-version}, you can upgrade or downgrade t
 
 In {product-title} {product-version} and later, you can edit the baseboard management controller (BMC) address in the `BareMetalHost` resource of a bare-metal node. The node must be in the `Provisioned`, `ExternallyProvisioned`, `Registering`, or `Available` state. Editing the BMC address in the `BareMetalHost` resource will not result in deprovisioning the node. See xref:../post_installation_configuration/bare-metal-configuration.adoc#editing-a-baremetalhost-resource_post-install-bare-metal-configuration[Editing a BareMetalHost resource] for additional details.
 
+[id="ocp-4-16-attaching-a-non-bootable-iso_{context}"]
+==== Attaching a non-bootable ISO
+
+In {product-title} {product-version} and later, you can attach a generic, non-bootable ISO virtual media image to a provisioned node by using the `DataImage` resource. After you apply the resource, the ISO image becomes accessible to the operating system on the next reboot.
+The node must use Redfish or drivers derived from it to support this feature. The node must be in the `Provisioned` or `ExternallyProvisioned` state. See xref:../post_installation_configuration/bare-metal-configuration.adoc#attaching-a-non-bootable-iso-to-a-bare-metal-node_post-install-bare-metal-configuration[Attaching a non-bootable ISO to a bare-metal node] for additional details.
+
 [id="ocp-4-16-monitoring_{context}"]
 === Monitoring
 


### PR DESCRIPTION
Added a release note for attaching an non-bootable ISO.

Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/HCIDOCS-72
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://77822--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-attaching-a-non-bootable-iso_release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
