### PR TITLE
[SRVCOM-1499] Overriding podDisruptionBudgets for High availability

### DIFF
--- a/eventing/tuning/serverless-ha.adoc
+++ b/eventing/tuning/serverless-ha.adoc
@@ -13,3 +13,4 @@ These controller instances compete to use a shared resource, known as the leader
 
 include::modules/serverless-config-replicas-eventing.adoc[leveloffset=+1]
 include::modules/serverless-config-replicas-kafka.adoc[leveloffset=+1]
+include::modules/serverless-overriding-pdbs-eventing.adoc[leveloffset=+1]

--- a/knative-serving/config-ha-services/ha-replicas-serving.adoc
+++ b/knative-serving/config-ha-services/ha-replicas-serving.adoc
@@ -7,3 +7,4 @@ include::_attributes/common-attributes.adoc[]
 High availability (HA) is available by default for the Knative Serving `activator`, `autoscaler`, `autoscaler-hpa`, `controller`, `webhook`, `domain-mapping`, `domainmapping-webhook`, `kourier-control`, and `kourier-gateway` components, which are configured to have two replicas each. You can change the number of replicas for these components by modifying the `spec.high-availability.replicas` value in the `KnativeServing` custom resource (CR).
 
 include::modules/serverless-config-replicas-serving.adoc[leveloffset=+1]
+include::modules/serverless-overriding-pdbs-serving.adoc[leveloffset=+1]

--- a/modules/serverless-overriding-pdbs-eventing.adoc
+++ b/modules/serverless-overriding-pdbs-eventing.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * /eventing/tuning/serverless-ha.adoc
+
+
+:_content-type: PROCEDURE
+[id="serverless-overriding-poddistruptionbudgets-eventing_{context}"]
+= Overriding disruption budgets
+
+A Pod Disruption Budget (PDB) is a standard feature of Kubernetes APIs that helps limit the disruption to an application when its pods need to be rescheduled for maintenance reasons.
+
+.Procedure
+
+* Override the default PDB for a specific resource by modifying the `minAvailable` configuration value in the `KnativeEventing` custom resource (CR).
+
+.Example PDB with a `minAvailable` seting of 70%
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeEventing
+metadata:
+ name: knative-eventing
+ namespace: knative-eventing
+spec:
+ podDisruptionBudgets:
+ - name: eventing-webhook
+   minAvailable: 70%
+----
+
+[NOTE]
+====
+If you disable high-availability, for example, by changing the `high-availability.replicas` value to `1`, make sure you also update the corresponding PDB `minAvailable` value to `0`. Otherwise, the pod disruption budget prevents automatic cluster or Operator updates.
+====

--- a/modules/serverless-overriding-pdbs-serving.adoc
+++ b/modules/serverless-overriding-pdbs-serving.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * /knative-serving/config-ha-services/ha-replicas-serving.adoc
+
+
+:_content-type: PROCEDURE
+[id="serverless-overriding-poddistruptionbudgets-serving_{context}"]
+= Overriding disruption budgets
+
+A Pod Disruption Budget (PDB) is a standard feature of Kubernetes APIs that helps limit the disruption to an application when its pods need to be rescheduled for maintenance reasons.
+
+.Procedure
+
+* Override the default PDB for a specific resource by modifying the `minAvailable` configuration value in the `KnativeServing` custom resource (CR).
+
+.Example PDB with a `minAvailable` seting of 70%
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+ name: knative-serving
+ namespace: knative-serving
+spec:
+ podDisruptionBudgets:
+ - name: activator-pdb
+   minAvailable: 70%
+----
+
+[NOTE]
+====
+If you disable high-availability, for example, by changing the `high-availability.replicas` value to `1`, make sure you also update the corresponding PDB `minAvailable` value to `0`. Otherwise, the pod disruption budget prevents automatic cluster or Operator updates.
+====


### PR DESCRIPTION
Version(s):
serverless-docs-1.32+

Issue:
https://issues.redhat.com/browse/SRVCOM-1499

Link to docs preview:

- https://77955--ocpdocs-pr.netlify.app/openshift-serverless/latest/knative-serving/config-ha-services/ha-replicas-serving.html
- https://77955--ocpdocs-pr.netlify.app/openshift-serverless/latest/eventing/tuning/serverless-ha.html

QE review:
- [x] QE has approved this change.
