### PR TITLE
[SRVCOM-2451] Log config docs for Serving and Eventing

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -419,6 +419,8 @@ Topics:
     File: serverless-tracing-open-telemetry
   - Name: Using Jaeger distributed tracing
     File: serverless-tracing-jaeger
+- Name: Configuring log settings for Serving and Eventing
+  File: serverless-config-log-settings
 ---
 # Integrations
 Name: Integrations

--- a/modules/serverless-config-log-settings-serving-eventing.adoc
+++ b/modules/serverless-config-log-settings-serving-eventing.adoc
@@ -1,0 +1,56 @@
+// Module included in the following assemblies:
+//
+// * serverless/observability/serverless-config-log-settings.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-config-log-settings-serving-eventing_{context}"]
+= Configuring log settings
+
+You can configure logging for Serving and Eventing in the `KnativeServing` custom resource (CR) and `KnativeEventing` CR.  
+
+.Procedure
+
+* Configure the log settings for Serving and Eventing by setting or modifying the `loglevel` value in the `KnativeServing` and `KnativeEventing` CR respectively. Here are two example configurations with all possible logging options set to level `info`:
++
+.KnativeServing CR
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+spec:
+  config:
+    logging:
+      loglevel.controller: "info"
+      loglevel.autoscaler: "info"
+      loglevel.queueproxy: "info"
+      loglevel.webhook: "info"
+      loglevel.activator: "info"
+      loglevel.hpaautoscaler: "info"
+      loglevel.net-certmanager-controller: "info"
+      loglevel.net-istio-controller: "info"
+      loglevel.net-kourier-controller: "info"
+----
++
+.KnativeEventing CR
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing
+spec:
+  config:
+    logging:
+      loglevel.controller: "info"
+      loglevel.eventing-webhook: "info"
+      loglevel.inmemorychannel-dispatcher: "info"
+      loglevel.inmemorychannel-webhook: "info"
+      loglevel.mt-broker-controller: "info"
+      loglevel.mt_broker_filter: "info"
+      loglevel.mt_broker_ingress: "info"
+      loglevel.pingsource-mt-adapter: "info"
+----

--- a/modules/serverless-config-log-supported-log-levels.adoc
+++ b/modules/serverless-config-log-supported-log-levels.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * serverless/observability/serverless-config-log-settings.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-config-log-supported-log-levels_{context}"]
+= Supported log levels
+
+The following `loglevel` values are supported:
+
+.Supported log levels
+[cols=2*,options="header"]
+|===
+|Log level
+|Description
+
+|`debug`
+|Fine-grained debugging
+
+|`info`
+|Normal logging
+
+|`warn`
+|Unexpected but non-critical errors
+
+|`error`
+|Critical errors; unexpected during normal operation
+
+
+|`dpanic` 
+|In debug mode, trigger a panic (crash)
+
+|===
+
+[WARNING]
+====
+Using the `debug` level for production might negatively affect performance.
+====

--- a/observability/serverless-config-log-settings.adoc
+++ b/observability/serverless-config-log-settings.adoc
@@ -1,0 +1,13 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="serverless-config-log-setting"]
+= Configuring log settings for Serving and Eventing
+:context: serverless-config-log-setting
+
+toc::[]
+
+You can configure logging for OpenShift Serverless Serving and OpenShift Serverless Eventing using the `KnativeServing` and `KnativeEventing` custom resource (CR). The level of logging is determined by the specified `loglevel` value.
+
+include::modules/serverless-config-log-supported-log-levels.adoc[leveloffset=+1]
+
+include::modules/serverless-config-log-settings-serving-eventing.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
serverless-docs-1.33+

Issue:
https://issues.redhat.com/browse/SRVCOM-2451

Link to docs preview:
https://78872--ocpdocs-pr.netlify.app/openshift-serverless/latest/observability/serverless-config-log-settings.html

QE review:
- [ ] QE has approved this change.
