### PR TITLE
OSDOCS-10548 Adding network minimum requirements for ROSA Classic

### DIFF
--- a/modules/mos-network-prereqs-min-bandwidth.adoc
+++ b/modules/mos-network-prereqs-min-bandwidth.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * rosa_planning/rosa-sts-aws-prereqs.adoc
+
+//Define the minimum bandwidth variable here so we can use this same module across all managed variants as testing completes for XCMSTRAT-422
+ifdef::openshift-rosa,openshift-rosa-classic,openshift-rosa-hcp,openshift-osd,openshift-azure[]
+:mos-min-bandwidth: 120{nbsp}Mbps
+endif::[]
+
+[id="mos-network-prereqs-min-bandwidth_{context}"]
+= Minimum bandwidth
+
+During cluster deployment, {product-title} requires a minimum bandwidth of {mos-min-bandwidth} between cluster resources and public internet resources. When network connectivity is slower than {mos-min-bandwidth} (for example, when connecting through a proxy) the cluster installation process times out and deployment fails.
+
+After deployment, network requirements are determined by your workload. However, a minimum bandwidth of {mos-min-bandwidth} helps to ensure timely cluster and operator upgrades.

--- a/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc
+++ b/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc
@@ -18,7 +18,12 @@ include::modules/rosa-aws-procedure.adoc[leveloffset=+1]
 include::modules/rosa-aws-scp.adoc[leveloffset=+2]
 include::modules/rosa-aws-iam.adoc[leveloffset=+1]
 include::modules/rosa-aws-provisioned.adoc[leveloffset=+1]
-include::modules/osd-aws-privatelink-firewall-prerequisites.adoc[leveloffset=+1]
+
+[id="rosa-without-sts-network-prereqs_{context}"]
+== Networking prerequisites
+
+include::modules/mos-network-prereqs-min-bandwidth.adoc[leveloffset=+2]
+include::modules/osd-aws-privatelink-firewall-prerequisites.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources

--- a/rosa_planning/rosa-cloud-expert-prereq-checklist.adoc
+++ b/rosa_planning/rosa-cloud-expert-prereq-checklist.adoc
@@ -158,6 +158,8 @@ ROSA clusters are hosted in an AWS account within an AWS organizational unit. A 
 
 Prerequisites needed from a networking standpoint.
 
+include::modules/mos-network-prereqs-min-bandwidth.adoc[leveloffset=+2]
+
 === Firewall
 
 * Configure your firewall to allow access to the domains and ports listed in xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs[AWS firewall prerequisites].

--- a/rosa_planning/rosa-sts-aws-prereqs.adoc
+++ b/rosa_planning/rosa-sts-aws-prereqs.adoc
@@ -70,14 +70,20 @@ With the STS deployment model, Red{nbsp}Hat is no longer responsible for creatin
 * For every cluster, you must have the necessary operator roles. See xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-operator-roles_rosa-sts-about-iam-resources[Cluster-specific Operator IAM role reference].
 
 include::modules/rosa-aws-provisioned.adoc[leveloffset=+1]
+
+[id="rosa-network-prereqs_{context}"]
+== Networking prerequisites
+
+include::modules/mos-network-prereqs-min-bandwidth.adoc[leveloffset=+2]
+
 // Keeping existing ID to prevent link breakage
 [id="osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs"]
-== AWS firewall prerequisites
+=== AWS firewall prerequisites
 
 If you are using a firewall to control egress traffic from your {product-title}, you must configure your firewall to grant access to the certain domain and port combinations below. {product-title} requires this access to provide a fully managed OpenShift service.
 
-include::modules/osd-aws-privatelink-firewall-prerequisites.adoc[leveloffset=+2]
-include::modules/rosa-hcp-firewall-prerequisites.adoc[leveloffset=+2]
+include::modules/osd-aws-privatelink-firewall-prerequisites.adoc[leveloffset=+3]
+include::modules/rosa-hcp-firewall-prerequisites.adoc[leveloffset=+3]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
Version(s): 4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-10548

Link to docs preview:
- [Prerequisites checklist](https://78475--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-cloud-expert-prereq-checklist.html#mos-network-prereqs-min-bandwidth_rosa-cloud-expert-prereq-checklist)
- [Detailed requirements for STS](https://78475--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs.html#rosa-network-prereqs_rosa-sts-aws-prereqs)
- [Detailed requirements for non-STS](https://78475--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs#rosa-without-sts-network-prereqs_prerequisites)

QE review:
- [x] QE has approved this change.

Additional information:
Approving SMEs are not available until next week so pushing to peer review first, and will hold off on MR until SME and QE review are complete.