### PR TITLE
OCPBUGS#35805: 4.16 RN: Rm Bundle API from OLMv1

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -1364,6 +1364,14 @@ For information about detecting legacy service account API token secrets that ar
 In this release, the functionality to authenticate to private registries on {aws-first}, {gcp-first}, and {azure-first} clusters is moved from the in-tree provider to binaries that ship with {product-title}. This change supports the default external cloud authentication provider behavior that is introduced in Kubernetes 1.29.
 
 [discrete]
+[id="ocp-4-16-builder-sa"]
+=== The builder service account is no longer created if the Build cluster capability is disabled
+
+With this release, if you disable the `Build` cluster capability, the `builder` service account and its corresponding secrets are no longer created.
+
+For more information, see xref:../installing/cluster-capabilities.adoc#build-config-capability_cluster-capabilities[Build capability].
+
+[discrete]
 [id="ocp-4-16-olmv1-default-upgrade-constraints_{context}"]
 === Default {olmv1} upgrade constraints changed to {olmv0} semantics (Technology Preview)
 
@@ -1372,12 +1380,12 @@ In {product-title} {product-version}, {olmv1-first} changes its default upgrade 
 For more information, see xref:../release_notes/ocp-4-16-release-notes.adoc#ocp-4-16-olmv1-legacy-olm-upgrade-edges_release-notes[Support for {olmv0} upgrade edges in {olmv1} (Technology Preview)].
 
 [discrete]
-[id="ocp-4-16-builder-sa"]
-=== The builder service account is no longer created if the Build cluster capability is disabled
+[id="ocp-4-16-olmv1-rm-bundle-api_{context}"]
+=== Removal of the RukPak Bundle API from {olmv1} (Technology Preview)
 
-With this release, if you disable the `Build` cluster capability, the `builder` service account and its corresponding secrets are no longer created.
+In {product-title} {product-version}, {olmv1-first} removes the `Bundle` API, which was provided by the RukPak component. The RukPak `BundleDeployment` API remains and supports `registry+v1` bundles for unpacking Kubernetes YAML manifests organized in the {olmv0-first} bundle format.
 
-For more information, see xref:../installing/cluster-capabilities.adoc#build-config-capability_cluster-capabilities[Build capability].
+For more information, see xref:../operators/olm_v1/arch/olmv1-rukpak.adoc#olmv1-rukpak[Rukpak (Technology Preview)].
 
 [id="ocp-4-16-deprecated-removed-features_{context}"]
 == Deprecated and removed features


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-35805

"Notable technical change" OCP 4.16 release note for https://github.com/openshift/openshift-docs/pull/78031.

Preview: https://78037--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-olmv1-rm-bundle-api_release-notes

NOTE: Moved the other OLMv1 TP "notable technical change" (`ocp-4-16-olmv1-default-upgrade-constraints`) down so that the 2 OLMv1 entries are together and listed last in the sequence. Functionally in the PR diff, that comes out looking like I moved the `ocp-4-16-builder-sa` note "up", FWIW.