### PR TITLE
Consolidated and Updated redirects for Observability for handling latest

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -185,42 +185,32 @@ AddType text/vtt                            vtt
     RewriteRule ^(rosa|dedicated)/logging/config/cluster-logging-moving-nodes.html /$1/logging/scheduling_resources/logging-node-selectors.html [NE,R=302]
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/logging/config/cluster-logging-log-store.html /container-platform/$1/logging/log_storage/logging-config-es-store.html [NE,R=302]
 
-    # Redirects for observability rework per https://github.com/openshift/openshift-docs/pull/71248
-    RewriteRule ^container-platform/4.14/power_monitoring/(.*)$ /container-platform/4.14/observability/power_monitoring/$1 [NE,R=302,L]
+    # Consolidated redirects for observability, monitoring, logging, and network observability
 
-    # Redirects for observability/monitoring per https://github.com/openshift/openshift-docs/pull/74679/
-    RewriteRule ^container-platform/(4\.12|4\.13|4\.14|4\.15)/observability/monitoring/cluster_observability_operator/configuring-the-cluster-observability-operator-to-monitor-a-service.html /container-platform/$1/observability/cluster_observability_operator/configuring-the-cluster-observability-operator-to-monitor-a-service.html [NE,R=302]
-    RewriteRule ^container-platform/(4\.12|4\.13|4\.14|4\.15)/observability/monitoring/cluster_observability_operator/installing-the-cluster-observability-operator.html /container-platform/$1/observability/cluster_observability_operator/installing-the-cluster-observability-operator.html [NE,R=302]
-    RewriteRule ^container-platform/(4\.12|4\.13|4\.14|4\.15)/observability/monitoring/cluster_observability_operator/cluster-observability-operator-overview.html /container-platform/$1/observability/cluster_observability_operator/cluster-observability-operator-overview.html [NE,R=302]
-    RewriteRule ^container-platform/(4\.12|4\.13|4\.14|4\.15)/observability/monitoring/cluster_observability_operator/cluster-observability-operator-release-notes.html /container-platform/$1/observability/cluster_observability_operator/cluster-observability-operator-release-notes.html [NE,R=302]
+    # Generic rule for moving sections under observability
+    RewriteRule ^container-platform/(4\.1[2-5]|latest)/(logging|monitoring|distr_tracing|otel|network_observability)/?(.*)$ /container-platform/$1/observability/$2/$3 [NE,R=302]
 
-    # Redirects for observability reorg per mleonov and https://github.com/openshift/openshift-docs/pull/74104
-    # including logging per https://github.com/openshift/openshift-docs/pull/74819
-    RewriteRule ^container-platform/(4\.12|4\.13|4\.14|4\.15)/distr_tracing/distr_tracing_rn/distr-tracing-rn-?(.*)$ /container-platform/$1/observability/distr_tracing/distr_tracing_rn/distr-tracing-rn-past-releases.html [NE,R=302]
-    RewriteRule ^container-platform/(4\.12|4\.13|4\.14|4\.15)/otel/otel_rn/otel-rn-?(.*)$ /container-platform/$1/observability/otel/otel_rn/otel-rn-past-releases.html [NE,R=302]
-    RewriteRule ^container-platform/(4\.12|4\.13|4\.14|4\.15)/(logging|monitoring|distr_tracing|otel)/?(.*)$ /container-platform/$1/observability/$2/$3 [NE,R=302]
-    RewriteRule ^container-platform/4.13/distr_tracing/distr_tracing_otel/distr-tracing-otel-installing.html /container-platform/4.13/observability/otel/otel-installing.html [NE,R=302]
-    RewriteRule ^container-platform/4.13/distr_tracing/distr_tracing_install/distr-tracing-deploying-otel.html /container-platform/4.13/observability/otel/otel-installing.html [NE,R=302]
-    RewriteRule ^container-platform/4.9/distr_tracing/distributed-tracing-release-notes.html /container-platform/latest/observability/distr_tracing/distr_tracing_rn/distr-tracing-rn-past-releases.html [NE,R=302]
-    RewriteRule ^container-platform/4.9/distr_tracing/distr_tracing_install/distr-tracing-installing.html /container-platform/latest/observability/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-installing.html [NE,R=302]
+    # Generic rule for ROSA and OpenShift Dedicated
     RewriteRule ^(rosa|dedicated)/(logging|monitoring)/?(.*)$ /$1/observability/$2/$3 [NE,R=302]
 
+    # Specific rules for Cluster Observability Operator
+    RewriteRule ^container-platform/(4\.1[2-5]|latest)/monitoring/cluster_observability_operator/(.*)$ /container-platform/$1/observability/cluster_observability_operator/$2 [NE,R=302]
 
-    # Redirects for network observability per https://github.com/openshift/openshift-docs/pull/73554
-    RewriteRule ^container-platform/(4\.12|4\.13|4\.14|4\.15)/network_observability/?(.*)$ /container-platform/$1/observability/network_observability/$2 [NE,R=302]
+    # Specific redirects for distributed tracing and OpenTelemetry
+    RewriteRule ^container-platform/(4\.1[2-5]|latest)/distr_tracing/distr_tracing_rn/distr-tracing-rn-?(.*)$ /container-platform/$1/observability/distr_tracing/distr_tracing_rn/distr-tracing-rn-past-releases.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.1[2-5]|latest)/otel/otel_rn/otel-rn-?(.*)$ /container-platform/$1/observability/otel/otel_rn/otel-rn-past-releases.html [NE,R=302]
 
-    # Redirect for log collection forwarding per https://github.com/openshift/openshift-docs/pull/64406
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/logging/config/cluster-logging-collector.html /container-platform/$1/logging/log_collection_forwarding/cluster-logging-collector.html [NE,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/logging/cluster-logging-eventrouter.html /container-platform/$1/logging/log_collection_forwarding/cluster-logging-eventrouter.html [NE,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/logging/cluster-logging-enabling-json-logging.html /container-platform/$1/logging/log_collection_forwarding/cluster-logging-enabling-json-logging.html [NE,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/logging/cluster-logging-external.html /container-platform/$1/logging/log_collection_forwarding/log-forwarding.html [NE,R=302]
+    # Specific redirects for older versions and special cases
+    RewriteRule ^container-platform/(4\.13|latest)/distr_tracing/distr_tracing_otel/distr-tracing-otel-installing.html /container-platform/$1/observability/otel/otel-installing.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.13|latest)/distr_tracing/distr_tracing_install/distr-tracing-deploying-otel.html /container-platform/$1/observability/otel/otel-installing.html [NE,R=302]
+    RewriteRule ^container-platform/4.9/distr_tracing/distributed-tracing-release-notes.html /container-platform/latest/observability/distr_tracing/distr_tracing_rn/distr-tracing-rn-past-releases.html [NE,R=302]
+    RewriteRule ^container-platform/4.9/distr_tracing/distr_tracing_install/distr-tracing-installing.html /container-platform/latest/observability/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-installing.html [NE,R=302]
 
-    # Redirect for network observability per https://github.com/openshift/openshift-docs/pull/65770
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/networking/network_observability/network-observability-operator-release-notes.html /container-platform/$1/network_observability/network-observability-operator-release-notes.html [NE,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/networking/network_observability/installing-operators.html /container-platform/$1/network_observability/installing-operators.html [NE,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/networking/network_observability/observing-network-traffic.html /container-platform/$1/network_observability/observing-network-traffic.html [NE,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/networking/network_observability/understanding-network-observability-operator.html /container-platform/$1/network_observability/understanding-network-observability-operator.html [NE,R=302]
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/networking/network_observability/configuring-operator.html /container-platform/$1/network_observability/configuring-operator.html [NE,R=302]
+    # Redirects for log collection forwarding (for versions 4.11 to 4.13 and latest)
+    RewriteRule ^container-platform/(4\.1[1-3]|latest)/logging/(.*)$ /container-platform/$1/logging/log_collection_forwarding/$2 [NE,R=302]
+
+    # Redirect for power monitoring (specific to 4.14 and latest)
+    RewriteRule ^container-platform/(4\.14|latest)/power_monitoring/(.*)$ /container-platform/$1/observability/power_monitoring/$2 [NE,R=302,L]
 
     # Redirects for Telco ZTP changes delivered in https://github.com/openshift/openshift-docs/pull/35889
     RewriteRule ^container-platform/(4\.10|4\.11)/scalability_and_performance/ztp-deploying-disconnected.html /container-platform/$1/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-clusters-at-scale.html [NE,R=302]


### PR DESCRIPTION
Based on Slack discussion.

>the redirects for Observability components for 4.16/latest OCP versions do not work as they do for previous versions (where, e.g., /monitoing/ gets redirected to /observability/monitoring/, etc.)



