### PR TITLE
[SRVKS-962] Add docs on setting timeouts for revisions

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -132,6 +132,8 @@ Topics:
     File: configuring-kourier
   - Name: Restrictive network policies
     File: restrictive-network-policies
+  - Name: Configuring revision timeouts
+    File: configuring-revision-timeouts
 - Name: Debugging OpenShift Serverless applications
   File: debugging-serverless-applications
 - Name: Kourier and Istio ingresses

--- a/knative-serving/config-applications/configuring-revision-timeouts.adoc
+++ b/knative-serving/config-applications/configuring-revision-timeouts.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="configuring-revision-timeouts"]
+= Configuring revision timeouts
+include::_attributes/common-attributes.adoc[]
+:context: configuring-revision-timeouts
+
+toc::[]
+
+You can configure timeout durations for revisions globally or individually to control the time spent on requests.
+
+include::modules/configuring-revision-timeout.adoc[leveloffset=+1]
+include::modules/configuring-maximum-revision-timeout.adoc[leveloffset=+1]

--- a/modules/configuring-maximum-revision-timeout.adoc
+++ b/modules/configuring-maximum-revision-timeout.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * knative-serving/config-applications/configuring-revision-timeouts.adoc
+:_content-type: PROCEDURE
+[id="configuring-maximum-revision-timeout_{context}"]
+= Configuring maximum revision timeout
+
+By seting the maximum revision timeout, you can ensure that no revision can exceed a specific limit.
+
+.Prerequisites
+
+* You have installed the {ServerlessOperatorName} and Knative Serving.
+* You have cluster administrator permissions on {ocp-product-title}, or cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
+
+.Procedure
+
+* To configure the maximum revision timeout, set the `max-revision-timeout-seconds` field in the `KnativeServing` custom resource (CR):
++
+[NOTE]
+----
+If this value is increased, the activator `terminationGracePeriodSeconds` should also be increased to prevent in-flight requests being disrupted.
+----
++
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+spec:
+  config:
+    defaults:
+      max-revision-timeout-seconds: "600"
+----

--- a/modules/configuring-revision-timeout.adoc
+++ b/modules/configuring-revision-timeout.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * knative-serving/config-applications/configuring-revision-timeouts.adoc
+:_content-type: PROCEDURE
+[id="configuring-revision-timeout_{context}"]
+= Configuring revision timeout
+
+You can configure the default number of seconds for the revision timeout based on the request.
+
+.Prerequisites
+
+* You have installed the {ServerlessOperatorName} and Knative Serving.
+* You have cluster administrator permissions on {ocp-product-title}, or cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
+
+.Procedure
+
+* Choose the appropriate method to configure the revision timeout:
+** To configure the revision timeout globally, set the `revision-timeout-seconds` field in the `KnativeServing` custom resource (CR):
++
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+spec:
+  config:
+    defaults:
+      revision-timeout-seconds: "300"
+----
++
+** To configure the timeout per revision by setting the `timeoutSeconds` field in your service definition:
++
+[source,yaml]
+----
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  namespace: my-ns
+spec:
+  template:
+    spec:
+      timeoutSeconds: 300
+      containers:
+      - image: ghcr.io/knative/helloworld-go:latest
+----


### PR DESCRIPTION
Version(s):
`serverless-docs-1.34`+

Issue:
https://issues.redhat.com/browse/SRVKS-962

Link to docs preview:
https://78824--ocpdocs-pr.netlify.app/openshift-serverless/latest/knative-serving/config-applications/configuring-revision-timeouts.html

QE review:
- [ ] QE has approved this change.