### PR TITLE
OSDOCS-11138: update RHDE page for Microshift 4.17

### DIFF
--- a/modules/about-rhde.adoc
+++ b/modules/about-rhde.adoc
@@ -44,9 +44,14 @@ The latest release notes for each product that is part of {product-title} are av
 ^|*Supported {microshift} Version&#8594;{microshift} Version Updates*
 
 ^|9.4
+^|4.17
+^|Generally Available
+^|4.17.0&#8594;4.17.z and 4.16&#8594;4.17
+
+^|9.4
 ^|4.16
 ^|Generally Available
-^|4.16.0&#8594;4.16.z, 4.14&#8594;4.16 and 4.15&#8594;4.16
+^|4.16.0&#8594;4.16.z, 4.14&#8594;4.16, 4.15&#8594;4.16 and 4.16&#8594;4.17
 
 ^|9.2, 9.3
 ^|4.15


### PR DESCRIPTION
Version(s):
N/A (no CPs, version "4" is for Pantheon only; versionless branch in the repo)
Can be merged, but Pantheon sync is EMBARGOED for after OCP 4.17 GA when the rest of the docs are published.

Issue:
[OSDOCS-11138](https://issues.redhat.com/browse/OSDOCS-11138)

Link to docs preview:
[Red Hat Device Edge product release compatibility matrix](https://78616--ocpdocs-pr.netlify.app/openshift-rhde/latest/overview/rhde-overview.html)

Review:
- [x] QE has approved this change.
- [x] SME has approved this change.

See also https://github.com/openshift/openshift-docs/pull/78509 for an approved version of this table.
