### PR TITLE
CNV#43195: RN - VM migration fails with virError

### DIFF
--- a/virt/release_notes/virt-4-16-release-notes.adoc
+++ b/virt/release_notes/virt-4-16-release-notes.adoc
@@ -191,6 +191,10 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 [id="virt-4-16-ki-virtualization"]
 ==== Virtualization
 
+//CNV-43195: 4.16 - VM migration fails with virError
+* VM migrations might fail on clusters with mixed CPU types. (link:https://issues.redhat.com/browse/CNV-43195[*CNV-43195*])
+** As a workaround, you can set the CPU model at the xref:../../virt/virtual_machines/advanced_vm_management/virt-schedule-vms.adoc#virt-schedule-supported-cpu-model-vms_virt-schedule-vms[VM spec level] or at the xref:../../virt/virtual_machines/advanced_vm_management/virt-configuring-default-cpu-model.adoc#virt-configuring-default-cpu-model_virt-configuring-default-cpu-model[cluster level].
+
 //CNV-36448: 4.16 - Unresolved
 * When adding a virtual Trusted Platform Module (vTPM) device to a Windows VM, the BitLocker Drive Encryption system check passes even if the vTPM device is not persistent. This is because a vTPM device that is not persistent stores and recovers encryption keys using ephemeral storage for the lifetime of the `virt-launcher` pod. When the VM migrates or is shut down and restarts, the vTPM data is lost. (link:https://issues.redhat.com/browse/CNV-36448[*CNV-36448*])
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
Bug: https://issues.redhat.com/browse/CNV-43195
Doc: https://issues.redhat.com/browse/CNV-43353

Link to docs preview:
https://77978--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-16-release-notes.html#virt-4-16-known-issues

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Due to the `virt-configuring-default-cpu-model` assembly and module having the same ID, I had to also fix that in this PR in order to properly link to it.
