### PR TITLE
OSDOCS-9882-BMH-2: Second installment of bug batching the BMH big fixes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -1845,6 +1845,12 @@ Kubernetes 1.29 removed the following deprecated APIs, so you must migrate manif
 
 * Previously, the Bare Metal Operator (BMO) was not using a leader lock to control incoming and outgoing Operator pod traffic. After an OpenShift `Deployment` object included a new Operator pod, the new pod competed with system resources, such as the `ClusterOperator` status, and this terminated any outgoing Operator pods. This issue also impacted clusters that do not include any bare-metal nodes. With this release, the BMO includes a leader lock to manage new pod traffic, and this fix resolves the competing pod issue. (link:https://issues.redhat.com/browse/OCPBUGS-25766[*OCPBUGS-25766*])
 
+* Previously, when you attempted to delete a `BareMetalHost` object before the installation started, the metal3 Operator attempted to create a `PreprovImage` image. The process of creating this image caused the `BareMetalHost` object to still exist in certain processes. With this release, an exception is added for this situation so that the `BareMetalHost` object is deleted without impacting running processes. (link:https://issues.redhat.com/browse/OCPBUGS-33048[*OCPBUGS-33048*])
+
+* Previously, a Redfish virtual media in the context of Hewlett Packard Enterprise (HPE) Lights Out (iLO) 5 had its bare-metal machine compression forcibly disabled to work around other unrelated issues in different hardware models. This caused the `FirmwareSchema` resource to be missing from each iLO 5 bare-metal machine. Each machine needs compression to fetch message registries from their Redfish Baseboard Management Controller (BMC) endpoints. With this release, each iLO 5 bare-metal machine that needs the `FirmwareSchema` resource does not have compression forcibly disabled. (link:https://issues.redhat.com/browse/OCPBUGS-31104[*OCPBUGS-31104*])
+
+* Previously, the `inspector.ipxe` configuration file used the `IRONIC_IP` variable, which did not account for IPv6 addresses because they have brackets. Consequently, when the user supplied an incorrect `boot_mac_address`, iPXE fell back to the `inspector.ipxe` configuration file, which supplied a malformed IPv6 host header since it did not contain brackets. With this release, the `inspector.ipxe` configuration file has been updated to use the `IRONIC_URL_HOST` variable, which accounts for IPv6 addresses and resolves the issue. (link:https://issues.redhat.com/browse/OCPBUGS-22699[*OCPBUGS-22699*])
+
 [discrete]
 [id="ocp-4-16-builds-bug-fixes_{context}"]
 ==== Builds


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-9882](https://issues.redhat.com/browse/OSDOCS-9882)

Link to docs preview:
[Bug fixes](https://77896--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-bug-fixes_release-notes)
