### PR TITLE
[OSDOCS#10055]: Correct the description list and remove the additional reference

### DIFF
--- a/modules/etcd-cert-alerts-metrics-signer.adoc
+++ b/modules/etcd-cert-alerts-metrics-signer.adoc
@@ -7,7 +7,7 @@
 = etcd certificate rotation alerts and metrics signer certificates
 
 Two alert types inform users about pending `etcd` certificate expiration:
-[horizontal]
+
 `etcdSignerCAExpirationWarning`:: Occurs 730 days until the signer expires.
 `etcdSignerCAExpirationCritical`:: Occurs 365 days until the signer expires.
 

--- a/security/certificate_types_descriptions/etcd-certificates.adoc
+++ b/security/certificate_types_descriptions/etcd-certificates.adoc
@@ -17,10 +17,6 @@ The CA certificates are valid for 10 years. The peer, client, and server certifi
 include::modules/rotating-certificate-authority.adoc[leveloffset=+1]
 include::modules/etcd-cert-alerts-metrics-signer.adoc[leveloffset=+1]
 
-.Additional resources
-
-* xref:../../security/certificate_types_descriptions/etcd-certificates.adoc#rotating-certificate-authority_cert-types-etcd-certificates[Rotating the etcd certificate]
-
 == Management
 
 These certificates are only managed by the system and are automatically rotated.


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-10055](https://issues.redhat.com/browse/OSDOCS-10055)

Link to docs preview: [etcd certificate rotation](https://78289--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificate_types_descriptions/etcd-certificates.html#etcd-cert-alerts-metrics-signer_cert-types-etcd-certificates)  Updated (7/1/2024)

QE review:
- [ ] N/A due to style change.

Additional information:
This PR updates #[77406](https://github.com/openshift/openshift-docs/pull/77406/files)

This PR corrects the rendering of a description link and removes a recursive additional reference.
