### PR TITLE
OSDOCS#11056: Agent docs cleanup

### DIFF
--- a/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 Use the following procedures to install an {product-title} cluster using the Agent-based Installer.
 
-[id="prerequisites_installing-with-agent-based-installer"]
+[id="prerequisites_installing-with-agent-based-installer_{context}"]
 == Prerequisites
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
@@ -17,7 +17,7 @@ Use the following procedures to install an {product-title} cluster using the Age
 
 
 // This anchor ID is extracted/replicated from the former installing-ocp-agent.adoc module to preserve links.
-[id="installing-ocp-agent_installing-with-agent-based-installer"]
+[id="installing-ocp-agent_installing-with-agent-based-installer_{context}"]
 == Installing {product-title} with the Agent-based Installer
 
 The following procedures deploy a single-node {product-title} in a disconnected environment. You can use these procedures as a basis and modify according to your requirements.
@@ -25,7 +25,7 @@ The following procedures deploy a single-node {product-title} in a disconnected 
 // Downloading the Agent-based Installer
 include::modules/installing-ocp-agent-download.adoc[leveloffset=+2]
 
-//Verifying architectures
+// Verifying the supported architecture for an Agent-based installation
 include::modules/agent-installer-architectures.adoc[leveloffset=+2]
 
 // Creating the preferred configuration inputs
@@ -38,9 +38,9 @@ include::modules/installing-ocp-agent-inputs.adoc[leveloffset=+2]
 * xref:../../installing/installing_with_agent_based_installer/understanding-disconnected-installation-mirroring.adoc#configuring-the-agent-based-installer-to-use-mirrored-images[Configuring the Agent-based Installer to use mirrored images]
 
 [id="installing-ocp-agent-opt-manifests_{context}"]
-=== Optional: Creating additional manifest files
+=== Creating additional manifest files
 
-You can create additional manifests to further configure your cluster beyond the configurations available in the `install-config.yaml` and `agent-config.yaml` files.
+As an optional task, you can create additional manifests to further configure your cluster beyond the configurations available in the `install-config.yaml` and `agent-config.yaml` files.
 
 // Creating a directory to contain additional manifests
 include::modules/installing-ocp-agent-manifest-folder.adoc[leveloffset=+3]
@@ -52,7 +52,7 @@ include::modules/installing-ocp-agent-manifest-folder.adoc[leveloffset=+3]
 // Partitioning the disk
 include::modules/installation-user-infra-machines-advanced.adoc[leveloffset=+3]
 
-// Optional: Using ZTP manifests
+// Using ZTP manifests
 include::modules/installing-ocp-agent-ZTP.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -61,7 +61,7 @@ include::modules/installing-ocp-agent-ZTP.adoc[leveloffset=+2]
 
 * See xref:../../edge_computing/ztp-deploying-far-edge-clusters-at-scale.adoc#ztp-deploying-far-edge-clusters-at-scale[Challenges of the network far edge] to learn more about {ztp-first}.
 
-// Optional: Encrypting the disk
+// Encrypting the disk
 include::modules/installing-ocp-agent-encrypt.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.adoc
+++ b/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.adoc
@@ -10,7 +10,9 @@ Use the following procedures to create the assets needed to PXE boot an {product
 
 The assets you create in these procedures will deploy a single-node {product-title} installation. You can use these procedures as a basis and modify configurations according to your requirements.
 
-[id="prerequisites_prepare-pxe-assets-agent"]
+See xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-with-agent-based-installer[Installing an {product-title} cluster with the Agent-based Installer] to learn about more configurations available with the Agent-based Installer.
+
+[id="prerequisites_prepare-pxe-assets-agent_{context}"]
 == Prerequisites
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
@@ -39,10 +41,10 @@ include::modules/installing-ocp-agent-ibm-z.adoc[leveloffset=+1]
 // Adding {ibm-z-title} agents with z/VM
 include::modules/installing-ocp-agent-ibm-z-zvm.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing_ibm_z/installing-ibm-z.adoc#installing-ibm-z[Installing a cluster with z/VM on {ibm-z-title} and {ibm-linuxone-title}]
+
 // Adding {ibm-z-name} agents with {op-system-base} KVM
 include::modules/installing-ocp-agent-ibm-z-kvm.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-[id="additional-resources_prepare-pxe-assets-agent"]
-== Additional resources
-* See xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-with-agent-based-installer[Installing an {product-title} cluster with the Agent-based Installer] to learn about more configurations available with the Agent-based Installer.

--- a/modules/agent-installer-architectures.adoc
+++ b/modules/agent-installer-architectures.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="agent-install-verifying-architectures_{context}"]
-= Verifying the supported architecture for installing an Agent-based Installer cluster
+= Verifying the supported architecture for an Agent-based installation
 
 Before installing an {product-title} cluster using the Agent-based Installer, you can verify the supported architecture on which you can install the cluster. This procedure is optional.
 

--- a/modules/installing-ocp-agent-ZTP.adoc
+++ b/modules/installing-ocp-agent-ZTP.adoc
@@ -4,9 +4,9 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="installing-ocp-agent-ztp_{context}"]
-= Optional: Using ZTP manifests
+= Using ZTP manifests
 
-You can use {ztp-first} manifests to configure your installation beyond the options available through the `install-config.yaml` and `agent-config.yaml` files.
+As an optional task, you can use {ztp-first} manifests to configure your installation beyond the options available through the `install-config.yaml` and `agent-config.yaml` files.
 
 [NOTE]
 ====
@@ -22,7 +22,7 @@ If you chose to configure the `install-config.yaml` and `agent-config.yaml` file
 
 .Procedure
 
-. Use the following command to generate ZTP cluster manifests:
+. Generate ZTP cluster manifests by running the following command:
 +
 [source,terminal]
 ----
@@ -36,7 +36,7 @@ If you have created the `install-config.yaml` and `agent-config.yaml` files, tho
 Any configurations made to the `install-config.yaml` and `agent-config.yaml` files are imported to the ZTP cluster manifests when you run the `openshift-install agent create cluster-manifests` command.
 ====
 
-. Navigate to the `cluster-manifests` directory:
+. Navigate to the `cluster-manifests` directory by running the following command:
 +
 [source,terminal]
 ----
@@ -48,7 +48,7 @@ For sample files, see the "Sample GitOps ZTP custom resources" section.
 
 . Disconnected clusters: If you did not define mirror configuration in the `install-config.yaml` file before generating the ZTP manifests, perform the following steps:
 
-.. Navigate to the `mirror` directory:
+.. Navigate to the `mirror` directory by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/installing-ocp-agent-download.adoc
+++ b/modules/installing-ocp-agent-download.adoc
@@ -21,6 +21,6 @@ Use this procedure to download the Agent-based Installer and the CLI needed for 
 
 . Click *Download Installer* to download and extract the install program.
 
-. You can either download or copy the pull secret by clicking on *Download pull secret* or *Copy pull secret*.
+. Download or copy the pull secret by clicking on *Download pull secret* or *Copy pull secret*.
 
 . Click *Download command-line tools* and place the `openshift-install` binary in a directory that is on your `PATH`.

--- a/modules/installing-ocp-agent-encrypt.adoc
+++ b/modules/installing-ocp-agent-encrypt.adoc
@@ -4,9 +4,9 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="installing-ocp-agent-encrypt_{context}"]
-= Optional: Encrypting the disk
+= Encrypting the disk
 
-Use this procedure to encrypt your disk or partition while installing {product-title} with the Agent-based Installer.
+As an optional task, you can use this procedure to encrypt your disk or partition while installing {product-title} with the Agent-based Installer.
 
 .Prerequisites
 
@@ -16,7 +16,7 @@ Use this procedure to encrypt your disk or partition while installing {product-t
 
 .Procedure
 
-. Use the following command to generate ZTP cluster manifests:
+. Generate ZTP cluster manifests by running the following command:
 +
 [source,terminal]
 ----
@@ -35,7 +35,7 @@ Any configurations made to the `install-config.yaml` and `agent-config.yaml` fil
 If you have already generated ZTP manifests, skip this step.
 ====
 
-. Navigate to the `cluster-manifests` directory:
+. Navigate to the `cluster-manifests` directory by running the following command:
 +
 [source,terminal]
 ----
@@ -51,6 +51,6 @@ diskEncryption:
     mode: tang <2>
     tangServers: "server1": "http://tang-server-1.example.com:7500" <3>
 ----
-<1> Specify which nodes to enable disk encryption on. Valid values are 'none', 'all', 'master', and 'worker'.
-<2> Specify which disk encryption mode to use. Valid values are 'tpmv2' and 'tang'.
+<1> Specify which nodes to enable disk encryption on. Valid values are `none`, `all`, `master`, and `worker`.
+<2> Specify which disk encryption mode to use. Valid values are `tpmv2` and `tang`.
 <3> Optional: If you are using Tang, specify the Tang servers.

--- a/modules/installing-ocp-agent-gather-log.adoc
+++ b/modules/installing-ocp-agent-gather-log.adoc
@@ -18,7 +18,7 @@ Use the following procedure to gather log data about a failed Agent-based instal
 +
 [source,terminal]
 ----
-$ ./openshift-install --dir <install_directory> agent wait-for bootstrap-complete --log-level=debug
+$ ./openshift-install --dir <installation_directory> agent wait-for bootstrap-complete --log-level=debug
 ----
 +
 .Example error message
@@ -56,7 +56,7 @@ $ ./openshift-install --dir <install_directory> agent wait-for install-complete 
 $ export KUBECONFIG=<install_directory>/auth/kubeconfig
 ----
 
-.. To gather information for debugging, run the following command:
+.. Gather information for debugging by running the following command:
 +
 [source,terminal]
 ----
@@ -70,6 +70,6 @@ $ oc adm must-gather
 $ tar cvaf must-gather.tar.gz <must_gather_directory>
 ----
 
-. Excluding the `/auth` subdirectory, attach the installation directory used during the deployment to your support case on the link:https://access.redhat.com[Red Hat Customer Portal].
+. Excluding the `/auth` subdirectory, attach the installation directory used during the deployment to your support case on the link:https://access.redhat.com[Red{nbsp}Hat Customer Portal].
 
 . Attach all other data gathered from this procedure to your support case.

--- a/modules/installing-ocp-agent-ibm-z-kvm.adoc
+++ b/modules/installing-ocp-agent-ibm-z-kvm.adoc
@@ -12,6 +12,7 @@ endif::[]
 = Adding {ibm-z-name} agents with {op-system-base} KVM
 
 Use the following procedure to manually add {ibm-z-name} agents with {op-system-base} KVM.
+Only use this procedure for {ibm-z-name} clusters with {op-system-base} KVM.
 
 [NOTE]
 ====
@@ -62,7 +63,7 @@ $ virt-install
     --memory=<memory> \
     --cpu host \
     --vcpus=<vcpus> \
-    --cdrom <agent.iso_image> \ <1>
+    --cdrom <agent_iso_image> \ <1>
     --disk pool=default,size=<disk_pool_size> \
     --network network:default,mac=<mac_address> \
     --graphics none \

--- a/modules/installing-ocp-agent-ibm-z-zvm.adoc
+++ b/modules/installing-ocp-agent-ibm-z-zvm.adoc
@@ -7,6 +7,7 @@
 = Adding {ibm-z-title} agents with z/VM
 
 Use the following procedure to manually add {ibm-z-name} agents with z/VM.
+Only use this procedure for {ibm-z-name} clusters with with z/VM.
 
 .Procedure
 
@@ -39,7 +40,7 @@ Leave all other parameters unchanged.
 
 . Punch the `kernel.img`,`generic.parm`, and `initrd.img` files to the virtual reader of the z/VM guest virtual machine.
 +
-For more information, see link:https://www.ibm.com/docs/en/zvm/latest?topic=commands-punch[PUNCH] in IBM Documentation.
+For more information, see link:https://www.ibm.com/docs/en/zvm/latest?topic=commands-punch[PUNCH] ({ibm-title} Documentation).
 +
 [TIP]
 ====
@@ -55,4 +56,4 @@ You can use the `CP PUNCH` command or, if you use Linux, the `vmur` command, to 
 $ ipl c
 ----
 +
-For more information, see link:https://www.ibm.com/docs/en/zvm/latest?topic=commands-ipl[IPL] in IBM Documentation.
+For more information, see link:https://www.ibm.com/docs/en/zvm/latest?topic=commands-ipl[IPL] ({ibm-title} Documentation).

--- a/modules/installing-ocp-agent-ibm-z.adoc
+++ b/modules/installing-ocp-agent-ibm-z.adoc
@@ -7,6 +7,7 @@
 = Manually adding {ibm-z-title} agents
 
 After creating the PXE assets, you can add {ibm-z-name} agents.
+Only use this procedure for {ibm-z-name} clusters.
 
 Depending on your {ibm-z-name} environment, you can choose from the following options:
 

--- a/modules/installing-ocp-agent-inputs.adoc
+++ b/modules/installing-ocp-agent-inputs.adoc
@@ -42,7 +42,7 @@ $ mkdir ~/<directory_name>
 This is the preferred method for the Agent-based installation. Using {ztp} manifests is optional.
 ====
 
-. Create the `install-config.yaml` file:
+. Create the `install-config.yaml` file by running the following command:
 +
 --
 [source,terminal]
@@ -77,7 +77,7 @@ pullSecret: '<pull_secret>' // <5>
 sshKey: '<ssh_pub_key>' // <6>
 EOF
 ----
-<1> Specify the system architecture. Valid values are `amd64`, `arm64`, `ppc64le`, and `s390x`. 
+<1> Specify the system architecture. Valid values are `amd64`, `arm64`, `ppc64le`, and `s390x`.
 +
 If you are using the release image with the `multi` payload, you can install the cluster on different architectures such as `arm64`, `amd64`, `s390x`, and `ppc64le`. Otherwise, you can install the cluster only on the `release architecture` displayed in the output of the `openshift-install version` command. For more information, see "Verifying the supported architecture for installing an Agent-based Installer cluster".
 <2> Required. Specify your cluster name.
@@ -133,7 +133,8 @@ platform:
 ====
 When you use a disconnected mirror registry, you must add the certificate file that you created previously for your mirror registry to the `additionalTrustBundle` field of the `install-config.yaml` file.
 ====
-. Create the `agent-config.yaml` file:
+
+. Create the `agent-config.yaml` file by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/sample-ztp-custom-resources.adoc
+++ b/modules/sample-ztp-custom-resources.adoc
@@ -6,11 +6,11 @@
 [id="sample-ztp-custom-resources_{context}"]
 = Sample {ztp} custom resources
 
-Optional: You can use {ztp-first} custom resource (CR) objects to install an {product-title} cluster with the Agent-based Installer.
+You can optionally use {ztp-first} custom resource (CR) objects to install an {product-title} cluster with the Agent-based Installer.
 
 You can customize the following {ztp} custom resources to specify more details about your {product-title} cluster. The following sample {ztp} custom resources are for a single-node cluster.
 
-*agent-cluster-install.yaml*
+.Example `agent-cluster-install.yaml` file
 
 [source,yaml,subs="attributes+"]
 ----
@@ -33,10 +33,10 @@ You can customize the following {ztp} custom resources to specify more details a
     provisionRequirements:
       controlPlaneAgents: 1
       workerAgents: 0
-    sshPublicKey: <YOUR_SSH_PUBLIC_KEY>
+    sshPublicKey: <ssh_public_key>
 ----
 
-*cluster-deployment.yaml*
+.Example `cluster-deployment.yaml` file
 
 [source,yaml]
 ----
@@ -64,7 +64,7 @@ spec:
     name: pull-secret
 ----
 
-*cluster-image-set.yaml*
+.Example `cluster-image-set.yaml` file
 
 [source,yaml,subs="attributes+"]
 ----
@@ -76,7 +76,7 @@ spec:
   releaseImage: registry.ci.openshift.org/ocp/release:{product-version}.0-0.nightly-2022-06-06-025509
 ----
 
-*infra-env.yaml*
+.Example `infra-env.yaml` file
 
 [source,yaml]
 ----
@@ -92,13 +92,13 @@ spec:
   cpuArchitecture: aarch64
   pullSecretRef:
     name: pull-secret
-  sshAuthorizedKey: <YOUR_SSH_PUBLIC_KEY>
+  sshAuthorizedKey: <ssh_public_key>
   nmStateConfigLabelSelector:
     matchLabels:
       cluster0-nmstate-label-name: cluster0-nmstate-label-value
 ----
 
-*nmstateconfig.yaml*
+.Example `nmstateconfig.yaml` file
 
 [source,yaml]
 ----
@@ -137,7 +137,7 @@ spec:
       macAddress: 52:54:01:aa:aa:a1
 ----
 
-**pull-secret.yaml**
+.Example `pull-secret.yaml` file
 
 [source,yaml]
 ----
@@ -148,5 +148,5 @@ metadata:
   name: pull-secret
   namespace: cluster0
 stringData:
-  .dockerconfigjson: 'YOUR_PULL_SECRET'
+  .dockerconfigjson: <pull_secret>
 ----


### PR DESCRIPTION
[OSDOCS-11056](https://issues.redhat.com/browse/OSDOCS-11056)

Versions: 4.13+

Just some style guide corrections for the Agent-based Installer docs.

QE review:
- I believe QE is not required for any of these edits, but please let me know if anyone disagrees and I can request a review.

Previews:

- [Installing a cluster with Agent-based Installer](https://78326--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer)
- [Preparing PXE assets for OCP](https://78326--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent)
