### PR TITLE
OSDOCS-11329: 4.16.3 RN

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3316,7 +3316,66 @@ This section will continue to be updated over time to provide notes on enhanceme
 ====
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
+//4.16.3
+[id="ocp-4-16-3_{context}"]
+=== RHSA-2024:4469 - {product-title} {product-version}.3 bug fix and security update
 
+Issued: 2024-07-16
+
+{product-title} release {product-version}.3, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:4469[RHSA-2024:4469] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:4472[RHBA-2024:4472] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.3 --pullspecs
+----
+
+[id="ocp-4-16-3-enhancements"]
+==== Enhancements
+
+The following enhancements are included in this z-stream release:
+
+[id="ocp-4-16-3-enhancements-azure-res-cap_{context}"]
+===== Configuring Capacity Reservation by using machine sets
+
+* {product-title} release {product-version}.3 introduces support for on-demand Capacity Reservation with Capacity Reservation groups on {azure-full} clusters.
+For more information, see _Configuring Capacity Reservation by using machine sets_ for xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#machineset-azure-capacity-reservation_creating-machineset-azure[compute] or xref:../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc#machineset-azure-capacity-reservation_cpmso-config-options-azure[control plane] machine sets. (link:https://issues.redhat.com/browse/OCPCLOUD-1646[*OCPCLOUD-1646*])
+
+[id="ocp-4-16-3-alternative-ingress-console-operator-API"]
+===== Adding alternative ingress for disabled ingress clusters
+
+* With this release, the console Operator configuration API can add alternative ingress to environments where the ingress cluster capability has been disabled. (link:https://issues.redhat.com/browse/OCPBUGS-33788[*OCPBUGS-33788*])
+
+[id="ocp-4-16-3-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, if `spec.grpcPodConfig.securityContextConfig` was not set for CatalogSource objects in namespaces with the PodSecurityAdmission "restricted" level enforced, the default securityContext was set as `restricted`. With this release, the OLM catalog operator configures the catalog pod with the securityContexts necessary to pass PSA validation and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-34979[*OCPBUGS-34979*])
+
+* Previously, the `HighOverallControlPlaneCPU` alert triggered warnings based on criteria for multi-node clusters with high availability. As a result, misleading alerts were triggered in {sno} clusters because the configuration did not match the environment criteria. This update refines the alert logic to use {sno}-specific queries and thresholds and account for workload partitioning settings. As a result, CPU utilization alerts in {sno} clusters are accurate and relevant to single-node configurations. (link:https://issues.redhat.com/browse/OCPBUGS-35831[*OCPBUGS-35831*])
+
+* Previously, the `--bind-address` to localhost caused the liveness test to fail for PowerVS clusters. With this release, the `--bind-address` to localhost is removed and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-35831[*OCPBUGS-36317*])
+
+* Previously, nodes that were booted using 4.1 and 4.2 boot images for {product-title} got stuck during provisioning because the `machine-config-daemon-firstboot.service` had incompatible machine-config-daemon binary code. With this release, the binary has been updated and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-36330[*OCPBUGS-36330*])
+
+* Previously, there was no access to the source registry when the `diskToMirror` action was performed on a fully disconnected environment. When using `oc-mirror v2` in `MirrorToDisk`, the catalog image and contents are stored under a subfolder under `working-dir` that corresponds to the digest of the image. Then, while using `DiskToMirror`, oc-mirror attempts to call the source registry to resolve the catalog image tag to a digest to find the corresponding subfolder on disk. With this release, `oc-mirror` interrogates the local cache during the `diskToMirror` process to determine this digest. (link:https://issues.redhat.com/browse/OCPBUGS-36386[*OCPBUGS-36386*])
+
+* Previously, if a new deployment was performed at the OSTree level on a host that was identical to the current deployment but on a different stateroot, the OSTree saw them as equal. This behavior incorrectly prevented the boot loader from updating when `set-default` was invoked, as OSTree did not recognize the two stateroots as a differentiation factor for deployments. With this release, OSTree's logic has been modified to consider the stateroots and allows OSTree to properly set the default deployment to a new deployment with different stateroots. (link:https://issues.redhat.com/browse/OCPBUGS-36386[*OCPBUGS-36386*])
+
+* Previously, Installer logs for AWS clusters contained unnecessary messages about the Elastic Kubernetes Service (EKS) that could lead to confusion. With this release, the EKS log lines are disabled and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-36447[*OCPBUGS-36447*])
+
+* Previously, a change of dependency targets was introduced in {product-title} 4.14 that prevented disconnected ARO installs from scaling up new nodes after they upgraded to affected versions. With this release, disconnected ARO installs can scale up new nodes after upgrading to {product-title} 4.16. (link:https://issues.redhat.com/browse/OCPBUGS-36536[*OCPBUGS-36536*])
+
+* Previously, connection refused on `port 9637` reported as _Target Down_ for Windows nodes because CRIO does not run on Windows nodes. With this release, Windows nodes are excluded from the Kubelet Service Monitor. (link:https://issues.redhat.com/browse/OCPBUGS-36717[*OCPBUGS-36717*])
+
+[id="ocp-4-16-3-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+//4.16.2
 [id="ocp-4-16-2_{context}"]
 === RHSA-2024:4316 - {product-title} {product-version}.2 bug fix and security update
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-11329

Link to docs preview:
https://78863--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-3_release-notes

QE review:
N/A

Additional information:
Errata URLs will return 404 until go-live (7/16)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
