### PR TITLE
Add OADP 1.4.0 release and upgrade notes

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3193,6 +3193,8 @@ Topics:
   - Name: OADP release notes
     Dir: release-notes
     Topics:
+    - Name: OADP 1.4 release notes
+      File: oadp-1-4-release-notes
     - Name: OADP 1.3 release notes
       File: oadp-release-notes-1-3
     - Name: OADP 1.2 release notes

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
@@ -1,0 +1,27 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="oadp-1-4-release-notes"]
+= OADP 1.4 release notes
+include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: oadp-1-4-release-notes
+
+toc::[]
+
+The release notes for OpenShift API for Data Protection (OADP) describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
+
+include::modules/oadp-1-4-0-release-notes.adoc[leveloffset=+1]
+include::modules/oadp-backing-up-dpa-configuration-1-4-0.adoc[leveloffset=+3]
+include::modules/oadp-upgrading-oadp-operator-1-4-0.adoc[leveloffset=+3]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../operators/admin/olm-upgrading-operators.adoc#olm-changing-update-channel_olm-upgrading-operators[Updating installed Operators]
+
+[id="oadp-converting-dpa-to-new-version-1-4-0_{context}"]
+=== Converting DPA to the new version
+
+To upgrade from OADP 1.3 to 1.4, no Data Protection Application (DPA) changes are required.
+
+[id="verifying-upgrade-1-4-0_{context}"]
+=== Verifying the upgrade
+
+Verify the installation by following steps from the link:https://docs.openshift.com/container-platform/4.15/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-2.html#verifying-upgrade-1-2-0_oadp-release-notes[Verifying the upgrade] section.

--- a/modules/oadp-1-4-0-release-notes.adoc
+++ b/modules/oadp-1-4-0-release-notes.adoc
@@ -1,0 +1,66 @@
+:_newdoc-version: 2.18.3
+:_template-generated: 2024-06-28
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-1-4-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-1-4-0-release-notes_{context}"]
+= OADP 1.4.0 release notes
+
+The {oadp-first} 1.4.0 release notes lists resolved issues and known issues.
+
+[id="resolved-issues-1-4-0_{context}"]
+== Resolved issues
+
+.Restore works correctly in {product-title} 4.16
+
+Previously, while restoring the deleted application namespace, the restore operation partially failed with the `resource name may not be empty` error in {product-title} 4.16.
+With this update, restore works as expected in {product-title} 4.16.
+link:https://issues.redhat.com/browse/OADP-4075[OADP-4075]
+
+.Data Mover backups work properly in the {product-title} 4.16 cluster
+
+Previously, Velero was using the earlier version of SDK where the `Spec.SourceVolumeMode` field did not exist. As a consequence, Data Mover backups failed in the {product-title} 4.16 cluster on the external snapshotter with v4.2 version. 
+With this update, external snapshotter is upgraded to v7.0 version and later. As a result, backups do not fail in the {product-title} 4.16 cluster.
+link:https://issues.redhat.com/browse/OADP-3922[OADP-3922]
+
+For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12438505[OADP 1.4.0 resolved issues] in Jira.
+
+
+[id="known-issues-1-4-0_{context}"]
+== Known issues
+
+.Backup fails when checksumAlgorithm is not set for MCG
+
+While performing a backup of any application with Noobaa as the backup location, if the `checksumAlgorithm` configuration parameter is not set, backup fails. To fix this problem, if you do not provide a value for `checksumAlgorithm` in the Backup Storage Location (BSL) configuration, an empty value is added.
+The empty value is only added for BSLs that are created using Data Protection Application (DPA) custom resource (CR), and this value is not added if BSLs are created using any other method.
+link:https://issues.redhat.com/browse/OADP-4274[OADP-4274]
+
+For a complete list of all known issues in this release, see the list of link:https://issues.redhat.com/issues/?filter=12438506[OADP 1.4.0 known issues] in Jira.
+
+
+[id="upgrade-notes-1-4-0_{context}"]
+== Upgrade notes
+
+[NOTE]
+====
+Always upgrade to the next minor version. *Do not* skip versions. To update to a later version, upgrade only one channel at a time. For example, to upgrade from {oadp-first} 1.1 to 1.3, upgrade first to 1.2, and then to 1.3.
+====
+
+[id="changes-oadp-1-3-to-1-4_{context}"]
+=== Changes from OADP 1.3 to 1.4
+
+The Velero server has been updated from version 1.12 to 1.14. Note that, there are no changes in the Data Protection Application (DPA).
+
+This changes the following:
+
+* The `velero-plugin-for-csi` code is now available in the Velero code, which means no `init` container is needed for the plugin anymore.
+
+* Velero changed client Burst and QPS defaults from 30 and 20 to 100 and 100 respectively.
+
+* The `velero-plugin-for-aws` plugin updated default value of the `spec.config.checksumAlgorithm` field in BackupStorageLocations (BSLs) from `""` (no checksum calculation) to the `CRC32` algorithm. For more information, see link:https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/release-1.10/backupstoragelocation.md[Velero plugins for AWS Backup Storage Location]. The checksum algorithm types are known to work only with AWS. 
+Several S3 providers require the `md5sum` to be disabled by setting the checksum algorithm to `""`. Confirm `md5sum` algorithm support and configuration with your storage provider. 
++
+In  OADP 1.4, the default value for BSLs created within DPA for this configuration is `""`. This default value means that the `md5sum` is not checked, which is consistent with OADP 1.3. For BSLs created within DPA, update it by using the `spec.backupLocations[].velero.config.checksumAlgorithm` field in the DPA. If your BSLs are created outside DPA, you can update this configuration by using `spec.config.checksumAlgorithm` in the BSLs.

--- a/modules/oadp-backing-up-dpa-configuration-1-4-0.adoc
+++ b/modules/oadp-backing-up-dpa-configuration-1-4-0.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-1-4-release-notes.adoc
+
+:_mod-docs-content-type: PROCEDURE
+
+[id="oadp-backing-up-dpa-configuration-1-4-0_{context}"]
+= Backing up the DPA configuration
+
+You must back up your current `DataProtectionApplication` (DPA) configuration.
+
+.Procedure
+* Save your current DPA configuration by running the following command:
++
+.Example
+[source,terminal]
+----
+$ oc get dpa -n openshift-adp -o yaml > dpa.orig.backup
+----

--- a/modules/oadp-upgrading-oadp-operator-1-4-0.adoc
+++ b/modules/oadp-upgrading-oadp-operator-1-4-0.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-1-4-release-notes.adoc
+
+:_mod-docs-content-type: PROCEDURE
+
+[id="oadp-upgrading-dpa-operator-1-4-0_{context}"]
+= Upgrading the OADP Operator
+
+Use the following procedure when upgrading the {oadp-first} Operator.
+
+.Procedure
+
+. Change your subscription channel for the OADP Operator from `stable-1.3` to `stable-1.4`.
+. Wait for the operator and containers to update and restart.
+


### PR DESCRIPTION
Version(s):
OADP 1.4.0
OCP 4.14 → OCP 4.16

Issue:
* [OADP-4002](https://issues.redhat.com/browse/OADP-4002)
* [OADP-4255](https://issues.redhat.com/browse/OADP-4255)

Link to docs preview:
https://78272--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
