### PR TITLE
Fixed some conditionals that were causing Asciidoc warnings.

### DIFF
--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -143,7 +143,12 @@ endif::openshift-rosa[]
 The following sections describe the IP address capacity for supported public cloud environments for use in your capacity calculation.
 
 [id="nw-egress-ips-capacity-aws_{context}"]
+ifndef::openshift-rosa[]
 === Amazon Web Services (AWS) IP address capacity limits
+endif::openshift-rosa[]
+ifdef::openshift-rosa[]
+== Amazon Web Services (AWS) IP address capacity limits
+endif::openshift-rosa[]
 
 On AWS, constraints on IP address assignments depend on the instance type configured. For more information, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI[IP addresses per network interface per instance type]
 


### PR DESCRIPTION
Version(s):
`enterprise-4.16+`

Link to docs preview:
- **[OCP, OpenShift SDN](https://78838--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/assigning-egress-ips.html#nw-egress-ips-public-cloud-platform-considerations_egress-ips)** untouched
- **[OCP, Networking](https://78838--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html#nw-egress-ips-public-cloud-platform-considerations_configuring-egress-ips-ovn)** untouched
- **[ROSA](https://78838--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html#nw-egress-ips-capacity-aws_configuring-egress-ips-ovn)**, elevated to a level 2 header

No QE review needed.

Additional information:
This PR adds conditionals around a header to display as a level 2 on ROSA while a level 3 on not ROSA.