### PR TITLE
[SRVCOM-2271] Update distributed tracing prerequisites

### DIFF
--- a/modules/serverless-open-telemetry.adoc
+++ b/modules/serverless-open-telemetry.adoc
@@ -11,7 +11,6 @@
 .Prerequisites
 
 * You have access to an {ocp-product-title} account with cluster administrator access.
-* You have not yet installed the {ServerlessOperatorName}, Knative Serving, and Knative Eventing. These must be installed after the {DTProductName} installation.
 * You have installed {DTProductName} by following the {ocp-product-title} "Installing distributed tracing" documentation.
 * You have installed the OpenShift CLI (`oc`).
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.


### PR DESCRIPTION
Version(s):
serverless-docs-1.33+

Issue:
https://issues.redhat.com/browse/SRVCOM-2271

Link to docs preview:
https://78875--ocpdocs-pr.netlify.app/openshift-serverless/latest/observability/tracing/serverless-tracing-open-telemetry.html

QE review:
- [x] QE has approved this change.
