### PR TITLE
Adds attribute for Cluster CAPI Operator

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -312,7 +312,9 @@ endif::openshift-origin[]
 :entra-short: Workload ID
 
 
-// Cluster API Providers
+// Cluster API terminology
+// Cluster CAPI Operator
+:cluster-capi-operator: Cluster CAPI Operator
 // Cluster API Provider Amazon Web Services (AWS)
 :cap-aws-first: Cluster API Provider Amazon Web Services (AWS)
 :cap-aws-short: Cluster API Provider AWS

--- a/machine_management/cluster_api_machine_management/cluster-api-about.adoc
+++ b/machine_management/cluster_api_machine_management/cluster-api-about.adoc
@@ -31,15 +31,15 @@ include::modules/capi-limitations.adoc[leveloffset=+2]
 [id="cluster-api-architecture_{context}"]
 == Cluster API architecture
 
-The {product-title} integration of the upstream Cluster API is implemented and managed by the Cluster CAPI Operator.
-The Cluster CAPI Operator and its operands are provisioned in the `openshift-cluster-api` namespace, in contrast to the Machine API, which uses the `openshift-machine-api` namespace.
+The {product-title} integration of the upstream Cluster API is implemented and managed by the {cluster-capi-operator}.
+The {cluster-capi-operator} and its operands are provisioned in the `openshift-cluster-api` namespace, in contrast to the Machine API, which uses the `openshift-machine-api` namespace.
 
-//The Cluster CAPI Operator
+//The {cluster-capi-operator}
 include::modules/capi-arch-operator.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../operators/operator-reference.adoc#cluster-capi-operator_cluster-operators-ref[Cluster CAPI Operator]
+* xref:../../operators/operator-reference.adoc#cluster-capi-operator_cluster-operators-ref[{cluster-capi-operator}]
 
 //Cluster API primary resources
 include::modules/capi-arch-resources.adoc[leveloffset=+2]

--- a/machine_management/cluster_api_machine_management/cluster-api-troubleshooting.adoc
+++ b/machine_management/cluster_api_machine_management/cluster-api-troubleshooting.adoc
@@ -12,7 +12,7 @@ include::snippets/technology-preview.adoc[]
 Use the information in this section to understand and recover from issues you might encounter.
 Generally, troubleshooting steps for problems with the Cluster API are similar to those steps for problems with the Machine API.
 
-The Cluster CAPI Operator and its operands are provisioned in the `openshift-cluster-api` namespace, whereas the Machine API uses the `openshift-machine-api` namespace. When using `oc` commands that reference a namespace, be sure to reference the correct one.
+The {cluster-capi-operator} and its operands are provisioned in the `openshift-cluster-api` namespace, whereas the Machine API uses the `openshift-machine-api` namespace. When using `oc` commands that reference a namespace, be sure to reference the correct one.
 
 //Returning the intended machines when using the CLI
 include::modules/ts-capi-cli-reference-intended-objects.adoc[leveloffset=+1]

--- a/modules/capi-arch-operator.adoc
+++ b/modules/capi-arch-operator.adoc
@@ -4,11 +4,11 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="capi-arch-operator_{context}"]
-= The Cluster CAPI Operator
+= The {cluster-capi-operator}
 
-The Cluster CAPI Operator is an {product-title} Operator that maintains the lifecycle of Cluster API resources.
+The {cluster-capi-operator} is an {product-title} Operator that maintains the lifecycle of Cluster API resources.
 This Operator is responsible for all administrative tasks related to deploying the Cluster API project within an {product-title} cluster.
 
-If a cluster is configured correctly to allow the use of the Cluster API, the Cluster CAPI Operator installs the Cluster API components on the cluster.
+If a cluster is configured correctly to allow the use of the Cluster API, the {cluster-capi-operator} installs the Cluster API components on the cluster.
 
-For more information, see the "Cluster CAPI Operator" entry in the _Cluster Operators reference_ content.
+For more information, see the "{cluster-capi-operator}" entry in the _Cluster Operators reference_ content.

--- a/modules/cco-short-term-creds-component-permissions-aws.adoc
+++ b/modules/cco-short-term-creds-component-permissions-aws.adoc
@@ -17,7 +17,7 @@ These permissions apply to all resources. Unless specified, there are no request
 |====
 |Component |Custom resource |Required permissions for services
 
-|Cluster CAPI Operator
+|{cluster-capi-operator}
 |`openshift-cluster-api-aws`
 |**EC2**
 

--- a/modules/cco-short-term-creds-component-permissions-azure.adoc
+++ b/modules/cco-short-term-creds-component-permissions-azure.adoc
@@ -24,7 +24,7 @@
 * `Microsoft.Network/publicIPAddresses/read`
 * `Microsoft.Network/publicIPAddresses/write`
 
-|Cluster CAPI Operator
+|{cluster-capi-operator}
 |`openshift-cluster-api-azure`
 |role: `Contributor` ^[1]^
 

--- a/modules/cluster-capi-operator.adoc
+++ b/modules/cluster-capi-operator.adoc
@@ -3,7 +3,7 @@
 // * operators/operator-reference.adoc
 
 [id="cluster-capi-operator_{context}"]
-= Cluster CAPI Operator
+= {cluster-capi-operator}
 
 [NOTE]
 ====
@@ -13,7 +13,7 @@ This Operator is available as a link:https://access.redhat.com/support/offerings
 [discrete]
 == Purpose
 
-The Cluster CAPI Operator maintains the lifecycle of Cluster API resources. This Operator is responsible for all administrative tasks related to deploying the Cluster API project within an {product-title} cluster.
+The {cluster-capi-operator} maintains the lifecycle of Cluster API resources. This Operator is responsible for all administrative tasks related to deploying the Cluster API project within an {product-title} cluster.
 
 [discrete]
 == Project

--- a/modules/mco-update-boot-images.adoc
+++ b/modules/mco-update-boot-images.adoc
@@ -17,7 +17,7 @@ This process could cause the following issues:
 * Certificate expiration issues
 * Version skew issues
 
-To avoid these issues, you can configure your cluster to update the boot image whenever you update your cluster. By modifying the `MachineConfiguration` object, you can enable this feature. Currently, the ability to update the boot image is available for only Google Cloud Platform (GCP) clusters and is not supported for Cluster CAPI Operator managed clusters.
+To avoid these issues, you can configure your cluster to update the boot image whenever you update your cluster. By modifying the `MachineConfiguration` object, you can enable this feature. Currently, the ability to update the boot image is available for only Google Cloud Platform (GCP) clusters and is not supported for {cluster-capi-operator} managed clusters.
 
 :FeatureName: The updating boot image feature
 include::snippets/technology-preview.adoc[]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
N/A

Link to docs preview:
- [Cluster API architecture](https://78112--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster-api-about#cluster-api-architecture_cluster-api-about)
- [Troubleshooting clusters that use the Cluster API](https://78112--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster-api-troubleshooting)
- [AWS component secret permissions requirements](https://78112--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-short-term-creds#cco-short-term-creds-component-permissions-aws_cco-short-term-creds)
- [Azure component secret permissions requirements](https://78112--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-short-term-creds#cco-short-term-creds-component-permissions-azure_cco-short-term-creds)
- [Cluster CAPI Operator](https://78112--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator-reference#cluster-capi-operator_cluster-operators-ref)
- [Updating boot images](https://78112--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks#mco-update-boot-images_post-install-machine-configuration-tasks)

QE review:
N/A

Additional information:
Prework so that Vale can enforce a rule to not use "CAPI" in docs.