### PR TITLE
4.16 GA for SD

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -158,7 +158,7 @@ openshift-dedicated:
     enterprise-3.11:
       name: '3'
       dir: dedicated/3
-    enterprise-4.15:
+    enterprise-4.16:
       name: ''
       dir: dedicated/
 openshift-aro:
@@ -181,7 +181,7 @@ openshift-rosa:
   site_name: Documentation
   site_url: https://docs.openshift.com/
   branches:
-    enterprise-4.15:
+    enterprise-4.16:
       name: ''
       dir: rosa/
     rosa-preview:
@@ -194,7 +194,7 @@ openshift-rosa-portal:
   site_name: Documentation
   site_url: https://docs.openshift.com/
   branches:
-    enterprise-4.15:
+    enterprise-4.16:
       name: ''
       dir: rosa-portal/
 openshift-webscale:
@@ -398,4 +398,4 @@ openshift-lightspeed:
   branches:
     lightspeed-docs-1.0tp1:
       name: '1.0tp1'
-      dir: lightspeed/1.0tp1      
+      dir: lightspeed/1.0tp1

--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -586,12 +586,12 @@ a|* 3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.9, 3.10, 3.11
 
 |`openshift-dedicated`
 |OpenShift Dedicated
-a|* No value set for the latest `dedicated/` build from the `enterprise-4.15` branch
+a|* No value set for the latest `dedicated/` build from the `enterprise-4.16` branch
 * 3 for the `dedicated/3` build from the `enterprise-3.11` branch
 
 |`openshift-rosa`
 |Red Hat OpenShift Service on AWS
-|No value set for the `rosa/` build from the `enterprise-4.15` branch
+|No value set for the `rosa/` build from the `enterprise-4.16` branch
 
 |`openshift-online`
 |OpenShift Online


### PR DESCRIPTION
Since ROSA and OSD might start tracking 4.16 after OCP GA, the SD changes are separate. See https://github.com/openshift/openshift-docs/pull/71921 for the combined 4.15 PR.