### PR TITLE
Removing use of 'CAPI' from release notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -67,13 +67,13 @@ With this release, you can now install {op-system} to iSCSI boot devices. Multip
 
 [id="ocp-4-16-installation-and-update-aws-capi_{context}"]
 ==== Cluster API replaces Terraform for AWS installations
-In {product-title} {product-version}, the installation program uses Cluster API (CAPI) instead of Terraform to provision cluster infrastructure during installations on AWS. There are several additional required permissions as a result of this change. For more information, see xref:../installing/installing_aws/installing-aws-account.adoc#installation-aws-permissions_installing-aws-account[Required AWS permissions for the IAM user].
+In {product-title} {product-version}, the installation program uses Cluster API instead of Terraform to provision cluster infrastructure during installations on AWS. There are several additional required permissions as a result of this change. For more information, see xref:../installing/installing_aws/installing-aws-account.adoc#installation-aws-permissions_installing-aws-account[Required AWS permissions for the IAM user].
 
-Additionally, SSH access to control plane and compute machines is no longer open to the machine network, but is restricted to the security groups associated with the control plane and compute plane machines.
+Additionally, SSH access to control plane and compute machines is no longer open to the machine network, but is restricted to the security groups associated with the control plane and compute machines.
 
 [WARNING]
 ====
-Installing a cluster on AWS into a secret or top-secret region has not been tested with CAPI as of the release of {product-title} {product-version}. This document will be updated when installation into a secret region has been tested. There is a known issue with Network Load Balancers' support for security groups in secret or top secret regions that causes installations to fail. For more information, see link:https://issues.redhat.com/browse/OCPBUGS-33311[*OCPBUGS-33311*].
+Installing a cluster on AWS into a secret or top-secret region by using the Cluster API implementation has not been tested as of the release of {product-title} {product-version}. This document will be updated when installation into a secret region has been tested. There is a known issue with Network Load Balancers' support for security groups in secret or top secret regions that causes installations to fail. For more information, see link:https://issues.redhat.com/browse/OCPBUGS-33311[*OCPBUGS-33311*].
 ====
 
 [id="ocp-4-16-installation-and-update-vsphere-capi_{context}"]
@@ -86,7 +86,7 @@ In {product-title} {product-version}, the installation program uses Cluster API 
 
 [id="ocp-4-16-installation-and-update-gcp-capi_{context}"]
 ==== Cluster API replaces Terraform for {gcp-first} installations (Technology Preview)
-In {product-title} {product-version}, the installation program uses Cluster API instead of Terraform to provision cluster infrastructure during installations on {gcp-short}. This feature is available as a Technology Preview in {product-title} {product-version}. To enable Technology Preview features, set the `featureSet: TechPreviewNoUpgrade` parameter in the `install-config.yaml` file before installation. Alternatively, add the following stanza to the `install-config.yaml` file before installation to enable Cluster API without any other Technology Preview features:
+In {product-title} {product-version}, the installation program uses Cluster API instead of Terraform to provision cluster infrastructure during installations on {gcp-short}. This feature is available as a Technology Preview in {product-title} {product-version}. To enable Technology Preview features, set the `featureSet: TechPreviewNoUpgrade` parameter in the `install-config.yaml` file before installation. Alternatively, add the following stanza to the `install-config.yaml` file before installation to enable Cluster API installation without any other Technology Preview features:
 
 [source,yaml]
 ----
@@ -2694,7 +2694,7 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |General Availability
 
-|CAPI infrastructure provider for GCP
+|Installing a cluster on GCP using the Cluster API implementation
 |Not Available
 |Not Available
 |Technology Preview
@@ -3125,7 +3125,7 @@ In the following tables, features are marked with the following statuses:
 
 * When a {product-title} {product-version} cluster is installed or configured as a postinstallation activity on a single VIOS host with virtual SCSI storage on {ibm-power-name} with multipath configured, the CoreOS nodes with multipath enabled fail to boot. This behavior is expected as only one path is available to the node. (link:https://issues.redhat.com/browse/OCPBUGS-32290[*OCPBUGS-32290*])
 
-* When using CPU load balancing on cgroupv2, a pod can fail to start if another pod that has access to exclusive CPUs already exists. This can happen when a pod is deleted and another one is quickly created to replace it. As a workaround, ensure that the old pod is fully terminated before attempting to create the new one. (link:https://issues.redhat.com/browse/OCPBUGS-34812[*OCPBUGS-34812*]) 
+* When using CPU load balancing on cgroupv2, a pod can fail to start if another pod that has access to exclusive CPUs already exists. This can happen when a pod is deleted and another one is quickly created to replace it. As a workaround, ensure that the old pod is fully terminated before attempting to create the new one. (link:https://issues.redhat.com/browse/OCPBUGS-34812[*OCPBUGS-34812*])
 
 [id="ocp-telco-ran-4-16-known-issues_{context}"]
 * The current PTP grandmaster clock (T-GM) implementation has a single National Marine Electronics Association (NMEA) sentence generator sourced from the GNSS without a backup NMEA sentence generator.


### PR DESCRIPTION
Removing incorrect usage of "CAPI" from the 4.16 release notes. no QE/SME ack required

Preview: https://78027--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-installation-and-update-aws-capi_release-notes