### PR TITLE
OCPBUGS#347772: [OSDK] Fix Golang version in prereqs

### DIFF
--- a/modules/osdk-common-prereqs.adoc
+++ b/modules/osdk-common-prereqs.adoc
@@ -36,7 +36,7 @@ endif::[]
 * Operator SDK CLI installed
 * OpenShift CLI (`oc`) {product-version}+ installed
 ifdef::golang[]
-* link:https://golang.org/dl/[Go] 1.19+
+* link:https://golang.org/dl/[Go] 1.21+
 endif::[]
 ifdef::ansible[]
 * link:https://docs.ansible.com/ansible/latest/roadmap/ROADMAP_2_15.html[Ansible] 2.15.0


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUGS-347772](https://issues.redhat.com/browse/OCPBUGS-34772)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
* https://78743--ocpdocs-pr.netlify.app/openshift-dedicated/latest/operators/operator_sdk/ansible/osdk-ansible-tutorial.html#osdk-common-prereqs_osdk-ansible-tutorial
* https://78743--ocpdocs-pr.netlify.app/openshift-dedicated/latest/operators/operator_sdk/golang/osdk-golang-tutorial.html#osdk-common-prereqs_osdk-golang-tutorial
* https://78743--ocpdocs-pr.netlify.app/openshift-dedicated/latest/operators/operator_sdk/helm/osdk-helm-tutorial.html#osdk-common-prereqs_osdk-helm-tutorial
* https://78743--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/ansible/osdk-ansible-quickstart.html#osdk-common-prereqs_osdk-ansible-quickstart
* https://78743--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/ansible/osdk-ansible-tutorial.html#osdk-common-prereqs_osdk-ansible-tutorial
* https://78743--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-quickstart.html#osdk-common-prereqs_osdk-golang-quickstart
* https://78743--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-tutorial.html#osdk-common-prereqs_osdk-golang-tutorial
* https://78743--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-helm-quickstart.html#osdk-common-prereqs_osdk-helm-quickstart
* https://78743--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-helm-tutorial.html#osdk-common-prereqs_osdk-helm-tutorial
* https://78743--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-hybrid-helm.html#osdk-common-prereqs_osdk-hybrid-helm
* https://78743--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/java/osdk-java-quickstart.html#osdk-common-prereqs_osdk-java-quickstart
* https://78743--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/java/osdk-java-tutorial.html#osdk-common-prereqs_osdk-java-tutorial
* https://78743--ocpdocs-pr.netlify.app/openshift-rosa/latest/operators/operator_sdk/ansible/osdk-ansible-tutorial.html#osdk-common-prereqs_osdk-ansible-tutorial
* https://78743--ocpdocs-pr.netlify.app/openshift-rosa/latest/operators/operator_sdk/golang/osdk-golang-tutorial.html#osdk-common-prereqs_osdk-golang-tutorial
* https://78743--ocpdocs-pr.netlify.app/openshift-rosa/latest/operators/operator_sdk/helm/osdk-helm-tutorial.html#osdk-common-prereqs_osdk-helm-tutorial
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
