### PR TITLE
[inernal-fix] add-missing-416-insights-operator-link

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -2170,6 +2170,8 @@ With this update, as the Agent-based installation method does not require libvir
 * The Insights Operator now collects instances outside of the `openshift-monitoring` of the following custom resources:
 - Kind: `Prometheus` Group: `monitoring.coreos.com`
 - Kind: `AlertManager` Group: `monitoring.coreos.com`
++
+(link:https://issues.redhat.com/browse/OCPBUGS-35086[*OCPBUGS-35086*])
 
 [discrete]
 [id="ocp-4-16-kube-controller-bug-fixes_{context}"]


### PR DESCRIPTION
Version(s):
4.16

Added a missing link to an Insights Operator note.

Preview link: [Insights Operator](https://77979--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-new-features-and-enhancements_release-notes)

![Uploading Screenshot from 2024-06-24 16-45-35.png…]()
