### PR TITLE
TELCODOCS-1916 - Removing RDS from 4.16+ docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3138,37 +3138,38 @@ Topics:
     File: cnf-image-based-upgrade-base
   - Name: Performing an image-based upgrade for single-node OpenShift clusters using GitOps ZTP
     File: ztp-image-based-upgrade
----
-Name: Reference design specifications
-Dir: telco_ref_design_specs
-Distros: openshift-origin,openshift-enterprise
-Topics:
-- Name: Telco reference design specifications
-  File: telco-ref-design-specs-overview
-- Name: Telco RAN DU reference design specification
-  Dir: ran
-  Topics:
-  - Name: Telco RAN DU reference design overview
-    File: telco-ran-ref-design-spec
-  - Name: Telco RAN DU use model overview
-    File: telco-ran-du-overview
-  - Name: RAN DU reference design components
-    File: telco-ran-ref-du-components
-  - Name: RAN DU reference design configuration CRs
-    File: telco-ran-ref-du-crs
-  - Name: Telco RAN DU software specifications
-    File: telco-ran-ref-software-artifacts
-- Name: Telco core reference design specification
-  Dir: core
-  Topics:
-  - Name: Telco core reference design overview
-    File: telco-core-rds-overview
-  - Name: Telco core use model overview
-    File: telco-core-rds-use-cases
-  - Name: Core reference design components
-    File: telco-core-ref-design-components
-  - Name: Core reference design configuration CRs
-    File: telco-core-ref-crs
+# Remove RDS from published docs until 4.16 RDS is released
+# ---
+# Name: Reference design specifications
+# Dir: telco_ref_design_specs
+# Distros: openshift-telco
+# Topics:
+# - Name: Telco reference design specifications
+#   File: telco-ref-design-specs-overview
+# - Name: Telco RAN DU reference design specification
+#   Dir: ran
+#   Topics:
+#   - Name: Telco RAN DU reference design overview
+#     File: telco-ran-ref-design-spec
+#   - Name: Telco RAN DU use model overview
+#     File: telco-ran-du-overview
+#   - Name: RAN DU reference design components
+#     File: telco-ran-ref-du-components
+#   - Name: RAN DU reference design configuration CRs
+#     File: telco-ran-ref-du-crs
+#   - Name: Telco RAN DU software specifications
+#     File: telco-ran-ref-software-artifacts
+# - Name: Telco core reference design specification
+#   Dir: core
+#   Topics:
+#   - Name: Telco core reference design overview
+#     File: telco-core-rds-overview
+#   - Name: Telco core use model overview
+#     File: telco-core-rds-use-cases
+#   - Name: Core reference design components
+#     File: telco-core-ref-design-components
+#   - Name: Core reference design configuration CRs
+#     File: telco-core-ref-crs
 ---
 Name: Specialized hardware and driver enablement
 Dir: hardware_enablement


### PR DESCRIPTION
As part of decommissioning docs.openshift work, we need to bring the Telco RDS docs into the public-facing docs.

Version(s):
enterprise-4.14+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1916

Link to docs previews:
* [Updates to public facing docs](https://78304--ocpdocs-pr.netlify.app/openshift-enterprise/latest/telco_ref_design_specs/ran/telco-ran-ref-design-spec)
* [Updates to previously published private openshift-telco 4.14 and 4.15 docs](https://file.emea.redhat.com/aireilly/TELCODOCS-1920/welcome/index.html)

QE review:
- [x] QE not required. Docs are unchanged, just changing location.