### PR TITLE
[SRVKS-1163] Linking Kafka related info in one place

### DIFF
--- a/eventing/kube-rbac-proxy-eventing.adoc
+++ b/eventing/kube-rbac-proxy-eventing.adoc
@@ -9,3 +9,6 @@ toc::[]
 The `kube-rbac-proxy` component provides internal authentication and authorization capabilities for Knative Eventing.
 
 include::modules/serverless-configuring-kube-rbac-proxy-resources-for-eventing.adoc[leveloffset=+1]
+
+[id="kube-rbac-proxy-eventing-kafka"]
+include::modules/serverless-configuring-kube-rbac-proxy-resources-for-kafka.adoc[leveloffset=+1]

--- a/install/serverless-kafka-admin.adoc
+++ b/install/serverless-kafka-admin.adoc
@@ -19,3 +19,13 @@ The `KnativeKafka` CR provides users with additional options, such as:
 * Kafka channel
 * Kafka broker
 * Kafka sink
+
+include::modules/serverless-install-kafka-odc.adoc[leveloffset=+1]
+
+[id="additional-resources_serverless-kafka-admin"]
+[role="_additional-resources"]
+== Additional resources for Apache Kafka in Knative Eventing:
+* xref:../eventing/event-sources/serverless-kafka-developer-source.adoc#serverless-kafka-developer-source[Source for apache Kafka]
+* xref:../eventing/event-sinks/serverless-kafka-developer-sink.adoc#serverless-kafka-developer-sink[Sink for Apache Kafka]
+* xref:../eventing/brokers/kafka-broker.adoc#kafka-broker[Knative broker implementation for Apache Kafka]
+* xref:../eventing/kube-rbac-proxy-eventing.adoc#kube-rbac-proxy-eventing-kafka[Configuring kube-rbac-proxy for Knative for Apache Kafka]

--- a/modules/serverless-configuring-kube-rbac-proxy-resources-for-kafka.adoc
+++ b/modules/serverless-configuring-kube-rbac-proxy-resources-for-kafka.adoc
@@ -25,7 +25,7 @@ metadata:
   namespace: knative-kafka
 spec:
   config:
-    workload:
+    deployment:
       "kube-rbac-proxy-cpu-request": "10m" <1>
       "kube-rbac-proxy-memory-request": "20Mi" <2>
       "kube-rbac-proxy-cpu-limit": "100m" <3>


### PR DESCRIPTION
Version(s):
serverless-docs-1.33+

Issue:
https://issues.redhat.com/browse/SRVKE-1163

Link to docs preview:
- https://78537--ocpdocs-pr.netlify.app/openshift-serverless/latest/eventing/kube-rbac-proxy-eventing.html
- https://78537--ocpdocs-pr.netlify.app/openshift-serverless/latest/install/serverless-kafka-admin.html

QE review:
- [x] QE has approved this change.
