### PR TITLE
WIP: CMA 2.13.1-421 release notes

### DIFF
--- a/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.adoc
+++ b/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.adoc
@@ -10,6 +10,31 @@ The following release notes are for previous versions of the Custom Metrics Auto
 
 For the current version, see xref:../../../nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc#nodes-cma-autoscaling-custom-rn[Custom Metrics Autoscaler Operator release notes].
 
+[id="nodes-pods-autoscaling-custom-rn-2121-394_{context}"]
+== Custom Metrics Autoscaler Operator 2.12.1-394 release notes
+
+This release of the Custom Metrics Autoscaler Operator 2.12.1-394 provides a bug fix for running the Operator in an {product-title} cluster. The following advisory is available for the link:https://access.redhat.com/errata/RHSA-2024:2901[RHSA-2024:2901].
+
+[IMPORTANT]
+====
+Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of Kubernetes-based Event Driven Autoscaler (KEDA).
+====
+
+[id="nodes-pods-autoscaling-custom-rn-2121-394-bugs_{context}"]
+=== Bug fixes
+
+* Previously, the `protojson.Unmarshal` function entered into an infinite loop when unmarshaling certain forms of invalid JSON. This condition could occur when unmarshaling into a message that contains a `google.protobuf.Any` value or when the `UnmarshalOptions.DiscardUnknown` option is set. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30305[*OCPBUGS-30305*])
+
+* Previously, when parsing a multipart form, either explicitly with the `Request.ParseMultipartForm` method or implicitly with the `Request.FormValue`, `Request.PostFormValue`, or `Request.FormFile` method, the limits on the total size of the parsed form were not applied to the memory consumed. This could cause memory exhaustion. With this fix, the parsing process now correctly limits the maximum size of form lines while reading a single form line. (link:https://issues.redhat.com/browse/OCPBUGS-30360[*OCPBUGS-30360*])
+
+* Previously, when following an HTTP redirect to a domain that is not on a  matching subdomain or on an exact match of the initial domain, an HTTP client would not forward sensitive headers, such as `Authorization` or `Cookie`. For example, a redirect from `example.com` to `www.example.com` would forward the `Authorization` header, but a redirect to `www.example.org` would not forward the header. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30365[*OCPBUGS-30365*])
+
+* Previously, verifying a certificate chain that contains a certificate with an unknown public key algorithm caused the certificate verification process to panic. This condition affected all crypto and  Transport Layer Security (TLS) clients and servers that set the `Config.ClientAuth` parameter to the `VerifyClientCertIfGiven` or `RequireAndVerifyClientCert` value. The default behavior is for TLS servers to not verify client certificates. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30370[*OCPBUGS-30370*])
+
+* Previously, if errors returned from the `MarshalJSON` method contained user-controlled data, an attacker could have used the data to break the contextual auto-escaping behavior of the HTML template package. This condition would allow for subsequent actions to inject unexpected content into the templates. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30397[*OCPBUGS-30397*])
+
+* Previously, the `net/http` and `golang.org/x/net/http2` Go packages did not limit the number of `CONTINUATION` frames for an HTTP/2 request. This condition could result in excessive CPU consumption. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30894[*OCPBUGS-30894*])
+
 [id="nodes-pods-autoscaling-custom-rn-2121-384_{context}"]
 == Custom Metrics Autoscaler Operator 2.12.1-384 release notes
 

--- a/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
+++ b/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
@@ -26,44 +26,49 @@ The following table defines the Custom Metrics Autoscaler Operator versions for 
 |{product-title} version
 |General availability
 
-|2.12.1
+|2.13.1
+|4.16
+|General availability
+
+|2.13.1
 |4.15
 |General availability
 
-|2.12.1
+|2.13.1
 |4.14
 |General availability
 
-|2.12.1
+|2.13.1
 |4.13
 |General availability
 
-|2.12.1
+|2.13.1
 |4.12
 |General availability
 |===
 
-[id="nodes-pods-autoscaling-custom-rn-2121-394_{context}"]
-== Custom Metrics Autoscaler Operator 2.12.1-394 release notes
+[id="nodes-pods-autoscaling-custom-rn-2131_{context}"]
+== Custom Metrics Autoscaler Operator 2.13.1 release notes
 
-This release of the Custom Metrics Autoscaler Operator 2.12.1-394 provides a bug fix for running the Operator in an {product-title} cluster. The following advisory is available for the link:https://access.redhat.com/errata/RHSA-2024:2901[RHSA-2024:2901].
+This release of the Custom Metrics Autoscaler Operator 2.13.1-421 provides a new feature and a bug fix for running the Operator in an {product-title} cluster. The following advisory is available for the link:https://access.redhat.com/errata/RHBA-2024:4837[RHBA-2024:4837].
 
 [IMPORTANT]
 ====
-Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of KEDA.
+Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of Kubernetes-based Event Driven Autoscaler (KEDA).
 ====
 
-[id="nodes-pods-autoscaling-custom-rn-2121-394-bugs_{context}"]
+[id="nodes-pods-autoscaling-custom-rn-2131-new_{context}"]
+=== New features and enhancements
+
+[id="nodes-pods-autoscaling-custom-rn-2131-new-ca_{context}"]
+==== Support for custom certificates with the Custom Metrics Autoscaler Operator 
+
+The Custom Metrics Autoscaler Operator can now use custom service CA certificates to connect securely to TLS-enabled metrics sources, such as an external Kafka cluster or an external Prometheus service. By default, the Operator uses automatically-generated service certificates to connect to on-cluster services only. There is a new field in the `KedaController` object that allows you to load custom server CA certificates for connecting to external services by using config maps. 
+
+For more information, see xref:../../../nodes/cma/nodes-cma-autoscaling-custom.adoc#nodes-cma-autoscaling-custom-ca_nodes-cma-autoscaling-custom[Custom CA certificates for the Custom Metrics Autoscaler].
+
+[id="nodes-pods-autoscaling-custom-rn-2.13.1-bugs_{context}"]
 === Bug fixes
 
-* Previously, the `protojson.Unmarshal` function entered into an infinite loop when unmarshaling certain forms of invalid JSON. This condition could occur when unmarshaling into a message that contains a `google.protobuf.Any` value or when the `UnmarshalOptions.DiscardUnknown` option is set. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30305[*OCPBUGS-30305*])
+* Previously, the `custom-metrics-autoscaler` and `custom-metrics-autoscaler-adapter` images were missing time zone information. As a consequence, scaled objects with `cron` triggers failed to work because the controllers were unable to find time zone information. With this fix, the image builds are updated to include time zone information. As a result, scaled objects containing `cron` triggers now function properly. Scaled objects containing `cron` triggers are currently not supported for the custom metrics autoscaler. (link:https://issues.redhat.com/browse/OCPBUGS-34018[*OCPBUGS-34018*])
 
-* Previously, when parsing a multipart form, either explicitly with the `Request.ParseMultipartForm` method or implicitly with the `Request.FormValue`, `Request.PostFormValue`, or `Request.FormFile` method, the limits on the total size of the parsed form were not applied to the memory consumed while reading a single form line. This could have permitted a maliciously crafted input containing very long lines to cause allocation of arbitrarily large amounts of memory, potentially leading to memory exhaustion. With this fix, the parsing process now correctly limits the maximum size of form lines. (link:https://issues.redhat.com/browse/OCPBUGS-30360[*OCPBUGS-30360*])
-
-* Previously, when following an HTTP redirect to a domain that is not on a  matching subdomain or on an exact match of the initial domain, an HTTP client would not forward sensitive headers, such as `Authorization` or `Cookie`. For example, a redirect from example.com to www.example.com would forward the `Authorization` header; but a redirect to www.example.org would not forward the header. A maliciously crafted HTTP redirect could have caused sensitive headers to be unexpectedly forwarded. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30365[*OCPBUGS-30365*])
-
-* Previously, verifying a certificate chain that contains a certificate with an unknown public key algorithm caused the certificate verification process to panic. This condition affected all crypto and TLS clients and servers that set the `Config.ClientAuth` parameter to the `VerifyClientCertIfGiven` or `RequireAndVerifyClientCert` value. The default behavior is for TLS servers to not verify client certificates. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30370[*OCPBUGS-30370*])
-
-* Previously, if errors returned from the `MarshalJSON` method contained user-controlled data, the data could have been used to break the contextual auto-escaping behavior of the HTML template package. This condition would allow for subsequent actions to inject unexpected content into the templates. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30397[*OCPBUGS-30397*])
-
-* Previously, the `net/http` and `golang.org/x/net/http2` Go packages did not limit the number of `CONTINUATION` frames that were read for an HTTP/2 request. This condition could permit an attacker to provide an arbitrarily large set of headers for a single request, which would be read, decoded, and subsequently discarded. This could result in excessive CPU consumption. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30894[*OCPBUGS-30894*])


### PR DESCRIPTION
Issue: https://errata.devel.redhat.com/docs/show/135827

4.12+

**DO NOT MERGE UNTIL Custom Metrics Autoscaler 2.13.1 releases.** Planned for 7/15 or 7/23. 

Previews:

* [Supported versions](https://78675--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.html#nodes-pods-autoscaling-custom-rn-versions_nodes-cma-autoscaling-custom-rn) -- Updated version in table
* [Custom Metrics Autoscaler Operator 2.13.1 release notes](https://78675--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.html#nodes-pods-autoscaling-custom-rn-2131_nodes-cma-autoscaling-custom-rn) -- New text.  The [bug text](https://github.com/openshift/openshift-docs/pull/78675/files#diff-6af965f377aff4b3c4946a1ede31a0a6195a602e1551d7bbb922f80c780e6721R73) was copied from an earlier [Custom Metrics Autoscaler release node](https://docs.openshift.com/container-platform/4.16/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.html#nodes-pods-autoscaling-custom-rn-2121-384-bugs_nodes-cma-autoscaling-custom-rn-past) without change (same problem came back).  Link to errata will not work until product GAs, link to Custom CA certificates for the Custom Metrics Autoscaler will not work until https://github.com/openshift/openshift-docs/pull/78275 merges
* [Custom Metrics Autoscaler Operator 2.12.1-394 release notes](https://78675--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past#nodes-pods-autoscaling-custom-rn-2121-394_nodes-cma-autoscaling-custom-rn-past) -- **NO REVIEW NEEDED** This section was copied over from [current release notes docs](https://docs.openshift.com/container-platform/4.15/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.html#nodes-pods-autoscaling-custom-rn-2121-394_nodes-cma-autoscaling-custom-rn). 
