### PR TITLE
OSDOCS-10919: adds 4.16.3 relnote to MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -210,3 +210,17 @@ Issued: 2024-07-09
 {product-title} release 4.16.2 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4318[RHBA-2024:4318] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4316[RHSA-2024:4316] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-16-3-dp_{context}"]
+=== RHBA-2024:4318 - {microshift-short} 4.16.3 bug fix and enhancement advisory
+
+Issued: 2024-07-16
+
+{product-title} release 4.16.3 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4471[RHBA-2024:4471] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4469[RHSA-2024:4469] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-16-3-bug-fixes_{context}"]
+==== Bug fixes
+
+* A mistake in validation allowed empty entries in the `listenAddress` configuration parameter. The empty entries prevented {microshift-short} from starting and rendered a difficult-to-understand error message. Empty entries in the list are now filtered.


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-10919](https://issues.redhat.com/browse/OSDOCS-10919)

Link to docs preview:
[4.16.3 release note](https://78844--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-3-dp_release-notes)

QE review:
- [x] QE has approved this change.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
