### PR TITLE
OCPBUGS-8962: Add docs for affinity parameter for image registry operator

### DIFF
--- a/modules/registry-operator-configuration-resource-overview.adoc
+++ b/modules/registry-operator-configuration-resource-overview.adoc
@@ -1,8 +1,9 @@
 // Module included in the following assemblies:
 //
 // * openshift_images/configuring-registry-operator.adoc
+// * registry/configuring-registry-operator.adoc
 
-
+:_mod-docs-content-type: REFERENCE
 [id="registry-operator-configuration-resource-overview_{context}"]
 = Image Registry Operator configuration parameters
 
@@ -38,8 +39,8 @@ The following values for `logLevel` are supported:
 | `operatorLogLevel`
 | The `operatorLogLevel` configuration parameter provides intent-based logging for the Operator itself and a simple way to manage coarse-grained logging choices that Operators must interpret for themselves. This configuration parameter defaults to `Normal`. It does not provide fine-grained control.
 
-The following values for `operatorLogLevel` are supported: 
- 
+The following values for `operatorLogLevel` are supported:
+
 * `Normal`
 * `Debug`
 * `Trace`
@@ -48,6 +49,11 @@ The following values for `operatorLogLevel` are supported:
 |`proxy`
 |Defines the Proxy to be used when calling master API
 and upstream registries.
+
+|`affinity`
+|You can use the `affinity` parameter to configure pod scheduling preferences and constraints for Image Registry Operator pods.
+
+Affinity settings can use the `podAffinity` or `podAntiAffinity` spec. Both options can use either `preferredDuringSchedulingIgnoredDuringExecution` rules or `requiredDuringSchedulingIgnoredDuringExecution` rules.
 
 |`storage`
 |`Storagetype`: Details for configuring registry storage, for example S3 bucket


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-8962

Link to docs preview:
https://78453--ocpdocs-pr.netlify.app/openshift-enterprise/latest/registry/configuring-registry-operator.html#registry-operator-configuration-resource-overview_configuring-registry-operator

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
