### PR TITLE
OCPBUGS#35930: Adds prereq to dynamic plugin get started

### DIFF
--- a/modules/dynamic-plug-in-development.adoc
+++ b/modules/dynamic-plug-in-development.adoc
@@ -9,6 +9,12 @@
 You can run the plugin using a local development environment. The {product-title} web console runs in a container connected to the cluster you have logged into.
 
 .Prerequisites
+* . Visit the link:https://github.com/openshift/console-plugin-template[`console-plugin-template`] repository containing a template for creating plugins in a new tab.
++
+[IMPORTANT]
+====
+Custom plugin code is not supported by Red Hat. Only link:https://access.redhat.com/solutions/5893251[Cooperative community support] is available for your plugin.
+====
 * You must have an OpenShift cluster running.
 * You must have the OpenShift CLI (`oc`) installed.
 * You must have link:https://yarnpkg.com/[`yarn`] installed.


### PR DESCRIPTION
Prereq was needed to dynamic plugin get started. We did some workaround originally because we don't link to GH in docs, and linked it to the example which is confusing.

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-35930

Link to docs preview:
https://77980--ocpdocs-pr.netlify.app/openshift-dedicated/latest/web_console/dynamic-plugin/dynamic-plugins-get-started.html#dynamic-plugin-development_dynamic-plugins-get-started

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
