### PR TITLE
OCPBUGS-35217: Fix incorrect example in Release Notes

### DIFF
--- a/modules/op-release-notes-1-14.adoc
+++ b/modules/op-release-notes-1-14.adoc
@@ -108,7 +108,7 @@ spec:
       value: https://ghe.mycompany.com
 ----
 
-* With this update, you can define default resource requirements for containers and init-containers in pods that {pipelines-shortname} creates when executing task runs. Use the `pipeline.options.configMaps.config-defaults.default-container-resource-requirements` spec in the `TektonConfig` CR to set these requirements. You can set the default values for all containers and also for particular containers by name or by prefix, such as `sidecar-*`.
+* With this update, you can define default resource requirements for containers and init-containers in pods that {pipelines-shortname} creates when executing task runs. Use the `pipeline.options.configMaps.config-defaults.data.default-container-resource-requirements` spec in the `TektonConfig` CR to set these requirements. You can set the default values for all containers and also for particular containers by name or by prefix, such as `sidecar-*`.
 
 [id="Operator-new-features-1-14_{context}"]
 === Operator


### PR DESCRIPTION
The field originally described does not work as expected. This commit adds the missing `data` field in the example.

Version(s): pipelines-docs-1.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-35217
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: -
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

In the Release notes for Red Hat OpenShift Pipelines General Availability 1.14 there is the following section (https://docs.openshift.com/pipelines/1.14/about/op-release-notes.html#new-features-1-14_op-release-notes):


> With this update, you can define default resource requirements for containers and init-containers in pods that OpenShift Pipelines creates when executing task runs. Use the pipeline.options.configMaps.config-defaults.default-container-resource-requirements spec in the TektonConfig CR to set these requirements. You can set the default values for all containers and also for particular containers by name or by prefix, such as sidecar-*.

However the field described does not work as expected. When trying to use `oc patch` to add content to such a field the user will get an error like this:

~~~
Error from server (BadRequest): admission webhook "webhook.operator.tekton.dev" denied the request: mutation failed: cannot decode incoming new object: json: unknown field "default-container-resource-requirements"
~~~

This commit fixes that issue.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
