### PR TITLE
Updating the redirect link at legacy RDS location

### DIFF
--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -45,7 +45,7 @@ ifdef::openshift-telco[]
 ====
 The telco core and telco RAN DU reference design specifications (RDS) are no longer published at this location.
 
-For the latest version of the telco RDS, see link:https://docs.openshift.com/container-platform/4.15/telco_ref_design_specs/telco-ref-design-specs-overview.html[Telco core and RAN DU reference design specifications].
+For the latest version of the telco RDS, see link:https://docs.openshift.com/container-platform/{product-version}/scalability_and_performance/telco_ref_design_specs/telco-ref-design-specs-overview.html[Telco core and RAN DU reference design specifications].
 ====
 
 endif::[]


### PR DESCRIPTION
[TELCODOCS-1916](https://issues.redhat.com//browse/TELCODOCS-1916): Updating redirect at the old RDS docs location, which was behind a login. The new RDS docs are public but we moved them to the scalability and performance section. So needed to update the redirect link.

Version(s):
main+, CP to 4.14 and 4.15

Issue:
https://issues.redhat.com/browse/TELCODOCS-1916

Link to docs preview:
https://file.emea.redhat.com/rohennes/TELCODOCS-1916-updating-redirect-link-for-archived-RDS/welcome/index.html

No QE needed.