### PR TITLE
[RHACS] Removed port number instances from Central endpoint 

### DIFF
--- a/cloud_service/installing_cloud_ocp/install-secured-cluster-cloud-ocp.adoc
+++ b/cloud_service/installing_cloud_ocp/install-secured-cluster-cloud-ocp.adoc
@@ -14,7 +14,7 @@ You can install {product-title-managed-short} on your secured clusters by using 
 * You have created your {osp} cluster and installed the Operator on it.
 * In the ACS Console in {product-title-managed-short}, you have created and downloaded the init bundle.
 * You applied the init bundle by using the `oc create` command.
-* During installation, you noted the *Central API Endpoint*, including the address and the port number. You can view this information by choosing *Advanced Cluster Security* -> *ACS Instances* from the cloud console navigation menu, and then clicking the ACS instance you created.
+* During installation, you noted the *Central API Endpoint* address. You can view this information by choosing *Advanced Cluster Security* -> *ACS Instances* from the cloud console navigation menu, and then clicking the ACS instance you created.
 
 [id="installing-sc-operator-cloud-ocp"]
 == Installing {product-title-short} on secured clusters by using the Operator

--- a/modules/acs-quick-install-secured-cluster-using-helm.adoc
+++ b/modules/acs-quick-install-secured-cluster-using-helm.adoc
@@ -27,10 +27,10 @@ Use the following instructions to install the `secured-cluster-services` Helm ch
 * You must have generated an {product-title-short} init bundle for your cluster.
 * You must have access to the Red{nbsp}Hat Container Registry and a pull secret for authentication. For information about downloading images from `registry.redhat.io`, see link:https://access.redhat.com/RegistryAuthentication[Red{nbsp}Hat Container Registry Authentication].
 ifndef::cloud-svc[]
-* You must have the address and the port number that you are exposing the Central service on.
+* You must have the address that you are exposing the Central service on.
 endif::cloud-svc[]
 ifdef::cloud-svc[]
-* You must have the *Central API Endpoint*, including the address and the port number. You can view this information by choosing *Advanced Cluster Security* -> *ACS Instances* from the cloud console navigation menu, then clicking the ACS instance you created.
+* You must have the *Central API Endpoint* address. You can view this information by choosing *Advanced Cluster Security* -> *ACS Instances* from the Red{nbsp}Hat Hybrid Cloud Console navigation menu, then clicking the ACS instance you created.
 endif::[]
 
 .Procedure
@@ -54,7 +54,7 @@ ifndef::cloud-svc[]
 <3> Specify the address and port number for Central. For example, `acs.domain.com:443`.
 endif::[]
 ifdef::cloud-svc[]
-<3> Enter the Central API Endpoint, including the address and the port number. You can view this information again in the Red{nbsp}Hat Hybrid Cloud Console console by choosing Advanced Cluster Security → ACS Instances, and then clicking the ACS instance you created.
+<3> Enter the *Central API Endpoint* address. You can view this information by choosing *Advanced Cluster Security* -> *ACS Instances* from the Red{nbsp}Hat Hybrid Cloud Console navigation menu, then clicking the {product-title-short} instance you created.
 endif::[]
 <4> Include the user name for your pull secret for Red{nbsp}Hat Container Registry authentication.
 <5> Include the password for your pull secret for Red{nbsp}Hat Container Registry authentication.

--- a/modules/install-secured-cluster-operator.adoc
+++ b/modules/install-secured-cluster-operator.adoc
@@ -30,9 +30,9 @@ You can install Secured Cluster services on your clusters by using the Operator,
 . If you are using *Form view*, enter the new project name by accepting or editing the default name. The default value is *stackrox-secured-cluster-services*.
 . Optional: Add any labels for the cluster.
 . Enter a unique name for your `SecuredCluster` custom resource.
-. For *Central Endpoint*, enter the address and port number of your Central instance. For example, if Central is available at `\https://central.example.com`, then specify the central endpoint as `central.example.com:443`.
+. For *Central Endpoint*, enter the address of your Central instance. For example, if Central is available at `\https://central.example.com`, then specify the central endpoint as `central.example.com`.
 ifdef::cloud-svc[]
-*  For {product-title-managed-short} use the *Central API Endpoint*, including the address and the port number. You can view this information by choosing *Advanced Cluster Security* -> *ACS Instances* from the cloud console navigation menu, then clicking the ACS instance you created.
+*  For {product-title-managed-short} use the *Central API Endpoint* address. You can view this information by choosing *Advanced Cluster Security* -> *ACS Instances* from the Red{nbsp}Hat Hybrid Cloud Console navigation menu, then clicking the {product-title-short} instance you created.
 endif::cloud-svc[]
 * Use the default value of `central.stackrox.svc:443` _only_ if you are installing secured cluster services in the same cluster where Central is installed.
 * Do not use the default value when you are configuring multiple clusters. Instead, use the hostname when configuring the *Central Endpoint* value for each cluster.

--- a/modules/install-secured-cluster-services-helm-chart.adoc
+++ b/modules/install-secured-cluster-services-helm-chart.adoc
@@ -21,7 +21,7 @@ ifndef::cloud-svc[]
 * You must have the address and the port number that you are exposing the Central service on.
 endif::cloud-svc[]
 ifdef::cloud-svc[]
-* You must have the *Central API Endpoint*, including the address and the port number. You can view this information by choosing *Advanced Cluster Security* -> *ACS Instances* from the cloud console navigation menu, then clicking the ACS instance you created.
+* You must have the *Central API Endpoint* address. You can view this information by choosing *Advanced Cluster Security* -> *ACS Instances* from the Red{nbsp}Hat Hybrid Cloud Console navigation menu, then clicking the {product-title-short} instance you created.
 endif::[]
 
 .Procedure

--- a/modules/install-sensor-roxctl.adoc
+++ b/modules/install-sensor-roxctl.adoc
@@ -45,7 +45,7 @@ ifndef::cloud-svc[]
 *** Add the port number after the address, for example, `wss://stackrox-central.example.com:443`.
 endif::cloud-svc[]
 ifdef::cloud-svc[]
-** Enter the Central API Endpoint, including the address and the port number. You can view this information again in the {cloud-console} by choosing *Advanced Cluster Security* -> *ACS Instances*, and then clicking the ACS instance you created.
+** Enter the *Central API Endpoint* address. You can view this information by choosing *Advanced Cluster Security* -> *ACS Instances* from the Red{nbsp}Hat Hybrid Cloud Console navigation menu, then clicking the {product-title-short} instance you created.
 endif::cloud-svc[]
 . Click *Next* to continue with the Sensor setup.
 . Click *Download YAML File and Keys* to download the cluster bundle (zip archive).

--- a/modules/installing-rhacs-ocp-steps.adoc
+++ b/modules/installing-rhacs-ocp-steps.adoc
@@ -16,7 +16,7 @@
 .. On the secured cluster, apply the init bundle that you created in {product-title-short} by performing one of these steps:
 * Use the {ocp} web console to import the YAML file of the init bundle that you created. Make sure you are in the `stackrox` namespace.
 * In the terminal window, run the `oc create -f <init_bundle>.yaml -n <stackrox>` command, specifying the path to the downloaded YAML file of the init bundle.
-.. On the secured cluster, use the {product-title-short} Operator to install Secured Cluster services into the `stackrox` namespace. When creating these services, be sure to enter the address and port number of Central in the *Central Endpoint* field so that the secured cluster can communicate with Central.
+.. On the secured cluster, use the {product-title-short} Operator to install Secured Cluster services into the `stackrox` namespace. When creating these services, be sure to enter the address of Central in the *Central Endpoint* field so that the secured cluster can communicate with Central.
 
 [id="installing-ocp-helm-steps"]
 == Installing {product-title-short} on {osp} by using Helm charts

--- a/modules/secured-cluster-services-config.adoc
+++ b/modules/secured-cluster-services-config.adoc
@@ -15,7 +15,7 @@
 | Name of your cluster.
 
 | `centralEndpoint`
-| Address, including port number, of the Central endpoint. If you are using a non-gRPC capable load balancer, use the WebSocket protocol by prefixing the endpoint address with `wss://`. When configuring multiple clusters, use the hostname for the address (for example, `central.example.com:443`).
+| Address of the Central endpoint. If you are using a non-gRPC capable load balancer, use the WebSocket protocol by prefixing the endpoint address with `wss://`. When configuring multiple clusters, use the hostname for the address. For example, `central.example.com`.
 
 | `sensor.endpoint`
 | Address of the Sensor endpoint including port number.


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-24846

- Removed the requirement of adding a port number when specifying Central endpoint for secured clusters.

Cherry-pick in `rhacs-docs-4.5`.

Preview:
- https://78007--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_ocp/install-secured-cluster-cloud-ocp.html
- https://78007--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_other/install-secured-cluster-cloud-other.html#installing-secured-cluster-services-quickly_install-secured-cluster-cloud-other
- https://78007--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/acs-high-level-overview.html#installing-ocp-operator-steps
- https://78007--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-ocp.html#install-secured-cluster-operator_install-secured-cluster-ocp
- https://78007--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_other/install-secured-cluster-other.html#secured-cluster-services-config_install-secured-cluster-other