### PR TITLE
OSDOCS-11289: Additional fixes for module not rendering correctly

### DIFF
--- a/modules/mgmt-power-remediation-baremetal-about.adoc
+++ b/modules/mgmt-power-remediation-baremetal-about.adoc
@@ -5,6 +5,7 @@
 :_mod-docs-content-type: PROCEDURE
 [id="mgmt-power-remediation-baremetal-about_{context}"]
 = About power-based remediation of bare metal
+
 In a bare metal cluster, remediation of nodes is critical to ensuring the overall health of the cluster. Physically remediating a cluster can be challenging and any delay in putting the machine into a safe or an operational state increases the time the cluster remains in a degraded state, and the risk that subsequent failures might bring the cluster offline. Power-based remediation helps counter such challenges.
 
 Instead of reprovisioning the nodes, power-based remediation uses a power controller to power off an inoperable node. This type of remediation is also called power fencing.
@@ -17,7 +18,7 @@ Power-based remediation provides the following capabilities:
 * Reduces the risk of data loss in hyperconverged environments
 * Reduces the downtime associated with recovering physical machines
 
-[id="machine-health-checks-bare-metal_{context}"]
+[id="mgmt-power-remediation-baremetal-about-health-checks_{context}"]
 == MachineHealthChecks on bare metal
 
 Machine deletion on bare metal cluster triggers reprovisioning of a bare metal host.
@@ -32,7 +33,7 @@ There are two ways to change the default remediation process from machine deleti
 
 After using one of these methods, unhealthy machines are power-cycled by using Baseboard Management Controller (BMC) credentials.
 
-[id="mgmt-understanding-remediation-process_{context}"]
+[id="mgmt-power-remediation-baremetal-about-understanding-remediation-process_{context}"]
 == Understanding the annotation-based remediation process
 
 The remediation process operates as follows:
@@ -49,7 +50,7 @@ The remediation process operates as follows:
 If the power operations did not complete, the bare metal machine controller triggers the reprovisioning of the unhealthy node unless this is a control plane node or a node that was provisioned externally.
 ====
 
-[id="mgmt-understanding-metal3-remediation-process_{context}"]
+[id="mgmt-power-remediation-baremetal-about-understanding-metal3-remediation-process_{context}"]
 == Understanding the metal3-based remediation process
 
 The remediation process operates as follows:
@@ -66,7 +67,7 @@ The remediation process operates as follows:
 If the power operations did not complete, the metal3 remediation controller triggers the reprovisioning of the unhealthy node unless this is a control plane node or a node that was provisioned externally.
 ====
 
-[id="mgmt-creating-mhc-baremetal_{context}"]
+[id="mgmt-power-remediation-baremetal-about-creating-mhc-baremetal_{context}"]
 == Creating a MachineHealthCheck resource for bare metal
 
 .Prerequisites
@@ -76,9 +77,11 @@ If the power operations did not complete, the metal3 remediation controller trig
 * Network access to the BMC interface of the unhealthy node.
 
 .Procedure
-. Create a `healthcheck.yaml` file that contains the definition of your machine health check.
-. Apply the `healthcheck.yaml` file to your cluster using the following command:
 
+. Create a `healthcheck.yaml` file that contains the definition of your machine health check.
+
+. Apply the `healthcheck.yaml` file to your cluster using the following command:
++
 [source,terminal]
 ----
 $ oc apply -f healthcheck.yaml
@@ -110,7 +113,6 @@ spec:
   maxUnhealthy: "40%" <6>
   nodeStartupTimeout: "10m" <7>
 ----
-
 <1> Specify the name of the machine health check to deploy.
 <2> For bare metal clusters, you must include the `machine.openshift.io/remediation-strategy: external-baremetal` annotation in the `annotations` section to enable power-cycle remediation. With this remediation strategy, unhealthy hosts are rebooted instead of removed from the cluster.
 <3> Specify a label for the machine pool that you want to check.
@@ -170,7 +172,7 @@ spec:
 The `matchLabels` are examples only; you must map your machine groups based on your specific needs. The `annotations` section does not apply to metal3-based remediation. Annotation-based remediation and metal3-based remediation are mutually exclusive.
 ====
 
-["mgmt-troubleshooting-issue-power-remediation_{context}"]
+["mgmt-power-remediation-baremetal-about-troubleshooting_{context}"]
 == Troubleshooting issues with power-based remediation
 
 To troubleshoot an issue with power-based remediation, verify the following:


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-11289

Link to docs preview:
https://78827--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/deploying-machine-health-checks.html#troubleshooting-issues-with-power-based-remediation

QE review:
- Not required, docs formatting changes only

Additional information:
Following up from https://github.com/openshift/openshift-docs/pull/78777 - issue with red text persists
