### PR TITLE
[enterprise-4.14] TELCODOCS-1916 - remove github link now that RDS is public

### DIFF
--- a/telco_ref_design_specs/core/telco-core-ref-crs.adoc
+++ b/telco_ref_design_specs/core/telco-core-ref-crs.adoc
@@ -10,11 +10,6 @@ toc::[]
 Use the following custom resources (CRs) to configure and deploy {product-title} clusters with the {rds} profile.
 Use the CRs to form the common baseline used in all the specific use models unless otherwise indicated.
 
-[NOTE]
-====
-The {rds} CRs are available in link:https://github.com/openshift-kni/telco-reference/tree/release-4.14[GitHub].
-====
-
 include::modules/telco-core-crs-resource-tuning.adoc[leveloffset=+1]
 
 include::modules/telco-core-crs-storage.adoc[leveloffset=+1]


### PR DESCRIPTION
Addendum to https://github.com/openshift/openshift-docs/pull/78304

QE review:
- [x] QE not required. Docs are unchanged, just removing illegal GitHub link