### PR TITLE
RHDEVDOCS-5822 - Change redirects

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -322,39 +322,39 @@ AddType text/vtt                            vtt
     # Builds using Shipwright landing page
     RewriteRule ^container-platform/(4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/builds_using_shipwright/overview-openshift-builds.html /builds/latest/about/overview-openshift-builds.html  [L,R=302]
 
-    # redirect gitops latest to 1.12
+    # redirect gitops latest to 1.13
     RewriteRule ^gitops/?$ /gitops/latest [R=302]
-    RewriteRule ^gitops/latest/?(.*)$ /gitops/1\.12/$1 [NE,R=302]
+    RewriteRule ^gitops/latest/?(.*)$ /gitops/1\.13/$1 [NE,R=302]
 
     # redirect top-level without filespec to the about file
-    RewriteRule ^gitops/(1\.8|1\.9|1\.10|1\.11|1\.12)/?$ /gitops/$1/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]
+    RewriteRule ^gitops/(1\.8|1\.9|1\.10|1\.11|1\.12|1\.13)/?$ /gitops/$1/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]
 
     # GitOps landing page
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/about-redhat-openshift-gitops.html /gitops/latest/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]
 
     # redirect any links to existing OCP embedded content to standalone equivalent for each assembly
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/gitops-release-notes.html/ /gitops/latest/release_notes/gitops-release-notes.html  [L,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/understanding-openshift-gitops.html /gitops/latest/understanding_openshift_gitops/about-redhat-openshift-gitops.html [L,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/installing-openshift-gitops.html /gitops/latest/installing_gitops/installing-openshift-gitops.html [L,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/uninstalling-openshift-gitops.html /gitops/latest/removing_gitops/uninstalling-openshift-gitops.html [L,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/setting-up-argocd-instance.html /gitops/latest/argocd_instance/setting-up-argocd-instance.html [L,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/monitoring-argo-cd-instances.html /gitops/latest/observability/monitoring/monitoring-argo-cd-instances.html [L,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/using-argo-rollouts-for-progressive-deployment-delivery.html /gitops/latest/argo_rollouts/using-argo-rollouts-for-progressive-deployment-delivery.html [L,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.html /gitops/latest/declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.html [L,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/deploying-a-spring-boot-application-with-argo-cd.html /gitops/latest/argocd_applications/deploying-a-spring-boot-application-with-argo-cd.html [L,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/argo-cd-custom-resource-properties.html /gitops/latest/argocd_instance/argo-cd-cr-component-properties.html [L,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/configuring-secure-communication-with-redis.html /gitops/latest/securing_openshift_gitops/configuring-secure-communication-with-redis.html [L,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/health-information-for-resources-deployment.html /gitops/latest/observability/monitoring/health-information-for-resources-deployment.html [L,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/configuring-sso-on-argo-cd-using-dex.html /gitops/latest/accesscontrol_usermanagement/configuring-sso-on-argo-cd-using-dex.html [L,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/configuring-sso-for-argo-cd-using-keycloak.html /gitops/latest/accesscontrol_usermanagement/configuring-sso-for-argo-cd-using-keycloak.html [L,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/configuring-argo-cd-rbac.html /gitops/latest/accesscontrol_usermanagement/configuring-argo-cd-rbac.html [L,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/configuring-resource-quota.html /gitops/latest/managing_resource/configuring-resource-quota.html [L,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/monitoring-argo-cd-custom-resource-workloads.html /gitops/latest/observability/monitoring/monitoring-argo-cd-custom-resource-workloads.html [L,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/viewing-argo-cd-logs.html /gitops/latest/observability/logging/viewing-argo-cd-logs.html [L,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/run-gitops-control-plane-workload-on-infra-nodes.html /gitops/latest/gitops_workloads_infranodes/run-gitops-control-plane-workload-on-infra-nodes.html [L,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/about-sizing-requirements-gitops.html /gitops/latest/installing_gitops/preparing-gitops-install.html [L,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/collecting-debugging-data-for-support.html /gitops/latest/understanding_openshift_gitops/gathering-gitops-diagnostic-information-for-support.html [L,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/troubleshooting-issues-in-GitOps.html /gitops/latest/troubleshooting_gitops_issues/auto-reboot-during-argo-cd-sync-with-machine-configurations.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/gitops-release-notes.html/ /gitops/latest/release_notes/gitops-release-notes.html  [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/understanding-openshift-gitops.html /gitops/latest/understanding_openshift_gitops/about-redhat-openshift-gitops.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/installing-openshift-gitops.html /gitops/latest/installing_gitops/installing-openshift-gitops.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/uninstalling-openshift-gitops.html /gitops/latest/removing_gitops/uninstalling-openshift-gitops.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/setting-up-argocd-instance.html /gitops/latest/argocd_instance/setting-up-argocd-instance.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/monitoring-argo-cd-instances.html /gitops/latest/observability/monitoring/monitoring-argo-cd-instances.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/using-argo-rollouts-for-progressive-deployment-delivery.html /gitops/latest/argo_rollouts/using-argo-rollouts-for-progressive-deployment-delivery.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.html /gitops/latest/declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/deploying-a-spring-boot-application-with-argo-cd.html /gitops/latest/argocd_applications/deploying-a-spring-boot-application-with-argo-cd.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/argo-cd-custom-resource-properties.html /gitops/latest/argocd_instance/argo-cd-cr-component-properties.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/configuring-secure-communication-with-redis.html /gitops/latest/securing_openshift_gitops/configuring-secure-communication-with-redis.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/health-information-for-resources-deployment.html /gitops/latest/observability/monitoring/health-information-for-resources-deployment.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/configuring-sso-on-argo-cd-using-dex.html /gitops/latest/accesscontrol_usermanagement/configuring-sso-on-argo-cd-using-dex.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/configuring-sso-for-argo-cd-using-keycloak.html /gitops/latest/accesscontrol_usermanagement/configuring-sso-for-argo-cd-using-keycloak.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/configuring-argo-cd-rbac.html /gitops/latest/accesscontrol_usermanagement/configuring-argo-cd-rbac.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/configuring-resource-quota.html /gitops/latest/managing_resource/configuring-resource-quota.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/monitoring-argo-cd-custom-resource-workloads.html /gitops/latest/observability/monitoring/monitoring-argo-cd-custom-resource-workloads.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/viewing-argo-cd-logs.html /gitops/latest/observability/logging/viewing-argo-cd-logs.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/run-gitops-control-plane-workload-on-infra-nodes.html /gitops/latest/gitops_workloads_infranodes/run-gitops-control-plane-workload-on-infra-nodes.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/about-sizing-requirements-gitops.html /gitops/latest/installing_gitops/preparing-gitops-install.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/collecting-debugging-data-for-support.html /gitops/latest/understanding_openshift_gitops/gathering-gitops-diagnostic-information-for-support.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/troubleshooting-issues-in-GitOps.html /gitops/latest/troubleshooting_gitops_issues/auto-reboot-during-argo-cd-sync-with-machine-configurations.html [L,R=302]
 
     # Pipelines handling unversioned and latest links
     RewriteRule ^pipelines/?$ /pipelines/latest [R=302]

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -248,6 +248,7 @@
               <%= distro %>
             </a>
             <select id="version-selector" onchange="versionSelector(this);">
+              <option value="1.13">1.13</option>
               <option value="1.12">1.12</option>
               <option value="1.11">1.11</option>
               <option value="1.10">1.10</option>


### PR DESCRIPTION
**This PR is for the GitOps 1.13 release that is scheduled for July 3, 2024. Do not merge until this date.**


**Version(s):** `main` only

**Issue:**
-  [RHDEVDOCS 5822](https://issues.redhat.com/browse/RHDEVDOCS-5822)
-  [RHDEVDOCS 5820](https://issues.redhat.com/browse/RHDEVDOCS-5820)
-  [RHDEVDOCS 5821](https://issues.redhat.com/browse/RHDEVDOCS-5821)

**Link to docs preview:**
https://68321--docspreview.netlify.app/

**SME and QE review:** Not applicable

**Additional information:** This PR updates the redirects in the `01-commercial.conf`, `_page_openshift.html.erb`, and `_distro_map.yml` files in the `main` for the 1.13 GitOps standalone doc. It does not alter documentation content.