### PR TITLE
OSDOCS 11250: Added securing routes with externally managed certificate section in cert-manager

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1125,6 +1125,8 @@ Topics:
     File: cert-manager-operator-issuer-acme
   - Name: Configuring certificates with an issuer
     File: cert-manager-creating-certificate
+  - Name: Securing OpenShift routes with cert-manager
+    File: cert-manager-securing-routes
   - Name: Monitoring the cert-manager Operator for Red Hat OpenShift
     File: cert-manager-monitoring
   - Name: Configuring log levels for cert-manager and the cert-manager Operator for Red Hat OpenShift

--- a/modules/cert-manager-configuring-routes.adoc
+++ b/modules/cert-manager-configuring-routes.adoc
@@ -1,0 +1,144 @@
+// Module included in the following assemblies:
+//
+// * security/cert_manager_operator/cert-manager-creating-certificate.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="cert-manager-configuring-routes_{context}"]
+= Configuring certificates to secure routes in your cluster
+
+The following steps demonstrate the process of utilizing the {cert-manager-operator} with the `Let's Encrypt` ACME HTTP-01 challenge type to secure the route resources in your OpenShift Cluster.
+
+.Prerequisites
+
+* You have installed the {cert-manager-operator} 1.14.0 or later.
+* You have enabled the `RouteExternalCertificate` feature gate.
+* You have the `create` and `update` permissions on the `routes/custom-host` sub-resource.
+* You have a `Service` that you want to expose.
+
+.Procedure
+
+. Create a `route` for your service using edge TLS termination and a custom `hostname`.
++
+[source, terminal]
+----
+$ oc create route edge <route_name> \ # <1>
+  --service=<service_name> \ # <2>
+  --hostname=<host_name> \ # <3>
+  --namespace=<namespace> # <4>
+----
+<1> Specify your route's name.
+<2> Specify the service you want to expose.
+<3> Specify the hostname of your route.
+<4> Specify the namespace where your route is located.
+
+. Create an `Issuer` to configure the http01 solver. For other ACME issuer types, see "Configuring ACME an issuer" in the "Additional Resources" section.
++
+.Example `Issuer.yaml` file
++
+[source, yaml]
+----
+$ oc create -f - << EOF
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt-acme
+  namespace: <namespace> # <1>
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-acme-account-key
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: openshift-default
+EOF
+----
+<1> Specify the namespace where the Issuer is located. It should be the same as your route's namespace.
+
+. Create a `Certificate` for the route.
++
+[source, yaml]
+----
+$ oc create -f - << EOF
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: example-route-cert
+  namespace: <namespace> # <1>
+spec:
+  commonName: <hostname> # <2>
+  dnsNames:
+    - <hostname> # <3>
+  usages:
+    - server auth
+  issuerRef:
+    kind: Issuer
+    name: letsencrypt-acme
+  secretName: <secret_name> # <4>
+EOF
+----
+<1> Specify the `namespace` where the `Certificate` is located. It should be the same as your route's namespace.
+<2> Specify the certificate's common name using the `hostname` of the route.
+<3> Add the `hostname` of your route to the certificate's DNS names.
+<4> Specify the name of the secret that contains the certificate.
+
+. Create a `Role` to provide the router service account permissions to read the referenced secret using the following command:
++
+[source, terminal]
+----
+$ oc create role secret-reader \
+  --verb=get,list,watch \
+  --resource=secrets \
+  --resource-name=<secret_name> \ # <1>
+  --namespace=<namespace> # <2>
+----
+<1> Specify the name of the secret that you want to grant access to. It should be consistent with your `secretName` specified in the Certificate.
+<2> Specify the namespace where both your secret and route reside.
+
+. Create a `RoleBinding` to bind the router service account with the newly created `Role` using the following command:
++
+[source, terminal]
+----
+$ oc create rolebinding secret-reader-binding \
+  --role=secret-reader \
+  --serviceaccount=openshift-ingress:router \
+  --namespace=<namespace> # <1>
+----
+<1> Specify the namespace where both your secret and route reside.
+
+. Update your route's `.spec.tls.externalCertificate` field to reference the previously created secret and use the certificate issued by {cert-manager-operator} using the following command:
++
+[source, terminal]
+----
+$ oc patch route <route_name> \
+  -n <namespace> \
+  --type=merge \
+  -p '{"spec":{"tls":{"externalCertificate":{"name":"<secret_name>"}}}}'
+----
+
+.Verification
+
+* Verify that the certificate is created and ready to use by running the following command:
++ 
+[source, terminal]
+----
+$ oc get certificate -n <namespace>
+$ oc get secret -n <namespace>
+----
+
+* Verify that the router is using the referenced external certificate by running the following command. The command should return with the status code `200 OK`.
++ 
+[source, terminal]
+----
+$ curl -IsS https://<hostname>
+----
+
+* Verify the server certificate's `subject`, `subjectAltName` and `issuer` are all as expected from the curl verbose outputs by running the following command:
++ 
+[source, terminal]
+----
+$ curl -v https://<hostname>
+----
++
+Now the route is successfully secured by the certificate from the referenced secret issued by {cert-manager-operator}. Cert-manager will automatically manage the certificate's lifecycle.

--- a/security/cert_manager_operator/cert-manager-securing-routes.adoc
+++ b/security/cert_manager_operator/cert-manager-securing-routes.adoc
@@ -1,0 +1,18 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="cert-manager-securing-routes"]
+= Securing OpenShift routes with cert-manager
+include::_attributes/common-attributes.adoc[]
+:context: cert-manager-securing-routes
+
+toc::[]
+
+In the {product-title} 4.16 release, the route API is extended to provide a configurable option to reference TLS certificates via secrets. With the "Configure routes with externally managed certificate" feature enabled, you can minimize errors from manual intervention, streamline the certificate management process, and enable the {product-title} router to promptly serve the referenced certificate.
+
+include::modules/cert-manager-configuring-routes.adoc[leveloffset=+1]
+
+[id="additional-resources_cert-manager-securing-routes"]
+== Additional resources
+
+* xref:../../networking/routes/secured-routes.html#nw-ingress-route-secret-load-external-cert_secured-routes[Creating a route with externally managed certificate]
+
+* xref:../../security/cert_manager_operator/cert-manager-operator-issuer-acme.adoc#cert-manager-operator-issuer-acme[Configuring an ACME issuer]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-11250
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://78502--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-securing-routes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
