### PR TITLE
OSDOCS-10990: 4.14.31 RN

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3322,6 +3322,32 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+[id="ocp-4-14-31"]
+=== RHSA-2024:4010 - {product-title} 4.14.31 bug fix and security updates
+
+Issued: 2024-06-26
+
+{product-title} release 4.14.31, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:4010[RHSA-2024:4010] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:4013[RHBA-2024:4013] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.31 --pullspecs
+----
+
+[id="ocp-4-14-31-bug-fixes"]
+==== Bug fixes
+
+* Previously, the logic for fetching the names of nodes from the host was not accounting for multiple values and terminated unexpectedly when it returned multiple values for the name that contained a space. With this release, the logic is updated to use only the first returned hostname as the node name and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-34716[*OCPBUGS-34716*])
+
+[id="ocp-4-14-31-updating"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 [id="ocp-4-14-30"]
 === RHSA-2024:3881 - {product-title} 4.14.30 bug fix and security updates
 
@@ -3343,12 +3369,12 @@ $ oc adm release info 4.14.30 --pullspecs
 
 The following enhancements are included in this z-stream release:
 
-[id="ocp-4-15-30-password-colon-character"]
+[id="ocp-4-14-30-password-colon-character"]
 ===== Allowing a colon character in pull secret passwords
 
 This release adds the ability to include a colon character in your pull secret password for the {product-title} {ai-full}. (link:https://issues.redhat.com/browse/OCPBUGS-35034[*OCPBUGS-35034*])
 
-[id="ocp-4-15-30-csi-topology-awareness"]
+[id="ocp-4-14-30-csi-topology-awareness"]
 ===== Configuring the topology feature for the Cinder CSI Driver
 
 Previously, the topology feature for the Cinder CSI Driver was always active, because you could not disable the topology feature. With this release, the topology feature is based on the compute and storage availability zones and you can disable the topology feature. (link:https://issues.redhat.com/browse/OCPBUGS-34792[*OCPBUGS-34792*])


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-10990

Link to docs preview:
https://78092--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-31

QE review:
N/A

Additional information:
Errata URLs may return 404 until shipped live (6/26)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
