### PR TITLE
PR for SRVCOM-3162: Update the Openshift Serverless 1.33 release notes with additional suggestions

### DIFF
--- a/modules/serverless-rn-1-33-0.adoc
+++ b/modules/serverless-rn-1-33-0.adoc
@@ -16,7 +16,7 @@
 * {ServerlessProductName} now uses Kourier 1.12.
 * {ServerlessProductName} now uses Knative (`kn`) CLI 1.12.
 * {ServerlessProductName} now uses Knative for Apache Kafka 1.12.
-* The `kn func` CLI plugin now uses `func` 1.13.
+* The `kn func` CLI plugin now uses `func` 1.14.
 
 * OpenShift Serverless on ARM64 is now available as Technology Preview.
 * The `NamespacedKafka` annotation is now deprecated. Use the standard Kafka broker without data plane isolation instead.
@@ -24,6 +24,10 @@
 * When enabling the automatic `EventType` auto-creation, you can now easily discover events available within the cluster. This functionality is available as a Developer Preview.
 
 * You can now use the Custom Metrics Autoscaler Operator to autoscale Knative Eventing sources for Apache Kafka sources, defined by a `KafkaSource` object. This functionality is available as a Technology Preview feature, offering enhanced scalability and efficiency for Kafka-based event sources within Knative Eventing.
+
+* You can now customize the internal Kafka topic properties when creating a Knative Broker with Kafka implementation. This improves efficiency and simplifies management.
+
+* The new trigger filters feature is now available as a Technology Preview. These filters are enabled by default and allows users to specify a set of filter expressions, where each expression evaluates to either true or false for each event.
 
 [id="known-issues-1-33-0_{context}"]
 == Known issues

--- a/modules/serverless-tech-preview-features.adoc
+++ b/modules/serverless-tech-preview-features.adoc
@@ -24,6 +24,12 @@ The following table provides information about which {ServerlessProductName} fea
 |-
 |-
 |TP
+
+|kn event plugin
+|-
+|TP
+|TP
+
 |Pipelines-as-code
 |-
 |TP


### PR DESCRIPTION
**Affected versions:** `serverless-docs-1.33`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVCOM-3162

**Doc preview:** 

- [Serverless 1.33.0 release notes](https://78008--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-rn-1-33-0_serverless-release-notes)
- [Generally Available and Technology Preview features table](https://78008--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-tech-preview-features_serverless-release-notes)
