### PR TITLE
Update MCO TP list in RN

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -536,17 +536,17 @@ With this release, {olmv1} displays the following status condition messages for 
 With this release, you can now garbage collect unused rendered machine configs. By using the `oc adm prune renderedmachineconfigs` command, you can view the unused rendered machine configs, determine which to remove, then batch delete the rendered machine configs that you no longer need. Having too many machine configs can make working with the machine configs confusing and can also contribute to disk space and performance issues. For more information, see xref:../post_installation_configuration/machine-configuration-tasks.adoc#machineconfig-garbage-collect_post-install-machine-configuration-tasks[Managing unused rendered machine configs].
 
 [id="ocp-4-16-machine-config-operator-node-disruption_{context}"]
-==== Node disruption policies
+==== Node disruption policies (Technology Preview)
 
 By default, when you make certain changes to the parameters in a `MachineConfig` object, the Machine Config Operator (MCO) drains and reboots the nodes associated with that machine config. However, you can create a node disruption policy in the MCO namespace that defines a set of Ignition config objects changes that would require little or no disruption to your workloads. For more information, see xref:../post_installation_configuration/machine-configuration-tasks.adoc#machine-config-node-disruption_post-install-machine-configuration-tasks[Understanding node restart behaviors after machine config changes].
 
 [id="ocp-4-16-machine-config-operator-on-cluster_{context}"]
-==== On-cluster {op-system} image layering
+==== On-cluster {op-system} image layering (Technology Preview)
 
 With {op-system-first} image layering, you can now automatically build the custom layered image directly in your cluster, as a Technology Preview feature. Previously, you needed to build the custom layered image outside of the cluster, then pull the image into the cluster. The image layering feature allows you to extend the functionality of your base {op-system} image by layering additional images onto the base image. For more information, see xref:../post_installation_configuration/coreos-layering.adoc#coreos-layering[RHCOS image layering].
 
 [id="ocp-4-16-machine-config-operator-boot-image_{context}"]
-==== Updating boot images
+==== Updating boot images (Technology Preview)
 
 By default, the MCO does not delete the boot image it uses to bring up a {op-system-first} node. Consequently, the boot image in your cluster is not updated along with your cluster. You can now configure your cluster to update the boot image whenever you update your cluster. For more information, see xref:../post_installation_configuration/machine-configuration-tasks.adoc#mco-update-boot-images_post-install-machine-configuration-tasks[Updating boot images].
 
@@ -2359,6 +2359,21 @@ In the following tables, features are marked with the following statuses:
 |Improved MCO state reporting
 |Not Available
 |Technology Preview
+|Technology Preview
+
+|On-cluster RHCOS image layering
+|Not Available
+|Not Available
+|Technology Preview
+
+|Node disruption policies
+|Not Available
+|Not Available
+|Technology Preview
+
+|Updating boot images
+|Not Available
+|Not Available
 |Technology Preview
 
 |====


### PR DESCRIPTION
Added Technology Preview MCO features to table in release notes. 

Previews
[Table 32. Machine Config Operator Technology Preview tracker](https://77868--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-technology-preview-tables_release-notes) -- Updated TP table with three new features.
[MCO new features](https://77868--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-machine-config-operator_release-notes) -- Added _(Technology Preview)_ to three new features. 
