### PR TITLE
OSDOCS#10016: Turn OLMv1 ext support admon into snippet

### DIFF
--- a/modules/olmv1-installing-an-operator.adoc
+++ b/modules/olmv1-installing-an-operator.adoc
@@ -9,15 +9,7 @@
 
 {olmv1-first} supports installing cluster extensions, including {olmv0} Operators via the `registry+v1` bundle format, that are scoped to the cluster. You can install an extension from a catalog by creating a custom resource (CR) and applying it to the cluster.
 
-[IMPORTANT]
-====
-Currently, {olmv1} supports the installation of extensions that meet the following criteria:
-
-* The extension must use the `AllNamespaces` install mode.
-* The extension must not use webhooks.
-
-Cluster extensions that use webhooks or that target a single or specified set of namespaces cannot be installed.
-====
+include::snippets/olmv1-tp-extension-support.adoc[]
 
 .Prerequisite
 

--- a/snippets/olmv1-tp-extension-support.adoc
+++ b/snippets/olmv1-tp-extension-support.adoc
@@ -1,0 +1,17 @@
+// Text snippet included in the following modules:
+//
+// * modules/olmv1-installing-an-operator.adoc
+// * release_notes/ocp-4-16-release-notes.adoc (enteprise-4.16 branch only)
+// * release_notes/ocp-4-15-release-notes.adoc (enteprise-4.15 branch only)
+
+:_mod-docs-content-type: SNIPPET
+
+[IMPORTANT]
+====
+Currently, {olmv1} supports the installation of extensions that meet the following criteria:
+
+* The extension must use the `AllNamespaces` install mode.
+* The extension must not use webhooks.
+
+Cluster extensions that use webhooks or that target a single or specified set of namespaces cannot be installed.
+====


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-10016

4.15+

No QE needed

Preview: https://78128--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/olm_v1/olmv1-installing-an-operator-from-a-catalog.html#olmv1-installing-an-operator_olmv1-installing-operator 

NOTE: Only 1 `include::` in this PR, but planning to also re-use it in release notes on the 4.15 and 4.16 versioned branches (will be follow-up PRs to make the "Text snippet included in the following modules" list true).