### PR TITLE
OCPBUGS-34846: add service token creation step

### DIFF
--- a/modules/nodes-cma-autoscaling-custom-prometheus-config.adoc
+++ b/modules/nodes-cma-autoscaling-custom-prometheus-config.adoc
@@ -16,6 +16,7 @@ These steps are not required for an external Prometheus source.
 You must perform the following tasks, as described in this section:
 
 * Create a service account to get a token.
+* Create the service token.
 * Create a role.
 * Add that role to the service account.
 * Reference the token in the trigger authentication object used by Prometheus.
@@ -48,7 +49,26 @@ where:
 +
 <service_account>:: Specifies the name of the service account.
 
-. Use the following command to locate the token assigned to the service account:
+. Use the following command to create the service token for the service account:
++
+[source,terminal]
+----
+$ oc apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: thanos-token
+  annotations:
+    kubernetes.io/service-account.name: <service_account>
+  type: kubernetes.io/service-account-token
+EOF
+----
++
+where:
++
+<service_account>:: Specifies the name of the service account.
+
+.. Use the following command to locate the token assigned to the service account:
 +
 [source,terminal]
 ----

--- a/modules/nw-autoscaling-ingress-controller.adoc
+++ b/modules/nw-autoscaling-ingress-controller.adoc
@@ -36,6 +36,21 @@ Tokens:              thanos-token-c422q
 Events:              <none>
 ----
 
+. Manually create the service account secret token with the following command:
++
+[source,terminal]
+----
+$ oc apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: thanos-token
+  annotations:
+    kubernetes.io/service-account.name: thanos
+  type: kubernetes.io/service-account-token
+EOF
+----
+
 . Define a `TriggerAuthentication` object within the `openshift-ingress-operator` namespace using the service account's token.
 
 .. Define the variable `secret` that contains the secret by running the following command:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-34846
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://78467--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/cma/nodes-cma-autoscaling-custom-trigger.html#nodes-cma-autoscaling-custom-prometheus-config_nodes-cma-autoscaling-custom-trigger
- https://78467--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/ingress-operator.html#nw-autoscaling-ingress-controller_configuring-ingress

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: will probably need to come back in for the 4.14 and 4.15 version with an `Optional:` qualifier, because sometimes the service token gets generated, sometimes it doesn't
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
