### PR TITLE
OSDOCS-11019: updates command parameters under installing in MicroShift

### DIFF
--- a/modules/microshift-creating-ostree-iso.adoc
+++ b/modules/microshift-creating-ostree-iso.adoc
@@ -19,10 +19,11 @@ Use the following procedure to create the ISO. The {op-system-ostree} Installer 
 
 . Start an `ostree` container image build by running the following command:
 +
-[source,terminal,subs="attributes+"]
+[source,terminal,subs="+quotes"]
 ----
-$ BUILDID=$(sudo composer-cli compose start-ostree --ref "rhel/{op-system-version-major}/$(uname -m)/edge" minimal-microshift edge-container | awk '{print $2}')
+$ BUILDID=$(sudo composer-cli compose start-ostree --ref "rhel/{op-system-version-major}/$(uname -m)/edge" __<microshift_blueprint>__ edge-container | awk '{print $2}') <1>
 ----
+<1> Replace _<microshift_blueprint>_ with the name of your blueprint.
 +
 This command also returns the identification (ID) of the build for monitoring.
 
@@ -37,16 +38,16 @@ $ sudo composer-cli compose status
 
 [source,terminal]
 ----
-ID                                     Status     Time                      Blueprint            Version   Type               Size
-cc3377ec-4643-4483-b0e7-6b0ad0ae6332   RUNNING    Wed Jun 7 12:26:23 2023   minimal-microshift   0.0.1     edge-container
+ID                                     Status     Time                     Blueprint                 Version   Type               Size
+cc3377ec-4643-4483-b0e7-6b0ad0ae6332   RUNNING    Wed Jun 7 12:26:23 2023  microshift_blueprint      0.0.1     edge-container
 ----
 +
 .Example output of a completed build
 
 [source,terminal]
 ----
-ID                                     Status     Time                      Blueprint            Version   Type               Size
-cc3377ec-4643-4483-b0e7-6b0ad0ae6332   FINISHED   Wed Jun 7 12:32:37 2023   minimal-microshift   0.0.1     edge-container
+ID                                     Status     Time                      Blueprint              Version   Type               Size
+cc3377ec-4643-4483-b0e7-6b0ad0ae6332   FINISHED   Wed Jun 7 12:32:37 2023   microshift_blueprint   0.0.1     edge-container
 ----
 +
 [NOTE]


### PR DESCRIPTION
Version(s):
4.14, 4.15, 4.16, 4.17

Issue:
[OSDOCS-11019](https://issues.redhat.com/browse/OSDOCS-11019)

Link to docs preview:
[Creating the RHEL for Edge image - edge image](https://78516--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree.html#microshift-creating-ostree-iso_microshift-embed-in-rpm-ostree)
[Creating the RHEL for Edge image - offline use](https://78516--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree-offline-use.html#microshift-creating-ostree-iso_microshift-embed-rpm-ostree-offline-use)

QE review:
- [x] QE has approved this change.
- [x] SME has approved this change.