### PR TITLE
OBSDOCS-1161: add steps to verify cluster observability operator sample service

### DIFF
--- a/modules/monitoring-deploying-a-sample-service-for-cluster-observability-operator.adoc
+++ b/modules/monitoring-deploying-a-sample-service-for-cluster-observability-operator.adoc
@@ -86,3 +86,21 @@ $ oc -n ns1-coo get pod
 NAME                                      READY     STATUS    RESTARTS   AGE
 prometheus-coo-example-app-0927545cb7-anskj   1/1       Running   0          81m
 ----
+
+.Verification
+
+To verify that the sample service has created a target and is returning metrics, follow these steps:
+
+. Run the following command to verify that the `ServiceMonitor` object has created a target:
+
+[source, terminal]
+----
+$ oc -n ns1-coo exec -c prometheus prometheus-example-coo-monitoring-stack-0 -- curl -s 'http://localhost:9090/api/v1/targets' | jq '.data.activeTargets[].discoveredLabels | select(.__meta_kubernetes_endpoints_label_app=="prometheus-coo-example-app")'
+----
+
+. Run the following command to verify that the service returns metrics when you query it:
+
+[source, terminal]
+----
+$ oc -n ns1-coo exec -c prometheus prometheus-example-coo-monitoring-stack-0 -- curl -s 'http://localhost:9090/api/v1/query?query=http_requests_total' | jq
+----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1161
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://78210--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/configuring-the-cluster-observability-operator-to-monitor-a-service.html#deploying-a-sample-service-for-cluster-observability-operator_configuring_the_cluster_observability_operator_to_monitor_a_service
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
