### PR TITLE
OSDOCS-10292: Azure Capacity Reservation with MAPI Rel Notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3311,6 +3311,22 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+[id="ocp-4-16-3_{context}"]
+=== RHSA-2024:TBD - {product-title} {product-version}.3 bug fix and security update
+
+Issued: 2024-07-16
+
+[id="ocp-4-16-3-enhancements_{context}"]
+==== Enhancements
+
+The following enhancement is included in this z-stream release:
+
+[id="ocp-4-16-3-enhancements-azure-res-cap_{context}"]
+===== Configuring Capacity Reservation by using machine sets
+
+{product-title} release {product-version}.3 introduces support for on-demand Capacity Reservation with Capacity Reservation groups on {azure-full} clusters.
+For more information, see _Configuring Capacity Reservation by using machine sets_ for xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#machineset-azure-capacity-reservation_creating-machineset-azure[compute] or xref:../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc#machineset-azure-capacity-reservation_cpmso-config-options-azure[control plane] machine sets.
+
 [id="ocp-4-16-2_{context}"]
 === RHSA-2024:4316 - {product-title} {product-version}.2 bug fix and security update
 


### PR DESCRIPTION
**NOTE**
This PR is for change management process and the new feature text should be incorporated directly into the 4.16.3 RN PR

Preview: 
[Configuring Capacity Reservation by using machine sets](https://78900--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-3-enhancements-azure-res-cap_release-notes)

CC @cbippley 

Main docs: #78800 (links rely on this PR merging) for [OSDOCS-10292](https://issues.redhat.com//browse/OSDOCS-10292)