### PR TITLE
OSDOCS-9882-oc2: Documented 2nd round of miscellaneous bug batching bug fixes for 4.16

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -1835,13 +1835,13 @@ Kubernetes 1.29 removed the following deprecated APIs, so you must migrate manif
 
 * Previously, some Kubernetes API server events did not have the correct timestamps. With this release, Kubernetes API server events now have the correct timestamps. (link:https://issues.redhat.com/browse/OCPBUGS-27074[*OCPBUGS-27074*])
 
-* Previously, the Kubernetes API Server Operator attempted to delete a Prometheus rule that was removed in {product-title} 4.13 to ensure it was deleted. This resulted resulted in failed deletion messages in the audit logs every few minutes. With this release, the Kubernetes API Server Operator no longer attempts to remove this nonexistent rule and there are no more failed deletion messages in the audit logs. (link:https://issues.redhat.com/browse/OCPBUGS-25894[*OCPBUGS-25894*])
+* Previously, the Kubernetes API Server Operator attempted to delete a Prometheus rule that was removed in {product-title} 4.13 to ensure it was deleted. This resulted in failed deletion messages in the audit logs every few minutes. With this release, the Kubernetes API Server Operator no longer attempts to remove this nonexistent rule and there are no more failed deletion messages in the audit logs. (link:https://issues.redhat.com/browse/OCPBUGS-25894[*OCPBUGS-25894*])
 
 [discrete]
 [id="ocp-4-16-bare-metal-hardware-bug-fixes_{context}"]
 ==== Bare Metal Hardware Provisioning
 
-* Previously, newer versions of Redfish used Manager resources to deprecate the Uniform Resource Identifier (URI) for the RedFish Virtual Media API. This caused any hardware that used the newer Redfish URI for Virtual Media to not be provisioned. With this release, the Ironic API identifies the correct Redfish URI to deploy for the RedFish Virtual Media API so that hardware relying on either the deprectaed or newer URI could be provisioned. (link:https://issues.redhat.com/browse/OCPBUGS-30171[*OCPBUGS-30171*])
+* Previously, newer versions of Redfish used Manager resources to deprecate the Uniform Resource Identifier (URI) for the RedFish Virtual Media API. This caused any hardware that used the newer Redfish URI for Virtual Media to not be provisioned. With this release, the Ironic API identifies the correct Redfish URI to deploy for the RedFish Virtual Media API so that hardware relying on either the deprecated or newer URI could be provisioned. (link:https://issues.redhat.com/browse/OCPBUGS-30171[*OCPBUGS-30171*])
 
 * Previously, the Bare Metal Operator (BMO) was not using a leader lock to control incoming and outgoing Operator pod traffic. After an OpenShift `Deployment` object included a new Operator pod, the new pod competed with system resources, such as the `ClusterOperator` status, and this terminated any outgoing Operator pods. This issue also impacted clusters that do not include any bare-metal nodes. With this release, the BMO includes a leader lock to manage new pod traffic, and this fix resolves the competing pod issue. (link:https://issues.redhat.com/browse/OCPBUGS-25766[*OCPBUGS-25766*])
 
@@ -1863,14 +1863,12 @@ Kubernetes 1.29 removed the following deprecated APIs, so you must migrate manif
 [id="ocp-4-16-cloud-compute-bug-fixes_{context}"]
 ==== Cloud Compute
 
-* Previously, the Cloud Controller Manager Operator used predefined roles on {gcp-first} instead of granular permissions.
-With this release, the Cloud Controller Manager Operator is updated to use granular permissions on {gcp-short} clusters.
+* Previously, the Cloud Controller Manager Operator used predefined roles on {gcp-first} instead of granular permissions. With this release, the Cloud Controller Manager (CCM) Operator is updated to use granular permissions on {gcp-short} clusters.
 (link:https://issues.redhat.com/browse/OCPBUGS-26479[*OCPBUGS-26479*])
 
 * Previously, the installation program populated the `network.devices`, `template` and `workspace` fields in the `spec.template.spec.providerSpec.value` section of the {vmw-full} control plane machine set custom resource (CR). These fields should be set in the {vmw-short} failure domain, and the installation program populating them caused unintended behaviors. Updating these fields did not trigger an update to the control plane machines, and these fields were cleared when the control plane machine set was deleted.
 +
-With this release, the installation program is updated to no longer populate values that are included in the failure domain configuration.
-If these values are not defined in a failure domain configuration, for instance on a cluster that is updated to {product-title} {product-version} from an earlier version, the values defined by the installation program are used.
+With this release, the installation program is updated to no longer populate values that are included in the failure domain configuration. If these values are not defined in a failure domain configuration, for instance on a cluster that is updated to {product-title} {product-version} from an earlier version, the values defined by the installation program are used.
 (link:https://issues.redhat.com/browse/OCPBUGS-32947[*OCPBUGS-32947*])
 
 * Previously, a node associated with a rebooting machine briefly having a status of `Ready=Unknown` triggered the `UnavailableReplicas` condition in the Control Plane Machine Set Operator. This condition caused the Operator to enter the `Available=False` state and trigger alerts because that state indicates a nonfunctional component that requires immediate administrator intervention. This alert should not have been triggered for the brief and expected unavailabilty while rebooting. With this release, a grace period for node unreadiness is added to avoid triggering unnecessary alerts. (link:https://issues.redhat.com/browse/OCPBUGS-34970[*OCPBUGS-34970*])
@@ -1915,30 +1913,19 @@ If these values are not defined in a failure domain configuration, for instance 
 [id="ocp-4-16-cloud-cred-operator-bug-fixes_{context}"]
 ==== Cloud Credential Operator
 
-* Previously, the Cloud Credential Operator was missing some permissions required to create a private cluster on {azure-first}.
-These missing permissions prevented installation of an {azure-short} private cluster using {entra-first}.
-This release includes the missing permissions and enables installation of an {azure-short} private cluster using {entra-short}.
-(link:https://issues.redhat.com/browse/OCPBUGS-25193[*OCPBUGS-25193*])
+* Previously, the Cloud Credential Operator (CCO) was missing some permissions required to create a private cluster on {azure-first}. These missing permissions prevented installation of an {azure-short} private cluster using {entra-first}. This release includes the missing permissions and enables installation of an {azure-short} private cluster using {entra-short}. (link:https://issues.redhat.com/browse/OCPBUGS-25193[*OCPBUGS-25193*])
 
 * Previously, a bug caused the Cloud Credential Operator (CCO) to report an incorrect mode in the metrics. Even though the cluster was in the default mode, the metrics reported that it was in the credentials removed mode. This update uses a live client in place of a cached client so that it is able to obtain the root credentials, and the CCO no longer reports an incorrect mode in the metrics. (link:https://issues.redhat.com/browse/OCPBUGS-26488[*OCPBUGS-26488*])
 
-* Previously, the Cloud Credential Operator credentials mode metric on an {product-title} cluster that uses {entra-first} reported using manual mode.
-With this release, clusters that use {entra-short} are updated to report that they are using manual mode with pod identity.
-(link:https://issues.redhat.com/browse/OCPBUGS-27446[*OCPBUGS-27446*])
+* Previously, the Cloud Credential Operator credentials mode metric on an {product-title} cluster that uses {entra-first} reported using manual mode. With this release, clusters that use {entra-short} are updated to report that they are using manual mode with pod identity. (link:https://issues.redhat.com/browse/OCPBUGS-27446[*OCPBUGS-27446*])
 
-* Previously, creating an {aws-first} root secret on a bare metal cluster caused the Cloud Credential Operator (CCO) pod to crash.
-The issue is resolved in this release.
-(link:https://issues.redhat.com/browse/OCPBUGS-28535[*OCPBUGS-28535*])
+* Previously, creating an {aws-first} root secret on a bare metal cluster caused the Cloud Credential Operator (CCO) pod to crash. The issue is resolved in this release. (link:https://issues.redhat.com/browse/OCPBUGS-28535[*OCPBUGS-28535*])
 
 * Previously, removing the root credential from a {gcp-first} cluster that used the Cloud Credential Operator (CCO) in mint mode caused the CCO to become degraded after approximately one hour.
 In a degraded state, the CCO cannot manage the component credential secrets on a cluster.
-The issue is resolved in this release.
-(link:https://issues.redhat.com/browse/OCPBUGS-28787[*OCPBUGS-28787*])
+The issue is resolved in this release. (link:https://issues.redhat.com/browse/OCPBUGS-28787[*OCPBUGS-28787*])
 
-* Previously, the Cloud Credential Operator (CCO) checked for a nonexistent `s3:HeadBucket` permission during installation on {aws-first}.
-When the CCO failed to find this permission, it considered the provided credentials insufficient for mint mode.
-With this release, the CCO no longer checks for the nonexistent permission.
-(link:https://issues.redhat.com/browse/OCPBUGS-31678[*OCPBUGS-31678*])
+* Previously, the Cloud Credential Operator (CCO) checked for a nonexistent `s3:HeadBucket` permission during installation on {aws-first}. When the CCO failed to find this permission, it considered the provided credentials insufficient for mint mode. With this release, the CCO no longer checks for the nonexistent permission. (link:https://issues.redhat.com/browse/OCPBUGS-31678[*OCPBUGS-31678*])
 
 [discrete]
 [id="ocp-4-16-cluster-version-operator-bug-fixes_{context}"]
@@ -1998,15 +1985,15 @@ With this release, the CCO no longer checks for the nonexistent permission.
 [id="ocp-4-16-hosted-control-plane-bug-fixes_{context}"]
 ==== Hosted Control Plane
 
-* Previously, Multus CNI required CSRs to be approved when you used the `Other` network type in hosted clusters. The proper RBAC rules were set only when the network type was `Other` and was set to Calico. As a consequence, the CSRs were not approved when the network type was `Other` and set to Cilium. With this update, the correct RBAC rules are set for all valid network types, and RBACs are now properly configured when you use the `Other` network type. (link:https://issues.redhat.com/browse/OCPBUGS-26977[*OCPBUGS-26977*])
+* Previously, Multus  Container Network Interface (CNI) required certificate signing requests (CSRs) to be approved when you used the `Other` network type in hosted clusters. The proper role-based access control (RBAC) rules were set only when the network type was `Other` and was set to Calico. As a consequence, the CSRs were not approved when the network type was `Other` and set to Cilium. With this update, the correct RBAC rules are set for all valid network types, and RBACs are now properly configured when you use the `Other` network type. (link:https://issues.redhat.com/browse/OCPBUGS-26977[*OCPBUGS-26977*])
 
 * Previously, an {aws-first} policy issue prevented the {cap-aws-short} from retrieving the necessary domain information. As a consequence, installing an {aws-short} hosted cluster with a custom domain failed. With this update, the policy issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-29391[*OCPBUGS-29391*])
 
 * Previously, in disconnected environments, the HyperShift Operator ignored registry overrides. As a consequence, changes to node pools were ignored, and node pools encountered errors. With this update, the metadata inspector works as expected during the HyperShift Operator reconciliation, and the override images are properly populated. (link:https://issues.redhat.com/browse/OCPBUGS-34773[*OCPBUGS-34773*])
 
-* Previously, the Hypershift Operator was not using the `RegistryOverrides` mechanism to inspect the image from the internal registry. With this release, the metadata inspector works as expected during the Hypershift Operator reconciliation, and the `OverrideImages` are properly populated. (link:https://issues.redhat.com/browse/OCPBUGS-32220[*OCPBUGS-32220*])
+* Previously, the HyperShift Operator was not using the `RegistryOverrides` mechanism to inspect the image from the internal registry. With this release, the metadata inspector works as expected during the HyperShift Operator reconciliation, and the `OverrideImages` are properly populated. (link:https://issues.redhat.com/browse/OCPBUGS-32220[*OCPBUGS-32220*])
 
-* Previously, the {product-title} Cluster Manager container did not have the correct TLS certificates. As a result, image streams could not be used in disconnected deployments. With this update, the TLS certificates are added as projected volumes. (link:https://issues.redhat.com/browse/OCPBUGS-34390[*OCPBUGS-34390*])
+* Previously, the {cluster-manager-first} container did not have the correct Transport Layer Security (TLS) certificates. As a result, image streams could not be used in disconnected deployments. With this update, the TLS certificates are added as projected volumes. (link:https://issues.redhat.com/browse/OCPBUGS-34390[*OCPBUGS-34390*])
 
 * Previously, the `azure-kms-provider-active` container in the KAS pod used an entrypoint statement in shell form in the Dockerfile. As a consequence, the container failed. To resolve this issue, use the `exec` form for the entrypoint statement. (link:https://issues.redhat.com/browse/OCPBUGS-33940[*OCPBUGS-33940*])
 
@@ -2018,7 +2005,7 @@ With this release, the CCO no longer checks for the nonexistent permission.
 
 * Previously, the `recycler-pod` template in hosted clusters in disconnected environments pointed to `quay.io/openshift/origin-tools:latest`. As a consequence, the recycler pods failed to start. With this update, the recycler pod image now points to the {produt-title} payload reference. (link:https://issues.redhat.com/browse/OCPBUGS-31398[*OCPBUGS-31398*])
 
-* With this update, in disconnected deployments, the HyperShift Operator receives the new ICSP/IDMS from the management cluster and adds them to the HyperShift Operator and the Control Plane Operator in every reconciliation loop. The changes to the ICSP/IDMS cause the `control-plane-operator` pod to be restarted. (link:https://issues.redhat.com/browse/OCPBUGS-29110[*OCPBUGS-29110*])
+* With this update, in disconnected deployments, the HyperShift Operator receives the new `ImageContentSourcePolicy` (ICSP) or `ImageDigestMirrorSet` (IDMS) from the management cluster and adds them to the HyperShift Operator and the Control Plane Operator in every reconciliation loop. The changes to the ICSP or IDMS cause the `control-plane-operator` pod to be restarted. (link:https://issues.redhat.com/browse/OCPBUGS-29110[*OCPBUGS-29110*])
 
 * With this update, the `ControllerAvailabilityPolicy` setting becomes immutable after it is set. Changing between `SingleReplica` and `HighAvailability` is not supported. (link:https://issues.redhat.com/browse/OCPBUGS-27282[*OCPBUGS-27282*])
 
@@ -2042,7 +2029,7 @@ With this release, the CCO no longer checks for the nonexistent permission.
 [id="ocp-4-16-installer-bug-fixes_{context}"]
 ==== Installer
 
-* Previously, installation of a three node cluster with an invalid configuration on {gcp-first} failed with a panic error that did not report the reason for the failure. With this release, the installation program validates the installation configuration to successfully install a three node cluster on {gcp-short}. (link:https://issues.redhat.com/browse/OCPBUGS-35103[*OCPBUGS-35103*])
+* Previously, installation of a three-node cluster with an invalid configuration on {gcp-first} failed with a panic error that did not report the reason for the failure. With this release, the installation program validates the installation configuration to successfully install a three-node cluster on {gcp-short}. (link:https://issues.redhat.com/browse/OCPBUGS-35103[*OCPBUGS-35103*])
 
 * Previously, installations with the Assisted Installer failed if the pull secret contained a colon in the password. With this release, pull secrets containing a colon in the password do not cause the Assisted Installer to fail. (link:https://issues.redhat.com/browse/OCPBUGS-34400[*OCPBUGS-34400*])
 
@@ -2058,7 +2045,7 @@ With this release, the CCO no longer checks for the nonexistent permission.
 
 * Previously, control plane nodes on {azure-first} clusters were using `Read-only` caches. With this release, {azure-first} control plane nodes use `ReadWrite` caches. (link:https://issues.redhat.com/browse/OCPBUGS-33470[*OCPBUGS-33470*])
 
-* Previously, when installing an Agent-based cluster with a proxy configured, the installation failed if the proxy configuration contained a string starting with a percent sign (`%`).  With this release, the installation program correctly validates this configuration text. (link:https://issues.redhat.com/browse/OCPBUGS-33024[*OCPBUGS-33024*])
+* Previously, when installing an Agent-based cluster with a proxy configured, the installation failed if the proxy configuration contained a string starting with a percent sign (`%`). With this release, the installation program correctly validates this configuration text. (link:https://issues.redhat.com/browse/OCPBUGS-33024[*OCPBUGS-33024*])
 
 * Previously, installations on {gcp-short} could fail because the installation program attempted to create a bucket twice. With this release, the installation program no longer attempts to create the bucket twice. (link:https://issues.redhat.com/browse/OCPBUGS-32133[*OCPBUGS-32133*])
 
@@ -2082,7 +2069,7 @@ With this release, the CCO no longer checks for the nonexistent permission.
 
 * Previously, when installing a cluster on {aws-first} Wavelengths or Local Zones into a region that supports either Wavelengths or Local Zones, but not both, the installation failed. With this release, installations into regions that support either Wavelengths or Local Zones can succeed. (link:https://issues.redhat.com/browse/OCPBUGS-27737[*OCPBUGS-27737*])
 
-* Previously, when a cluster installation was attempted that used the same cluster name and base domain as an existing cluster and the installation failed due to DNS record set conflicts, removal of the second cluster would also remove the DNS record sets in the original cluster. With this release, the stored metadata contains the private zone name rather than the cluster domain, so only the correct DNS records are deleted rom a removed cluster. (link:https://issues.redhat.com/browse/OCPBUGS-27156[*OCPBUGS-27156*])
+* Previously, when a cluster installation was attempted that used the same cluster name and base domain as an existing cluster and the installation failed due to DNS record set conflicts, removal of the second cluster would also remove the DNS record sets in the original cluster. With this release, the stored metadata contains the private zone name rather than the cluster domain, so only the correct DNS records are deleted from a removed cluster. (link:https://issues.redhat.com/browse/OCPBUGS-27156[*OCPBUGS-27156*])
 
 * Previously, platform specific passwords that were configured in the installation configuration file of an Agent-based installation could be present in the output of the `agent-gather` command. With this release, passwords are redacted from the `agent-gather` output. (link:https://issues.redhat.com/browse/OCPBUGS-26434[*OCPBUGS-26434*])
 
@@ -2128,9 +2115,11 @@ With this release, the CCO no longer checks for the nonexistent permission.
 
 * Previously, when deleting a `ClusterResourceQuota` resource using the foreground deletion cascading strategy, the removal failed to complete. With this release, `ClusterResourceQuota` resources are deleted properly when using the foreground cascading strategy. (link:https://issues.redhat.com/browse/OCPBUGS-22301[*OCPBUGS-22301*])
 
+////
 [discrete]
 [id="ocp-4-16-kube-scheduler-bug-fixes_{context}"]
 ==== Kubernetes Scheduler
+////
 
 [discrete]
 [id="ocp-4-16-machine-config-operator-bug-fixes_{context}"]
@@ -2140,9 +2129,9 @@ With this release, the CCO no longer checks for the nonexistent permission.
 
 * Previously, the default value of the `nodeStatusUpdateFrequency` parameter was changed from `0s` to `10s`. This change inadvertently caused the `nodeStatusReportFrequency` to increase significantly, because the value was linked to the `nodeStatusReportFrequency` value. This resulted in high CPU usage on control plane operators and the API server. This fix manually sets the `nodeStatusReportFrequency` value to `5m`, which prevents this high CPU usage. (link:https://issues.redhat.com/browse/OCPBUGS-29713[*OCPBUGS-29713*])
 
-* Previously, a typo in an environment variable prevented a script from detecting if the `node.env` file was present. Because of this, the `node.env` file would be overwritten on every restart, preventing the kubelet hostname from being fixed. With this fix the typo is corrected. As a result, edits to the `node.env` are now persist across reboots. (link:https://issues.redhat.com/browse/OCPBUGS-27261[*OCPBUGS-27261*])
+* Previously, a typographical error in an environment variable prevented a script from detecting if the `node.env` file was present. Because of this, the `node.env` file would be overwritten on every restart, preventing the kubelet hostname from being fixed. With this fix the typographical error is corrected. As a result, edits to the `node.env` are now persist across reboots. (link:https://issues.redhat.com/browse/OCPBUGS-27261[*OCPBUGS-27261*])
 
-* Previously, when the `kube-apiserver` server Certificate Authority (CA) certificate was rotated, the MCO did not properly react and update the on-disk kubelet kubeconfig. This meant that the kubelet and some pods on the node were eventually unable to communicate with the APIserver, causing the node to enter the `NotReady` state. With this release, the Machine Config Operator (MCO) properly reacts to the change, and updates the on-disk kubeconfig such that authenticated communication with the APIServer can continue when this rotates, and also restarts kubelet/MCDaemon pod. The certificate authority has 10-year validity, so this rotation should happen rarely and is generally non-disruptive. (link:https://issues.redhat.com/browse/OCPBUGS-25821[*OCPBUGS-25821*])
+* Previously, when the `kube-apiserver` server Certificate Authority (CA) certificate was rotated, the Machine Config Operator (MCO) did not properly react and update the on-disk kubelet kubeconfig. This meant that the kubelet and some pods on the node were eventually unable to communicate with the APIserver, causing the node to enter the `NotReady` state. With this release, the MCO properly reacts to the change, and updates the on-disk kubeconfig such that authenticated communication with the APIServer can continue when this rotates, and also restarts kubelet/MCDaemon pod. The certificate authority has 10-year validity, so this rotation should happen rarely and is generally non-disruptive. (link:https://issues.redhat.com/browse/OCPBUGS-25821[*OCPBUGS-25821*])
 
 * Previously, when a new node was added to or removed from a cluster, the `MachineConfigNode` (MCN) objects did not react. As a result, extraneous MCN objects existed. With this release, the Machine Config Operator removes and adds MCN objects as appropriate when nodes are added or removed. (link:https://issues.redhat.com/browse/OCPBUGS-24416[*OCPBUGS-24416*])
 
@@ -2194,7 +2183,7 @@ With this release, the CCO no longer checks for the nonexistent permission.
 
 * Previously there was an issue causing an error message on the *Image Manifest Vulnerability* page after an Image Manifest Vulnerability (IMV) was created in the CLI. With this release, the error message no longer shows. (link:https://issues.redhat.com/browse/OCPBUGS-28967[*OCPBUGS-28967*])
 
-* Previously, when using the modal dialog in a hook as part of the actions hook, an error occured because the console framework passed null objects as part of the render cycle. With this release, `getGroupVersionKindForResource` is now null-safe and will return `undefined` if the `apiVersion` or `kind` are undefined. Additionally, the run time error for `useDeleteModal` no longer occurs, but note that it will not work with an `undefined` resource. (link:https://issues.redhat.com/browse/OCPBUGS-28856[*OCPBUGS-28856*])
+* Previously, when using the modal dialog in a hook as part of the actions hook, an error occurred because the console framework passed null objects as part of the render cycle. With this release, `getGroupVersionKindForResource` is now null-safe and will return `undefined` if the `apiVersion` or `kind` are undefined. Additionally, the run time error for `useDeleteModal` no longer occurs, but note that it will not work with an `undefined` resource. (link:https://issues.redhat.com/browse/OCPBUGS-28856[*OCPBUGS-28856*])
 
 * Previously, the *Expand PersistentVolumeClaim* modal assumes the `pvc.spec.resources.requests.stroage` value includes a unit. With this release, the size is updated to 2GiB and you can change the value of the persistent volume claim (PVC). (link:https://issues.redhat.com/browse/OCPBUGS-27779[*OCPBUGS-27779*])
 
@@ -2275,6 +2264,7 @@ With this release, the CCO no longer checks for the nonexistent permission.
 * Previously, when a MAC address changed on the physical interface being used by OVN-Kubernetes, it would not be updated correctly within OVN-Kubernetes and could cause traffic disruption and Kube API outages from the node for a prolonged period of time. This was most common when a bond interface was being used, where the MAC address of the bond might swap depending on which device was the first to come up. With this release, the issues if fixed so that OVN-Kubernetes dynamically detects MAC address changes and updates it correctly. (link:https://issues.redhat.com/browse/OCPBUGS-18716[*OCPBUGS-18716*])
 
 * Previously, the global navigation satellite system (GNSS) module was capable of reporting both the GPS `fix` position and the GNSS `offset` position, which represents the offset between the GNSS module and the constellations. The previous T-GM did not use the `ubloxtool` CLI tool to probe the `ublox` module for reading `offset` and `fix` positions. Instead, it could only read the GPS `fix` information via GPSD. The reason for this was that the previous implementation of the `ubloxtool` CLI tool took 2 seconds to receive a response, and with every call it increased CPU usage by threefold. With this release, the `ubloxtool` request is now optimized, and the GPS `offset` position is now available. (link:https://issues.redhat.com/browse/OCPBUGS-17422[*OCPBUGS-17422*])
+
 * Previously, `EgressIP` pods hosted by a secondary interface would not failover because of a race condition. Users would receive an error message indicating that the `EgressIP` pod could not be assigned because it conflicted with an existing IP address. With this release, the `EgressIP` pod moves to an egress node. (https://issues.redhat.com/browse/OCPBUGS-20209[*OCPBUGS-20209*])
 
 * Previously, when a MAC address changed on the physical interface being used by OVN-Kubernetes, it would not be updated correctly within OVN-Kubernetes and could cause traffic disruption and Kube API outages from the node for a prolonged period of time. This was most common when a bond interface was being used, where the MAC address of the bond might swap depending on which device was the first to come up. With this release, the issues if fixed so that OVN-Kubernetes dynamically detects MAC address changes and updates it correctly. (link:https://issues.redhat.com/browse/OCPBUGS-18716[*OCPBUGS-18716*])
@@ -2339,15 +2329,15 @@ To retain the catalog rebuilding functionality, use `--rebuild-catalog`. However
 
 * Previously, oc-mirror would not stop and return a valid error code when mirroring failed. With this release, oc-mirror now exits with the correct error code when encountering “operator not found”, unless the `--continue-on-error` flag is used. (link:https://issues.redhat.com/browse/OCPBUGS-23003[*OCPBUGS-23003*])
 
-* Previously, when mirroring operators, oc-mirror would ignore the `maxVersion` constraint in `imageSetConfig` if both `minVersion` and `maxVersion` were specified. This resulted in mirroring all bundles up to the channel head. With this release, oc-mirror now considers the `maxVersion` constraint as specified in `imageSetConfig`.
-(link:https://issues.redhat.com/browse/OCPBUGS-21865[*OCPBUGS-21865*])
+* Previously, when mirroring operators, oc-mirror would ignore the `maxVersion` constraint in `imageSetConfig` if both `minVersion` and `maxVersion` were specified. This resulted in mirroring all bundles up to the channel head. With this release, oc-mirror now considers the `maxVersion` constraint as specified in `imageSetConfig`. (link:https://issues.redhat.com/browse/OCPBUGS-21865[*OCPBUGS-21865*])
 
-* Previously, oc-mirror failed to mirror releases using `eus-\*` channels, as it did not recognize that `eus-\*` channels are designated for even-numbered releases only. With this release, oc-mirror plugin now properly acknowledges that `eus-\*` channels are intended for even-numbered releases, enabling users to successfully mirror releases using these channels.
-(link:https://issues.redhat.com/browse/OCPBUGS-19429[*OCPBUGS-19429*])
+* Previously, oc-mirror failed to mirror releases using `eus-\*` channels, as it did not recognize that `eus-\*` channels are designated for even-numbered releases only. With this release, oc-mirror plugin now properly acknowledges that `eus-\*` channels are intended for even-numbered releases, enabling users to successfully mirror releases using these channels. (link:https://issues.redhat.com/browse/OCPBUGS-19429[*OCPBUGS-19429*])
 
 * Previously, the addition of the `defaultChannel` field in the `mirror.operators.catalog.packages` file enabled users to specify their preferred channel, overriding the `defaultChannel` set in the operator. With this release, oc-mirror plugin now enforces an initial check if the `defaultChannel` field is set, users must also define it in the channels section of the `ImageSetConfig`. This update ensures that the specified `defaultChannel` is properly configured and applied during operator mirroring. (link:https://issues.redhat.com/browse/OCPBUGS-385[*OCPBUGS-385*])
 
 * Previously, when running a cluster with FIPS enabled, you might have received the following error when running the {oc-first} on a {op-system-base} 9 system: `FIPS mode is enabled, but the required OpenSSL backend is unavailable`. With this release, the default version of OpenShift CLI (`oc`) is compiled with {op-system-base-full} 9 and works properly when running a cluster with FIPS enabled on {op-system-base} 9. Additionally, a version of `oc` compiled with {op-system-base} 8 is also provided, which must be used if you are running a cluster with FIPS enabled on {op-system-base} 8. (link:https://issues.redhat.com/browse/OCPBUGS-23386[*OCPBUGS-23386*], link:https://issues.redhat.com/browse/OCPBUGS-28540[*OCPBUGS-28540*])
+
+* Previously, role bindings related to the `ImageRegistry`, `Build`, and `DeploymentConfig` capabilities were created in every namespace, even if the capability was disabled. With this release, the role bindings are only created if the cluster capability is enabled on the cluster. (link:https://issues.redhat.com/browse/OCPBUGS-34384[*OCPBUGS-34384*])
 
 [discrete]
 [id="ocp-4-16-olm-bug-fixes_{context}"]
@@ -2413,7 +2403,7 @@ If the value of the `requests.storage` field in the `PersistentVolumeClaim` obje
 
 * Previously, the secrets store Container Storage Interface driver on Hosted Control Planes failed to mount secrets because of a bug in the CLI. With this release, the driver is able to mount volumes and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-34759[*OCPBUGS-34759*])
 
-* Previously, static Persistent Volumes (PVs) in Azure Workload Identity clusters could not be configured due to a bug in the driver, causing PV mounts to fail. With this release, the driver works and static PVs mount correctly. (link:https://issues.redhat.com/browse/OCPBUGS-32785[*OCPBUGS-32785*])
+* Previously, static Persistent Volumes (PVs) in {azure-first} Workload Identity clusters could not be configured due to a bug in the driver, causing PV mounts to fail. With this release, the driver works and static PVs mount correctly. (link:https://issues.redhat.com/browse/OCPBUGS-32785[*OCPBUGS-32785*])
 
 [discrete]
 [id="ocp-4-16-windows-containers-bug-fixes_{context}"]


### PR DESCRIPTION
Covers: Console Metal3 Plugin", "Windows Containers", Unknown, "Driver Toolkit", "Console Storage Plugin", Release, Build, "Samples Operator", "Low latency validation tooling", "GitOps ZTP", "TALM Operator", "Observability UI", "Logical Volume Manager Storage", "Performance Addon Operator", secondary-scheduler-operator, Helm, "LCA operator


Version(s):
4.16

Issue:
[OSDOCS-9882](https://issues.redhat.com/browse/OSDOCS-9882)

Link to docs preview:
[Bug fixes](https://77949--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-bug-fixes_release-notes)
