### PR TITLE
Fixes live migration ip addresses

### DIFF
--- a/modules/nw-ovn-kubernetes-live-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-live-migration-about.adoc
@@ -67,14 +67,15 @@ During the limited live migration, both OVN-Kubernetes and OpenShift SDN run in 
 ** `InternalTransitSwitchSubnet`
 ** `internalJoinSubnet`
 
-* Unless otherwise configured, OVN-Kubernetes uses the following IP address ranges:
-** `100.64.0.0/16`. This IP address range is used for the `internalJoinSubnet` parameter of OVN-Kubernetes by default. If this IP address range is already in use, enter the following command to update it to `100.63.0.0/16`:
+* OVN-Kubernetes reserves the `100.64.0.0/16` and `100.88.0.0/16` IP address ranges. If OpenShift SDN has been configured to use either of these IP address ranges, you must patch them to use a different IP address range before starting the limited live migration.
+
+** `100.64.0.0/16`. This IP address range is used for the `internalJoinSubnet` parameter of OVN-Kubernetes by default. If this IP address range is already in use, enter the following command to update it to a different range, for example, `100.63.0.0/16`:
 +
 [source,terminal]
 ----
 $ oc patch network.operator.openshift.io cluster --type='merge' -p='{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"ipv4":{"internalJoinSubnet": "100.63.0.0/16"}}}}}'
 ----
-** `100.88.0.0/16`. This IP address range is used for the `internalTransSwitchSubnet` parameter of OVN-Kubernetes by default. If this IP address range is already in use by another network, enter the following command to update it to `100.99.0.0/16`:
+** `100.88.0.0/16`. This IP address range is used for the `internalTransSwitchSubnet` parameter of OVN-Kubernetes by default. If this IP address range is already in use, enter the following command to update it to a different range, for example, `100.99.0.0/16`:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://77984--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#considerations-live-migrating-ovn-kubernetes-network-provider_migrate-from-openshift-sdn

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
