### PR TITLE
OSDOCS-10991 OCP 4.12.60 Release Notes

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -4782,3 +4782,33 @@ $ oc adm release info 4.12.59 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-12-60"]
+=== RHSA-2024:4006 - {product-title} 4.12.60 bug fix and security update
+
+Issued: 2024-06-27
+
+{product-title} release 4.12.60, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:4006[RHSA-2024:4006] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4008[RHSA-2024:4008] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.60 --pullspecs
+----
+
+[id="ocp-4-12-60-bug-fixes"]
+==== Bug fixes
+
+* Previously, for the `cluster:capacity_cpu_cores:sum` metric, nodes with the`infra` role but not `master` role were not assigned a value of `infra` for the `label_node_role_kubernetes_io` label. With this update, nodes with the `infra` role but not `master` role are now correctly labeled as `infra` for this metric. (link:https://issues.redhat.com/browse/OCPBUGS-35558[*OCPBUGS-35558*])
+
+* Previously, when an Ingress Controller was configured with client SSL/TLS, but did not have the `clientca-configmap` finalizer, the Ingress Operator would try to add the finalizer without checking whether the Ingress Controller was marked for deletion. Consequently, if an Ingress Controller was configured with client SSL/TLS and was subsequently deleted, the Operator would correctly remove the finalizer. It would then repeatedly try and fail to update the IngressController to add the finalizer back, resulting in error messages in the Operator's logs.
++
+With this update, the Ingress Operator does not add the `clientca-configmap` finalizer to an Ingress Controller that is marked for deletion. As a result, the Ingress Operator does not attempt incorrect updates and does not log the associated errors. (link:https://issues.redhat.com/browse/OCPBUGS-35027[*OCPBUGS-35027*])
+
+* Previously, timeout values larger than what Golang could parse were not properly validated. Consequently, timeout values larger than what HAProxy could parse caused issues with HAProxy. With this update, if the timeout specifies a value larger than what can be parsed, the value is capped at the maximum value that HAProxy can parse. As a result, issues are no longer caused by HAProxy. (link:https://issues.redhat.com/browse/OCPBUGS-33432[*OCPBUGS-33432*])
+
+[id="ocp-4-12-60-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-10991](https://issues.redhat.com/browse/OSDOCS-10991)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Preview](https://77965--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-60)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Not needed
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Advisory links will not work until release day, June 27.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
