### PR TITLE
OCPBUGS-33339: Adding a step in the CLI procedure for SriovOperatorConfig resource

### DIFF
--- a/modules/nw-sriov-installing-operator.adoc
+++ b/modules/nw-sriov-installing-operator.adoc
@@ -22,7 +22,7 @@ As a cluster administrator, you can install the Operator using the CLI.
 
 .Procedure
 
-. To create the `openshift-sriov-network-operator` namespace, enter the following command:
+. Create the `openshift-sriov-network-operator` namespace by entering the following command:
 +
 [source,terminal]
 ----
@@ -36,7 +36,7 @@ metadata:
 EOF
 ----
 
-. To create an OperatorGroup CR, enter the following command:
+. Create an `OperatorGroup` custom resource (CR) by entering the following command:
 +
 [source,terminal]
 ----
@@ -52,7 +52,7 @@ spec:
 EOF
 ----
 
-. To create a Subscription CR for the SR-IOV Network Operator, enter the following command:
+. Create a `Subscription` CR for the SR-IOV Network Operator by entering the following command:
 +
 [source,terminal]
 ----
@@ -69,8 +69,27 @@ spec:
   sourceNamespace: openshift-marketplace
 EOF
 ----
+. Create an `SriovoperatorConfig` resource by entering the following command:
++
+[source,terminal]
+----
+$ cat <<EOF | oc create -f -
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovOperatorConfig
+metadata:
+  name: default
+  namespace: openshift-sriov-network-operator
+spec:
+  enableInjector: true
+  enableOperatorWebhook: true
+  logLevel: 2
+  disableDrain: false
+EOF
+----
 
-. To verify that the Operator is installed, enter the following command:
+.Verification
+
+* Check that the Operator is installed by entering the following command:
 +
 [source,terminal]
 ----
@@ -82,7 +101,7 @@ $ oc get csv -n openshift-sriov-network-operator \
 [source,terminal,subs="attributes+"]
 ----
 Name                                         Phase
-sriov-network-operator.{product-version}.0-202310121402   Succeeded
+sriov-network-operator.{product-version}.0-202406131906   Succeeded
 ----
 
 [id="install-operator-web-console_{context}"]


### PR DESCRIPTION
[OCPBUGS#33339]: Adding a step in the CLI procedure for SriovOperatorConfig resource

Version(s): 

Issue: https://issues.redhat.com/browse/OCPBUGS-33339?filter=12419640

Link to docs preview:
https://78466--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/installing-sriov-operator.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
