### PR TITLE
Document creating user-defined cluster roles for cluster-scoped instances

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -100,6 +100,8 @@ Distros: openshift-gitops
 Topics:
 - Name: Configuring an OpenShift cluster by deploying an application with cluster configurations
   File: configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations
+- Name: Customizing permissions by creating user-defined cluster roles for cluster-scoped instances
+  File: customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances
 - Name: Sharding clusters across Argo CD Application Controller replicas
   File: sharding-clusters-across-argo-cd-application-controller-replicas
 ---

--- a/argocd_instance/setting-up-argocd-instance.adoc
+++ b/argocd_instance/setting-up-argocd-instance.adoc
@@ -19,12 +19,19 @@ To manage cluster configurations or deploy applications, you can install and dep
 
 // Installing an Argo CD instance
 include::modules/gitops-argo-cd-installation.adoc[leveloffset=+1]
-
 [role="_additional-resources"]
 .Additional resources 
 * link:https://argocd-operator.readthedocs.io/en/latest/usage/routes/#setting-tls-modes-for-routes[Configuring the route TLS termination]
 * xref:../argocd_instance/argo-cd-cr-component-properties.adoc#argo-cd-properties_argo-cd-cr-component-properties[Argo CD custom resource properties]
 * link:https://docs.openshift.com/container-platform/latest/rest_api/network_apis/route-route-openshift-io-v1.html#spec-tls[Specification for TLS termination configuration]
+* xref:../declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc#using-argo-cd-instance-to-manage-cluster-scoped-resources_configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations[Using an Argo CD instance to manage cluster-scoped resources]
+* xref:../declarative_clusterconfig/customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances.adoc#gitops-disabling-the-creation-of-the-default-cluster-roles-for-the-cluster-scoped-instance_customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances[Disabling the creation of the default cluster roles for the cluster-scoped instance]
+
+// Configuring common cluster roles by specifying user-defined cluster roles for namespace-scoped instances
+include::modules/gitops-configuring-common-cluster-roles-by-specifying-user-defined-cluster-roles-for-namespace-scoped-instances.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources 
+* xref:../declarative_clusterconfig/customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances.adoc#customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances[Customizing permissions by creating user-defined cluster roles for cluster-scoped instances]
 
 // Enabling replicas for Argo CD server and repo server
 include::modules/gitops-enable-replicas-for-argo-cd-server.adoc[leveloffset=+1]

--- a/declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc
+++ b/declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc
@@ -54,6 +54,9 @@ include::modules/gitops-inbuilt-permissions-for-cluster-config.adoc[leveloffset=
 
 // Adding permissions for cluster configuration
 include::modules/gitops-additional-permissions-for-cluster-config.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources 
+* xref:../declarative_clusterconfig/customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances.adoc#customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances[Customizing permissions by creating user-defined cluster roles for cluster-scoped instances]
 
 // Installing OLM Operators using Red Hat OpenShift GitOps
 include::modules/gitops-installing-olm-operators-using-gitops.adoc[leveloffset=+1]

--- a/declarative_clusterconfig/customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances.adoc
+++ b/declarative_clusterconfig/customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances.adoc
@@ -1,0 +1,72 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances"]
+= Customizing permissions by creating user-defined cluster roles for cluster-scoped instances
+:context: customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances
+
+toc::[]
+
+For the default cluster-scoped instance, the {gitops-title} Operator grants additional permissions for managing certain cluster-scoped resources. Consequently, as a cluster administrator, when you deploy an Argo CD as a cluster-scoped instance, the Operator creates additional cluster roles and cluster role bindings for the {gitops-shortname} control plane components. These cluster roles and cluster role bindings provide the additional permissions that Argo CD requires to operate at the cluster level. 
+
+If you do not want the cluster-scoped instance to have all of the Operator-given permissions and choose to add or remove permissions to cluster-wide resources, you must first disable the creation of the default cluster roles for the cluster-scoped instance. Then, you can customize permissions for the following cluster-scoped instances:
+
+* Default ArgoCD instance (default cluster-scoped instance)
+* User-defined cluster-scoped Argo CD instance
+
+This guide provides instructions with examples to help you create a user-defined cluster-scoped Argo CD instance, deploy an Argo CD application in your defined namespace that contains custom configurations for your cluster, disable the creation of the default cluster roles for the cluster-scoped instance, and customize permissions for user-defined cluster-scoped instances by creating new cluster roles and cluster role bindings for the {gitops-shortname} control plane components. 
+
+[NOTE]
+====
+As a developer, if you are creating an Argo CD application and deploying cluster-wide resources, ensure that your cluster administrator grants the necessary permissions to them.
+
+Otherwise, after the Argo CD reconciliation, you will see an authentication error message in the application's `Status` field similar to the following example:
+
+.Example authentication error message
+
+[source,terminal]
+----
+persistentvolumes is forbidden: User "system:serviceaccount:gitops-demo:argocd-argocd-application-controller" cannot create resource "persistentvolumes" in API group "" at the cluster scope.
+----
+====
+
+[id="prerequisites_customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances"]
+== Prerequisites
+
+* You have installed {gitops-title} 1.13.0  or a later version on your {OCP} cluster.
+* You have installed the OpenShift CLI (`oc`).
+* You have installed the {gitops-title} `argocd` CLI.
+* You have installed a xref:../declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc#using-argo-cd-instance-to-manage-cluster-scoped-resources_configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations[cluster-scoped Argo CD instance] in your defined namespace. For example, `spring-petclinic`. 
+* You have validated that the user-defined cluster-scoped instance is configured with the cluster roles and cluster role bindings for the following components:
++
+** Argo CD Application Controller
+** Argo CD server
+** Argo CD ApplicationSet Controller (provided the ApplicationSet Controller is created)
++
+* You have deployed a `cluster-configs` xref:../declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc#creating-an-application-by-using-the-argo-cd-dashboard_configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations[Argo CD application] with the `customclusterrole` link:https://github.com/redhat-developer/openshift-gitops-getting-started/tree/main/customclusterrole[path] in the `spring-petclinic` namespace and created the `test-gitops-ns` namespace and `test-gitops-pv` persistent volume resources.
++
+[NOTE]
+====
+The `cluster-configs` Argo CD application must be managed by a user-defined cluster-scoped instance with the following parameters set:
+
+* The `selfHeal` field value set to `true`
+* The `syncPolicy` field value set to `automated`
+* The  *Label* field set to the `app.kubernetes.io/part-of=argocd` value
+* The  *Label* field set to the `argocd.argoproj.io/managed-by=<user_defined_namespace>` value so that the Argo CD instance in your defined namespace can manage your namespace
+* The  *Label* field set to the `app.kubernetes.io/name=<user_defined_argocd_instance>` value
+====
+
+// Disabling the creation of the default cluster-scoped instance
+include::modules/gitops-disabling-the-creation-of-the-default-cluster-roles-for-the-cluster-scoped-instance.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+* xref:../argocd_instance/setting-up-argocd-instance.adoc#setting-up-argocd-instance[Installing a user-defined Argo CD instance]
+
+// Customizing permissions for cluster-scoped instances
+include::modules/gitops-customizing-permissions-for-cluster-scoped-instances.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances"]
+== Additional resources
+
+* xref:../declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc#gitops-additional-permissions-for-cluster-config_configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations[Adding permissions for cluster configuration]
+* xref:../argocd_instance/setting-up-argocd-instance.adoc#gitops-configuring-common-cluster-roles-by-specifying-user-defined-cluster-roles-for-namespace-scoped-instances_setting-up-argocd-instance[Configuring common cluster roles by specifying user-defined cluster roles for namespace-scoped instances]

--- a/declarative_clusterconfig/sharding-clusters-across-argo-cd-application-controller-replicas.adoc
+++ b/declarative_clusterconfig/sharding-clusters-across-argo-cd-application-controller-replicas.adoc
@@ -20,5 +20,10 @@ include::modules/gitops-argo-cd-dynamic-scaling.adoc[leveloffset=+1]
 include::modules/gitops-argo-cd-dynamic-scaling-in-web-console.adoc[leveloffset=+2]
 
 include::modules/gitops-argo-cd-dynamic-scaling-by-using-cli.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+* xref:../argocd_instance/argo-cd-cr-component-properties.adoc#argo-cd-properties_argo-cd-cr-component-properties[Argo CD custom resource properties]
+
+* link:https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-autoscaling.html[Automatically scaling pods with the horizontal pod autoscaler]
 
 

--- a/modules/gitops-additional-permissions-for-cluster-config.adoc
+++ b/modules/gitops-additional-permissions-for-cluster-config.adoc
@@ -38,6 +38,11 @@ rules:
 . Select the *Subject* as *ServiceAccount* and the provide the *Subject namespace* and *name*.
 .. *Subject namespace*: `openshift-gitops`
 .. *Subject name*: `openshift-gitops-argocd-application-controller`
++
+[NOTE]
+====
+The value of *Subject name* depends on the {gitops-shortname} control plane components for which you create the cluster roles and cluster role bindings.
+====
 . Click *Create*. The YAML file for the `ClusterRoleBinding` object is as follows:
 +
 [source,yaml]

--- a/modules/gitops-argo-cd-dynamic-scaling-by-using-cli.adoc
+++ b/modules/gitops-argo-cd-dynamic-scaling-by-using-cli.adoc
@@ -83,11 +83,4 @@ NAME                                           READY   STATUS    RESTARTS   AGE
 openshift-gitops-application-controller-0      1/1     Running   0          2m  <1>
 ----
 +
-<1> The number of Argo CD Application Controller pods must be equal to or greater than the value of `minShard`.
-
-[role="_additional-resources"]
-[id="additional-resources_argocd-cr-properties"]
-= Additional resources
-* link:https://docs.openshift.com/gitops/1.11/argocd_instance/argo-cd-cr-component-properties.html#argo-cd-properties_argo-cd-cr-component-properties[Argo CD custom resource properties]
-
-* link:https://docs.openshift.com/container-platform/4.14/nodes/pods/nodes-pods-autoscaling.html[Automatically scaling pods with the horizontal pod autoscaler]
+<1> The number of Argo CD Application Controller pods must be greater than or equal to the value of `minShard`.

--- a/modules/gitops-configuring-common-cluster-roles-by-specifying-user-defined-cluster-roles-for-namespace-scoped-instances.adoc
+++ b/modules/gitops-configuring-common-cluster-roles-by-specifying-user-defined-cluster-roles-for-namespace-scoped-instances.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// * argocd_instance/setting-up-argocd-instance.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="gitops-configuring-common-cluster-roles-by-specifying-user-defined-cluster-roles-for-namespace-scoped-instances_{context}"]
+= Configuring common cluster roles by specifying user-defined cluster roles for namespace-scoped instances
+
+As a cluster administrator, when you give an Argo CD access to a namespace by using the `argocd.argoproj.io/managed-by` label, the Argo CD assumes `namespace-admin` privileges. The {gitops-title} Operator then automatically creates role bindings for all managed namespaces of the following {gitops-shortname} control plane components:
+
+* Argo CD Application Controller
+* Argo CD server
+* Argo CD ApplicationSet Controller
+
+When you provide namespaces to non-administrator users, for example, development teams, they can use the `namespace-admin` privileges to modify objects such as network policies. Installing an Argo CD instance in these namespaces gives the development teams `admin` privileges and indirectly elevates their assigned privileges. These roles are highly privileged and can delete all resources. As a preventive action, you can define a specific set of reduced permissions to meet your security requirements by configuring common cluster roles for all managed namespaces in the role bindings that the Operator creates for the Argo CD Application Controller and Argo CD server components.
+
+To configure common cluster roles for all managed namespaces, you can specify user-defined cluster roles for the `CONTROLLER_CLUSTER_ROLE` and `SERVER_CLUSTER_ROLE` environment variables in the Operator's `Subscription` object YAML file. As a result, instead of creating the default `admin` role, the Operator uses the existing user-defined cluster roles and creates role bindings for all managed namespaces.
+
+.Prerequisites
+
+* You have logged in to the {OCP} cluster as an administrator.
+
+* You have installed the {gitops-title} Operator on your {OCP} cluster.
+
+.Procedure
+
+. In the *Administrator* perspective, navigate to *Administration* -> *CustomResourceDefinitions*.
+. Find the *Subscription* CRD and click to open it.
+. Select the *Instances* tab and click the *openshift-gitops-operator* subscription.
+. Select the *YAML* tab and make your customization:
+** Specify the user-defined cluster roles for the `CONTROLLER_CLUSTER_ROLE` and `SERVER_CLUSTER_ROLE` environment variables:
++
+.Example Subscription
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-gitops-operator
+  namespace: openshift-gitops-operator
+spec:
+  config:
+    env: 
+    - name: CONTROLLER_CLUSTER_ROLE 
+      value: gitops-controller-role # <1>
+    - name: SERVER_CLUSTER_ROLE
+      value: gitops-server-role # <2>
+----
+<1> The name of the environment variable for the Argo CD Application Controller component.
+<2> The name of the environment variable for the Argo CD server component.
+
+[TIP]
+====
+Alternatively, you can inject the preceding environment variables directly into the Operator's `Deployment` object YAML file.
+==== 

--- a/modules/gitops-customizing-permissions-for-cluster-scoped-instances.adoc
+++ b/modules/gitops-customizing-permissions-for-cluster-scoped-instances.adoc
@@ -1,0 +1,95 @@
+// Module included in the following assembly:
+//
+// * declarative_clusterconfig/customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="gitops-customizing-permissions-for-cluster-scoped-instances_{context}"]
+= Customizing permissions for cluster-scoped instances
+
+As a cluster administrator, to customize permissions for cluster-scoped instances, you must create new cluster roles and cluster role bindings for the {gitops-shortname} control plane components. 
+
+For example purposes, the following instructions focus only on user-defined cluster-scoped instances.
+
+.Procedure
+
+. Open the *Administrator* perspective of the web console and go to *User Management* -> *Roles* -> *Create Role*.
+
+. Use the following `ClusterRole` YAML template to add rules to specify the additional permissions.
++
+.Example cluster role YAML template
+
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: example-spring-petclinic-argocd-application-controller # <1>
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - '*'
+    resources:
+      - '*'
+  - verbs:
+      - '*'
+    apiGroups:
+      - ''
+    resources: # <2>
+      - namespaces 
+      - persistentvolumes 
+----
+<1> The name of the cluster role according to the <argocd_name>-<argocd_namespace>-<control_plane_component> naming convention.
+<2> The resources to which you want to grant permissions at the cluster level.
+
+. Click *Create* to add the cluster role.
+
+. Find the service account used by the control plane component you are customizing permissions for, by performing the following steps:
++
+.. Go to *Workloads* -> *Pods*.
+.. From the *Project* drop-down menu, select the project where the user-defined cluster-scoped instance is installed.
+.. Click the pod of the control plane component and go to the *YAML* tab.
+.. Find the `spec.ServiceAccount` field and note the service account.
+
+. Go to *User Management* -> *RoleBindings* -> *Create binding*.
+
+. Click *Create binding*.
+
+. Select *Binding type* as *Cluster-wide role binding (ClusterRoleBinding)*.
+
+. Enter a unique value for *RoleBinding name* by following the <argocd_name>-<argocd_namespace>-<control_plane_component> naming convention.
+
+. Select the newly created cluster role from the drop-down list for *Role name*.
+
+. Select the *Subject* as *ServiceAccount* and the provide the *Subject namespace* and *name*.
+.. *Subject namespace*: `spring-petclinic`
+.. *Subject name*: `example-argocd-application-controller`
++
+[NOTE]
+====
+For *Subject name*, ensure that the value you configure is the same as the value of the `spec.ServiceAccount` field of the control plane component you are customizing permissions for.
+====
+
+. Click *Create*. 
++
+You have created the required permissions for the control plane component's service account and namespace. The YAML file for the `ClusterRoleBinding` object looks similar to the following example:
++
+.Example YAML file for a cluster role binding
+
+[source,yaml]
+----
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: example-spring-petclinic-argocd-application-controller
+subjects:
+  - kind: ServiceAccount
+    name: example-argocd-application-controller
+    namespace: spring-petclinic
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: example-spring-petclinic-argocd-application-controller
+----

--- a/modules/gitops-disabling-the-creation-of-the-default-cluster-roles-for-the-cluster-scoped-instance.adoc
+++ b/modules/gitops-disabling-the-creation-of-the-default-cluster-roles-for-the-cluster-scoped-instance.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assembly:
+//
+// * declarative_clusterconfig/customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="gitops-disabling-the-creation-of-the-default-cluster-roles-for-the-cluster-scoped-instance_{context}"]
+= Disabling the creation of the default cluster roles for the cluster-scoped instance
+
+To add or remove permissions to cluster-wide resources, as needed, you must disable the creation of the default cluster roles for the cluster-scoped instance by editing the YAML file of the Argo CD custom resource (CR).
+
+.Procedure
+
+. In the Argo CD CR, set the value of the `.spec.defaultClusterScopedRoleDisabled` field to `true`:
++
+.Example Argo CD CR
+
+[source,yaml]
+----
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: example # <1>
+  namespace: spring-petclinic # <2>
+# ...
+spec:
+  defaultClusterScopedRoleDisabled: true # <3>
+# ...
+----
+<1> The name of the cluster-scoped instance.
+<2> The namespace where you want to run the cluster-scoped instance.
+<3> The flag value that disables the creation of the default cluster roles for the cluster-scoped instance. If you want the Operator to recreate the default cluster roles and cluster role bindings for the cluster-scoped instance, set the field value to `false`.
++
+.Sample output
+[source,terminal]
+----
+argocd.argoproj.io/example configured
+----
+
+. Verify that the {gitops-title} Operator has deleted the default cluster roles and cluster role bindings for the {gitops-shortname} control plane components by running the following commands:
++
+[source,terminal]
+----
+$ oc get ClusterRoles/<argocd_name>-<argocd_namespace>-<control_plane_component>
+----
++
+[source,terminal]
+----
+$ oc get ClusterRoleBindings/<argocd_name>-<argocd_namespace>-<control_plane_component>
+----
++
+.Sample output
+[source,terminal]
+----
+No resources found
+----
++
+The default cluster roles and cluster role bindings for the cluster-scoped instance are not created. As a cluster administrator, you can now create and customize permissions for cluster-scoped instances by creating new cluster roles and cluster role bindings for the {gitops-shortname} control plane components.

--- a/modules/gitops-enabling-the-application-set-resources-in-non-control-plane-namespaces.adoc
+++ b/modules/gitops-enabling-the-application-set-resources-in-non-control-plane-namespaces.adoc
@@ -6,7 +6,7 @@
 [id="gitops-enabling-the-application-set-resources-in-non-control-plane-namespaces_{context}"]
 = Enabling the application set resources in non-control plane namespaces
 
-As an Argo CD administrator, you can define a certain set of non-control plane namespaces wherein users can create, update, and reconcile `ApplicationSet` resources. You must explicitly enable and configure the `ArgoCD` and `ApplicationSet` custom resources (CRs) as per your requirements.
+As a cluster administrator, you can define a certain set of non-control plane namespaces wherein users can create, update, and reconcile `ApplicationSet` resources. You must explicitly enable and configure the `ArgoCD` and `ApplicationSet` custom resources (CRs) as per your requirements.
 
 .Procedure
 

--- a/modules/gitops-using-argo-cd-instance-to-manage-cluster-scoped-resources.adoc
+++ b/modules/gitops-using-argo-cd-instance-to-manage-cluster-scoped-resources.adoc
@@ -19,7 +19,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: openshift-gitops-operator
-  namespace: openshift-operators
+  namespace: openshift-gitops-operator
 # ...
 spec:
   config:


### PR DESCRIPTION
Jira issue : [RHDEVDOCS-6038](https://issues.redhat.com/browse/RHDEVDOCS-6038)

Aligned team: DevTools 
Cherry-pick to versions: `gitops-docs-1.13`

Docs preview:

- [Configuring common cluster roles by specifying user-defined cluster roles for namespace-scoped instances](https://77943--ocpdocs-pr.netlify.app/openshift-gitops/latest/argocd_instance/setting-up-argocd-instance#gitops-configuring-common-cluster-roles-by-specifying-user-defined-cluster-roles-for-namespace-scoped-instances_setting-up-argocd-instance)
- [Adding permissions for cluster configuration](https://77943--ocpdocs-pr.netlify.app/openshift-gitops/latest/declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations#gitops-additional-permissions-for-cluster-config_configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations)
- [Customizing permissions by creating user-defined cluster roles for cluster-scoped instances](https://77943--ocpdocs-pr.netlify.app/openshift-gitops/latest/declarative_clusterconfig/customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances)
- [Installing a user-defined Argo CD instance](https://77943--ocpdocs-pr.netlify.app/openshift-gitops/latest/argocd_instance/setting-up-argocd-instance#gitops-argo-cd-installation_setting-up-argocd-instance)
- [Enabling dynamic scaling of shards by using the CLI](https://77943--ocpdocs-pr.netlify.app/openshift-gitops/latest/declarative_clusterconfig/sharding-clusters-across-argo-cd-application-controller-replicas#gitops-argo-cd-dynamic-scaling-by-using-cli_sharding-clusters-across-argo-cd-application-controller-replicas)
- [Enabling the application set resources in non-control plane namespaces](https://77943--ocpdocs-pr.netlify.app/openshift-gitops/latest/argocd_application_sets/managing-app-sets-in-non-control-plane-namespaces#gitops-enabling-the-application-set-resources-in-non-control-plane-namespaces_managing-app-sets-in-non-control-plane-namespaces)
- [Using an Argo CD instance to manage cluster-scoped resources](https://77943--ocpdocs-pr.netlify.app/openshift-gitops/latest/declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations#using-argo-cd-instance-to-manage-cluster-scoped-resources_configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations)


SME review: @jparsai

QE review: @varshab1210, @mehabhalodiya, @trdoyle81 (any one of them)

Peer review: 

Additional information: **Note to peer reviewers** - GA date is next week Wednesday and I am also working on a couple of more L/XL PRs. In the best interest of time and urgency, I highly appreciate your help with the Peer review of this PR. Thank you!