### PR TITLE
OCPBUGS-35909:Updated the OVNK add network section with note about de…

### DIFF
--- a/networking/multiple_networks/configuring-additional-network.adoc
+++ b/networking/multiple_networks/configuring-additional-network.adoc
@@ -92,13 +92,13 @@ spec:
     type: Raw
 ----
 <1> An array of one or more additional network configurations.
-
-<2> The name for the additional network attachment that you are
-creating. The name must be unique within the specified `namespace`.
-
-<3> The namespace to create the network attachment in. If
-you do not specify a value, then the `default` namespace is used.
-
+<2> The name for the additional network attachment that you are creating. The name must be unique within the specified `namespace`.
+<3> The namespace to create the network attachment in. If you do not specify a value then the `default` namespace is used.
++
+[IMPORTANT]
+====
+To prevent namespace issues for the OVN-Kubernetes network plugin, do not name your additional network attachment `default`, because this namespace is reserved for the `default` additional network attachment.
+====
 <4> A CNI plugin configuration in JSON format.
 
 [id="{context}_configuration-additional-network-yaml"]


### PR DESCRIPTION
Version(s):
4.13+

Issue:
[OCPBUGS-35909](https://issues.redhat.com/browse/OCPBUGS-35909)

Link to docs preview:
[Configuration of an additional network through the Cluster Network Operator](https://78160--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html#configuring-additional-network_configuration-additional-network-cno)

- [x] SME has approved this change.
- [x] QE has approved this change.

Requested a review in the forum-ocp-sdn channel.

