### PR TITLE
RHDEVDOCS 6077 simple format fix for previous merge

### DIFF
--- a/snippets/ref-s2i-task.adoc
+++ b/snippets/ref-s2i-task.adoc
@@ -67,4 +67,4 @@ spec:
 * The parameter name `TLS_VERIFY` was changed to `TLSVERIFY`.
 * The `IMAGE_URL` result was added.
 
-:lang:
+:!lang:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
please cp to pipelines-docs-1.15

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
RHDEVDOCS 6077

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://78144--ocpdocs-pr.netlify.app/openshift-pipelines/latest/create/remote-pipelines-tasks-resolvers#resolver-cluster-tasks-ref_remote-pipelines-tasks-resolvers

QE review:
N/A
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
This is a simple fix - an attribute at the end of a snippet was set to empty instead of unset. The documentation text is not changed, so no SME nor QE review is necessary.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
