### PR TITLE
[OSDOCS-11154]: What's new for OSD on GCP: Regions enabled as per XCMSTRAT-434

### DIFF
--- a/osd_whats_new/osd-whats-new.adoc
+++ b/osd_whats_new/osd-whats-new.adoc
@@ -15,6 +15,19 @@ With its foundation in Kubernetes, {product-title} is a complete {OCP} cluster p
 [id="osd-new-changes-and-updates_{context}"]
 == New changes and updates
 
+[id="osd-q3-2024_{context}"]
+=== Q3 2024
+* **{product-title} regions added.** {product-title} on {GCP} is now available in the following additional regions:
+** Melbourne (`australia-southeast2`)
+** Milan (`europe-west8`)
+** Turin (`europe-west12`)
+** Madrid (`europe-southwest1`)
+** Santiago (`southamerica-west1`)
+** Doha (`me-central1`)
+** Dammam (`me-central2`)
+
+For more information on region availabilities, see xref:../osd_architecture/osd_policy/osd-service-definition.adoc#regions-availability-zones_osd-service-definition[Regions and availability zones].
+
 [id="osd-q2-2024_{context}"]
 === Q2 2024
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.16 +
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-11154
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://78309--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_whats_new/osd-whats-new.html#osd-q3-2024_osd-whats-new
QE review:
- [ ] QE has approved this change. **(QE not required. This is an addition to What's New (release notes) based on [XCMSTRAT-434, which ](https://issues.redhat.com/browse/XCMSTRAT-434)/https://issues.redhat.com/browse/OSDOCS-10205, which has already been approved. Note that the new regions included in this PR match what has already been merged in the live docs. 
![image](https://github.com/openshift/openshift-docs/assets/122639474/88769349-f154-4063-a413-8b6fc01e43cc)
** 
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
