### PR TITLE
OCPBUGS-36737: RHACM 2.11 delayed until July 18th so reverted to 2.10 in docs

### DIFF
--- a/modules/ztp-telco-ran-software-versions.adoc
+++ b/modules/ztp-telco-ran-software-versions.adoc
@@ -53,7 +53,7 @@ The Red Hat telco RAN DU {product-version} solution has been validated using the
 |4.16
 
 |{rh-rhacm-first}
-|2.11
+|2.10
 
 |{gitops-title}
 |1.12


### PR DESCRIPTION
OCPBUGS-36737: RHACM 2.11 delayed until July 18th so reverted to 2.10 in docs until then

Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OCPBUGS-36737

Link to docs preview:
https://78615--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-preparing-the-hub-cluster.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

RHACM 2.11 release delayed so need to revert to 2.10 until then.
FYI - https://redhat-internal.slack.com/archives/C012L9Y9C79/p1720117963230629