### PR TITLE
OBSDOCS-1173: Remove 'Next Steps' sections from the Monitoring docs

### DIFF
--- a/observability/monitoring/application-monitoring.adoc
+++ b/observability/monitoring/application-monitoring.adoc
@@ -14,7 +14,3 @@ include::snippets/technology-preview.adoc[leveloffset=+0]
 include::modules/monitoring-configuring-cluster-for-application-monitoring.adoc[leveloffset=+1]
 include::modules/monitoring-configuring-monitoring-for-an-application.adoc[leveloffset=+1]
 include::modules/monitoring-exposing-custom-application-metrics-for-horizontal-pod-autoscaling.adoc[leveloffset=+1]
-
-== Next steps
-
-* To automatically adjust the number of pods in which the application runs, xref:../../observability/monitoring/application-monitoring.adoc#application-monitoring[configure Horizontal Pod Autoscaling for the application.]

--- a/observability/monitoring/configuring-the-monitoring-stack.adoc
+++ b/observability/monitoring/configuring-the-monitoring-stack.adoc
@@ -22,7 +22,7 @@ and demonstrates several common configuration scenarios.
 [IMPORTANT]
 ====
 Not all configuration parameters for the monitoring stack are exposed.
-Only the parameters and fields listed in the xref:../monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc#cluster-monitoring-operator-configuration-reference[Config map reference for the {cmo-full}] are supported for configuration.
+Only the parameters and fields listed in the xref:../../observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc#cluster-monitoring-operator-configuration-reference[Config map reference for the {cmo-full}] are supported for configuration.
 ====
 
 ifndef::openshift-dedicated,openshift-rosa[]
@@ -35,14 +35,14 @@ endif::openshift-dedicated,openshift-rosa[]
 // include::modules/monitoring-maintenance-and-support.adoc[leveloffset=+1]
 
 // .Additional resources
-// xref:../monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc#cluster-monitoring-operator-configuration-reference[Config map reference for the {cmo-full}]
+// xref:../../observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc#cluster-monitoring-operator-configuration-reference[Config map reference for the {cmo-full}]
 
 [id="maintenance-and-support_{context}"]
 == Maintenance and support for monitoring
 
-Not all configuration options for the monitoring stack are exposed. The only supported way of configuring {product-title} monitoring is by configuring the {cmo-first} using the options described in the xref:../monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc#cluster-monitoring-operator-configuration-reference[Config map reference for the {cmo-full}]. *Do not use other configurations, as they are unsupported.*
+Not all configuration options for the monitoring stack are exposed. The only supported way of configuring {product-title} monitoring is by configuring the {cmo-first} using the options described in the xref:../../observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc#cluster-monitoring-operator-configuration-reference[Config map reference for the {cmo-full}]. *Do not use other configurations, as they are unsupported.*
 
-Configuration paradigms might change across Prometheus releases, and such cases can only be handled gracefully if all configuration possibilities are controlled. If you use configurations other than those described in the xref:../monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc#cluster-monitoring-operator-configuration-reference[Config map reference for the {cmo-full}], your changes will disappear because the {cmo-short} automatically reconciles any differences and resets any unsupported changes back to the originally defined state by default and by design.
+Configuration paradigms might change across Prometheus releases, and such cases can only be handled gracefully if all configuration possibilities are controlled. If you use configurations other than those described in the xref:../../observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc#cluster-monitoring-operator-configuration-reference[Config map reference for the {cmo-full}], your changes will disappear because the {cmo-short} automatically reconciles any differences and resets any unsupported changes back to the originally defined state by default and by design.
 
 ifdef::openshift-dedicated,openshift-rosa[]
 [IMPORTANT]
@@ -318,11 +318,4 @@ include::modules/monitoring-disabling-the-local-alertmanager.adoc[leveloffset=+1
 .Additional resources
 * link:https://prometheus.io/docs/alerting/latest/alertmanager/[Prometheus Alertmanager documentation]
 * xref:../../observability/monitoring/managing-alerts.adoc#[Managing alerts]
-endif::openshift-dedicated,openshift-rosa[]
-
-ifndef::openshift-dedicated,openshift-rosa[]
-== Next steps
-
-* xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
-* Learn about xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[remote health reporting] and, if necessary, opt out of it.
 endif::openshift-dedicated,openshift-rosa[]

--- a/observability/monitoring/enabling-alert-routing-for-user-defined-projects.adoc
+++ b/observability/monitoring/enabling-alert-routing-for-user-defined-projects.adoc
@@ -46,7 +46,3 @@ ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user defined projects]
 endif::openshift-dedicated,openshift-rosa[]
 * xref:../../observability/monitoring/managing-alerts.adoc#creating-alert-routing-for-user-defined-projects_managing-alerts[Creating alert routing for user-defined projects]
-
-== Next steps
-
-* xref:../../observability/monitoring/managing-alerts.adoc#managing-alerts[Managing alerts]

--- a/observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc
+++ b/observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc
@@ -41,7 +41,3 @@ include::modules/monitoring-excluding-a-user-defined-project-from-monitoring.ado
 
 // Disabling monitoring for user-defined projects
 include::modules/monitoring-disabling-monitoring-for-user-defined-projects.adoc[leveloffset=+1]
-
-== Next steps
-
-* xref:../../observability/monitoring/managing-metrics.adoc#managing-metrics[Managing metrics]

--- a/observability/monitoring/managing-alerts.adoc
+++ b/observability/monitoring/managing-alerts.adoc
@@ -117,9 +117,4 @@ include::modules/monitoring-applying-a-custom-configuration-to-alertmanager-for-
 * See link:https://prometheus.io/docs/alerting/configuration/[Alertmanager configuration] for configuring alerting through different alert receivers.
 ifndef::openshift-rosa,openshift-dedicated[]
 * See xref:../../observability/monitoring/enabling-alert-routing-for-user-defined-projects.adoc#enabling-alert-routing-for-user-defined-projects[Enabling alert routing for user-defined projects] to learn how to enable a dedicated instance of Alertmanager for user-defined alert routing.
-
-
-== Next steps
-
-* xref:../../observability/monitoring/reviewing-monitoring-dashboards.adoc#reviewing-monitoring-dashboards[Reviewing monitoring dashboards]
 endif::[]

--- a/observability/monitoring/monitoring-overview.adoc
+++ b/observability/monitoring/monitoring-overview.adoc
@@ -50,14 +50,3 @@ ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#granting-users-permission-to-monitor-user-defined-projects_enabling-monitoring-for-user-defined-projects[Granting users permission to monitor user-defined projects]
 * xref:../../security/tls-security-profiles.adoc#tls-security-profiles[Configuring TLS security profiles]
 endif::openshift-dedicated,openshift-rosa[]
-
-[id="next-steps_monitoring-overview"]
-== Next steps
-
-ifndef::openshift-dedicated,openshift-rosa[]
-* xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#configuring-the-monitoring-stack[Configuring the monitoring stack]
-endif::openshift-dedicated,openshift-rosa[]
-
-ifdef::openshift-dedicated,openshift-rosa[]
-* xref:../../observability/monitoring/sd-accessing-monitoring-for-user-defined-projects.adoc#sd-accessing-monitoring-for-user-defined-projects[Accessing monitoring for user-defined projects]
-endif::openshift-dedicated,openshift-rosa[]

--- a/observability/monitoring/reviewing-monitoring-dashboards.adoc
+++ b/observability/monitoring/reviewing-monitoring-dashboards.adoc
@@ -55,8 +55,3 @@ ifndef::openshift-dedicated,openshift-rosa[]
 
 * xref:../../applications/odc-monitoring-project-and-application-metrics-using-developer-perspective.adoc#monitoring-project-and-application-metrics-using-developer-perspective[Monitoring project and application metrics using the Developer perspective]
 endif::openshift-dedicated,openshift-rosa[]
-
-[id="next-steps_reviewing-monitoring-dashboards"]
-== Next steps
-
-* xref:../../observability/monitoring/accessing-third-party-monitoring-apis.adoc#accessing-third-party-monitoring-apis[Accessing monitoring APIs by using the CLI]

--- a/observability/monitoring/sd-accessing-monitoring-for-user-defined-projects.adoc
+++ b/observability/monitoring/sd-accessing-monitoring-for-user-defined-projects.adoc
@@ -27,8 +27,3 @@ Custom Prometheus instances and the Prometheus Operator installed through Operat
 ====
 
 Optionally, you can disable monitoring for user-defined projects during or after a cluster installation.
-
-[id="accessing-user-defined-monitoring-next-steps"]
-== Next steps
-
-* xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#configuring-the-monitoring-stack_configuring-the-monitoring-stack[Configuring the monitoring stack]


### PR DESCRIPTION
Version(s): `enterprise-4.12` and later

Issue: [OBSDOCS-1173](https://issues.redhat.com/browse/OBSDOCS-1173)

Link to docs preview: https://78549--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/monitoring-overview

QE review:
- [x] QE has approved this change.

**Additional information:** because the docs moved under docs.redhat.com, this hard-coded navigation section is no longer necessary because docs.redhat.com has built-in **Previous** and **Next** navigation.