### PR TITLE
OSDOCS-10726: Updating kafka replicas and cacheMaxSize in the resource considerations table

### DIFF
--- a/modules/network-observability-resources-table.adoc
+++ b/modules/network-observability-resources-table.adoc
@@ -20,9 +20,10 @@ The examples outlined in the table demonstrate scenarios that are tailored to sp
 | *Network Observability controller memory limit* | 400Mi (default)        | 400Mi (default)   | 400Mi (default)    | 400Mi (default)
 | *eBPF sampling rate*                | 50 (default)           | 50 (default)      | 50 (default)       | 50 (default)
 | *eBPF memory limit*                 | 800Mi (default)        | 800Mi (default)   | 800Mi (default)    | 1600Mi
+| *cacheMaxSize*                      | 50,000                 | 100,000 (default) | 100,000 (default)  | 100,000 (default)
 | *FLP memory limit*                  | 800Mi (default)        | 800Mi (default)   | 800Mi (default)    | 800Mi (default)
 | *FLP Kafka partitions*              | N/A                    | 48                | 48                 | 48
-| *Kafka consumer replicas*           | N/A                    | 24                | 24                 | 24
+| *Kafka consumer replicas*           | N/A                    | 6                 | 12                 | 18
 | *Kafka brokers*                     | N/A                    | 3 (default)       | 3 (default)        | 3 (default)
 |===
 [.small]


### PR DESCRIPTION
OSDOCS#10726: Updating kafka replicas and cacheMaxSize in the resource considerations table. 

Version(s): 4.17

Issue:
[JIRA](https://issues.redhat.com/browse/OSDOCS-10726)
https://issues.redhat.com/browse/OSDOCS-10726

Link to docs preview: https://78332--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/configuring-operator.html

QE review: QE approved
