### PR TITLE
Update ocp-4-14-release-notes.adoc, since there is no plan to remove icsp in future release.

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -4299,7 +4299,7 @@ $ oc adm release info 4.14.3 --pullspecs
 +
 [IMPORTANT]
 ====
-Using an ICSP object to configure repository mirroring is a deprecated feature. Deprecated functionality is still included in {product-title} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.
+Using an ICSP object to configure repository mirroring is a deprecated feature. Deprecated functionality is still included in {product-title} and continues to be supported. However, it might be removed in a future release of this product. Because it is deprecated functionality, avoid using it for new deployments.
 ====
 
 * Previously, `LoadBalancer` services were not created for a deployment if a node contained an additional port with the `enable_port_security` parameter set to `false`. With this release, `LoadBalancer` services are created for a deployment that contains additional ports with this setting. (link:https://issues.redhat.com/browse/OCPBUGS-22974[*OCPBUGS-22974*])


### PR DESCRIPTION
SInce there is no plan to remove ICSP object hence we need to update the release notes accordingly.

From this:
Using an ICSP object to configure repository mirroring is a deprecated feature. Deprecated functionality is still included in OpenShift Container Platform and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.

To this:
Using an ICSP object to configure repository mirroring is a deprecated feature. Deprecated functionality is still included in OpenShift Container Platform and continues to be supported; however, It might be removed in a future release of this product. Because it is deprecated functionality, avoid using it for new deployments.

Version(s):
4.13, 4.14, 4.15

PR - https://github.com/openshift/openshift-docs/pull/78465 has been already merged for 4.15

Issue:
https://issues.redhat.com/browse/OCPBUGS-36519

Link to docs preview:
https://docs.redhat.com/en/documentation/openshift_container_platform/4.15/html/release_notes/ocp-4-15-release-notes#ocp-4-15-nodes-icsp-idms-compatibility