### PR TITLE
CNV-43775: Removing real-time checkup release note

### DIFF
--- a/virt/release_notes/virt-4-16-release-notes.adoc
+++ b/virt/release_notes/virt-4-16-release-notes.adoc
@@ -66,11 +66,11 @@ This release adds new features and enhancements related to the following compone
 [id="virt-4-16-virtualization"]
 === Virtualization
 
-//CNV-29170 Real-time cluster configuration
-* You can xref:../../virt/virtual_machines/advanced_vm_management/virt-configuring-cluster-realtime-workloads.adoc#virt-configuring-cluster-realtime-workloads[configure an {product-title} cluster] to run real-time virtual machine (VM) workloads that require low and predictable latency.
+//CNV-29170 Real-time cluster configuration (Uncomment the note below when feature goes out with a 4.16.z release)
+//* You can xref:../../virt/virtual_machines/advanced_vm_management/virt-configuring-cluster-realtime-workloads.adoc#virt-configuring-cluster-realtime-workloads[configure an {product-title} cluster] to run real-time virtual machine (VM) workloads that require low and predictable latency.
 
-//CNV-29192 Running real-time checkup
-* You can now run a predefined xref:../../virt/monitoring/virt-running-cluster-checkups.adoc#virt-running-real-time-checkup_virt-running-cluster-checkups[checkup] to verify that your {product-title} cluster is configured to run virtualized real-time workloads.
+//CNV-29192 Running real-time checkup (Uncomment the note below when feature goes out with a 4.16.z release)
+//* You can now run a predefined xref:../../virt/monitoring/virt-running-cluster-checkups.adoc#virt-running-real-time-checkup_virt-running-cluster-checkups[checkup] to verify that your {product-title} cluster is configured to run virtualized real-time workloads.
 
 //CNV-33366 Release note: NEW - Adopt UEFI in all Windows versions
 * Windows 10 VMs now boot using UEFI with TPM.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-43775](https://issues.redhat.com//browse/CNV-43775)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://78345--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-16-release-notes.html#virt-4-16-virtualization
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: N/A
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Commented out the two release notes associated with real-time checkup and cluster configuration because the feature is no longer being included in the 4.16 release.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
