### PR TITLE
[internal-only] 4-16-rn-doc-tidy: Clean up of 4.16 release notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Red Hat {product-title} provides developers and IT organizations with a hybrid cloud application platform for deploying both new and existing applications on secure, scalable resources with minimal configuration and management. {product-title} supports a wide selection of programming languages and frameworks, such as Java, JavaScript, Python, Ruby, and PHP.
+Red{nbsp}Hat {product-title} provides developers and IT organizations with a hybrid cloud application platform for deploying both new and existing applications on secure, scalable resources with minimal configuration and management. {product-title} supports a wide selection of programming languages and frameworks, such as Java, JavaScript, Python, Ruby, and PHP.
 
 Built on {op-system-base-full} and Kubernetes, {product-title} provides a more secure and scalable multitenant operating system for today's enterprise-class applications, while delivering integrated application runtimes and libraries. {product-title} enables organizations to meet security, privacy, compliance, and governance requirements.
 
@@ -32,7 +32,7 @@ Beyond this, Red{nbsp}Hat also offers a 12-month additional EUS add-on, denoted 
 //The support lifecycle for odd-numbered releases, such as {product-title} 4.15, on all supported architectures, including `x86_64`, 64-bit ARM (`aarch64`), {ibm-power-name} (`ppc64le`), and {ibm-z-name} (`s390x`) architectures is 18 months.
 For more information about support for all versions, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
 
-Commencing with the {product-version} release, Red Hat is simplifying the administration and management of Red Hat shipped cluster Operators with the introduction of three new life cycle classifications; Platform Aligned, Platform Agnostic, and Rolling Stream. These life cycle classifications provide additional ease and transparency for cluster administrators to understand the life cycle policies of each Operator and form cluster maintenance and upgrade plans with predictable support boundaries. For more information, see link:https://access.redhat.com/webassets/avalon/j/includes/session/scribe/?redirectTo=https%3A%2F%2Faccess.redhat.com%2Fsupport%2Fpolicy%2Fupdates%2Fopenshift_operators[OpenShift Operator Life Cycles].
+Commencing with the {product-version} release, Red{nbsp}Hat is simplifying the administration and management of Red{nbsp}Hat shipped cluster Operators with the introduction of three new life cycle classifications; Platform Aligned, Platform Agnostic, and Rolling Stream. These life cycle classifications provide additional ease and transparency for cluster administrators to understand the life cycle policies of each Operator and form cluster maintenance and upgrade plans with predictable support boundaries. For more information, see link:https://access.redhat.com/webassets/avalon/j/includes/session/scribe/?redirectTo=https%3A%2F%2Faccess.redhat.com%2Fsupport%2Fpolicy%2Fupdates%2Fopenshift_operators[OpenShift Operator Life Cycles].
 
 // Added in 4.14. Language came directly from Kirsten Newcomer.
 {product-title} is designed for FIPS. When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the `x86_64`, `ppc64le`, and `s390x` architectures.
@@ -59,8 +59,7 @@ This release adds improvements related to the following components and concepts.
 
 [id="ocp-4-16-iscsi-support_{context}"]
 ==== Support for iSCSI boot volumes
-
-With this release, you can now install {op-system} to iSCSI boot devices. Multipathing for iSCSI is also supported. For more information, see xref:../installing/installing_bare_metal/installing-bare-metal.adoc#rhcos-install-iscsi-manual_installing-bare-metal[Installing {op-system} manually on an iSCSI boot device] and xref:../installing/installing_bare_metal/installing-bare-metal.adoc#rhcos-install-iscsi-ibft_installing-bare-metal[Installing {op-system} on an iSCSI boot device using iBFT].
+With this release, you can now install {op-system} to Small Computer Systems Interface (iSCSI) boot devices. Multipathing for iSCSI is also supported. For more information, see xref:../installing/installing_bare_metal/installing-bare-metal.adoc#rhcos-install-iscsi-manual_installing-bare-metal[Installing {op-system} manually on an iSCSI boot device] and xref:../installing/installing_bare_metal/installing-bare-metal.adoc#rhcos-install-iscsi-ibft_installing-bare-metal[Installing {op-system} on an iSCSI boot device using iBFT]
 
 [id="ocp-4-16-raid-intel-vroc_{context}"]
 ==== Support for RAID storage using Intel(R) Virtual RAID on CPU (VROC)
@@ -70,14 +69,14 @@ With this release, you can now install {op-system} to Intel(R) VROC RAID devices
 === Installation and update
 
 [id="ocp-4-16-installation-and-update-aws-capi_{context}"]
-==== Cluster API replaces Terraform for AWS installations
-In {product-title} {product-version}, the installation program uses Cluster API instead of Terraform to provision cluster infrastructure during installations on AWS. There are several additional required permissions as a result of this change. For more information, see xref:../installing/installing_aws/installing-aws-account.adoc#installation-aws-permissions_installing-aws-account[Required AWS permissions for the IAM user].
+==== Cluster API replaces Terraform for {aws-short} installations
+In {product-title} {product-version}, the installation program uses Cluster API (CAPI) instead of Terraform to provision cluster infrastructure during installations on {aws-full}. There are several additional required permissions as a result of this change. For more information, see xref:../installing/installing_aws/installing-aws-account.adoc#installation-aws-permissions_installing-aws-account[Required {aws-short} permissions for the IAM user].
 
-Additionally, SSH access to control plane and compute machines is no longer open to the machine network, but is restricted to the security groups associated with the control plane and compute machines.
+Additionally, SSH access to control plane and compute machines is no longer open to the machine network, but SSH access is restricted to the security groups associated with the control plane and compute plane machines.
 
 [WARNING]
 ====
-Installing a cluster on AWS into a secret or top-secret region by using the Cluster API implementation has not been tested as of the release of {product-title} {product-version}. This document will be updated when installation into a secret region has been tested. There is a known issue with Network Load Balancers' support for security groups in secret or top secret regions that causes installations to fail. For more information, see link:https://issues.redhat.com/browse/OCPBUGS-33311[*OCPBUGS-33311*].
+Installing a cluster on {aws-first} into a secret or top-secret region has not been tested with CAPI as of the release of {product-title} {product-version}. This document will be updated when installation into a secret region has been tested. There is a known issue with Network Load Balancer support for security groups in secret or top secret regions that causes installations to fail. For more information, see link:https://issues.redhat.com/browse/OCPBUGS-33311[*OCPBUGS-33311*].
 ====
 
 [id="ocp-4-16-installation-and-update-vsphere-capi_{context}"]
@@ -99,12 +98,12 @@ featureGates:
 - ClusterAPIInstall=true
 ----
 
-For more information, see xref:../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-configuration-parameters-optional_installation-config-parameters-gcp[Installation configuration parameters].
+For more information, see xref:../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-configuration-parameters-optional_installation-config-parameters-gcp[Optional configuration parameters].
 
 [id="ocp-4-16-installation-and-update-ingress-capability_{context}"]
 ==== Ingress capability
 
-Ingress capability is now a configurable cluster capability and is optional for Red{nbsp}Hat Hypershift. It is not configurable and is always enabled for standalone {product-title}.
+Ingress capability is now a configurable cluster capability and is optional for Red{nbsp}Hat HyperShift. It is not configurable and is always enabled for standalone {product-title}.
 
 [WARNING]
 ====
@@ -125,8 +124,7 @@ With this update, if you install a FIPS-enabled cluster, you must run the instal
 [id="ocp-4-16-installation-and-update-vsphere-tagging_{context}"]
 ==== Optional additional tags for {vmw-first}
 
-In {product-title} {product-version}, you can add up to ten tags to attach to the VMs provisioned by a {vmw-first} cluster.
-These tags are in addition to the unique cluster-specific tag that the installation program uses to identify and remove associated VMs when a cluster is decommissioned.
+In {product-title} {product-version}, you can add up to ten tags to attach to the virtual machines (VMs) provisioned by a {vmw-first} cluster. These tags are in addition to the unique cluster-specific tag that the installation program uses to identify and remove associated VMs when a cluster is decommissioned.
 
 You can define the tags on the {vmw-first} VMs in the `install-config.yaml` file during cluster creation.
 For more information, see xref:../installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc#installation-installer-provisioned-vsphere-config-yaml_installing-restricted-networks-installer-provisioned-vsphere[Sample `install-config.yaml` file for an installer-provisioned {vmw-first} cluster].
@@ -135,15 +133,15 @@ You can define tags for compute or control plane machines on an existing cluster
 For more information, see "Adding tags to machines by using machine sets" for xref:../machine_management/creating_machinesets/creating-machineset-vsphere.adoc#machine-api-vmw-add-tags_creating-machineset-vsphere[compute] or xref:../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.adoc#machine-api-vmw-add-tags_cpmso-config-options-vsphere[control plane] machine sets.
 
 [id="ocp-4-16-admin-ack-updating_{context}"]
-==== Required administrator acknowledgment when updating from {product-title} 4.15 to 4.16
+==== Required administrator acknowledgment when updating from {product-title} 4.15 to {product-version}
 
-{product-title} 4.16 uses Kubernetes 1.29, which removed several xref:../release_notes/ocp-4-16-release-notes.adoc#ocp-4-16-removed-kube-1-29-apis_{context}[deprecated APIs].
+{product-title} {product-version} uses Kubernetes 1.29, which removed several xref:../release_notes/ocp-4-16-release-notes.adoc#ocp-4-16-removed-kube-1-29-apis_{context}[deprecated APIs].
 
-A cluster administrator must provide manual acknowledgment before the cluster can be updated from {product-title} 4.15 to 4.16. This is to help prevent issues after updating to {product-title} 4.16, where APIs that have been removed are still in use by workloads, tools, or other components running on or interacting with the cluster. Administrators must evaluate their cluster for any APIs in use that will be removed and migrate the affected components to use the appropriate new API version. After this is done, the administrator can provide the administrator acknowledgment.
+A cluster administrator must provide manual acknowledgment before the cluster can be updated from {product-title} 4.15 to {product-version}. This is to help prevent issues after updating to {product-title} {product-version}, where APIs that have been removed are still in use by workloads, tools, or other components running on or interacting with the cluster. Administrators must evaluate their cluster for any APIs in use that will be removed and migrate the affected components to use the appropriate new API version. After this is done, the administrator can provide the administrator acknowledgment.
 
-All {product-title} 4.15 clusters require this administrator acknowledgment before they can be updated to {product-title} 4.16.
+All {product-title} 4.15 clusters require this administrator acknowledgment before they can be updated to {product-title} {product-version}.
 
-For more information, see xref:../updating/preparing_for_updates/updating-cluster-prepare.adoc#updating-cluster-prepare[Preparing to update to {product-title} 4.16].
+For more information, see xref:../updating/preparing_for_updates/updating-cluster-prepare.adoc#updating-cluster-prepare[Preparing to update to {product-title} {product-version}].
 
 [id="ocp-4-16-installation-and-update-kubeadmin_{context}"]
 ==== Secure kubeadmin password from being displayed in the console
@@ -154,25 +152,24 @@ With this release, you can prevent the `kubeadmin` password from being displayed
 ==== OpenShift-based Appliance Builder (Technology Preview)
 
 With this release, the OpenShift-based Appliance Builder is available as a Technology Preview feature.
-The Appliance Builder enables self-contained {product-title} cluster installations, meaning that it does not rely on internet connectivity or external registries.
-It is a container-based utility that builds a disk image that includes the Agent-based Installer, which can then be used to install multiple {product-title} clusters.
+The Appliance Builder enables self-contained {product-title} cluster installations, meaning that it does not rely on internet connectivity or external registries. It is a container-based utility that builds a disk image that includes the Agent-based Installer, which can then be used to install multiple {product-title} clusters.
 
 For more information, see the link:https://access.redhat.com/articles/7065136[OpenShift-based Appliance Builder User Guide].
 
 [id="ocp-4-16-installation-and-update-byoip_{context}"]
-==== Bring your own IPv4 (BYOIP) feature enabled for installation on AWS
+==== Bring your own IPv4 (BYOIP) feature enabled for installation on {aws-short}
 
-With this release, you can enable bring your own public IPv4 addresses (BYOIP) feature when installing on AWS by using the `publicIpv4Pool` field to allocate Elastic IP addresses (EIPs). You must ensure that you have the xref:../installing/installing_aws/installing-aws-account.adoc#installation-aws-permissions_installing-aws-account[required permissions] to enable BYOIP. For more information, see xref:../installing/installing_aws/installation-config-parameters-aws.adoc#installation-configuration-parameters-optional-aws_installation-config-parameters-aws[Optional AWS configuration parameters].
+With this release, you can enable bring your own public IPv4 addresses (BYOIP) feature when installing on {aws-first} by using the `publicIpv4Pool` field to allocate Elastic IP addresses (EIPs). You must ensure that you have the xref:../installing/installing_aws/installing-aws-account.adoc#installation-aws-permissions_installing-aws-account[required permissions] to enable BYOIP. For more information, see xref:../installing/installing_aws/installation-config-parameters-aws.adoc#installation-configuration-parameters-optional-aws_installation-config-parameters-aws[Optional {aws-short} configuration parameters].
 
 [id="ocp-4-16-installation-and-update-gcp-regions_{context}"]
 ==== Deploy {gcp-short} in the Dammam (Saudi Arabia) and Johannesburg (South Africa) regions
 
-You can deploy {product-title} {product-version} in {gcp-first} in the Dammam, Saudi Arabia (`me-central2`) region and in the Johannesburg, South Africa (`africa-south1`) region. For more information, see xref:../installing/installing_gcp/installing-gcp-account.adoc#installation-gcp-regions_installing-gcp-account[Supported GCP regions].
+You can deploy {product-title} {product-version} in {gcp-first} in the Dammam, Saudi Arabia (`me-central2`) region and in the Johannesburg, South Africa (`africa-south1`) region. For more information, see xref:../installing/installing_gcp/installing-gcp-account.adoc#installation-gcp-regions_installing-gcp-account[Supported {gcp-short} regions].
 
 [id="ocp-4-16-installation-nvidia-machine-types_{context}"]
 ==== Installation on NVIDIA H100 instance types on {gcp-first}
 
-With this release, you can deploy compute nodes on GPU-enabled NVIDIA H100 machines when installing a cluster on {gcp-short}. For more information, see xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installation-gcp-tested-machine-types_installing-gcp-customizations[Tested instance types for GCP] and Google's documentation about the link:https://cloud.google.com/compute/docs/accelerator-optimized-machines[Accelerator-optimized machine family].
+With this release, you can deploy compute nodes on GPU-enabled NVIDIA H100 machines when installing a cluster on {gcp-short}. For more information, see xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installation-gcp-tested-machine-types_installing-gcp-customizations[Tested instance types for {gcp-short}] and Google's documentation about the link:https://cloud.google.com/compute/docs/accelerator-optimized-machines[Accelerator-optimized machine family].
 
 [id="ocp-4.16-postinstallation-configuration_{context}"]
 === Postinstallation configuration
@@ -204,7 +201,7 @@ This feature provides support for installing an Agent-based Installer cluster wi
 
 [id="ocp-4-16-web-console-language"]
 ==== Language support for French and Spansih
-With this release, French and Spanish are suported in the web console. You can update the language in the web console from the *Language* list on the *User Preferences* page.
+With this release, French and Spanish are supported in the web console. You can update the language in the web console from the *Language* list on the *User Preferences* page.
 
 [id="ocp-4-16-patternfly4-deprecated"]
 ==== Patternfly 4 is now deprecated with {product-version}
@@ -227,7 +224,7 @@ With this release, the {product-title} web console supports node certificate sig
 [id="ocp-4-16-cross-storage-class-clone-restore"]
 ===== Cross Storage Class clone and restore
 
-With this release, you can choose a storage class from the same provider when completing clone or restore operations. This flexibility allows seamless transitions between storage classes with different replica counts. For example, moving from a storage class with 3 replicas to 2/1 replicas.
+With this release, you can select a storage class from the same provider when completing clone or restore operations. This flexibility allows seamless transitions between storage classes with different replica counts. For example, moving from a storage class with 3 replicas to 2/1 replicas.
 
 [id="ocp-4-16-developer-perspective_{context}"]
 ==== Developer Perspective
@@ -240,10 +237,10 @@ This release introduces the following updates to the *Developer* perspective of 
 [id="ocp-4-16-console-telemetry"]
 ===== Console Telemetry
 
-With this release, anonymized user analytics were enabled if cluster telemetry is also enabled. This is the default for most of the cluster and provides Red Hat with metrics for how the web console is used. Cluster administrators can update this in each cluster and opt-in, opt-out, or disable frontend telemetry.
+With this release, anonymized user analytics were enabled if cluster telemetry is also enabled. This is the default for most of the cluster and provides Red{nbsp}Hat with metrics for how the web console is used. Cluster administrators can update this in each cluster and opt-in, opt-out, or disable front-end telemetry.
 
 [id="ocp-4-16-openshift-cli_{context}"]
-=== OpenShift CLI (`oc`)
+=== OpenShift CLI (oc)
 
 [id="ocp-4-16-oc-mirror-v2_{context}"]
 ==== oc-mirror plugin v2 (Technology Preview)
@@ -290,7 +287,7 @@ While oc-mirror plugin v2 brings numerous enhancements, some features from oc-mi
 
 * Helm Charts: Helm charts are not present in oc-mirror plugin v2.
 
-* `ImageSetConfig v1alpha2`: The api version `v1alpha2` is not available, users must update to `v2alpha1`.
+* `ImageSetConfig v1alpha2`: The API version `v1alpha2` is not available, users must update to `v2alpha1`.
 
 * Storage Metadata (`storageConfig`): Storage metadata is not used in oc-mirror plugin v2 `ImageSetConfiguration`.
 
@@ -308,14 +305,14 @@ The oc-mirror OpenShift CLI (`oc`) plugin is used to mirror all the required {pr
 
 
 [id="ocp-4-16-oc-adm-upgrade-status-tp_{context}"]
-==== Introducing the `oc adm upgrade status` command (Technology Preview)
+==== Introducing the oc adm upgrade status command (Technology Preview)
 
 Previously, the `oc adm upgrade` command provided limited information about the status of a cluster update. This release adds the `oc adm upgrade status` command, which decouples status information from the `oc adm upgrade` command and provides specific information regarding a cluster update, including the status of the control plane and worker node updates.
 
 [id="ocp-4-16-duplicate-short-name-warning_{context}"]
 ==== Warning for duplicate resource short names
 
-With this release, if you query a resource by using its short name, the OpenShift CLI  (`oc`) returns a warning if more than one custom resource definition (CRD) with the same short name exists in the cluster.
+With this release, if you query a resource by using its short name, the {oc-first} returns a warning if more than one custom resource definition (CRD) with the same short name exists in the cluster.
 
 .Example warning
 [source,terminal]
@@ -332,7 +329,7 @@ This release introduces a new `--interactive` flag for the `oc delete` command. 
 === {ibm-z-title} and {ibm-linuxone-title}
 
 With this release, {ibm-z-name} and {ibm-linuxone-name} are now compatible with {product-title} {product-version}. You can perform the installation with z/VM, LPAR, or {op-system-base-full} Kernel-based Virtual Machine (KVM). For installation instructions, see
-xref:../installing/installing_ibm_z/preparing-to-install-on-ibm-z.adoc#preparing-to-install-on-ibm-z[Installing a cluster with on {ibm-z-title} and {ibm-linuxone-title}].
+xref:../installing/installing_ibm_z/preparing-to-install-on-ibm-z.adoc#preparing-to-install-on-ibm-z[Preparing to install on {ibm-z-title} and {ibm-linuxone-title}].
 
 [IMPORTANT]
 ====
@@ -710,8 +707,7 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 [id="ocp-4-16-auth-entra-migration_{context}"]
 ==== Enabling {entra-first} on existing clusters
 
-In this release, you can enable {entra-first} to use short-term credentials on an existing {azure-first} {product-title} cluster.
-This functionality is now also supported in versions 4.14 and 4.15 of {product-title}.
+In this release, you can enable {entra-first} to use short-term credentials on an existing {azure-first} {product-title} cluster. This functionality is now also supported in versions 4.14 and 4.15 of {product-title}.
 For more information, see xref:../post_installation_configuration/changing-cloud-credentials-configuration.adoc#post-install-enable-token-auth_changing-cloud-credentials-configuration[Enabling token-based authentication].
 
 [id="ocp-4-16-networking_{context}"]
@@ -720,9 +716,9 @@ For more information, see xref:../post_installation_configuration/changing-cloud
 [id="ocp-4-16-networking-openshift-sdn-upgrade-block_{context}"]
 ==== OpenShift SDN network plugin blocks future major upgrades
 
-As part of the {product-title} transition to OVN-Kubernetes as the only supported network plugin, starting with {product-title} 4.16, if your cluster uses the OpenShift SDN network plugin, you cannot upgrade to future major versions of {product-title} without migrating to OVN-Kubernetes. For more information about migrating to OVN-Kubernetes, see xref:../networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc#migrate-from-openshift-sdn[Migrating from the OpenShift SDN network plugin].
+As part of the {product-title} move to OVN-Kubernetes as the only supported network plugin, starting with {product-title} {product-version}, if your cluster uses the OpenShift SDN network plugin, you cannot upgrade to future major versions of {product-title} without migrating to OVN-Kubernetes. For more information about migrating to OVN-Kubernetes, see xref:../networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc#migrate-from-openshift-sdn[Migrating from the OpenShift SDN network plugin].
 
-If you attempt an upgrade, the Cluster Network Operator reports the following status:
+If you try an upgrade, the Cluster Network Operator reports the following status:
 
 [source,yaml]
 ----
@@ -738,9 +734,7 @@ If you attempt an upgrade, the Cluster Network Operator reports the following st
 [id="ocp-4-16-ptp-dual-nic-gm-ga_{context}"]
 ==== Dual-NIC Intel E810 Westport Channel as PTP grandmaster clock (Generally Available)
 
-Configuring linuxptp services as grandmaster clock (T-GM) for dual Intel E810 Westport Channel NICs is now a generally available feature in {product-title}.
-The host system clock is synchronized from the NIC that is connected to the Global Navigation Satellite Systems (GNSS) time source. The second NIC is synced to the 1PPS timing output provided by the NIC that is connected to GNSS.
-For more information see xref:../networking/ptp/configuring-ptp.adoc#configuring-linuxptp-services-as-grandmaster-clock-dual-nic_configuring-ptp[Configuring linuxptp services as a grandmaster clock for dual E810 Westport Channel NICs].
+Configuring `linuxptp` services as grandmaster clock (T-GM) for dual Intel E810 Westport Channel network interface controllers (NICs) is now a generally available feature in {product-title}. The host system clock is synchronized from the NIC that is connected to the Global Navigation Satellite Systems (GNSS) time source. The second NIC is synced to the 1PPS timing output provided by the NIC that is connected to GNSS. For more information see xref:../networking/ptp/configuring-ptp.adoc#configuring-linuxptp-services-as-grandmaster-clock-dual-nic_configuring-ptp[Configuring linuxptp services as a grandmaster clock for dual E810 Westport Channel NICs].
 
 [id="ocp-4-16-ptp-dual-nic-tbc-ha_{context}"]
 ==== Dual-NIC Intel E810 PTP boundary clock with highly available system clock (Generally Available)
@@ -752,12 +746,12 @@ For more information, see xref:../networking/ptp/configuring-ptp.adoc#ptp-config
 [id="ocp-4-16-networking-connectivity-pod-placement_{context}"]
 ==== Configuring pod placement to check network connectivity
 
-To periodically test network connectivity amongst cluster components, the Cluster Network Operator (CNO) creates the `network-check-source` deployment and the `network-check-target` daemon set. In {product-title} 4.16, you can configure the nodes by setting node selectors and run the source and target pods to check the network connectivity. For more information, see xref:../networking/verifying-connectivity-endpoint.adoc#verifying-connectivity-endpoint[Verifying connectivity to an endpoint].
+To periodically test network connectivity among cluster components, the Cluster Network Operator (CNO) creates the `network-check-source` deployment and the `network-check-target` daemon set. In {product-title} {product-version}, you can configure the nodes by setting node selectors and run the source and target pods to check the network connectivity. For more information, see xref:../networking/verifying-connectivity-endpoint.adoc#verifying-connectivity-endpoint[Verifying connectivity to an endpoint].
 
 [id="ocp-4-16-networking-multiple-cidr_{context}"]
 ==== Define multiple CIDR blocks for one network security group (NSG) rule
 
-With this release, IP addresses and ranges are handled more efficiently in NSGs for {product-title} clusters hosted on Azure. As a result, the maximum limit of CIDRs for all Ingress Controllers in Azure clusters, using the `allowedSourceRanges` field, increases from approximately 1000 to 4000 CIDRs.
+With this release, IP addresses and ranges are handled more efficiently in NSGs for {product-title} clusters hosted on {azure-first}. As a result, the maximum limit of Classless Inter-Domain Routings (CIDRs) for all Ingress Controllers in {azure-first} clusters, using the `allowedSourceRanges` field, increases from approximately 1000 to 4000 CIDRs.
 
 [id="ocp-4-16-sdn-ovnk-migration-nutanix-support_{context}"]
 ==== Migration from OpenShift SDN to OVN-Kubernetes on Nutanix
@@ -769,7 +763,7 @@ With this release, migration from the OpenShift SDN network plugin to OVN-Kubern
 
 With this release, OVN-Kubernetes uses a new `DNSNameResolver` custom resource to keep track of DNS records in your egress firewall rules, and is available as a Technology Preview. This custom resource supports the use of both wildcard DNS names and regular DNS names and allows access to DNS names regardless of the IP addresses associated with its change.
 
-For more information, see xref:../networking/network_security/egress_firewall/configuring-egress-firewall-ovn.adoc#nw-coredns-egress-firewall[Improved DNS resolution and resolving wildcard domain names].
+For more information, see xref:../networking/network_security/egress_firewall/configuring-egress-firewall-ovn.adoc#nw-coredns-egress-firewall_configuring-egress-firewall-ovn[Improved DNS resolution and resolving wildcard domain names].
 
 [id="ocp-4-16-networking-sriov-draining_{context}"]
 ==== Parallel node draining during SR-IOV network policy updates
@@ -781,26 +775,30 @@ For further information, see xref:../networking/hardware_networks/configuring-sr
 [id="ocp-4-16-networking-create-sriovoperatorconfig_{context}"]
 ==== SR-IOV Network Operator no longer automatically creates the SriovOperatorConfig CR
 
-As of {product-title} 4.16, the SR-IOV Network Operator no longer automatically creates a `SriovOperatorConfig` custom resource (CR). Create the `SriovOperatorConfig` CR using the procedure described in xref:../networking/hardware_networks/configuring-sriov-operator.adoc#nw-sriov-configuring-operator_configuring-sriov-operator[Configuring the SR-IOV Network Operator].
+As of {product-title} {product-version}, the SR-IOV Network Operator no longer automatically creates a `SriovOperatorConfig` custom resource (CR). Create the `SriovOperatorConfig` CR by using the procedure described in xref:../networking/hardware_networks/configuring-sriov-operator.adoc#nw-sriov-configuring-operator_configuring-sriov-operator[Configuring the SR-IOV Network Operator].
 
 [id="ocp-4-16-q-in-q-support_{context}"]
 ==== Supporting double-tagged packets (QinQ)
 
-This release introduces 802.1Q-in-802.1Q also known as QinQ support. QinQ introduces a second VLAN tag, where the service provider designates the outer tag for their use, offering them flexibility, while the inner tag remains dedicated to the customer’s VLAN. When two VLAN tags are present in a packet, the outer VLAN tag can be either 802.1Q or 802.1ad. The inner VLAN tag must always be 802.1Q.
+This release introduces 802.1Q-in-802.1Q also known as _QinQ support_. QinQ introduces a second VLAN tag, where the service provider designates the outer tag for their use, offering them flexibility, while the inner tag remains dedicated to the customer’s VLAN. When two VLAN tags are present in a packet, the outer VLAN tag can be either 802.1Q or 802.1ad. The inner VLAN tag must always be 802.1Q.
 
 For more information, see xref:../networking/hardware_networks/configuring-sriov-qinq-support.adoc#configuring-qinq-support[Configuring QinQ support for SR-IOV enabled workloads].
 
 [id="ocp-4-16-networking-user-managed-lb_{context}"]
 ==== Configuring a user-managed load balancer for on-premise infrastructure
 
-With this release, you can configure an {product-title} cluster on any on-premise infrastructure, such as bare-metal, {vmw-first}, {rh-openstack-first}, or Nutanix, to use a user-managed load balancer in place of the default load balancer. For this configuration, you must specify `loadBalancer.type: UserManaged` in your cluster’s `install-config.yaml` file.
+With this release, you can configure an {product-title} cluster on any on-premise infrastructure, such as bare metal, {vmw-first}, {rh-openstack-first}, or Nutanix, to use a user-managed load balancer in place of the default load balancer. For this configuration, you must specify `loadBalancer.type: UserManaged` in your cluster’s `install-config.yaml` file.
 
 For more information about this feature on bare-metal infrastructure, see xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#nw-osp-services-external-load-balancer_ipi-install-installation-workflow[Services for a user-managed load balancer] in _Setting up the environment for an OpenShift installation_.
 
 [id="ocp-4-16-detect-warning-for-iptables_{context}"]
 ==== Detect and warning for iptables
 With this release, if you have pods in your cluster using `iptables` rules the following event message is given to warn against future deprecation:
-`This pod appears to have created one or more iptables rules. IPTables is deprecated and will no longer be available in RHEL 10 and later. You should consider migrating to another API such as nftables or eBPF.`
+
+[source,terminal]
+----
+This pod appears to have created one or more iptables rules. IPTables is deprecated and will no longer be available in RHEL 10 and later. You should consider migrating to another API such as nftables or eBPF.
+----
 
 For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_firewalls_and_packet_filters/getting-started-with-nftables_firewall-packet-filters#doc-wrapper[Getting started with nftables]. If you are running third-party software, check with your vendor to ensure they will have an `nftables` based version available soon.
 
@@ -826,9 +824,7 @@ For more information, see xref:../networking/ovn_kubernetes_network_provider/con
 [id="ocp-4-16-networking-metallb-frr-k8s_{context}"]
 ==== Integration of MetalLB and FRR-K8s (Technology Preview)
 
-This release introduces `FRR-K8s`, a Kubernetes based `DaemonSet` that exposes a subset of the `FRR` API in a Kubernetes-compliant manner.
-As a cluster administrator, you can use the `FRRConfiguration` custom resource (CR) to configure the MetalLB Operator to use the `FRR-K8s` daemon set as the backend.
-You can use this to operate FRR services, such as receiving routes.
+This release introduces `FRR-K8s`, a Kubernetes based `DaemonSet` that exposes a subset of the `FRR` API in a Kubernetes-compliant manner. As a cluster administrator, you can use the `FRRConfiguration` custom resource (CR) to configure the MetalLB Operator to use the `FRR-K8s` daemon set as the backend. You can use this to operate FRR services, such as receiving routes.
 
 For more information, see xref:../networking/metallb/metallb-frr-k8s.adoc#metallb-configure-frr-k8s[Configuring the integration of MetalLB and FRR-K8s].
 
@@ -843,7 +839,7 @@ For more information, see xref:../networking/ovn_kubernetes_network_provider/con
 
 Previously, when migrating from OpenShift SDN to OVN-Kubernetes, the only available option was an _offline_ migration method. This process included some downtime, during which clusters were unreachable.
 
-This release introduces a _live_ migration method. The live migration method is the process in which the OpenShift SDN network plugin and its network configurations, connections, and associated resources are migrated to the OVN-Kubernetes network plugin without service interruption. It is available for {product-title}, {product-dedicated}, {product-rosa}, and Azure Red Hat OpenShift deployment types. It is not available for HyperShift deployment types. This migration method is valuable for deployment types that require constant service availability and offers the following benefits:
+This release introduces a _live_ migration method. The live migration method is the process in which the OpenShift SDN network plugin and its network configurations, connections, and associated resources are migrated to the OVN-Kubernetes network plugin without service interruption. It is available for {product-title}, {product-dedicated}, {product-rosa}, and {azure-first} Red{nbsp}Hat OpenShift deployment types. It is not available for HyperShift deployment types. This migration method is valuable for deployment types that require constant service availability and offers the following benefits:
 
 * Continuous service availability
 
@@ -873,6 +869,7 @@ For more information about these configuration fields, see xref:../networking/cl
 
 The Telemetry and the Insights Operator collects telemetry on IPsec connections. For more information, see xref:../support/remote_health_monitoring/showing-data-collected-by-remote-health-monitoring.adoc#showing-data-collected-from-the-cluster_showing-data-collected-by-remote-health-monitoring[Showing data collected by Telemetry].
 
+////
 [id="ocp-4-16-registry_{context}"]
 [id="overlapping-ip-configuration-multi-tenant-networks-whereabouts"]
 ==== Overlapping IP configuration for multi-tenant networks with Whereabouts
@@ -887,37 +884,38 @@ For more information about this feature, see xref:../networking/multiple_network
 
 [id="ocp-4-16-registry"]
 === Registry
+////
 
 [id="ocp-4-16-storage_{context}"]
 === Storage
 
 [id="ocp-4-16-storage-secrets-store-csi-driver-vault_{context}"]
 ==== HashiCorp Vault is now available for the {secrets-store-operator} (Technology Preview)
-You can now use the {secrets-store-operator} to mount secrets from HashiCorp Vault to a CSI volume in {product-title}. The {secrets-store-operator} is available as a Technology Preview feature.
+You can now use the {secrets-store-operator} to mount secrets from HashiCorp Vault to a Container Storage Interface (CSI) volume in {product-title}. The {secrets-store-operator} is available as a Technology Preview feature.
 
 For the full list of available secrets store providers, see xref:../nodes/pods/nodes-pods-secrets-store.adoc#secrets-store-providers_nodes-pods-secrets-store[Secrets store providers].
 
 For information about using the {secrets-store-operator} to mount secrets from HashiCorp Vault, see xref:../nodes/pods/nodes-pods-secrets-store.adoc#secrets-store-vault_nodes-pods-secrets-store[Mounting secrets from HashiCorp Vault].
 
 [id="ocp-4-16-storage-clone-azure-file"]
-==== Volume cloning supported for Azure File (Technology Preview)
-{product-title} 4.16 introduces volume cloning for the Microsoft Azure File Container Storage Interface (CSI) Driver Operator as a Technology Preview feature. Volume cloning duplicates an existing persistent volume (PV) to help protect against data loss in {product-title}. You can also use a volume clone just as you would use any standard volume.
+==== Volume cloning supported for {azure-first} File (Technology Preview)
+{product-title} {product-version} introduces volume cloning for the {azure-first} File Container Storage Interface (CSI) Driver Operator as a Technology Preview feature. Volume cloning duplicates an existing persistent volume (PV) to help protect against data loss in {product-title}. You can also use a volume clone just as you would use any standard volume.
 
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-azure-file.adoc#persistent-storage-csi-azure-file[Azure File CSI Driver Operator] and xref:..//storage/container_storage_interface/persistent-storage-csi-cloning.adoc#persistent-storage-csi-cloning[CSI volume cloning].
 
 [id="ocp-4-16-storage-node-expansion-secret"]
 ==== Node Expansion Secret is generally available
-The Node Expansion Secret feature allows your cluster to expand storage of mounted volumes, even when access to those volumes requires a secret (for example, a credential for accessing a Storage Area Network (SAN) fabric) to perform the node expand operation. {product-title} 4.16 supports this feature as generally available.
+The Node Expansion Secret feature allows your cluster to expand storage of mounted volumes, even when access to those volumes requires a secret (for example, a credential for accessing a Storage Area Network (SAN) fabric) to perform the node expand operation. {product-title} {product-version} supports this feature as generally available.
 
 [id="ocp-4-16-vsphere-max-snapshot"]
 ==== Changing vSphere CSI maximum number of snapshots is generally available
-The default maximum number of snapshots in VMware vSphere Container Storage Interface (CSI) is 3 per volume. In {product-title} 4.16, you can now change this maximum number of snapshots to a maximum of 32 per volume. You also have granular control of the maximum number of snapshots for vSAN and Virtual Volume datastores. {product-title} 4.16 supports this feature as generally available.
+The default maximum number of snapshots in {vmw-first} Container Storage Interface (CSI) is 3 per volume. In {product-title} {product-version}, you can now change this maximum number of snapshots to a maximum of 32 per volume. You also have granular control of the maximum number of snapshots for vSAN and Virtual Volume datastores. {product-title} {product-version} supports this feature as generally available.
 
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-change-max-snapshot_persistent-storage-csi-vsphere[Changing the maximum number of snapshots for vSphere].
 
 [id="ocp-4-16-pv-last-phase-transition-time"]
 ==== Persistent volume last phase transition time parameter (Technology Preview)
-In {product-title} 4.16 introduces a new parameter, `LastPhaseTransitionTime`, which has a timestamp that is updated every time a persistent volume (PV) transitions to a different phase (`pv.Status.Phase`). This feature is being released with Technology Preview status.
+In {product-title} {product-version} introduces a new parameter, `LastPhaseTransitionTime`, which has a timestamp that is updated every time a persistent volume (PV) transitions to a different phase (`pv.Status.Phase`). This feature is being released with Technology Preview status.
 
 [id="ocp-4-16-storage-csi-smb-cifs-driver-operator"]
 ==== Persistent storage using CIFS/SMB CSI Driver Operator (Technology Preview)
@@ -929,18 +927,20 @@ For more information, see xref:../storage/container_storage_interface/persistent
 ==== RWOP with SELinux context mount is generally available
 {product-title} 4.14 introduced a new access mode with Technical Preview status for persistent volumes (PVs) and persistent volume claims (PVCs) called ReadWriteOncePod (RWOP). RWOP can be used only in a single pod on a single node compared to the existing ReadWriteOnce access mode where a PV or PVC can be used on a single node by many pods. If the driver enables it, RWOP uses the SELinux context mount set in the `PodSpec` or container, which allows the driver to mount the volume directly with the correct SELinux labels. This eliminates the need to recursively relabel the volume, and pod startup can be significantly faster.
 
-In {product-title} 4.16, this feature is generally available.
+In {product-title} {product-version}, this feature is generally available.
 
 For more information, see xref:../storage/understanding-persistent-storage.adoc#pv-access-modes_understanding-persistent-storage[Access modes].
 
 [id="ocp-4-16-storage-csi-vsphere-compliance-check"]
 ==== vSphere CSI Driver 3.1 updated CSI topology requirements
-To support VMware vSphere Container Storage Interface (CSI) volume provisioning and usage in multi-zonal clusters, the deployment should match certain requirements imposed by CSI driver. These requirements have changed starting with 3.1.0, and although {product-title} 4.16 accepts both the old and new tagging methods, you should use the new tagging method since VMware considers the old way an invalid configuration; thus to prevent problems, you should not use the old tagging method.
+To support {vmw-first} Container Storage Interface (CSI) volume provisioning and usage in multi-zonal clusters, the deployment should match certain requirements imposed by CSI driver. These requirements have changed starting with 3.1.0, and although {product-title} {product-version} accepts both the old and new tagging methods, you should use the new tagging method since {vmw-first} considers the old way an invalid configuration. To prevent problems, you should not use the old tagging method.
 
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-csi-topology-requirements[vSphere CSI topology requirements].
 
-//[id="ocp-4-16-oci"]
-//what is this heading?
+////
+[id="ocp-4-16-oci"]
+=== {oci-first}
+////
 
 [id="ocp-4-16-storage-thick-provisioning_{context}"]
 ==== Support for configuring thick-provisioned storage
@@ -980,7 +980,7 @@ For more information about adding devices to a volume group, see xref:../storage
 [id="ocp-4-16-olmv1-ce-rename_{context}"]
 ==== Operator API renamed to ClusterExtension (Technology Preview)
 
-Earlier Technology Preview phases of {olmv1-first} introduced a new `Operator` API, provided as `operator.operators.operatorframework.io` by the Operator Controller component. In {product-title} 4.16, this API is renamed `ClusterExtension`, provided as `clusterextension.olm.operatorframework.io`, for this Technology Preview phase of {olmv1}.
+Earlier Technology Preview phases of {olmv1-first} introduced a new `Operator` API, provided as `operator.operators.operatorframework.io` by the Operator Controller component. In {product-title} {product-version}, this API is renamed `ClusterExtension`, provided as `clusterextension.olm.operatorframework.io`, for this Technology Preview phase of {olmv1}.
 
 This API still streamlines management of installed extensions, which includes Operators via the `registry+v1` bundle format, by consolidating user-facing APIs into a single object. The rename to `ClusterExtension` addresses the following:
 
@@ -1003,13 +1003,13 @@ With this release, {olmv1} displays the following status condition messages for 
 [id="ocp-4-16-olmv1-legacy-olm-upgrade-edges_{context}"]
 ==== Support for {olmv0} upgrade edges in {olmv1} (Technology Preview)
 
-When determining upgrade edges for an installed cluster extension, {olmv1-first} supports {olmv0} semantics starting in {product-title} 4.16. This support follows the behavior from {olmv0}, including `replaces`, `skips`, and `skipRange` directives, with a few noted differences.
+When determining upgrade edges for an installed cluster extension, {olmv1-first} supports {olmv0} semantics starting in {product-title} {product-version}. This support follows the behavior from {olmv0}, including `replaces`, `skips`, and `skipRange` directives, with a few noted differences.
 
 By supporting {olmv0} semantics, {olmv1} now honors the upgrade graph from catalogs accurately.
 
 [NOTE]
 ====
-Support for semantic versioning (semver) upgrade constraints was introduced in {product-title} 4.15 but disabled in 4.16 in favor of {olmv0} semantics during this Technology Preview phase.
+Support for semantic versioning (semver) upgrade constraints was introduced in {product-title} 4.15 but disabled in {product-version} in favor of {olmv0} semantics during this Technology Preview phase.
 ====
 
 For more information, see xref:../operators/olm_v1/olmv1-installing-an-operator-from-a-catalog.adoc#upgrade-constraint-semantics_olmv1-installing-operator[Upgrade constraint semantics].
@@ -1051,7 +1051,7 @@ By default, when you make certain changes to the parameters in a `MachineConfig`
 [id="ocp-4-16-machine-config-operator-on-cluster_{context}"]
 ==== On-cluster {op-system} image layering (Technology Preview)
 
-With {op-system-first} image layering, you can now automatically build the custom layered image directly in your cluster, as a Technology Preview feature. Previously, you needed to build the custom layered image outside of the cluster, then pull the image into the cluster. The image layering feature allows you to extend the functionality of your base {op-system} image by layering additional images onto the base image. For more information, see xref:../post_installation_configuration/coreos-layering.adoc#coreos-layering[RHCOS image layering].
+With {op-system-first} image layering, you can now automatically build the custom layered image directly in your cluster, as a Technology Preview feature. Previously, you needed to build the custom layered image outside of the cluster, then pull the image into the cluster. You can use the image layering feature to extend the functionality of your base {op-system} image by layering additional images onto the base image. For more information, see xref:../post_installation_configuration/coreos-layering.adoc#coreos-layering[RHCOS image layering].
 
 [id="ocp-4-16-machine-config-operator-boot-image_{context}"]
 ==== Updating boot images (Technology Preview)
@@ -1071,9 +1071,7 @@ For more information, see xref:../machine_management/applying-autoscaling.adoc#c
 [id="ocp-4-16-capi-tp-vmw_{context}"]
 ==== Managing machines with the Cluster API for {vmw-full} (Technology Preview)
 
-This release introduces the ability to manage machines by using the upstream Cluster API, integrated into {product-title}, as a Technology Preview for {vmw-full} clusters.
-This capability is in addition or an alternative to managing machines with the Machine API.
-For more information, see xref:../machine_management/cluster_api_machine_management/cluster-api-about.adoc#cluster-api-about[About the Cluster API].
+This release introduces the ability to manage machines by using the upstream Cluster API, integrated into {product-title}, as a Technology Preview for {vmw-full} clusters. This capability is in addition or an alternative to managing machines with the Machine API. For more information, see xref:../machine_management/cluster_api_machine_management/cluster-api-about.adoc#cluster-api-about[About the Cluster API].
 
 [id="ocp-4-16-cpms-fd-vmw_{context}"]
 ==== Defining a {vmw-short} failure domain for a control plane machine set
@@ -1148,7 +1146,7 @@ Red{nbsp}Hat does not guarantee backward compatibility for recording rules or al
 [id="ocp-4-16-monitoring-metrics-server-to-access-metrics-api-ga"]
 ==== Metrics Server component to access the Metrics API general availability (GA)
 
-Metrics Server component is now generally available and automatically installed instead of the deprecated Prometheus Adapter. Metrics Server collects resource metrics and exposes them in the `metrics.k8s.io` Metrics API service for use by other tools and APIs, which frees the core platform Prometheus stack from handling this functionality. For more information, see xref:../observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc#metricsserverconfig[MetricsServerConfig] in the config map API reference for the Cluster Monitoring Operator.
+The Metrics Server component is now generally available and automatically installed instead of the deprecated Prometheus Adapter. Metrics Server collects resource metrics and exposes them in the `metrics.k8s.io` Metrics API service for use by other tools and APIs, which frees the core platform Prometheus stack from handling this functionality. For more information, see xref:../observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc#metricsserverconfig[MetricsServerConfig] in the config map API reference for the Cluster Monitoring Operator.
 
 [id="ocp-4-16-monitoring-new-role-to-allow-read-only-access-to-alertmanager-api"]
 ==== New monitoring role to allow read-only access to the Alertmanager API
@@ -1158,7 +1156,7 @@ This release introduces a new `monitoring-alertmanager-view` role to allow read-
 [id="ocp-4-16-monitoring-vpa-metrics-available-in-kube-state-metrics-agent"]
 ==== VPA metrics are available in the kube-state-metrics agent
 
-Vertical Pod Autoscaler (VPA) metrics are now available through the `kube-state-metrics` agent. VPA metrics follow a similar exposition format like they did before being deprecated and removed from native support upstream.
+Vertical Pod Autoscaler (VPA) metrics are now available through the `kube-state-metrics` agent. VPA metrics follow a similar exposition format just as they did before being deprecated and removed from native support upstream.
 
 [id="ocp-4-16-monitoring-change-in-proxy-service-for-monitoring-components"]
 ==== Change in proxy service for monitoring components
@@ -1189,11 +1187,11 @@ For more information, see xref:../scalability_and_performance/enabling-workload-
 [id="ocp-4-16-nodes-cgroupv2-default_{context}"]
 ==== Linux Control Groups version 2 is now supported with the performance profile feature
 
-Beginning with {product-title} 4.16, Control Groups version 2 (cgroup v2), also known as cgroup2 or cgroupsv2, is enabled by default for all new deployments, even when performance profiles are present.
+Beginning with {product-title} {product-version}, Control Groups version 2 (cgroup v2), also known as cgroup2 or cgroupsv2, is enabled by default for all new deployments, even when performance profiles are present.
 
 Since {product-title} 4.14, cgroups v2 has been the default, but the performance profile feature required the use of cgroups v1. This issue has been resolved.
 
-cgroup v1 is still used in upgraded clusters with performance profiles that have initial installation dates before {product-title} 4.16. cgroup v1 can still be used in the current version by changing the `cgroupMode` field in the `node.config` object to `v1`.
+cgroup v1 is still used in upgraded clusters with performance profiles that have initial installation dates before {product-title} {product-version}. cgroup v1 can still be used in the current version by changing the `cgroupMode` field in the `node.config` object to `v1`.
 
 For more information, see xref:../nodes/clusters/nodes-cluster-cgroups-2.adoc#nodes-clusters-cgroups-2[Configuring the Linux cgroup version on your nodes].
 
@@ -1205,18 +1203,15 @@ With this release, you can increase the disk quota in etcd. This is a Technology
 [id="ocp-4-16-reserved-core-freq-tuning_{context}"]
 ====  Reserved core frequency tuning
 
-With this release, the Node Tuning Operator supports setting CPU frequencies in the `PerformanceProfile` for reserved and isolated core CPUs.
-This is an optional feature that you can use to define specific frequencies.
+With this release, the Node Tuning Operator supports setting CPU frequencies in the `PerformanceProfile` for reserved and isolated core CPUs. This is an optional feature that you can use to define specific frequencies.
 The Node Tuning Operator then sets those frequencies by enabling the `intel_pstate` CPUFreq driver in the Intel hardware.
 You must follow Intel's recommendations on frequencies for FlexRAN-like applications, which require the default CPU frequency to be set to a lower value than the default running frequency.
 
 [id="ocp-4-16-node-tuning-operator-intel_{context}"]
 ====  Node Tuning Operator intel_pstate driver default setting
 
-Previously, for the RAN DU-profile, setting the `realTime` workload hint to `true` in the `PerformanceProfile` always disabled the `intel_pstate`.
-With this release, the Node Tuning Operator detects the underlying Intel hardware using `TuneD` and appropriately sets the `intel_pstate` kernel parameter based on the processor’s generation.
-This decouples the `intel_pstate` from the `realTime` and `highPowerConsumption` workload hints.
-The `intel_pstate` now depends only on the underlying processor generation.
+Previously, for the RAN DU-profile, setting the `realTime` workload hint to `true` in the `PerformanceProfile` always disabled the `intel_pstate`. With this release, the Node Tuning Operator detects the underlying Intel hardware using `TuneD` and appropriately sets the `intel_pstate` kernel parameter based on the processor’s generation.
+This decouples the `intel_pstate` from the `realTime` and `highPowerConsumption` workload hints. The `intel_pstate` now depends only on the underlying processor generation.
 
 For pre-IceLake processors, the `intel_pstate` is deactivated by default, whereas for IceLake and later generation processors, the `intel_pstate` is set to `active`.
 
@@ -1247,8 +1242,7 @@ For more information, see xref:../edge_computing/cnf-talm-for-cluster-upgrades.a
 [id="ocp-4-16-edge-computing-accelerated-ztp_{context}"]
 ==== Accelerated provisioning of {ztp} (Technology Preview)
 
-With this release, you can reduce the time taken for cluster installation by using accelerated provisioning of {ztp} for {sno}.
-Accelerated ZTP speeds up installation by applying Day 2 manifests derived from policies at an earlier stage.
+With this release, you can reduce the time taken for cluster installation by using accelerated provisioning of {ztp} for {sno}. Accelerated ZTP speeds up installation by applying Day 2 manifests derived from policies at an earlier stage.
 
 The benefits of accelerated provisioning of {ztp} increase with the scale of your deployment.
 Full acceleration gives more benefit on a larger number of clusters.
@@ -1260,7 +1254,7 @@ For more information, see xref:../edge_computing/ztp-deploying-far-edge-sites.ad
 ==== Image-based upgrade for {sno} clusters using {lcao}
 
 With this release, you can use the {lcao} to orchestrate an image-based upgrade for {sno} clusters from {product-title} <4.y> to <4.y+2>, and <4.y.z> to <4.y.z+n>.
-The {lcao} generates an OCI image that matches the configuration of participating clusters.
+The {lcao} generates an Open Container Initiative (OCI) image that matches the configuration of participating clusters.
 In addition to the OCI image, the image-based upgrade uses the `ostree` library and the OADP Operator to reduce upgrade and service outage duration when transitioning between the original and target platform versions.
 
 For more information, see xref:../edge_computing/image_based_upgrade/cnf-understanding-image-based-upgrade.adoc#understanding-image-based-upgrade-for-sno[Understanding the image-based upgrade for {sno} clusters].
@@ -1283,7 +1277,7 @@ For more information, see xref:../edge_computing/ztp-deploying-far-edge-sites.ad
 [id="ocp-4-16-etcd-certificates_{context}"]
 === Security
 
-A new signer certificate authority (CA), `openshift-etcd`, is now available to sign certificates. It is contained in a trust bundle with the existing CA. Two CA secrets,`etcd-signer` and `etcd-metric-signer`, are also available for rotation. Starting with this release, all certificates will move to a proven library. This change allows for the automatic rotation of all certificates that were not managed by `cluster-etcd-operator`. All node-based certificates will continue with the current update process.
+A new signer certificate authority (CA), `openshift-etcd`, is now available to sign certificates. This CA is contained in a trust bundle with the existing CA. Two CA secrets,`etcd-signer` and `etcd-metric-signer`, are also available for rotation. Starting with this release, all certificates will move to a proven library. This change allows for the automatic rotation of all certificates that were not managed by `cluster-etcd-operator`. All node-based certificates will continue with the current update process.
 
 [id="ocp-4-16-notable-technical-changes_{context}"]
 == Notable technical changes
@@ -1307,7 +1301,7 @@ A new signer certificate authority (CA), `openshift-etcd`, is now available to s
 [id="ocp-4-16-sha-haproxy-support-removed_{context}"]
 === SHA-1 certificates no longer supported for use with HAProxy
 
-SHA-1 certificates are no longer supported for use with HAProxy. Both existing and new routes using SHA-1 certificates in {product-title} 4.16 are rejected and no longer function. For more information about creating secure routes, see xref:../networking/routes/secured-routes.html[Secured Routes].
+SHA-1 certificates are no longer supported for use with HAProxy. Both existing and new routes that use SHA-1 certificates in {product-title} {product-version} are rejected and no longer function. For more information about creating secure routes, see xref:../networking/routes/secured-routes.html[Secured Routes].
 
 [discrete]
 [id="ocp-4-16-etcd-tuning-profiles_{context}"]
@@ -1334,7 +1328,7 @@ Always verify compliance with your organization's security standards when modify
 
 [discrete]
 [id="ocp-4-16-remove-dasd-artifact_{context}"]
-=== {op-system} `dasd` image artifacts no longer supported on {ibm-z-name} and {ibm-linuxone-name} (`s390x`)
+=== {op-system} dasd image artifacts no longer supported on {ibm-z-name} and {ibm-linuxone-name} (s390x)
 
 With this release, `dasd` image artifacts for the `s390x` architecture are removed from the {product-title} image building pipeline. You can still use the `metal4k` image artifact, which is identical and contains the same functionality.
 
@@ -1350,26 +1344,25 @@ With {product-title} {product-version}, OVN-Kubernetes now supports the use of `
 [id="ocp-4-16-legacy-sa-tokens_{context}"]
 === Legacy service account API token secrets are no longer generated for each service account
 
-Prior to {product-title} 4.16, when the integrated {product-registry} was enabled, a legacy service account API token secret was generated for every service account in the cluster. Starting with {product-title} 4.16, when the integrated {product-registry} is enabled, the legacy service account API token secret is no longer generated for each service account.
+Before {product-title} {product-version}, when the integrated {product-registry} was enabled, a legacy service account API token secret was generated for every service account in the cluster. Starting with {product-title} {product-version}, when the integrated {product-registry} is enabled, the legacy service account API token secret is no longer generated for each service account.
 
 Additionally, when the integrated {product-registry} is enabled, the image pull secret generated for every service account no longer uses a legacy service account API token. Instead, the image pull secret now uses a bound service account token that is automatically refreshed before it expires.
 
 For more information, see xref:../nodes/pods/nodes-pods-secrets.adoc#auto-generated-sa-token-secrets_nodes-pods-secrets[Automatically generated image pull secrets].
 
-For information about detecting legacy service account API token secrets that are in use in your cluster or deleting them if they are not needed, see the Red Hat Knowledgebase article link:https://access.redhat.com/articles/7058801[Long-lived service account API tokens in OpenShift Container Platform].
+For information about detecting legacy service account API token secrets that are in use in your cluster or deleting them if they are not needed, see the Red{nbsp}Hat Knowledgebase article link:https://access.redhat.com/articles/7058801[Long-lived service account API tokens in OpenShift Container Platform].
 
 [discrete]
 [id="ocp-4-16-support-ext-cloud-auth_{context}"]
 === Support for external cloud authentication providers
 
-In this release, the functionality to authenticate to private registries on {aws-first}, {gcp-first}, and {azure-first} clusters is moved from the in-tree provider to binaries that ship with {product-title}.
-This change supports the default external cloud authentication provider behavior that is introduced in Kubernetes 1.29.
+In this release, the functionality to authenticate to private registries on {aws-first}, {gcp-first}, and {azure-first} clusters is moved from the in-tree provider to binaries that ship with {product-title}. This change supports the default external cloud authentication provider behavior that is introduced in Kubernetes 1.29.
 
 [discrete]
 [id="ocp-4-16-olmv1-default-upgrade-constraints_{context}"]
 === Default {olmv1} upgrade constraints changed to {olmv0} semantics (Technology Preview)
 
-In {product-title} 4.16, {olmv1-first} changes its default upgrade constraints from semantic versioning (semver) to {olmv0} semantics.
+In {product-title} {product-version}, {olmv1-first} changes its default upgrade constraints from semantic versioning (semver) to {olmv0} semantics.
 
 For more information, see xref:../release_notes/ocp-4-16-release-notes.adoc#ocp-4-16-olmv1-legacy-olm-upgrade-edges_release-notes[Support for {olmv0} upgrade edges in {olmv1} (Technology Preview)].
 
@@ -1522,22 +1515,22 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |Deprecated
 
-|`platform.aws.preserveBootstrapIgnition` parameter for Amazon Web Services (AWS)
+|`platform.aws.preserveBootstrapIgnition` parameter for {aws-first}
 |General Availability
 |General Availability
 |Deprecated
 
-|Terraform infrastructure provider for AWS, vSphere and Nutanix
+|Terraform infrastructure provider for {aws-first}, {vmw-first} and Nutanix
 |General Availability
 |General Availability
 |Removed
 
-|Terraform infrastructure provider for GCP
+|Terraform infrastructure provider for {gcp-first}
 |General Availability
 |General Availability
 |Removable as Technology Preview
 
-|Installing a cluster on Alibaba Cloud with installer-provisioned infrastructure
+|Installing a cluster on {alibaba} with installer-provisioned infrastructure
 |Technology Preview
 |Technology Preview
 |Removed
@@ -1586,6 +1579,7 @@ In the following tables, features are marked with the following statuses:
 //|====
 //|Feature |4.14 |4.15 |4.16
 //|====
+
 [discrete]
 [id="ocp-4-16-networking-dep-rem_{context}"]
 === Networking deprecated and removed features
@@ -1709,12 +1703,12 @@ In the following tables, features are marked with the following statuses:
 [id="ocp-4-14-nodes-cgroupv1-deprecated_{context}"]
 ==== Linux Control Groups version 1 is now deprecated
 
-In {op-system-base-full} 9, the default mode is cgroup v2. When {op-system-base-full} 10 is released, systemd will not support booting in the cgroup v1 mode and only cgroup v2 mode will be available. As such, cgroup v1 is deprecated in {product-title} 4.16 and later. cgroup v1 will be removed in a future {product-title} release.
+In {op-system-base-full} 9, the default mode is cgroup v2. When {op-system-base-full} 10 is released, systemd will not support booting in the cgroup v1 mode and only cgroup v2 mode will be available. As such, cgroup v1 is deprecated in {product-title} {product-version} and later. cgroup v1 will be removed in a future {product-title} release.
 
 [id="ocp-4-16-deprecation-samples-operator_{context}"]
 ==== Cluster Samples Operator
 
-The Cluster Samples Operator is deprecated with the {product-title} 4.16 release. The Cluster Samples Operator will stop managing and providing support to the non-S2I samples (image streams and templates). No new templates, samples or non-Source-to-Image (Non-S2I) image streams will be added to the Cluster Samples Operator. However, the existing S2I builder image streams and templates will continue to receive updates until the Cluster Samples Operator is removed in a future release.
+The Cluster Samples Operator is deprecated with the {product-title} {product-version} release. The Cluster Samples Operator will stop managing and providing support to the non-S2I samples (image streams and templates). No new templates, samples or non-Source-to-Image (Non-S2I) image streams will be added to the Cluster Samples Operator. However, the existing S2I builder image streams and templates will continue to receive updates until the Cluster Samples Operator is removed in a future release.
 
 [id="ocp-4-16-rhel-worker-nodes-deprecation_{context}"]
 ==== Package-based {op-system-base} compute machines
@@ -1740,7 +1734,7 @@ The following related base images for Operator projects are _not_ deprecated. Th
 For information about the unsupported, community-maintained, version of the Operator SDK, see link:https://sdk.operatorframework.io[Operator SDK (Operator Framework)].
 
 [id="ocp-4-16-deprecation-preserveBootstrapIgnition_{context}"]
-==== The `preserveBootstrapIgnition` parameter on {aws-first} is deprecated
+==== The preserveBootstrapIgnition parameter on {aws-first} is deprecated
 
 The `preserveBootstrapIgnition` parameter for {aws-full} in `the install-config.yaml` file has been deprecated. You can use the `bestEffortDeleteIgnition` parameter instead.
 
@@ -1750,14 +1744,14 @@ The `preserveBootstrapIgnition` parameter for {aws-full} in `the install-config.
 [id="ocp-4-16-nodes-diskpartition-deprecated_{context}"]
 ==== Deprecated disk partition configuration method
 
-The `nodes.diskPartition` section in the `SiteConfig` custom resource (CR) is deprecated with the {product-title} 4.16 release. It has been replaced with the `ignitionConfigOverride` method, which provides a more flexible way of creating a disk partition for any use case.
+The `nodes.diskPartition` section in the `SiteConfig` custom resource (CR) is deprecated with the {product-title} {product-version} release. This configuration has been replaced with the `ignitionConfigOverride` method, which provides a more flexible way of creating a disk partition for any use case.
 
 For more information, see xref:../edge_computing/policygenerator_for_ztp/ztp-advanced-policygenerator-config.adoc#ztp-configuring-disk-partitioning_ztp-advanced-policygenerator-config[Configuring disk partitioning with SiteConfig].
 
 [id="ocp-4-16-removed-features-platform-operators_{context}"]
 ==== Removal of platform Operators and plain bundles (Technology Preview)
 
-{product-title} {product-version} removes platform Operators (Technology Preview) and plain bundles (Technology Preview), which were protoypes for {olmv1-first} (Technology Preview).
+{product-title} {product-version} removes platform Operators (Technology Preview) and plain bundles (Technology Preview), which were prototypes for {olmv1-first} (Technology Preview).
 
 //.APIs removed from Kubernetes 1.29
 //[cols="2,2,2",options="header",]
@@ -1796,7 +1790,7 @@ With this release, the documentation for the Service Binding Operator (SBO) has 
 
 [id="ocp-4-16-alicloud-csi-driver-removed_{context}"]
 ==== AliCloud CSI Driver Operator is no longer supported
-{product-title} 4.16 no longer supports AliCloud Container Storage Interface (CSI) Driver Operator.
+{product-title} {product-version} no longer supports AliCloud Container Storage Interface (CSI) Driver Operator.
 
 [id="ocp-4-16-removed-kube-1-29-apis_{context}"]
 ==== Beta APIs removed from Kubernetes 1.29
@@ -1817,7 +1811,6 @@ Kubernetes 1.29 removed the following deprecated APIs, so you must migrate manif
 |`flowcontrol.apiserver.k8s.io/v1beta2`
 |`flowcontrol.apiserver.k8s.io/v1` or `flowcontrol.apiserver.k8s.io/v1beta3`
 |link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#flowcontrol-resources-v129[Yes]
-
 |===
 
 //[id="ocp-4-16-future-deprecation"]
@@ -1858,7 +1851,7 @@ Kubernetes 1.29 removed the following deprecated APIs, so you must migrate manif
 
 * Previously, the `hostmount-anyuid` security context constraints (SCC) did not have a built-in cluster role because the name of the SCC was incorrectly named `hostmount` in the cluster role. With this release, the SCC name in the cluster role was updated properly to `hostmount-anyuid`, so the `hostmount-anyuid` SCC now has a functioning cluster role. (link:https://issues.redhat.com/browse/OCPBUGS-33184[*OCPBUGS-33184*])
 
-* Previously, clusters that were created before {product-title} 4.7 had several secrets of type `SecretTypeTLS`. Upon upgrading to {product-title} 4.16, these secrets are deleted and re-created with the type `kubernetes.io/tls`. This removal could cause a race condition and the contents of the secrets could be lost. With this release, the secret type change now happens automatically and clusters created before {product-title} 4.7 can upgrade to 4.16 without risking losing the contents of these secrets. (link:https://issues.redhat.com/browse/OCPBUGS-31384[*OCPBUGS-31384*])
+* Previously, clusters that were created before {product-title} 4.7 had several secrets of type `SecretTypeTLS`. Upon upgrading to {product-title} {product-version}, these secrets are deleted and re-created with the type `kubernetes.io/tls`. This removal could cause a race condition and the contents of the secrets could be lost. With this release, the secret type change now happens automatically and clusters created before {product-title} 4.7 can upgrade to {product-version} without risking losing the contents of these secrets. (link:https://issues.redhat.com/browse/OCPBUGS-31384[*OCPBUGS-31384*])
 
 * Previously, some Kubernetes API server events did not have the correct timestamps. With this release, Kubernetes API server events now have the correct timestamps. (link:https://issues.redhat.com/browse/OCPBUGS-27074[*OCPBUGS-27074*])
 
@@ -1884,7 +1877,7 @@ Kubernetes 1.29 removed the following deprecated APIs, so you must migrate manif
 [id="ocp-4-16-builds-bug-fixes_{context}"]
 ==== Builds
 
-* Previously, clusters that updated from earlier versions to 4.16 continued to allow builds to be triggered by unauthenticated webhooks. With this release, new clusters require build webhooks to be authenticated. Builds are not triggered by unauthenticated webhooks unless a cluster administrator allows unauthenticated webhooks in the namespace or cluster. (link:https://issues.redhat.com/browse/OCPBUGS-33378[*OCPBUGS-33378*])
+* Previously, clusters that updated from earlier versions to {product-version} continued to allow builds to be triggered by unauthenticated webhooks. With this release, new clusters require build webhooks to be authenticated. Builds are not triggered by unauthenticated webhooks unless a cluster administrator allows unauthenticated webhooks in the namespace or cluster. (link:https://issues.redhat.com/browse/OCPBUGS-33378[*OCPBUGS-33378*])
 
 * Previously, if the developer or cluster administrator used lowercase environment variable names for proxy information, these environment variables were carried into the build output container image. At runtime, the proxy settings were active and had to be unset. With this release, lowercase versions of the `++*++_PROXY` environment variables are prevented from leaking into built container images. Now, `buildDefaults` are only kept during the build and settings created for the build process only are removed before pushing the image in the registry. (link:https://issues.redhat.com/browse/OCPBUGS-34825[*OCPBUGS-34825*])
 
@@ -1892,8 +1885,7 @@ Kubernetes 1.29 removed the following deprecated APIs, so you must migrate manif
 [id="ocp-4-16-cloud-compute-bug-fixes_{context}"]
 ==== Cloud Compute
 
-* Previously, the Cloud Controller Manager Operator used predefined roles on {gcp-first} instead of granular permissions. With this release, the Cloud Controller Manager (CCM) Operator is updated to use granular permissions on {gcp-short} clusters.
-(link:https://issues.redhat.com/browse/OCPBUGS-26479[*OCPBUGS-26479*])
+* Previously, the Cloud Controller Manager (CCM) Operator used predefined roles on {gcp-first} instead of granular permissions. With this release, the CCM Operator is updated to use granular permissions on {gcp-short} clusters. (link:https://issues.redhat.com/browse/OCPBUGS-26479[*OCPBUGS-26479*])
 
 * Previously, the installation program populated the `network.devices`, `template` and `workspace` fields in the `spec.template.spec.providerSpec.value` section of the {vmw-full} control plane machine set custom resource (CR). These fields should be set in the {vmw-short} failure domain, and the installation program populating them caused unintended behaviors. Updating these fields did not trigger an update to the control plane machines, and these fields were cleared when the control plane machine set was deleted.
 +
@@ -1938,8 +1930,7 @@ With this release, the installation program is updated to no longer populate val
 
 * Previously, the logic that fetches the name of a node did not account for the possibility of multiple values for the returned hostname from the {aws-short} metadata service. When multiple domains are configured for a VPC  Dynamic Host Configuration Protocol (DHCP) option, this hostname might return multiple values. The space between multiple values caused the logic to crash. With this release, the logic is updated to use only the first returned hostname as the node name. (link:https://issues.redhat.com/browse/OCPBUGS-10498[*OCPBUGS-10498*])
 
-* Previously, the Machine API Operator requested unnecessary `virtualMachines/extensions` permissions on {azure-first} clusters.
-The unnecessary credentials request is removed in this release. (link:https://issues.redhat.com/browse/OCPBUGS-29956[*OCPBUGS-29956*])
+* Previously, the Machine API Operator requested unnecessary `virtualMachines/extensions` permissions on {azure-first} clusters. The unnecessary credentials request is removed in this release. (link:https://issues.redhat.com/browse/OCPBUGS-29956[*OCPBUGS-29956*])
 
 [discrete]
 [id="ocp-4-16-cloud-cred-operator-bug-fixes_{context}"]
@@ -1953,9 +1944,7 @@ The unnecessary credentials request is removed in this release. (link:https://is
 
 * Previously, creating an {aws-first} root secret on a bare metal cluster caused the Cloud Credential Operator (CCO) pod to crash. The issue is resolved in this release. (link:https://issues.redhat.com/browse/OCPBUGS-28535[*OCPBUGS-28535*])
 
-* Previously, removing the root credential from a {gcp-first} cluster that used the Cloud Credential Operator (CCO) in mint mode caused the CCO to become degraded after approximately one hour.
-In a degraded state, the CCO cannot manage the component credential secrets on a cluster.
-The issue is resolved in this release. (link:https://issues.redhat.com/browse/OCPBUGS-28787[*OCPBUGS-28787*])
+* Previously, removing the root credential from a {gcp-first} cluster that used the Cloud Credential Operator (CCO) in mint mode caused the CCO to become degraded after approximately one hour. In a degraded state, the CCO cannot manage the component credential secrets on a cluster. The issue is resolved in this release. (link:https://issues.redhat.com/browse/OCPBUGS-28787[*OCPBUGS-28787*])
 
 * Previously, the Cloud Credential Operator (CCO) checked for a nonexistent `s3:HeadBucket` permission during installation on {aws-first}. When the CCO failed to find this permission, it considered the provided credentials insufficient for mint mode. With this release, the CCO no longer checks for the nonexistent permission. (link:https://issues.redhat.com/browse/OCPBUGS-31678[*OCPBUGS-31678*])
 
@@ -1963,7 +1952,7 @@ The issue is resolved in this release. (link:https://issues.redhat.com/browse/OC
 [id="ocp-4-16-cluster-version-operator-bug-fixes_{context}"]
 ==== Cluster Version Operator
 
-* This release expands the `ClusterOperatorDown` and `ClusterOperatorDegraded` alerts to cover ClusterVersion conditions and send alerts for `Available=False` (`ClusterOperatorDown`) and `Failing=True` (`ClusterOperatorDegraded`). In previous releases, those alerts only covered ClusterOperator conditions. (link:https://issues.redhat.com/browse/OCPBUGS-9133[*OCPBUGS-9133*])
+* This release expands the `ClusterOperatorDown` and `ClusterOperatorDegraded` alerts to cover ClusterVersion conditions and send alerts for `Available=False` (`ClusterOperatorDown`) and `Failing=True` (`ClusterOperatorDegraded`). In previous releases, those alerts only covered `ClusterOperator` conditions. (link:https://issues.redhat.com/browse/OCPBUGS-9133[*OCPBUGS-9133*])
 
 * Previously, Cluster Version Operator (CVO) changes that were introduced in {product-title} 4.15.0, 4.14.0, 4.13.17, and 4.12.43 caused failing risk evaluations to block the CVO from fetching new update recommendations. When the risk evaluations failed, the bug caused the CVO to overlook the update recommendation service. With this release, the CVO continues to poll the update recommendation service, regardless of whether update risks are being successfully evaluated and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-25708[*OCPBUGS-25708*])
 
@@ -1975,7 +1964,7 @@ The issue is resolved in this release. (link:https://issues.redhat.com/browse/OC
 
 * Previously, after installing the Pipelines Operator, Pipeline templates took some time to become available in the cluster, but users were still able to create the deployment. With this update, the *Create* button on the *Import from Git* page is disabled if there is no pipeline template present for the resource selected. (link:https://issues.redhat.com/browse/OCPBUGS-34142[*OCPBUGS-34142*])
 
-* Previously, the maximum number of nodes was set to `100` on the *Topology* page. A persistant alert, "Loading is taking longer than expected." was provided. With this update, the limit of nodes is increased to `300`. (link:https://issues.redhat.com/browse/OCPBUGS-32307[*OCPBUGS-32307*])
+* Previously, the maximum number of nodes was set to `100` on the *Topology* page. A persistent alert, "Loading is taking longer than expected." was provided. With this update, the limit of nodes is increased to `300`. (link:https://issues.redhat.com/browse/OCPBUGS-32307[*OCPBUGS-32307*])
 
 * With this update, an alert message to notify you that Service Bindings are deprecated with {product-title} 4.15 was added to the *ServiceBinding list*, *ServiceBinding details*, *Add*, and *Topology* pages when creating a `ServiceBinding`, binding a component, or a `ServiceBinding` was found in the current namespace. (link:https://issues.redhat.com/browse/OCPBUGS-32222[*OCPBUGS-32222*])
 
@@ -2017,7 +2006,7 @@ The issue is resolved in this release. (link:https://issues.redhat.com/browse/OC
 [id="ocp-4-16-hosted-control-plane-bug-fixes_{context}"]
 ==== Hosted control planes
 
-* Previously, Multus  Container Network Interface (CNI) required certificate signing requests (CSRs) to be approved when you used the `Other` network type in hosted clusters. The proper role-based access control (RBAC) rules were set only when the network type was `Other` and was set to Calico. As a consequence, the CSRs were not approved when the network type was `Other` and set to Cilium. With this update, the correct RBAC rules are set for all valid network types, and RBACs are now properly configured when you use the `Other` network type. (link:https://issues.redhat.com/browse/OCPBUGS-26977[*OCPBUGS-26977*])
+* Previously, Multus Container Network Interface (CNI) required certificate signing requests (CSRs) to be approved when you used the `Other` network type in hosted clusters. The proper role-based access control (RBAC) rules were set only when the network type was `Other` and was set to Calico. As a consequence, the CSRs were not approved when the network type was `Other` and set to Cilium. With this update, the correct RBAC rules are set for all valid network types, and RBACs are now properly configured when you use the `Other` network type. (link:https://issues.redhat.com/browse/OCPBUGS-26977[*OCPBUGS-26977*])
 
 * Previously, an {aws-first} policy issue prevented the {cap-aws-short} from retrieving the necessary domain information. As a consequence, installing an {aws-short} hosted cluster with a custom domain failed. With this update, the policy issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-29391[*OCPBUGS-29391*])
 
@@ -2035,7 +2024,7 @@ The issue is resolved in this release. (link:https://issues.redhat.com/browse/OC
 
 * Previously, the pod security violation alert was missing in hosted clusters. With this update, the alert is added to hosted clusters. (link:https://issues.redhat.com/browse/OCPBUGS-31263[*OCPBUGS-31263*])
 
-* Previously, the `recycler-pod` template in hosted clusters in disconnected environments pointed to `quay.io/openshift/origin-tools:latest`. As a consequence, the recycler pods failed to start. With this update, the recycler pod image now points to the {produt-title} payload reference. (link:https://issues.redhat.com/browse/OCPBUGS-31398[*OCPBUGS-31398*])
+* Previously, the `recycler-pod` template in hosted clusters in disconnected environments pointed to `quay.io/openshift/origin-tools:latest`. As a consequence, the recycler pods failed to start. With this update, the recycler pod image now points to the {product-title} payload reference. (link:https://issues.redhat.com/browse/OCPBUGS-31398[*OCPBUGS-31398*])
 
 * With this update, in disconnected deployments, the HyperShift Operator receives the new `ImageContentSourcePolicy` (ICSP) or `ImageDigestMirrorSet` (IDMS) from the management cluster and adds them to the HyperShift Operator and the Control Plane Operator in every reconciliation loop. The changes to the ICSP or IDMS cause the `control-plane-operator` pod to be restarted. (link:https://issues.redhat.com/browse/OCPBUGS-29110[*OCPBUGS-29110*])
 
@@ -2057,7 +2046,7 @@ The issue is resolved in this release. (link:https://issues.redhat.com/browse/OC
 
 * Previously, the Image Registry Operator had maintained its own list of {ibm-power-server-name} regions, so any new regions were not added to the list. With this release, the Operator relies on an external library for accessing regions so that it can support new regions. (link:https://issues.redhat.com/browse/OCPBUGS-26767[*OCPBUGS-26767*])
 
-* Previously, the image registry Azure path-fix job incorrectly required the presence of `AZURE_CLIENT_ID` and `TENANT_CLIENT_ID` parameters to function. This caused a valid configuration to throw an error message. With this release, a check is added to the Identity and Access Management (IAM) service account key to validate if these parameters are needed, so that a cluster upgrade operation no longer fails. (link:https://issues.redhat.com/browse/OCPBUGS-32328[*OCPBUGS-32328*])
+* Previously, the image registry {azure-first} path-fix job incorrectly required the presence of `AZURE_CLIENT_ID` and `TENANT_CLIENT_ID` parameters to function. This caused a valid configuration to throw an error message. With this release, a check is added to the Identity and Access Management (IAM) service account key to validate if these parameters are needed, so that a cluster upgrade operation no longer fails. (link:https://issues.redhat.com/browse/OCPBUGS-32328[*OCPBUGS-32328*])
 
 * Previously, the image registry did not support {aws-first} region `ca-west-1`. With this release, the image registry can now be deployed in this region. (link:https://issues.redhat.com/browse/OCPBUGS-29233[*OCPBUGS-29233*])
 
@@ -2115,7 +2104,7 @@ The issue is resolved in this release. (link:https://issues.redhat.com/browse/OC
 
 * Previously, platform specific passwords that were configured in the installation configuration file of an Agent-based installation could be present in the output of the `agent-gather` command. With this release, passwords are redacted from the `agent-gather` output. (link:https://issues.redhat.com/browse/OCPBUGS-26434[*OCPBUGS-26434*])
 
-* Previously, a {product-title} cluster installed with version 4.15 or 4.16 showed a default upgrade channel of version 4.14. With this release, clusters have the correct upgrade channel after installation. (link:https://issues.redhat.com/browse/OCPBUGS-26048[*OCPBUGS-26048*])
+* Previously, a {product-title} cluster installed with version 4.15 or {product-version} showed a default upgrade channel of version 4.14. With this release, clusters have the correct upgrade channel after installation. (link:https://issues.redhat.com/browse/OCPBUGS-26048[*OCPBUGS-26048*])
 
 * Previously, when deleting a {vmw-full} cluster, some `TagCategory` objects failed to be deleted. With this release, all cluster-related objects are correctly deleted when the cluster is removed. (link:https://issues.redhat.com/browse/OCPBUGS-25841[*OCPBUGS-25841*])
 
@@ -2166,8 +2155,6 @@ Platform.BareMetal.externalBridge: Invalid value: "baremetal": could not find in
 ----
 +
 With this update, as the Agent-based installation method does not require libvirt, this erroneous validation has been disabled and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-30941[*OCPBUGS-30941*])
-
-* Previously, {product-title} upgrades for Ansible caused an error as the IPsec configuration was not idempotent. With this release, the issue is resolved. Now, all IPsec configurations for OpenShift Ansible playbooks are idempotent. (link:https://issues.redhat.com/browse/OCPBUGS-30802[*OCPBUGS-30802*])
 
 * Previously, using network types with dual-stack networking other than Open vSwitch-based software-defined networking (SDN) or Open Virtual Network (OVN) caused a validation error. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-30232[*OCPBUGS-30232*])
 
@@ -2293,11 +2280,11 @@ With this update, as the Agent-based installation method does not require libvir
 
 * Previously, when configuring a {vmw-full} connection,  the `resourcepool-path` key was not added to the {vmw-full} config map which might have caused issues connecting to {vmw-full}. With this release, there are no longer issues connecting to {vmw-full}. (link:https://issues.redhat.com/browse/OCPBUGS-25927[*OCPBUGS-25927*])
 
-* Previously, there was missing text in the *Customer feedback* modal. With this release, the link text is restored and the correct Red Hat image is displayed. (link:https://issues.redhat.com/browse/OCPBUGS-25843[*OCPBUGS-25843*])
+* Previously, there was missing text in the *Customer feedback* modal. With this release, the link text is restored and the correct Red{nbsp}Hat image is displayed. (link:https://issues.redhat.com/browse/OCPBUGS-25843[*OCPBUGS-25843*])
 
 * Previously, the *Update cluster* modal would not open when clicking *Select a version* from the *Cluster Settings* page. With this release, the *Update cluster* modal shows when clicking *Select a version*. (link:https://issues.redhat.com/browse/OCPBUGS-25780[*OCPBUGS-25780*])
 
-* Previously, on a mobile device, the filter part in the resource section of the *Search* page did not work on a mobile device. With this release, filtering now works as expected ona mobile device. (link:https://issues.redhat.com/browse/OCPBUGS-25530[*OCPBUGS-25530*])
+* Previously, on a mobile device, the filter part in the resource section of the *Search* page did not work on a mobile device. With this release, filtering now works as expected on a mobile device. (link:https://issues.redhat.com/browse/OCPBUGS-25530[*OCPBUGS-25530*])
 
 * Previously, the console Operator was using a client instead of listeners for fetching a cluster resource. This caused the Operator to do operations on resources with an older revision. With this release, the console Operator uses list to fetch data from cluster instead of clients. (link:https://issues.redhat.com/browse/OCPBUGS-25484[*OCPBUGS-25484*])
 
@@ -2355,10 +2342,6 @@ With this update, as the Agent-based installation method does not require libvir
 
 * Previously, if a pod selected by an `EgressIP` through a secondary interface had its label removed, another pod in the same namespace would also lose its `EgressIP` assignment, breaking its connection to the external host. With this release, the issue is fixed, so that when a pod label is removed and it stops using the `EgressIP`, other pods with the matching label continue to use the `EgressIP` without interruption. (link:https://issues.redhat.com/browse/OCPBUGS-20220[*OCPBUGS-20220*])
 
-* Previously, `EgressIP` pods hosted by a secondary interface did not failover because of a race condition. Users would receive an error message indicating that the `EgressIP` pod could not be assigned because it conflicted with an existing IP address. With this release, the `EgressIP` pod moves to an egress node. (https://issues.redhat.com/browse/OCPBUGS-20209[*OCPBUGS-20209*])
-
-* Previously, when a MAC address changed on the physical interface being used by OVN-Kubernetes, it would not be updated correctly within OVN-Kubernetes and could cause traffic disruption and Kube API outages from the node for a prolonged period of time. This was most common when a bond interface was being used, where the MAC address of the bond might swap depending on which device was the first to come up. With this release, the issues if fixed so that OVN-Kubernetes dynamically detects MAC address changes and updates it correctly. (link:https://issues.redhat.com/browse/OCPBUGS-18716[*OCPBUGS-18716*])
-
 * Previously, the global navigation satellite system (GNSS) module was capable of reporting both the GPS `fix` position and the GNSS `offset` position, which represents the offset between the GNSS module and the constellations. The previous T-GM did not use the `ubloxtool` CLI tool to probe the `ublox` module for reading `offset` and `fix` positions. Instead, it could only read the GPS `fix` information via GPSD. The reason for this was that the previous implementation of the `ubloxtool` CLI tool took 2 seconds to receive a response, and with every call it increased CPU usage by threefold. With this release, the `ubloxtool` request is now optimized, and the GPS `offset` position is now available. (link:https://issues.redhat.com/browse/OCPBUGS-17422[*OCPBUGS-17422*])
 
 * Previously, `EgressIP` pods hosted by a secondary interface would not failover because of a race condition. Users would receive an error message indicating that the `EgressIP` pod could not be assigned because it conflicted with an existing IP address. With this release, the `EgressIP` pod moves to an egress node. (https://issues.redhat.com/browse/OCPBUGS-20209[*OCPBUGS-20209*])
@@ -2399,8 +2382,6 @@ With this update, session affinity without a timeout is possible by setting the 
 [id="ocp-4-16-openshift-cli-bug-fixes_{context}"]
 ==== OpenShift CLI (oc)
 
-* Previously, during the disk-to-mirror process for fully disconnected environments, the oc-mirror plugin v1 failed to mirror the catalog image when access to Red{nbsp}Hat registries was blocked. Additionally, if the `ImageSetConfiguration` used a `targetCatalog` for the mirrored catalog, mirroring would fail due to incorrect catalog image references regardless of the workflow. This issue has been resolved by updating the catalog image source for mirroring to the mirror registry. (link:https://issues.redhat.com/browse/OCPBUGS-31536[*OCPBUGS-31536*])
-
 * Previously, when mirroring operator images with incompatible semantic versioning, oc-mirror plugin v2 (Technology Preview) would fail and exit. This fix ensures that a warning appears in the console, indicating the skipped image and allowing the mirroring process to continue without interruption. (link:https://issues.redhat.com/browse/OCPBUGS-34587[*OCPBUGS-34587*])
 
 * Previously, oc-mirror plugin v2 (Technology Preview) failed to mirror certain Operator catalogs that included image references with both `tag` and `digest` formats. This issue prevented the creation of cluster resources, such as `ImageDigestMirrorSource` (IDMS) and `ImageTagMirrorSource` (ITMS). With this update, oc-mirror resolves the issue by skipping images that have both `tag` and `digest` references, while displaying an appropriate warning message in the console output. (link:https://issues.redhat.com/browse/OCPBUGS-33196[*OCPBUGS-33196*])
@@ -2418,8 +2399,7 @@ To retain the catalog rebuilding functionality, use `--rebuild-catalog`. However
 
 * Previously, users encountered sequence errors when using the `tar.gz` artifact with the oc-mirror plugin. To resolve this, the oc-mirror plugin now ignores these errors when executed with the `--skip-pruning` flag. This update ensures that the sequence error, which no longer affects the order of `tar.gz` usage in mirroring, is effectively handled. (link:https://issues.redhat.com/browse/OCPBUGS-23496[*OCPBUGS-23496*])
 
-* Previously, when using the oc-mirror plugin to mirror local Open Container Initiative Operator catalogs located in hidden folders, oc-mirror previously failed with an error: ".hidden_folder/data/publish/latest/catalog-oci/manifest-list/kubebuilder/kube-rbac-proxy@sha256:db06cc4c084dd0253134f156dddaaf53ef1c3fb3cc809e5d81711baa4029ea4c is not a valid image reference: invalid reference format “. With this release, oc-mirror now calculates references to images within local Open Container Initiative catalogs differently, ensuring that the paths to hidden catalogs no longer disrupt the mirroring process.
-(link:https://issues.redhat.com/browse/OCPBUGS-23327[*OCPBUGS-23327*])
+* Previously, when using the oc-mirror plugin to mirror local Open Container Initiative Operator catalogs located in hidden folders, oc-mirror previously failed with an error: ".hidden_folder/data/publish/latest/catalog-oci/manifest-list/kubebuilder/kube-rbac-proxy@sha256:db06cc4c084dd0253134f156dddaaf53ef1c3fb3cc809e5d81711baa4029ea4c is not a valid image reference: invalid reference format “. With this release, oc-mirror now calculates references to images within local Open Container Initiative catalogs differently, ensuring that the paths to hidden catalogs no longer disrupt the mirroring process. (link:https://issues.redhat.com/browse/OCPBUGS-23327[*OCPBUGS-23327*])
 
 * Previously, oc-mirror would not stop and return a valid error code when mirroring failed. With this release, oc-mirror now exits with the correct error code when encountering “operator not found”, unless the `--continue-on-error` flag is used. (link:https://issues.redhat.com/browse/OCPBUGS-23003[*OCPBUGS-23003*])
 
@@ -2452,6 +2432,7 @@ To retain the catalog rebuilding functionality, use `--rebuild-catalog`. However
 * Previously, the default catalog source pod would not receive updates, requiring users to manually re-create it to get updates. This was caused by image IDs for catalog pods not getting detected correctly. This bug fix updates {olm} to correctly detect catalog pod image IDs, and as a result, default catalog sources are updated as expected. (link:https://issues.redhat.com/browse/OCPBUGS-31438[*OCPBUGS-31438*])
 
 * Previously, users could experience Operator installation errors due to {olm} not being able to find existing `ClusterRoleBinding` or `Service` resources and creating them a second time. This bug fix updates {olm} to pre-create these objects, and as a result these installation errors no longer occur. (link:https://issues.redhat.com/browse/OCPBUGS-24009[*OCPBUGS-24009*])
+
 ////
 [discrete]
 [id="ocp-4-16-openshift-api-server-bug-fixes_{context}"]
@@ -2462,7 +2443,7 @@ To retain the catalog rebuilding functionality, use `--rebuild-catalog`. However
 [id="ocp-4-16-rhcos-bug-fixes_{context}"]
 ==== {op-system-first}
 
-* Previously, the OVS network configured before the `kdump` service generated its special initramfs. When the `kdump` service started, it picked up the network-manager configuration files and copied them into the `kdump` initramfs. When the node rebooted into the `kdump` initramfs, the kernel crash dump upload over the network failed because OVN did not run into the initramfs and the virtual interface was not configured. With this release, the ordering has been updated so that the `kdump` starts and builds the `kdump` initramfs before the OVS networking configuration is set up and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-30239[*OCPBUGS-30239*])
+* Previously, the OVS network configured before the `kdump` service generated its special `initramfs`. When the `kdump` service started, it picked up the network-manager configuration files and copied them into the `kdump` `initramfs`. When the node rebooted into the `kdump` `initramfs`, the kernel crash dump upload over the network failed because OVN did not run into the `initramfs` and the virtual interface was not configured. With this release, the ordering has been updated so that the `kdump` starts and builds the `kdump` `initramfs` before the OVS networking configuration is set up and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-30239[*OCPBUGS-30239*])
 
 [discrete]
 [id="ocp-4-16-scalability-and-performance-bug-fixes_{context}"]
@@ -2496,7 +2477,7 @@ If the value of the `requests.storage` field in the `PersistentVolumeClaim` obje
 
 * Previously, CPU limits for the {aws-first} Elastic File Store (EFS) Container Storage Interface (CSI) driver container could cause performance degradation of volumes managed by the {aws-short} EFS CSI Driver Operator. With this release, the CPU limits from the {aws-short} EFS CSI driver container are removed to help prevent potential performance degradation. (link:https://issues.redhat.com/browse/OCPBUGS-28551[*OCPBUGS-28551*])
 
-* Previously, the Azure Disk CSI driver was not properly counting allocatable volumes on certain instance types and exceeded the maximum. As a result, the pod could not start. With this release, the count table for the Azure Disk CSI driver has been updated to include new instance types. The pod now runs and data can be read and written to the properly configured volumes. (link:https://issues.redhat.com/browse/OCPBUGS-18701[*OCPBUGS-18701*])
+* Previously, the {azure-first} Disk CSI driver was not properly counting allocatable volumes on certain instance types and exceeded the maximum. As a result, the pod could not start. With this release, the count table for the {azure-first} Disk CSI driver has been updated to include new instance types. The pod now runs and data can be read and written to the properly configured volumes. (link:https://issues.redhat.com/browse/OCPBUGS-18701[*OCPBUGS-18701*])
 
 * Previously, the secrets store Container Storage Interface driver on Hosted Control Planes failed to mount secrets because of a bug in the CLI. With this release, the driver is able to mount volumes and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-34759[*OCPBUGS-34759*])
 
@@ -2510,7 +2491,7 @@ If the value of the `requests.storage` field in the `PersistentVolumeClaim` obje
 [id="ocp-4-16-technology-preview-tables_{context}"]
 == Technology Preview features status
 
-Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red Hat Customer Portal for these features:
+Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red{nbsp}Hat Customer Portal for these features:
 
 link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
 
@@ -2698,12 +2679,12 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
-|User-defined labels and tags for Google Cloud Platform (GCP)
+|User-defined labels and tags for {gcp-first}
 |Technology Preview
 |Technology Preview
 |Technology Preview
 
-|Installing a cluster on Alibaba Cloud by using installer-provisioned infrastructure
+|Installing a cluster on {alibaba} by using installer-provisioned infrastructure
 |Technology Preview
 |Technology Preview
 |Removed
@@ -2713,7 +2694,7 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
-|{product-title} on Oracle Cloud Infrastructure (OCI)
+|{product-title} on {oci-first}
 |Developer Preview
 |Technology Preview
 |Technology Preview
@@ -2723,7 +2704,7 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
-|Static IP addresses with vSphere (IPI only)
+|Static IP addresses with {vmw-first} (IPI only)
 |Technology Preview
 |Technology Preview
 |General Availability
@@ -2733,7 +2714,7 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |General Availability
 
-|Installing a cluster on GCP using the Cluster API implementation
+|Installing a cluster on {gcp-short} using the Cluster API implementation
 |Not Available
 |Not Available
 |Technology Preview
@@ -2995,7 +2976,7 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.14 |4.15 |4.16
 
-|Hosted control planes for {product-title} on Amazon Web Services (AWS)
+|Hosted control planes for {product-title} on {aws-first}
 |Technology Preview
 |Technology Preview
 |Technology Preview
@@ -3015,7 +2996,7 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
-|Hosted control planes for an ARM64 {product-title} cluster on AWS
+|Hosted control planes for an ARM64 {product-title} cluster on {aws-full}
 |Technology Preview
 |Technology Preview
 |Technology Preview
@@ -3060,12 +3041,12 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |General Availability
 
-|Cloud controller manager for Alibaba Cloud
+|Cloud controller manager for {alibaba}
 |Technology Preview
 |Technology Preview
 |Technology Preview
 
-|Cloud controller manager for Google Cloud Platform
+|Cloud controller manager for {gcp-full}
 |Technology Preview
 |General Availability
 |General Availability
@@ -3193,9 +3174,9 @@ This issue affects CPU load balancing features, which depend on the CPU Manager 
 
 * If you delete a `SriovNetworkNodePolicy` resource for a virtual function with a `vfio-pci` driver type, the SR-IOV Network Operator is unable to reconcile the policy. As a consequence the `sriov-device-plugin` pod enters a continuous restart loop. As a workaround, delete all remaining policies affecting the physical function, then re-create them. (link:https://issues.redhat.com/browse/OCPBUGS-34934[*OCPBUGS-34934*])
 
-* If the controller pod terminates while cloning is in progress, the Azure File clone persistent volume claims (PVCs) remain in the Pending state. To resolve this issue, delete any affected clone PVCs, and then recreate the PVCs. (link:https://issues.redhat.com/browse/OCPBUGS-35977[*OCPBUGS-35977*])
+* If the controller pod terminates while cloning is in progress, the {azure-first} File clone persistent volume claims (PVCs) remain in the Pending state. To resolve this issue, delete any affected clone PVCs, and then recreate the PVCs. (link:https://issues.redhat.com/browse/OCPBUGS-35977[*OCPBUGS-35977*])
 
-* There is no log pruning available for azcopy (underlying tool running copy jobs) in Azure, so this might eventually lead to filling up a root device of the controller pod, and you have to manually clean this up. (link:https://issues.redhat.com/browse/OCPBUGS-35980[*OCPBUGS-35980*])
+* There is no log pruning available for azcopy (underlying tool running copy jobs) in {azure-first}, so this might eventually lead to filling up a root device of the controller pod, and you have to manually clean this up. (link:https://issues.redhat.com/browse/OCPBUGS-35980[*OCPBUGS-35980*])
 
 * The limited live migration method stops when the `mtu` parameter of a `ConfigMap` object in the `openshift-network-operator` namespace is missing.
 +
@@ -3220,13 +3201,13 @@ data:
 [id="ocp-4-16-asynchronous-errata-updates_{context}"]
 == Asynchronous errata updates
 
-Security, bug fix, and enhancement updates for {product-title} {product-version} are released as asynchronous errata through the Red Hat Network. All {product-title} {product-version} errata is https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. See the https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle] for more information about asynchronous errata.
+Security, bug fix, and enhancement updates for {product-title} {product-version} are released as asynchronous errata through the Red{nbsp}Hat Network. All {product-title} {product-version} errata is https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. See the https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle] for more information about asynchronous errata.
 
-Red Hat Customer Portal users can enable errata notifications in the account settings for Red Hat Subscription Management (RHSM). When errata notifications are enabled, users are notified through email whenever new errata relevant to their registered systems are released.
+Red{nbsp}Hat Customer Portal users can enable errata notifications in the account settings for Red{nbsp}Hat Subscription Management (RHSM). When errata notifications are enabled, users are notified through email whenever new errata relevant to their registered systems are released.
 
 [NOTE]
 ====
-Red Hat Customer Portal user accounts must have systems registered and consuming {product-title} entitlements for {product-title} errata notification emails to generate.
+Red{nbsp}Hat Customer Portal user accounts must have systems registered and consuming {product-title} entitlements for {product-title} errata notification emails to generate.
 ====
 
 This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {product-title} {product-version}. Versioned asynchronous releases, for example with the form {product-title} {product-version}.z, will be detailed in subsections. In addition, releases in which the errata text cannot fit in the space provided by the advisory will be detailed in subsections that follow.


### PR DESCRIPTION
Version(s):
4.16

[Link to docs preview](https://78011--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html)


