### PR TITLE
[enterprise-4.16] OSDOCS#10016: Add OLMv1 ext install admon to 4.16 RN

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -995,6 +995,8 @@ This API still streamlines management of installed extensions, which includes Op
 
 For more information, see xref:../operators/olm_v1/arch/olmv1-operator-controller.adoc#olmv1-operator-controller[Operator Controller].
 
+include::snippets/olmv1-tp-extension-support.adoc[]
+
 [id="ocp-4-16-olm-improved-status-conditions_{context}"]
 ==== Improved status condition messages and deprecation notices for cluster extensions in {olmv1-first} (Technology Preview)
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-10016

4.16

(4.15 version of the same change = https://github.com/openshift/openshift-docs/pull/78195)

No QE needed.

Find a spot to include this admonition snippet in 4.16 RN.

Preview: https://78194--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-olmv1-ce-rename_release-notes 

No CM needed, simply adding this existing admonition to another spot for visibility.