### PR TITLE
CNV#43342: RN - VMs require 1GiB memory for mem hotplug

### DIFF
--- a/virt/release_notes/virt-4-16-release-notes.adoc
+++ b/virt/release_notes/virt-4-16-release-notes.adoc
@@ -101,6 +101,12 @@ This release adds new features and enhancements related to the following compone
 +
 On {op-system-base-full} 9, xref:../../virt/monitoring/virt-exposing-downward-metrics.adoc#virt-viewing-downward-metrics-cli_virt-exposing-downward-metrics[use the command line] to view downward metrics. The `vm-dump-metrics` tool is not supported on the {op-system-base-full} 9 platform.
 
+[id="virt-4-16-notable-technical-changes"]
+=== Notable Technical Changes
+
+//CNV-43342: RN: VMs require 1GiB memory
+* VMs require a minimum of 1 GiB of allocated memory to enable memory hotplug. If a VM has less than 1 GiB of allocated memory, then memory hotplug is disabled.
+
 [id="virt-4-16-deprecated-removed"]
 == Deprecated and removed features
 //NOTE: Comment out deprecated and removed features (and their IDs) if not used in a release


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/CNV-43342

Link to docs preview:
https://78025--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-16-release-notes.html#virt-4-16-notable-technical-changes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Since this didn't really belong in the "new and changed" feature section, I borrowed OCP's RN method of "Notable Technical Changes" and added that to our release note file, with this story included in it.
