### PR TITLE
TRACING-4297: update storage secret table

### DIFF
--- a/modules/distr-tracing-tempo-config-default.adoc
+++ b/modules/distr-tracing-tempo-config-default.adoc
@@ -82,7 +82,7 @@ spec:
 |
 
 |`storage:`
-|Configuration options that define the storage. All storage-related options must be placed under `storage` and not under the `allInOne` or other component options.
+|Configuration options that define the storage.
 |
 |
 

--- a/modules/distr-tracing-tempo-config-storage.adoc
+++ b/modules/distr-tracing-tempo-config-storage.adoc
@@ -11,23 +11,35 @@ You can configure object storage for the {TempoShortName} in the `TempoStack` cu
 
 .General storage parameters used by the {TempoOperator} to define distributed tracing storage
 [options="header"]
-[cols="a, a, a, a"]
+[cols="a, a, a"]
 |===
-|Parameter |Description |Values |Default value
-|`spec.storage.secret.type`
-|Type of storage to use for the deployment.
-|`memory`. Memory storage is only appropriate for development, testing, demonstrations, and proof of concept environments because the data does not persist when the pod is shut down.
-|`memory`
+|Parameter |Description |Values
 
-|`storage.secretname`
+|`storage.secret.type`
+|Type of object storage to use for the deployment.
+|`azure`, `gcs` or `s3`
+
+
+|`storage.secret.name`
 |Name of the secret that contains the credentials for the set object storage type.
 |
-|N/A
+
+|`storage.tls.enable`
+|Optional: Enables TLS when communicating with object storage.
+|
 
 |`storage.tls.caName`
-|CA is the name of a `ConfigMap` object containing a CA certificate.
+|Optional: Name of a ConfigMap containing a CA certificate (service-ca.crt). It needs to be in the same namespace as the `TempoStack` custom resource.
 |
+
+|`storage.tls.certName`
+|Optional: Name of a Secret containing a certificate (tls.crt) and private key (tls.key). It needs to be in the same namespace as the `TempoStack` custom resource.
 |
+
+|`storage.tls.minVersion`
+|Optional: The minimum acceptable TLS version.
+|
+
 |===
 
 include::snippets/distr-tracing-tempo-required-secret-parameters.adoc[]


### PR DESCRIPTION
Version(s):


Issue:
https://issues.redhat.com/browse/TRACING-4297

Link to docs preview:
https://78484--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-configuring.html#distr-tracing-tempo-config-storage_distr-tracing-tempo-configuring

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
cc @max-cx 