### PR TITLE
OSDOCS-10914: adds 4.14.31 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -558,3 +558,12 @@ Issued: 2024-06-19
 {product-title} release 4.14.30 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:3884[RHBA-2024:3884] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:3881[RHSA-2024:3881] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-14-31-dp"]
+=== RHBA-2024:4012 - {microshift-short} 4.14.31 bug fix and security update advisory
+
+Issued: 2024-06-26
+
+{product-title} release 4.14.31 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4012[RHBA-2024:4012] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4010[RHSA-2024:4010] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-10914](https://issues.redhat.com/browse/OSDOCS-10914)

Link to docs preview:
[4-14-31](https://77856--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes.html#microshift-4-14-31-dp)

QE review:
- N/A stock text

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
