### PR TITLE
OCPBUGS#25816: link to changing IAM account postinstall

### DIFF
--- a/modules/installation-aws-add-iam-roles.adoc
+++ b/modules/installation-aws-add-iam-roles.adoc
@@ -14,7 +14,7 @@ Instead of allowing the installation program to create IAM instance profiles wit
 
 .Procedure
 
-. Update `compute.platform.aws.iamRole` with an existing role for the control plane machines.
+. Update `compute.platform.aws.iamRole` with an existing role for the compute machines.
 +
 .Sample `install-config.yaml` file with an IAM role for compute instances
 [source,yaml]
@@ -26,7 +26,7 @@ compute:
     aws:
       iamRole: ExampleRole
 ----
-. Update `controlPlane.platform.aws.iamRole` with an existing role for the compute machines.
+. Update `controlPlane.platform.aws.iamRole` with an existing role for the control plane machines.
 +
 .Sample `install-config.yaml` file with an IAM role for control plane instances
 [source,yaml]
@@ -39,3 +39,8 @@ controlPlane:
       iamRole: ExampleRole
 ----
 . Save the file and reference it when installing the {product-title} cluster.
+
+[NOTE]
+====
+To change or update an IAM account after the cluster has been installed, see link:https://access.redhat.com/solutions/4284011[RHOCP 4 AWS cloud-credentials access key is expired] (Red{nbsp}Hat Knowledgebase).
+====


### PR DESCRIPTION
[OCPBUGS-25816](https://issues.redhat.com/browse/OCPBUGS-25816)

Versions: 4.12+

This PR adds a link to a KCS that describes how to change/update the IAM account for an AWS cluster after it has already been installed, since the docs only describe how to select an account during/before installation.

QE review:
- [x] QE has approved this change.

Preview: [Specifying an existing IAM role](https://78098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#specify-an-existing-iam-role_installing-aws-account)