### PR TITLE
OCPBUGS-32227#adding Butane installation step

### DIFF
--- a/modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc
+++ b/modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc
@@ -23,6 +23,12 @@ image::152_OpenShift_Config_NTP_0421.png[Configuring NTP for disconnected cluste
 {product-title} nodes must agree on a date and time to run properly. When compute nodes retrieve the date and time from the NTP servers on the control plane nodes, it enables the installation and operation of clusters that are not connected to a routable network and thereby do not have access to a higher stratum NTP server.
 
 .Procedure
+. Install Butane on your installation host by using the following command:
++
+[source,terminal]
+----
+$ sudo dnf -y install butane
+----
 
 . Create a Butane config, `99-master-chrony-conf-override.bu`, including the contents of the `chrony.conf` file for the control plane nodes.
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Versions:
4.13+

Issue:
https://issues.redhat.com/browse/OCPBUGS-32227

Link to docs preview:
https://78482--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-ntp-for-disconnected-clusters_ipi-install-installation-workflow

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
