### PR TITLE
OSDOCS-10918: adds 4.16.2 release note MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -191,7 +191,7 @@ Issued: 2024-06-27
 
 {product-title} release 4.16.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:0043[RHSA-2024:0043] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0041[RHSA-2024:0041] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
 [id="microshift-4-16-1-dp_{context}"]
 === RHBA-2024:4158 - {microshift-short} 4.16.1 bug fix and enhancement advisory
@@ -200,4 +200,13 @@ Issued: 2024-07-03
 
 {product-title} release 4.16.1 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4158[RHBA-2024:4158] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4156[RHSA-2024:4156] advisory.
 
-For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deploy_microshift-embed-in-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-16-2-dp_{context}"]
+=== RHBA-2024:4318 - {microshift-short} 4.16.2 bug fix and enhancement advisory
+
+Issued: 2024-07-09
+
+{product-title} release 4.16.2 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4318[RHBA-2024:4318] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4316[RHSA-2024:4316] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-10918](https://issues.redhat.com/browse/OSDOCS-10918)

Link to docs preview:
[4.16.2 async release note](https://78617--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-2-dp_release-notes)

QE review:
- N/A stock text

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
