### PR TITLE
OADP-4378: Error in provider variable for OADP ODF and Virt docs

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 :context: installing-oadp-kubevirt
 :installing-oadp-kubevirt:
 :credentials: cloud-credentials
-:provider: kubevirt
+:provider: gcp
 
 toc::[]
 

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
@@ -5,7 +5,7 @@ include::_attributes/common-attributes.adoc[]
 :context: installing-oadp-ocs
 :installing-oadp-ocs:
 :credentials: cloud-credentials
-:provider: oadp-ocs
+:provider: gcp
 
 toc::[]
 


### PR DESCRIPTION
## JIRA

* [OADP-4378](https://issues.redhat.com/browse/OADP-4378)

### Version(s):

* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16

### Link to docs preview:

* [OADP Virt Installing the Data Protection Application 1.3](https://77957--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.html#oadp-installing-dpa-1-3_installing-oadp-kubevirt)

![image](https://github.com/openshift/openshift-docs/assets/106804821/0e3d96e8-1e7f-478a-ba8e-854b0d82195f)

* [OADP - ODF Installing the Data Protection Application 1.2 and earlier](https://77957--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.html#oadp-installing-dpa-1-2-and-earlier_installing-oadp-ocs)

![image](https://github.com/openshift/openshift-docs/assets/106804821/714d6e46-fd91-4a65-b029-7ec2487324f5)

* [OADP - ODF Installing the Data Protection Application 1.3](https://77957--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.html#oadp-installing-dpa-1-3_installing-oadp-ocs)

![image](https://github.com/openshift/openshift-docs/assets/106804821/a1234476-e7f4-4451-8fb3-4f52b9d70904)






### QE review:
- [x] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
