### PR TITLE
OBSDOCS-1164-Logging 5.8.9 Release Notes

### DIFF
--- a/modules/logging-release-notes-5-8-9.adoc
+++ b/modules/logging-release-notes-5-8-9.adoc
@@ -1,0 +1,30 @@
+// module included in /logging/logging-5-8-release-notes
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-5-8-9_{context}"]
+= Logging 5.8.9
+This release includes link:https://access.redhat.com/errata/RHBA-2024:4334[OpenShift Logging Bug Fix Release 5.8.9] and link:https://access.redhat.com/errata/RHBA-2024:4335[OpenShift Logging Bug Fix Release 5.8.9].
+
+[id="logging-release-notes-5-8-9-bug-fixes"]
+== Bug fixes
+
+* Before this update, an issue prevented selecting pods that no longer existed, even if they had generated logs. With this update, this issue has been fixed, allowing selection of such pods. (link:https://issues.redhat.com/browse/LOG-5698[LOG-5698])
+
+* Before this update, LokiStack was missing a route for the Volume API, which caused the following error: `404 not found`. With this update, LokiStack exposes the Volume API, resolving the issue. (link:https://issues.redhat.com/browse/LOG-5750[LOG-5750])
+
+* Before this update, the Elasticsearch operator overwrote all service account annotations without considering ownership. As a result, the `kube-controller-manager` recreated service account secrets because it logged the link to the owning service account. With this update, the Elasticsearch operator merges annotations, resolving the issue. (link:https://issues.redhat.com/browse/LOG-5776[LOG-5776])
+
+[id="logging-release-notes-5-8-9-CVEs"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2023-6597[CVE-2023-6597]
+* link:https://access.redhat.com/security/cve/CVE-2024-0450[CVE-2024-0450]
+* link:https://access.redhat.com/security/cve/CVE-2024-3651[CVE-2024-3651]
+* link:https://access.redhat.com/security/cve/CVE-2024-6387[CVE-2024-6387]
+* link:https://access.redhat.com/security/cve/CVE-2024-24790[CVE-2024-24790]
+* link:https://access.redhat.com/security/cve/CVE-2024-26735[CVE-2024-26735]
+* link:https://access.redhat.com/security/cve/CVE-2024-26993[CVE-2024-26993]
+* link:https://access.redhat.com/security/cve/CVE-2024-32002[CVE-2024-32002]
+* link:https://access.redhat.com/security/cve/CVE-2024-32004[CVE-2024-32004]
+* link:https://access.redhat.com/security/cve/CVE-2024-32020[CVE-2024-32020]
+* link:https://access.redhat.com/security/cve/CVE-2024-32021[CVE-2024-32021]
+* link:https://access.redhat.com/security/cve/CVE-2024-32465[CVE-2024-32465]

--- a/observability/logging/logging_release_notes/logging-5-8-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-8-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-8-9.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-8-8.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-8-7.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Logging Z-Stream Release Notes - 5.8.9
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1164

Fix Version: 4.12, 4.13, 4.14, 4.15

Doc Preview: https://78514--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging_release_notes/logging-5-8-release-notes.html#logging-release-notes-5-8-9_logging-5-8-release-notes

SME Review: @periklis 
QE Review: @anpingli 
Peer Review: @abrennan89 @maxwelldb 