### PR TITLE
OSDOCS-9882-cloud-cluster-etc: bug batching 2nd round for cluster and cloud 4.16 bug fixes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -1905,6 +1905,9 @@ If these values are not defined in a failure domain configuration, for instance 
 
 * Previously, the logic that fetches the name of a node did not account for the possibility of multiple values for the returned hostname from the {aws-short} metadata service. When multiple domains are configured for a VPC  Dynamic Host Configuration Protocol (DHCP) option, this hostname might return multiple values. The space between multiple values caused the logic to crash. With this release, the logic is updated to use only the first returned hostname as the node name. (link:https://issues.redhat.com/browse/OCPBUGS-10498[*OCPBUGS-10498*])
 
+* Previously, the Machine API Operator requested unnecessary `virtualMachines/extensions` permissions on {azure-first} clusters.
+The unnecessary credentials request is removed in this release. (link:https://issues.redhat.com/browse/OCPBUGS-29956[*OCPBUGS-29956*])
+
 [discrete]
 [id="ocp-4-16-cloud-cred-operator-bug-fixes_{context}"]
 ==== Cloud Credential Operator


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-9882](https://issues.redhat.com/browse/OSDOCS-9882)

Link to docs preview:
[Bug fixes](https://77901--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-bug-fixes_release-notes)
