### PR TITLE
WIP: OSDOCS11271: Unable to specify custom CAs for Custom Metrics Autoscaler

### DIFF
--- a/modules/nodes-cma-autoscaling-custom-install.adoc
+++ b/modules/nodes-cma-autoscaling-custom-install.adoc
@@ -31,6 +31,13 @@ $ oc delete crd scaledobjects.keda.k8s.io
 $ oc delete crd triggerauthentications.keda.k8s.io
 ----
 
+* Optional: If you need the Custom Metrics Autoscaler Operator to connect to off-cluster services, such as an external Kafka cluster or an external Prometheus service, put any required service CA certificates into a config map. The config map must exist in the same namespace where the Operator is installed. For example:
++
+[source,terminal]
+----
+$ oc create configmap -n openshift-keda thanos-cert  --from-file=ca-cert.pem
+----
+
 .Procedure
 
 . In the {product-title} web console, click *Operators* -> *OperatorHub*.
@@ -96,9 +103,12 @@ spec:
   operator:
     logLevel: info <2>
     logEncoder: console <3>
+    caConfigMaps: <4>
+    - thanos-cert
+    - kafka-cert
   metricsServer:
-    logLevel: '0' <4>
-    auditConfig: <5>
+    logLevel: '0' <5>
+    auditConfig: <6>
       logFormat: "json"
       logOutputVolumeClaim: "persistentVolumeClaimName"
       policy:
@@ -115,7 +125,8 @@ spec:
 <1> Specifies a single namespace in which the Custom Metrics Autoscaler Operator should scale applications. Leave it blank or leave it empty to scale applications in all namespaces. This field should have a namespace or be empty. The default value is empty.
 <2> Specifies the level of verbosity for the Custom Metrics Autoscaler Operator log messages. The allowed values are `debug`, `info`, `error`. The default is `info`.
 <3> Specifies the logging format for the Custom Metrics Autoscaler Operator log messages. The allowed values are `console` or `json`. The default is `console`.
-<4> Specifies the logging level for the Custom Metrics Autoscaler Metrics Server. The allowed values are `0` for `info` and `4` or `debug`. The default is `0`.
-<5> Activates audit logging for the Custom Metrics Autoscaler Operator and specifies the audit policy to use, as described in the "Configuring audit logging" section.
+<4> Optional: Specifies one or more config maps with CA certificates, which the Custom Metrics Autoscaler Operator can use to connect securely to TLS-enabled metrics sources.
+<5> Specifies the logging level for the Custom Metrics Autoscaler Metrics Server. The allowed values are `0` for `info` and `4` or `debug`. The default is `0`.
+<6> Activates audit logging for the Custom Metrics Autoscaler Operator and specifies the audit policy to use, as described in the "Configuring audit logging" section.
 
 .. Click *Create* to create the KEDA controller.

--- a/modules/sd-nodes-cma-autoscaling-custom-install.adoc
+++ b/modules/sd-nodes-cma-autoscaling-custom-install.adoc
@@ -34,6 +34,13 @@ $ oc delete crd triggerauthentications.keda.k8s.io
 
 * Ensure that the `keda` namespace exists. If not, you must manaully create the `keda` namespace.
 
+* Optional: If you need the Custom Metrics Autoscaler Operator to connect to off-cluster services, such as an external Kafka cluster or an external Prometheus service, put any required service CA certificates into a config map. The config map must exist in the same namespace where the Operator is installed. For example:
++
+[source,terminal]
+----
+$ oc create configmap -n openshift-keda thanos-cert  --from-file=ca-cert.pem
+----
+
 .Procedure
 
 . In the {product-title} web console, click *Operators* -> *OperatorHub*.
@@ -110,9 +117,12 @@ spec:
   operator:
     logLevel: info <2>
     logEncoder: console <3>
+    caConfigMaps: <4>
+    - thanos-cert
+    - kafka-cert
   metricsServer:
-    logLevel: '0' <4>
-    auditConfig: <5>
+    logLevel: '0' <5>
+    auditConfig: <6>
       logFormat: "json"
       logOutputVolumeClaim: "persistentVolumeClaimName"
       policy:
@@ -129,7 +139,8 @@ spec:
 <1> Specifies a single namespace in which the Custom Metrics Autoscaler Operator should scale applications. Leave it blank or leave it empty to scale applications in all namespaces. This field should have a namespace or be empty. The default value is empty.
 <2> Specifies the level of verbosity for the Custom Metrics Autoscaler Operator log messages. The allowed values are `debug`, `info`, `error`. The default is `info`.
 <3> Specifies the logging format for the Custom Metrics Autoscaler Operator log messages. The allowed values are `console` or `json`. The default is `console`.
-<4> Specifies the logging level for the Custom Metrics Autoscaler Metrics Server. The allowed values are `0` for `info` and `4` or `debug`. The default is `0`.
-<5> Activates audit logging for the Custom Metrics Autoscaler Operator and specifies the audit policy to use, as described in the "Configuring audit logging" section.
+<4> Optional: Specifies one or more config maps with CA certificates, which the Custom Metrics Autoscaler Operator can use to connect securely to TLS-enabled metrics sources.
+<5> Specifies the logging level for the Custom Metrics Autoscaler Metrics Server. The allowed values are `0` for `info` and `4` or `debug`. The default is `0`.
+<6> Activates audit logging for the Custom Metrics Autoscaler Operator and specifies the audit policy to use, as described in the "Configuring audit logging" section.
 
 .. Click *Create* to create the KEDA controller.

--- a/nodes/cma/nodes-cma-autoscaling-custom.adoc
+++ b/nodes/cma/nodes-cma-autoscaling-custom.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 As a developer, you can use Custom Metrics Autoscaler Operator for Red Hat OpenShift to specify how {product-title} should automatically increase or decrease the number of pods for a deployment, stateful set, custom resource, or job based on custom metrics that are not based only on CPU or memory.
 
-The Custom Metrics Autoscaler Operator is an optional operator, based on the Kubernetes Event Driven Autoscaler (KEDA), that allows workloads to be scaled using additional metrics sources other than pod metrics.
+The Custom Metrics Autoscaler Operator is an optional Operator, based on the Kubernetes Event Driven Autoscaler (KEDA), that allows workloads to be scaled using additional metrics sources other than pod metrics.
 
 The custom metrics autoscaler currently supports only the Prometheus, CPU, memory, and Apache Kafka metrics.
 
@@ -52,3 +52,18 @@ image::564_OpenShift_Custom_Metrics_Autoscaler_0224.png[Custom metrics autoscale
 6. As a it operates, a workload can affect the scaling metrics. For example, if a workload is scaled up to handle work in a Kafka queue, the queue size decreases after the workload processes all the work. As a result, the workload is scaled down.
 
 7. If the metrics are in a range specified by the `minReplicaCount` value, the custom metrics autoscaler controller disables all scaling, and leaves the replica count at a fixed level. If the metrics exceed that range, the custom metrics autoscaler controller enables scaling and allows the HPA to scale the workload. While scaling is disabled, the HPA does not take any action.
+
+[id="nodes-cma-autoscaling-custom-ca_{context}"]
+== Custom CA certificates for the Custom Metrics Autoscaler
+
+By default, the Custom Metrics Autoscaler Operator uses automatically-generated service CA certificate to connect to on-cluster services. 
+
+If you want to use off-cluster services that require custom CA certificates, you can add the required certificates to a config map. Then, add the config map to the `KedaController` custom resource as described in xref:../../nodes/cma/nodes-cma-autoscaling-custom-install.adoc#nodes-cma-autoscaling-custom-install[Installing the custom metrics autoscaler]. The Operator loads those certificates on start-up and registers them as trusted by the Operator. 
+
+The config maps can contain one or more certificate files that contain one or more PEM-encoded CA certificates. Or, you can use separate config maps for each certificate file.
+
+[NOTE]
+====
+If you later update the config map to add additional certificates, you must restart the `keda-operator-*` pod for the changes to take effect.
+====
+


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-11271

**DO NOT MERGE UNTIL Custom Metrics Autoscaler 2.13.1 releases.** Planned for 7/15 or 7/23. 

Previews:
* Custom Metrics Autoscaler Operator overview -> [Custom CA certs for the Custom Metrics Autoscaler](https://78275--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom.html#nodes-cma-autoscaling-custom-ca_nodes-cma-autoscaling-custom) -- New section

* OCP: [Installing the custom metrics autoscaler](https://78275--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-install#nodes-cma-autoscaling-custom-install_nodes-cma-autoscaling-custom-install) -- Added third prereq and callout <4> in step 8.d.
* OSD: [Installing the custom metrics autoscaler](https://78275--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/cma/nodes-cma-autoscaling-custom-install.html#sd-nodes-cma-autoscaling-custom-install_nodes-cma-autoscaling-custom-install) -- Added fifth prereq and callout <4> in step 9.d.

* ROSA: [Installing the custom metrics autoscaler](https://78275--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/cma/nodes-cma-autoscaling-custom-install.html#sd-nodes-cma-autoscaling-custom-install_nodes-cma-autoscaling-custom-install) -- Added fifth prereq and callout <4> in step 9.d.

[KEDA:5860](https://github.com/openshift/kedacore-keda/pull/24/files) 
[CMA: 24](https://github.com/openshift/kedacore-keda/pull/24/files)