### PR TITLE
CNV-44280: Swap documentation update

### DIFF
--- a/modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc
+++ b/modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc
@@ -185,7 +185,12 @@ spec:
           [Service]
           Type=oneshot
           Environment=SWAP_SIZE_MB=5000
-          ExecStart=/bin/sh -c "sudo dd if=/dev/zero of=/var/tmp/swapfile count=$SWAP_SIZE_MB bs=1MiB && sudo chmod 600 /var/tmp/swapfile && sudo mkswap /var/tmp/swapfile && sudo swapon /var/tmp/swapfile && free -h"
+          ExecStart=/bin/sh -c "sudo dd if=/dev/zero of=/var/tmp/swapfile count=${SWAP_SIZE_MB} bs=1M && \
+          sudo chmod 600 /var/tmp/swapfile && \
+          sudo mkswap /var/tmp/swapfile && \
+          sudo swapon /var/tmp/swapfile && \
+          free -h && \
+          sudo systemctl set-property --runtime system.slice MemorySwapMax=0 IODeviceLatencyTargetSec=\"/ 50ms\""
 
           [Install]
           RequiredBy=kubelet-dependencies.target


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/CNV-44280

CNV 4.16
OCP 4.16+

Preview: https://78660--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-configuring-higher-vm-workload-density.html#virt-using-wasp-agent-to-configure-higher-vm-workload-density_virt-configuring-higher-vm-workload-density