### PR TITLE
Update machine-pools-hcp.adoc

### DIFF
--- a/modules/machine-pools-hcp.adoc
+++ b/modules/machine-pools-hcp.adoc
@@ -6,7 +6,7 @@
 [id="machine-pools-hcp_{context}"]
 = Machine pools in {hcp-title} clusters
 
-In {hcp-title} clusters, the hosted control plane spans three availability zones (AZ) in the installed cloud region. Each machine pool in a {hcp-title} cluster deploys in a single subnet within a single AZ. Each of these AZs can have only one machine pool. 
+In {hcp-title} clusters, the hosted control plane spans three availability zones (AZ) in the installed cloud region. Each machine pool in a {hcp-title} cluster deploys in a single subnet within a single AZ. Each of these AZs can have only one subnet. 
 
 Each machine pool in an {hcp-title} cluster upgrades independently. Because the machine pools upgrade independently, they must remain within 2 minor (Y-stream) versions of the hosted control plane. For example, if your hosted control plane is 4.16.z, your machine pools must be at least 4.14.z.
 

--- a/modules/machine-pools-hcp.adoc
+++ b/modules/machine-pools-hcp.adoc
@@ -6,7 +6,7 @@
 [id="machine-pools-hcp_{context}"]
 = Machine pools in {hcp-title} clusters
 
-In {hcp-title} clusters, the hosted control plane spans three availability zones (AZ) in the installed cloud region. Each machine pool in a {hcp-title} cluster deploys in a single subnet within a single AZ. Each of these AZs can have only one subnet. 
+In {hcp-title} clusters, the hosted control plane spans three availability zones (AZ) in the installed cloud region. Each machine pool in a {hcp-title} cluster deploys in a single subnet within a single AZ. Each of these AZs can have only one private subnet. 
 
 Each machine pool in an {hcp-title} cluster upgrades independently. Because the machine pools upgrade independently, they must remain within 2 minor (Y-stream) versions of the hosted control plane. For example, if your hosted control plane is 4.16.z, your machine pools must be at least 4.14.z.
 


### PR DESCRIPTION
Should say each of these AZs can only have one subnet instead of one Machine Pool.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
