### PR TITLE
OCPBUGS#36470: Updated the subscription name in "Uninstalling the Multiarch Tuning Operator by using the CLI" proc

### DIFF
--- a/modules/multi-arch-uninstalling-using-cli.adoc
+++ b/modules/multi-arch-uninstalling-using-cli.adoc
@@ -21,13 +21,28 @@ You must delete the `ClusterPodPlacementConfig` object before uninstalling the M
 
 .Procedure
 
+. Get the `Subscription` object name for the Multiarch Tuning Operator by running the following command: 
++
+[source,terminal]
+----
+$ oc get subscription.operators.coreos.com -n <namespace> <1>
+----
+<1> Replace `<namespace>` with the name of the namespace where you want to uninstall the Multiarch Tuning Operator.
++
+.Example output
+[source,terminal]
+----
+NAME                                  PACKAGE                     SOURCE             CHANNEL
+openshift-multiarch-tuning-operator   multiarch-tuning-operator   redhat-operators   tech-preview
+----
+
 . Get the `currentCSV` value for the Multiarch Tuning Operator by running the following command:
 +
 [source,terminal]
 ----
-$ oc get subscription.operators.coreos.com multiarch-tuning-operator -n <namespace> -o yaml | grep currentCSV <1>
+$ oc get subscription.operators.coreos.com <subscription_name> -n <namespace> -o yaml | grep currentCSV <1>
 ----
-<1> Replace `<namespace>` with the name of the namespace where you want to uninstall the Multiarch Tuning Operator.
+<1> Replace `<subscription_name>` with the `Subscription` object name. For example: `openshift-multiarch-tuning-operator`. Replace `<namespace>` with the name of the namespace where you want to uninstall the Multiarch Tuning Operator.
 +
 .Example output
 [source,terminal]
@@ -39,9 +54,9 @@ currentCSV: multiarch-tuning-operator.v0.9.0
 +
 [source,terminal]
 ----
-$ oc delete subscription.operators.coreos.com openshift-multiarch-tuning-operator -n <namespace> <1>
+$ oc delete subscription.operators.coreos.com <subscription_name> -n <namespace> <1>
 ----
-<1> Replace `<namespace>` with the name of the namespace where you want to uninstall the Multiarch Tuning Operator.
+<1> Replace `<subscription_name>` with the `Subscription` object name. Replace `<namespace>` with the name of the namespace where you want to uninstall the Multiarch Tuning Operator.
 +
 .Example output
 [source,terminal]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OCPBUGS-36470](https://issues.redhat.com/browse/OCPBUGS-36470)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[Uninstalling the Multiarch Tuning Operator by using the CLI](https://78506--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.html#multi-architecture-uninstalling-using-cli_multiarch-tuning-operator)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->