### PR TITLE
OSDOCS: CNV-40769 - Correcting SCSI type in LUN disk sharing doc (re-redux)

### DIFF
--- a/modules/virt-configuring-disk-sharing-lun.adoc
+++ b/modules/virt-configuring-disk-sharing-lun.adoc
@@ -6,11 +6,14 @@
 [id="virt-configuring-disk-sharing-lun_{context}"]
 = Configuring disk sharing by using LUN
 
-You can configure a LUN-backed virtual machine (VM) disk to be shared among multiple virtual machines by enabling SCSI persistent reservation. Enabling the shared option allows you to use advanced SCSI commands, such as those required for a Windows failover clustering implementation, against the underlying storage. Any disk to be shared must be in block mode.
+To secure data on your VM from outside access, you can enable SCSI persistent reservation and configure a LUN-backed virtual machine disk to be shared among multiple virtual machines. By enabling the shared option, you can use advanced SCSI commands, such as those required for a Windows failover clustering implementation, for managing the underlying storage.
 
-A disk of type `LUN` exposes the volume as a LUN device to the VM. This allows the VM to execute arbitrary iSCSI command passthrough on the disk.
+When a storage volume is configured as the `LUN` disk type, a VM can use the volume as a logical unit number (LUN) device. As a result, the VM can deploy and manage the disk by using SCSI commands.
 
-You reserve a LUN through the SCSI persistent reserve options to protect data on the VM from outside access. To enable the reservation, you configure the feature gate option. You then activate the option on the LUN disk to issue SCSI device-specific input and output controls (IOCTLs) that the VM requires.
+You reserve a LUN through the SCSI persistent reserve options. To enable the reservation: 
+
+. Configure the feature gate option
+. Activate the feature gate option on the LUN disk to issue SCSI device-specific input and output controls (IOCTLs) that the VM requires.
 
 You can set an error policy for each LUN disk. The error policy controls how the hypervisor behaves when an input/output error occurs on a disk Read or Write. The default behavior stops the guest and generates a Kubernetes event.
 
@@ -23,8 +26,12 @@ For a LUN disk with an iSCSi connection and a persistent reservation, as require
 * The volume access mode must be `ReadWriteMany` (RWX) if the VMs that are sharing disks are running on different nodes.
 +
 If the VMs that are sharing disks are running on the same node, `ReadWriteOnce` (RWO) volume access mode is sufficient.
+
 * The storage provider must support a Container Storage Interface (CSI) driver that uses the SCSI protocol.
+
 * If you are a cluster administrator and intend to configure disk sharing by using LUN, you must enable the cluster's feature gate on the `HyperConverged` custom resource (CR).
+
+* Disks that you want to share must be in block mode.
 
 .Procedure
 

--- a/virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc
@@ -11,7 +11,7 @@ You can configure shared disks to allow multiple virtual machines (VMs) to share
 You configure disk sharing by exposing the storage as either of these types:
 
 * An ordinary VM disk
-* A logical unit number (LUN) disk with an iSCSi connection and raw device mapping, as required for Windows Failover Clustering for shared volumes
+* A logical unit number (LUN) disk with an SCSI connection and raw device mapping, as required for Windows Failover Clustering for shared volumes
 
 In addition to configuring disk sharing, you can also set an error policy for each ordinary VM disk or LUN disk. The error policy controls how the hypervisor behaves when an input/output error occurs on a disk Read or Write.
 


### PR DESCRIPTION
Version(s):
4.15 and later

Issue:
https://issues.redhat.com/browse/CNV-40769

Link to docs preview:
https://78487--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.html

QE review:
[ ] QE has approved this change.

Additional information:
This is another attempt at merging https://github.com/openshift/openshift-docs/pull/76003 and https://github.com/openshift/openshift-docs/pull/78464 , both of which I seem to have messed up during resolution of conflicts with main