### PR TITLE
#CNV-36241 - minor spacing fix

### DIFF
--- a/modules/virt-configuring-secondary-dns-server.adoc
+++ b/modules/virt-configuring-secondary-dns-server.adoc
@@ -55,9 +55,9 @@ metadata:
   name: kubevirt-hyperconverged
   namespace: {CNVNamespace}
 spec:
-    featureGates:
-      deployKubeSecondaryDNS: true
-    kubeSecondaryDNSNameServerIP: "10.46.41.94" <1>
+  featureGates:
+    deployKubeSecondaryDNS: true
+  kubeSecondaryDNSNameServerIP: "10.46.41.94" <1>
 # ...
 ----
 <1> Specify the external IP address exposed by the load balancer service.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-36241](https://issues.redhat.com//browse/CNV-36241)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://78730--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-accessing-vm-secondary-network-fqdn.html#virt-configuring-secondary-dns-server_virt-accessing-vm-secondary-network-fqdn 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
