### PR TITLE
[internal-fix] OCPBUGS-35910: Fixed typo in the Considerations for live migration to…

### DIFF
--- a/modules/nw-ovn-kubernetes-live-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-live-migration-about.adoc
@@ -44,7 +44,7 @@ The following table provides information about the supported platforms for the l
 
 Before using the live migration method to the OVN-Kubernetes network plugin, cluster administrators should consider the following information:
 
-* The live migration procedure is unsupported for clusters with OpenShift SDN multitenant mode enabled. 
+* The live migration procedure is unsupported for clusters with OpenShift SDN multitenant mode enabled.
 
 * Egress router pods block the live migration process. They must be removed before beginning the live migration process.
 
@@ -68,7 +68,7 @@ During the live migration, both OVN-Kubernetes and OpenShift SDN run in parallel
 ** `internalJoinSubnet`
 
 * Unless otherwise configured, OVN-Kubernetes uses the following IP address ranges:
-** `100.64.0.0/1`. This IP address range is used for the `internalJoinSubnet` parameter of OVN-Kubernetes by default. If this IP address range is already in use, enter the following command to update it to `100.63.0.0/16`:
+** `100.64.0.0/16`. This IP address range is used for the `internalJoinSubnet` parameter of OVN-Kubernetes by default. If this IP address range is already in use, enter the following command to update it to `100.63.0.0/16`:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OCPBUGS-35910 ](https://issues.redhat.com/browse/OCPBUGS-35910)

Link to docs preview:
[Considerations for live migration to the OVN-Kubernetes network plugin](https://77981--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#considerations-live-migrating-ovn-kubernetes-network-provider_migrate-from-openshift-sdn)