### PR TITLE
CNV-36131: Incorrect statement: VM must be stopped before snapshotting

### DIFF
--- a/modules/virt-creating-vm-snapshot-web.adoc
+++ b/modules/virt-creating-vm-snapshot-web.adoc
@@ -17,7 +17,6 @@ The VM snapshot includes disks that meet the following requirements:
 
 . Navigate to *Virtualization* -> *VirtualMachines* in the web console.
 . Select a VM to open the *VirtualMachine details* page.
-. If the VM is running, click the options menu {kebab} and select *Stop* to power it down.
 . Click the *Snapshots* tab and then click *Take Snapshot*.
 . Enter the snapshot name.
 . Expand *Disks included in this Snapshot* to see the storage volumes to be included in the snapshot.


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/CNV-36131

OCP 4.16+
CNV 4.16+

Preview: https://78412--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/backup_restore/virt-backup-restore-snapshots.html#virt-creating-vm-snapshot-web_virt-backup-restore-snapshots