### PR TITLE
OSDOCS-10335: Add missing trust policies to ROSA docs

### DIFF
--- a/modules/rosa-sts-account-wide-roles-and-policies.adoc
+++ b/modules/rosa-sts-account-wide-roles-and-policies.adoc
@@ -658,6 +658,78 @@ The account number present in the `sts_installer_trust_policy.json` and `sts_sup
 ----
 ====
 
+.ROSA OCM role and policy file
+[cols="1,2",options="header"]
+|===
+
+|Resource|Description
+
+|`ManagedOpenShift-OCM-Role`
+|You use this IAM role to create and maintain ROSA clusters in  {cluster-manager}.
+
+|===
+
+.`sts_ocm_role_trust_policy.json`
+[%collapsible]
+====
+[source,json]
+----
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::710019948333:role/RH-Managed-OpenShift-Installer"
+            },
+            "Action": "sts:AssumeRole",
+            "Condition": {
+                "StringEquals": {
+                    "sts:ExternalId": "<OCM_account_ID>"
+                }
+            }
+        }
+    ]
+}
+----
+====
+
+.ROSA user role and policy file
+[cols="1,2",options="header"]
+|===
+
+|Resource|Description
+
+|`ManagedOpenShift-User-<OCM_user>-Role`
+|An IAM role used by Red{nbsp}Hat to verify the customer's AWS identity.
+
+|===
+
+.`sts_user_role_trust_policy.json`
+[%collapsible]
+====
+[source,json]
+----
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::710019948333:role/RH-Managed-OpenShift-Installer"
+            },
+            "Action": "sts:AssumeRole",
+            "Condition": {
+                "StringEquals": {
+                    "sts:ExternalId": "<OCM_account_ID>"
+                }
+            }
+        }
+    ]
+}
+----
+====
+
 .ROSA Ingress Operator IAM policy and policy file
 [cols="1,2",options="header"]
 |===


### PR DESCRIPTION
Version(s):
* enterprise-4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-10335

Link to docs preview:
* https://78246--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-sts-about-iam-resources.html#rosa-sts-account-wide-roles-and-policies-creation-methods_rosa-sts-about-iam-resources


QE review:
- [x] QE has approved this change.
