### PR TITLE
Changing the status of MCG in MTC (and OADP) documentation

### DIFF
--- a/modules/migration-configuring-mcg.adoc
+++ b/modules/migration-configuring-mcg.adoc
@@ -11,13 +11,21 @@
 = Retrieving Multicloud Object Gateway credentials
 
 ifdef::installing-3-4,installing-mtc[]
-You must retrieve the Multicloud Object Gateway (MCG) credentials and S3 endpoint in order to configure MCG as a replication repository for the {mtc-full} ({mtc-short}).
+You must retrieve the Multicloud Object Gateway (MCG) credentials and S3 endpoint, which you need to configure MCG as a replication repository for the {mtc-full} ({mtc-short})
+
+You must retrieve the Multicloud Object Gateway (MCG) credentials, which you need to create a `Secret` custom resource (CR) for {mtc-short}.
 endif::[]
-You must retrieve the Multicloud Object Gateway (MCG) credentials in order to create a `Secret` custom resource (CR) for the OpenShift API for Data Protection (OADP).
+
+ifdef::installing-oadp-mcg[]
+You must retrieve the Multicloud Object Gateway (MCG) credentials, which you need to create a `Secret` custom resource (CR) for the OpenShift API for Data Protection (OADP).
+endif::[]
 //ifdef::installing-oadp-mcg[]
 //endif::[]
 
-MCG is a component of {rh-storage}.
+[NOTE]
+====
+Although the MCG Operator is link:https://catalog.redhat.com/software/containers/ocs4/mcg-rhel8-operator/5ddbcefbdd19c71643b56ce9?architecture=amd64&image=64243f5dcd0eb61355af9abd[deprecated], the MCG plugin is still available for {rh-storage}. To download the plugin, browse to link:https://access.redhat.com/downloads/content/547/ver=4/rhel---9/4.15.4/x86_64/product-software[Download {rh-storage-first}] and download the appropriate MCG plugin for your operating system.
+====
 
 .Prerequisites
 ifdef::openshift-origin[]
@@ -25,16 +33,16 @@ ifdef::openshift-origin[]
 +
 If you have the pull secret, add the `redhat-operators` catalog to the OperatorHub custom resource (CR) as shown in _Configuring {product-title} to use Red Hat Operators_.
 endif::[]
-* You must deploy {rh-storage} by using the appropriate link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9[OpenShift Data Foundation deployment guide].
+* You must deploy {rh-storage} by using the appropriate link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.15[{rh-storage-first} deployment guide].
 
 .Procedure
-
-. Obtain the S3 endpoint, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY` by running the link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.9/html/managing_hybrid_and_multicloud_resources/accessing-the-multicloud-object-gateway-with-your-applications_rhodf#accessing-the-Multicloud-object-gateway-from-the-terminal_rhodf[`describe` command] on the `NooBaa` custom resource.
 ifdef::installing-3-4,installing-mtc[]
+* Obtain the S3 endpoint, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY` by running the link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.15/html/managing_hybrid_and_multicloud_resources/accessing-the-multicloud-object-gateway-with-your-applications_rhodf#accessing-the-Multicloud-object-gateway-from-the-terminal_rhodf[`describe` command] on the `NooBaa` custom resource.
 +
 You use these credentials to add MCG as a replication repository.
 endif::[]
 ifdef::installing-oadp-mcg[]
+. Obtain the S3 endpoint, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY` by running the link:https://docs.redhat.com/en/documentation//red_hat_openshift_data_foundation/4.15/html/managing_hybrid_and_multicloud_resources/accessing-the-multicloud-object-gateway-with-your-applications_rhodf#accessing-the-Multicloud-object-gateway-from-the-terminal_rhodf[`describe` command] on the `NooBaa` custom resource.
 . Create a `credentials-velero` file:
 +
 [source,terminal]


### PR DESCRIPTION
MTC 1.8
OADP 1.3+, OCP 4.13+

Resolves https://issues.redhat.com/browse/MIG-1535 by changing the description of MCG in the MTC installation instructions. The same module also appears in OADP documentation, so the previews include the proposed changes to both the MTC and OADP documentation. 

Previews:

- MTC dicumentation:  https://78361--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/installing-3-4.html#migration-configuring-mcg_installing-3-4
- OADP documentation: https://78361--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.html#migration-configuring-mcg_installing-oadp-mcg

MTC/OADP QE approved (same staff for both, same individual approved)
