### PR TITLE
OSDOCS-9882-machineconfig: Bug bacthed the Machine Config bug fixes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -1978,6 +1978,26 @@ With this release, the CCO no longer checks for the nonexistent permission.
 [id="ocp-4-16-machine-config-operator-bug-fixes_{context}"]
 ==== Machine Config Operator
 
+* Previously, the `MachineConfigNode` object was not created with a proper owner. As a result, the `MachineConfigNode` object could not be garbage collected, meaning that previously generated, but no longer useful, objects were not removed. With this release, the proper owner is set upon the creation of the `MachineConfigNode` object and objects that become obsolete are available for garbage collection.(link:https://issues.redhat.com/browse/OCPBUGS-30090[*OCPBUGS-30090*])
+
+* Previously, the default value of the `nodeStatusUpdateFrequency` parameter was changed from `0s` to `10s`. This change inadvertently caused the `nodeStatusReportFrequency` to increase significantly, because the value was linked to the `nodeStatusReportFrequency` value. This resulted in high CPU usage on control plane operators and the API server. This fix manually sets the `nodeStatusReportFrequency` value to `5m`, which prevents this high CPU usage. (link:https://issues.redhat.com/browse/OCPBUGS-29713[*OCPBUGS-29713*])
+
+* Previously, a typo in an environment variable prevented a script from detecting if the `node.env` file was present. Because of this, the `node.env` file would be overwritten on every restart, preventing the kubelet hostname from being fixed. With this fix the typo is corrected. As a result, edits to the `node.env` are now persist across reboots. (link:https://issues.redhat.com/browse/OCPBUGS-27261[*OCPBUGS-27261*])
+
+* Previously, when the `kube-apiserver` server Certificate Authority (CA) certificate was rotated, the MCO did not properly react and update the on-disk kubelet kubeconfig. This meant that the kubelet and some pods on the node were eventually unable to communicate with the APIserver, causing the node to enter the `NotReady` state. With this release, the Machine Config Operator (MCO) properly reacts to the change, and updates the on-disk kubeconfig such that authenticated communication with the APIServer can continue when this rotates, and also restarts kubelet/MCDaemon pod. The certificate authority has 10-year validity, so this rotation should happen rarely and is generally non-disruptive. (link:https://issues.redhat.com/browse/OCPBUGS-25821[*OCPBUGS-25821*])
+
+* Previously, when a new node was added to or removed from a cluster, the `MachineConfigNode` (MCN) objects did not react. As a result, extraneous MCN objects existed. With this release, the Machine Config Operator removes and adds MCN objects as appropriate when nodes are added or removed. (link:https://issues.redhat.com/browse/OCPBUGS-24416[*OCPBUGS-24416*])
+
+* Previously, the `nodeip-configuration` service did not send logs to the serial console, which made it difficult to debug problems when networking is not available and there is no access to the node. With this release, the `nodeip-configuration` service logs output to the serial console for easier debugging when there is no network access to the node. (link:https://issues.redhat.com/browse/OCPBUGS-19628[*OCPBUGS-19628*])
+
+* Previously, when a `MachineConfigPool` had the `OnClusterBuild` functionality enabled and the `configmap` was updated with an invalid `imageBuilderType`, the machine-config ClusterOperator was not degraded. With this release, the Machine Config Operator (MCO) `ClusterOperator` status now validates the `OnClusterBuild` inputs each time it syncs, ensuring that if those are invalid, the `ClusterOperator` is degraded. (link:https://issues.redhat.com/browse/OCPBUGS-18955[*OCPBUGS-18955*])
+
+* Previously, when the `machine config not found` error was reported, there was not enough information to troubleshoot and correct the problem. With this release, an alert and metric have been added to the Machine Config Operator. As a result, you have more information to troubleshoot and remediate the `machine config not found` error. (link:https://issues.redhat.com/browse/OCPBUGS-17788[*OCPBUGS-17788*])
+
+* Previously, the Afterburn service used to set the hostname on nodes timed out while waiting for the metadata service to become available, causing issues when deploying with OVN-Kubernetes. Now, the Afterburn service waits longer for the metadata service to become available, resolving these timeouts. (link:https://issues.redhat.com/browse/OCPBUGS-11936[*OCPBUGS-11936*])
+
+* Previously, when a node was removed from a `MachineConfigPool`, the Machine Config Operator (MCO) did not report an error or the removal of the node. The MCO does not support managing nodes when they are not in a pool and there was no indication that node management ceased after the node was removed. With this release, if a node is removed from all pools, the MCO now logs an error. (link:https://issues.redhat.com/browse/OCPBUGS-5452[*OCPBUGS-5452*])
+
 [discrete]
 [id="ocp-4-16-management-console-bug-fixes_{context}"]
 ==== Management Console


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-9882](https://issues.redhat.com/browse/OSDOCS-9882)

Link to docs preview:
[Bug fixes](https://77885--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-bug-fixes_release-notes)
