### PR TITLE
OBSDOCS-1125: remove OCP version from UWM overview

### DIFF
--- a/modules/monitoring-enabling-monitoring-for-user-defined-projects.adoc
+++ b/modules/monitoring-enabling-monitoring-for-user-defined-projects.adoc
@@ -10,7 +10,7 @@ Cluster administrators can enable monitoring for user-defined projects by settin
 
 [IMPORTANT]
 ====
-In {product-title} {product-version} you must remove any custom Prometheus instances before enabling monitoring for user-defined projects.
+You must remove any custom Prometheus instances before enabling monitoring for user-defined projects.
 ====
 
 [NOTE]

--- a/observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc
+++ b/observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} {product-version}, you can enable monitoring for user-defined projects in addition to the default platform monitoring. You can monitor your own projects in {product-title} without the need for an additional monitoring solution. Using this feature centralizes monitoring for core platform components and user-defined projects.
+In {product-title}, you can enable monitoring for user-defined projects in addition to the default platform monitoring. You can monitor your own projects in {product-title} without the need for an additional monitoring solution. Using this feature centralizes monitoring for core platform components and user-defined projects.
 
 include::snippets/monitoring-custom-prometheus-note.adoc[]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1125
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://78256--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/enabling-monitoring-for-user-defined-projects.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- No QE required. Only removes irrelevant OCP version from text.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Removes irrelevant OCP version from user-defined projects overview in the OCP monitoring docs.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
