### PR TITLE
OSDOCS#11328: Removing unsupported versions of the descheduler operator

### DIFF
--- a/nodes/scheduling/descheduler/index.adoc
+++ b/nodes/scheduling/descheduler/index.adoc
@@ -8,6 +8,9 @@ toc::[]
 
 While the xref:../../../nodes/scheduling/nodes-scheduler-about.adoc#nodes-scheduler-about[scheduler] is used to determine the most suitable node to host a new pod, the descheduler can be used to evict a running pod so that the pod can be rescheduled onto a more suitable node.
 
+:operator-name: The {descheduler-operator}
+include::snippets/operator-not-available.adoc[]
+
 // About the descheduler
 include::modules/nodes-descheduler-about.adoc[leveloffset=+1]
 

--- a/nodes/scheduling/descheduler/nodes-descheduler-configuring.adoc
+++ b/nodes/scheduling/descheduler/nodes-descheduler-configuring.adoc
@@ -8,6 +8,9 @@ toc::[]
 
 You can run the descheduler in {product-title} by installing the {descheduler-operator} and setting the desired profiles and other customizations.
 
+:operator-name: The {descheduler-operator}
+include::snippets/operator-not-available.adoc[]
+
 // Installing the descheduler
 include::modules/nodes-descheduler-installing.adoc[leveloffset=+1]
 

--- a/nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
+++ b/nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
@@ -10,58 +10,7 @@ The {descheduler-operator} allows you to evict pods so that they can be reschedu
 
 These release notes track the development of the {descheduler-operator}.
 
+:operator-name: The {descheduler-operator}
+include::snippets/operator-not-available.adoc[]
+
 For more information, see xref:../../../nodes/scheduling/descheduler/index.adoc#nodes-descheduler-about_nodes-descheduler-about[About the descheduler].
-
-[id="descheduler-operator-release-notes-5.0.1"]
-== Release notes for {descheduler-operator} 5.0.1
-
-Issued: 2024-07-01
-
-The following advisory is available for the {descheduler-operator} 5.0.1:
-
-* link:https://access.redhat.com/errata/RHSA-2024:3617[RHSA-2024:3617]
-
-[id="descheduler-operator-5.0.1-notable-changes"]
-=== New features and enhancements
-
-* You can now install and use the {descheduler-operator} in an {product-title} cluster running in FIPS mode.
-+
---
-include::snippets/fips-snippet.adoc[]
---
-
-[id="descheduler-operator-5.0.1-bug-fixes"]
-=== Bug fixes
-
-* This release of the {descheduler-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
-
-// No known issues to list
-// [id="descheduler-operator-5.0.1-known-issues"]
-// === Known issues
-//
-// * TODO
-
-[id="descheduler-operator-release-notes-5.0.0"]
-== Release notes for {descheduler-operator} 5.0.0
-
-Issued: 2024-03-06
-
-The following advisory is available for the {descheduler-operator} 5.0.0:
-
-* link:https://access.redhat.com/errata/RHSA-2024:0302[RHSA-2024:0302]
-
-[id="descheduler-operator-5.0.0-notable-changes"]
-=== Notable changes
-
-* With this release, the {descheduler-operator} delivers updates independent of the {product-title} minor version release stream.
-
-[id="descheduler-operator-5.0.0-bug-fixes"]
-=== Bug fixes
-
-* Previously, the descheduler pod logs showed the following warning about the Operator's version: `failed to convert Descheduler minor version to float`. With this update, the warning is no longer shown. (link:https://issues.redhat.com/browse/OCPBUGS-14042[*OCPBUGS-14042*])
-
-// No known issues to list
-// [id="descheduler-operator-5.0.0-known-issues"]
-// === Known issues
-//
-// * TODO

--- a/nodes/scheduling/descheduler/nodes-descheduler-uninstalling.adoc
+++ b/nodes/scheduling/descheduler/nodes-descheduler-uninstalling.adoc
@@ -8,5 +8,8 @@ toc::[]
 
 You can remove the {descheduler-operator} from {product-title} by uninstalling the Operator and removing its related resources.
 
+:operator-name: The {descheduler-operator}
+include::snippets/operator-not-available.adoc[]
+
 // Uninstalling the descheduler
 include::modules/nodes-descheduler-uninstalling.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-11328

Link to docs preview:
https://78902--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/descheduler/index.html
https://78902--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/descheduler/nodes-descheduler-configuring.html
https://78902--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/descheduler/nodes-descheduler-release-notes.html
https://78902--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/descheduler/nodes-descheduler-uninstalling.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
