### PR TITLE
OSDOCS#11053: Removing incorrect name attribute for rosa edit mpool

### DIFF
--- a/modules/creating-a-machine-pool-cli.adoc
+++ b/modules/creating-a-machine-pool-cli.adoc
@@ -178,7 +178,7 @@ mymachinepool  Yes          3-6       m5.xlarge      app=db, tier=backend       
 +
 [source,terminal]
 ----
-$ rosa describe machinepool --cluster=<cluster_name> mymachinepool
+$ rosa describe machinepool --cluster=<cluster_name> --machinepool=mymachinepool
 ----
 +
 .Example output

--- a/modules/removing-custom-config-from-machinepool.adoc
+++ b/modules/removing-custom-config-from-machinepool.adoc
@@ -21,7 +21,7 @@ To remove all `KubeletConfig` objects from the machine pool, set an empty value 
 +
 [source,terminal]
 ----
-$ rosa edit machinepool -c <cluster_name> --kubeletconfigs="" --name <machinepool_name>
+$ rosa edit machinepool -c <cluster_name> --kubeletconfigs="" <machinepool_name>
 ----
 
 .Verification steps
@@ -29,5 +29,5 @@ $ rosa edit machinepool -c <cluster_name> --kubeletconfigs="" --name <machinepoo
 +
 [source,terminal]
 ----
-$ rosa describe machinepool --cluster <cluster_name> --name <machinepool_name>
+$ rosa describe machinepool --cluster <cluster_name> --machinepool=<machinepool_name>
 ----

--- a/modules/rosa-adding-node-labels.adoc
+++ b/modules/rosa-adding-node-labels.adoc
@@ -103,7 +103,7 @@ I: Updated machine pool 'db-nodes-mp' on cluster 'mycluster'
 +
 [source,terminal]
 ----
-$ rosa describe machinepool --cluster=<cluster_name> <machine-pool-name>
+$ rosa describe machinepool --cluster=<cluster_name> --machinepool=<machine-pool-name>
 ----
 +
 .Example output

--- a/modules/rosa-adding-tags-cli.adoc
+++ b/modules/rosa-adding-tags-cli.adoc
@@ -49,7 +49,7 @@ I: To view all machine pools, run 'rosa list machinepools --cluster mycluster'
 +
 [source,terminal]
 ----
-$ rosa describe machinepool --cluster=<cluster_name> <machine_pool_name>
+$ rosa describe machinepool --cluster=<cluster_name> --machinepool=<machinepool_name>
 ----
 +
 .Example output

--- a/modules/rosa-adding-taints-cli.adoc
+++ b/modules/rosa-adding-taints-cli.adoc
@@ -104,7 +104,7 @@ I: Updated machine pool 'db-nodes-mp' on cluster 'mycluster'
 +
 [source,terminal]
 ----
-$ rosa describe machinepool --cluster=<cluster_name> <machine-pool-name>
+$ rosa describe machinepool --cluster=<cluster_name> --machinepool=<machinepool_name>
 ----
 +
 .Example output

--- a/modules/rosa-edit-objects.adoc
+++ b/modules/rosa-edit-objects.adoc
@@ -234,7 +234,7 @@ Allows edits to the machine pool in a cluster.
 .Syntax
 [source,terminal]
 ----
-$ rosa edit machinepool --cluster=<cluster_name_or_id> <machinepool_ID> [arguments]
+$ rosa edit machinepool --cluster=<cluster_name_or_id> <machinepool_name> [arguments]
 ----
 
 .Arguments

--- a/modules/rosa-list-objects.adoc
+++ b/modules/rosa-list-objects.adoc
@@ -743,7 +743,7 @@ Describes a specific machine pool configured on a cluster.
 .Syntax
 [source,terminal]
 ----
-$ rosa describe machinepool --cluster=<cluster_name> --machinepool=<machinepool_name>| <cluster_id> <machinepool_id> [arguments]
+$ rosa describe machinepool --cluster=[<cluster_name>|<cluster_id>] --machinepool=<machinepool_name> [arguments]
 ----
 
 .Arguments

--- a/modules/rosa-node-drain-grace-period.adoc
+++ b/modules/rosa-node-drain-grace-period.adoc
@@ -37,7 +37,7 @@ db-nodes-mp  No           2         m5.xlarge    [...] us-east-1a          No   
 +
 [source,terminal]
 ----
-$ rosa describe machinepool --cluster <cluster_name> <machinepool_name>
+$ rosa describe machinepool --cluster <cluster_name> --machinepool=<machinepool_name>
 ----
 +
 .Example output

--- a/modules/setting-higher-pid-limit-on-machinepool.adoc
+++ b/modules/setting-higher-pid-limit-on-machinepool.adoc
@@ -25,7 +25,7 @@ Changing the `podPidsLimit` on an existing machine pool triggers nodes in the ma
 +
 [source,terminal]
 ----
-$ rosa create kubeletconfig -c <cluster_name> --name=<kubeletconfig_name>  --pod-pids-limit=<value>
+$ rosa create kubeletconfig -c <cluster_name> --name=<kubeletconfig_name> --pod-pids-limit=<value>
 ----
 +
 For example, the following command creates a `set-high-pids` `KubeletConfig` object for the `my-cluster` cluster that sets a maximum of 16,384 PIDs per pod:
@@ -42,13 +42,13 @@ $ rosa create kubeletconfig -c my-cluster --name=set-high-pids --pod-pids-limit=
 +
 [source,terminal]
 ----
-$ rosa create machinepool -c <cluster_name> --kubelet-configs=<kubeletconfig_name> --name <machinepool_name>
+$ rosa create machinepool -c <cluster_name> --name <machinepool_name> --kubelet-configs=<kubeletconfig_name>
 ----
 ** For an existing machine pool:
 +
 [source,terminal]
 ----
-$ rosa edit machinepool -c <cluster_name> --kubelet-configs=<kubeletconfig_name> --name <machinepool_name>
+$ rosa edit machinepool -c <cluster_name> --kubelet-configs=<kubeletconfig_name> <machinepool_name>
 ----
 --
 +
@@ -56,14 +56,14 @@ For example, the following command associates the `set-high-pids` `KubeletConfig
 +
 [source,terminal]
 ----
-$ rosa edit machinepool -c my-cluster --kubelet-configs=set-high-pids --name=high-pid-pool
+$ rosa edit machinepool -c my-cluster --kubelet-configs=set-high-pids high-pid-pool
 ----
 +
 A rolling reboot of worker nodes is triggered when a new `KubeletConfig` object is attached to an existing machine pool. You can check the progress of the rollout in the machine pool description:
 +
 [source,terminal]
 ----
-$ rosa describe machinepool --cluster <cluster_name> --name <machinepool_name>
+$ rosa describe machinepool --cluster <cluster_name> --machinepool <machinepool_name>
 ----
 
 .Verification


### PR DESCRIPTION
Version(s): 4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-11053

Link to docs preview:
- https://78480--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli.html
- https://78480--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa-configuring-pid-limits.html
- https://78480--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html

QE review:
- [x] QE has approved this change.