### PR TITLE
OBSDOCS-1102

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2734,6 +2734,8 @@ Topics:
         File: log6x-about
       - Name: Configuring LokiStack storage
         File: log6x-loki
+      - Name: Log output types
+        File: log6x-output
       - Name: Configuring log forwarding
         File: log6x-clf
       - Name: Visualization for logging

--- a/modules/log6x-configuring-otlp-output.adoc
+++ b/modules/log6x-configuring-otlp-output.adoc
@@ -1,0 +1,63 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/logging-6.0/log6x-clf.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="log6x-configuring-otlp-output_{context}"]
+= Configuring OTLP output
+
+The OpenTelemetry Protocol (OTLP) output allows the cluster administrator to collect and forward logs to OTLP receivers. The OTLP output sends data over HTTP using JSON encoding by adhering to the https://opentelemetry.io/docs/specs/otlp/[OpenTelemetry Observability Framework].
+
+:FeatureName: The OTLP output log forwarder
+include::snippets/technology-preview.adoc[]
+
+.Prerequisites
+
+* You must have a `serviceAccount` in the same namespace in which you create the `ClusterLogForwarder`. Additionally, for this `ClusterLogForwarder` you must have the `collect-audit-logs`, `collect-application-logs`, and `collect-infrastructure-logs` cluster roles. For more information see link:https://docs.openshift.com/container-platform/4.16/observability/logging/log_collection_forwarding/log-forwarding.html#log-collection-rbac-permissions_log-forwarding[Authorizing log collection RBAC permissions].
+
+.Procedure
+
+* To enable OTLP, create or edit the `ClusterLogForwarder` CR using the template below:
++
+////
+.Example ClusterLogForwarder CR
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  annotations:
+    observability.openshift.io/tech-preview-otlp-output: "enabled"
+  name: clf-otlp
+spec:
+  serviceAccount:
+    name: <service_account_name>
+  outputs:
+  - name: otlp
+    type: otlp
+    otlp:
+      tuning:
+        compression: gzip 
+        delivery: atLeastOnce
+        maxRetryDuration: 20
+        maxWrite: 10M
+        minRetryDuration: 5
+      url: <otlp-url>
+  pipelines:
+  - inputRefs:
+    - application
+    - infrastructure
+    - audit
+    name: otlp-logs
+    outputRefs:
+    - otlp
+  serviceAccount:
+    name: logging-otlp
+----
+////
+
+[NOTE]
+====
+The OTLP output uses the OpenTelemetry data model, which is different from other log output formats. The OTLP output does not send ViaQ logs. Instead, it adheres to the https://opentelemetry.io/docs/specs/semconv/[OpenTelemetry Semantic Conventions] and https://opentelemetry.io/docs/specs/otel/logs/data-model/[Logs Data Model].
+====
+

--- a/modules/log6x-supported-log-outputs.adoc
+++ b/modules/log6x-supported-log-outputs.adoc
@@ -1,0 +1,97 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/logging-6.0/log6x-output.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="log6x-supported-log-outputs_{context}"]
+= Supported log forwarding outputs
+
+Outputs can be any of the following types:
+
+.Supported log output types
+[cols="5",options="header"]
+|===
+|Output type
+|Protocol
+|Tested with
+|Logging versions
+|Supported collector type
+
+|Elasticsearch v6
+|HTTP 1.1
+|6.8.1, 6.8.23
+|5.6+
+|Fluentd, Vector
+
+|Elasticsearch v7
+|HTTP 1.1
+|7.12.2, 7.17.7, 7.10.1
+|5.6+
+|Fluentd, Vector
+
+|Elasticsearch v8
+|HTTP 1.1
+|8.4.3, 8.6.1
+|5.6+
+|Fluentd ^[1]^, Vector
+
+|Fluent Forward
+|Fluentd forward v1
+|Fluentd 1.14.6, Logstash 7.10.1, Fluentd 1.14.5
+|5.4+
+|Fluentd
+
+|Google Cloud Logging
+|REST over HTTPS
+|Latest
+|5.7+
+|Vector
+
+|HTTP
+|HTTP 1.1
+|Fluentd 1.14.6, Vector 0.21
+|5.7+
+|Fluentd, Vector
+
+|Kafka
+|Kafka 0.11
+|Kafka 2.4.1, 2.7.0, 3.3.1
+|5.4+
+|Fluentd, Vector
+
+|Loki
+|REST over HTTP and HTTPS
+|2.3.0, 2.5.0, 2.7, 2.2.1
+|5.4+
+|Fluentd, Vector
+
+|Splunk
+|HEC
+|8.2.9, 9.0.0
+|5.7+
+|Vector
+
+|Syslog
+|RFC3164, RFC5424
+|Rsyslog 8.37.0-9.el7, rsyslog-8.39.0
+|5.4+
+|Fluentd, Vector ^[2]^
+
+|Amazon CloudWatch
+|REST over HTTPS
+|Latest
+|5.4+
+|Fluentd, Vector
+
+|OTLP
+|HTTP using JSON encoding
+|Latest
+|6.0
+|Vector
+|===
+[.small]
+--
+. Fluentd does not support Elasticsearch 8 in the {logging} version 5.6.2 and older versions.
+. Vector supports Syslog in the {logging} version 5.7 and higher.
+. OTLP output log forwarder is a Technology Preview feature only.
+--

--- a/observability/logging/logging-6.0/log6x-clf.adoc
+++ b/observability/logging/logging-6.0/log6x-clf.adoc
@@ -5,3 +5,13 @@ include::_attributes/common-attributes.adoc[]
 :context: logging-6x
 
 toc::[]
+
+The `ClusterLogForwarder` CR serves as a single point of configuration for log forwarding, making it easier to manage and maintain log collection and forwarding rules.
+
+* Defines inputs (sources) for log collection
+* Specifies outputs (destinations) for log forwarding
+* Configures filters for log processing
+* Defines pipelines to route logs from inputs to outputs
+* Indicates management state (managed or unmanaged)
+
+include::modules/log6x-configuring-otlp-output.adoc[leveloffset=+1]

--- a/observability/logging/logging-6.0/log6x-output.adoc
+++ b/observability/logging/logging-6.0/log6x-output.adoc
@@ -1,0 +1,30 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="log6x-output-types"]
+= Log output types
+:context: logging-output-types
+
+toc::[]
+
+Outputs define the destination where logs are sent to from a log forwarder. You can configure multiple types of outputs in the `ClusterLogForwarder` custom resource (CR) to send logs to servers that support different protocols.
+
+include::modules/log6x-supported-log-outputs.adoc[leveloffset=+1]
+
+[id="log6x-output-types-descriptions"]
+== Output type descriptions
+
+`loki`:: Loki, a horizontally scalable, highly available, multi-tenant log aggregation system.
+`kafka`:: A Kafka broker. The `kafka` output can use a TCP or TLS connection.
+`elasticsearch`:: An external Elasticsearch instance. The `elasticsearch` output can use a TLS connection.
+`fluentdForward`:: An external log aggregation solution that supports Fluentd. This option uses the Fluentd `forward` protocols. The `fluentForward` output can use a TCP or TLS connection and supports shared-key authentication by providing a `shared_key` field in a secret. Shared-key authentication can be used with or without TLS.
++
+[IMPORTANT]
+====
+The `fluentdForward` output is only supported if you are using the Fluentd collector. It is not supported if you are using the Vector collector. If you are using the Vector collector, you can forward logs to Fluentd by using the `http` output.
+====
++
+`syslog`:: An external log aggregation solution that supports the syslog link:https://tools.ietf.org/html/rfc3164[RFC3164] or link:https://tools.ietf.org/html/rfc5424[RFC5424] protocols. The `syslog` output can use a UDP, TCP, or TLS connection.
+`cloudwatch`:: Amazon CloudWatch, a monitoring and log storage service hosted by Amazon Web Services (AWS).
+`cloudlogging`:: Google Cloud Logging, a monitoring and log storage service hosted by Google Cloud Platform (GCP).
+`otlp`:: OpenTelemetry Protocol (OTLP) describes the protocol for encoding, transporting, and delivering telemetry data between sources using the https://opentelemetry.io/docs/specs/otlp/[OTLP Specification].
+


### PR DESCRIPTION
[OBSDOCS-1102](https://issues.redhat.com/browse/OBSDOCS-1102): Document Enabling OpenTelemetry in Cluster Logging Operator

Aligned team: Observability
OCP version for cherry-picking: 
JIRA issues: [OBSDOCS-1102](https://issues.redhat.com/browse/OBSDOCS-1102)
Preview pages: [Configuring OTLP output](https://78924--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.0/log6x-clf.html#configuring-otlp-output_logging-6x), [Log output types](https://78924--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.0/log6x-output)
SME review **requested**: @cahartma 
QE review **requested**:  @anpingli 
Peer review **requested**: 

**Note:** As discussed with docs team, this PR content will be integrated in larger PR: https://github.com/openshift/openshift-docs/pull/80999/files, so this PR is not intended to merge.