### PR TITLE
CNV#34493: StorageProfile default behavior clarification

### DIFF
--- a/modules/virt-customizing-storage-profile.adoc
+++ b/modules/virt-customizing-storage-profile.adoc
@@ -77,7 +77,7 @@ You can use storage profiles to set a default cloning method for a storage class
 
 Cloning strategies can be specified by setting the `cloneStrategy` attribute in a storage profile to one of these values:
 
-* `snapshot` is used by default when snapshots are configured. This cloning strategy uses a temporary volume snapshot to clone the volume. The storage provisioner must support Container Storage Interface (CSI) snapshots.
+* `snapshot` is used by default when snapshots are configured. The CDI will use the snapshot method if it recognizes the storage provider and the provider supports Container Storage Interface (CSI) snapshots. This cloning strategy uses a temporary volume snapshot to clone the volume.
 * `copy` uses a source pod and a target pod to copy data from the source volume to the target volume. Host-assisted cloning is the least efficient method of cloning.
 * `csi-clone` uses the CSI clone API to efficiently clone an existing volume without using an interim volume snapshot. Unlike `snapshot` or `copy`, which are used by default if no storage profile is defined, CSI volume cloning is only used when you specify it in the `StorageProfile` object for the provisioner's storage class.
 
@@ -108,3 +108,24 @@ status:
 <1> Specify the access mode.
 <2> Specify the volume mode.
 <3> Specify the default cloning strategy.
+
+[id="virt-customizing-storage-profile-providers-and-default-behaviors_{context}"]
+.Storage providers and default behaviors
+
+[cols="1,1",options="header"]
+|===
+|Storage provider|Default behavior
+|rook-ceph.rbd.csi.ceph.com|Snapshot
+|openshift-storage.rbd.csi.ceph.com|Snapshot
+|csi-vxflexos.dellemc.com|CSI Clone
+|csi-isilon.dellemc.com|CSI Clone
+|csi-powermax.dellemc.com|CSI Clone
+|csi-powerstore.dellemc.com|CSI Clone
+|hspc.csi.hitachi.com|CSI Clone
+|csi.hpe.com|CSI Clone
+|spectrumscale.csi.ibm.com|CSI Clone
+|rook-ceph.rbd.csi.ceph.com|CSI Clone
+|openshift-storage.rbd.csi.ceph.com|CSI Clone
+|cephfs.csi.ceph.com|CSI Clone
+|openshift-storage.cephfs.csi.ceph.com|CSI Clone
+|===

--- a/virt/storage/virt-configuring-storage-profile.adoc
+++ b/virt/storage/virt-configuring-storage-profile.adoc
@@ -8,9 +8,9 @@ toc::[]
 
 A storage profile provides recommended storage settings based on the associated storage class. A storage profile is allocated for each storage class.
 
-If the Containerized Data Importer (CDI) does not recognize your storage provider, you must configure storage profiles.
+The Containerized Data Importer (CDI) recognizes a storage provider if it has been configured to identify and interact with the storage provider's capabilities.
 
-For recognized storage types, CDI provides values that optimize the creation of PVCs.  However, you can configure automatic settings for a storage class if you customize the storage profile.
+For recognized storage types, the CDI provides values that optimize the creation of PVCs. You can also configure automatic settings for the storage class by customizing the storage profile. If the CDI does not recognize your storage provider, you must configure storage profiles.
 
 ifndef::openshift-rosa,openshift-dedicated[]
 [IMPORTANT]


### PR DESCRIPTION
Version(s):
4.14, 4.15, 4.16

Issue:
https://issues.redhat.com/browse/CNV-34493

Link to docs preview:
https://78757--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-configuring-storage-profile.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
