### PR TITLE
OCPBUGS#33700:Added routes note for soure IP address in IController doc

### DIFF
--- a/modules/nw-ingress-controller-configuration-proxy-protocol.adoc
+++ b/modules/nw-ingress-controller-configuration-proxy-protocol.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * ingress/configure-ingress-operator.adoc
+// * networking/ingress-operator.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-ingress-controller-configuration-proxy-protocol_{context}"]
@@ -10,7 +10,25 @@ A cluster administrator can configure link:https://www.haproxy.org/download/1.8/
 
 [WARNING]
 ====
-The PROXY protocol is unsupported for the default Ingress Controller with installer-provisioned clusters on non-cloud platforms that use a Keepalived Ingress VIP.
+The default Ingress Controller with installer-provisioned clusters on non-cloud platforms that use a Keepalived Ingress Virtual IP (VIP) do not support the PROXY protocol.
+====
+
+The PROXY protocol enables the load balancer to preserve the original client addresses for connections that the Ingress Controller receives. The original client addresses are useful for logging, filtering, and injecting HTTP headers. In the default configuration, the connections that the Ingress Controller receives contain only the source IP address that is associated with the load balancer.
+
+[IMPORTANT]
+====
+For a passthrough route configuration, servers in {product-title} clusters cannot observe the original client source IP address. If you need to know the original client source IP address, configure Ingress access logging for your Ingress Controller so that you can view the client source IP addresses.
+
+For re-encrypt and edge routes, the {product-title} router sets the `Forwarded` and `X-Forwarded-For` headers so that application workloads check the client source IP address.
+
+For more information about Ingress access logging, see "Configuring Ingress access logging".
+====
+
+Configuring the PROXY protocol for an Ingress Controller is not supported when using the `LoadBalancerService` endpoint publishing strategy type. This restriction is because when {product-title} runs in a cloud platform, and an Ingress Controller specifies that a service load balancer should be used, the Ingress Operator configures the load balancer service and enables the PROXY protocol based on the platform requirement for preserving source addresses.
+
+[IMPORTANT]
+====
+You must configure both {product-title} and the external load balancer to use either the PROXY protocol or TCP.
 ====
 
 This feature is not supported in cloud deployments. This restriction is because when {product-title} runs in a cloud platform, and an Ingress Controller specifies that a service load balancer should be used, the Ingress Operator configures the load balancer service and enables the PROXY protocol based on the platform requirement for preserving source addresses.
@@ -24,7 +42,7 @@ You must configure both {product-title} and the external load balancer to either
 * You created an Ingress Controller.
 
 .Procedure
-. Edit the Ingress Controller resource:
+. Edit the Ingress Controller resource by entering the following command in your CLI:
 +
 [source,terminal]
 ----
@@ -33,25 +51,44 @@ $ oc -n openshift-ingress-operator edit ingresscontroller/default
 
 . Set the PROXY configuration:
 +
-* If your Ingress Controller uses the hostNetwork endpoint publishing strategy type, set the `spec.endpointPublishingStrategy.hostNetwork.protocol` subfield to `PROXY`:
+* If your Ingress Controller uses the `HostNetwork` endpoint publishing strategy type, set the `spec.endpointPublishingStrategy.hostNetwork.protocol` subfield to `PROXY`:
 +
 .Sample `hostNetwork` configuration to `PROXY`
 [source,yaml]
 ----
+# ...
   spec:
     endpointPublishingStrategy:
       hostNetwork:
         protocol: PROXY
       type: HostNetwork
+# ...
 ----
-* If your Ingress Controller uses the NodePortService endpoint publishing strategy type, set the `spec.endpointPublishingStrategy.nodePort.protocol` subfield to `PROXY`:
+
+* If your Ingress Controller uses the `NodePortService` endpoint publishing strategy type, set the `spec.endpointPublishingStrategy.nodePort.protocol` subfield to `PROXY`:
 +
 .Sample `nodePort` configuration to `PROXY`
 [source,yaml]
 ----
+# ...
   spec:
     endpointPublishingStrategy:
       nodePort:
         protocol: PROXY
       type: NodePortService
+# ...
+----
+
+* If your Ingress Controller uses the `Private` endpoint publishing strategy type, set the `spec.endpointPublishingStrategy.private.protocol` subfield to `PROXY`:
++
+.Sample `private` configuration to `PROXY`
+[source,yaml]
+----
+# ...
+  spec:
+    endpointPublishingStrategy:
+      private:
+        protocol: PROXY
+    type: Private
+# ...
 ----

--- a/networking/ingress-operator.adoc
+++ b/networking/ingress-operator.adoc
@@ -94,8 +94,15 @@ include::modules/nw-using-ingress-forwarded.adoc[leveloffset=+2]
 
 include::modules/nw-http2-haproxy.adoc[leveloffset=+2]
 
+// Configuring the PROXY protocol for an Ingress Controller
 include::modules/nw-ingress-controller-configuration-proxy-protocol.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../networking/ingress-operator.adoc#nw-configure-ingress-access-logging_configuring-ingress[Configuring Ingress access logging]
+
+// Specifying an alternative cluster domain using the appsDomain option
 include::modules/nw-ingress-configuring-application-domain.adoc[leveloffset=+2]
 
 include::modules/nw-ingress-converting-http-header-case.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OCPBUGS-33700](https://issues.redhat.com/browse/OCPBUGS-33700)

Link to docs preview:
* [Configuring the PROXY protocol for an Ingress Controller-Dedicated](https://78097--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/ingress-operator.html#nw-ingress-controller-configuration-proxy-protocol_configuring-ingress)
* [Configuring the PROXY protocol for an Ingress Controller-ROSA](https://78097--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ingress-operator.html#nw-ingress-controller-configuration-proxy-protocol_configuring-ingress)
* [Configuring the PROXY protocol for an Ingress Controller-Enterprise](https://78097--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-ingress-controller-configuration-proxy-protocol_configuring-ingress)

- [x] SME has approved this change.
- [x] QE has approved this change.
