### PR TITLE
OSDOCS-9350-deepdive-1 for External IP assigned to a svc

### DIFF
--- a/modules/nw-externalip-about.adoc
+++ b/modules/nw-externalip-about.adoc
@@ -29,7 +29,7 @@ This feature is supported only in non-cloud deployments.
 For cloud deployments, use the load balancer services for automatic deployment of a cloud load balancer to target the endpoints of a service.
 ====
 
-You can assign an external IP address in the following ways:
+You can use either a MetalLB implementation or an IP failover deployment to attach an ExternalIP resource to a service in the following ways:
 
 Automatic assignment of an external IP::
 {product-title} automatically assigns an IP address from the `autoAssignCIDRs` CIDR block to the `spec.externalIPs[]` array when you create a `Service` object with `spec.type=LoadBalancer` set.

--- a/modules/nw-ingress-sharding-route-labels.adoc
+++ b/modules/nw-ingress-sharding-route-labels.adoc
@@ -14,10 +14,7 @@ selector.
 .Ingress sharding using route labels
 image::nw-sharding-route-labels.png[A diagram showing multiple Ingress Controllers with different route selectors serving any route containing a label that matches a given route selector regardless of the namespace a route belongs to]
 
-Ingress Controller sharding is useful when balancing incoming traffic load among
-a set of Ingress Controllers and when isolating traffic to a specific Ingress
-Controller. For example, company A goes to one Ingress Controller and company B
-to another.
+Ingress Controller sharding is useful when balancing incoming traffic load among a set of Ingress Controllers and when isolating traffic to a specific Ingress Controller. For example, company A goes to one Ingress Controller and company B to another.
 
 .Procedure
 
@@ -25,7 +22,6 @@ to another.
 +
 [source,yaml]
 ----
-# cat router-internal.yaml
 apiVersion: operator.openshift.io/v1
 kind: IngressController
 metadata:

--- a/modules/nw-overlapped-sharding.adoc
+++ b/modules/nw-overlapped-sharding.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="nw-overlapped-sharding_{context}"]
-== Overlapped sharding example
+= Overlapped sharding example
 
 An example of a configured Ingress Controller `devops-router` that has the label selector `spec.namespaceSelector.matchExpressions` with key values set to `dev` and `ops`:
 

--- a/modules/nw-service-externalip-create.adoc
+++ b/modules/nw-service-externalip-create.adoc
@@ -6,23 +6,29 @@
 [id="nw-service-externalip-create_{context}"]
 = Attaching an ExternalIP to a service
 
-You can attach an ExternalIP to a service. If your cluster is configured to allocate an ExternalIP automatically, you might not need to manually attach an ExternalIP to the service.
+You can attach an ExternalIP resource to a service. If you configured your cluster to automatically attach the resource to a service, you might not need to manually attach an ExternalIP to the service.
+
+The examples in the procedure use a scenario that manually attaches an ExternalIP resource to a service in a cluster with an IP failover configuration. 
 
 .Procedure
 
-. Optional: To confirm what IP address ranges are configured for use with ExternalIP, enter the following command:
+. Confirm compatible IP address ranges for the ExternalIP resource by entering the following command in your CLI:
 +
 [source,terminal]
 ----
 $ oc get networks.config cluster -o jsonpath='{.spec.externalIP}{"\n"}'
 ----
 +
-If `autoAssignCIDRs` is set, {product-title} automatically assigns an ExternalIP to a new `Service` object if the `spec.externalIPs` field is not specified.
+[NOTE]
+====
+If `autoAssignCIDRs` is set and you did not specify a value for `spec.externalIPs` in the ExternalIP resource, {product-title} automatically assigns ExternalIP to a new `Service` object.
+====
 
-. Attach an ExternalIP to the service.
-
-.. If you are creating a new service, specify the `spec.externalIPs` field and provide an array of one or more valid IP addresses. For example:
+. Choose one of the following options to attach an ExternalIP resource to the service:
 +
+.. If you are creating a new service, specify a value in the `spec.externalIPs` field and array of one or more valid IP addresses in the `allowedCIDRs` parameter.
++
+.Example of service YAML configuration file that supports an ExternalIP resource
 [source,yaml]
 ----
 apiVersion: v1
@@ -30,11 +36,12 @@ kind: Service
 metadata:
   name: svc-with-externalip
 spec:
-  ...
   externalIPs:
-  - 192.174.120.10
+    policy:
+      allowedCIDRs:
+      - 192.168.123.0/28
 ----
-
++
 .. If you are attaching an ExternalIP to an existing service, enter the following command. Replace `<name>` with the service name. Replace `<ip_address>` with a valid ExternalIP address. You can provide multiple IP addresses separated by commas.
 +
 [source,terminal]

--- a/networking/configuring_ingress_cluster_traffic/configuring-externalip.adoc
+++ b/networking/configuring_ingress_cluster_traffic/configuring-externalip.adoc
@@ -14,10 +14,13 @@ This functionality is generally most useful for clusters installed on bare-metal
 
 * Your network infrastructure must route traffic for the external IP addresses to your cluster.
 
+// About ExternalIP
 include::modules/nw-externalip-about.adoc[leveloffset=+1]
 
+// ExternalIP address block configuration
 include::modules/nw-externalip-object.adoc[leveloffset=+1]
 
+// Configure external IP address blocks for your cluster
 include::modules/nw-externalip-configuring.adoc[leveloffset=+1]
 
 [id="configuring-externalip-next-steps"]

--- a/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-service-external-ip.adoc
+++ b/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-service-external-ip.adoc
@@ -6,9 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can attach an external IP address to a service so that it is available to traffic outside the cluster.
-This is generally useful only for a cluster installed on bare metal hardware.
-The external network infrastructure must be configured correctly to route traffic to the service.
+You can use either a MetalLB implementation or an IP failover deployment to attach an ExternalIP resource to a service so that the service is available to traffic outside your {product-title} cluster. Hosting an external IP address in this way is only applicable for a cluster installed on bare-metal hardware. 
+
+You must ensure that you correctly configure the external network infrastructure to route traffic to the service.
 
 [id="configuring-ingress-cluster-traffic-service-external-ip-prerequisites"]
 == Prerequisites
@@ -25,5 +25,9 @@ include::modules/nw-service-externalip-create.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="configuring-ingress-cluster-traffic-service-external-ip-additional-resources"]
 == Additional resources
+
+* xref:../../networking/metallb/about-metallb.adoc#about-metallb[About MetalLB and the MetalLB Operator]
+
+* xref:../../networking/configuring-ipfailover.adoc#configuring-ipfailover[Configuring IP failover]
 
 * xref:../../networking/configuring_ingress_cluster_traffic/configuring-externalip.adoc#configuring-externalip[Configuring ExternalIPs for services]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
(https://issues.redhat.com/browse/OSDOCS-9350)

Link to docs preview:
* [About ExternalIP](https://78778--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-externalip.html#nw-externalip-about_configuring-externalip)
* [Attaching an ExternalIP to a service](https://78778--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-service-external-ip.html#nw-service-externalip-create_configuring-ingress-cluster-traffic-service-external-ip)


- [x] SME has approved this change.
- [x] QE has approved this change.


Additional information:
* [SME doc](https://docs.google.com/document/d/13w_tqS-xFFFrb74jF_rcgApUuXwrBsjVaEQGY2mE0KI/edit#heading=h.nn1hdtqlfcrd)
* [Configuring IP failover](https://docs.openshift.com/container-platform/4.16/networking/configuring-ipfailover.html)
* [About MetalLB and the MetalLB Operator](https://docs.openshift.com/container-platform/4.16/networking/metallb/about-metallb.html#nw-metallb-when-metallb_about-metallb-and-metallb-operator)
* [Attaching an ExternalIP to a service](https://docs.openshift.com/container-platform/4.16/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-service-external-ip.html#nw-service-externalip-create_configuring-ingress-cluster-traffic-service-external-ip)
* [configuration for ExternalIP](https://docs.openshift.com/container-platform/4.13/networking/configuring_ingress_cluster_traffic/configuring-externalip.html#nw-externalip-configuring_configuring-externalip)
