### PR TITLE
OCPBUGS#35232: Moving vSphere vols not supported

### DIFF
--- a/modules/persistent-storage-csi-vsphere-limitations.adoc
+++ b/modules/persistent-storage-csi-vsphere-limitations.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
+//
+
+:content-type: CONCEPT
+[id="persistent-storage-csi-vsphere-limitations_{context}"]
+= vSphere CSI limitations
+
+The following limitations apply to the vSphere Container Storage Interface (CSI) Driver Operator:
+
+* The vSphere CSI Driver supports dynamic and static provisioning. However, when using static provisioning in the PV specifications, do not use the key `storage.kubernetes.io/csiProvisionerIdentity` in `csi.volumeAttributes` because this key indicates dynamically provisioned PVs.
+
+* Migrating persistent container volumes between datastores using the vSphere client interface is not supported with {product-title}.

--- a/storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
@@ -29,12 +29,9 @@ For new installations, {product-title} 4.13 and later provides automatic migrati
 CSI automatic migration should be seamless. Migration does not change how you use all existing API objects, such as persistent volumes, persistent volume claims, and storage classes.
 ====
 
-[NOTE]
-====
-The vSphere CSI Driver supports dynamic and static provisioning. When using static provisioning in the PV specifications, do not use the key `storage.kubernetes.io/csiProvisionerIdentity` in `csi.volumeAttributes` because this key indicates dynamically provisioned PVs.
-====
-
 include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
+
+include::modules/persistent-storage-csi-vsphere-limitations.adoc[leveloffset=+1]
 
 include::modules/persistent-storage-csi-vsphere-stor-policy.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-35232
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://78114--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-vsphere.html#persistent-storage-csi-vsphere-limitations_persistent-storage-csi-vsphere
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

**PTAL**: @gcharot @duanwei33 @gnufied 
