### PR TITLE
OSDOCS-10917: adds 4.15.20 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -358,3 +358,12 @@ Issued: 2024-06-28
 The {product-title} release 4.15.19 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4043[RHBA-2024:4043] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4041[RHSA-2024:4041] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-15-20-dp"]
+=== RHBA-2024:4153 - {microshift-short} 4.15.20 bug fix and security update advisory
+
+Issued: 2024-07-02
+
+The {product-title} release 4.15.20 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4153[RHBA-2024:4153] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4151[RHSA-2024:4151] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-10917](https://issues.redhat.com/browse/OSDOCS-10917)

Link to docs preview:
[4-15-20 async release note](https://78305--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-20-dp)

QE review:
- N/A stock text

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
