### PR TITLE
OCPBUGS-34715 - troubleshooting DNS in disconnected environment

### DIFF
--- a/modules/k8s-nmstate-troubleshooting-dns-disconnected-env-dnsmasq.adoc
+++ b/modules/k8s-nmstate-troubleshooting-dns-disconnected-env-dnsmasq.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// * networking/k8s_nmstate/k8s-nmstate-troubleshooting-node-network.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="troubleshooting-dns-disconnected-env-dnsmasq_{context}"]
+= Configuring the dnsmasq DNS server
+
+If you are using `dnsmasq` as the DNS server, you can delegate resolution of the `root-servers.net` domain to another DNS server, for example, by creating a new configuration file that resolves `root-servers.net` using a DNS server that you specify.
+
+. Create a configuration file that delegates the domain `root-servers.net` to another DNS server by running the following command:
++
+[source,terminal]
+----
+$ echo 'server=/root-servers.net/<DNS_server_IP>'> /etc/dnsmasq.d/delegate-root-servers.net.conf
+----
+
+. Restart the `dnsmasq` service by running the following command:
++
+[source,terminal]
+----
+$ systemctl restart dnsmasq
+----
+
+. Confirm that the `root-servers.net` domain is delegated to another DNS server by running the following command:
++
+[source,terminal]
+----
+$ journalctl -u dnsmasq|grep root-servers.net
+----
++
+.Example output
++
+[source,terminal]
+----
+Jul 03 15:31:25 rhel-8-10 dnsmasq[1342]: using nameserver 192.168.1.1#53 for domain root-servers.net
+----
+
+. Verify that the DNS server can resolve the NS record for the `root-servers.net` domain by running the following command:
++
+[source,terminal]
+----
+$ host -t NS root-servers.net. 127.0.0.1
+----
++
+.Example output
++
+[source,terminal]
+----
+Using domain server:
+Name: 127.0.0.1
+Address: 127.0.0.1#53
+Aliases:
+root-servers.net name server root-servers.net.
+----

--- a/modules/k8s-nmstate-troubleshooting-dns-disconnected-env.adoc
+++ b/modules/k8s-nmstate-troubleshooting-dns-disconnected-env.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// * networking/k8s_nmstate/k8s-nmstate-troubleshooting-node-network.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="troubleshooting-dns-disconnected-env_{context}"]
+= Troubleshooting DNS connectivity issues in a disconnected environment
+
+If you experience DNS connectivity issues when configuring `nmstate` in a disconnected environment, you can configure the DNS server to resolve the list of name servers for the domain `root-servers.net`.
+
+== Configuring the bind9 DNS named server  
+
+For a cluster configured to query a `bind9` DNS server, you can add the `root-servers.net` zone to a configuration file that contains at least one NS record.
+For example you can use the `/var/named/named.localhost` as a zone file that already matches this criteria.
+
+.Procedure
+
+. Add the `root-servers.net` zone at the end of the `/etc/named.conf` configuration file by running the following command:
++
+[source,terminal]
+----
+$ cat >> /etc/named.conf <<EOF
+zone "root-servers.net" IN {
+    	type master;
+    	file "named.localhost";
+};
+EOF
+----
+
+. Restart the `named` service by running the following command:
++
+[source,terminal]
+----
+$ systemctl restart named
+----
+
+. Confirm that the `root-servers.net` zone is present by running the following command:
++
+[source,terminal]
+----
+$ journalctl -u named|grep root-servers.net
+----
++
+.Example output
+[source,terminal]
+----
+Jul 03 15:16:26 rhel-8-10 bash[xxxx]: zone root-servers.net/IN: loaded serial 0
+Jul 03 15:16:26 rhel-8-10 named[xxxx]: zone root-servers.net/IN: loaded serial 0
+----
+
+. Verify that the DNS server can resolve the NS record for the `root-servers.net` domain by running the following command:
++
+[source,terminal]
+----
+$ host -t NS root-servers.net. 127.0.0.1
+----
++
+.Example output
++
+[source,terminal]
+----
+Using domain server:
+Name: 127.0.0.1
+Address: 127.0.0.53
+Aliases:
+root-servers.net name server root-servers.net.
+----

--- a/networking/k8s_nmstate/k8s-nmstate-troubleshooting-node-network.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-troubleshooting-node-network.adoc
@@ -15,3 +15,7 @@ This includes issues such as:
 * The host loses connection to the API server.
 
 include::modules/virt-troubleshooting-incorrect-policy-config.adoc[leveloffset=+1]
+
+include::modules/k8s-nmstate-troubleshooting-dns-disconnected-env.adoc[leveloffset=+1]
+
+include::modules/k8s-nmstate-troubleshooting-dns-disconnected-env-dnsmasq.adoc[leveloffset=+2]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> ---> 
OCPBUGS-34715 - troubleshooting DNS in disconnected environment

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 

- 4.17
- 4.16
- 4.15
- 4.14
- 4.13
- 4.12

<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-34715
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Troubleshooting DNS connectivity issues in a disconnected environment](https://78594--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-troubleshooting-node-network.html#troubleshooting-dns-disconnected-env_k8s-nmstate-troubleshooting-node-network)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
