### PR TITLE
Removing use of 'CAPI' from AWS install

### DIFF
--- a/installing/installing_aws/ipi/installing-aws-secret-region.adoc
+++ b/installing/installing_aws/ipi/installing-aws-secret-region.adoc
@@ -15,7 +15,7 @@ To configure a cluster in either region, you change parameters in the `install c
 
 [WARNING]
 ====
-In {product-title} {product-version}, the installation program uses Cluster API (CAPI) instead of Terraform to provision cluster infrastructure during installations on AWS. Installing a cluster on AWS into a secret or top-secret region has not been tested with CAPI as of the release of {product-title} {product-version}. This document will be updated when installation into a secret region has been tested.
+In {product-title} {product-version}, the installation program uses Cluster API instead of Terraform to provision cluster infrastructure during installations on AWS. Installing a cluster on AWS into a secret or top-secret region by using the Cluster API implementation has not been tested as of the release of {product-title} {product-version}. This document will be updated when installation into a secret region has been tested.
 
 There is a known issue with Network Load Balancers' support for security groups in secret or top secret regions that causes installations in these regions to fail. For more information, see link:https://issues.redhat.com/browse/OCPBUGS-33311[OCPBUGS-33311].
 ====


### PR DESCRIPTION
No QE ack required as no technical content is changing.
Preview: https://78052--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-secret-region.html