### PR TITLE
OBSDOCS-1162

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2762,6 +2762,10 @@ Topics:
     Topics:
     - Name: Configuring CPU and memory limits for Logging components
       File: cluster-logging-memory
+    - Name: Using tolerations to control Logging pod placement
+      File: cluster-logging-tolerations
+    - Name: Moving logging subsystem resources with node selectors
+      File: cluster-logging-moving-nodes
     - Name: Configuring systemd-journald for Logging
       File: cluster-logging-systemd
   - Name: Log collection and forwarding

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -1265,6 +1265,10 @@ Topics:
     Topics:
     - Name: Configuring CPU and memory limits for Logging components
       File: cluster-logging-memory
+    - Name: Using tolerations to control Logging pod placement
+      File: cluster-logging-tolerations
+    - Name: Moving logging subsystem resources with node selectors
+      File: cluster-logging-moving-nodes
     #- Name: Configuring systemd-journald and Fluentd
     #  File: cluster-logging-systemd
   - Name: Log collection and forwarding

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1536,6 +1536,10 @@ Topics:
     Topics:
     - Name: Configuring CPU and memory limits for Logging components
       File: cluster-logging-memory
+    - Name: Using tolerations to control Logging pod placement
+      File: cluster-logging-tolerations
+    - Name: Moving logging subsystem resources with node selectors
+      File: cluster-logging-moving-nodes
     #- Name: Configuring systemd-journald and Fluentd
     #  File: cluster-logging-systemd
   - Name: Log collection and forwarding

--- a/modules/cluster-logging-collector.adoc
+++ b/modules/cluster-logging-collector.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/config/cluster-logging-tolerations.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="cluster-logging-collector_{context}"]
+= Using tolerations to control log collector pod placement
+
+You can ensure which nodes the logging collector pods run on and prevent
+other workloads from using those nodes by using tolerations on the pods.
+
+You apply tolerations to logging collector pods through the `ClusterLogging` custom resource (CR)
+and apply taints to a node through the node specification. You can use taints and tolerations
+to ensure the pod does not get evicted for things like memory and CPU issues.
+
+By default, the logging collector pods have the following toleration:
+
+[source,yaml]
+----
+tolerations:
+- key: "node-role.kubernetes.io/master"
+  operator: "Exists"
+  effect: "NoExecute"
+----
+
+.Prerequisites
+
+* {clo} and {es-op} must be installed.
+
+.Procedure
+
+. Use the following command to add a taint to a node where you want logging collector pods to schedule logging collector pods:
++
+[source,terminal]
+----
+$ oc adm taint nodes <node_name> <key>=<value>:<effect>
+----
++
+For example:
++
+[source,terminal]
+----
+$ oc adm taint nodes node1 collector=node:NoExecute
+----
++
+This example places a taint on `node1` that has key `collector`, value `node`, and taint effect `NoExecute`.
+You must use the `NoExecute` taint effect. `NoExecute` schedules only pods that match the taint and removes existing pods
+that do not match.
+
+. Edit the `collection` stanza of the `ClusterLogging` custom resource (CR) to configure a toleration for the logging collector pods:
++
+[source,yaml]
+----
+  collection:
+    logs:
+      type: "fluentd"
+      fluentd:
+        tolerations:
+        - key: "collector"  <1>  
+          operator: "Exists"    <2> 
+          effect: "NoExecute"   <3>  
+          tolerationSeconds: 6000   <4>  
+----
+<1> Specify the key that you added to the node.
+<2> Specify the `Exists` operator to require the `key`/`value`/`effect` parameters to match.
+<3> Specify the `NoExecute` effect.
+<4> Optionally, specify the `tolerationSeconds` parameter to set how long a pod can remain bound to a node before being evicted.
+
+This toleration matches the taint created by the `oc adm taint` command. A pod with this toleration would be able to schedule onto `node1`.

--- a/modules/cluster-logging-elasticsearch-tolerations.adoc
+++ b/modules/cluster-logging-elasticsearch-tolerations.adoc
@@ -1,0 +1,70 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/config/cluster-logging-tolerations.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="cluster-logging-elasticsearch-tolerations_{context}"]
+= Using tolerations to control log store pod placement
+
+You can control which nodes the log store pods runs on and prevent
+other workloads from using those nodes by using tolerations on the pods.
+
+You apply tolerations to the log store pods through the `ClusterLogging` custom resource (CR)
+and apply taints to a node through the node specification. A taint on a node is a `key:value pair` that
+instructs the node to repel all pods that do not tolerate the taint. Using a specific `key:value` pair
+that is not on other pods ensures only the log store pods can run on that node.
+
+By default, the log store pods have the following toleration:
+
+[source,yaml]
+----
+tolerations:
+- effect: "NoExecute"
+  key: "node.kubernetes.io/disk-pressure"
+  operator: "Exists"
+----
+
+.Prerequisites
+
+* {clo} and {es-op} must be installed.
+
+.Procedure
+
+. Use the following command to add a taint to a node where you want to schedule the OpenShift Logging pods:
++
+[source,terminal]
+----
+$ oc adm taint nodes <node_name> <key>=<value>:<effect>
+----
++
+For example:
++
+[source,terminal]
+----
+$ oc adm taint nodes node1 elasticsearch=node:NoExecute
+----
++
+This example places a taint on `node1` that has key `elasticsearch`, value `node`, and taint effect `NoExecute`.
+Nodes with the `NoExecute` effect schedule only pods that match the taint and remove existing pods
+that do not match.
+
+. Edit the `logstore` section of the `ClusterLogging` CR to configure a toleration for the Elasticsearch pods:
++
+[source,yaml]
+----
+  logStore:
+    type: "elasticsearch"
+    elasticsearch:
+      nodeCount: 1
+      tolerations:
+      - key: "elasticsearch"  <1>
+        operator: "Exists"  <2>
+        effect: "NoExecute"  <3>
+        tolerationSeconds: 6000  <4>
+----
+<1> Specify the key that you added to the node.
+<2> Specify the `Exists` operator to require a taint with the key `elasticsearch` to be present on the Node.
+<3> Specify the `NoExecute` effect.
+<4> Optionally, specify the `tolerationSeconds` parameter to set how long a pod can remain bound to a node before being evicted.
+
+This toleration matches the taint created by the `oc adm taint` command. A pod with this toleration could be scheduled onto `node1`.

--- a/modules/cluster-logging-kibana-tolerations.adoc
+++ b/modules/cluster-logging-kibana-tolerations.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/config/cluster-logging-tolerations.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="cluster-logging-kibana-tolerations_{context}"]
+= Using tolerations to control log visualizer pod placement
+
+You can control the node where the log visualizer pod runs and prevent
+other workloads from using those nodes by using tolerations on the pods.
+
+You apply tolerations to the log visualizer pod through the `ClusterLogging` custom resource (CR)
+and apply taints to a node through the node specification. A taint on a node is a `key:value pair` that
+instructs the node to repel all pods that do not tolerate the taint. Using a specific `key:value` pair
+that is not on other pods ensures only the Kibana pod can run on that node.
+
+.Prerequisites
+
+* {clo} and {es-op} must be installed.
+
+.Procedure
+
+. Use the following command to add a taint to a node where you want to schedule the log visualizer pod:
++
+[source,terminal]
+----
+$ oc adm taint nodes <node_name> <key>=<value>:<effect>
+----
++
+For example:
++
+[source,terminal]
+----
+$ oc adm taint nodes node1 kibana=node:NoExecute
+----
++
+This example places a taint on `node1` that has key `kibana`, value `node`, and taint effect `NoExecute`.
+You must use the `NoExecute` taint effect. `NoExecute` schedules only pods that match the taint and remove existing pods
+that do not match.
+
+. Edit the `visualization` section of the `ClusterLogging` CR to configure a toleration for the Kibana pod:
++
+[source,yaml]
+----
+  visualization:
+    type: "kibana"
+    kibana:
+      tolerations:
+      - key: "kibana"   <1>  
+        operator: "Exists"  <2>  
+        effect: "NoExecute" <3>  
+        tolerationSeconds: 6000 <4> 
+----
+<1> Specify the key that you added to the node.
+<2> Specify the `Exists` operator to require the `key`/`value`/`effect` parameters to match.
+<3> Specify the `NoExecute` effect.
+<4> Optionally, specify the `tolerationSeconds` parameter to set how long a pod can remain bound to a node before being evicted.
+
+This toleration matches the taint created by the `oc adm taint` command. A pod with this toleration would be able to schedule onto `node1`.
+
+

--- a/modules/infrastructure-moving-logging.adoc
+++ b/modules/infrastructure-moving-logging.adoc
@@ -1,0 +1,232 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/config/cluster-logging-moving-nodes.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="infrastructure-moving-logging_{context}"]
+= Moving OpenShift Logging resources
+
+You can configure the Cluster Logging Operator to deploy the pods for OpenShift Logging components, such as Elasticsearch and Kibana, to different nodes. You cannot move the Cluster Logging Operator pod from its installed location.
+
+For example, you can move the Elasticsearch pods to a separate node because of high CPU, memory, and disk requirements.
+
+.Prerequisites
+
+* {clo} and {es-op} must be installed. These features are not installed by default.
+
+.Procedure
+
+. Edit the `ClusterLogging` custom resource (CR) in the `openshift-logging` project:
++
+[source,terminal]
+----
+$ oc edit ClusterLogging instance
+----
++
+[source,yaml]
+----
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogging
+
+...
+
+spec:
+  collection:
+    logs:
+      fluentd:
+        resources: null
+      type: fluentd
+  logStore:
+    elasticsearch:
+      nodeCount: 3
+      nodeSelector: <1>
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        value: reserved
+      - effect: NoExecute
+        key: node-role.kubernetes.io/infra
+        value: reserved
+      redundancyPolicy: SingleRedundancy
+      resources:
+        limits:
+          cpu: 500m
+          memory: 16Gi
+        requests:
+          cpu: 500m
+          memory: 16Gi
+      storage: {}
+    type: elasticsearch
+  managementState: Managed
+  visualization:
+    kibana:
+      nodeSelector: <1>
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        value: reserved
+      - effect: NoExecute
+        key: node-role.kubernetes.io/infra
+        value: reserved
+      proxy:
+        resources: null
+      replicas: 1
+      resources: null
+    type: kibana
+
+...
+----
+<1> Add a `nodeSelector` parameter with the appropriate value to the component you want to move. You can use a `nodeSelector` in the format shown or use `<key>: <value>` pairs, based on the value specified for the node. If you added a taint to the infrasructure node, also add a matching toleration.
+
+.Verification
+
+To verify that a component has moved, you can use the `oc get pod -o wide` command.
+
+For example:
+
+* You want to move the Kibana pod from the `ip-10-0-147-79.us-east-2.compute.internal` node:
++
+[source,terminal]
+----
+$ oc get pod kibana-5b8bdf44f9-ccpq9 -o wide
+----
++
+.Example output
+[source,terminal]
+----
+NAME                      READY   STATUS    RESTARTS   AGE   IP            NODE                                        NOMINATED NODE   READINESS GATES
+kibana-5b8bdf44f9-ccpq9   2/2     Running   0          27s   10.129.2.18   ip-10-0-147-79.us-east-2.compute.internal   <none>           <none>
+----
+
+* You want to move the Kibana pod to the `ip-10-0-139-48.us-east-2.compute.internal` node, a dedicated infrastructure node:
++
+[source,terminal]
+----
+$ oc get nodes
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                         STATUS   ROLES          AGE   VERSION
+ip-10-0-133-216.us-east-2.compute.internal   Ready    master         60m   v1.21.0
+ip-10-0-139-146.us-east-2.compute.internal   Ready    master         60m   v1.21.0
+ip-10-0-139-192.us-east-2.compute.internal   Ready    worker         51m   v1.21.0
+ip-10-0-139-241.us-east-2.compute.internal   Ready    worker         51m   v1.21.0
+ip-10-0-147-79.us-east-2.compute.internal    Ready    worker         51m   v1.21.0
+ip-10-0-152-241.us-east-2.compute.internal   Ready    master         60m   v1.21.0
+ip-10-0-139-48.us-east-2.compute.internal    Ready    infra          51m   v1.21.0
+----
++
+Note that the node has a `node-role.kubernetes.io/infra: ''` label:
++
+[source,terminal]
+----
+$ oc get node ip-10-0-139-48.us-east-2.compute.internal -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+kind: Node
+apiVersion: v1
+metadata:
+  name: ip-10-0-139-48.us-east-2.compute.internal
+  selfLink: /api/v1/nodes/ip-10-0-139-48.us-east-2.compute.internal
+  uid: 62038aa9-661f-41d7-ba93-b5f1b6ef8751
+  resourceVersion: '39083'
+  creationTimestamp: '2020-04-13T19:07:55Z'
+  labels:
+    node-role.kubernetes.io/infra: ''
+...
+----
+
+* To move the Kibana pod, edit the `ClusterLogging` CR to add a node selector:
++
+[source,yaml]
+----
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogging
+
+...
+
+spec:
+
+...
+
+  visualization:
+    kibana:
+      nodeSelector: <1>
+        node-role.kubernetes.io/infra: ''
+      proxy:
+        resources: null
+      replicas: 1
+      resources: null
+    type: kibana
+----
+<1> Add a node selector to match the label in the node specification.
+
+* After you save the CR, the current Kibana pod is terminated and new pod is deployed:
++
+[source,terminal]
+----
+$ oc get pods
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                            READY   STATUS        RESTARTS   AGE
+cluster-logging-operator-84d98649c4-zb9g7       1/1     Running       0          29m
+elasticsearch-cdm-hwv01pf7-1-56588f554f-kpmlg   2/2     Running       0          28m
+elasticsearch-cdm-hwv01pf7-2-84c877d75d-75wqj   2/2     Running       0          28m
+elasticsearch-cdm-hwv01pf7-3-f5d95b87b-4nx78    2/2     Running       0          28m
+fluentd-42dzz                                   1/1     Running       0          28m
+fluentd-d74rq                                   1/1     Running       0          28m
+fluentd-m5vr9                                   1/1     Running       0          28m
+fluentd-nkxl7                                   1/1     Running       0          28m
+fluentd-pdvqb                                   1/1     Running       0          28m
+fluentd-tflh6                                   1/1     Running       0          28m
+kibana-5b8bdf44f9-ccpq9                         2/2     Terminating   0          4m11s
+kibana-7d85dcffc8-bfpfp                         2/2     Running       0          33s
+----
+
+* The new pod is on the `ip-10-0-139-48.us-east-2.compute.internal` node:
++
+[source,terminal]
+----
+$ oc get pod kibana-7d85dcffc8-bfpfp -o wide
+----
++
+.Example output
+[source,terminal]
+----
+NAME                      READY   STATUS        RESTARTS   AGE   IP            NODE                                        NOMINATED NODE   READINESS GATES
+kibana-7d85dcffc8-bfpfp   2/2     Running       0          43s   10.131.0.22   ip-10-0-139-48.us-east-2.compute.internal   <none>           <none>
+----
+
+* After a few moments, the original Kibana pod is removed.
++
+[source,terminal]
+----
+$ oc get pods
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                            READY   STATUS    RESTARTS   AGE
+cluster-logging-operator-84d98649c4-zb9g7       1/1     Running   0          30m
+elasticsearch-cdm-hwv01pf7-1-56588f554f-kpmlg   2/2     Running   0          29m
+elasticsearch-cdm-hwv01pf7-2-84c877d75d-75wqj   2/2     Running   0          29m
+elasticsearch-cdm-hwv01pf7-3-f5d95b87b-4nx78    2/2     Running   0          29m
+fluentd-42dzz                                   1/1     Running   0          29m
+fluentd-d74rq                                   1/1     Running   0          29m
+fluentd-m5vr9                                   1/1     Running   0          29m
+fluentd-nkxl7                                   1/1     Running   0          29m
+fluentd-pdvqb                                   1/1     Running   0          29m
+fluentd-tflh6                                   1/1     Running   0          29m
+kibana-7d85dcffc8-bfpfp                         2/2     Running   0          62s
+----

--- a/observability/logging/config/cluster-logging-moving-nodes.adoc
+++ b/observability/logging/config/cluster-logging-moving-nodes.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="cluster-logging-moving-nodes"]
+= Moving {logging} resources with node selectors
+:context: cluster-logging-moving
+
+toc::[]
+
+You can use node selectors to deploy the Elasticsearch and Kibana pods to different nodes.
+
+include::modules/infrastructure-moving-logging.adoc[leveloffset=+1]

--- a/observability/logging/config/cluster-logging-tolerations.adoc
+++ b/observability/logging/config/cluster-logging-tolerations.adoc
@@ -1,0 +1,103 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+[id="cluster-logging-tolerations"]
+= Using tolerations to control OpenShift Logging pod placement
+:context: cluster-logging-tolerations
+
+toc::[]
+
+You can use taints and tolerations to ensure that {logging} pods run
+on specific nodes and that no other workload can run on those nodes.
+
+Taints and tolerations are simple `key:value` pair. A taint on a node
+instructs the node to repel all pods that do not tolerate the taint.
+
+The `key` is any string, up to 253 characters and the `value` is any string up to 63 characters.
+The string must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
+
+.Sample {logging} CR with tolerations
+[source,yaml]
+----
+apiVersion: "logging.openshift.io/v1"
+kind: "ClusterLogging"
+metadata:
+  name: "instance"
+  namespace: openshift-logging
+...
+spec:
+  managementState: "Managed"
+  logStore:
+    type: "elasticsearch"
+    elasticsearch:
+      nodeCount: 3
+      tolerations: <1>
+      - key: "logging"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 6000
+      resources:
+        limits:
+          memory: 16Gi
+        requests:
+          cpu: 200m
+          memory: 16Gi
+      storage: {}
+      redundancyPolicy: "ZeroRedundancy"
+  visualization:
+    type: "kibana"
+    kibana:
+      tolerations: <2>
+      - key: "logging"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 6000
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: 100m
+          memory: 1Gi
+      replicas: 1
+  collection:
+    logs:
+      type: "fluentd"
+      fluentd:
+        tolerations: <3>
+        - key: "logging"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 6000
+        resources:
+          limits:
+            memory: 2Gi
+          requests:
+            cpu: 100m
+            memory: 1Gi
+----
+
+<1> This toleration is added to the Elasticsearch pods.
+<2> This toleration is added to the Kibana pod.
+<3> This toleration is added to the logging collector pods.
+
+// The following include statements pull in the module files that comprise
+// the assembly. Include any combination of concept, procedure, or reference
+// modules required to cover the user story. You can also include other
+// assemblies.
+
+include::modules/cluster-logging-elasticsearch-tolerations.adoc[leveloffset=+1]
+
+include::modules/cluster-logging-kibana-tolerations.adoc[leveloffset=+1]
+
+include::modules/cluster-logging-collector.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="cluster-logging-tolerations-addtl-resources"]
+== Additional resources
+
+ifdef::openshift-enterprise,openshift-origin[]
+* xref:../../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations[Controlling pod placement using node taints].
+endif::[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* link:https://docs.openshift.com/container-platform/latest/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations[Controlling pod placement using node taints].
+endif::[]


### PR DESCRIPTION
[OBSDOCS-1162](https://issues.redhat.com/browse/OBSDOCS-1162): How to configure nodeSelector and tolerations for Elasticsearch
Aligned team: Observability
OCP version for cherry-picking: 4.12+
JIRA issues: [OBSDOCS-1162](https://issues.redhat.com/browse/OBSDOCS-1162)

Preview pages: 
https://78156--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/config/cluster-logging-tolerations.html
https://78156--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/config/cluster-logging-moving-nodes.html

SME review **requested**: @r2d2rnd
QE review **requested**: 
Peer review **requested**: 

Note: We need to have @libander peer review also here.

