### PR TITLE
OSDOCS-10601: Updates to Custom admin group access for netobserv

### DIFF
--- a/modules/logging-loki-log-access.adoc
+++ b/modules/logging-loki-log-access.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * network_observability/installing-operators.adoc
+// * observability/network_observability/installing-operators.adoc
 // * logging/cluster-logging-loki.adoc
 
 :_mod-docs-content-type: CONCEPT
@@ -74,7 +74,21 @@ subjects:
 // tag::CustomAdmin[]
 == Custom admin group access
 
-If you have a large deployment with a number of users who require broader permissions, you can create a custom group using the `adminGroup` field. Users who are members of any group specified in the `adminGroups` field of the `LokiStack` CR are considered admins. Admin users have access to all application logs in all namespaces, if they also get assigned the `cluster-logging-application-view` role.
+// tag::LokiMode[]
+If you have a large deployment with several users who require broader permissions, you can create a custom group using the `adminGroup` field. Users who are members of any group specified in the `adminGroups` field of the `LokiStack` CR are considered administrators. 
+// end::LokiMode[]
+
+// tag::NetObservMode[]
+If you need to see cluster-wide logs without necessarily being an administrator, or if you already have any group defined that you want to use here, you can specify a custom group using the `adminGroup` field. Users who are members of any group specified in the `adminGroups` field of the `LokiStack` custom resource (CR) have the same read access to logs as administrators. 
+// end::NetObservMode[]
+
+// tag::LokiMode[] 
+Administrator users have access to all application logs in all namespaces, if they also get assigned the `cluster-logging-application-view` role.
+// end::LokiMode[]
+
+// tag::NetObservMode[]
+Administrator users have access to all network logs across the cluster.
+// end::NetObservMode[]
 
 .Example LokiStack CR
 [source,yaml]
@@ -82,8 +96,14 @@ If you have a large deployment with a number of users who require broader permis
 apiVersion: loki.grafana.com/v1
 kind: LokiStack
 metadata:
+# tag::LokiMode[]
   name: logging-loki
   namespace: openshift-logging
+# end::LokiMode[]
+# tag::NetObservMode[]
+  name: loki
+  namespace: netobserv
+# end::NetObservMode[]
 spec:
   tenants:
 # tag::LokiMode[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-10601
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
