### PR TITLE
OSSM-6713 [DOC] Installation and upgrade tasks for OSSM 2.6 release

### DIFF
--- a/modules/ossm-upgrade-25-26-changes.adoc
+++ b/modules/ossm-upgrade-25-26-changes.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+// * service_mesh/v2x/upgrading-ossm.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ossm-upgrade-25-26-changes_{context}"]
+= Upgrade changes from version 2.5 to version 2.6
+
+//Jaeger disabled by default goes in "Upgrading" and 2.6 Rel Notes
+== {JaegerName} default setting change
+
+This release disables {JaegerName} by default for new instances of the `ServiceMeshControlPlane` resource.
+
+When updating existing instances of the `ServiceMeshControlPlane` resource to {SMProductName} version 2.6, {JaegerShortName} remains enabled by default.
+
+{SMProductName} 2.6 is the last release that includes support for {JaegerName} and {es-op}. Both {JaegerShortName} and {es-op} will be removed in the next release. If you are currently using {JaegerShortName} and {es-op}, you must migrate to {TempoName} and {OTELName}.
+
+== Envoy sidecar container default setting change
+
+To enhance pod startup times, Istio now includes a `startupProbe` in sidecar containers by default. The pod's readiness probes do not start until the Envoy sidecar has started.

--- a/service_mesh/v2x/upgrading-ossm.adoc
+++ b/service_mesh/v2x/upgrading-ossm.adoc
@@ -36,6 +36,8 @@ Although you can deploy multiple versions of the control plane in the same clust
 
 For more information about migrating your extensions, refer to xref:../../service_mesh/v2x/ossm-extensions.adoc#ossm-extensions-migration-overview_ossm-extensions[Migrating from ServiceMeshExtension to WasmPlugin resources].
 
+include::modules/ossm-upgrade-25-26-changes.adoc[leveloffset=+2]
+
 include::modules/ossm-upgrade-24-25-changes.adoc[leveloffset=+2]
 
 include::modules/ossm-upgrade-23-24-changes.adoc[leveloffset=+2]


### PR DESCRIPTION
**OSSM 2.6**

[OSSM-6713](https://issues.redhat.com//browse/OSSM-6713) [DOC] Installation and upgrade tasks for OSSM 2.6 release

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSSM-6713

Link to docs preview:
https://78142--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/upgrading-ossm.html#ossm-upgrade-25-26-changes_ossm-upgrade

Reviews:
- [x] PM has approved this change.
- [x] Dev has approved this change. 
- [x] QE has approved this change.
- [x] OCP Doc Peer Review
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Reviews and dates added for quick reference of what PRs are where for OSSM 2.6.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
