### PR TITLE
OSDOCS-10369:Add info on CPMS to OSD/ROSA docs.

### DIFF
--- a/architecture/control-plane.adoc
+++ b/architecture/control-plane.adoc
@@ -68,6 +68,12 @@ endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/etcd-overview.adoc[leveloffset=+1]
 
+// These modules only apply to ROSA/OSD
+ifdef::openshift-dedicated,openshift-rosa[]
+include::modules/cpmso-feat-auto-update.adoc[leveloffset=+1]
+include::modules/cpmso-control-plane-recovery.adoc[leveloffset=+1]
+endif::openshift-dedicated,openshift-rosa[]
+
 // These xrefs do not apply to OSD/ROSA
 ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]

--- a/modules/cpmso-control-plane-recovery.adoc
+++ b/modules/cpmso-control-plane-recovery.adoc
@@ -1,6 +1,13 @@
 // Module included in the following assemblies:
 //
 // * machine_management/cpmso-resiliency.adoc
+// * rosa/architecture/control-plane.adoc
+// * osd/architecture/control-plane.adoc
+
+ifeval::["{context}" == "control-plane"]
+:rosa-classic:
+:osd:
+endif::[]
 
 :_mod-docs-content-type: CONCEPT
 [id="cpmso-control-plane-recovery_{context}"]
@@ -8,6 +15,7 @@
 
 The Control Plane Machine Set Operator automates the recovery of control plane machines. When a control plane machine is deleted, the Operator creates a replacement with the configuration that is specified in the `ControlPlaneMachineSet` custom resource (CR).
 
+ifndef::openshift-dedicated,openshift-rosa[]
 For clusters that use control plane machine sets, you can configure a machine health check. The machine health check deletes unhealthy control plane machines so that they are replaced.
 
 [IMPORTANT]
@@ -18,3 +26,9 @@ This configuration ensures that the machine health check takes no action when mu
 
 If the etcd cluster is degraded, manual intervention might be required. If a scaling operation is in progress, the machine health check should allow it to finish.
 ====
+endif::openshift-dedicated,openshift-rosa[]
+
+ifeval::["{context}" == "control-plane"]
+:!rosa-classic:
+:!osd:
+endif::[]

--- a/modules/cpmso-feat-auto-update.adoc
+++ b/modules/cpmso-feat-auto-update.adoc
@@ -1,13 +1,49 @@
 // Module included in the following assemblies:
 //
 // * machine_management/control_plane_machine_management/cpmso-managing-machines.adoc
+// * rosa/architecture/control-plane.adoc
+// * osd/architecture/control-plane.adoc
+
+ifeval::["{context}" == "control-plane"]
+:rosa-classic:
+:osd:
+endif::[]
 
 :_mod-docs-content-type: CONCEPT
 [id="cpmso-feat-auto-update_{context}"]
 = Automatic updates to the control plane configuration
+//Not for ROSA/OSD:
+ifndef::openshift-dedicated,openshift-rosa[]
+The `RollingUpdate` update strategy automatically propagates changes to your control plane configuration.
+This update strategy is the default configuration for the control plane machine set.
 
-The `RollingUpdate` update strategy automatically propagates changes to your control plane configuration. This update strategy is the default configuration for the control plane machine set.
-
-For clusters that use the `RollingUpdate` update strategy, the Operator creates a replacement control plane machine with the configuration that is specified in the CR. When the replacement control plane machine is ready, the Operator deletes the control plane machine that is marked for replacement. The replacement machine then joins the control plane.
+For clusters that use the `RollingUpdate` update strategy, the Operator creates a replacement control plane machine with the configuration that is specified in the CR.
+When the replacement control plane machine is ready, the Operator deletes the control plane machine that is marked for replacement.
+The replacement machine then joins the control plane.
 
 If multiple control plane machines are marked for replacement, the Operator protects etcd health during replacement by repeating this replacement process one machine at a time until it has replaced each machine.
+endif::openshift-dedicated,openshift-rosa[]
+
+//For ROSA/OSD:
+ifdef::openshift-dedicated,openshift-rosa[]
+
+On {product-title} clusters, control plane machine sets automatically propagate changes to your control plane configuration.
+When a control plane machine needs to be replaced, the Control Plane Machine Set Operator creates a replacement machine based on the configuration specified by the `ControlPlaneMachineSet` custom resource (CR). When the new control plane machine is ready, the Operator safely drains and terminates the old control plane machine in a way that mitigates any potential negative effects on cluster API or workload availability.
+
+[IMPORTANT]
+====
+You cannot request that control plane machine replacements happen only during maintenance windows. The Control Plane Machine Set Operator acts to ensure cluster stability. Waiting for a maintenance window could result in cluster stability being compromised.
+====
+
+A control plane machine can be marked for replacement at any time, typically because the machine has fallen out of spec or entered an unhealthy state. Such replacements are a normal part of a cluster's lifecycle and not a cause for concern. SRE will be alerted to the issue automatically if any part of a control plane node replacement fails.
+
+[NOTE]
+====
+Depending on when the {product-title} cluster was originally created, the introduction of control plane machine sets might leave one or two control plane nodes with labels or machine names that are inconsistent with the other control plane nodes. For example `clustername-master-0`, `clustername-master-1`,and `clustername-master-2-abcxyz`. Such naming inconsistencies do not affect the workings of the cluster and are not a cause for concern.
+====
+endif::openshift-dedicated,openshift-rosa[]
+
+ifeval::["{context}" == "control-plane"]
+:!rosa-classic:
+:!osd:
+endif::[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+

Issue:
[OSDOCS-10369](https://issues.redhat.com/browse/OSDOCS-10369)

Link to docs preview:

ROSA Docs:
[Automatic updates to the control plane configuration](https://78165--ocpdocs-pr.netlify.app/openshift-rosa/latest/architecture/control-plane.html#cpmso-feat-auto-update_control-plane)

OSD Docs:
[Automatic updates to the control plane configuration](https://78165--ocpdocs-pr.netlify.app/openshift-dedicated/latest/architecture/control-plane.html#cpmso-feat-auto-update_control-plane)

OCP Docs:
[Automatic updates to the control plane configuration](https://78165--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-managing-machines#cpmso-feat-auto-update_cpmso-managing-machines)

Peer review:
- [x] Peer reviewer has approved this change.

SME review:
- [x] SME has approved this change.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
