### PR TITLE
COS-2831: troubleshooting/operating-system:  document kdump support over NFS

### DIFF
--- a/modules/troubleshooting-enabling-kdump-day-one.adoc
+++ b/modules/troubleshooting-enabling-kdump-day-one.adoc
@@ -68,6 +68,19 @@ systemd:
 <4> If you want to change the contents of `/etc/sysconfig/kdump` from the default, include this section and modify the `inline` subsection accordingly.
 <5> For the `ppc64le` platform, replace `nr_cpus=1` with `maxcpus=1`, which is not supported on this platform.
 
+[NOTE]
+====
+To export the dumps to NFS targets, the `nfs` kernel module must be explicitly added to the configuration file:
+
+.Example `/etc/kdump.conf` file
+[source,text]
+----
+nfs server.example.com:/export/cores
+core_collector makedumpfile -l --message-level 7 -d 31
+extra_modules nfs
+----
+====
+
 . Use Butane to generate a machine config YAML file, `99-worker-kdump.yaml`, containing the configuration to be delivered to the nodes:
 +
 [source,terminal]


### PR DESCRIPTION
On RHCOS, the nfs module is explicitly excluded from the initramfs: https://github.com/coreos/fedora-coreos-config/blob/de0416b8820cffa2ea3b7dbd9e95a9cc0ad9a42b/overlay.d/05core/usr/lib/dracut/dracut.conf.d/coreos-omits.conf#L7 Thus, setting an NFS target destination in kdump.conf will not work because the kdump initramfs will not have the NFS module. Add instruction on how to add the module to enable the functionality.

This may not be necessary if kdump auto-detect the required modules: See https://github.com/rhkdump/kdump-utils/issues/11

Version(s):
All versions that ship kdump, so 4.11 and above releases

Issue:
https://issues.redhat.com/browse/OCPBUGS-31755

Link to docs preview:
https://78300--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/troubleshooting/troubleshooting-operating-system-issues.html#enabling-kdump-day-one

QE review:
- [ ] QE has approved this change.



