### PR TITLE
OSDOCS-10772: Add “Learning” section

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -150,8 +150,6 @@ Topics:
       File: cloud-experts-getting-started-simple-cli-guide
     - Name: Detailed CLI guide
       File: cloud-experts-getting-started-detailed-cli-guide
-    - Name: Hosted Control Planes guide
-      File: cloud-experts-getting-started-hcp
     - Name: Simple UI guide
       File: cloud-experts-getting-started-simple-ui-guide
     - Name: Detailed UI guide

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -78,6 +78,16 @@ Topics:
 #   File: rosa-oidc-overview
 #  - Name: Training for ROSA
 #    File: rosa-training
+---
+Name: Learning about ROSA
+Dir: rosa_learning
+Distros: openshift-rosa-hcp
+Topics:
+- Name: Creating a cluster workshop
+  Dir: cloud-experts-getting-started-deploying
+  Topics:
+  - Name: Deploying a cluster
+    File: cloud-experts-getting-started-hcp
 # ---
 # Name: Architecture
 # Dir: architecture
@@ -138,21 +148,6 @@ Topics:
 #     File: cloud-experts-getting-started-what-is-rosa
 #   - Name: ROSA with AWS STS explained
 #     File: cloud-experts-rosa-sts-explained
-#   - Name: Deploying a cluster
-#     Dir: cloud-experts-getting-started-deploying
-#     Topics:
-#     - Name: Choosing a deployment method
-#       File: cloud-experts-getting-started-choose-deployment-method
-#     - Name: Simple CLI guide
-#       File: cloud-experts-getting-started-simple-cli-guide
-#     - Name: Detailed CLI guide
-#       File: cloud-experts-getting-started-detailed-cli-guide
-#     - Name: Hosted Control Planes guide
-#       File: cloud-experts-getting-started-hcp
-#     - Name: Simple UI guide
-#       File: cloud-experts-getting-started-simple-ui-guide
-#     - Name: Detailed UI guide
-#       File: cloud-experts-getting-started-detailed-ui
 - Name: Creating an admin user
   File: cloud-experts-getting-started-admin
 #   - Name: Setting up an identity provider

--- a/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-choose-deployment-method.adoc
+++ b/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-choose-deployment-method.adoc
@@ -19,6 +19,5 @@ If you want:
 * A user interface - xref:../../cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-simple-ui-guide.adoc#cloud-experts-getting-started-simple-ui-guide[Simple UI guide]
 * The CLI commands with details - xref:../../cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-detailed-cli-guide.adoc#cloud-experts-getting-started-detailed-cli-guide[Detailed CLI guide]
 * A user interface with details - xref:../../cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-detailed-ui.adoc#cloud-experts-getting-started-detailed-ui[Detailed UI guide]
-* To experiment with the newest ROSA technologies - xref:../../cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-hcp.adoc#cloud-experts-getting-started-detailed-ui-guide[ROSA with HCP]
 
 All of the above deployment options work well for this tutorial. If you are doing this tutorial for the first time, the xref:../../cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-simple-cli-guide.adoc#cloud-experts-getting-started-simple-cli-guide[Simple CLI guide] is the simplest and recommended method.

--- a/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-hcp.adoc
+++ b/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-hcp.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="cloud-experts-getting-started-detailed-ui-guide"]
-= Tutorial: Hosted Control Planes guide
+[id="cloud-experts-getting-started-hcp-guide"]
+= Workshop: Creating a cluster
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-getting-started-hcp
 
@@ -8,14 +8,13 @@ toc::[]
 
 //rosaworkshop.io content metadata
 //Brought into ROSA product docs 2023-11-21
+//Updated for HCP 2024-07-01  
 
-This tutorial outlines deploying a {hcp-title-first} cluster.  
-
-With {hcp-title}, you can decouple the control plane from the data plane. This is a new deployment model for ROSA in which the control plane is hosted in a Red{nbsp}Hat-owned AWS account. The control plane is no longer hosted in your AWS account, reducing your AWS infrastructure expenses. The control plane is dedicated to a single cluster and is highly available. For more information, see the xref:../../../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly[{hcp-title} documentation].
+Follow this workshop to deploy a sample {product-title}(ROSA) cluster. You can then use your cluster in other learning workshops.
 
 == Prerequisites
 
-Before deploying a {hcp-title} cluster, you must have the following resources:
+Before deploying a ROSA cluster, you must have the following resources:
 
 * VPC - This is a bring-your-own VPC model, also referred to as BYO-VPC.
 * OIDC - OIDC configuration and an OIDC provider with that specific configuration.


### PR DESCRIPTION
[OSDOCS-10772](https://issues.redhat.com//browse/OSDOCS-10772): Add “Learning” section

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-10772

Link to docs preview:
ROSA HCP: 
ROSA Classic: https://78328--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-choose-deployment-method.html

QE review:
No QE review needed

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
