### PR TITLE
OCPBUGS-30569: Adding bug fix release note missed at 4.16 GA

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -2441,6 +2441,9 @@ With this update, session affinity without a timeout is possible by setting the 
 
 * Previously, the TuneD daemon could unnecessarily reload an additional time after a Tuned custom resource (CR) update. With this release, the Tuned object has been removed and the TuneD (daemon) profiles are carried directly in the Tuned Profile Kubernetes objects. As a result, the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-32469[*OCPBUGS-32469*])
 
+
+* Previously, when restarting a {sno} cluster with a performance profile applied, a race condition caused systemd processes to remain in the root directory instead of being moved to `/sys/fs/cgroup/cpuset/system.slice`. With this release, systemd processes are moved to `/sys/fs/cgroup/cpuset/system.slice` as expected following a {sno} node restart. (link:https://issues.redhat.com/browse/OCPBUGS-31692[*OCPBUGS-31692*])
+
 [discrete]
 [id="ocp-4-16-openshift-cli-bug-fixes_{context}"]
 ==== OpenShift CLI (oc)


### PR DESCRIPTION
OCPBUGS-30569: Adding bug fix missed a 4.16 GA. It's affects users restarting a SNO node with a performance profile applied. 

Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OCPBUGS-30569

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This was previously review and approved, but the bug didn't make GA because it was set to private. It has since been made public so we can doc it.

Change management ACKs received. Following the "announce a change" CM procedure to get this merged, then notify stakeholders.