### PR TITLE
s/access.redhat/docs.redhat in build_for_portal.py

### DIFF
--- a/build_for_portal.py
+++ b/build_for_portal.py
@@ -25,7 +25,7 @@ cli.init_logging(False, True)
 
 list_of_errors = []
 CLONE_DIR = "."
-BASE_PORTAL_URL = "https://access.redhat.com/documentation/en-us/"
+BASE_PORTAL_URL = "https://docs.redhat.com/en-us/documentation"
 # ID_RE = re.compile("^\[(?:\[|id=\'|#)(.*?)(\'?,.*?)?(?:\]|\')?\]", re.M | re.DOTALL)
 ID_RE = re.compile(
     "^\[(?:\[|id='|#|id=\")(.*?)('?,.*?)?(?:\]|'|\")?\]", re.M | re.DOTALL


### PR DESCRIPTION
Since access.redhat.com links are redirecting to docs.redhat.com, and some of those are behaving poorly in the 4.16 content, we should change this in source.