### PR TITLE
cleaning up Cluster API terms in the 4.16 rel notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -1419,9 +1419,9 @@ This release introduces the ability to deploy to new {ibm-power-name} Virtual Se
 
 [discrete]
 [id="ocp-4-16-power-vs-capi_{context}"]
-=== {ibm-power-name} Virtual Verver cluster API updated to 0.8.0
+=== {ibm-power-name} Virtual Server updated to use {cap-ibm-first} 0.8.0
 
-With this release, the {ibm-power-name} VS CAPI has been updated to version 0.8.0.
+With this release, the {ibm-power-name} Virtual Server has been updated to use {cap-ibm-first} version 0.8.0.
 
 [discrete]
 [id="ocp-4-16-debug-guid_{context}"]
@@ -2205,7 +2205,7 @@ With this release, the issue has been fixed and upgrade times are reduced.
 
 * Previously, when the {ibm-power-server-name} platform had no Dynamic Host Configuration Protocol (DHCP) network name, the DHCP resource was not deleted. With this release, a check looks for any DHCP resources with an `ERROR` state and deletes them so that this issue no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-35224[*OCPBUGS-35224*])
 
-* Previously, when creating a {ibm-power-server-name} cluster on installer-provisioned infrastructure by using the Cluster API, the load balancer would become busy and stall. With this release, you can use the 'AddIPToLoadBalancerPool' command in a `PollUntilContextCancel` loop to restart the load balancer. (link:https://issues.redhat.com/browse/OCPBUGS-35088[*OCPBUGS-35088*])
+* Previously, when creating an {ibm-power-server-name} cluster on installer-provisioned infrastructure by using the Cluster API, the load balancer would become busy and stall. With this release, you can use the `AddIPToLoadBalancerPool` command in a `PollUntilContextCancel` loop to restart the load balancer. (link:https://issues.redhat.com/browse/OCPBUGS-35088[*OCPBUGS-35088*])
 
 * Previously, an installer-provisioned installation on a bare-metal platform with FIPS-enabled nodes caused installation failures. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-34985[*OCPBUGS-34985*])
 
@@ -3045,7 +3045,7 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |General Availability
 
-|CAPO integration into the cluster CAPI Operator
+|{rh-openstack} integration into the {cluster-capi-operator}
 |Not Available
 |Technology Preview
 |Technology Preview


### PR DESCRIPTION
Version(s):
4.16

Issue:
N/A

Link to docs preview:
* [IBM Power® Virtual Server updated to use Cluster API Provider IBM Cloud 0.8.0](https://78889--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-power-vs-capi_release-notes)
* [Red Hat OpenStack Platform (RHOSP) Technology Preview features](https://78889--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#red-hat-openstack-platform-rhosp-technology-preview-features)

QE review: 
(I think not needed)
- [ ] QE has approved this change.

Additional information: