### PR TITLE
OBSDOCS-1163-Logging 5.9.4 Release Notes

### DIFF
--- a/modules/logging-release-notes-5-9-4.adoc
+++ b/modules/logging-release-notes-5-9-4.adoc
@@ -1,0 +1,30 @@
+//module included in logging-5-9-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-5-9-4_{context}"]
+= Logging 5.9.4
+This release includes link:https://access.redhat.com/errata/RHBA-2024:4333[OpenShift Logging Bug Fix Release 5.9.4]
+
+[id="logging-release-notes-5-9-4-bug-fixes"]
+== Bug Fixes
+
+* Before this update, an incorrectly formatted timeout configuration caused the OCP plugin to crash. With this update, a validation prevents the crash and informs the user about the incorrect configuration. (link:https://issues.redhat.com/browse/LOG-5373[LOG-5373])
+
+* Before this update, workloads with labels containing `-` caused an error in the collector when normalizing log entries. With this update, the configuration change ensures the collector uses the correct syntax. (link:https://issues.redhat.com/browse/LOG-5524[LOG-5524])
+
+* Before this update, an issue prevented selecting pods that no longer existed, even if they had generated logs. With this update, this issue has been fixed, allowing selection of such pods. (link:https://issues.redhat.com/browse/LOG-5697[LOG-5697])
+
+* Before this update, the Loki Operator would crash if the `CredentialRequest` specification was registered in an environment without the `cloud-credentials-operator`. With this update, the `CredentialRequest` specification only registers in environments that are `cloud-credentials-operator` enabled. (link:https://issues.redhat.com/browse/LOG-5701[LOG-5701])
+
+* Before this update, the Logging Operator watched and processed all config maps across the cluster. With this update, the dashboard controller only watches the config map for the logging dashboard. (link:https://issues.redhat.com/browse/LOG-5702[LOG-5702])
+
+* Before this update, the `ClusterLogForwarder` introduced an extra space in the message payload which did not follow the `RFC3164` specification. With this update, the extra space has been removed, fixing the issue. (link:https://issues.redhat.com/browse/LOG-5707[LOG-5707])
+
+
+* Before this update, removing the seeding for `grafana-dashboard-cluster-logging` as a part of (link:https://issues.redhat.com/browse/LOG-5308[LOG-5308]) broke new greenfield deployments without dashboards. With this update, the Logging Operator seeds the dashboard at the beginning and continues to update it for changes. (link:https://issues.redhat.com/browse/LOG-5747[LOG-5747])
+
+* Before this update, LokiStack was missing a route for the Volume API causing the following error: `404 not found`. With this update, LokiStack exposes the Volume API, resolving the issue. (link:https://issues.redhat.com/browse/LOG-5749[LOG-5749])
+
+[id="logging-release-notes-5-9-4-CVEs"]
+== CVEs
+
+link:https://access.redhat.com/security/cve/CVE-2024-24790[CVE-2024-24790]

--- a/observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-9-4.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-9-3.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-9-2.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Logging Z-Stream Release Notes - 5.9.4
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1163

Fix Version: 4.13, 4.14, 4.15, 4.16

Doc Preview: https://78507--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/logging_release_notes/logging-5-9-release-notes.html


SME Review: @periklis 
QE Review: @anpingli 
Peer Review: @snarayan-redhat 