### PR TITLE
OSDOCS#41196: Reordering steps for configuring a DNS server

### DIFF
--- a/modules/virt-configuring-secondary-dns-server.adoc
+++ b/modules/virt-configuring-secondary-dns-server.adoc
@@ -16,6 +16,31 @@ The Cluster Network Addons Operator (CNAO) deploys a Domain Name Server (DNS) se
 
 .Procedure
 
+. Edit the `HyperConverged` CR in your default editor by running the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+----
+
+. Enable the DNS server and monitoring components according to the following example:
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: {CNVNamespace}
+spec:
+    featureGates:
+      deployKubeSecondaryDNS: true <1>
+# ...
+----
+<1> Enables the DNS server
+
+. Save the file and exit the editor.
+
 . Create a load balancer service to expose the DNS server outside the cluster by running the `oc expose` command according to the following example:
 +
 [source,terminal,subs="attributes+"]
@@ -38,14 +63,14 @@ NAME       TYPE             CLUSTER-IP     EXTERNAL-IP      PORT(S)          AGE
 dns-lb     LoadBalancer     172.30.27.5    10.46.41.94      53:31829/TCP     5s
 ----
 
-. Edit the `HyperConverged` CR in your default editor by running the following command:
+. Edit the `HyperConverged` CR again:
 +
 [source,terminal,subs="attributes+"]
 ----
 $ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
-. Enable the DNS server and monitoring components according to the following example:
+. Add the external IP address that you previously retrieved to the `kubeSecondaryDNSNameServerIP` field in the enterprise DNS server records. For example:
 +
 [source,yaml,subs="attributes+"]
 ----
@@ -77,16 +102,7 @@ spec:
 openshift.example.com
 ----
 
-. Point to the DNS server by using one of the following methods:
-
-* Add the `kubeSecondaryDNSNameServerIP` value to the `resolv.conf` file on your local machine.
-+
-[NOTE]
-====
-Editing the `resolv.conf` file overwrites existing DNS settings.
-====
-
-* Add the `kubeSecondaryDNSNameServerIP` value and the cluster FQDN to the enterprise DNS server records. For example:
+. Point to the DNS server. To do so, add the `kubeSecondaryDNSNameServerIP` value and the cluster FQDN to the enterprise DNS server records. For example:
 +
 [source,terminal]
 ----
@@ -95,5 +111,6 @@ vm.<FQDN>. IN NS ns.vm.<FQDN>.
 +
 [source,terminal]
 ----
-ns.vm.<FQDN>. IN A 10.46.41.94
+ns.vm.<FQDN>. IN A <kubeSecondaryDNSNameServerIP>
 ----
+

--- a/modules/virt-connecting-vm-secondarynw-using-fqdn.adoc
+++ b/modules/virt-connecting-vm-secondarynw-using-fqdn.adoc
@@ -14,6 +14,13 @@ You can access a running virtual machine (VM) attached to a secondary network in
 * The IP address of the VM is public.
 * You configured the DNS server for secondary networks.
 * You retrieved the fully qualified domain name (FQDN) of the cluster.
++
+To obtain the FQDN, use the `oc get` command as follows:
++
+[source,terminal]
+----
+$ oc get dnses.config.openshift.io cluster -o json | jq .spec.baseDomain
+----
 
 .Procedure
 


### PR DESCRIPTION
Version(s):
4.15 and later

Issue:
https://issues.redhat.com/browse/CNV-41196

Link to docs preview:
https://78735--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-accessing-vm-secondary-network-fqdn.html

QE review:
- [x] QE has approved this change.