### PR TITLE
OSDOCS-6062: Steps to create a NodeFeatureDiscovery instance using the CLI for disconnected environment

### DIFF
--- a/hardware_enablement/psap-node-feature-discovery-operator.adoc
+++ b/hardware_enablement/psap-node-feature-discovery-operator.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="node-feature-discovery-operator"]
+[id="psap-node-feature-discovery-operator"]
 = Node Feature Discovery Operator
 include::_attributes/common-attributes.adoc[]
-:context: node-feature-discovery-operator
+:context: psap-node-feature-discovery-operator
 
 toc::[]
 
@@ -12,7 +12,16 @@ include::modules/psap-node-feature-discovery-operator.adoc[leveloffset=+1]
 
 include::modules/psap-installing-node-feature-discovery-operator.adoc[leveloffset=+1]
 
-include::modules/psap-using-node-feature-discovery-operator.adoc[leveloffset=+1]
+[id="psap-node-feature-discovery-operator-using-the-operator"]
+== Using the Node Feature Discovery Operator
+
+The Node Feature Discovery (NFD) Operator orchestrates all resources needed to run the Node-Feature-Discovery daemon set by watching for a `NodeFeatureDiscovery` custom resource (CR). Based on the `NodeFeatureDiscovery` CR, the Operator creates the operand (NFD) components in the selected namespace. You can edit the CR to use another namespace, image, image pull policy, and `nfd-worker-conf` config map, among other options.
+
+As a cluster administrator, you can create a `NodeFeatureDiscovery` CR by using the {oc-first} or the web console.
+
+include::modules/creating-nfd-cr-cli.adoc[leveloffset=+2]
+include::modules/creating-nfd-cr-cli-disconnected.adoc[leveloffset=+2]
+include::modules/creating-nfd-cr-web-console.adoc[leveloffset=+2]
 
 include::modules/psap-configuring-node-feature-discovery.adoc[leveloffset=+1]
 

--- a/modules/creating-nfd-cr-cli-disconnected.adoc
+++ b/modules/creating-nfd-cr-cli-disconnected.adoc
@@ -1,0 +1,167 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/psap-node-feature-discovery-operator.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="creating-nfd-cr-cli-disconnected_{context}"]
+= Creating a NodeFeatureDiscovery CR by using the CLI in a disconnected environment
+
+As a cluster administrator, you can create a `NodeFeatureDiscovery` CR instance by using the {oc-first}.
+
+.Prerequisites
+
+* You have access to an {product-title} cluster
+* You installed the {oc-first}.
+* You logged in as a user with `cluster-admin` privileges.
+* You installed the the NFD Operator.
+* You have access to a mirror registry with the required images.
+* You installed the `skopeo` CLI tool.
+
+.Procedure
+
+. Determine the digest of the registry image:
+
+.. Run the following command:
++
+[source,terminal]
+----
+$ skopeo inspect docker://registry.redhat.io/openshift4/ose-node-feature-discovery:<openshift_version>
+----
++
+.Example command
+[source,terminal]
+----
+$ skopeo inspect docker://registry.redhat.io/openshift4/ose-node-feature-discovery:v4.12
+----
+
+.. Inspect the output to identify the image digest:
++
+.Example output
+[source,terminal]
+----
+{
+  ...
+  "Digest": "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+  ...
+}
+----
+
+. Use the `skopeo` CLI tool to copy the image from `registry.redhat.io` to your mirror registry, by running the following command:
++
+[source,terminal]
+----
+skopeo copy docker://registry.redhat.io/openshift4/ose-node-feature-discovery@<image_digest> docker://<mirror_registry>/openshift4/ose-node-feature-discovery@<image_digest>
+----
++
+.Example command
+[source,terminal]
+----
+skopeo copy docker://registry.redhat.io/openshift4/ose-node-feature-discovery@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef docker://<your-mirror-registry>/openshift4/ose-node-feature-discovery@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+----
+
+. Create a `NodeFeatureDiscovery` CR:
++
+.Example `NodeFeatureDiscovery` CR
+[source,yaml,subs="attributes+"]
+----
+apiVersion: nfd.openshift.io/v1
+kind: NodeFeatureDiscovery
+metadata:
+  name: nfd-instance
+spec:
+  operand:
+    image: <mirror_registry>/openshift4/ose-node-feature-discovery@<image_digest>
+    imagePullPolicy: Always
+  workerConfig:
+    configData: |
+      core:
+      #  labelWhiteList:
+      #  noPublish: false
+        sleepInterval: 60s
+      #  sources: [all]
+      #  klog:
+      #    addDirHeader: false
+      #    alsologtostderr: false
+      #    logBacktraceAt:
+      #    logtostderr: true
+      #    skipHeaders: false
+      #    stderrthreshold: 2
+      #    v: 0
+      #    vmodule:
+      ##   NOTE: the following options are not dynamically run-time configurable
+      ##         and require a nfd-worker restart to take effect after being changed
+      #    logDir:
+      #    logFile:
+      #    logFileMaxSize: 1800
+      #    skipLogHeaders: false
+      sources:
+        cpu:
+          cpuid:
+      #     NOTE: whitelist has priority over blacklist
+            attributeBlacklist:
+              - "BMI1"
+              - "BMI2"
+              - "CLMUL"
+              - "CMOV"
+              - "CX16"
+              - "ERMS"
+              - "F16C"
+              - "HTT"
+              - "LZCNT"
+              - "MMX"
+              - "MMXEXT"
+              - "NX"
+              - "POPCNT"
+              - "RDRAND"
+              - "RDSEED"
+              - "RDTSCP"
+              - "SGX"
+              - "SSE"
+              - "SSE2"
+              - "SSE3"
+              - "SSE4.1"
+              - "SSE4.2"
+              - "SSSE3"
+            attributeWhitelist:
+        kernel:
+          kconfigFile: "/path/to/kconfig"
+          configOpts:
+            - "NO_HZ"
+            - "X86"
+            - "DMI"
+        pci:
+          deviceClassWhitelist:
+            - "0200"
+            - "03"
+            - "12"
+          deviceLabelFields:
+            - "class"
+  customConfig:
+    configData: |
+          - name: "more.kernel.features"
+            matchOn:
+            - loadedKMod: ["example_kmod3"]
+----
+
+. Create the `NodeFeatureDiscovery` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----
+
+.Verification
+
+. Check the status of the `NodeFeatureDiscovery` CR by running the following command:
++
+[source,terminal]
+----
+$ oc get nodefeaturediscovery nfd-instance -o yaml
+----
+
+. Check that the pods are running without `ImagePullBackOff` errors by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n <nfd_namespace>
+----

--- a/modules/creating-nfd-cr-cli.adoc
+++ b/modules/creating-nfd-cr-cli.adoc
@@ -3,29 +3,23 @@
 // * hardware_enablement/psap-node-feature-discovery-operator.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="using-the-node-feature-discovery-operator_{context}"]
-= Using the Node Feature Discovery Operator
+[id="creating-nfd-cr-cli_{context}"]
+= Creating a NodeFeatureDiscovery CR by using the CLI
 
-The Node Feature Discovery (NFD) Operator orchestrates all resources needed to run the Node-Feature-Discovery daemon set by watching for a `NodeFeatureDiscovery` CR. Based on the `NodeFeatureDiscovery` CR, the Operator will create the operand (NFD) components in the desired namespace. You can edit the CR to choose another `namespace`, `image`, `imagePullPolicy`, and `nfd-worker-conf`, among other options.
-
-As a cluster administrator, you can create a `NodeFeatureDiscovery` instance using the {product-title} CLI or the web console.
-
-[id="create-cd-cli_{context}"]
-== Create a NodeFeatureDiscovery instance using the CLI
-
-As a cluster administrator, you can create a `NodeFeatureDiscovery` CR instance using the CLI.
+As a cluster administrator, you can create a `NodeFeatureDiscovery` CR instance by using the {oc-first}.
 
 .Prerequisites
 
-* An {product-title} cluster
-* Install the OpenShift CLI (`oc`).
-* Log in as a user with `cluster-admin` privileges.
-* Install the NFD Operator.
+* You have access to an {product-title} cluster
+* You installed the {oc-first}.
+* You logged in as a user with `cluster-admin` privileges.
+* You installed the the NFD Operator.
 
 .Procedure
 
-. Create the following `NodeFeatureDiscovery` Custom Resource (CR), and then save the YAML in the `NodeFeatureDiscovery.yaml` file:
+. Create a `NodeFeatureDiscovery` CR:
 +
+.Example `NodeFeatureDiscovery` CR
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: nfd.openshift.io/v1
@@ -110,18 +104,16 @@ spec:
             - loadedKMod: ["example_kmod3"]
 ----
 
-For more details on how to customize NFD workers, refer to the link:https://kubernetes-sigs.github.io/node-feature-discovery/v0.10/advanced/worker-configuration-reference.html[Configuration file reference of nfd-worker].
-
-. Create the `NodeFeatureDiscovery` CR instance by running the following command:
+. Create the `NodeFeatureDiscovery` CR by running the following command:
 +
 [source,terminal]
 ----
-$ oc create -f NodeFeatureDiscovery.yaml
+$ oc apply -f <filename>
 ----
 
 .Verification
 
-* To verify that the instance is created, run:
+. Check that the `NodeFeatureDiscovery` CR was created by running the following command:
 +
 [source,terminal]
 ----
@@ -141,14 +133,3 @@ nfd-worker-xqbws                          1/1     Running   0          60s
 ----
 +
 A successful deployment shows a `Running` status.
-
-[id="create-nfd-cr-web-console_{context}"]
-== Create a NodeFeatureDiscovery CR using the web console
-
-.Procedure
-
-. Navigate to the *Operators* -> *Installed Operators* page.
-. Find *Node Feature Discovery* and see a box under *Provided APIs*.
-. Click *Create instance*.
-. Edit the values of the `NodeFeatureDiscovery` CR.
-. Click *Create*.

--- a/modules/creating-nfd-cr-web-console.adoc
+++ b/modules/creating-nfd-cr-web-console.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/psap-node-feature-discovery-operator.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="creating-nfd-cr-web-console_{context}"]
+= Creating a NodeFeatureDiscovery CR by using the web console
+
+As a cluster administrator, you can create a `NodeFeatureDiscovery` CR by using the {product-title} web console.
+
+.Prerequisites
+
+* You have access to an {product-title} cluster
+* You logged in as a user with `cluster-admin` privileges.
+* You installed the the NFD Operator.
+
+.Procedure
+
+. Navigate to the *Operators* -> *Installed Operators* page.
+. In the *Node Feature Discovery* section, under *Provided APIs*, click *Create instance*.
+. Edit the values of the `NodeFeatureDiscovery` CR.
+. Click *Create*.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-6062

Link to docs preview:
https://78787--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/psap-node-feature-discovery-operator.html#psap-node-feature-discovery-operator-using-the-operator

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
The previous version of these docs contained 2 procedures inside one module file, so I have split these into 2 modules for CLI and web console, and added a third module for CLI in a disconnected env.
