### PR TITLE
OBSDOCS-1181: fix-incorrect-filename-in-CLI-command-for-COO-sample-sevice

### DIFF
--- a/modules/monitoring-specifying-how-a-service-is-monitored-by-cluster-observability-operator.adoc
+++ b/modules/monitoring-specifying-how-a-service-is-monitored-by-cluster-observability-operator.adoc
@@ -53,7 +53,7 @@ This configuration defines a `ServiceMonitor` object that the `MonitoringStack` 
 +
 [source,terminal]
 ----
-$ oc apply -f example-app-service-monitor.yaml
+$ oc apply -f example-coo-app-service-monitor.yaml
 ----
 
 . Verify that the `ServiceMonitor` resource is created by running the following command and observing the output:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1181
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://78659--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/configuring-the-cluster-observability-operator-to-monitor-a-service.html#specifying-how-a-service-is-monitored-by-cluster-observability-operator_configuring_the_cluster_observability_operator_to_monitor_a_service
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Fixes an incorrect filename in a CLI command for the sample service for Cluster Observability Operator
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
