### PR TITLE
MGMT-18015 Unable to deploy Latest OCP 4.16 - generating manifests fails with 'GLIBC_2.34' not found

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3157,6 +3157,8 @@ In the following tables, features are marked with the following statuses:
 
 * When installing a cluster on {aws-first} using Local Zones, edge nodes fail to deploy if deployed in the `us-east-1-iah-2a` region. (link:https://issues.redhat.com/browse/OCPBUGS-35538[*OCPBUGS-35538*])
 
+* Installing {product-title} {product-version} with the Infrastructure Operator, Central Infrastructure Management, or ZTP methods using ACM versions 2.10.3 or earlier is not possible. This is because of a change in the dynamically linked installer binary,`openshift-baremetal-install`, which in {product-title} {product-version} requires a Red Hat Enterprise Linux (RHEL) 9 host to run successfully. It is planned to use the statically linked binary in future versions of ACM to avoid this issue. (link:https://issues.redhat.com/browse/ACM-12405[*ACM-12405*])
+
 * For a bonding network interface that holds a `br-ex` bridge device, do not set the `mode=6 balance-alb` bond mode in a node network configuration. This bond mode is not supported on {product-title} and it can cause the Open vSwitch (OVS) bridge device to disconnect from your networking environment. (link:https://issues.redhat.com/browse/OCPBUGS-34430[*OCPBUGS-34430*])
 
 // HCIDOCS-365 - This issue should be fixed soon, in a 4.16.z release


### PR DESCRIPTION
[MGMT-18015]: Unable to deploy Latest OCP 4.16 - generating manifests fails with 'GLIBC_2.34' not found

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16 RN
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/MGMT-18015
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://78073--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-known-issues_release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
