### PR TITLE
Adds constraint note to egressIP object example yaml

### DIFF
--- a/modules/nw-egress-ips-object.adoc
+++ b/modules/nw-egress-ips-object.adoc
@@ -23,7 +23,7 @@ spec:
 ----
 <1> The name for the `EgressIPs` object.
 
-<2> An array of one or more IP addresses.
+<2> An array of one or more IP addresses. Must be either IPv4 or IPv6. You cannot configure both IPv4 and IPv6 egress IPs in the same `EgressIP` object.
 
 <3> One or more selectors for the namespaces to associate the egress IP addresses with.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-36497

Link to docs preview:
https://78423--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html#nw-egress-ips-object_configuring-egress-ips-ovn

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
