### PR TITLE
Swaps live migration to limited live migration

### DIFF
--- a/modules/how-the-live-migration-process-works.adoc
+++ b/modules/how-the-live-migration-process-works.adoc
@@ -39,7 +39,7 @@ Cluster Network Operator (CNO)::
 * Triggers the Machine Config Operator (MCO) to apply the new machine config to each machine config pool, which includes node cordoning, draining, and rebooting.
 * OVN-Kubernetes adds nodes to the appropriate zones and recreates pods using OVN-Kubernetes as the default CNI plugin.
 * Removes migration-related fields from the network.operator CR and performs cleanup actions, such as deleting OpenShift SDN resources and redeploying OVN-Kubernetes in normal mode with the necessary configurations.
-* Waits for the OVN-Kubernetes redeployment and updates the status conditions in the `network.config` CR to indicate migration completion. If your migration is blocked, see "Checking live migration metrics" for information on troubleshooting the issue.
+* Waits for the OVN-Kubernetes redeployment and updates the status conditions in the `network.config` CR to indicate migration completion. If your migration is blocked, see "Checking limited live migration metrics" for information on troubleshooting the issue.
 --
 |===
 

--- a/modules/live-migration-metrics-information.adoc
+++ b/modules/live-migration-metrics-information.adoc
@@ -4,12 +4,12 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="live-migration-metrics-information"]
-= Information about live migration metrics
+= Information about limited live migration metrics
 
 The following table shows you the available metrics and the label values populated from the `openshift_network_operator_live_migration_procedure` expression. Use this information to monitor progress or to troubleshoot the migration.
 
 
-.Live migration metrics
+.Limited live migration metrics
 [cols="1a,1a",options="header"]
 |===
 | Metric | Label values
@@ -17,16 +17,16 @@ The following table shows you the available metrics and the label values populat
 *`openshift_network_operator_live_migration_blocked:`*::
 +
 --
-A Prometheus gauge vector metric. A metric that contains a constant `1` value labeled with the reason that the CNI live migration might not have started. This metric is available when the CNI live migration has started by annotating the `Network` custom resource. +
-This metric is not published unless the live migration is blocked. 
+A Prometheus gauge vector metric. A metric that contains a constant `1` value labeled with the reason that the CNI limited live migration might not have started. This metric is available when the CNI limited live migration has started by annotating the `Network` custom resource. +
+This metric is not published unless the limited live migration is blocked. 
 --
 | 
 The list of label values includes the following::
 +
 --
 * `UnsupportedCNI`: Unable to migrate to the unsupported target CNI. Valid CNI is `OVNKubernetes` when migrating from OpenShift SDN.
-* `UnsupportedHyperShiftCluster`: Live migration is unsupported within an HCP cluster.
-* `UnsupportedSDNNetworkIsolationMode`: OpenShift SDN is configured with an unsupported network isolation mode `Multitenant`. Migrate to a supported network isolation mode before performing live migration.
+* `UnsupportedHyperShiftCluster`: Limited live migration is unsupported within an HCP cluster.
+* `UnsupportedSDNNetworkIsolationMode`: OpenShift SDN is configured with an unsupported network isolation mode `Multitenant`. Migrate to a supported network isolation mode before performing limited live migration.
 * `UnsupportedMACVLANInterface`: Remove the egress router or any pods which contain the pod annotation `pod.network.openshift.io/assign-macvlan`. 
 Find the offending pod's namespace or pod name with the following command: +
  +
@@ -37,9 +37,9 @@ Find the offending pod's namespace or pod name with the following command: +
 *`openshift_network_operator_live_migration_condition:`*::
 +
 --
-A metric which represents the status of each condition type for the CNI live migration. The set of status condition types is defined for `network.config` to support observability of the CNI live migration. +
-A `1` value represents condition status `true`. A `0` value represents `false`. `-1` represents unknown. This metric is available when the CNI live migration has started by annotating the `Network` custom resource (CR). +
-This metric is only available when the live migration has been triggered by adding the relevant annotation to the `Network` CR cluster, otherwise, it is not published. If the following condition types are not present within the Network CR cluster, the metric and their labels are cleared.
+A metric which represents the status of each condition type for the CNI limited live migration. The set of status condition types is defined for `network.config` to support observability of the CNI limited live migration. +
+A `1` value represents condition status `true`. A `0` value represents `false`. `-1` represents unknown. This metric is available when the CNI limited live migration has started by annotating the `Network` custom resource (CR). +
+This metric is only available when the limited live migration has been triggered by adding the relevant annotation to the `Network` CR cluster, otherwise, it is not published. If the following condition types are not present within the Network CR cluster, the metric and their labels are cleared.
 --
 | 
 The list of label values includes the following::

--- a/modules/nw-ovn-kubernetes-checking-live-migration-metrics.adoc
+++ b/modules/nw-ovn-kubernetes-checking-live-migration-metrics.adoc
@@ -4,17 +4,17 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="checking-live-migration-metrics"]
-= Checking live migration metrics 
+= Checking limited live migration metrics 
 
-Metrics are available to monitor the progress of the live migration. Metrics can be viewed on the {product-title} web console, or by using the `oc` CLI.
+Metrics are available to monitor the progress of the limited live migration. Metrics can be viewed on the {product-title} web console, or by using the `oc` CLI.
 
 .Prerequisites
 
-* You have initiated a live migration to OVN-Kubernetes.
+* You have initiated a limited live migration to OVN-Kubernetes.
 
 .Procedure
 
-. To view live migration metrics on the {product-title} web console:
+. To view limited live migration metrics on the {product-title} web console:
 
 .. Click *Observe* -> *Metrics*.
 
@@ -72,4 +72,4 @@ $ oc -n openshift-monitoring exec -c prometheus prometheus-k8s-0 -- curl -k -H "
 ...
 ----
 
-The table in "Information about live migration metrics" shows you the available metrics and the label values populated from the `openshift_network_operator_live_migration_procedure` expression. Use this information to monitor progress or to troubleshoot the migration.
+The table in "Information about limited live migration metrics" shows you the available metrics and the label values populated from the `openshift_network_operator_live_migration_procedure` expression. Use this information to monitor progress or to troubleshoot the migration.

--- a/modules/nw-ovn-kubernetes-live-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-live-migration-about.adoc
@@ -3,30 +3,30 @@
 // * networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
 
 [id="nw-ovn-kubernetes-live-migration-about_{context}"]
-= Live migration to the OVN-Kubernetes network plugin overview
+= Limited live migration to the OVN-Kubernetes network plugin overview
 
-The live migration method is the process in which the OpenShift SDN network plugin and its network configurations, connections, and associated resources, are migrated to the OVN-Kubernetes network plugin without service interruption. It is available for {product-title}, {product-dedicated}, {product-rosa}, and Azure Red Hat OpenShift deployment types. It is not available for HyperShift deployment types. This migration method is valuable for deployment types that require constant service availability and offers the following benefits:
+The limited live migration method is the process in which the OpenShift SDN network plugin and its network configurations, connections, and associated resources, are migrated to the OVN-Kubernetes network plugin without service interruption. It is available for {product-title}, {product-dedicated}, {product-rosa}, and Azure Red Hat OpenShift deployment types. It is not available for HyperShift deployment types. This migration method is valuable for deployment types that require constant service availability and offers the following benefits:
 
 * Continuous service availability
 * Minimized downtime
 * Automatic node rebooting
 * Seamless transition from the OpenShift SDN network plugin to the OVN-Kubernetes network plugin
 
-Although a rollback procedure is provided, the live migration is intended to be a one-way process.
+Although a rollback procedure is provided, the limited live migration is intended to be a one-way process.
 
 include::snippets/sdn-deprecation-statement.adoc[]
 
-The following sections provide more information about the live migration method.
+The following sections provide more information about the limited live migration method.
 
 [id="supported-platforms-live-migrating-ovn-kubernetes"]
-== Supported platforms when using the live migration method
+== Supported platforms when using the limited live migration method
 
-The following table provides information about the supported platforms for the live migration type.
+The following table provides information about the supported platforms for the limited live migration type.
 
-.Supported platforms for the live migration method
+.Supported platforms for the limited live migration method
 [cols="1,1", options="header"]
 |===
-| Platform              | Live Migration
+| Platform              | Limited Live Migration
 
 | Bare metal hardware (IPI and UPI)             |&#10003;
 | Amazon Web Services (AWS) (IPI and UPI)       |&#10003;
@@ -40,19 +40,19 @@ The following table provides information about the supported platforms for the l
 |===
 
 [id="considerations-live-migrating-ovn-kubernetes-network-provider_{context}"]
-== Considerations for live migration to the OVN-Kubernetes network plugin
+== Considerations for limited live migration to the OVN-Kubernetes network plugin
 
-Before using the live migration method to the OVN-Kubernetes network plugin, cluster administrators should consider the following information:
+Before using the limited live migration method to the OVN-Kubernetes network plugin, cluster administrators should consider the following information:
 
-* The live migration procedure is unsupported for clusters with OpenShift SDN multitenant mode enabled.
+* The limited live migration procedure is unsupported for clusters with OpenShift SDN multitenant mode enabled. 
 
-* Egress router pods block the live migration process. They must be removed before beginning the live migration process.
+* Egress router pods block the limited live migration process. They must be removed before beginning the limited live migration process.
 
-* During the live migration, multicast, egress IP addresses, and egress firewalls are temporarily disabled. They can be migrated from OpenShift SDN to OVN-Kubernetes after the live migration process has finished.
+* During the limited live migration, multicast, egress IP addresses, and egress firewalls are temporarily disabled. They can be migrated from OpenShift SDN to OVN-Kubernetes after the limited live migration process has finished.
 
 * The migration is intended to be a one-way process. However, for users that want to rollback to OpenShift-SDN, migration from OpenShift-SDN to OVN-Kubernetes must have succeeded. Users can follow the same procedure below to migrate to the OpenShift SDN network plugin from the OVN-Kubernetes network plugin.
 
-* The live migration is not supported on HyperShift clusters.
+* The limited live migration is not supported on HyperShift clusters.
 
 * OpenShift SDN does not support IPsec. After the migration, cluster administrators can enable IPsec.
 
@@ -60,9 +60,9 @@ Before using the live migration method to the OVN-Kubernetes network plugin, clu
 
 * The cluster MTU is the MTU value for pod interfaces. It is always less than your hardware MTU to account for the cluster network overlay overhead. The overhead is 100 bytes for OVN-Kubernetes and 50 bytes for OpenShift SDN.
 +
-During the live migration, both OVN-Kubernetes and OpenShift SDN run in parallel. OVN-Kubernetes manages the cluster network of some nodes, while OpenShift SDN manages the cluster network of others. To ensure that cross-CNI traffic remains functional, the Cluster Network Operator updates the routable MTU to ensure that both CNIs share the same overlay MTU. As a result, after the migration has completed, the cluster MTU is 50 bytes less.
+During the limited live migration, both OVN-Kubernetes and OpenShift SDN run in parallel. OVN-Kubernetes manages the cluster network of some nodes, while OpenShift SDN manages the cluster network of others. To ensure that cross-CNI traffic remains functional, the Cluster Network Operator updates the routable MTU to ensure that both CNIs share the same overlay MTU. As a result, after the migration has completed, the cluster MTU is 50 bytes less.
 
-* Some parameters of OVN-Kubernetes cannot be changed after installation. The following parameters can be set only before starting the live migration:
+* Some parameters of OVN-Kubernetes cannot be changed after installation. The following parameters can be set only before starting the limited live migration:
 
 ** `InternalTransitSwitchSubnet`
 ** `internalJoinSubnet`
@@ -81,8 +81,8 @@ $ oc patch network.operator.openshift.io cluster --type='merge' -p='{"spec":{"de
 $ oc patch network.operator.openshift.io cluster --type='merge' -p='{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"ipv4":{"internalTransitSwitchSubnet": "100.99.0.0/16"}}}}}'
 ----
 
-* In most cases, the live migration is independent of the secondary interfaces of pods created by the Multus CNI plugin. However, if these secondary interfaces were set up on the default network interface controller (NIC) of the host, for example, using MACVLAN, IPVLAN, SR-IOV, or bridge interfaces with the default NIC as the control node, OVN-Kubernetes might encounter malfunctions. Users should remove such configurations before proceeding with the live migration.
+* In most cases, the limited live migration is independent of the secondary interfaces of pods created by the Multus CNI plugin. However, if these secondary interfaces were set up on the default network interface controller (NIC) of the host, for example, using MACVLAN, IPVLAN, SR-IOV, or bridge interfaces with the default NIC as the control node, OVN-Kubernetes might encounter malfunctions. Users should remove such configurations before proceeding with the limited live migration.
 
 * When there are multiple NICs inside of the host, and the default route is not on the interface that has the Kubernetes NodeIP, you must use the offline migration instead.
 
-* All `DaemonSet` objects in the `openshift-sdn` namespace, which are not managed by the Cluster Network Operator (CNO), must be removed before initiating the live migration. These unmanaged daemon sets can cause the migration status to remain incomplete if not properly handled.
+* All `DaemonSet` objects in the `openshift-sdn` namespace, which are not managed by the Cluster Network Operator (CNO), must be removed before initiating the limited live migration. These unmanaged daemon sets can cause the migration status to remain incomplete if not properly handled.

--- a/modules/nw-ovn-kubernetes-live-migration.adoc
+++ b/modules/nw-ovn-kubernetes-live-migration.adoc
@@ -5,9 +5,9 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-ovn-kubernetes-live-migration_{context}"]
-= Migrating to the OVN-Kubernetes network plugin by using the live migration method
+= Migrating to the OVN-Kubernetes network plugin by using the limited live migration method
 
-The following procedure checks for egress router resources and uses the live migration method to migrate from the OpenShift SDN network plugin to the OVN-Kubernetes network plugin.
+The following procedure checks for egress router resources and uses the limited live migration method to migrate from the OpenShift SDN network plugin to the OVN-Kubernetes network plugin.
 
 .Prerequisites
 
@@ -17,12 +17,12 @@ The following procedure checks for egress router resources and uses the live mig
 * You have created a recent backup of the etcd database.
 * The cluster is in a known good state without any errors.
 * Before migration to OVN-Kubernetes, a security group rule must be in place to allow UDP packets on port `6081` for all nodes on all cloud platforms.
-* Cluster administrators must remove any egress router pods before beginning the live migration. For more information about egress router pods, see "Deploying an egress router pod in redirect mode".
-* You have reviewed the "Considerations for live migration to the OVN-Kubernetes network plugin" section of this document.
+* Cluster administrators must remove any egress router pods before beginning the limited live migration. For more information about egress router pods, see "Deploying an egress router pod in redirect mode".
+* You have reviewed the "Considerations for limited live migration to the OVN-Kubernetes network plugin" section of this document.
 
 .Procedure
 
-. Before initiating the live migration, you must check for any egress router pods. If there is an egress router pod on the cluster when performing a live migration, the Network Operator blocks the migration and returns the following error: 
+. Before initiating the limited live migration, you must check for any egress router pods. If there is an egress router pod on the cluster when performing a limited live migration, the Network Operator blocks the migration and returns the following error: 
 +
 [source,text]
 ----
@@ -46,7 +46,7 @@ $ oc get pods --all-namespaces -o json | jq '.items[] | select(.metadata.annotat
 }
 ----
 +
-** Alternatively, you can query metrics on the {product-title} web console or by using the `oc` CLI to check for egress router pods. For more information, see "Checking live migration metrics".
+** Alternatively, you can query metrics on the {product-title} web console or by using the `oc` CLI to check for egress router pods. For more information, see "Checking limited live migration metrics".
 
 . Enter the following command to remove an egress router pod:
 +
@@ -85,7 +85,7 @@ $ oc get network.config.openshift.io cluster -o jsonpath='{.status.networkType}'
 $ oc get network.config cluster -o=jsonpath='{.status.conditions}' | jq .
 ----
 +
-You can check live migration metrics for troubleshooting issues. For more information, see "Checking live migration metrics".
+You can check limited live migration metrics for troubleshooting issues. For more information, see "Checking limited live migration metrics".
 
 . Complete the following steps only if the migration succeeds and your cluster is in a good state:
 

--- a/modules/nw-ovn-kubernetes-rollback-live.adoc
+++ b/modules/nw-ovn-kubernetes-rollback-live.adoc
@@ -4,9 +4,9 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-ovn-kubernetes-rollback-live_{context}"]
-= Using the live migration method to roll back to the OpenShift SDN network plugin
+= Using the limited live migration method to roll back to the OpenShift SDN network plugin
 
-As a cluster administrator, you can roll back to the OpenShift SDN Container Network Interface (CNI) network plugin by using the live migration method. During the migration with this method, nodes are automatically rebooted and service to the cluster is not interrupted.
+As a cluster administrator, you can roll back to the OpenShift SDN Container Network Interface (CNI) network plugin by using the limited live migration method. During the migration with this method, nodes are automatically rebooted and service to the cluster is not interrupted.
 
 [IMPORTANT]
 ====

--- a/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can migrate to the OVN-Kubernetes network plugin from the OpenShift SDN network plugin using the _offline_ migration method or the _live_ migration method.
+As a cluster administrator, you can migrate to the OVN-Kubernetes network plugin from the OpenShift SDN network plugin using the _offline_ migration method or the limited live migration method.
 
 To learn more about OVN-Kubernetes, read xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes#about-ovn-kubernetes[About the OVN-Kubernetes network plugin].
 

--- a/networking/ovn_kubernetes_network_provider/rollback-to-openshift-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/rollback-to-openshift-sdn.adoc
@@ -6,12 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can roll back to the OpenShift SDN network plugin from the OVN-Kubernetes network plugin using either the _offline_ migration method, or the _live_ migration method. This can only be done after the migration to the OVN-Kubernetes network plugin has successfully completed.
+As a cluster administrator, you can roll back to the OpenShift SDN network plugin from the OVN-Kubernetes network plugin using either the _offline_ migration method, or the limited live migration method. This can only be done after the migration to the OVN-Kubernetes network plugin has successfully completed.
 
 [NOTE]
 ====
 * If you used the offline migration method to migrate to the OpenShift SDN network plugin from the OVN-Kubernetes network plugin, you should use the offline migration rollback method. 
-* If you used the live migration method to migrate to the OpenShift SDN network plugin from the OVN-Kubernetes network plugin, you should use the live migration rollback method.
+* If you used the limited live migration method to migrate to the OpenShift SDN network plugin from the OVN-Kubernetes network plugin, you should use the limited live migration rollback method.
 ====
 
 include::snippets/sdn-deprecation-statement.adoc[]


### PR DESCRIPTION
This is a simple name change. 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-10662 final followup

Link to docs preview:
https://77956--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html
https://77956--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/rollback-to-openshift-sdn.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
