### PR TITLE
OADP-4452 updated kubernetes images to kubernetes resources

### DIFF
--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr.adoc
@@ -11,7 +11,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-You back up Kubernetes images, internal images, and persistent volumes (PVs) by creating a `Backup` custom resource (CR).
+You back up Kubernetes resources, internal images, and persistent volumes (PVs) by creating a `Backup` custom resource (CR).
 
 .Prerequisites
 

--- a/modules/oadp-creating-backup-cr.adoc
+++ b/modules/oadp-creating-backup-cr.adoc
@@ -6,7 +6,7 @@
 [id="oadp-creating-backup-cr_{context}"]
 = Creating a Backup CR
 
-You back up Kubernetes images, internal images, and persistent volumes (PVs) by creating a `Backup` custom resource (CR).
+To back up Kubernetes resources, internal images, and persistent volumes (PVs), create a Backup custom resource (CR).
 
 .Prerequisites
 


### PR DESCRIPTION
## Jira 

* [OADP-4452](https://issues.redhat.com/browse/OADP-4452)

Updated 'kubernetes images' to 'kubernetes resources' 

##  Version

* OCP 4.12 → OCP 4.17

## Preview

* [Creating a Backup CR](https://78619--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr.html)

## QE Review

* [x] QE has approved this change.
