### PR TITLE
OSDOCS-9790: [rosa-] Issue in file rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc

### DIFF
--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
@@ -42,7 +42,10 @@ For a full list of the supported certificates, see the xref:../rosa_architecture
 
 The procedures in this document use the `auto` mode in the ROSA CLI to immediately create the required IAM resources using the current AWS account. The required resources include the account-wide IAM roles and policies, cluster-specific Operator roles and policies, and OpenID Connect (OIDC) identity provider.
 
-Alternatively, you can use `manual` mode, which outputs the `aws` commands needed to create the IAM resources instead of deploying them automatically. For steps to deploy a {hcp-title} cluster by using `manual` mode or with customizations, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-sts-creating-cluster-using-customizations_rosa-sts-creating-a-cluster-with-customizations[Creating a cluster using customizations].
+Alternatively, you can use `manual` mode, which outputs the `aws` commands needed to create the IAM resources instead of deploying them automatically.
+
+//Add this reference when the page is created for HCP.
+//For steps to deploy a {hcp-title} cluster with customizations, see xref:...
 
 [id="next-steps-hcp_{context}"]
 .Next steps


### PR DESCRIPTION
[OSDOCS-9790](https://issues.redhat.com//browse/OSDOCS-9790): [rosa-] Issue in file rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-9790

Link to docs preview:
https://78145--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html

QE review:
No QE needed.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
