### PR TITLE
OSDOCS#10151 - Improving ROSA disaster recovery and cluster state backup info

### DIFF
--- a/modules/rosa-sdpolicy-platform.adoc
+++ b/modules/rosa-sdpolicy-platform.adoc
@@ -21,56 +21,6 @@ ifndef::rosa-with-hcp[]
 {product-title} (ROSA) platform.
 endif::rosa-with-hcp[]
 
-[id="rosa-sdpolicy-backup-policy_{context}"]
-== Cluster backup policy
-
-[IMPORTANT]
-====
-Red{nbsp}Hat does not provide a backup method for ROSA clusters with STS, which is the default. It is critical that customers have a backup plan for their applications and application data. 
-ifndef::rosa-with-hcp[]
-The table below only applies to clusters created with IAM user credentials.
-endif::rosa-with-hcp[]
-====
-
-Application and application data backups are not a part of the
-ifdef::rosa-with-hcp[]
-{hcp-title-first} service.
-endif::rosa-with-hcp[]
-ifndef::rosa-with-hcp[]
-{product-title} service.
-The following table outlines the cluster backup policy.
-
-//Verify if the corresponding tables in policy-incident.adoc and rosa-policy-incident.adoc also need to be updated.
-
-[cols= "3a,2a,2a,3a",options="header"]
-
-|===
-|Component
-|Snapshot frequency
-|Retention
-|Notes
-
-.2+|Full object store backup
-|Daily
-|7 days
-.2+|This is a full backup of all Kubernetes objects like etcd. No persistent volumes (PVs) are backed up in this backup schedule.
-
-|Weekly
-|30 days
-
-|Full object store backup
-|Hourly
-|24 hour
-|This is a full backup of all Kubernetes objects like etcd. No PVs are backed up in this backup schedule.
-
-|Node root volume
-|Never
-|N/A
-|Nodes are considered to be short-term. Nothing critical should be stored on a node's root volume.
-
-|===
-endif::rosa-with-hcp[]
-
 [id="rosa-sdpolicy-autoscaling_{context}"]
 == Autoscaling
 Node autoscaling is available on
@@ -124,6 +74,61 @@ ifndef::rosa-with-hcp[]
 {product-title}
 endif::rosa-with-hcp[]
 clusters at this time. However, custom labels are supported when creating new machine pools.
+
+[id="rosa-sdpolicy-backup-policy_{context}"]
+== Cluster backup policy
+
+[IMPORTANT]
+====
+Red Hat does not provide a backup method for ROSA clusters with STS. It is critical that customers have a backup plan for their applications and application data.
+====
+
+Application and application data backups are not a part of the
+ifdef::rosa-with-hcp[]
+{hcp-title-first} service.
+endif::rosa-with-hcp[]
+ifndef::rosa-with-hcp[]
+{product-title} service.
+
+ifndef::rosa-with-hcp[]
+
+[%collapsible]
+====
+The table below only applies to non-STS clusters. The following components are used by Red Hat in extenuating circumstances.
+
+//Verify if the corresponding tables in policy-incident.adoc and rosa-policy-incident.adoc also need to be updated.
+
+[cols= "3a,2a,2a,3a",options="header"]
+
+|===
+|Component
+|Snapshot frequency
+|Retention
+|Notes
+
+.2+|Full object store backup
+|Daily
+|7 days
+.2+|This is a full backup of all Kubernetes objects like etcd. No persistent volumes (PVs) are backed up in this backup schedule.
+
+|Weekly
+|30 days
+
+|Full object store backup
+|Hourly
+|24 hour
+|This is a full backup of all Kubernetes objects like etcd. No PVs are backed up in this backup schedule.
+
+|Node root volume
+|Never
+|N/A
+|Nodes are considered to be short-term. Nothing critical should be stored on a node's root volume.
+|===
+
+endif::rosa-with-hcp[]
+====
+
+endif::rosa-with-hcp[]
 
 [id="rosa-sdpolicy-openshift-version_{context}"]
 == OpenShift version


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
enterprise-4.16+

Issue:
[OSDOCS-10151](https://issues.redhat.com/browse/OSDOCS-10151)

Link to docs preview:
[ROSA with HCP](https://78695--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-platform_rosa-hcp-service-definition) - Changed wording and does not contain cluster backup policy table.
[Cluster backup policy](https://78695--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-backup-policy_rosa-service-definition) - moved from the top of the Platform section to below Node Labels within the Platform section, changed wording.

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->