### PR TITLE
SRVCOM-3050 Performs redirects for the 1.33 Serverless docs

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -295,22 +295,22 @@ AddType text/vtt                            vtt
     RewriteRule ^container-platform/(4\.9|4\.10|4\.11|4\.12)/serverless/develop/serverless-traffic-management.html /container-platform/$1/serverless/knative-serving/traffic-splitting/traffic-splitting-overview.html [NE,R=302]
 
 
-    # redirect latest to 1.32
+    # redirect latest to 1.33
     RewriteRule ^serverless/?$ /serverless/latest [R=302]
-    RewriteRule ^serverless/latest/?(.*)$ /serverless/1\.32/$1 [NE,R=302]
+    RewriteRule ^serverless/latest/?(.*)$ /serverless/1\.33/$1 [NE,R=302]
 
     # redirect top-level without filespec to the about file
-    RewriteRule ^serverless/(1\.28|1\.29|1\.30|1\.31|1\.32)/?$ /serverless/$1/about/about-serverless.html [L,R=302]
+    RewriteRule ^serverless/(1\.28|1\.29|1\.30|1\.31|1\.32|1\.33)/?$ /serverless/$1/about/about-serverless.html [L,R=302]
 
     # redirect rel notes
-    RewriteRule ^container-platform/(4\.10|4\.11|4\.12|4\.13|4\.14)/serverless/serverless-release-notes.html$ /serverless/1.32/about/serverless-release-notes.html [L,R=302]
-    RewriteRule ^(rosa|dedicated)/serverless/serverless-release-notes.html$ /serverless/1.32/about/serverless-release-notes.html [L,R=302]
+    RewriteRule ^container-platform/(4\.10|4\.11|4\.12|4\.13|4\.14)/serverless/serverless-release-notes.html$ /serverless/1.33/about/serverless-release-notes.html [L,R=302]
+    RewriteRule ^(rosa|dedicated)/serverless/serverless-release-notes.html$ /serverless/1.33/about/serverless-release-notes.html [L,R=302]
 
     # redirect any links to existing OCP embedded content to standalone equivalent
-    RewriteRule ^container-platform/(4\.10|4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/serverless/?(.*)$ /serverless/1.32/$2  [L,R=302]
+    RewriteRule ^container-platform/(4\.10|4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/serverless/?(.*)$ /serverless/1.33/$2  [L,R=302]
 
     # redirect any links to existing ROSA/Dedicated embedded content to standalone equivalent
-    RewriteRule ^(rosa|dedicated)/serverless/?(.*)$ /serverless/1.32/$2  [L,R=302]
+    RewriteRule ^(rosa|dedicated)/serverless/?(.*)$ /serverless/1.33/$2  [L,R=302]
 
     # redirect builds latest to 1.0
     RewriteRule ^builds/?$ /builds/latest [R=302]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[SRVCOM-3050](https://issues.redhat.com/browse/SRVCOM-3050)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
N/A 

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
