### PR TITLE
[RHACS] Update Debian support

### DIFF
--- a/modules/scanning-images.adoc
+++ b/modules/scanning-images.adoc
@@ -148,7 +148,7 @@ Scanner identifies vulnerabilities in images that contain the following Linux di
 | `ubuntu:14.04`, `ubuntu:16.04`, `ubuntu:18.04`, `ubuntu:20.04`,`ubuntu:22.04`, `ubuntu:23.10`, `ubuntu:24.04`
 
 The following vulnerability sources are not updated by the vendor:
-`ubuntu:12.04`, `ubuntu:12.10`, `ubuntu:13.04`, `ubuntu:14.10`, `ubuntu:15.04`, `ubuntu::15.10`, `ubuntu::16.10`, `ubuntu:17.04`, `ubuntu:17.10`, `ubuntu:18.10`, `ubuntu:19.04`, `ubuntu:19.10`, `ubuntu:20.10`, `ubuntu:21.04`, `ubuntu:21.10`, `ubuntu:22.10`, `ubuntu:23.04`
+`ubuntu:12.04`, `ubuntu:12.10`, `ubuntu:13.04`, `ubuntu:14.10`, `ubuntu:15.04`, `ubuntu::15.10`, `ubuntu::16.10`, `ubuntu:17.04`, `ubuntu:17.10`, `ubuntu:18.10`, `ubuntu:19.04`, `ubuntu:19.10`, `ubuntu:20.10`, `ubuntu:21.04`, `ubuntu:21.10`, `ubuntu:22.10`, `ubuntu:23.04`, `debian:8`^[1]^, `debian:9`^[1]^, `debian:10`^[1]^
 |===
 . Only supported in the StackRox Scanner.
 . Only supported in Scanner V4.


### PR DESCRIPTION
Update Debian OSes

Cherrypick into `rhacs-docs-4.5`

Preview: https://78610--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/examine-images-for-vulnerabilities.html#supported-operating-systems_examine-images-for-vulnerabilities