### PR TITLE
OCPBUILD#7: Noting that builder SA isn't created if Build capability …

### DIFF
--- a/modules/build-config-capability.adoc
+++ b/modules/build-config-capability.adoc
@@ -13,5 +13,10 @@ The `Build` capability enables the `Build` API. The `Build` API manages the life
 
 [IMPORTANT]
 ====
-If the `Build` capability is disabled, the cluster cannot use `Build` or `BuildConfig` resources. Disable the capability only if `Build` and `BuildConfig` resources are not required in the cluster.
+If you disable the `Build` capability, the following resources will not be available in the cluster:
+
+* `Build` and `BuildConfig` resources
+* The `builder` service account
+
+Disable the `Build` capability only if you do not require `Build` and `BuildConfig` resources or the `builder` service account in the cluster.
 ====

--- a/modules/service-accounts-default.adoc
+++ b/modules/service-accounts-default.adoc
@@ -60,6 +60,11 @@ Three service accounts are automatically created in each project:
 pushing images to any imagestream in the project using the internal Docker
 registry.
 
+[NOTE]
+====
+The `builder` service account is not created if the `Build` cluster capability is not enabled.
+====
+
 |`deployer`
 |Used by deployment pods and given the `system:deployer` role, which allows
 viewing and modifying replication controllers and pods in the project.


### PR DESCRIPTION
…is disabled

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16

Issue:
N/A

Link to docs preview:
* https://78044--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/using-service-accounts-in-applications.html#default-service-accounts-and-roles_using-service-accounts
* https://78044--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/cluster-capabilities.html#build-config-capability_cluster-capabilities

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

This update came out of what was announced at the 4.16 what's new presentation
