### PR TITLE
TELCODOCS-1930 Removing note Currently, disabling CPU load balancing is not supported by cgroup v2.

### DIFF
--- a/modules/node-tuning-operator.adoc
+++ b/modules/node-tuning-operator.adoc
@@ -52,11 +52,6 @@ The cluster administrator configures a performance profile to define node-level 
 * Choosing CPUs for housekeeping.
 * Choosing CPUs for running workloads.
 
-[NOTE]
-====
-Currently, disabling CPU load balancing is not supported by cgroup v2. As a result, you might not get the desired behavior from performance profiles if you have cgroup v2 enabled. Enabling cgroup v2 is not recommended if you are using performance profiles.
-====
-
 The Node Tuning Operator is part of a standard {product-title} installation in version 4.1 and later.
 
 [NOTE]


### PR DESCRIPTION
[TELCODOCS-1930]: Remove note "Currently, disabling CPU load balancing is not supported .."

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:  https://issues.redhat.com/browse/TELCODOCS-1930
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://78307--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-node-tuning-operator.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
