### PR TITLE
OSSM-6457 OSSM 2.6.0 (At Stage): [DOC] Release Notes, Known Issues an…

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -172,8 +172,8 @@ endif::[]
 :product-rosa: Red Hat OpenShift Service on AWS
 :SMProductName: Red Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 2.5.2
-:MaistraVersion: 2.5
+:SMProductVersion: 2.6.0
+:MaistraVersion: 2.6
 :KialiProduct: Kiali Operator provided by Red Hat
 :SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin
 :SMPluginShort: OSSMC plugin

--- a/modules/ossm-rn-fixed-issues.adoc
+++ b/modules/ossm-rn-fixed-issues.adoc
@@ -16,20 +16,26 @@ Provide the following info for each issue if possible:
 
 The following issues have been resolved in the current release:
 
-//current release is 2.5.2/2.4.8/2.3.12 scheduled for May 22, 2024
+//current release is 2.6/2.5.3/2.4.9 is scheduled for July 10, 2024 --> delayed. New estimated release date: July 24, 2024. New estimated release date: July 31, 2024.
 
-* https://issues.redhat.com/browse/OSSM-6331[OSSM-6331] Previously, the `smcp.general.logging.componentLevels` spec accepted invalid `LogLevel` values, and the `ServiceMeshControlPlane` resource was still created. Now, the terminal shows an error message if an invalid value is used, and the control plane is not created.
+//https://issues.redhat.com/browse/OSSM-6766[OSSM-6766] moved to "Kiali known issues"
 
-* https://issues.redhat.com/browse/OSSM-6290[OSSM-6290] Previously, the **Project** filter of the **Istio Config** list page did not work correctly. All `istio config` items were displayed from all namespaces even if you selected a specific project from the drop-down menu. Now, only the `istio config` items that belong to the selected project in the filter dropdown are displayed.
+* https://issues.redhat.com/browse/OSSM-6754[OSSM-6754] Previously, in {product-title} 4.15, when users navigated to a *Service details* page, clicked the *Service Mesh* tab, and refreshed the page, the *Service Mesh details* page remained stuck on Service Mesh content information, even though the active tab was the default *Details* tab. Now, after a refresh, users can navigate through the different tabs of the *Service details* page without issue.
 
-* https://issues.redhat.com/browse/OSSM-6298[OSSM-6298] Previously, when you clicked an item reference within the {SMPlugin}, the console sometimes performed multiple redirects before opening the desired page. As a result, navigating back to the previous page that was open in the console caused your web browser to open the wrong page. Now, these redirects do not occur, and clicking *Back* in a web browser brings you to the correct page.
-
-* https://issues.redhat.com/browse/OSSM-6299[OSSM-6299] Previously, in {product-title} 4.15, when you clicked the **Node graph** menu option of any node menu within the traffic graph, the node graph was not displayed. Instead, the page refreshed with the same traffic graph. Now, clicking the **Node graph** menu option correctly displays the node graph.
+* https://issues.redhat.com/browse/OSSM-2101[OSSM-2101] Previously, the Istio Operator never deleted the `istio-cni-node` DaemonSet and other CNI resources when they were no longer needed. Now, after upgrading the Operator, if there is at least one SMCP installed in the cluster, the Operator reconciles this SMCP, and then deletes all unused CNI installations (even very old CNI versions as early as v2.0).
 
 The following issues have been resolved in previous releases:
 
 [id="ossm-rn-fixed-issues-ossm_{context}"]
 == {SMProductShortName} fixed issues
+//The explanations of these issues have been reviewed/approved in previous releases.
+* https://issues.redhat.com/browse/OSSM-6331[OSSM-6331] Previously, the `smcp.general.logging.componentLevels` spec accepted invalid `LogLevel` values, and the `ServiceMeshControlPlane` resource was still created. Now, the terminal shows an error message if an invalid value is used, and the control plane is not created.
+
+* https://issues.redhat.com/browse/OSSM-6290[OSSM-6290] Previously, the **Project** filter drop-down of the **Istio Config** list page did not work correctly. All `istio config` items were displayed from all namespaces even if you selected a specific project from the drop-down menu. Now, only the `istio config` items that belong to the selected project in the filter drop-down are displayed.
+
+* https://issues.redhat.com/browse/OSSM-6298[OSSM-6298] Previously, when you clicked an item reference within the {SMPlugin}, the console sometimes performed multiple redirects before opening the desired page. As a result, navigating back to the previous page that was open in the console caused your web browser to open the wrong page. Now, these redirects do not occur, and clicking *Back* in a web browser opens the correct page.
+
+* https://issues.redhat.com/browse/OSSM-6299[OSSM-6299] Previously, in {product-title} 4.15, when you clicked the **Node graph** menu option of any node menu within the traffic graph, the node graph was not displayed. Instead, the page refreshed with the same traffic graph. Now, clicking the **Node graph** menu option correctly displays the node graph.
 
 * https://issues.redhat.com/browse/OSSM-6177[OSSM-6177] Previously, when validation messages were enabled in the `ServiceMeshControlPlane` (SMCP), the `istiod` crashed continuously unless `GatewayAPI` support was enabled. Now, when validation messages are enabled but `GatewayAPI` support is not, the `istiod` does not continuously crash.
 

--- a/modules/ossm-rn-known-issues.adoc
+++ b/modules/ossm-rn-known-issues.adoc
@@ -201,6 +201,9 @@ New issues for Kiali should be created in the link:https://issues.redhat.com/pro
 
 These are the known issues in Kiali:
 
+* https://issues.redhat.com/browse/OSSM-6766[OSSM-6766] The {SMPlugin} fails if the user wants to update a namespace (for example, enable/disable injection) or create any Istio object (for example, create traffic policies).
+
+Workaround: Use the standalone Kiali application to update a namespace or create any Istio object.
 //Keep KIALI-2206 in RN as this is for information purposes.
 * link:https://issues.jboss.org/browse/KIALI-2206[KIALI-2206] When you are accessing the Kiali console for the first time, and there is no cached browser data for Kiali, the “View in Grafana” link on the Metrics tab of the Kiali Service Details page redirects to the wrong location. The only way you would encounter this issue is if you are accessing Kiali for the first time.
 //Keep KIALI-507 in RN as this is for information purposes.

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -15,6 +15,193 @@ Module included in the following assemblies:
 
 This release adds improvements related to the following components and concepts.
 
+//Includes 2.6, 2.5.3, 2.4.9.
+
+//OSSM 2.6 Release Day tentatively scheduled for Wednesday, July 10, 2024 --> delayed. New estimated release date: July 24, 2024.
+
+//This release will include new features such as OTEL+Tempo, Gateway API, and perhaps some others.
+
+[id="new-features-ossm-2-6"]
+== New features {SMProductName} version 2.6
+
+This release of {SMProductName} adds new features, addresses Common Vulnerabilities and Exposures (CVEs), and is supported on {product-title} 4.12 and later.
+
+This release ends maintenance support for {SMProductName} version 2.3. If you are using {SMProductShortName} version 2.3, you should update to a supported version.
+
+include::snippets/ossm-current-version-support-snippet.adoc[]
+//FIPS messaging verified with Matt Werner, CS, OCP on 06/27/2024 via Slack. It is also the same FIPS messaging currently used by Serverless.
+//Per Scott Dodson on 07/15/204 via Slack, confirmed that RHEL 2.9 has been submitted for FIPS validation. Admonition updated accordingly.
+//Per Kirsten Newcomer on 07/16/2024 via Slack, FIPS messaging for Service Mesh has been changed. Jamie (PM) has agreed with change.
+[IMPORTANT]
+====
+{SMProductName} is designed for FIPS. {SMProductShortName} uses the RHEL cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on the x86_64, ppc64le, and s390x architectures.
+For more information about the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic Module Validation Program]. For the latest NIST status for the individual versions of RHEL cryptographic libraries that have been submitted for validation, see link:https://access.redhat.com/articles/compliance_activities_and_gov_standards#fips-140-2-and-fips-140-3-2[Compliance Activities and Government Standards].
+====
+
+[id="component-versions-ossm-2-6"]
+=== Component versions for {SMProductName} version 2.6
+
+//Component versions updated 07/25/2024.
+//Component tables for 2.5.3 and 2.4.9 updated 07/25/2024
+
+|===
+|Component |Version
+
+|Istio
+|1.20.8
+
+|Envoy Proxy
+|1.28.5
+
+|Kiali
+|1.73.9
+|===
+
+[id="istio-1-20-support-ossm-2-6"]
+=== Istio 1.20 support
+//Jamie
+//OSSM 2.6 supports both Istio 1.19 and Istio 1.20 but only include Istio 1.20.
+//Listing 2 items that are supported instead of only what is not supported.
+
+Service Mesh 2.6 is based on Istio 1.20, which provides new features and product enhancements, including:
+
+* Native sidecars are supported on {product-title} 4.16 or later.
++
+.Example `ServiceMeshControlPlane` resource
+[source,yaml]
+----
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: basic
+spec:
+  runtime:
+    components:
+      pilot:
+        container:
+          env:
+            ENABLE_NATIVE_SIDECARS: "true"
+----
+
+* Traffic mirroring in Istio 1.20 now supports multiple destinations. This feature enables the mirroring of traffic to various endpoints, allowing for simultaneous observation across different service versions or configurations.
+
+While {SMProductName} supports many Istio 1.20 features, the following exceptions should be noted:
+
+//List what is NOT SUPPORTED --> same as 2.5 so copied from 2.5 entry
+* Ambient mesh is not supported
+* QuickAssist Technology (QAT) PrivateKeyProvider in Istio is not supported
+
+[id="istio-kiali-bundle-image-name-changes-ossm-2-6"]
+=== Istio and Kiali bundle image name changes
+//This content may need to be removed for 2.6 as per Dev via Slack, name change may need to be reversed.
+//Filip. Approve 07/11/2024
+This release updates the Istio bundle image name and the Kiali bundle image name to better align with Red Hat naming conventions.
+
+* Istio bundle image name: `openshift-service-mesh/istio-operator-bundle`
+* Kiali bundle image name: `openshift-service-mesh/kiali-operator-bundle`
+
+[id="integration-otel-tempo-ossm-2-6"]
+=== Integration with {TempoName} and {OTELName}
+//Yuanlin
+This release introduces a generally available integration of the tracing extension provider(s) {TempoName} and {OTELName}.
+
+You can expose tracing data to the {TempoName} by appending a named element and the `opentelemetry` provider to the `spec.meshConfig.extensionProviders` specification in the `ServiceMehControlPlane` resource. Then, a telemetry custom resource configures Istio proxies to collect trace spans and send them to the OpenTelemetry Collector endpoint.
+
+You can create a {OTELName} instance in a mesh namespace and configure it to send tracing data to a tracing platform backend service.
+
+//Still true for 2.6
+//Asked in forum-ocp-tracing channel 06/24/2024, verified 06/25/2024
+[NOTE]
+====
+{TempoName} Stack is not supported on {ibm-z-title}.
+====
+
+[id="jaeger-default-setting-change-ossm-2-6"]
+=== {JaegerName} default setting change
+//also included in "Upgrading --> Upgrading 2.5 to 2.6" but added here for increased visibility.
+//Dean. Approved 07/11/2024
+This release disables {JaegerName} by default for new instances of the `ServiceMeshControlPlane` resource.
+
+When updating existing instances of the `ServiceMeshControlPlane` resource to {SMProductName} version 2.6, {JaegerShortName} remains enabled by default.
+
+{SMProductName} 2.6 is the last release that includes support for {JaegerName} and {es-op}. Both {JaegerShortName} and {es-op} will be removed in the next release. If you are currently using {JaegerShortName} and {es-op}, you need to switch to {TempoName} and {OTELName}.
+
+//Gateway API Update for 2.6 OSSM-5854
+//Kubernetes Gateway API and {product-title} Gateway API are the same. It is referenced as {product-title} Gateway API in 2.5 and as {product-title} Gateway API here https://docs.openshift.com/container-platform/4.15/nodes/clusters/nodes-cluster-enabling-features.html so to be consistent, it is also referenced as {product-title} Gateway API for 2.6.
+[id="gateway-api-ga-cluster-wide-deployments-ossm-2-6"]
+=== {product-title} Gateway API generally available for cluster-wide deployments
+//Jacek. Approved 07/11/2024
+This release introduces the General Availability of {product-title} Gateway API, also known as the Kubernetes Gateway API, which is enabled by default only for cluster-wide deployments.
+
+Gateway API is now enabled by default if cluster-wide mode is enabled (`spec.mode: ClusterWide`). It can be enabled even if the custom resource definitions (CRDs) are not installed in the cluster.
+
+[IMPORTANT]
+====
+Gateway API for multitenant mesh deployments is still in Technology Preview.
+====
+
+Refer to the following table to determine which Gateway API version should be installed with the OpenShift {SMProductShortName} version you are using:
+
+|===
+|Service Mesh Version | Istio Version | Gateway API Version | Notes
+
+|2.6
+|1.20.x
+|1.0.0
+|N/A
+
+|2.5.x
+|1.18.x
+|0.6.2
+|Use the experimental branch because `ReferenceGrand` is missing in v0.6.2.
+
+|2.4.x
+|1.16.x
+|0.5.1
+|For multitenant mesh deployment, all Gateway API CRDs must be present. Use the experimental branch.
+|===
+
+You can disable this feature by setting `PILOT_ENABLE_GATEWAY_API` to `false`:
+
+[source,yaml]
+----
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: basic
+spec:
+  runtime:
+    components:
+      pilot:
+        container:
+          env:
+            PILOT_ENABLE_GATEWAY_API: "false"
+----
+
+[id="new-features-ossm-2-5-3"]
+== New features {SMProductName} version 2.5.3
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.12 and later.
+
+[id="component-versions-ossm-2-5-3"]
+=== Component versions for {SMProductName} version 2.5.3
+
+// Release is scheduled for July 10, 2024. --> delayed
+//Includes 2.6, 2.5.3, 2.4.9. 2.6 ends support for v2.3
+
+|===
+|Component |Version
+
+|Istio
+|1.18.5
+
+|Envoy Proxy
+|1.26.8
+
+|Kiali
+|1.73.9
+|===
+
 [id="new-features-ossm-2-5-2"]
 == New features {SMProductName} version 2.5.2
 
@@ -23,8 +210,6 @@ This release adds improvements related to the following components and concepts.
 //Includes 2.5.2, 2.4.8, 2.3.12
 
 This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.12 and later.
-
-The most current version of the {SMProductName} Operator can be used with all supported versions of {SMProductShortName}. The version of {SMProductShortName} is specified using the `ServiceMeshControlPlane`.
 
 === Component versions for {SMProductName} version 2.5.2
 
@@ -178,6 +363,30 @@ A new version of the Gateway API custom resource definition (CRD) is now availab
 |For multitenant mesh deployment, all Gateway API CRDs must be present. Use the experimental branch.
 |===
 
+[id="new-features-ossm-2-4-9"]
+== New features {SMProductName} version 2.4.9
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.12 and later.
+
+[id="component-versions-2-4-9"]
+=== Component versions for {SMProductName} version 2.4.9
+
+// Release is scheduled for July 10, 2024. --> delayed
+//Includes 2.6, 2.5.3, 2.4.9. 2.6 ends support for v2.3
+
+|===
+|Component |Version
+
+|Istio
+|1.16.7
+
+|Envoy Proxy
+|1.24.12
+
+|Kiali
+|1.65.11
+|===
+
 [id="new-features-ossm-2-4-8"]
 == New features {SMProductName} version 2.4.8
 
@@ -186,8 +395,6 @@ A new version of the Gateway API custom resource definition (CRD) is now availab
 //Includes 2.5.2, 2.4.8, 2.3.12
 
 This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.12 and later.
-
-The most current version of the {SMProductName} Operator can be used with all supported versions of {SMProductShortName}. The version of {SMProductShortName} is specified using the `ServiceMeshControlPlane`.
 
 === Component versions for {SMProductName} version 2.4.8
 
@@ -538,8 +745,6 @@ endif::openshift-rosa,openshift-dedicated[]
 //Includes 2.5.2, 2.4.8, 2.3.12
 
 This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.12 and later.
-
-The most current version of the {SMProductName} Operator can be used with all supported versions of {SMProductShortName}. The version of {SMProductShortName} is specified using the `ServiceMeshControlPlane`.
 
 === Component versions for {SMProductName} version 2.3.12
 


### PR DESCRIPTION
**OSSM 2.6** 

REMAINS: Component table updates for 2.6, 2.5.3, and 2.4.9

[OSSM-6457](https://issues.redhat.com//browse/OSSM-6457) OSSM 2.6.0 (At Stage): [DOC] Release Notes, Known Issues and Bug Fixes

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSSM-6457

Link to docs preview:

2.6: https://77982--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes.html 

2.5.3: https://77982--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes.html#new-features-ossm-2-5-3

2.4.9: https://77982--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes.html#new-features-ossm-2-4-9

Fixed Issues: https://77982--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes.html#ossm-rn-fixed-issues_ossm-release-notes BUT only the following:

[OSSM-6766] 
[OSSM-6754]
[OSSM-2101]

Previous bug fixes (in this case, from 2.5.2), were reviewed/approved in a previous release, and have been copy/pasted as is to {SMProductShortName} fixed issues. They do not need to be reviewed again. 

Reviews:
- [x] PM has approved this change.
- [x] Dev has approved this change. 
- [x] QE has approved this change. --> QE will review after the Component Tables have been updated, and the tables will be updated when the components are known, which is likely a day or 2 before Release Day.
- [x] OCP Doc Peer Review Round 1 for 2.6 New Features, and Fixed issues.
- [x] OCP Doc Peer Review Round 2 for Component Table updates for 2.6, 2.5.3, and 2.4.9.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Reviews and dates added for quick reference of what PRs are where for OSSM 2.6.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
