### PR TITLE
OSSM-6772 [DOC] Remove commands from Clean up Operator resources

### DIFF
--- a/modules/ossm-remove-cleanup.adoc
+++ b/modules/ossm-remove-cleanup.adoc
@@ -28,21 +28,6 @@ The OpenShift Elasticsearch Operator is installed in `openshift-operators-redhat
 +
 [source,terminal]
 ----
-$ oc delete validatingwebhookconfiguration/openshift-operators.servicemesh-resources.maistra.io
-----
-+
-[source,terminal]
-----
-$ oc delete mutatingwebhookconfiguration/openshift-operators.servicemesh-resources.maistra.io
-----
-+
-[source,terminal]
-----
-$ oc delete svc maistra-admission-controller -n openshift-operators
-----
-+
-[source,terminal]
-----
 $ oc -n openshift-operators delete ds -lmaistra-version
 ----
 +
@@ -79,11 +64,6 @@ $ oc get crds -o name | grep '.*\.kiali\.io' | xargs -r -n 1 oc delete
 [source,terminal]
 ----
 $ oc delete crds jaegers.jaegertracing.io
-----
-+
-[source,terminal]
-----
-$ oc delete cm -n openshift-operators maistra-operator-cabundle
 ----
 +
 [source,terminal]


### PR DESCRIPTION
**OSSM 2.6**

[OSSM-6772](https://issues.redhat.com//browse/OSSM-6772) [DOC] Remove commands from Clean up Operator resources

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+ 

Issue:
https://issues.redhat.com/browse/OSSM-6772

Link to docs preview:
https://78463--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/removing-ossm#ossm-remove-cleanup_removing-ossm

Reviews:
- [x] Dev has approved this change. (07/10/2024)
- [x] QE has approved this change. (07/10/2024)
- [x] OCP Doc Peer Review (07/10/2024)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Reviews and dates added for quick reference of what PRs are where for OSSM 2.6.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
