### PR TITLE
[enterprise-4.15] OSDOCS#10016: Add OLMv1 ext install admon to 4.15 RN

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -858,6 +858,9 @@ The Catalog API now uses an HTTP service to serve catalog content on the cluster
 include::snippets/olmv1-cli-only.adoc[]
 
 For more information, see xref:../operators/olm_v1/index.adoc#olmv1-about[About Operator Lifecycle Manager 1.0].
+
+include::snippets/olmv1-tp-extension-support.adoc[]
+
 //
 //[id="ocp-4-15-osdk"]
 //=== Operator development


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-10016

4.15

(4.16 version of the same change = https://github.com/openshift/openshift-docs/pull/78194)

No QE needed.

Find a spot to include this admonition snippet in 4.15 RN.

Preview: https://78195--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-olmv1

No CM needed, simply adding this existing admonition to another spot for visibility.