### PR TITLE
Simply nmconnection files

### DIFF
--- a/modules/installation-user-infra-machines-advanced-customizing-live-network-config.adoc
+++ b/modules/installation-user-infra-machines-advanced-customizing-live-network-config.adoc
@@ -27,10 +27,6 @@ id=bond0
 type=bond
 interface-name=bond0
 multi-connect=1
-permissions=
-
-[ethernet]
-mac-address-blacklist=
 
 [bond]
 miimon=100
@@ -41,8 +37,6 @@ method=auto
 
 [ipv6]
 method=auto
-
-[proxy]
 ----
 
 . Create a connection profile for a secondary interface to add to the bond. For example, create the `bond0-proxy-em1.nmconnection` file in your local directory with the following content:
@@ -55,11 +49,7 @@ type=ethernet
 interface-name=em1
 master=bond0
 multi-connect=1
-permissions=
 slave-type=bond
-
-[ethernet]
-mac-address-blacklist=
 ----
 
 . Create a connection profile for a secondary interface to add to the bond. For example, create the `bond0-proxy-em2.nmconnection` file in your local directory with the following content:
@@ -72,11 +62,7 @@ type=ethernet
 interface-name=em2
 master=bond0
 multi-connect=1
-permissions=
 slave-type=bond
-
-[ethernet]
-mac-address-blacklist=
 ----
 
 ifeval::["{boot-media}" == "ISO image"]


### PR DESCRIPTION
Remove empty properties that are not needed to make the documentation more focussed. It also removes an unused property
(`mac-address-blacklist`) that is deprecated as part of the conscious language efforts in NetworkManager.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
all

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This change is valid for all supported OCP releases but not necessary.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

/label merge-review-needed

@bengal @ffmancera @cathay4t FYI