### PR TITLE
OSDOCS-11188: adds note about greenboot.conf customization persistenc…

### DIFF
--- a/modules/microshift-greenboot-dir-structure.adoc
+++ b/modules/microshift-greenboot-dir-structure.adoc
@@ -39,3 +39,11 @@ Returning a nonzero exit code from any script means that script has failed. Gree
 * `/etc/greenboot/green.d` contains scripts that run after Greenboot has declared the start successful.
 
 * `/etc/greenboot/red.d` contains scripts that run after Greenboot has declared the startup as failed, including the `40_microshift_pre_rollback.sh` prerollback script. This script is executed right before a system rollback. The script performs {microshift-short} pod and OVN-Kubernetes cleanup to avoid potential conflicts after the system is rolled back to a previous version.
+
+[IMPORTANT]
+====
+If you customize the values of any environment variable in the `/etc/greenboot/greenboot.conf` file, these changes can be lost when the greenboot RPM package is updated or downgraded.
+
+* To retain customizations when building system images with {microshift-short}, add the `greenboot.conf` file to a blueprint.
+* To retain customizations when using an RPM installation, apply changes to the `greenboot.conf` file after you install {microshift-short} and greenboot RPMs.
+====


### PR DESCRIPTION
Version(s):
4.16, 4.17+

Issue:
[OSDOCS-11188](https://issues.redhat.com/browse/OSDOCS-11188)

Link to docs preview:
[Important admonition just above MicroShift scripts section](https://78712--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-greenboot.html#microshift-health-script_microshift-greenboot)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
