### PR TITLE
TRACING-3783: Add documentation for the OTEL Collector monitoring dashboards

### DIFF
--- a/modules/otel-troubleshoot-metrics.adoc
+++ b/modules/otel-troubleshoot-metrics.adoc
@@ -32,8 +32,6 @@ The Operator creates a `<cr_name>-collector-monitoring` telemetry service that y
 ----
 <1> The address at which the internal collector metrics are exposed. Defaults to `:8888`.
 
-// TODO Operator 0.82.0 has spec.observability.metrics.enableMetrics config that creates ServiceMonitors for users
-
 . Retrieve the metrics by running the following command, which uses the port-forwarding Collector pod:
 +
 [source,terminal]
@@ -42,3 +40,19 @@ $ oc port-forward <collector_pod>
 ----
 
 . Access the metrics endpoint at `+http://localhost:8888/metrics+`.
+
+Alternatively, you can enable the creation of PodMonitors or ServiceMonitors (depending on the deployment mode of the OpenTelemetryCollector) to scrap the internal metrics by setting to `true` the `enableMetrics` setting.
+
++
+[source,yaml]
+----
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+spec:
+  mode: deployment
+  observability:
+    metrics:
+      enableMetrics: true # <1>
+----
+
+If `User Workload Monitoring` is enabled, you will be able to visualize the scraped metrics in the `Observe` section from the OpenShift Console. Note you can select to visualize the specific metrics from an OpenTelemetry Collector instance or OpenTelemetry component (processor, receiver or exporter).


### PR DESCRIPTION
Version(s): 4.17, 4.16, 4.15, 4.14, 4.13, 4.12

Issue: [TRACING-3783](https://issues.redhat.com/browse/TRACING-3783)

Link to docs preview: https://77831--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-troubleshooting.html

QE review:
- [ ] QE has approved this change.


Additional information: I included the documentation missed in a TODO statement.