### PR TITLE
puts a xref back that was breaking builds

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -288,6 +288,8 @@ With this release, migration from the OpenShift SDN network plugin to OVN-Kubern
 
 With this release, OVN-Kubernetes uses a new `DNSNameResolver` custom resource to keep track of DNS records in your egress firewall rules, and is available as a Technology Preview. This custom resource supports the use of both wildcard DNS names and regular DNS names and allows access to DNS names regardless of the IP addresses associated with its change.
 
+For more information, see xref:../networking/network_security/egress_firewall/configuring-egress-firewall-ovn.adoc#nw-coredns-egress-firewall[Improved DNS resolution and resolving wildcard domain names].
+
 [id="ocp-4-16-networking-sriov-draining_{context}"]
 ==== Parallel node draining during SR-IOV network policy updates
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
Puts back an xref that was previously removed because it was breaking builds due to the nwt refactoring.
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
