### PR TITLE
OSDOCS-8209: Add more details to vSphere nodes example

### DIFF
--- a/modules/installation-vsphere-installer-infra-static-ip-nodes.adoc
+++ b/modules/installation-vsphere-installer-infra-static-ip-nodes.adoc
@@ -13,22 +13,49 @@ By default, the installation program is configured to use the DHCP for the netwo
 
 After you define one or more machine pools in your `install-config.yaml` file, you can define network definitions for nodes on your network. Ensure that the number of network definitions matches the number of machine pools that you configured for your cluster.
 
-The following example shows a network configuration for a node with the role `compute`:
-
+.Example network configuration that specifies different roles
 [source,yaml]
 ----
----
+# ...
 platform:
   vsphere:
     hosts:
-    - role: compute <1>
+    - role: bootstrap # <1>
       networkDevice:
         ipAddrs:
-        - 192.168.204.10/24 <2>
-        gateway: 192.168.204.1 <3>
+        - 192.168.204.10/24 # <2>
+        gateway: 192.168.204.1 # <3>
+        nameservers: # <4>
+        - 192.168.204.1
+    - role: control-plane
+      networkDevice:
+        ipAddrs:
+        - 192.168.204.11/24
+        gateway: 192.168.204.1
         nameservers:
-        - 192.168.204.1 <4>
----
+        - 192.168.204.1
+    - role: control-plane
+      networkDevice:
+        ipAddrs:
+        - 192.168.204.12/24
+        gateway: 192.168.204.1
+        nameservers:
+        - 192.168.204.1
+    - role: control-plane
+      networkDevice:
+        ipAddrs:
+        - 192.168.204.13/24
+        gateway: 192.168.204.1
+        nameservers:
+        - 192.168.204.1
+    - role: compute
+      networkDevice:
+        ipAddrs:
+        - 192.168.204.14/24
+        gateway: 192.168.204.1
+        nameservers:
+        - 192.168.204.1
+# ...
 ----
 <1> Valid network definition values include `bootstrap`, `control-plane`, and `compute`. You must list at least one `bootstrap` network definition in your `install-config.yaml` configuration file.
 <2> Lists IPv4, IPv6, or both IP addresses that the installation program passes to the network interface. The machine API controller assigns all configured IP addresses to the default network interface.


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-8209

Link to docs preview:
https://78381--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.html#installation-vsphere-installer-infra-static-ip-nodes_ipi-vsphere-installation-reqs

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
