### PR TITLE
OSDOCS#42796: Fixing the default value of macspoofchk

### DIFF
--- a/modules/virt-creating-linux-bridge-nad-cli.adoc
+++ b/modules/virt-creating-linux-bridge-nad-cli.adoc
@@ -37,7 +37,7 @@ spec:
     "name": "bridge-network", <3>
     "type": "cnv-bridge", <4>
     "bridge": "bridge-interface", <5>
-    "macspoofchk": true, <6>
+    "macspoofchk": false, <6>
     "vlan": 100, <7>
     "preserveDefaultVlan": false <8>
   }'
@@ -47,7 +47,7 @@ spec:
 <3> The name for the configuration. It is recommended to match the configuration name to the `name` value of the network attachment definition.
 <4> The actual name of the Container Network Interface (CNI) plugin that provides the network for this network attachment definition. Do not change this field unless you want to use a different CNI.
 <5> The name of the Linux bridge configured on the node.
-<6> Optional: Flag to enable MAC spoof check. When set to `true`, you cannot change the MAC address of the pod or guest interface. This attribute provides security against a MAC spoofing attack by allowing only a single MAC address to exit the pod.
+<6> Optional: A flag to enable the MAC spoof check. When set to `true`, you cannot change the MAC address of the pod or guest interface. This attribute allows only a single MAC address to exit the pod, which provides security against a MAC spoofing attack.
 <7> Optional: The VLAN tag. No additional VLAN configuration is required on the node network configuration policy.
 <8> Optional: Indicates whether the VM connects to the bridge through the default VLAN. The default value is `true`.
 +


### PR DESCRIPTION
Version(s):
4.15 and later, probably also 4.14

Issue:
https://issues.redhat.com/browse/CNV-42796

Link to docs preview:
https://78823--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-linux-bridge.html

QE review:
- [x] QE has approved this change.