### PR TITLE
[RHACS] Updated supported OS version numbers and names

### DIFF
--- a/modules/scanning-images.adoc
+++ b/modules/scanning-images.adoc
@@ -121,7 +121,7 @@ Scanner identifies vulnerabilities in images that contain the following Linux di
 | Distribution | Version
 
 | link:https://www.alpinelinux.org/[Alpine Linux]
-| `alpine:3.2`^[1]^,`alpine:3.3`, `alpine:3.4`, `alpine:3.5`, `alpine:3.6`, `alpine:3.7`, `alpine:3.8`, `alpine:3.9`, `alpine:3.10`, `alpine:3.11`, `alpine:3.12`, `alpine:3.13`, `alpine:3.14`, `alpine:3.15`, `alpine:3.16`, `alpine:3.17`, `alpine:3.18`, `alpine:3.19`^[2]^, `alpine:edge`
+| `alpine:3.2`^[1]^,`alpine:3.3`, `alpine:3.4`, `alpine:3.5`, `alpine:3.6`, `alpine:3.7`, `alpine:3.8`, `alpine:3.9`, `alpine:3.10`, `alpine:3.11`, `alpine:3.12`, `alpine:3.13`, `alpine:3.14`, `alpine:3.15`, `alpine:3.16`, `alpine:3.17`, `alpine:3.18`, `alpine:3.19`, `alpine:3.20`, `alpine:edge`
 
 | link:https://aws.amazon.com/amazon-linux-ami[Amazon Linux]
 | `amzn:2018.03`, `amzn:2`, `amzn:2023`^[2]^
@@ -130,25 +130,25 @@ Scanner identifies vulnerabilities in images that contain the following Linux di
 | `centos:6`^[1]^, `centos:7`^[1]^, `centos:8`^[1]^
 
 | link:https://www.debian.org/releases/[Debian]
-| `debian:10`, `debian:11`, `debian:12`, `debian:unstable`, `distroless`
+| `debian:10`, `debian:11`, `debian:12`, `debian:unstable`^[1]^, `distroless`
 
 | link:https://www.oracle.com/linux/[Oracle Linux]
-| versions 5-9^[2]^
+| `ol:5`^[2]^, `ol:6`^[2]^, `ol:7`^[2]^, `ol:8`^[2]^, `ol:9`^[2]^
 
 | link:https://vmware.github.io/photon/assets/files/html/3.0/Introduction.html[Photon OS]
-| 1.0^[2]^, 2.0^[2]^, 3.0 ^[2]^
+| `photon:1.0`^[2]^, `photon:2.0`^[2]^, `photon:3.0`^[2]^
 
 | link:https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux[{op-system-base-full}]
 | `rhel:6`^[3]^, `rhel:7`^[3]^, `rhel:8`^[3]^, `rhel:9`^[3]^
 
 | link:https://www.suse.com/[SUSE]
-| SLES 11, 12, 15^[2]^; openSUSE Leap 42.3, 15.0, 15.1^[2]^; SUSE Linux^[2]^
+| `sles:11`^[2]^, `sles:12`^[2]^, `sles:15`^[2]^, `opensuse-leap:15.0`^[2]^, `opensuse-leap:15.1`^[2]^
 
 | link:http://releases.ubuntu.com/[Ubuntu]
-| `ubuntu:14.04`, `ubuntu:16.04`, `ubuntu:18.04`, `ubuntu:20.04`, `ubuntu:21.04`, `ubuntu:21.10`, `ubuntu:22.04`, `ubuntu:22.10`, `ubuntu:23.04`, `ubuntu:23.10`
+| `ubuntu:14.04`, `ubuntu:16.04`, `ubuntu:18.04`, `ubuntu:20.04`,`ubuntu:22.04`, `ubuntu:23.10`, `ubuntu:24.04`
 
 The following vulnerability sources are not updated by the vendor:
-`ubuntu:12.04`, `ubuntu:12.10`, `ubuntu:13.04`, `ubuntu:14.10`, `ubuntu:15.04`, `ubuntu::15.10`, `ubuntu::16.10`, `ubuntu:17.04`, `ubuntu:17.10`, `ubuntu:18.10`, `ubuntu:19.04`, `ubuntu:19.10`, `ubuntu:20.10`,
+`ubuntu:12.04`, `ubuntu:12.10`, `ubuntu:13.04`, `ubuntu:14.10`, `ubuntu:15.04`, `ubuntu::15.10`, `ubuntu::16.10`, `ubuntu:17.04`, `ubuntu:17.10`, `ubuntu:18.10`, `ubuntu:19.04`, `ubuntu:19.10`, `ubuntu:20.10`, `ubuntu:21.04`, `ubuntu:21.10`, `ubuntu:22.10`, `ubuntu:23.04`
 |===
 . Only supported in the StackRox Scanner.
 . Only supported in Scanner V4.


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-24931

- Updated supported OS and version numbers for 4.5

Cherrypick into `rhacs-docs-4.5`

Preview: https://78006--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/examine-images-for-vulnerabilities.html#supported-operating-systems_examine-images-for-vulnerabilities

---

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.
