### PR TITLE
WMCO 10.16 add index back with message of no WMCO docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2638,12 +2638,12 @@ Topics:
 #- Name: Manage secure signatures with sigstore
 #  File: nodes-sigstore-using
 ---
-# Name: Windows Container Support for OpenShift
-# Dir: windows_containers
-# Distros: openshift-origin,openshift-enterprise
-# Topics:
-#- Name: Red Hat OpenShift support for Windows Containers overview
-#  File: index
+Name: Windows Container Support for OpenShift
+Dir: windows_containers
+Distros: openshift-origin,openshift-enterprise
+Topics:
+- Name: Red Hat OpenShift support for Windows Containers overview
+  File: index
 #- Name: Red Hat OpenShift support for Windows Containers release notes
 #  File: windows-containers-release-notes-10-15-x
 #- Name: Understanding Windows container workloads
@@ -2673,7 +2673,7 @@ Topics:
 #  File: removing-windows-nodes
 #- Name: Disabling Windows container workloads
 #  File: disabling-windows-container-workloads
-# ---
+---
 Name: OpenShift sandboxed containers
 Dir: sandboxed_containers
 Distros: openshift-enterprise

--- a/windows_containers/index.adoc
+++ b/windows_containers/index.adoc
@@ -6,6 +6,11 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+Documentation for {productwinc} will be available for {product-title} {product-version} in the near future.
+
+////
+Hiding until WMCO 10.16.0 GAs
+
 You can add Windows nodes either by creating a xref:../windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc#creating-windows-machineset-aws[compute machine set] or by specifying existing Bring-Your-Own-Host (BYOH) Window instances through a xref:../windows_containers/byoh-windows-instance.adoc#byoh-windows-instance[configuration map].
 
 [NOTE]
@@ -31,3 +36,4 @@ You can xref:../windows_containers/disabling-windows-container-workloads.adoc#di
 
 * Uninstalling the Windows Machine Config Operator
 * Deleting the Windows Machine Config Operator namespace
+////


### PR DESCRIPTION
We have hidden the WMCO docs for 4.16 until the WMCO 10.16.0  GAs (currently, planned for 7/22). This PR replaces the WMCO index.doc file with a previously-used statement that the docs are not available at this time. 

A [bug was filed](https://issues.redhat.com/browse/OSDOCS-11153) related to the issue and a [Slack thread initiated](https://redhat-internal.slack.com/archives/CM4ERHBJS/p1719847942773449).

Preview: https://78587--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/index.html

No QE