### PR TITLE
OSDOCS-11257 OCP Release Notes 4.14.32

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3326,6 +3326,82 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+[id="ocp-4-14-32_{context}"]
+=== RHSA-2024:4329 - {product-title} 4.14.32 bug fix and security updates
+
+Issued: 2024-07-11
+
+{product-title} release 4.14.32, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:4329[RHSA-2024:4329] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:4332[RHBA-2024:4332] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.32 --pullspecs
+----
+
+[id="ocp-4-14-32-enhancements_{context}"]
+==== Enhancements
+
+The following enhancements are included in this z-stream release:
+
+[id="ocp-4-14-32-pipeline-trigger_{context}"]
+===== New custom resource definitions for pipeline plugin
+
+This release updates the pipelines plugin to support the latest Pipeline Trigger API version for the custom resource definitions (CRDs) `ClusterTriggerBinding`, `TriggerTemplate`, and `EventListener`. (link:https://issues.redhat.com/browse/OCPBUGS-35723[*OCPBUGS-35723*])
+
+[id="ocp-4-14-32-_{context}"]
+===== Controller for defragmentating etcd
+
+This release introduces a controller to defragment etcd for hosted clusters on Hypershift. (link:https://issues.redhat.com/browse/OCPBUGS-35290[*OCPBUGS-35723*])
+
+[id="ocp-4-14-32-insights-operator-resources_{context}"]
+===== Insights Operator collects new resources
+
+The Insights Operator now collects the `Prometheus` and `AlertManager` resources in addition to the `openshift-monitoring` custom resource. (link:https://issues.redhat.com/browse/OCPBUGS-36380[*OCPBUGS-36380*])
+
+[id="ocp-4-14-32-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the `alertmanager-trusted-ca-bundle` `ConfigMap` was not injected into the user-defined Alertmanager container, which prevented the verification of HTTPS web servers receiving alert notifications. With this update, the trusted CA bundle `ConfigMap` is mounted into the Alertmanager container at the `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` path. (link:https://issues.redhat.com/browse/OCPBUGS-36416[*OCPBUGS-36416*])
+
+* Previously, for clusters updated from older versions of {product-title}, enabling `kdump` on an OVN-enabled cluster sometimes prevented the node from rejoining the cluster or returning to the `Ready` state. This fix removes problematic stale data from older {product-title} versions and ensures this kind of stale data is always cleaned up. The node can now start correctly and rejoin the cluster. (link:https://issues.redhat.com/browse/OCPBUGS-36356[*OCPBUGS-36356*])
+
+* Previously, AWS HyperShift clusters leveraged their Virtual Private Cloud's (VPC's) primary CIDR range to generate security group rules on the data plane. As a consequence, installing AWS HyperShift clusters into an AWS VPC with multiple CIDR ranges could cause the generated security group rules to be insufficient. With this update, security group rules are generated based on the provided Machine CIDR range instead to resolve this issue. (link:https://issues.redhat.com/browse/OCPBUGS-36159[*OCPBUGS-36159*])
+
+* Previously, a bug in `growpart` caused the device to lock which, prevented the LUKS-encrypted devices from opening. The system would fail to boot successfully. With this release, `growpart` was removed from the process and the the system will boot successfully.(link:https://issues.redhat.com/browse/OCPBUGS-35989[*OCPBUGS-35989*])
+
+* Previously, in user provisioned infrastructure clusters that were updated from older versions, `failureDomains` might be missing in Infrastructure objects which caused certain checks to fail. With this release, a fallback `failureDomains` is synthesized from `cloudConfig` if none are available in `infrastructures.config.openshift.io`. (link:https://issues.redhat.com/browse/OCPBUGS-35913[*OCPBUGS-35913*])
+
+* Previously, when installing a cluster on {vmw-first}, the installation failed if an ESXi host was in maintenance mode because the installation program could not retrieve version information from the host. With this update, the installation program does not attempt to retrieve version information from ESXi hosts that are in maintenance mode, allowing the installation to proceed. (link:https://issues.redhat.com/browse/OCPBUGS-35827[*OCPBUGS-35827*])
+
+* Previously, a bug in systemd might cause the `coreos-multipath-trigger.service` unit to hang forever. The system would fail to finish booting. With this release, systemd was removed and the boot is successful. (link:https://issues.redhat.com/browse/OCPBUGS-35750[*OCPBUGS-35750*])
+
+* Previously, registry overrides configured by a cluster administrator on the management side applied to non-relevant data-plane components. With this release, registry overrides no longer apply to these components.(link:https://issues.redhat.com/browse/OCPBUGS-35549[*OCPBUGS-35549*]).
+
+* Previously, the OpenShift Cluster Manager container did not have the right TLS Certificates. As a result, image streams could not be used in disconnected deployments. With this update, the TLS Certificates are added as projected volumes. (link:https://issues.redhat.com/browse/OCPBUGS-35482[*OCPBUGS-35482*])
+
+* Previously, in disconnected environments, the HyperShift Operator ignored registry overrides. As a consequence, changes to node pools were ignored, and node pools encountered errors. With this update, the metadata inspector works as expected during the HyperShift Operator reconciliation, and the override images are properly populated. (link:https://issues.redhat.com/browse/OCPBUGS-35401[*OCPBUGS-35401*])
+
+* Previously, the secrets-store CSI driver on Hypershift was failing to mount secrets due to an issue with the Hypershift CLI. With this release, the driver is able to mount volumes and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-35183[*OCPBUGS-35183*])
+
+* Previously, the reduction of the network queue did not work as expected for inverted rules such as `!ens0`. This happened because the exclamation mark symbol was duplicated in the generated tuned profile. With this release, the duplication no longer occurs so that inverted rules apply as intended. (link:https://issues.redhat.com/browse/OCPBUGS-35012[*OCPBUGS-35012*])
+
+* Previously, a race condition meant the Kubelet might report a false error relating to a failed resize from the volume resizer. With this release, the race condition has been fixed and the false error is no longer printed. (link:https://issues.redhat.com/browse/OCPBUGS-33964[*OCPBUGS-33964*])
+
+* Previously, escaped strings were not handled properly when editing a vSphere connection, causing broken vSphere configuration. With this update, the escape strings work as expected and the vSphere configuration no longer breaks. (link:https://issues.redhat.com/browse/OCPBUGS-33942[*OCPBUGS-33942*])
+
+* Previously, when the default gateway of a node was set to `vlan` and multiple network manager connections had the same name, the node would fail as it could not configure the default OVN-Kubernetes bridge. With this release, the `configure-ovs.sh` shell script includes an `nmcli connection show uuid` command that retrieves the correct network manager connection if many connections with the same name exist. (link:https://issues.redhat.com/browse/OCPBUGS-33590[*OCPBUGS-33590*])
+
+* Previously, when manually restarting the `kubelet` service on a node, some state files were deleted after an assumed node reboot, which led to kubelet resetting the CPU Manager state. After the state reset, the CPU Manager computes new CPU assignments to running workloads. As a result, the new and initial `cpuset` configurration might differ. With this update, the `cpuset` configuration is correctly restored after a kubelet restart. (link:https://issues.redhat.com/browse/OCPBUGS-32472[*OCPBUGS-32472*])
+
+[id="ocp-4-14-32-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 [id="ocp-4-14-31"]
 === RHSA-2024:4010 - {product-title} 4.14.31 bug fix and security updates
 


### PR DESCRIPTION
Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-11257](https://issues.redhat.com/browse/OSDOCS-11257)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to [docs preview](https://78693--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-32)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
Not needed
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Advisory links won't work until July 11.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
