### PR TITLE
OCPBUGS-36595: Add missing link to Installing Butane

### DIFF
--- a/edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/cnf-image-based-upgrade-shared-container-partition.adoc
+++ b/edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/cnf-image-based-upgrade-shared-container-partition.adoc
@@ -12,3 +12,8 @@ You can do this at install time.
 include::modules/cnf-image-based-upgrade-shared-container-partition.adoc[leveloffset=+1]
 
 include::modules/ztp-image-based-upgrade-shared-container-partition.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../installing/install_config/installing-customizing.adoc#installation-special-config-butane-install_installing-customizing[Installing Butane]

--- a/modules/ztp-image-based-upgrade-shared-container-partition.adoc
+++ b/modules/ztp-image-based-upgrade-shared-container-partition.adoc
@@ -14,7 +14,7 @@ You must complete this procedure at installation time.
 
 .Prerequisites
 
-* Install Butane.
+* Install Butane. For more information, see "Installing Butane".
 
 .Procedure
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16, 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-36595
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://78655--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/cnf-image-based-upgrade-shared-container-partition.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
