### PR TITLE
TRACING-4224: add documentation for routing connector

### DIFF
--- a/observability/otel/otel-collector/otel-collector-connectors.adoc
+++ b/observability/otel/otel-collector/otel-collector-connectors.adoc
@@ -8,6 +8,45 @@ toc::[]
 
 A connector connects two pipelines. It consumes data as an exporter at the end of one pipeline and emits data as a receiver at the start of another pipeline. It can consume and emit data of the same or different data type. It can generate and emit data to summarize the consumed data, or it can merely replicate or route data.
 
+[id="routing-connector_{context}"]
+== Routing Connector
+
+:FeatureName: The Routing Connector
+include::snippets/technology-preview.adoc[]
+
+.OpenTelemetry Collector custom resource with an enabled Routing Connector
+[source,yaml]
+----
+  config: |
+    connectors:
+      routing:
+        table: <1>
+          - statement: route() where attributes["X-Tenant"] == "dev" <2>
+            pipelines: [traces/dev] <3>
+          - statement: route() where attributes["X-Tenant"] == "prod"
+            pipelines: [traces/prod]
+        default_pipelines: [traces/dev] <4>
+        error_mode: ignore <5>
+        match_once: false <6>
+    service:
+      pipelines:
+        traces/in:
+          receivers: [otlp]
+          exporters: [routing]
+        traces/dev:
+          receivers: [routing]
+          exporters: [otlp/dev]
+        traces/prod:
+          receivers: [routing]
+          exporters: [otlp/prod]
+----
+<1> Connector routing table.
+<2> Routing condition writen as OTTL statement.
+<3> Pipelines where the matching telemetry data will be exported.
+<4> Pipeline where the telemetry data will be sent when none of the conditions is satisfied.
+<5> Determines how the error should be managed. `propagate` (default) will log an error and drop the payload. `ignore` will ignore the condition and try to match with the next one.  `silent` will do the same as `ignore` but without logging the error.
+<6>  When enabled (default is `false`), the payload will be routed only to the first pipeline whose routing condition is met.
+
 [id="forward-connector_{context}"]
 == Forward Connector
 


### PR DESCRIPTION
Version(s):  4.17, 4.16, 4.15, 4.14, 4.13, 4.12

Issue: [TRACING-4224](https://issues.redhat.com//browse/TRACING-4224)

Link to docs preview: https://78614--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-collector/otel-collector-connectors.html

QE review:
- [x] QE has approved this change.
