### PR TITLE
OSSM-6641 Most current version snippet

### DIFF
--- a/snippets/ossm-current-version-support-snippet.adoc
+++ b/snippets/ossm-current-version-support-snippet.adoc
@@ -1,0 +1,7 @@
+// Snippets included in the following assemblies and modules:
+//
+// * service_mesh/v2x/ossm-rn-new-features.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+The most current version of the {SMProductName} Operator can be used with all supported versions of {SMProductShortName}. The version of {SMProductShortName} is specified using the `ServiceMeshControlPlane`.


### PR DESCRIPTION
[OSSM-6641](https://issues.redhat.com//browse/OSSM-6641) Most current version snippet

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSSM-6641

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
QE is not needed for this PR. Content already exists in previously published Release Notes; this makes it easier for writers to update Release Notes.

Additional information:

Snippet created to use in OSSM Release Notes, starting with OSSM 2.6, to help clarify Operator vs ServiceMeshControlPlane for 2.x docs. Writers won't have to copy/pasta; they'll be able to use this Snippet instead.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
