### PR TITLE
OCPBUGS-36292: Expanded Configuring the PROXY protocol for an Ingress…

### DIFF
--- a/modules/nw-ingress-controller-configuration-proxy-protocol.adoc
+++ b/modules/nw-ingress-controller-configuration-proxy-protocol.adoc
@@ -6,18 +6,18 @@
 [id="nw-ingress-controller-configuration-proxy-protocol_{context}"]
 = Configuring the PROXY protocol for an Ingress Controller
 
-A cluster administrator can configure https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt[the PROXY protocol] when an Ingress Controller uses either the `HostNetwork` or `NodePortService` endpoint publishing strategy types. The PROXY protocol enables the load balancer to preserve the original client addresses for connections that the Ingress Controller receives. The original client addresses are useful for logging, filtering, and injecting HTTP headers. In the default configuration, the connections that the Ingress Controller receives only contain the source address that is associated with the load balancer.
-
-This feature is not supported in cloud deployments. This restriction is because when {product-title} runs in a cloud platform, and an IngressController specifies that a service load balancer should be used, the Ingress Operator configures the load balancer service and enables the PROXY protocol based on the platform requirement for preserving source addresses.
-
-[IMPORTANT]
-====
-You must configure both {product-title} and the external load balancer to either use the PROXY protocol or to use TCP.
-====
+A cluster administrator can configure link:https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt[the PROXY protocol] when an Ingress Controller uses either the `HostNetwork`, `NodePortService`, or `Private` endpoint publishing strategy types. The PROXY protocol enables the load balancer to preserve the original client addresses for connections that the Ingress Controller receives. The original client addresses are useful for logging, filtering, and injecting HTTP headers. In the default configuration, the connections that the Ingress Controller receives only contain the source address that is associated with the load balancer.
 
 [WARNING]
 ====
 The PROXY protocol is unsupported for the default Ingress Controller with installer-provisioned clusters on non-cloud platforms that use a Keepalived Ingress VIP.
+====
+
+This feature is not supported in cloud deployments. This restriction is because when {product-title} runs in a cloud platform, and an Ingress Controller specifies that a service load balancer should be used, the Ingress Operator configures the load balancer service and enables the PROXY protocol based on the platform requirement for preserving source addresses.
+
+[IMPORTANT]
+====
+You must configure both {product-title} and the external load balancer to either use the PROXY protocol or to use Transmission Control Protocol (TCP).
 ====
 
 .Prerequisites


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OCPBUGS-36292](https://issues.redhat.com/browse/OCPBUGS-36292)

Link to docs preview:
* [Configuring the PROXY protocol for an Ingress Controller - OKD](https://78234--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/ingress-operator.html#nw-ingress-controller-configuration-proxy-protocol_configuring-ingress)
* [Configuring the PROXY protocol for an Ingress Controller - ROSA](https://78234--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ingress-operator.html#nw-ingress-controller-configuration-proxy-protocol_configuring-ingress)
* [Configuring the PROXY protocol for an Ingress Controller - Enterprise](https://78234--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-ingress-controller-configuration-proxy-protocol_configuring-ingress)

[X] QE approved this PR
[X] SME approved this PR

Additional info:

* Expands on [OCPBUGS-33700](https://issues.redhat.com/browse/OCPBUGS-33700)

