### PR TITLE
[enterprise-4.15] Turn OLMv1 ext support admon into snippet

### DIFF
--- a/modules/olmv1-installing-an-operator.adoc
+++ b/modules/olmv1-installing-an-operator.adoc
@@ -9,15 +9,7 @@
 
 {olmv1-first} supports installing Operators and extensions scoped to the cluster. You can install an Operator or extension from a catalog by creating a custom resource (CR) and applying it to the cluster.
 
-[IMPORTANT]
-====
-Currently, {olmv1} supports the installation Operators and extensions that meet the following criteria:
-
-* The Operator or extension must use the `AllNamespaces` install mode.
-* The Operator or extension must not use webhooks.
-
-Operators and extensions that use webhooks or that target a single or specified set of namespaces cannot be installed.
-====
+include::snippets/olmv1-tp-extension-support.adoc[]
 
 .Prerequisite
 

--- a/snippets/olmv1-tp-extension-support.adoc
+++ b/snippets/olmv1-tp-extension-support.adoc
@@ -1,0 +1,17 @@
+// Text snippet included in the following modules:
+//
+// * modules/olmv1-installing-an-operator.adoc
+// * release_notes/ocp-4-16-release-notes.adoc (enteprise-4.16 branch only)
+// * release_notes/ocp-4-15-release-notes.adoc (enteprise-4.15 branch only)
+
+:_mod-docs-content-type: SNIPPET
+
+[IMPORTANT]
+====
+Currently, {olmv1} supports the installation of Operators and extensions that meet the following criteria:
+
+* The Operator or extension must use the `AllNamespaces` install mode.
+* The Operator or extension must not use webhooks.
+
+Operators or extensions that use webhooks or that target a single or specified set of namespaces cannot be installed.
+====


### PR DESCRIPTION
Manual 4.15 cp of https://github.com/openshift/openshift-docs/pull/78128, which conflicted because in 4.15 we had yet to change instances of "Operators or extensions" to simply "cluster extensions" or just "extensions". Tweaks the snippet slightly for just this 4.15 branch to keep things as they were there.