### PR TITLE
OSDOCS-11201: updates attributes file in MicroShift

### DIFF
--- a/_attributes/attributes-microshift.adoc
+++ b/_attributes/attributes-microshift.adoc
@@ -4,12 +4,12 @@
 :experimental:
 :imagesdir: images
 :OCP: OpenShift Container Platform
-:ocp-version: 4.16
+:ocp-version: 4.17
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
 :product-title-first: Red Hat build of MicroShift (MicroShift)
 :microshift-short: MicroShift
 :product-registry: OpenShift image registry
-:product-version: 4.16
+:product-version: 4.17
 :rhel-major: rhel-9
 :op-system-base-full: Red Hat Enterprise Linux (RHEL)
 :op-system: RHEL
@@ -19,6 +19,6 @@
 :op-system-version: 9.4
 :op-system-version-major: 9
 :op-system-bundle: Red Hat Device Edge
-:rpm-repo-version: rhocp-4.16
+:rpm-repo-version: rhocp-4.17
 :rhde-version: 4
 :VirtProductName: OpenShift Virtualization

--- a/microshift_updating/microshift-about-updates.adoc
+++ b/microshift_updating/microshift-about-updates.adoc
@@ -6,11 +6,11 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-Updates are supported on {product-title} beginning with the General Availability version 4.14. With the 4.16 release, the following updates are supported:
+Updates are supported on {product-title} beginning with the General Availability version 4.14. With the 4.17 release, the following updates are supported:
 
 * A maximum of two minor versions to the next in sequence, for example, from 4.14 to 4.16.
-* One minor version to the next in sequence, for example, from 4.15 to 4.16.
-* Patch updates are also supported from z-stream to z-stream, for example 4.16.1 to 4.16.2.
+* One minor version to the next in sequence, for example, from 4.16 to 4.17.
+* Patch updates are also supported from z-stream to z-stream, for example 4.17.1 to 4.17.2.
 
 [id="microshift-about-updates-understanding-microshift-updates_{context}"]
 == Understanding {microshift-short} updates

--- a/microshift_updating/microshift-update-rpms-manually.adoc
+++ b/microshift_updating/microshift-update-rpms-manually.adoc
@@ -6,7 +6,7 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-Updating {product-title} for non-OSTree systems such as {op-system-base-full} requires downloading then updating the RPMs. For patch releases, such as 4.16.1 to 4.16.2, download and update the RPMs. For minor-version release updates, add the step of enabling the update repository using your subscription manager.
+Updating {product-title} for non-OSTree systems such as {op-system-base-full} requires downloading then updating the RPMs. For patch releases, such as 4.17.1 to 4.17.2, download and update the RPMs. For minor-version release updates, add the step of enabling the update repository using your subscription manager.
 
 [IMPORTANT]
 ====

--- a/microshift_updating/microshift-update-rpms-ostree.adoc
+++ b/microshift_updating/microshift-update-rpms-ostree.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 Updating {microshift-short} on an `rpm-ostree` system such as {op-system-ostree-first} requires building a new {op-system-ostree} image containing the new version of {microshift-short} and any associated optional RPMs. After you have the `rpm-ostree` image with {microshift-short} embedded, direct your system to boot into that operating system image.
 
-The procedures are the same for minor-version and patch updates. For example, use the same steps to upgrade from 4.14 to 4.16 or from 4.16.0 to 4.16.1.
+The procedures are the same for minor-version and patch updates. For example, use the same steps to upgrade from 4.16 to 4.17 or from 4.17.0 to 4.17.1.
 
 include::snippets/microshift-rhde-compatibility-table-snip.adoc[leveloffset=+1]
 

--- a/modules/microshift-updating-rpms-y.adoc
+++ b/modules/microshift-updating-rpms-y.adoc
@@ -6,12 +6,7 @@
 [id="microshift-updating-rpms_{context}"]
 = Applying minor-version updates with RPMs
 
-Updating a {microshift-short} minor version on non `rpm-ostree` systems such as {op-system-base-full} requires downloading then updating the RPMs. For example, use the following procedure to update from 4.15 to 4.16.
-
-[IMPORTANT]
-====
-You can only update {microshift-short} from one version to the next in sequence. Jumping minor versions is not supported. For example, must update 4.15 to 4.16.
-====
+Updating a {microshift-short} minor version on non `rpm-ostree` systems such as {op-system-base-full} requires downloading then updating the RPMs. For example, use the following procedure to update from 4.16 to 4.17.
 
 .Prerequisites
 * The system requirements for installing {microshift-short} have been met.

--- a/modules/microshift-updating-rpms-z.adoc
+++ b/modules/microshift-updating-rpms-z.adoc
@@ -6,7 +6,7 @@
 [id="microshift-applying-patch-updates-rpms_{context}"]
 = Applying patch updates using RPMs
 
-Updating {microshift-short} on non `rpm-ostree` systems such as {op-system-base-full} requires downloading then updating the RPMs. A system reboot is not required for patch updates. For example, use the following procedure to upgrade from 4.14.0 to 4.14.1.
+Updating {microshift-short} on non `rpm-ostree` systems such as {op-system-base-full} requires downloading then updating the RPMs. A system reboot is not required for patch updates. For example, use the following procedure to upgrade from 4.17.0 to 4.17.1.
 
 .Prerequisites
 * The system requirements for installing {microshift-short} have been met.

--- a/snippets/microshift-rhde-compatibility-table-snip.adoc
+++ b/snippets/microshift-rhde-compatibility-table-snip.adoc
@@ -17,9 +17,14 @@
 ^|*Supported {microshift-short} Version&#8594;{microshift-short} Version Updates*
 
 ^|9.4
+^|4.17
+^|Generally Available
+^|4.17.0&#8594;4.17.z and 4.16&#8594;4.17
+
+^|9.4
 ^|4.16
 ^|Generally Available
-^|4.16.0&#8594;4.16.z, 4.14&#8594;4.16 and 4.15&#8594;4.16
+^|4.16.0&#8594;4.16.z, 4.14&#8594;4.16, 4.15&#8594;4.16 and 4.16&#8594;4.17
 
 ^|9.2, 9.3
 ^|4.15

--- a/snippets/microshift-update-paths-snip.adoc
+++ b/snippets/microshift-update-paths-snip.adoc
@@ -12,7 +12,11 @@ Before updating {microshift-short} or {op-system}, determine the compatibilities
 
 *{product-title} update paths*
 
+{microshift-short} version 4.17::
+* Version 4.17 to 4.17.z on {op-system} or {op-system-ostree} 9.4
+
 {microshift-short} version 4.16::
+* Version 4.16 on {op-system} or {op-system-ostree} 9.4 to 4.17 on {op-system} or {op-system-ostree} 9.4
 * Version 4.16 to 4.16.z on {op-system} or {op-system-ostree} 9.4
 
 {microshift-short} version 4.15::


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OSDOCS-11201](https://issues.redhat.com/browse/OSDOCS-11201)

Link to docs preview:
1. All the changes made under installing for the rhde compatibility matrix can be seen below:
[RPM package](https://78509--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-install-rpm#microshift-install-rpm-rhde-compatibility-table)
[RHEL for EDGE image](https://78509--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree#embed-ostree-rhde-compatibility-table)
[offline use](https://78509--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree-offline-use#embed-offline-rhde-compatibility-table)

2. All the changes made under updating  can be seen in [About updates](https://78509--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-about-updates)

QE review:
- [x] QE has approved this change.
- [x] SME has approved this change.

