### PR TITLE
PR for SRVLOGIC-355: Add the Openshift Serverless Logic GA entry in the Serverless 1.33 release notes.

### DIFF
--- a/modules/serverless-rn-1-33-0.adoc
+++ b/modules/serverless-rn-1-33-0.adoc
@@ -18,7 +18,12 @@
 * {ServerlessProductName} now uses Knative for Apache Kafka 1.12.
 * The `kn func` CLI plugin now uses `func` 1.14.
 
+* OpenShift Serverless Logic is now generally available (GA). This release includes an overview of OpenShift Serverless Logic; instructions on creating, running, and deploying workflows; and guidelines for the installation and uninstallation of {ServerlessLogicOperatorName}. Additionally, it includes steps for configuring OpenAPI services and endpoints, and techniques for troubleshooting the services. For more information, see link:https://docs.openshift.com/serverless/latest/about/serverless-logic-overview.html[OpenShift Serverless Logic overview].
++
+You can also refer to the additional documentation. For more details, see link:https://openshift-knative.github.io/docs/docs/latest/serverless-logic/about.html[the Serverless Logic documentation].
+
 * {ServerlessProductName} on ARM64 is now available as Technology Preview.
+
 * The `NamespacedKafka` annotation is now deprecated. Use the standard Kafka broker without data plane isolation instead.
 
 * When enabling the automatic `EventType` auto-creation, you can now easily discover events available within the cluster. This functionality is available as a Developer Preview.

--- a/modules/serverless-tech-preview-features.adoc
+++ b/modules/serverless-tech-preview-features.adoc
@@ -15,6 +15,11 @@ The following table provides information about which {ServerlessProductName} fea
 |====
 |Feature |1.31|1.32|1.33
 
+|OpenShift Serverless Logic
+|TP
+|TP
+|GA
+
 |ARM64 support
 |-
 |-


### PR DESCRIPTION
**Affecting versions:** `serverless-docs-1.33`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVLOGIC-355

**Doc previews:** 
- [OpenShift Serverless 1.33 release notes](https://78505--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-rn-1-33-0_serverless-release-notes)
- [Generally Available and Technology Preview features](https://78505--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-tech-preview-features_serverless-release-notes)