### PR TITLE
OSDOCS-11099: add relnotes file 4.17 MicroShift

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -33,8 +33,8 @@ Name: Release notes
 Dir: microshift_release_notes
 Distros: microshift
 Topics:
-- Name: Red Hat build of MicroShift 4.16 release notes
-  File: microshift-4-16-release-notes
+- Name: Red Hat build of MicroShift 4.17 release notes
+  File: microshift-4-17-release-notes
 ---
 Name: Getting started
 Dir: microshift_getting_started

--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -1,5 +1,5 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="microshift-4-16-release-notes"]
+[id="microshift-4-17-release-notes"]
 = {product-title} {product-version} release notes
 include::_attributes/attributes-microshift.adoc[]
 :context: release-notes
@@ -11,9 +11,9 @@ toc::[]
 {microshift-short} is designed to make control plane restarts economical and be lifecycle-managed as a single unit by the operating system. Updates, roll-backs, and configuration changes consist of simply staging another version in parallel and then - without relying on a network - flipping to and from that version and restarting.
 
 //TODO verify K8s version and another other relevant notes
-[id="microshift-4-16-about-this-release_{context}"]
+[id="microshift-4-17-about-this-release_{context}"]
 == About this release
-Version 4.16 of {product-title} includes new features and enhancements. {microshift-short} was introduced as Generally Available with {microshift-short} 4.14. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. {microshift-short} is derived from {OCP} {OCP-version} and uses the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
+Version 4.17 of {product-title} includes new features and enhancements. {microshift-short} was introduced as Generally Available with {microshift-short} 4.14. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. {microshift-short} is derived from {OCP} {OCP-version} and uses the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
 
 You can deploy {microshift-short} clusters to on-premise, cloud, disconnected, and offline environments.
 
@@ -22,25 +22,25 @@ You can deploy {microshift-short} clusters to on-premise, cloud, disconnected, a
 
 For lifecycle information, see the link:https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{product-title} Life Cycle Policy].
 
-[id="microshift-4-16-new-features-and-enhancements_{context}"]
+[id="microshift-4-17-new-features-and-enhancements_{context}"]
 == New features and enhancements
 
 This release adds improvements related to the following components and concepts.
 
 //L3 major categories with features in each as L4s
-[id="microshift-4-16-rhel_{context}"]
+[id="microshift-4-17-rhel_{context}"]
 === {op-system-base-full}
 * {microshift-short} {product-version} runs on {op-system-base-full} 9.4.
 
-[id="microshift-4-16-updating_{context}"]
+[id="microshift-4-17-updating_{context}"]
 === Updating
 Updating two minor versions in a single step is now supported. Updates for both single-version minor releases and patch releases are still supported.
 
-[id="microshift-4-16-updates-supported_{context}"]
+[id="microshift-4-17-updates-supported_{context}"]
 ==== Update two minor versions in a single step
 See the following list for details:
 
-* You can update from one long-life-cycle version of {microshift-short} directly to another, without applying the intermediate version. For example, you can update directly to 4.16 from 4.14. Updating 4.14 to 4.15 before updating to 4.16 is no longer required.
+* You can update from one long-life-cycle version of {microshift-short} directly to another, without applying the intermediate version. For example, you can update directly to 4.17 from 4.14. Updating 4.14 to 4.15 before updating to 4.17 is no longer required.
 * Now, you can focus on developing applications for your devices in remote locations and with limited bandwidth, rather than planning for updates.
 * {microshift-short} offers in-place updates on {op-system-ostree} systems with automatic system rollback capabilities and automatic back up and restore functions.
 * Updates of the RPMs on a non-OSTree system such as {op-system} are also supported.
@@ -48,72 +48,72 @@ See the following list for details:
 
 //TODO add new features and enhancements as needed, L4 [discrete] headings
 
-//[id="microshift-4-16-installation"]
+//[id="microshift-4-17-installation"]
 //=== Installation
 
-[id="microshift-4-16-configuring_{context}"]
+[id="microshift-4-17-configuring_{context}"]
 === Configuring
 
-[id="microshift-4-16-custom-cert-auths_{context}"]
+[id="microshift-4-17-custom-cert-auths_{context}"]
 ==== Customizable certificate authorities for the API server are supported
 With this release, you can configure a custom server certificate that has been issued by an external certificate authority (CA). The default API server certificate is issued by an internal {microshift-short} cluster CA. You can now replace this certificate with one that is issued by a CA that clients trust. See xref:../microshift_configuring/microshift-custom-ca.adoc#microshift-custom-ca[Configuring custom certificate authorities].
 
-[id="microshift-4-16-audit-logging-config_{context}"]
+[id="microshift-4-17-audit-logging-config_{context}"]
 ==== Configurable policies for log file rotation and retention
 You can now configure audit logging policies to manage the retention policies for log files, ensuring that edge devices with limited storage capacities are not hampered by accumulated logging data. To configure audit log policies, use settings such as a maximum file size limit and maximum retained files to set a limit on log storage size. You can also choose an audit policy profile to specify the data collected. See xref:../microshift_configuring/microshift-audit-logs-config.adoc#microshift-audit-logs-config[Configuring audit logs].
 
-[id="microshift-4-16-certificates-cleaning_{context}"]
+[id="microshift-4-17-certificates-cleaning_{context}"]
 ==== Support for cleaning up certificates
 With this release, you can clean up custom certificates. For more information, see xref:../microshift_configuring/microshift-custom-ca.adoc#microshift-custom-ca-certificates-cleaning_microshift-custom-ca[Cleaning up and recreating the custom certificates].
 
-[id="microshift-4-16-networking_{context}"]
+[id="microshift-4-17-networking_{context}"]
 === Networking
 
-[id="microshift-4-16-multus_{context}"]
+[id="microshift-4-17-multus_{context}"]
 ==== Multiple networks capability now available
 With this release, using multiple networks is supported with the {microshift-short} Multus plugin. If you have advanced networking requirements, you can attach additional networks to a pod for high-performance network configurations. After installing the {microshift-short} Multus RPM package, you can use the Bridge, MACVLAN, or IPVLAN plugins to create additional networks. See xref:../microshift_networking/microshift_multiple_networks/microshift-cni-multus.adoc#microshift-multus-intro_microshift-cni-multus[Additional networks in {microshift-short}].
 
-[id="microshift-4-16-configure-ingress-router_{context}"]
+[id="microshift-4-17-configure-ingress-router_{context}"]
 ==== Custom configurations for the ingress router are supported
 You can now configure ingress routes to create access to multiple services inside your {microshift-short} cluster. You can use a variety of combinations to customize the endpoint configuration for your use case. See xref:../microshift_networking/microshift-nw-router.adoc#microshift-nw-router-con_microshift-nw-router[About configuring the router].
 
-[id="microshift-4-16-configure-route-admission-policy_{context}"]
+[id="microshift-4-17-configure-route-admission-policy_{context}"]
 ==== Configuring the route admission policy now available
 You can now configure the route admission policy to allow routes to claim different paths of the same hostname across namespaces. See xref:../microshift_networking/microshift-nw-router.adoc#microshift-configuring-route-admission_microshift-nw-router[Configuring the route admission policy].
 
-//[id="microshift-4-16-storage"]
+//[id="microshift-4-17-storage"]
 //=== Storage
 
-[id="microshift-4-16-running-apps_{context}"]
+[id="microshift-4-17-running-apps_{context}"]
 === Running applications
 
-[id="microshift-4-16-gitops_{context}"]
+[id="microshift-4-17-gitops_{context}"]
 ==== GitOps with Argo CD now available
 With this release, you can use the GitOps with Argo CD agent derived from GitOps 1.12 with {microshift-short}. Using GitOps means you can update a single Git repository and automate the deployment of new applications or updates to existing ones. You can also use your Git repository as an audit trail of changes so that you can create processes such as review and approval for merging pull requests that implement configuration changes.
 See xref:../microshift_running_apps/microshift-gitops.adoc#microshift-gitops[Automating application management with the GitOps controller].
 
-[id="microshift-4-16-support_{context}"]
+[id="microshift-4-17-support_{context}"]
 === Support
 
-[id="microshift-4-16-support-updates_{context}"]
+[id="microshift-4-17-support-updates_{context}"]
 ==== Getting a cluster ID
 With this release, you can get the ID of a {microshift-short} cluster. When opening a support case, you can provide the cluster ID to Red{nbsp}Hat Support to help in identifying issues with your cluster. See xref:../microshift_support/microshift-getting-cluster-id.adoc#microshift-getting-cluster-id[Getting your cluster ID].
 
-[id="microshift-4-16-security_{context}"]
+[id="microshift-4-17-security_{context}"]
 === Security and compliance
 
-[id="microshift-4-16-ssl-medium-cipher-suites_{context}"]
+[id="microshift-4-17-ssl-medium-cipher-suites_{context}"]
 ==== SSL Medium Strength Cipher Suites now supported
 During an SSL handshake between a client and a server, the cipher to use is negotiated between them. With this release, SSL Medium Strength Cipher Suites are now supported for the kube-controller-manager daemon, kube-scheduler control-plane process, and kubelet "node agent." This enhancement to the internal communication between kubernetes components improves control plane communications security. (link:https://issues.redhat.com/browse/OCPBUGS-29037[OCPBUGS-29037])
 
-[id="microshift-4-16-doc-enhancements_{context}"]
+[id="microshift-4-17-doc-enhancements_{context}"]
 === Documentation enhancements
 
-[id="microshift-4-16-route-config_{context}"]
+[id="microshift-4-17-route-config_{context}"]
 ==== Route configuration now documented
 With this release, specific details for creating and managing supported route configurations are documented, see xref:../microshift_networking/microshift-configuring-routes.adoc#microshift-configuring-routes[Configuring routes].
 
-//[id="microshift-4-16-deprecated-and-removed"]
+//[id="microshift-4-17-deprecated-and-removed"]
 //== Deprecated and removed features
 
 //Some features available in previous releases of {microshift-short} have been deprecated or removed.
@@ -129,7 +129,7 @@ With this release, specific details for creating and managing supported route co
 //.{product-title} deprecated and removed features tracker
 //[cols="5,1,1,1",options="header"]
 //|====
-//|Feature |4.14 |4.15 |4.16
+//|Feature |4.14 |4.15 |4.17
 
 //|Network configuration flags
 //|Removed
@@ -143,34 +143,34 @@ With this release, specific details for creating and managing supported route co
 //|====
 
 //NOTE: Do NOT repeat bug fixes already noted in previous version z-streams
-[id="microshift-4-16-bug-fixes_{context}"]
+[id="microshift-4-17-bug-fixes_{context}"]
 == Bug fixes
 
 //[discrete]
-//[id="microshift-4-16-installation-bug-fixes"]
+//[id="microshift-4-17-installation-bug-fixes"]
 //=== Installation
 
 [discrete]
-[id="microshift-4-16-networking-bug-fixes"]
+[id="microshift-4-17-networking-bug-fixes"]
 === Networking
 
 Previously, the {microshift-short} load balancer controller tried to update the IP addresses of every `LoadBalancer` service in the cluster. Some of these services, such as those with a defined `loadBalancerClass`, have their own update procedures for external IPs. This conflicted with the {microshift-short} controller. Now, services that have a `loadBalancerClass` are filtered and IP addresses owned by other load balancer services are ignored by {microshift-short}. (link:https://issues.redhat.com/browse/OCPBUGS-30833[OCPBUGS-30833])
 
 [discrete]
-[id="microshift-4-16-support-bug-fixes"]
+[id="microshift-4-17-support-bug-fixes"]
 === Support
 
 Previously, when `microshift-etcd` unexpectedly exited, {microshift-short} tried to restart so that `microshift-etcd` could restart, but there was a lingering unit fragment. Every attempt to restart `microshift-etcd` failed, making the system unusable. The `--collect` flag was added to the `systemd-run` invocation used to start `microshift-etcd`. The additional flag results in systemd cleaning up the unit fragment even if the unit failed. The system now recovers and restarts. (link:https://issues.redhat.com/browse/OCPBUGS-33588[OCPBUGS-33588])
 
 //check status for next release+
-[id="microshift-4-16-known-issues_{context}"]
+[id="microshift-4-17-known-issues_{context}"]
 == Known issues
 
-[id="microshift-4-16-pods-writing-files-excess-memory-limits-crash_{context}"]
+[id="microshift-4-17-pods-writing-files-excess-memory-limits-crash_{context}"]
 === Pods crash when writing files that exceed memory limits
 Because of an issue with {op-system-base}, when a pod tries to write files that are larger than configured memory limits to a persistent volume claim, the pod might crash with an out-of-memory error. The pod status shows `OOMKilled` when this occurs. Use the following workarounds to avoid this issue: link:https://access.redhat.com/solutions/7076169[Pods writing files larger than memory limit to PVCs tend to OOM frequently running on MicroShift](Red Hat Knowledgebase).
 
-[id="microshift-4-16-asynchronous-errata-updates_{context}"]
+[id="microshift-4-17-asynchronous-errata-updates_{context}"]
 == Asynchronous errata updates
 
 Security, bug fix, and enhancement updates for {microshift-short} {product-version} are released as asynchronous errata through the Red Hat Network. All {microshift-short} {product-version} errata are https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. For more information about asynchronous errata, read the https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{microshift-short} Life Cycle].
@@ -184,11 +184,11 @@ Red Hat Customer Portal user accounts must have systems registered and consuming
 
 This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections.
 
-[id="microshift-4-16-0-dp_{context}"]
-=== RHEA-2024:0043 - {microshift-short} 4.16.0 bug fix and security update advisory
+[id="microshift-4-17-0-dp_{context}"]
+=== RHEA-2024:0043 - {microshift-short} 4.17.0 bug fix and security update advisory
 
 Issued: 2024-06-27
 
-{product-title} release 4.16.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:0043[RHSA-2024:0043] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0041[RHSA-2024:0041] advisory.
+{product-title} release 4.17.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:0043[RHSA-2024:0043] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0041[RHSA-2024:0041] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].

--- a/microshift_welcome/index.adoc
+++ b/microshift_welcome/index.adoc
@@ -16,7 +16,7 @@ To get started with {microshift-short}, use the following links:
 
 * xref:../microshift_getting_started/microshift-understanding.adoc#microshift-understanding[Understanding {product-title}]
 * xref:../microshift_install/microshift-install-rpm.adoc#microshift-install-rpm[Installing {product-title}]
-* xref:../microshift_release_notes/microshift-4-16-release-notes.adoc#microshift-4-16-release-notes[{product-title} release notes]
+* xref:../microshift_release_notes/microshift-4-17-release-notes.adoc#microshift-4-17-release-notes[{product-title} release notes]
 
 For related information, use the following links:
 


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-11099](https://issues.redhat.com/browse/OSDOCS-11099)

Link to docs preview:
[Release notes template for 4.17](https://78224--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html)

QE review:
- N/A docs plumbing

Additional information:
Build file PR #78223