### PR TITLE
Fixing syntax typo

### DIFF
--- a/modules/nw-controlling-dns-pod-placement.adoc
+++ b/modules/nw-controlling-dns-pod-placement.adoc
@@ -6,7 +6,7 @@
 [id="nw-controlling-dns-pod-placement_{context}"]
 = Controlling DNS pod placement
 
-The DNS Operator has two daemon sets: one for CoreDNS called `dns-default` and one for managing the `/etc/hosts` file `called node-resolver`.
+The DNS Operator has two daemon sets: one for CoreDNS called `dns-default` and one for managing the `/etc/hosts` file called `node-resolver`.
 
 You might find a need to control which nodes have CoreDNS pods assigned and running, although this is not a common operation. For example, if the cluster administrator has configured security policies that can prohibit communication between pairs of nodes, that would necessitate restricting the set of nodes on which the daemonset for CoreDNS runs. If DNS pods are running on some nodes in the cluster and the nodes where DNS pods are not running have network connectivity to nodes where DNS pods are running, DNS service will be available to all pods.
 


### PR DESCRIPTION
This typo was accidentally introduced in https://github.com/openshift/openshift-docs/commit/3214b39730dccc1d867ca60f680c8030463330fd#diff-c8eaf305d233830db1eb6ff27314ee8d4f01fcf309bd40b597a1a25be332b758R9

Version(s):
4.16+