### PR TITLE
[SRVCOM-3134] Update API version for connecting-channel-sinks

### DIFF
--- a/modules/serverless-creating-subscriptions-yaml.adoc
+++ b/modules/serverless-creating-subscriptions-yaml.adoc
@@ -21,14 +21,14 @@ After you have created a channel and an event sink, you can create a subscriptio
 +
 [source,yaml]
 ----
-apiVersion: messaging.knative.dev/v1beta1
+apiVersion: messaging.knative.dev/v1
 kind: Subscription
 metadata:
   name: my-subscription <1>
   namespace: default
 spec:
   channel: <2>
-    apiVersion: messaging.knative.dev/v1beta1
+    apiVersion: messaging.knative.dev/v1
     kind: Channel
     name: example-channel
   delivery: <3>


### PR DESCRIPTION
Version(s):
serverless-docs-1.33+

Issue:
https://issues.redhat.com/browse/SRVCOM-3134

Link to docs preview:
https://78923--ocpdocs-pr.netlify.app/openshift-serverless/latest/eventing/channels/connecting-channels-sinks.html

QE review:
- [x] QE has approved this change.