### PR TITLE
add indent statement to multiline cli guidance

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -1419,14 +1419,17 @@ The following example shows a more complex use of user-chosen elements and presc
 
 [[backslash-for-long-code-line]]
 ==== Backslash for long lines of code
-For long lines of code that you want to break up among multiple lines, use a backslash to show the line break. For example:
+For long lines of code that you want to break up among multiple lines, use a backslash to show the line break and indent all lines under the first with two spaces. For example:
 
+....
+[source,terminal]
 ----
 $ oc get endpoints --all-namespaces --template \
-    '{{ range .items }}{{ .metadata.namespace }}:{{ .metadata.name }} \
-    {{ range .subsets }}{{ range .addresses }}{{ .ip }} \
-    {{ end }}{{ end }}{{ "\n" }}{{ end }}' | awk '/ 172\.30\./ { print $1 }'
+  '{{ range .items }}{{ .metadata.namespace }}:{{ .metadata.name }} \
+  {{ range .subsets }}{{ range .addresses }}{{ .ip }} \
+  {{ end }}{{ end }}{{ "\n" }}{{ end }}' | awk '/ 172\.30\./ { print $1 }'
 ----
+....
 
 [[callouts-in-codeblocks]]
 ==== Callouts in code blocks


### PR DESCRIPTION
Version(s):
`main`

Issue:
N/A

Link to docs preview:
[Backslash for long lines of code](https://github.com/openshift/openshift-docs/blob/ec742cb474716891db6858e2b66805542b6b4bb0/contributing_to_docs/doc_guidelines.adoc#backslash-for-long-lines-of-code)

QE review:
N/A

Additional information:
Noticed this omission during peer review