### PR TITLE
Re-adds whereabouts feature to 416 RNs

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -829,7 +829,7 @@ You can use this to operate FRR services, such as receiving routes.
 For more information, see xref:../networking/metallb/metallb-frr-k8s.adoc#metallb-configure-frr-k8s[Configuring the integration of MetalLB and FRR-K8s].
 
 [id="ocp-4-16-anp"]
-=== AdminNetworkPolicy is generally available
+==== AdminNetworkPolicy is generally available
 This feature provides two new APIs, `AdminNetworkPolicy` (ANP) and `BaselineAdminNetworkPolicy` (BANP). Before namespaces are created, cluster Administrators can use ANP and BANP to apply cluster-scoped network policies and safeguards for an entire cluster. Because it is cluster scoped, ANP provides Administrators a solution to manage the security of their network at scale without having to duplicate their network policies on each namespace.
 
 For more information, see xref:../networking/ovn_kubernetes_network_provider/converting-to-dual-stack.adoc#nw-dual-stack-convert_converting-to-dual-stack[Converting to a dual-stack cluster network] in _Converting to IPv4/IPv6 dual-stack networking_.
@@ -852,6 +852,17 @@ This release introduces a _live_ migration method. The live migration method is 
 Migration to OVN-Kubernetes is intended to be a one-way process.
 
 For more information, see xref:../networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc#nw-ovn-kubernetes-live-migration-about_migrate-from-openshift-sdn[Live migration to the OVN-Kubernetes network plugin overview].
+
+[id="overlapping-ip-configuration-multi-tenant-networks-whereabouts"]
+==== Overlapping IP configuration for multi-tenant networks with Whereabouts
+
+Previously, it was not possible to configure the same CIDR range twice and to have the Whereabouts CNI plugin assign IP addresses from these ranges independently. This limitation caused issues in multi-tenant environments where different groups might need to select overlapping CIDR ranges. 
+
+With this release, the Whereabouts CNI plugin supports overlapping IP address ranges through the inclusion of a `network_name` parameter. Administrators can use the `network_name` parameter to configure the same CIDR range multiple times within separate `NetworkAttachmentDefinitions`, which enables independent IP address assignments for each range.
+
+This feature also includes enhanced namespace handling, stores `IPPool` custom resources (CRs) in the appropriate namespaces, and supports cross-namespaces when permitted by Multus. These improvements provide greater flexibility and management capabilities in multi-tenant environments.
+
+For more information about this feature, see xref:../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-whereabouts_configuring-additional-network[Dynamic IP address assignment configuration with Whereabouts].
 
 [id="ocp-4-16-networking-changing-ovn-kubernetes-network-plugin-internal-range_{context}"]
 ==== Support for changing the OVN-Kubernetes network plugin internal IP address ranges


### PR DESCRIPTION
All original acks received at https://github.com/openshift/openshift-docs/pull/76374 

Version(s):
4.16 

Issue:
No issue. Re-adding a removed RN.

Link to docs preview:
https://78276--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#overlapping-ip-configuration-multi-tenant-networks-whereabouts

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
