### PR TITLE
Move attributes file so that RHOSP properly renders

### DIFF
--- a/registry/configuring_registry_storage/configuring-registry-storage-osp.adoc
+++ b/registry/configuring_registry_storage/configuring-registry-storage-osp.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="configuring-registry-storage-openstack"]
 = Configuring the registry for {rh-openstack}
-include::_attributes/common-attributes.adoc[]
 :context: configuring-registry-storage-openstack
 
 toc::[]


### PR DESCRIPTION
Attribute does not render because the link is located below the title. 

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-35954

Link to docs preview:
https://78108--ocpdocs-pr.netlify.app/openshift-enterprise/latest/registry/configuring_registry_storage/configuring-registry-storage-osp.html

QE is not needed.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
