### PR TITLE
[OCPBUGS-36700] Document state of support for Windows CSI drivers

### DIFF
--- a/modules/wmco-supported-csi-drivers.adoc
+++ b/modules/wmco-supported-csi-drivers.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * windows_containers/scheduling-windows-workloads.adoc
+
+[id="wmco-supported-csi-drivers_{context}"]
+= Support for Windows CSI drivers
+
+{productwinc} installs link:https://github.com/kubernetes-csi/csi-proxy[CSI Proxy] on all Windows nodes in the cluster. CSI Proxy is a plug-in that enables CSI drivers to perform storage operations on the node. 
+
+To use persistent storage with Windows workloads, you must deploy a specific Windows CSI driver daemon set, as described in your storage provider's documentation. By default, the WMCO does not automatically create the Windows CSI driver daemon set. See the list of supported link:https://kubernetes-csi.github.io/docs/drivers.html#production-drivers[production drivers] in the Kubernetes Container Storage Interface (CSI) Documentation.

--- a/windows_containers/scheduling-windows-workloads.adoc
+++ b/windows_containers/scheduling-windows-workloads.adoc
@@ -31,4 +31,6 @@ include::modules/creating-runtimeclass.adoc[leveloffset=+1]
 
 include::modules/sample-windows-workload-deployment.adoc[leveloffset=+1]
 
+include::modules/wmco-supported-csi-drivers.adoc[leveloffset=+1]
+
 include::modules/machineset-manually-scaling.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-36700

Our support statement for storage needs to be added to the OCP docs for 4.14 and later releases.
https://github.com/openshift/windows-machine-config-operator/?tab=readme-ov-file#storage

Preview
WMCO -> Scheduling Windows container workloads -> [Support for support for Windows CSI drivers](https://78605--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/scheduling-windows-workloads.html#wmco-supported-csi-drivers_scheduling-windows-workloads)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
