### PR TITLE
CNV-43775: Commenting out real-time documentation

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -4240,8 +4240,8 @@ Topics:
       File: virt-vm-control-plane-tuning
     - Name: Assigning compute resources
       File: virt-assigning-compute-resources
-    - Name: Running real-time workloads
-      File: virt-configuring-cluster-realtime-workloads
+#    - Name: Running real-time workloads
+#      File: virt-configuring-cluster-realtime-workloads
     - Name: About multi-queue functionality
       File: virt-about-multi-queue
   - Name: VM disks

--- a/virt/monitoring/virt-monitoring-overview.adoc
+++ b/virt/monitoring/virt-monitoring-overview.adoc
@@ -8,8 +8,8 @@ toc::[]
 
 You can monitor the health of your cluster and virtual machines (VMs) with the following tools:
 
-Monitoring OpenShift Virtualization VMs health status::
-View the overall health of your OpenShift Virtualization environment in the web console by navigating to the *Home* -> *Overview* page in the {product-title} web console. The *Status* card displays the overall health of OpenShift Virtualization based on the alerts and conditions.
+Monitoring {VirtProductName} VM health status::
+View the overall health of your {VirtProductName} environment in the web console by navigating to the *Home* -> *Overview* page in the {product-title} web console. The *Status* card displays the overall health of {VirtProductName} based on the alerts and conditions.
 
 ifndef::openshift-rosa,openshift-dedicated[]
 xref:../../virt/monitoring/virt-running-cluster-checkups.adoc#virt-running-cluster-checkups[{product-title} cluster checkup framework]::
@@ -17,7 +17,7 @@ Run automated tests on your cluster with the {product-title} cluster checkup fra
 * Network connectivity and latency between two VMs attached to a secondary network interface
 * VM running a Data Plane Development Kit (DPDK) workload with zero packet loss
 * Cluster storage is optimally configured for {VirtProductName}
-* The {product-title} cluster can run real-time virtualized workloads.
+//* The {product-title} cluster can run real-time virtualized workloads.
 endif::openshift-rosa,openshift-dedicated[]
 
 //:FeatureName: The {product-title} cluster checkup framework

--- a/virt/monitoring/virt-running-cluster-checkups.adoc
+++ b/virt/monitoring/virt-running-cluster-checkups.adoc
@@ -14,8 +14,8 @@ xref:../../virt/monitoring/virt-running-cluster-checkups.adoc#virt-checking-clus
 Verifies that a node can run a VM with a Data Plane Development Kit (DPDK) workload with zero packet loss.
 xref:../../virt/monitoring/virt-running-cluster-checkups.adoc#virt-checking-storage-configuration_virt-running-cluster-checkups[Storage checkup]::
 Verifies if the cluster storage is optimally configured for {VirtProductName}.
-xref:../../virt/monitoring/virt-running-cluster-checkups.adoc#virt-running-real-time-checkup_virt-running-cluster-checkups[Real-time checkup]::
-Verifies that your {product-title} cluster can run virtualized real-time workloads.
+//xref:../../virt/monitoring/virt-running-cluster-checkups.adoc#virt-running-real-time-checkup_virt-running-cluster-checkups[Real-time checkup]::
+//Verifies that your {product-title} cluster can run virtualized real-time workloads.
 
 :FeatureName: The {VirtProductName} cluster checkup framework
 include::snippets/technology-preview.adoc[]
@@ -45,6 +45,7 @@ include::modules/virt-dpdk-config-map-parameters.adoc[leveloffset=+2]
 
 include::modules/virt-building-vm-containerdisk-image.adoc[leveloffset=+2]
 
+////
 include::modules/virt-running-real-time-checkup.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -55,6 +56,7 @@ include::modules/virt-real-time-config-map-parameters.adoc[leveloffset=+2]
 
 include::modules/virt-building-real-time-container-disk-image.adoc[leveloffset=+2]
 
+////
 include::modules/virt-checking-storage-configuration.adoc[leveloffset=+1]
 
 ifndef::openshift-rosa,openshift-dedicated[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-43775](https://issues.redhat.com//browse/CNV-43775)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://78341--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/monitoring/virt-monitoring-overview.html
https://78341--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-running-cluster-checkups.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: N/A
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Removing documentation for real-time checkup and cluster configuration because the feature is being taken out of the 4.16 release.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
