### PR TITLE
OSDOCS#35593: Update example resource for auto-updates

### DIFF
--- a/modules/virt-autoupdate-custom-bootsource.adoc
+++ b/modules/virt-autoupdate-custom-bootsource.adoc
@@ -37,6 +37,9 @@ spec:
       name: centos7-image-cron
       annotations:
         cdi.kubevirt.io/storage.bind.immediate.requested: "true" <1>
+      labels:
+        instancetype.kubevirt.io/default-preference: centos.7
+        instancetype.kubevirt.io/default-instancetype: u1.medium
     spec:
       schedule: "0 */12 * * *" <2>
       template:
@@ -47,14 +50,13 @@ spec:
           storage:
             resources:
               requests:
-                storage: 10Gi
+                storage: 30Gi
+      garbageCollect: Outdated
       managedDataSource: centos7 <4>
-      retentionPolicy: "None" <5>
 ----
 <1> This annotation is required for storage classes with `volumeBindingMode` set to `WaitForFirstConsumer`.
 <2> Schedule for the job specified in cron format.
 <3> Use to create a data volume from a registry source. Use the default `pod` `pullMethod` and not `node` `pullMethod`, which is based on the `node` docker cache. The `node` docker cache is useful when a registry image is available via `Container.Image`, but the CDI importer is not authorized to access it.
 <4> For the custom image to be detected as an available boot source, the name of the image's `managedDataSource` must match the name of the template's `DataSource`, which is found under `spec.dataVolumeTemplates.spec.sourceRef.name` in the VM template YAML file.
-<5> Use `All` to retain data volumes and data sources when the cron job is deleted. Use `None` to delete data volumes and data sources when the cron job is deleted.
 
 . Save the file.


### PR DESCRIPTION
Version(s):
4.15 and later

Issue:
https://issues.redhat.com/browse/CNV-35593

Link to docs preview:
https://78673--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-automatic-bootsource-updates.html

QE review:
- [x] QE has approved this change.