### PR TITLE
replaces instances of VMware datacenter with two words

### DIFF
--- a/modules/capi-yaml-machine-set-vsphere.adoc
+++ b/modules/capi-yaml-machine-set-vsphere.adoc
@@ -40,10 +40,10 @@ spec:
           zone: <zone_a>
           server: <vcenter_server_name>
           topology:
-            datacenter: <region_a_datacenter>
-            computeCluster: "</region_a_datacenter/host/zone_a_cluster>"
-            resourcePool: "</region_a_datacenter/host/zone_a_cluster/Resources/resource_pool>"
-            datastore: "</region_a_datacenter/datastore/datastore_a>"
+            datacenter: <region_a_data_center>
+            computeCluster: "</region_a_data_center/host/zone_a_cluster>"
+            resourcePool: "</region_a_data_center/host/zone_a_cluster/Resources/resource_pool>"
+            datastore: "</region_a_data_center/datastore/datastore_a>"
             networks:
             - port-group
 ----

--- a/modules/capi-yaml-machine-template-vsphere.adoc
+++ b/modules/capi-yaml-machine-template-vsphere.adoc
@@ -23,7 +23,7 @@ spec:
       server: <vcenter_server_ip> # <5>
       diskGiB: 128
       cloneMode: linkedClone # <6>
-      datacenter: <vcenter_datacenter_name> # <7>
+      datacenter: <vcenter_data_center_name> # <7>
       datastore: <vcenter_datastore_name> # <8>
       folder: <vcenter_vm_folder_path> # <9>
       resourcePool: <vsphere_resource_pool> # <10>
@@ -51,8 +51,8 @@ The following values are valid:
 +
 When using the `linkedClone` type, the disk size matches the clone source instead of using the `diskGiB` value.
 For more information, see the {vmw-short} documentation about VM clone types.
-<7> Specify the vCenter Datacenter to deploy the compute machine set on.
-<8> Specify the vCenter Datastore to deploy the compute machine set on.
+<7> Specify the vCenter data center to deploy the compute machine set on.
+<8> Specify the vCenter datastore to deploy the compute machine set on.
 <9> Specify the path to the vSphere VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
 <10> Specify the vSphere resource pool for your VMs.
 <11> Specify the vSphere VM network to deploy the compute machine set to.

--- a/modules/configuring-vsphere-regions-zones.adoc
+++ b/modules/configuring-vsphere-regions-zones.adoc
@@ -10,7 +10,7 @@
 :_mod-docs-content-type: PROCEDURE
 [id="configuring-vsphere-regions-zones_{context}"]
 = Configuring regions and zones for a VMware vCenter
-You can modify the default installation configuration file, so that you can deploy an {product-title} cluster to multiple vSphere datacenters that run in a single VMware vCenter.
+You can modify the default installation configuration file, so that you can deploy an {product-title} cluster to multiple vSphere data centers that run in a single VMware vCenter.
 
 The default `install-config.yaml` file configuration from the previous release of {product-title} is deprecated. You can continue to use the deprecated default configuration, but the `openshift-installer` will prompt you with a warning message that indicates the use of deprecated fields in the configuration file.
 
@@ -24,7 +24,7 @@ The example uses the `govc` command. The `govc` command is an open source comman
 +
 [IMPORTANT]
 ====
-You must specify at least one failure domain for your {product-title} cluster, so that you can provision datacenter objects for your VMware vCenter server. Consider specifying multiple failure domains if you need to provision virtual machine nodes in different datacenters, clusters, datastores, and other components. To enable regions and zones, you must define multiple failure domains for your {product-title} cluster.
+You must specify at least one failure domain for your {product-title} cluster, so that you can provision data center objects for your VMware vCenter server. Consider specifying multiple failure domains if you need to provision virtual machine nodes in different data centers, clusters, datastores, and other components. To enable regions and zones, you must define multiple failure domains for your {product-title} cluster.
 ====
 
 .Procedure
@@ -46,7 +46,7 @@ $ govc tags.category.create -d "OpenShift region" openshift-region
 $ govc tags.category.create -d "OpenShift zone" openshift-zone
 ----
 
-. To create a region tag for each region vSphere datacenter where you want to deploy your cluster, enter the following command in your terminal:
+. To create a region tag for each region vSphere data center where you want to deploy your cluster, enter the following command in your terminal:
 +
 [source,terminal]
 ----
@@ -60,23 +60,23 @@ $ govc tags.create -c <region_tag_category> <region_tag>
 $ govc tags.create -c <zone_tag_category> <zone_tag>
 ----
 
-. Attach region tags to each vCenter datacenter object by entering the following command:
+. Attach region tags to each vCenter data center object by entering the following command:
 +
 [source,terminal]
 ----
-$ govc tags.attach -c <region_tag_category> <region_tag_1> /<datacenter_1>
+$ govc tags.attach -c <region_tag_category> <region_tag_1> /<data_center_1>
 ----
 
-. Attach the zone tags to each vCenter datacenter object by entering the following command:
+. Attach the zone tags to each vCenter data center object by entering the following command:
 +
 [source,terminal]
 ----
-$ govc tags.attach -c <zone_tag_category> <zone_tag_1> /<datacenter_1>/host/vcs-mdcnc-workload-1
+$ govc tags.attach -c <zone_tag_category> <zone_tag_1> /<data_center_1>/host/vcs-mdcnc-workload-1
 ----
 
 . Change to the directory that contains the installation program and initialize the cluster deployment according to your chosen installation requirements.
 
-.Sample `install-config.yaml` file with multiple datacenters defined in a vSphere center
+.Sample `install-config.yaml` file with multiple data centers defined in a vSphere center
 
 [source,yaml]
 ----
@@ -100,32 +100,32 @@ platform:
     vcenters:
 ---
     datacenters:
-      - <datacenter1_name>
-      - <datacenter2_name>
+      - <data_center_1_name>
+      - <data_center_2_name>
     failureDomains:
     - name: <machine_pool_zone_1>
       region: <region_tag_1>
       zone: <zone_tag_1>
       server: <fully_qualified_domain_name>
       topology:
-        datacenter: <datacenter1>
-        computeCluster: "/<datacenter1>/host/<cluster1>"
+        datacenter: <data_center_1>
+        computeCluster: "/<data_center_1>/host/<cluster1>"
         networks:
         - <VM_Network1_name>
-        datastore: "/<datacenter1>/datastore/<datastore1>"
-        resourcePool: "/<datacenter1>/host/<cluster1>/Resources/<resourcePool1>"
-        folder: "/<datacenter1>/vm/<folder1>"
+        datastore: "/<data_center_1>/datastore/<datastore1>"
+        resourcePool: "/<data_center_1>/host/<cluster1>/Resources/<resourcePool1>"
+        folder: "/<data_center_1>/vm/<folder1>"
     - name: <machine_pool_zone_2>
       region: <region_tag_2>
       zone: <zone_tag_2>
       server: <fully_qualified_domain_name>
       topology:
-        datacenter: <datacenter2>
-        computeCluster: "/<datacenter2>/host/<cluster2>"
+        datacenter: <data_center_2>
+        computeCluster: "/<data_center_2>/host/<cluster2>"
         networks:
         - <VM_Network2_name>
-        datastore: "/<datacenter2>/datastore/<datastore2>"
-        resourcePool: "/<datacenter2>/host/<cluster2>/Resources/<resourcePool2>"
-        folder: "/<datacenter2>/vm/<folder2>"
+        datastore: "/<data_center_2>/datastore/<datastore2>"
+        resourcePool: "/<data_center_2>/host/<cluster2>/Resources/<resourcePool2>"
+        folder: "/<data_center_2>/vm/<folder2>"
 ---
 ----

--- a/modules/cpmso-yaml-failure-domain-vsphere.adoc
+++ b/modules/cpmso-yaml-failure-domain-vsphere.adoc
@@ -8,9 +8,9 @@
 
 On {vmw-full} infrastructure, the cluster-wide infrastructure Custom Resource Definition (CRD), `infrastructures.config.openshift.io`, defines failure domains for your cluster.
 The `providerSpec` in the `ControlPlaneMachineSet` custom resource (CR) specifies names for failure domains that the control plane machine set uses to ensure control plane nodes are deployed to the appropriate failure domain.
-A failure domain is an infrastructure resource made up of a control plane machine set, a vCenter datacenter, vCenter datastore, and a network.
+A failure domain is an infrastructure resource made up of a control plane machine set, a vCenter data center, vCenter datastore, and a network.
 
-By using a failure domain resource, you can use a control plane machine set to deploy control plane machines on  separate clusters or datacenters.
+By using a failure domain resource, you can use a control plane machine set to deploy control plane machines on  separate clusters or data centers.
 A control plane machine set also balances control plane machines across defined failure domains to provide fault tolerance capabilities to your infrastructure.
 
 [NOTE]

--- a/modules/cpmso-yaml-provider-spec-vsphere.adoc
+++ b/modules/cpmso-yaml-provider-spec-vsphere.adoc
@@ -41,7 +41,7 @@ spec:
             userDataSecret:
               name: master-user-data <9>
             workspace: <10>
-              datacenter: <vcenter_datacenter_name> <11>
+              datacenter: <vcenter_data_center_name> <11>
               datastore: <vcenter_datastore_name> <12>
               folder: <path_to_vcenter_vm_folder> <13>
               resourcePool: <vsphere_resource_pool> <14>
@@ -69,8 +69,8 @@ If you specify this value in the provider specification when using failure domai
 If the cluster is configured to use a failure domain, these parameters are configured in the failure domain.
 If you specify these values in the provider specification when using failure domains, the Control Plane Machine Set Operator ignores them.
 ====
-<11> Specifies the vCenter Datacenter for the control plane.
-<12> Specifies the vCenter Datastore for the control plane.
+<11> Specifies the vCenter data center for the control plane.
+<12> Specifies the vCenter datastore for the control plane.
 <13> Specifies the path to the vSphere VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
 <14> Specifies the vSphere resource pool for your VMs.
 <15> Specifies the vCenter server IP or fully qualified domain name.

--- a/modules/images-configuration-registry-mirror.adoc
+++ b/modules/images-configuration-registry-mirror.adoc
@@ -25,7 +25,7 @@ Setting up repository mirroring can be done in the following ways:
 
 * At {product-title} installation:
 +
-By pulling container images needed by {product-title} and then bringing those images behind your company's firewall, you can install {product-title} into a datacenter that is in a disconnected environment.
+By pulling container images needed by {product-title} and then bringing those images behind your company's firewall, you can install {product-title} into a data center that is in a disconnected environment.
 
 * After {product-title} installation:
 +
@@ -53,6 +53,6 @@ requested from the source repository.
 
 For new clusters, you can use IDMS, ITMS, and ICSP CRs objects as desired. However, using IDMS and ITMS is recommended.
 
-If you upgraded a cluster, any existing ICSP objects remain stable, and both IDMS and ICSP objects are supported. Workloads using ICSP objects continue to function as expected. However, if you want to take advantage of the fallback policies introduced in the IDMS CRs, you can migrate current workloads to IDMS objects by using the `oc adm migrate icsp` command as shown in the *Converting ImageContentSourcePolicy (ICSP) files for image registry repository mirroring* section that follows. Migrating to IDMS objects does not require a cluster reboot. 
+If you upgraded a cluster, any existing ICSP objects remain stable, and both IDMS and ICSP objects are supported. Workloads using ICSP objects continue to function as expected. However, if you want to take advantage of the fallback policies introduced in the IDMS CRs, you can migrate current workloads to IDMS objects by using the `oc adm migrate icsp` command as shown in the *Converting ImageContentSourcePolicy (ICSP) files for image registry repository mirroring* section that follows. Migrating to IDMS objects does not require a cluster reboot.
 
 include::snippets/idms-global-pull-secret.adoc[]

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -2692,7 +2692,7 @@ endif::vsphere[]
   vsphere:
     failureDomains:
       region:
-|If you define multiple failure domains for your cluster, you must attach the tag to each vCenter datacenter. To define a region, use a tag from the `openshift-region` tag category. For a single vSphere datacenter environment, you do not need to attach a tag, but you must enter an alphanumeric value, such as `datacenter`, for the parameter.
+|If you define multiple failure domains for your cluster, you must attach the tag to each vCenter data center. To define a region, use a tag from the `openshift-region` tag category. For a single vSphere data center environment, you do not need to attach a tag, but you must enter an alphanumeric value, such as `datacenter`, for the parameter.
 |String
 
 |platform:
@@ -2706,7 +2706,7 @@ endif::vsphere[]
   vsphere:
     failureDomains:
       zone:
-|If you define multiple failure domains for your cluster, you must attach a tag to each vCenter cluster. To define a zone, use a tag from the `openshift-zone` tag category. For a single vSphere datacenter environment, you do not need to attach a tag, but you must enter an alphanumeric value, such as `cluster`, for the parameter.
+|If you define multiple failure domains for your cluster, you must attach a tag to each vCenter cluster. To define a zone, use a tag from the `openshift-zone` tag category. For a single vSphere data center environment, you do not need to attach a tag, but you must enter an alphanumeric value, such as `cluster`, for the parameter.
 |String
 
 |platform:
@@ -2722,8 +2722,8 @@ endif::vsphere[]
     failureDomains:
       topology:
         datacenter:
-|Lists and defines the datacenters where {product-title} virtual machines (VMs) operate.
-The list of datacenters must match the list of datacenters specified in the `vcenters` field.
+|Lists and defines the data centers where {product-title} virtual machines (VMs) operate.
+The list of data centers must match the list of data centers specified in the `vcenters` field.
 |String
 
 ifdef::vsphere[]
@@ -2758,9 +2758,9 @@ endif::agent[]
     failureDomains:
       topology:
         folder:
-|Optional: The absolute path of an existing folder where the user creates the virtual machines, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
+|Optional: The absolute path of an existing folder where the user creates the virtual machines, for example, `/<data_center_name>/vm/<folder_name>/<subfolder_name>`.
 ifdef::vsphere[]
-If you do not provide this value, the installation program creates a top-level folder in the datacenter virtual machine folder that is named with the infrastructure ID. If you are providing the infrastructure for the cluster and you do not want to use the default `StorageClass` object, named `thin`, you can omit the `folder` parameter from the `install-config.yaml` file.
+If you do not provide this value, the installation program creates a top-level folder in the data center virtual machine folder that is named with the infrastructure ID. If you are providing the infrastructure for the cluster and you do not want to use the default `StorageClass` object, named `thin`, you can omit the `folder` parameter from the `install-config.yaml` file.
 endif::vsphere[]
 |String
 
@@ -2778,9 +2778,9 @@ endif::vsphere[]
       topology:
         resourcePool:
 
-|Optional: The absolute path of an existing resource pool where the installation program creates the virtual machines, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
+|Optional: The absolute path of an existing resource pool where the installation program creates the virtual machines, for example, `/<data_center_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
 ifdef::vsphere[]
-If you do not specify a value, the installation program installs the resources in the root of the cluster under `/<datacenter_name>/host/<cluster_name>/Resources`.
+If you do not specify a value, the installation program installs the resources in the root of the cluster under `/<data_center_name>/host/<cluster_name>/Resources`.
 endif::vsphere[]
 |String
 
@@ -2814,7 +2814,7 @@ endif::vsphere[]
   vsphere:
     vcenters:
       datacenters:
-|Lists and defines the datacenters where {product-title} virtual machines (VMs) operate. The list of datacenters must match the list of datacenters specified in the `failureDomains` field.
+|Lists and defines the data centers where {product-title} virtual machines (VMs) operate. The list of data centers must match the list of data centers specified in the `failureDomains` field.
 |String
 
 |platform:
@@ -2880,7 +2880,7 @@ endif::vsphere[]
 |platform:
   vsphere:
     datacenter:
-|Defines the datacenter where {product-title} virtual machines (VMs) operate.
+|Defines the data center where {product-title} virtual machines (VMs) operate.
 |String
 
 |platform:
@@ -2893,7 +2893,7 @@ endif::vsphere[]
   vsphere:
     folder:
 |Optional: The absolute path of an existing folder where the installation program creates the virtual machines. If you do not provide this value, the installation program creates a folder that is named with the infrastructure ID in the data center virtual machine folder.
-|String, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
+|String, for example, `/<data_center_name>/vm/<folder_name>/<subfolder_name>`.
 
 ifdef::vsphere[]
 |platform:
@@ -2922,8 +2922,8 @@ endif::vsphere[]
 |platform:
   vsphere:
     resourcePool:
-|Optional: The absolute path of an existing resource pool where the installation program creates the virtual machines. If you do not specify a value, the installation program installs the resources in the root of the cluster under `/<datacenter_name>/host/<cluster_name>/Resources`.
-|String, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
+|Optional: The absolute path of an existing resource pool where the installation program creates the virtual machines. If you do not specify a value, the installation program installs the resources in the root of the cluster under `/<data_center_name>/host/<cluster_name>/Resources`.
+|String, for example, `/<data_center_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
 
 |platform:
   vsphere:

--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -333,7 +333,7 @@ The installation program connects to your vCenter instance.
 +
 [NOTE]
 ====
-After you create the installation configuration file, you can modify the file to create a multiple vSphere datacenters environment. This means that you can deploy an {product-title} cluster to multiple vSphere datacenters that run in a single VMware vCenter. For more information about creating this environment, see the section named _VMware vSphere region and zone enablement_.
+After you create the installation configuration file, you can modify the file to create a multiple vSphere data center environment. This means that you can deploy an {product-title} cluster to multiple vSphere data centers that run in a single VMware vCenter. For more information about creating this environment, see the section named _VMware vSphere region and zone enablement_.
 ====
 
 ... Select the default vCenter datastore to use.

--- a/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
+++ b/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
@@ -55,13 +55,13 @@ platform:
       region: <default_region_name>
       server: <fully_qualified_domain_name>
       topology:
-        computeCluster: "/<datacenter>/host/<cluster>"
-        datacenter: <datacenter>
-        datastore: "/<datacenter>/datastore/<datastore>" <6>
+        computeCluster: "/<data_center>/host/<cluster>"
+        datacenter: <data_center>
+        datastore: "/<data_center>/datastore/<datastore>" <6>
         networks:
         - <VM_Network_name>
-        resourcePool: "/<datacenter>/host/<cluster>/Resources/<resourcePool>" <7>
-        folder: "/<datacenter_name>/vm/<folder_name>/<subfolder_name>"
+        resourcePool: "/<data_center>/host/<cluster>/Resources/<resourcePool>" <7>
+        folder: "/<data_center_name>/vm/<folder_name>/<subfolder_name>"
         tagIDs: <8>
         - <tag_id>  <9>
       zone: <default_zone_name>
@@ -69,7 +69,7 @@ platform:
     - 10.0.0.2
     vcenters:
     - datacenters:
-      - <datacenter>
+      - <data_center>
       password: <password>
       port: 443
       server: <fully_qualified_domain_name>

--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -47,17 +47,17 @@ platform:
       region: <default_region_name>
       server: <fully_qualified_domain_name>
       topology:
-        computeCluster: "/<datacenter>/host/<cluster>"
-        datacenter: <datacenter> <7>
-        datastore: "/<datacenter>/datastore/<datastore>" <8>
+        computeCluster: "/<data_center>/host/<cluster>"
+        datacenter: <data_center> <7>
+        datastore: "/<data_center>/datastore/<datastore>" <8>
         networks:
         - <VM_Network_name>
-        resourcePool: "/<datacenter>/host/<cluster>/Resources/<resourcePool>" <9>
-        folder: "/<datacenter_name>/vm/<folder_name>/<subfolder_name>" <10>
+        resourcePool: "/<data_center>/host/<cluster>/Resources/<resourcePool>" <9>
+        folder: "/<data_center_name>/vm/<folder_name>/<subfolder_name>" <10>
       zone: <default_zone_name>
     vcenters:
     - datacenters:
-      - <datacenter>
+      - <data_center>
       password: <password> <11>
       port: 443
       server: <fully_qualified_domain_name> <12>
@@ -134,7 +134,7 @@ the cluster uses this values as the number of etcd endpoints in the cluster, the
 value must match the number of control plane machines that you deploy.
 <5> The cluster name that you specified in your DNS records.
 <6> Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
-<7> The vSphere datacenter.
+<7> The vSphere data center.
 <8> The path to the vSphere datastore that holds virtual machine files, templates, and ISO images.
 +
 [IMPORTANT]
@@ -143,8 +143,8 @@ You can specify the path of any datastore that exists in a datastore cluster. By
 
 If you must specify VMs across multiple datastores, use a `datastore` object to specify a failure domain in your cluster's `install-config.yaml` configuration file. For more information, see "VMware vSphere region and zone enablement".
 ====
-<9> Optional: For installer-provisioned infrastructure, the absolute path of an existing resource pool where the installation program creates the virtual machines, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`. If you do not specify a value, resources are installed in the root of the cluster `/example_datacenter/host/example_cluster/Resources`.
-<10> Optional: For installer-provisioned infrastructure, the absolute path of an existing folder where the installation program creates the virtual machines, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`. If you do not provide this value, the installation program creates a top-level folder in the datacenter virtual machine folder that is named with the infrastructure ID. If you are providing the infrastructure for the cluster and you do not want to use the default `StorageClass` object, named `thin`, you can omit the `folder` parameter from the `install-config.yaml` file.
+<9> Optional: For installer-provisioned infrastructure, the absolute path of an existing resource pool where the installation program creates the virtual machines, for example, `/<data_center_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`. If you do not specify a value, resources are installed in the root of the cluster `/example_data_center/host/example_cluster/Resources`.
+<10> Optional: For installer-provisioned infrastructure, the absolute path of an existing folder where the installation program creates the virtual machines, for example, `/<data_center_name>/vm/<folder_name>/<subfolder_name>`. If you do not provide this value, the installation program creates a top-level folder in the data center virtual machine folder that is named with the infrastructure ID. If you are providing the infrastructure for the cluster and you do not want to use the default `StorageClass` object, named `thin`, you can omit the `folder` parameter from the `install-config.yaml` file.
 <11> The password associated with the vSphere user.
 <12> The fully-qualified hostname or IP address of the vCenter server.
 +

--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -81,7 +81,7 @@ endif::upi[]
 `VApp.Import`
 `VirtualMachine.Config.AddNewDisk`
 
-|vSphere Datastore
+|vSphere datastore
 |Always
 |
 [%hardbreaks]
@@ -129,7 +129,7 @@ endif::upi[]
 `VirtualMachine.Provisioning.MarkAsTemplate`
 `VirtualMachine.Provisioning.DeployTemplate`
 
-|vSphere vCenter Datacenter
+|vSphere vCenter data center
 |If the installation program creates the virtual machine folder. For user-provisioned infrastructure, `VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API. See the "Minimum permissions for the Machine API" table.
 |
 [%hardbreaks]
@@ -212,7 +212,7 @@ endif::upi[]
 `VApp.Import`
 `"Virtual machine"."Change Configuration"."Add new disk"`
 
-|vSphere Datastore
+|vSphere datastore
 |Always
 |
 [%hardbreaks]
@@ -259,7 +259,7 @@ endif::upi[]
 `"Virtual machine".Provisioning."Mark as template"`
 `"Virtual machine".Provisioning."Deploy template"`
 
-|vSphere vCenter Datacenter
+|vSphere vCenter data center
 |If the installation program creates the virtual machine folder. For user-provisioned infrastructure, `VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API.
 |
 [%hardbreaks]
@@ -315,7 +315,7 @@ Additionally, the user requires some `ReadOnly` permissions, and some of the rol
 |False
 |Listed required privileges
 
-.2+|vSphere vCenter Datacenter
+.2+|vSphere vCenter data center
 |Existing folder
 |False
 |`ReadOnly` permission
@@ -333,7 +333,7 @@ Additionally, the user requires some `ReadOnly` permissions, and some of the rol
 |True
 |Listed required privileges
 
-|vSphere vCenter Datastore
+|vSphere vCenter datastore
 |Always
 |False
 |Listed required privileges
@@ -474,7 +474,7 @@ ifndef::upi[]
 `VirtualMachine.Provisioning.MarkAsTemplate`
 `VirtualMachine.Provisioning.DeployTemplate`
 
-|vSphere vCenter Datacenter
+|vSphere vCenter data center
 |If the installation program creates the virtual machine folder. For user-provisioned infrastructure, `VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API. If your cluster does use the Machine API and you want to set the minimum set of permissions for the API, see the "Minimum permissions for the Machine API" table.
 |
 [%hardbreaks]
@@ -552,7 +552,7 @@ endif::upi[]
 [%hardbreaks]
 `Host.Config.Storage`
 
-|vSphere Datastore
+|vSphere datastore
 |Always
 |
 [%hardbreaks]
@@ -586,7 +586,7 @@ endif::upi[]
 `VirtualMachine.Provisioning.Clone`
 `VirtualMachine.Provisioning.DeployTemplate`
 
-|vSphere vCenter Datacenter
+|vSphere vCenter data center
 |If the installation program creates the virtual machine folder. For user-provisioned infrastructure, `VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API. If your cluster does use the Machine API and you want to set the minimum set of permissions for the API, see the "Minimum permissions for the Machine API" table.
 |
 [%hardbreaks]
@@ -633,7 +633,7 @@ endif::upi[]
 [%hardbreaks]
 `Host.Config.Storage`
 
-|vSphere Datastore
+|vSphere datastore
 |Always
 |
 [%hardbreaks]
@@ -654,7 +654,7 @@ endif::upi[]
 `VirtualMachine.Config.AddExistingDisk`
 `VirtualMachine.Config.AddRemoveDevice`
 
-|vSphere vCenter Datacenter
+|vSphere vCenter data center
 |If the installation program creates the virtual machine folder. For user-provisioned infrastructure, `VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API. If your cluster does use the Machine API and you want to set the minimum set of permissions for the API, see the "Minimum permissions for the Machine API" table.
 |
 [%hardbreaks]
@@ -700,7 +700,7 @@ endif::upi[]
 [%hardbreaks]
 `Read Only`
 
-|vSphere Datastore
+|vSphere datastore
 |Always
 |
 [%hardbreaks]
@@ -731,7 +731,7 @@ endif::upi[]
 `VirtualMachine.Provisioning.Clone`
 `VirtualMachine.Provisioning.DeployTemplate`
 
-|vSphere vCenter Datacenter
+|vSphere vCenter data center
 |If the installation program creates the virtual machine folder. For user-provisioned infrastructure, `VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API.
 |
 [%hardbreaks]

--- a/modules/installation-vsphere-machines.adoc
+++ b/modules/installation-vsphere-machines.adoc
@@ -92,9 +92,9 @@ ifdef::openshift-origin[]
 . Obtain the {op-system} images from the link:https://getfedora.org/en/coreos/download?tab=metal_virtualized&stream=stable[{op-system} Downloads] page
 endif::openshift-origin[]
 
-. In the vSphere Client, create a folder in your datacenter to store your VMs.
+. In the vSphere Client, create a folder in your data center to store your VMs.
 .. Click the *VMs and Templates* view.
-.. Right-click the name of your datacenter.
+.. Right-click the name of your data center.
 .. Click *New Folder* -> *New VM and Template Folder*.
 .. In the window that is displayed, enter the folder name. If you did not specify an existing folder in the `install-config.yaml` file, then create a folder with the same name as the infrastructure ID. You use this folder name so vCenter dynamically provisions storage in the appropriate location for its Workspace configuration.
 
@@ -139,7 +139,7 @@ Ensure that all virtual machine names across a vSphere installation are unique.
 ====
 .. On the *Select a name and folder* tab, select the name of the folder that you created for the cluster.
 
-.. On the *Select a compute resource* tab, select the name of a host in your datacenter.
+.. On the *Select a compute resource* tab, select the name of a host in your data center.
 +
 .. On the *Select clone options* tab, select *Customize this virtual machine's hardware*.
 

--- a/modules/installation-vsphere-regions-zones.adoc
+++ b/modules/installation-vsphere-regions-zones.adoc
@@ -11,7 +11,7 @@
 [id="installation-vsphere-regions-zones_{context}"]
 = VMware vSphere region and zone enablement
 
-You can deploy an {product-title} cluster to multiple vSphere datacenters that run in a single VMware vCenter. Each datacenter can run multiple clusters. This configuration reduces the risk of a hardware failure or network outage that can cause your cluster to fail. To enable regions and zones, you must define multiple failure domains for your {product-title} cluster.
+You can deploy an {product-title} cluster to multiple vSphere data centers that run in a single VMware vCenter. Each data center can run multiple clusters. This configuration reduces the risk of a hardware failure or network outage that can cause your cluster to fail. To enable regions and zones, you must define multiple failure domains for your {product-title} cluster.
 
 [IMPORTANT]
 ====
@@ -20,14 +20,14 @@ The VMware vSphere region and zone enablement feature requires the vSphere Conta
 For a cluster that was upgraded from a previous release, you must enable CSI automatic migration for the cluster. You can then configure multiple regions and zones for the upgraded cluster.
 ====
 
-The default installation configuration deploys a cluster to a single vSphere datacenter. If you want to deploy a cluster to multiple vSphere datacenters, you must create an installation configuration file that enables the region and zone feature.
+The default installation configuration deploys a cluster to a single vSphere data center. If you want to deploy a cluster to multiple vSphere data centers, you must create an installation configuration file that enables the region and zone feature.
 
-The default `install-config.yaml` file includes `vcenters` and `failureDomains` fields, where you can specify multiple vSphere datacenters and clusters for your {product-title} cluster. You can leave these fields blank if you want to install an {product-title} cluster in a vSphere environment that consists of single datacenter.
+The default `install-config.yaml` file includes `vcenters` and `failureDomains` fields, where you can specify multiple vSphere data centers and clusters for your {product-title} cluster. You can leave these fields blank if you want to install an {product-title} cluster in a vSphere environment that consists of single data center.
 
 The following list describes terms associated with defining zones and regions for your cluster:
 
 * Failure domain: Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
-* Region: Specifies a vCenter datacenter. You define a region by using a tag from the  `openshift-region` tag category.
+* Region: Specifies a vCenter data center. You define a region by using a tag from the  `openshift-region` tag category.
 * Zone: Specifies a vCenter cluster. You define a zone by using a tag from the `openshift-zone` tag category.
 
 [NOTE]
@@ -35,13 +35,13 @@ The following list describes terms associated with defining zones and regions fo
 If you plan on specifying more than one failure domain in your `install-config.yaml` file, you must create tag categories, zone tags, and region tags in advance of creating the configuration file.
 ====
 
-You must create a vCenter tag for each vCenter datacenter, which represents a region. Additionally, you must create a vCenter tag for each cluster than runs in a datacenter, which represents a zone. After you create the tags, you must attach each tag to their respective datacenters and clusters.
+You must create a vCenter tag for each vCenter data center, which represents a region. Additionally, you must create a vCenter tag for each cluster than runs in a data center, which represents a zone. After you create the tags, you must attach each tag to their respective data centers and clusters.
 
-The following table outlines an example of the relationship among regions, zones, and tags for a configuration with multiple vSphere datacenters running in a single VMware vCenter.
+The following table outlines an example of the relationship among regions, zones, and tags for a configuration with multiple vSphere data centers running in a single VMware vCenter.
 
 [cols="2,2a,4a",options="header"]
 |===
-|Datacenter (region)| Cluster (zone)| Tags
+|Data center (region)| Cluster (zone)| Tags
 
 .4+|us-east
 

--- a/modules/machine-vsphere-machines.adoc
+++ b/modules/machine-vsphere-machines.adoc
@@ -42,7 +42,7 @@ Ensure that all virtual machine names across a vSphere installation are unique.
 
 . On the *Select a name and folder* tab, select the name of the folder that you created for the cluster.
 
-. On the *Select a compute resource* tab, select the name of a host in your datacenter.
+. On the *Select a compute resource* tab, select the name of a host in your data center.
 
 . On the *Select storage* tab, select storage for your configuration and disk files.
 

--- a/modules/machineset-creating.adoc
+++ b/modules/machineset-creating.adoc
@@ -168,7 +168,7 @@ template:
         userDataSecret:
           name: worker-user-data <3>
         workspace:
-          datacenter: <vcenter_datacenter_name>
+          datacenter: <vcenter_data_center_name>
           datastore: <vcenter_datastore_name>
           folder: <vcenter_vm_folder_path>
           resourcepool: <vsphere_resource_pool>

--- a/modules/machineset-vsphere-required-permissions.adoc
+++ b/modules/machineset-vsphere-required-permissions.adoc
@@ -39,7 +39,7 @@ If you cannot use an account with global administrative privileges, you must cre
 [%hardbreaks]
 `Resource.AssignVMToPool`
 
-|vSphere Datastore
+|vSphere datastore
 |Always
 |
 [%hardbreaks]
@@ -67,7 +67,7 @@ If you cannot use an account with global administrative privileges, you must cre
 `VirtualMachine.Inventory.Delete`
 `VirtualMachine.Provisioning.Clone`
 
-|vSphere vCenter Datacenter
+|vSphere vCenter data center
 |If the installation program creates the virtual machine folder
 |
 [%hardbreaks]
@@ -96,7 +96,7 @@ The following table details the permissions and propagation settings that are re
 |Not required
 |Listed required privileges
 
-.2+|vSphere vCenter Datacenter
+.2+|vSphere vCenter data center
 |Existing folder
 |Not required
 |`ReadOnly` permission
@@ -110,7 +110,7 @@ The following table details the permissions and propagation settings that are re
 |Required
 |Listed required privileges
 
-|vSphere vCenter Datastore
+|vSphere vCenter datastore
 |Always
 |Not required
 |Listed required privileges

--- a/modules/machineset-yaml-vsphere.adoc
+++ b/modules/machineset-yaml-vsphere.adoc
@@ -100,7 +100,7 @@ ifndef::infra[]
           userDataSecret:
             name: worker-user-data
           workspace:
-            datacenter: <vcenter_datacenter_name> <6>
+            datacenter: <vcenter_data_center_name> <6>
             datastore: <vcenter_datastore_name> <7>
             folder: <vcenter_vm_folder_path> <8>
             resourcepool: <vsphere_resource_pool> <9>
@@ -111,7 +111,7 @@ ifdef::infra[]
           userDataSecret:
             name: worker-user-data
           workspace:
-            datacenter: <vcenter_datacenter_name> <7>
+            datacenter: <vcenter_data_center_name> <7>
             datastore: <vcenter_datastore_name> <8>
             folder: <vcenter_vm_folder_path> <9>
             resourcepool: <vsphere_resource_pool> <10>
@@ -129,8 +129,8 @@ ifndef::infra[]
 <3> Specify the node label to add.
 <4> Specify the vSphere VM network to deploy the compute machine set to. This VM network must be where other compute machines reside in the cluster.
 <5> Specify the vSphere VM template to use, such as `user-5ddjd-rhcos`.
-<6> Specify the vCenter Datacenter to deploy the compute machine set on.
-<7> Specify the vCenter Datastore to deploy the compute machine set on.
+<6> Specify the vCenter data center to deploy the compute machine set on.
+<7> Specify the vCenter datastore to deploy the compute machine set on.
 <8> Specify the path to the vSphere VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
 <9> Specify the vSphere resource pool for your VMs.
 <10> Specify the vCenter server IP or fully qualified domain name.
@@ -147,8 +147,8 @@ After adding the `NoSchedule` taint on the infrastructure node, existing DNS pod
 
 <5> Specify the vSphere VM network to deploy the compute machine set to. This VM network must be where other compute machines reside in the cluster.
 <6> Specify the vSphere VM template to use, such as `user-5ddjd-rhcos`.
-<7> Specify the vCenter Datacenter to deploy the compute machine set on.
-<8> Specify the vCenter Datastore to deploy the compute machine set on.
+<7> Specify the vCenter data center to deploy the compute machine set on.
+<8> Specify the vCenter datastore to deploy the compute machine set on.
 <9> Specify the path to the vSphere VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
 <10> Specify the vSphere resource pool for your VMs.
 <11> Specify the vCenter server IP or fully qualified domain name.

--- a/modules/nodes-vsphere-scaling-machines-static-ip.adoc
+++ b/modules/nodes-vsphere-scaling-machines-static-ip.adoc
@@ -59,7 +59,7 @@ spec:
       userDataSecret:
         name: worker-user-data
       workspace:
-        datacenter: <vcenter_datacenter_name>
+        datacenter: <vcenter_data_center_name>
         datastore: <vcenter_datastore_name>
         folder: <vcenter_vm_folder_path>
         resourcepool: <vsphere_resource_pool>

--- a/modules/persistent-storage-csi-vsphere-top-aware-overview.adoc
+++ b/modules/persistent-storage-csi-vsphere-top-aware-overview.adoc
@@ -7,7 +7,7 @@
 [id="persistent-storage-csi-vsphere-top-aware-overview_{context}"]
 = vSphere CSI topology overview
 
-{product-title} provides the ability to deploy {product-title} for vSphere on different zones and regions, which allows you to deploy over multiple compute clusters and datacenters, thus helping to avoid a single point of failure. 
+{product-title} provides the ability to deploy {product-title} for vSphere on different zones and regions, which allows you to deploy over multiple compute clusters and data centers, thus helping to avoid a single point of failure.
 
 This is accomplished by defining zone and region categories in vCenter, and then assigning these categories to different failure domains, such as a compute cluster, by creating tags for these zone and region categories. After you have created the appropriate categories, and assigned tags to vCenter objects, you can create additional machinesets that create virtual machines (VMs) that are responsible for scheduling pods in those failure domains.
 
@@ -17,29 +17,29 @@ The following example defines two failure domains with one region and two zones:
 |===
 |Compute cluster | Failure domain |Description
 
-|Compute cluster: ocp1, 
-Datacenter: Atlanta
+|Compute cluster: ocp1,
+Data center: Atlanta
 |openshift-region: us-east-1 (tag), openshift-zone: us-east-1a (tag)
 |This defines a failure domain in region us-east-1 with zone us-east-1a.
 
-|Computer cluster: ocp2, 
-Datacenter: Atlanta
+|Computer cluster: ocp2,
+Data center: Atlanta
 |openshift-region: us-east-1 (tag), openshift-zone: us-east-1b (tag)
 |This defines a different failure domain within the same region called us-east-1b.
 |===
 
-== vSphere CSI topology requirements 
+== vSphere CSI topology requirements
 The following guidelines are recommended for vSphere CSI topology:
 
-* You are strongly recommended to add topology tags to datacenters and compute clusters, and *not* to hosts. 
+* You are strongly recommended to add topology tags to data centers and compute clusters, and *not* to hosts.
 +
-`vsphere-problem-detector` provides alerts if the `openshift-region` or `openshift-zone` tags are not defined at the datacenter or compute cluster level, and each topology tag (`openshift-region` or `openshift-zone`) should occur only once in the hierarchy.
+`vsphere-problem-detector` provides alerts if the `openshift-region` or `openshift-zone` tags are not defined at the data center or compute cluster level, and each topology tag (`openshift-region` or `openshift-zone`) should occur only once in the hierarchy.
 +
 [NOTE]
 ====
 Ignoring this recommendation only results in a log warning from the CSI driver and duplicate tags lower in the hierarchy, such as hosts, are ignored; VMware considers this an invalid configuration, and therefore to prevent problems you should not use it.
 ====
 
-* Volume provisioning requests in topology-aware environments attempt to create volumes in datastores accessible to all hosts under a given topology segment. This includes hosts that do not have Kubernetes node VMs running on them. For example, if the vSphere Container Storage Plug-in driver receives a request to provision a volume in zone-a, applied on the Datacenter dc-1, all hosts under dc-1 must have access to the datastore selected for volume provisioning. The hosts include those that are directly under dc-1, and those that are a part of clusters inside dc-1.
+* Volume provisioning requests in topology-aware environments attempt to create volumes in datastores accessible to all hosts under a given topology segment. This includes hosts that do not have Kubernetes node VMs running on them. For example, if the vSphere Container Storage Plug-in driver receives a request to provision a volume in `zone-a`, applied on the data center `dc-1`, all hosts under `dc-1` must have access to the datastore selected for volume provisioning. The hosts include those that are directly under `dc-1`, and those that are a part of clusters inside `dc-1`.
 
 * For additional recommendations, you should read the VMware https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/3.0/vmware-vsphere-csp-getting-started/GUID-162E7582-723B-4A0F-A937-3ACE82EAFD31.html[Guidelines and Best Practices for Deployment with Topology] section.

--- a/modules/references-regions-zones-infrastructure-vsphere.adoc
+++ b/modules/references-regions-zones-infrastructure-vsphere.adoc
@@ -14,7 +14,7 @@ The following table lists mandatory parameters for defining multiple regions and
 |Parameter | Description
 
 |`vcenters` | The vCenter server for your {product-title} cluster. You can only specify one vCenter for your cluster.
-|`datacenters` | vCenter datacenters where VMs associated with the {product-title} cluster will be created or presently exist.
+|`datacenters` | vCenter data centers where VMs associated with the {product-title} cluster will be created or presently exist.
 |`port` | The TCP port of the vCenter server.
 |`server` | The fully qualified domain name (FQDN) of the vCenter server.
 |`failureDomains`| The list of failure domains.
@@ -22,7 +22,7 @@ The following table lists mandatory parameters for defining multiple regions and
 |`region` | The value of the `openshift-region` tag assigned to the topology for the failure failure domain.
 |`zone` | The value of the `openshift-zone` tag assigned to the topology for the failure failure domain.
 |`topology`| The vCenter reources associated with the failure domain.
-|`datacenter` | The datacenter associated with the failure domain.
+|`datacenter` | The data center associated with the failure domain.
 |`computeCluster` | The full path of the compute cluster associated with the failure domain.
 |`resourcePool` | The full path of the resource pool associated with the failure domain.
 |`datastore` | The full path of the datastore associated with the failure domain.

--- a/modules/specifying-regions-zones-infrastructure-vsphere.adoc
+++ b/modules/specifying-regions-zones-infrastructure-vsphere.adoc
@@ -9,7 +9,7 @@ You can configure the `infrastructures.config.openshift.io` configuration resour
 
 Topology-aware features for the cloud controller manager and the vSphere Container Storage Interface (CSI) Operator Driver require information about the vSphere topology where you host your {product-title} cluster. This topology information exists in the `infrastructures.config.openshift.io` configuration resource.
 
-Before you specify regions and zones for your cluster, you must ensure that all datacenters and compute clusters contain tags, so that the cloud provider can add labels to your node. For example, if `datacenter-1` represents `region-a` and `compute-cluster-1` represents `zone-1`, the cloud provider adds an `openshift-region` category label with a value of `region-a` to `datacenter-1`.  Additionally, the cloud provider adds an `openshift-zone` category tag with a value of `zone-1` to `compute-cluster-1`.
+Before you specify regions and zones for your cluster, you must ensure that all data centers and compute clusters contain tags, so that the cloud provider can add labels to your node. For example, if `data-center-1` represents `region-a` and `compute-cluster-1` represents `zone-1`, the cloud provider adds an `openshift-region` category label with a value of `region-a` to `data-center-1`.  Additionally, the cloud provider adds an `openshift-zone` category tag with a value of `zone-1` to `compute-cluster-1`.
 
 [NOTE]
 ====
@@ -18,14 +18,14 @@ You can migrate control plane nodes with vMotion capabilities to a failure domai
 
 .Prerequisites
 * You created the `openshift-region` and `openshift-zone` tag categories on the vCenter server.
-* You ensured that each datacenter and compute cluster contains tags that represent the name of their associated region or zone, or both.
+* You ensured that each data center and compute cluster contains tags that represent the name of their associated region or zone, or both.
 * Optional: If you defined *API* and *Ingress* static IP addresses to the installation program, you must ensure that all regions and zones share a common layer 2 network. This configuration ensures that API and Ingress Virtual IP (VIP) addresses can interact with your cluster.
 
 // Add link(s) that points to Day-0 docs for creating tags as soon as the Day-0 content is merged.
 
 [IMPORTANT]
 ====
-If you do not supply tags to all datacenters and compute clusters before you create a node or migrate a node, the cloud provider cannot add the `topology.kubernetes.io/zone` and `topology.kubernetes.io/region` labels to the node. This means that services cannot route traffic to your node.
+If you do not supply tags to all data centers and compute clusters before you create a node or migrate a node, the cloud provider cannot add the `topology.kubernetes.io/zone` and `topology.kubernetes.io/region` labels to the node. This means that services cannot route traffic to your node.
 ====
 
 .Procedure
@@ -50,8 +50,8 @@ spec:
     vsphere:
       vcenters:
         - datacenters:
-            - <region_a_datacenter>
-            - <region_b_datacenter>
+            - <region_a_data_center>
+            - <region_b_data_center>
           port: 443
           server: <your_vcenter_server>
       failureDomains:

--- a/modules/windows-machineset-vsphere.adoc
+++ b/modules/windows-machineset-vsphere.adoc
@@ -52,7 +52,7 @@ spec:
           userDataSecret:
             name: windows-user-data <8>
           workspace:
-             datacenter: <vcenter_datacenter_name> <9>
+             datacenter: <vcenter_data_center_name> <9>
              datastore: <vcenter_datastore_name> <10>
              folder: <vcenter_vm_folder_path> <11>
              resourcePool: <vsphere_resource_pool> <12>
@@ -67,7 +67,7 @@ $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 <2> Specify the Windows compute machine set name. The compute machine set name cannot be more than 9 characters long, due to the way machine names are generated in vSphere.
 <3> Configure the compute machine set as a Windows machine.
 <4> Configure the Windows node as a compute machine.
-<5> Specify the size of the vSphere Virtual Machine Disk (VMDK). 
+<5> Specify the size of the vSphere Virtual Machine Disk (VMDK).
 +
 [NOTE]
 ====
@@ -83,8 +83,8 @@ Do not specify the original VM template. The VM template must remain off and mus
 ====
 +
 <8> The `windows-user-data` is created by the WMCO when the first Windows machine is configured. After that, the `windows-user-data` is available for all subsequent compute machine sets to consume.
-<9> Specify the vCenter Datacenter to deploy the compute machine set on.
-<10> Specify the vCenter Datastore to deploy the compute machine set on.
+<9> Specify the vCenter data center to deploy the compute machine set on.
+<10> Specify the vCenter datastore to deploy the compute machine set on.
 <11> Specify the path to the vSphere VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
 <12> Optional: Specify the vSphere resource pool for your Windows VMs.
 <13> Specify the vCenter server IP or fully qualified domain name.


### PR DESCRIPTION
Version(s):
4.16+

Issue:
N/A

Link to docs preview:
- [Understanding image registry repository mirroring](https://78317--ocpdocs-pr.netlify.app/openshift-dedicated/latest/openshift_images/image-configuration.html#images-configuration-registry-mirror_image-configuration) (dedicated)
- [Understanding image registry repository mirroring](https://78317--ocpdocs-pr.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration.html#images-configuration-registry-mirror_image-configuration) (OCP)
- [Understanding image registry repository mirroring](https://78317--ocpdocs-pr.netlify.app/openshift-rosa/latest/openshift_images/image-configuration.html#images-configuration-registry-mirror_image-configuration) (ROSA)
- [Additional VMware vSphere configuration parameters](https://78317--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere.html#installation-configuration-parameters-additional-vsphere_installation-config-parameters-vsphere)
- [VMware vSphere region and zone enablement](https://78317--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations#installation-vsphere-regions-zones_installing-vsphere-installer-provisioned-customizations)
- [Creating the installation configuration file](https://78317--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations#installation-initializing_installing-vsphere-installer-provisioned-customizations)
- [Sample YAML for a compute machine set custom resource on vSphere](https://78317--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-vsphere#machineset-yaml-vsphere_creating-machineset-vsphere)
- [Sample VMware vSphere provider specification](https://78317--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere#cpmso-yaml-provider-spec-vsphere_cpmso-config-options-vsphere)
- [Sample YAML for a Cluster API machine template resource on VMware vSphere](https://78317--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-vsphere#capi-yaml-machine-template-vsphere_cluster-api-config-options-vsphere)
- [Configuring the vSphere connection settings](https://78317--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/installing-vsphere-post-installation-configuration#configuring-vSphere-connection-settings_installing-vsphere-post-installation-configuration)
- [vSphere CSI topology overview](https://78317--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-vsphere.html#persistent-storage-csi-vsphere-top-aware-overview_persistent-storage-csi-vsphere)
- [vSphere CSI topology requirements](https://78317--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-vsphere.html#vsphere-csi-topology-requirements)
- [Sample YAML for a Windows MachineSet object on vSphere](https://78317--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.html#windows-machineset-vsphere_creating-windows-machineset-vsphere)

QE review:
N/A (terms compliance)

Additional information:

- Based on [VMware docs](https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-vcenter-esxi-management/GUID-7FDFBDBE-F8AC-4D00-AE5E-3F14D7472FAF.html) usage
- "datastore" is [one word but lowercase](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.storage.doc/GUID-D5AB2BAD-C69A-4B8D-B468-25D86B8D39CE.html)
- Azure seems to use "datacenter" so only changed VMware instances