### PR TITLE
[OSDOCS-10985]Reinstate information pertaining to https://issues.redhat.com/browse/OSDOCS-10434

### DIFF
--- a/modules/sd-planning-considerations.adoc
+++ b/modules/sd-planning-considerations.adoc
@@ -70,25 +70,25 @@ GCP control plane and infrastructure node size:
 |custom-16-131072-ext
 |===
 
-// GCP control plane and infrastructure node size for clusters created on or after 6 June 2024:
-// [options="header",cols="2a,2a,2a"]
-// |===
-// |Number of compute nodes
-// |Control plane size
-// |Infrastructure node size
+GCP control plane and infrastructure node size for clusters created on or after 21 June 2024:
+[options="header",cols="2a,2a,2a"]
+|===
+|Number of compute nodes
+|Control plane size
+|Infrastructure node size
 
-// |1 to 25
-// |n2-standard-8
-// |n2-highmem-4
+|1 to 25
+|n2-standard-8
+|n2-highmem-4
 
-// |26 to 100
-// |n2-standard-16
-// |n2-highmem-8
+|26 to 100
+|n2-standard-16
+|n2-highmem-8
 
-// |101 to 180
-// |n2-standard-32
-// |n2-highmem-16
-// |===
+|101 to 180
+|n2-standard-32
+|n2-highmem-16
+|===
 
 endif::[]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.15+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-10985
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change. **QE has already reviewed and approved https://issues.redhat.com/browse/OSDOCS-10434. This is the same info but was accidentally greenlit prematurely from stakeholder.** 
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
https://77853--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/osd-limits-scalability.html#node-sizing-during-installation_osd-limits-scalability
Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
