### PR TITLE
OCPBUGS-36373: Update extra manifest examples in IBU docs

### DIFF
--- a/modules/cnf-image-based-upgrade-prep-extramanifests.adoc
+++ b/modules/cnf-image-based-upgrade-prep-extramanifests.adoc
@@ -10,14 +10,15 @@ You can create additional manifests that you want to apply to the target cluster
 
 .Procedure
 
-. Create a YAML file that contains your extra manifests:
+. Create a YAML file that contains your extra manifests, such as SR-IOV.
 +
+.Example SR-IOV resources
 [source,yaml]
 ----
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodePolicy
 metadata:
-  name: "pci-sriov-net-e5l"
+  name: "example-sriov-node-policy"
   namespace: openshift-sriov-network-operator
 spec:
   deviceType: vfio-pci
@@ -29,12 +30,12 @@ spec:
   mtu: 1500
   numVfs: 8
   priority: 99
-  resourceName: pci_sriov_net_e5l
+  resourceName: example-sriov-node-policy
 ---
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetwork
 metadata:
-  name: "networking-e5l"
+  name: "example-sriov-network"
   namespace: openshift-sriov-network-operator
 spec:
   ipam: |-
@@ -42,7 +43,7 @@ spec:
     }
   linkState: auto
   networkNamespace: sriov-namespace
-  resourceName: pci_sriov_net_e5l
+  resourceName: example-sriov-node-policy
   spoofChk: "on"
   trust: "off"
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16, 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-36373
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://78299--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/cnf-image-based-upgrade-prep-resources.html#cnf-image-based-upgrade-creating-backup-extra-manifests_nongitops
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
