### PR TITLE
OSDOCS-11023: adds KI and workaround link to MicroShift 4.16.0

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -162,7 +162,15 @@ Previously, the {microshift-short} load balancer controller tried to update the 
 
 Previously, when `microshift-etcd` unexpectedly exited, {microshift-short} tried to restart so that `microshift-etcd` could restart, but there was a lingering unit fragment. Every attempt to restart `microshift-etcd` failed, making the system unusable. The `--collect` flag was added to the `systemd-run` invocation used to start `microshift-etcd`. The additional flag results in systemd cleaning up the unit fragment even if the unit failed. The system now recovers and restarts. (link:https://issues.redhat.com/browse/OCPBUGS-33588[OCPBUGS-33588])
 
-[id="microshift-4-16-asynchronous-errata-updates"]
+//check status for next release+
+[id="microshift-4-16-known-issues_{context}"]
+== Known issues
+
+[id="microshift-4-16-pods-writing-files-excess-memory-limits-crash_{context}"]
+=== Pods crash when writing files that exceed memory limits
+Because of an issue with {op-system-base}, when a pod tries to write files that are larger than configured memory limits to a persistent volume claim, the pod might crash with an out-of-memory error. The pod status shows `OOMKilled` when this occurs. Use the following workarounds to avoid this issue: link:https://access.redhat.com/solutions/7076169[Pods writing files larger than memory limit to PVCs tend to OOM frequently running on MicroShift](Red Hat Knowledgebase).
+
+[id="microshift-4-16-asynchronous-errata-updates_{context}"]
 == Asynchronous errata updates
 
 Security, bug fix, and enhancement updates for {microshift-short} {product-version} are released as asynchronous errata through the Red Hat Network. All {microshift-short} {product-version} errata are https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. For more information about asynchronous errata, read the https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{microshift-short} Life Cycle].
@@ -176,7 +184,7 @@ Red Hat Customer Portal user accounts must have systems registered and consuming
 
 This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections.
 
-[id="microshift-4-16-0-dp"]
+[id="microshift-4-16-0-dp_{context}"]
 === RHEA-2024:0043 - {microshift-short} 4.16.0 bug fix and security update advisory
 
 Issued: 2024-06-27


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-11023](https://issues.redhat.com/browse/OSDOCS-11023)

Link to docs preview:
[4.16.0 release note known issues](https://78086--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-known-issues_release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
SME review:
- [X] SME has approved this change.

Additional information:
[KCS article draft](https://access.redhat.com/solutions/7076169)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
