### PR TITLE
PR for SRVCOM-3164: Remove the TP note about "Go function container" from the 1.32 Serverless release notes

### DIFF
--- a/modules/serverless-rn-1-32-0.adoc
+++ b/modules/serverless-rn-1-32-0.adoc
@@ -26,8 +26,6 @@ See link:https://openshift-knative.github.io/docs/docs/latest/serverless-logic/a
 
 * {FunctionsProductName} now supports {pipelines-shortname} versions from `1.10` till `1.14` (latest). The older versions of {pipelines-shortname} are no longer compatible with {FunctionsProductName}. 
 
-* {FunctionsProductName} now supports Go function container and is now available as a Technology Preview (TP) feature.
-
 * On-cluster function building, including using {pac} is now supported on IBM zSystems (s390x) and IBM Power (ppc64le) on {rh-storage} storage only.
 
 * You can now subscribe a function to a set of events by using the `func subscribe` command. This links your function to `CloudEvent` objects defined by your filters and enables automated responses.


### PR DESCRIPTION
**Affected versions for cherry-picking**: `serverless-docs-1.32+`

**Tracking JIRA**: https://issues.redhat.com/browse/SRVCOM-3164

**Doc previews**: [Serverless 1.32.0 release notes](https://78196--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-rn-1-32-0_serverless-release-notes)

**`Note: This PR will go through the change management process.`**