### PR TITLE
OSDOCS-10925: adds 4.14.33 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -576,3 +576,12 @@ Issued: 2024-07-11
 {product-title} release 4.14.32 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4331[RHBA-2024:4331] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4329[RHSA-2024:4329] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-14-33-dp_{context}"]
+=== RHBA-2024:4481 - {microshift-short} 4.14.33 bug fix and security update advisory
+
+Issued: 2024-07-17
+
+{product-title} release 4.14.33 is now available. The list of enhancements and bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4481[RHBA-2024:4481] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4479[RHSA-2024:4479] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-10925](https://issues.redhat.com/browse/OSDOCS-10925)

Link to docs preview:
[4.14.33 async relnote](https://78883--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes.html#microshift-4-14-33-dp_release-notes)

QE review:
- NA stock text.