### PR TITLE
PR for SRVCOM-2979: Added a note about Eventing monitoring dashboards in ODC developer view in 1.33 Openshift Serverless release notes

### DIFF
--- a/modules/serverless-rn-1-33-0.adoc
+++ b/modules/serverless-rn-1-33-0.adoc
@@ -18,10 +18,12 @@
 * {ServerlessProductName} now uses Knative for Apache Kafka 1.12.
 * The `kn func` CLI plugin now uses `func` 1.14.
 
-* OpenShift Serverless on ARM64 is now available as Technology Preview.
+* {ServerlessProductName} on ARM64 is now available as Technology Preview.
 * The `NamespacedKafka` annotation is now deprecated. Use the standard Kafka broker without data plane isolation instead.
 
 * When enabling the automatic `EventType` auto-creation, you can now easily discover events available within the cluster. This functionality is available as a Developer Preview.
+
+* You can now explore the Knative Eventing monitoring dashboards directly within the *Observe* tab of the developer view in the OpenShift Developer Console.
 
 * You can now use the Custom Metrics Autoscaler Operator to autoscale Knative Eventing sources for Apache Kafka sources, defined by a `KafkaSource` object. This functionality is available as a Technology Preview feature, offering enhanced scalability and efficiency for Kafka-based event sources within Knative Eventing.
 


### PR DESCRIPTION
**Affected versions for cherry-picking**: `serverless-docs-1.33`

**Tracking JIRA**: https://issues.redhat.com/browse/SRVCOM-2979

**Doc previews**: [Serverless 1.33.0 release notes](https://78193--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-rn-1-33-0_serverless-release-notes)

**`Note: This PR will go through the change management process.`** 