### PR TITLE
OSDOCS-10959: Fixed a DNS example in the Examples: IP management file

### DIFF
--- a/modules/virt-example-nmstate-IP-management.adoc
+++ b/modules/virt-example-nmstate-IP-management.adoc
@@ -116,20 +116,21 @@ metadata:
 spec:
   nodeSelector:
     kubernetes.io/hostname: <target_node>
-dns-resolver:
-  config:
-    search:
-    - example.com
-    - example.org
-    server:
-    - 2001:db8:f::1
-    - 192.0.2.251
+  desiredState:
+    dns-resolver:
+      config:
+        search:
+        - example.com
+        - example.org
+        server:
+        - 2001:db8:f::1
+        - 192.0.2.251
 # ...
 ----
 
 The following examples show situations that require configuring a network interface to store DNS values:
 
-* Configure a static DNS for a network interface with an automatic IP configuration. Note that for this configuration, you must set the `auto-dns` parameter to `false`, so that the Kubernetes NMState Operator can store custom DNS settings for the network interface. 
+* Configure a static DNS for a network interface with an automatic IP configuration. Note that for this configuration, you must set the `auto-dns` parameter to `false`, so that the Kubernetes NMState Operator can store custom DNS settings for the network interface.
 +
 [source,yaml]
 ----


### PR DESCRIPTION
Version(s):
4.13+

Issue:
[OSDOCS-10959](https://issues.redhat.com/browse/OSDOCS-10959)

Link to docs preview:
[DNS](https://78118--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#virt-example-nmstate-IP-management-dns_k8s_nmstate-updating-node-network-config)

- [x] SME has approved this change.
- [x] QE has approved this change.
