### PR TITLE
[RHACS] ROX-11587:  Document additional example when an edge to internal entities appears on the Network Graph

### DIFF
--- a/modules/network-graph-20-view.adoc
+++ b/modules/network-graph-20-view.adoc
@@ -87,9 +87,9 @@ The following scenarios can lead to a connection being categorized as one involv
 * A deployment communicating with the orchestrator API
 * A deployment communicating using a networking CNI plugin, for example, Calico
 * A restart of Sensor, resulting in a reset of the mapping of IP addresses to past deployments, for example, when Sensor does not recognize the IP addresses of past entities or past IP addresses of existing entities
+* A connection that involves an entity not managed by the orchestrator (in some cases, that might be seen as _outside of the cluster_) but is using an IP address from the private address space as defined in RFC 1918
 
 Internal entities are indicated with an icon as shown in the following graphic. Clicking on *Internal entities* shows the flows for these entities.
 
 .Internal entities example
 image::network-graph-internal-entities.png[Network graph showing internal entities]
-


### PR DESCRIPTION
In this PR, I expand the list of examples that explain why the network graph may display an edge to 'Internal Entities'. 

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
- RHACS: Applies to all versions that show the 'Internal Entities' on the network graph, i.e., 4.4 and higher.

Issue:
- Customer reported bug that lead to discovering the discrepancy being documented here: [ROX-11587](https://issues.redhat.com/browse/ROX-11587)  

[Link to docs preview
](https://78876--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-network-policies.html#internal-entities-connections_manage-network-policies)

QE review: (**ACS has no QE, reviewed/ack'd by SME**)
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
