### PR TITLE
OSDOCS-11255 OCP 4.16.2 Release Notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -2059,9 +2059,9 @@ With this release, the installation program is updated to no longer populate val
 [id="ocp-4-16-edge-computing-bug-fixes_{context}"]
 ==== Edge computing
 
-* Previously, an issue with image based upgrades on clusters that use proxy configurations caused operator rollouts that lengthened startup times. 
-With this release, the issue has been fixed and upgrade times are reduced. 
-(link:https://issues.redhat.com/browse/OCPBUGS-33471[*OCPBUGS-33471*]) 
+* Previously, an issue with image based upgrades on clusters that use proxy configurations caused operator rollouts that lengthened startup times.
+With this release, the issue has been fixed and upgrade times are reduced.
+(link:https://issues.redhat.com/browse/OCPBUGS-33471[*OCPBUGS-33471*])
 
 [discrete]
 [id="ocp-4-16-cloud-etcd-operator-bug-fixes_{context}"]
@@ -3311,13 +3311,12 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
-//Update with relevant advisory information
-[id="ocp-4-16-0-ga_{context}"]
-=== RHSA-2024:0041 - {product-title} {product-version}.0 image release, bug fix, and security update advisory
+[id="ocp-4-16-2_{context}"]
+=== RHSA-2024:4316 - {product-title} {product-version}.2 bug fix and security update
 
-Issued: 2024-06-27
+Issued: 2024-07-09
 
-{product-title} release {product-version}.0, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:0041[RHSA-2024:0041] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0045[RHSA-2024:0045] advisory.
+{product-title} release {product-version}.2, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:4316[RHSA-2024:4316] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:4319[RHBA-2024:4319] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory.
 
@@ -3325,9 +3324,63 @@ You can view the container images in this release by running the following comma
 
 [source,terminal]
 ----
-$ oc adm release info 4.16.0 --pullspecs
+$ oc adm release info 4.16.2 --pullspecs
 ----
-//replace 4.y.z for the correct values for the release. You do not need to update oc to run this command.
+
+[id="ocp-4-16-2-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, for clusters upgraded from older versions of {product-title}, enabling `kdump` on an OVN-enabled cluster sometimes prevented the node from rejoining the cluster or returning to the `Ready` state.
+With this release, stale data is removed from older {product-title} versions and ensures this stale data is always cleaned up. The node can now start correctly and rejoin the cluster. (link:https://issues.redhat.com/browse/OCPBUGS-36198[*OCPBUGS-36198*])
+
+* Previously, unexpected output would appear in the terminal when creating an installer-provisioned infrastructure (IPI) cluster. With this release, the issue has been resolved and the unexpected output no longer appears. (link:https://issues.redhat.com/browse/OCPBUGS-36156[*OCPBUGS-36156*])
+
+* Previously, the {product-title} console did not show filesystem metrics on the nodes list. With this release, the filesystem metrics now appear in the nodes table. (link:https://issues.redhat.com/browse/OCPBUGS-35946[*OCPBUGS-35946*])
+
+* Previously, the Prometheus dashboard showed up empty for non-multi-cluster environments. With this release, the dashboard populates the dashboard panels as expected for both cases. (link:https://issues.redhat.com/browse/OCPBUGS-35904[*OCPBUGS-35904*])
+
+* Previously, a regression in 4.16.0 caused new baremetal installer-provisioned infrastructure (IPI) installations to fail when proxies were used. This was caused by one of the services in the bootstrap virtual machine (VM) trying to access IP address 0.0.0.0 through the proxy. With this release, this service no longer accesses 0.0.0.0. (link:https://issues.redhat.com/browse/OCPBUGS-35818[*OCPBUGS-35818*])
+
+* Previously, the {cap-ibm-first} waited for some resources to be created before creating the load balancers on {ibm-power-server-title} clusters. This delay sometimes resulted in the load balancers not being created before the 15 minute timeout. With this release, the timeout has been increased. (link:https://issues.redhat.com/browse/OCPBUGS-35722[*OCPBUGS-35722*])
+
+* Previously, when installing a cluster on {rh-openstack-first} using the Cluster API implementation, the additional security group rule added to control plane nodes for compact clusters was forcing IPv4 protocol and prevented deploying dual-stack clusters. This was a regression from installations using Terraform. With this release, the rule now uses the correct protocol based on the requested IP version. (link:https://issues.redhat.com/browse/OCPBUGS-35718[*OCPBUGS-35718*])
+
+* Previously, the internal image registry would not correctly authenticate users on clusters configured with external OpenID Connect (OIDC) users, making it impossible for users to push or pull images to and from the internal image registry. With this release, the internal image registry starts using the SelfSubjectReview API, dropping use of the {product-title} specific user API, which is not available on clusters configured with external OIDC users, making it possible to successfully authenticate with the image registry again. (link:https://issues.redhat.com/browse/OCPBUGS-35567[*OCPBUGS-35567*])
+
+* Prevously, an errant code change resulted in a duplicated `oauth.config.openshift.io` item on the *Global Configuration* page. With this update, the duplicated item is removed. (link:https://issues.redhat.com/browse/OCPBUGS-35565[*OCPBUGS-35565*])
+
+* Previously, with `oc-mirror` v2, when mirroring fails due to various reasons, such as network errors or invalid operator catalog content, `oc-mirror` did not generate cluster resources. With this bug fix, `oc-mirror` v2 performs the following actions:
+ ** Pursues mirroring other images when errors occur on Operator images and additional images, and aborts mirroring when errors occur on release images.
+ ** Generates cluster resources for the cluster based on subset of correctly mirrored images.
+ ** Collects all mirroring errors in a log file.
+ ** Logs all mirroring errors in a separate log file.
+(link:https://issues.redhat.com/browse/OCPBUGS-35409[*OCPBUGS-35409*])
+
+* Previously, pseudolocalization was not working in the {product-title} console due to a configuration issue. With this release, the issue is resolved and pseudolocalization works again. (link:https://issues.redhat.com/browse/OCPBUGS-35408[*OCPBUGS-35408*])
+
+* Previously, the `must-gather` process ran too long while collecting CPU-related performance data for nodes due to collecting the data sequentially for each node. With this release, the node data is collected in parallel, which significantly shortens the `must-gather` data collection time. (link:https://issues.redhat.com/browse/OCPBUGS-35357[*OCPBUGS-35357*])
+
+* Previously, builds could not set the `GIT_LFS_SKIP_SMUDGE` environment variable and use its value when cloning source code. This caused builds to fail for some git repositories with LFS files. With this release, the build is allowed to set this environment variable and use it during the git clone step of the build. (link:https://issues.redhat.com/browse/OCPBUGS-35283[*OCPBUGS-35283*])
+
+* Previously, registry overrides were present in non-relevant data plane images. With this release, the way {product-title} propagates the override-registries has been modified and the issue is fixed. (link:https://issues.redhat.com/browse/OCPBUGS-34602[*OCPBUGS-34602*])
+
+* Previously, RegistryMirrorProvider images were not being updated during the reconciliation because RegistryMirrorProvider was modifying the cached image directly instead of the internal entries. With this release, the way we update the images has been modified, avoiding the cache and doing it directly in the entries so the bug no longer presents. (link:https://issues.redhat.com/browse/OCPBUGS-34569[*OCPBUGS-34569*])
+
+* Previously, the `alertmanager-trusted-ca-bundle` `ConfigMap` was not injected into the user-defined Alertmanager container, which prevented the verification of HTTPS web servers receiving alert notifications. With this update, the trusted CA bundle `ConfigMap` is mounted into the Alertmanager container at the `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` path. (link:https://issues.redhat.com/browse/OCPBUGS-34530[*OCPBUGS-34530*])
+
+* Previously, for {aws-first} clusters that use {sts-first}, the Cloud Credential Operator (CCO) checked the value of `awsSTSIAMRoleARN` in  the `CredentialsRequest` custom resource to create a secret. When `awsSTSIAMRoleARN` was not present, CCO logged an error. The issue is resolved in this release. (link:https://issues.redhat.com/browse/OCPBUGS-34117[*OCPBUGS-34117*])
+
+* Previously, with the OVN-Kubernetes setting for routing-via-host set to shared gateway mode, its default value, OVN-Kubernetes did not correctly handle traffic streams that mixed non-fragmented and fragmented packets from the IP layer on cluster ingress. This caused connection resets or packet drops. With this release, OVN-Kubernetes correctly reassembles and handles external traffic IP packet fragments on ingress. (link:https://issues.redhat.com/browse/OCPBUGS-29511[*OCPBUGS-29511*])
+
+[id="ocp-4-16-2-known-issue_{context}"]
+==== Known issue
+
+* If the `ConfigMap` maximum transmission unit (MTU) is absent in the namespace `openshift-network-operator`, users have to create the `ConfigMap` manually with the machine MTU value, before starting the live migration. Otherwise, the live migration will get stuck and fail. (link:https://issues.redhat.com/browse/OCPBUGS-35829[*OCPBUGS-35829*])
+
+[id="ocp-4-16-2-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-16-1_{context}"]
 === RHSA-2024:4156 - {product-title} {product-version}.1 bug fix and security update
@@ -3374,3 +3427,21 @@ $ oc adm release info 4.16.1 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+//Update with relevant advisory information
+[id="ocp-4-16-0-ga_{context}"]
+=== RHSA-2024:0041 - {product-title} {product-version}.0 image release, bug fix, and security update advisory
+
+Issued: 2024-06-27
+
+{product-title} release {product-version}.0, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:0041[RHSA-2024:0041] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0045[RHSA-2024:0045] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.0 --pullspecs
+----
+//replace 4.y.z for the correct values for the release. You do not need to update oc to run this command.


### PR DESCRIPTION
Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-11255](https://issues.redhat.com/browse/OSDOCS-11255)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs[ preview](https://78608--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-2_release-notes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
Not needed
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Advisory links will not work until the release is shipped. 

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
