### PR TITLE
OCPBUGS#34352: Removed redhat-support-tool references

### DIFF
--- a/modules/support-collecting-network-trace.adoc
+++ b/modules/support-collecting-network-trace.adoc
@@ -118,6 +118,11 @@ $ tcpdump -nn -s 0 -i ens5 -w /host/var/tmp/my-cluster-node_$(date +%d_%m_%Y-%H_
 ----
 <1> The toolbox container mounts the host's root directory at `/host`. Reference the absolute path from the toolbox container's root directory, including `/host/`, when specifying files to upload through the `redhat-support-tool` command.
 +
+[NOTE]
+====
+`redhat-support-tool` is supported only in containers based on RHEL 8.
+====
+
 * Upload the file to an existing Red Hat support case.
 .. Concatenate the `sosreport` archive by running the `oc debug node/<node_name>` command and redirect the output to a file. This command assumes you have exited the previous `oc debug` session:
 +

--- a/modules/support-generating-a-sosreport-archive.adoc
+++ b/modules/support-generating-a-sosreport-archive.adoc
@@ -123,6 +123,11 @@ The checksum is: 382ffc167510fd71b4f12a4f40b97a4e
 ----
 <1> The toolbox container mounts the host's root directory at `/host`. Reference the absolute path from the toolbox container's root directory, including `/host/`, when specifying files to upload through the `redhat-support-tool` command.
 +
+[NOTE]
+====
+`redhat-support-tool` is supported only in containers based on RHEL 8.
+====
+
 * Upload the file to an existing Red Hat support case.
 .. Concatenate the `sosreport` archive by running the `oc debug node/<node_name>` command and redirect the output to a file. This command assumes you have exited the previous `oc debug` session:
 +

--- a/modules/support-providing-diagnostic-data-to-red-hat.adoc
+++ b/modules/support-providing-diagnostic-data-to-red-hat.adoc
@@ -97,3 +97,8 @@ If an existing `toolbox` pod is already running, the `toolbox` command outputs `
 # redhat-support-tool addattachment -c 01234567 /host/var/tmp/my-diagnostic-data.tar.gz <1>
 ----
 <1> The toolbox container mounts the host's root directory at `/host`. Reference the absolute path from the toolbox container's root directory, including `/host/`, when specifying files to upload through the `redhat-support-tool` command.
++
+[NOTE]
+====
+`redhat-support-tool` is supported only in containers based on RHEL 8.
+====

--- a/support/index.adoc
+++ b/support/index.adoc
@@ -54,7 +54,12 @@ xref:../support/gathering-cluster-data.adoc#gathering-cluster-data[Gather data a
 * *Bootstrap node journal logs*: Gather `bootkube.service` `journald` unit logs and container logs from the bootstrap node to troubleshoot bootstrap-related issues.
 * *Cluster node journal logs*: Gather `journald` unit logs and logs within `/var/log` on individual cluster nodes to troubleshoot node-related issues.
 * *A network trace*: Provide a network packet trace from a specific {product-title} cluster node or a container to Red Hat Support to help troubleshoot network-related issues.
-* *Diagnostic data*: Use the `redhat-support-tool` command to gather(?) diagnostic data about your cluster.
+* *Diagnostic data*: Use the `redhat-support-tool` command to gather diagnostic data about your cluster.
++
+[NOTE]
+====
+`redhat-support-tool` is supported only in containers based on RHEL 8.
+====
 endif::openshift-rosa,openshift-dedicated[]
 
 [id='support-overview-troubleshooting-issues']


### PR DESCRIPTION
Version(s): 4.13+

Issue: https://issues.redhat.com/browse/OCPBUGS-34352

Link to docs preview:  https://78703--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/index.html#support-overview-gather-data-cluster

Review:
- [x] QE has approved this change.
- [x] SME has approved this change.