### PR TITLE
[enterprise-4.12] OADP-4003: Update OADP and Velero attributes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -43,6 +43,8 @@ endif::openshift-origin[]
 :hybrid-console-second: Hybrid Cloud Console
 :oadp-first: OpenShift API for Data Protection (OADP)
 :oadp-full: OpenShift API for Data Protection
+:oadp-version: 1.4.0
+:oadp-short: OADP
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
 :product-registry: OpenShift image registry
 :rh-storage-first: Red Hat OpenShift Data Foundation
@@ -66,7 +68,7 @@ ifdef::openshift-origin[]
 endif::[]
 // Backup and restore
 :velero-domain: velero.io
-:velero-version: 1.12
+:velero-version: 1.14
 :launch: image:app-launcher.png[title="Application Launcher"]
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers

--- a/modules/velero-oadp-version-relationship.adoc
+++ b/modules/velero-oadp-version-relationship.adoc
@@ -17,5 +17,8 @@
 | 1.2.1 | link:https://{velero-domain}/docs/v1.11/[1.11] | 4.11 and later
 | 1.2.2 | link:https://{velero-domain}/docs/v1.11/[1.11] | 4.11 and later
 | 1.2.3 | link:https://{velero-domain}/docs/v1.11/[1.11] | 4.11 and later
-| 1.3.0 | link:https://{velero-domain}/docs/v1.12/[1.12] | 4.12 and later
+| 1.3.0 | link:https://{velero-domain}/docs/v1.12/[1.12] | 4.10 - 4.15
+| 1.3.1 | link:https://{velero-domain}/docs/v1.12/[1.12] | 4.10 - 4.15
+| 1.3.2 | link:https://{velero-domain}/docs/v1.12/[1.12] | 4.10 - 4.15
+| 1.4.0 | link:https://{velero-domain}/docs/v1.14/[1.14] | 4.14 and later
 |===


### PR DESCRIPTION
Manual cherry-pick of the [PR](https://github.com/openshift/openshift-docs/pull/76841)
Add the correct OCP version
Fix OCP version for OADP 1.3.x
Add OCP and velero version for OADP 1.3.2
Fix atrribute version to avoid 404 error