### PR TITLE
OSDOCS-10989: Documented the 4.15.19 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2730,6 +2730,45 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.15.19
+[id="ocp-4-15-19"]
+=== RHSA-2024:4041 - {product-title} 4.15.19 bug fix and security update
+
+Issued: 2024-06-27
+
+{product-title} release 4.15.19 is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2024:4041[RHSA-2024:4041] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHBA-2024:4044[RHBA-2024:4044] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.19 --pullspecs
+----
+
+[id="ocp-4-15-19-bug-fixes"]
+==== Bug fixes
+
+* Previously, when a new version of a Custom Resource Definition (CRD) specified a new conversion strategy, this conversion strategy was expected to successfully convert resources. This was not the case because Operator Lifecycle Manager (OLM) cannot run the new conversion strategies for CRD validation without actually performing the update operation. With this release, the OLM implementation generates a warning message during the update process when CRD validations fail with the existing conversion strategy and the new conversion strategy is specified in the new version of the CRD. (link:https://issues.redhat.com/browse/OCPBUGS-35720[*OCPBUGS-35720*]).
+
+* Previously, during node reboots, especially during update operations, the node that interacts with the rebooting machine entered a `Ready=Unknown` state for a short amount of time. This situation caused the Control Plane Machine Set Operator to enter an `UnavailableReplicas` condition and then an `Available=false` state. The `Available=false` state triggers alerts that demand urgent action, but in this case, intervention was only required for a short period of time until the node rebooted. With this release, a grace period for node unreadiness is provided where if a node enters an unready state, the Control Plane Machine Set Operator does not instantly enter an `UnavailableReplicas` condition or an `Available=false` state. (link:https://issues.redhat.com/browse/OCPBUGS-34971[*OCPBUGS-34971*]).
+
+* Previously, the OpenShift Cluster Manager container did not have the right TLS Certificates. As a result, image streams could not be used in disconnected deployments. With this update, the TLS Certificates are added as projected volumes. (link:https://issues.redhat.com/browse/OCPBUGS-34580[*OCPBUGS-34580*])
+
+* Previously, when a serverless function was created in the create serverless form, `BuilldConfig` was not created. With this update, if the Pipelines Operator is not installed, or if the pipeline resource is not created for particular resource, or if the pipeline is not added while creating a serverless function, the `BuildConfig` is created as expected. (link:https://issues.redhat.com/browse/OCPBUGS-34350[*OCPBUGS-34350*])
+
+* Previously, the reduction of the network queue did not work as expected for inverted rules such as `!ens0`. This happened because the exclamation mark symbol was duplicated in the generated tuned profile. With this release, the duplication no longer occurs so that inverted rules apply as intended. (link:https://issues.redhat.com/browse/OCPBUGS-33929[*OCPBUGS-33929*]).
+
+* Previously, registry overrides configured by a cluster administrator on the management side applied to non-relevant data-plane components. With this release, registry overrides no longer apply to these components. (link:https://issues.redhat.com/browse/OCPBUGS-33627[*OCPBUGS-33627*]).
+
+* Previously, when installing a cluster on {vmw-first}, the installation failed if an ESXi host was in maintenance mode because the installation program could not retrieve version information from the host. With this update, the installation program does not attempt to retrieve version information from ESXi hosts that are in maintenance mode, allowing the installation to proceed. (link:https://issues.redhat.com/browse/OCPBUGS-31387[*OCPBUGS-31387*])
+
+[id="ocp-4-15-19-updating"]
+==== Updating
+To update an existing {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+// 4.15.18
 [id="ocp-4-15-18"]
 === RHSA-2024:3889 - {product-title} 4.15.18 bug fix and security update
 
@@ -2754,7 +2793,7 @@ The following enhancements are included in this z-stream release:
 [id="ocp-4-15-18-unservable-future-versions-status-condition"]
 ===== Introducing the UnservableFutureVersions status condition for SHA1 routes
 
-* {product-title} {product-version} does not support SHA1 certificates on routes. Consequently, upgrades from 4.15 to {product-version} will cause routes with SHA1 certificates to be rejected. 
+* {product-title} {product-version} does not support SHA1 certificates on routes. Consequently, upgrades from 4.15 to {product-version} causes routes with SHA1 certificates to be rejected.
 +
 This update introduces a new `UnservableInFutureVersions` status condition to routes that contain a SHA1 certificate. Additionally, it adds an `admin-gate` to block upgrades if this new status is present on any route. As a result, if cluster administrators have routes that use SHA1 certificates in {product-title} 4.15, they must either upgrade these certificates to a support algorithm or provide an `admin-ack` for the created `admin-gate`. This `admin-ack` allows administrators to proceed with the upgrade without resolving the SHA1 certificate issues, even though the routes will be rejected. (link:https://issues.redhat.com/browse/OCPBUGS-28928[*OCPBUGS-28928*]).
 


### PR DESCRIPTION
Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-10989

Link to docs preview: [4.15.19](https://77953--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-19)

Additional info:

![Screenshot from 2024-06-27 15-44-51](https://github.com/openshift/openshift-docs/assets/57954076/237f28f8-8d0e-4919-bdc9-263346ae8dc2)



