### PR TITLE
One backup CR per location

### DIFF
--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
@@ -7,9 +7,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-Frequent backups might consume storage on the backup storage location. Check the frequency of backups, retention time, and the amount of data of the persistent volumes (PVs) if using non-local backups, for example, S3 buckets.
-Because all taken backup remains until expired, also check the time to live (TTL) setting of the schedule.
-
+Frequent backups might consume storage on the backup storage location. Check the frequency of backups, retention time, and the amount of data of the persistent volumes (PVs) if using non-local backups, for example, S3 buckets. Because all taken backup remains until expired, also check the time to live (TTL) setting of the schedule.
 
 You can back up applications by creating a `Backup` custom resource (CR). For more information, see xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr.adoc#oadp-creating-backup-cr-doc[Creating a Backup CR].
 
@@ -19,6 +17,7 @@ endif::openshift-rosa,openshift-rosa-hcp[]
 
 ifndef::openshift-rosa,openshift-rosa-hcp[]
 * The `Backup` CR creates backup files for Kubernetes resources and internal images on S3 object storage.
+* You need to create one `Backup` CR per storage location. For example, to perform a backup that includes a backup of a local snapshot and a backup of an offsite location, you need to create two `Backup` CRs, one for each location.
 * If your cloud provider has a native snapshot API or supports CSI snapshots, the `Backup` CR backs up persistent volumes (PVs) by creating snapshots. For more information about working with CSI snapshots, see xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-pvs-csi-doc.adoc#oadp-backing-up-pvs-csi-doc[Backing up persistent volumes with CSI snapshots].
 
 For more information about CSI volume snapshots, see xref:../../../storage/container_storage_interface/persistent-storage-csi-snapshots.adoc#persistent-storage-csi-snapshots[CSI volume snapshots].


### PR DESCRIPTION
OADP 1.4.x ; OCP 4.12+

Resolves https://issues.redhat.com/browse/OADP-1791 by adding a bulleted list item that explains that a separate `Backup` CR is needed per location. 

Preview: https://78734--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html [small edit to initial sentence; added 2nd bullet in list]