### PR TITLE
[internal-fix] OSDOCS-9350-feedback: Addressed feedback from OSDOCS-9350

### DIFF
--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -6,7 +6,7 @@
 [id="nw-ingress-controller-configuration-parameters_{context}"]
 = Ingress Controller configuration parameters
 
-The `ingresscontrollers.operator.openshift.io` resource includes optional configuration parameters that you can configure to meet specific needs for your organization.
+The `Infrastructure` custom resource (CR) includes optional configuration parameters that you can configure to meet specific needs for your organization.
 
 [cols="3a,8a",options="header"]
 |===
@@ -67,7 +67,7 @@ endif::openshift-rosa[]
 ifndef::openshift-rosa,openshift-dedicated[]
 For non-cloud environments, such as a bare-metal platform, use the `NodePortService`, `HostNetwork`, or `Private` fields to configure the endpoint publishing strategy for your Ingress Controller.
 
-If you do not set a value in one of these fields, the default value is based on binding ports specified in the `infrastructure.config.openshift.io/cluster` `.status.platform` resource.
+If you do not set a value in one of these fields, the default value is based on binding ports specified in the `.status.platform` value in the `Infrastructure` CR.
 endif::openshift-rosa,openshift-dedicated[]
 
 ifndef::openshift-rosa[]

--- a/networking/nw-configuring-ingress-controller-endpoint-publishing-strategy.adoc
+++ b/networking/nw-configuring-ingress-controller-endpoint-publishing-strategy.adoc
@@ -10,9 +10,9 @@ The `endpointPublishingStrategy` is used to publish the Ingress Controller endpo
 
 [IMPORTANT]
 ====
-On {rh-openstack-first}, the `LoadBalancerService` endpoint publishing strategy is only supported if a cloud provider is configured to create health monitors. For {rh-openstack} 16.2, this strategy is only possible if you use the Amphora Octavia provider.
+On {rh-openstack-first}, the `LoadBalancerService` endpoint publishing strategy is supported only if a cloud provider is configured to create health monitors. For {rh-openstack} 16.2, this strategy is possible only if you use the Amphora Octavia provider.
 
-For more information, see the " Setting {rh-openstack} Cloud Controller Manager options" section of the {rh-openstack} installation documentation.
+For more information, see the "Setting {rh-openstack} Cloud Controller Manager options" section of the {rh-openstack} installation documentation.
 ====
 
 // Ingress Controller endpoint publishing strategy


### PR DESCRIPTION
Addresses feedback from https://github.com/openshift/openshift-docs/pull/77368

Version(s):
4.12+ 

Link to docs preview:
* [Ingress Controller configuration parameters](https://78503--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/ingress-operator.html#nw-ingress-controller-configuration-parameters_configuring-ingress)
* [Configuring the Ingress Controller endpoint publishing strategy](https://78503--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/nw-configuring-ingress-controller-endpoint-publishing-strategy.html)

