### PR TITLE
[enterprise-4.15] OSDOCS#10137: Adding RNs for descheduler 5.0.1

### DIFF
--- a/nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
+++ b/nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
@@ -12,6 +12,40 @@ These release notes track the development of the {descheduler-operator}.
 
 For more information, see xref:../../../nodes/scheduling/descheduler/index.adoc#nodes-descheduler-about_nodes-descheduler-about[About the descheduler].
 
+[id="descheduler-operator-release-notes-5.0.1"]
+== Release notes for {descheduler-operator} 5.0.1
+
+Issued: 2024-07-01
+
+The following advisory is available for the {descheduler-operator} 5.0.1:
+
+* link:https://access.redhat.com/errata/RHSA-2024:3617[RHSA-2024:3617]
+
+[id="descheduler-operator-5.0.1-notable-changes"]
+=== New features and enhancements
+
+* You can now install and use the {descheduler-operator} in an {product-title} cluster running in FIPS mode.
++
+--
+[IMPORTANT]
+====
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode].
+
+When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
+====
+--
+
+[id="descheduler-operator-5.0.1-bug-fixes"]
+=== Bug fixes
+
+* This release of the {descheduler-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
+
+// No known issues to list
+// [id="descheduler-operator-5.0.1-known-issues"]
+// === Known issues
+//
+// * TODO
+
 [id="descheduler-operator-release-notes-5.0.0"]
 == Release notes for {descheduler-operator} 5.0.0
 


### PR DESCRIPTION
Manual CP of #76905.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

Had to do a manual CP because the fips-snippet.adoc doesn't exist in 4.15, so the build failed. Updated to do a hard code of at important block.
