### PR TITLE
OSDOCS-10984 OSDOCS-11291 Minor fix to section title and firewall

### DIFF
--- a/modules/rosa-hcp-aws-private-create-cluster.adoc
+++ b/modules/rosa-hcp-aws-private-create-cluster.adoc
@@ -3,7 +3,7 @@
 // * rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc
 :_mod-docs-content-type: PROCEDURE
 [id="rosa-hcp-aws-private-create-cluster_{context}"]
-= Creating an AWS private cluster
+= Creating a private {hcp-title} cluster using the ROSA CLI
 
 You can create a private cluster with multiple availability zones (Multi-AZ) on {hcp-title} using the ROSA command line interface (CLI), `rosa`.
 

--- a/modules/rosa-hcp-firewall-prerequisites.adoc
+++ b/modules/rosa-hcp-firewall-prerequisites.adoc
@@ -64,6 +64,10 @@ endif::rosa-classic-sts[]
 |443
 |Required. Hosts a signature store that a container client requires for verifying images when pulling them from `registry.access.redhat.com`. 
 
+|`api.openshift.com`
+|443
+|Required. Used to check for available updates to the cluster.
+
 |`mirror.openshift.com`
 |443
 |Required. Used to access mirrored installation content and images. This site is also a source of release image signatures, although the Cluster Version Operator (CVO) needs only a single functioning source.

--- a/rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc
+++ b/rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc
@@ -6,7 +6,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-This document describes how to create a {hcp-title-first} private cluster.
+For {hcp-title-first} workloads that do not require public internet access, you can create a private cluster.
 
 //include::modules/osd-aws-privatelink-about.adoc[leveloffset=+1]
 //include::modules/osd-aws-privatelink-required-resources.adoc[leveloffset=+1]
@@ -24,7 +24,8 @@ xref:../rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.a
 [id="additional-resources_rosa-hcp-aws-privatelink-creating-cluster"]
 == Additional resources
 
-* xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs[AWS PrivateLink firewall prerequisites]
+* xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-hcp-firewall-prerequisites_rosa-sts-aws-prereqs[AWS PrivateLink firewall prerequisites]
+//* xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs[AWS PrivateLink firewall prerequisites]
 * xref:../rosa_getting_started/rosa-sts-getting-started-workflow.adoc#rosa-sts-overview-of-the-deployment-workflow[Overview of the ROSA with STS deployment workflow]
 * xref:../rosa_install_access_delete_clusters/rosa-sts-deleting-cluster.adoc#rosa-sts-deleting-cluster[Deleting a ROSA cluster]
 * xref:../architecture/rosa-architecture-models.adoc#rosa-architecture-models[ROSA architecture models]


### PR DESCRIPTION
Version(s): 4.15+

Issue:
- https://issues.redhat.com/browse/OSDOCS-10984
- https://issues.redhat.com/browse/OSDOCS-11291

Link to docs preview:
https://78762--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-aws-private-creating-cluster.html
https://78762--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs.html

QE review: Minor enough to not need review IMO - api.openshift.com is a well-established requirement
- [x] QE has approved this change.