### PR TITLE
ROX-18614: add multi-tenancy guide

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -266,6 +266,8 @@ Topics:
     File: remove-admin-user
   - Name: Configuring short-lived access
     File: configure-short-lived-access
+  - Name: Understanding multi-tenancy
+    File: understanding-multi-tenancy
 - Name: Using the system health dashboard
   File: use-system-health-dashboard
 - Name: Using the administration events page

--- a/operating/manage-user-access/understanding-multi-tenancy.adoc
+++ b/operating/manage-user-access/understanding-multi-tenancy.adoc
@@ -1,0 +1,96 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="understanding-multi-tenancy"]
+= Understanding multi-tenancy
+include::modules/common-attributes.adoc[]
+:context: understanding-multi-tenancy
+
+toc::[]
+
+[role="_abstract"]
+
+{product-title} provides ways to implement multi-tenancy within a Central instance.
+
+You can implement multi-tenancy by using role-based access control (RBAC) and access scopes within {product-title-short}.
+
+[id="understanding-resource-scoping"]
+== Understanding resource scoping
+
+{product-title-short} includes resources which are used within RBAC.
+In addition to associating permissions for a resource, each resource is also scoped.
+
+In {product-title-short}, resources are scoped as the following types:
+
+* Global scope, where a resource is not assigned to any cluster or namespace
+* Cluster scope, where a resource is assigned to particular clusters
+* Namespace scope, where a resource is assigned to particular namespaces
+
+The scope of resources is important when creating custom access scopes.
+Custom access scopes are used to create multi-tenancy within {product-title-short}.
+
+Only resources which are cluster or namespace scoped are applicable for scoping in access scopes. Globally scoped resources are not scoped by access scopes.
+Therefore, multi-tenancy within {product-title-short} can only be achieved for resources that are scoped either by cluster or namespace.
+
+[id="multi-tenancy-per-namespace-config-example"]
+== Multi-tenancy per namespace configuration example
+
+A common example for multi-tenancy within {product-title-short} is associating users with a specific namespace and only allowing them access to their specific namespace.
+
+The following example combines a custom permission set, access scope, and role. The user or group assigned with this role can only see CVE information, violations, and information about deployments in the particular namespace or cluster scoped to them.
+
+.Procedure
+
+. In the {product-title-short} portal, select *Platform Configuration* -> *Access Control*.
+. Select *Permission Sets*.
+. Click *Create permission set*.
+. Enter a *Name* and *Description* for the permission set.
+. Select the following resources and access level and click *Save*:
+** `READ` Alert
+** `READ` Deployment
+** `READ` DeploymentExtension
+** `READ` Image
+** `READ` K8sRole
+** `READ` K8sRoleBinding
+** `READ` K8sSubject
+** `READ` NetworkGraph
+** `READ` NetworkPolicy
+** `READ` Secret
+** `READ` ServiceAccount
+. Select *Access Scopes*.
+. Click *Create access scope*.
+. Enter a *Name* and *Description* for the access scope.
+. In the *Allowed resources* section, select the namespace you want to use for scoping and click *Save*.
+. Select *Roles*.
+. Click *Create role*.
+. Enter a *Name* and *Description* for the role.
+. Select the previously created *Permission Set* and *Access scope* for the role and click *Save*.
+. Assign the role to your required user or group. See xref:../../operating/manage-user-access/manage-role-based-access-control-3630.adoc#assign-role-to-user-or-group_manage-role-based-access-control[Assigning a role to a user or a group].
+
+[NOTE]
+====
+The {product-title-short} dashboard options for users with the sample role are minimal compared to options available to an administrator.
+Only relevant pages are visible for the user.
+====
+
+[id="mutli-tenancy-limitations"]
+== Limitations
+
+Achieving multi-tenancy within {product-title-short} is not possible for resources with a *global scope*.
+
+The following resources have a global scope:
+
+* Access
+* Administration
+* Detection
+* Integration
+* VulnerabilityManagementApprovals
+* VulnerabilityManagementRequests
+* WatchedImage
+* WorkflowAdministration
+
+These resources are shared across all users within a {product-title-short} Central instance and cannot be scoped.
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../operating/manage-user-access/manage-role-based-access-control-3630.adoc#create-a-custom-permission-set_manage-role-based-access-control[Creating a custom permission set]
+* xref:../../operating/manage-user-access/manage-role-based-access-control-3630.adoc#create-a-custom-access-scope_manage-role-based-access-control[Create a custom access scope]
+* xref:../../operating/manage-user-access/manage-role-based-access-control-3630.adoc#create-a-custom-role-3630_manage-role-based-access-control[Create a custom role]


### PR DESCRIPTION
Version(s):
Latest RHACS (4.5/6)

Issue:
[ROX-18614](https://issues.redhat.com/browse/ROX-18614)

Link to docs preview:
https://78917--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-user-access/understanding-multi-tenancy.html

Additional information:
A quick guide with an example of how to setup multi-tenancy within ACS, as well as information about scoping of resources to better understand the current configuration and its limitations.
