### PR TITLE
OADP-1443 - updated dpa for oadp 1.2 and 1.3 for volume snapshot credential

### DIFF
--- a/modules/oadp-installing-dpa-1-2-and-earlier.adoc
+++ b/modules/oadp-installing-dpa-1-2-and-earlier.adoc
@@ -61,35 +61,39 @@ spec:
   configuration:
     velero:
       defaultPlugins:
-        - openshift <1>
+        - openshift # <1>
         - aws
-      resourceTimeout: 10m <2>
+      resourceTimeout: 10m # <2>
     restic:
-      enable: true <3>
+      enable: true # <3>
       podConfig:
-        nodeSelector: <node_selector> <4>
+        nodeSelector: <node_selector> # <4>
   backupLocations:
     - name: default
       velero:
         provider: {provider}
         default: true
         objectStorage:
-          bucket: <bucket_name> <5>
-          prefix: <prefix> <6>
+          bucket: <bucket_name> # <5>
+          prefix: <prefix> # <6>
         config:
           region: <region>
           profile: "default"
-          s3ForcePathStyle: "true" <7>
-          s3Url: <s3_url> <8>
+          s3ForcePathStyle: "true" # <7>
+          s3Url: <s3_url> # <8>
         credential:
           key: cloud
-          name: {credentials} <9>
-  snapshotLocations: <10>
+          name: {credentials} # <9>
+  snapshotLocations: # <10>
     - velero:
         provider: {provider}
         config:
-          region: <region> <11>
+          region: <region> # <11>
           profile: "default"
+        credential:
+          key: cloud
+          name: {credentials} # <12>
+          
 ----
 <1> The `openshift` plugin is mandatory.
 <2> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.
@@ -102,6 +106,7 @@ spec:
 <9> Specify the name of the `Secret` object that you created. If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
 <10> Specify a snapshot location, unless you use CSI snapshots or Restic to back up PVs.
 <11> The snapshot location must be in the same region as the PVs.
+<12> Specify the name of the `Secret` object that you created. If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the snapshot location. If your backup and snapshot locations use different credentials, create separate profiles in the `credentials-velero` file.
 endif::[]
 ifdef::installing-oadp-azure[]
 +
@@ -117,28 +122,28 @@ spec:
     velero:
       defaultPlugins:
         - azure
-        - openshift <1>
-      resourceTimeout: 10m <2>
+        - openshift # <1>
+      resourceTimeout: 10m # <2>
     restic:
-      enable: true <3>
+      enable: true # <3>
       podConfig:
-        nodeSelector: <node_selector> <4>
+        nodeSelector: <node_selector> # <4>
   backupLocations:
     - velero:
         config:
-          resourceGroup: <azure_resource_group> <5>
-          storageAccount: <azure_storage_account_id> <6>
-          subscriptionId: <azure_subscription_id> <7>
+          resourceGroup: <azure_resource_group> # <5>
+          storageAccount: <azure_storage_account_id> # <6>
+          subscriptionId: <azure_subscription_id> # <7>
           storageAccountKeyEnvVar: AZURE_STORAGE_ACCOUNT_ACCESS_KEY
         credential:
           key: cloud
-          name: {credentials}  <8>
+          name: {credentials}  # <8>
         provider: {provider}
         default: true
         objectStorage:
-          bucket: <bucket_name> <9>
-          prefix: <prefix> <10>
-  snapshotLocations: <11>
+          bucket: <bucket_name> # <9>
+          prefix: <prefix> # <10>
+  snapshotLocations: # <11>
     - velero:
         config:
           resourceGroup: <azure_resource_group>
@@ -146,6 +151,9 @@ spec:
           incremental: "true"
         name: default
         provider: {provider}
+        credential:
+          key: cloud
+          name: {credentials} # <12>
 ----
 <1> The `openshift` plugin is mandatory.
 <2> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.
@@ -158,6 +166,7 @@ spec:
 <9> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
 <10> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
 <11> You do not need to specify a snapshot location if you use CSI snapshots or Restic to back up PVs.
+<12> Specify the name of the `Secret` object that you created. If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
 endif::[]
 ifdef::installing-oadp-gcp[]
 +
@@ -173,29 +182,32 @@ spec:
     velero:
       defaultPlugins:
         - gcp
-        - openshift <1>
-      resourceTimeout: 10m <2>
+        - openshift # <1>
+      resourceTimeout: 10m # <2>
     restic:
-      enable: true <3>
+      enable: true # <3>
       podConfig:
-        nodeSelector: <node_selector> <4>
+        nodeSelector: <node_selector> # <4>
   backupLocations:
     - velero:
         provider: {provider}
         default: true
         credential:
-          key: cloud <5>
-          name: {credentials} <6>
+          key: cloud # <5>
+          name: {credentials} # <6>
         objectStorage:
-          bucket: <bucket_name> <7>
-          prefix: <prefix> <8>
-  snapshotLocations: <9>
+          bucket: <bucket_name> # <7>
+          prefix: <prefix> # <8>
+  snapshotLocations: # <9>
     - velero:
         provider: {provider}
         default: true
         config:
           project: <project>
-          snapshotLocation: us-west1 <10>
+          snapshotLocation: us-west1 # <10>
+        credential:
+          key: cloud
+          name: {credentials} # <11>
 ----
 <1> The `openshift` plugin is mandatory.
 <2> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.
@@ -207,6 +219,7 @@ spec:
 <8> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
 <9> Specify a snapshot location, unless you use CSI snapshots or Restic to back up PVs.
 <10> The snapshot location must be in the same region as the PVs.
+<11> Specify the name of the `Secret` object that you created. If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the snapshot location.
 endif::[]
 ifdef::installing-oadp-mcg[]
 +
@@ -222,28 +235,28 @@ spec:
     velero:
       defaultPlugins:
         - aws
-        - openshift <1>
-      resourceTimeout: 10m <2>
+        - openshift # <1>
+      resourceTimeout: 10m # <2>
     restic:
-      enable: true <3>
+      enable: true # <3>
       podConfig:
-        nodeSelector: <node_selector> <4>
+        nodeSelector: <node_selector> # <4>
   backupLocations:
     - velero:
         config:
           profile: "default"
           region: minio
-          s3Url: <url> <5>
+          s3Url: <url> # <5>
           insecureSkipTLSVerify: "true"
           s3ForcePathStyle: "true"
         provider: {provider}
         default: true
         credential:
           key: cloud
-          name: {credentials} <6>
+          name: {credentials} # <6>
         objectStorage:
-          bucket: <bucket_name> <7>
-          prefix: <prefix> <8>
+          bucket: <bucket_name> # <7>
+          prefix: <prefix> # <8>
 ----
 <1> The `openshift` plugin is mandatory.
 <2> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.
@@ -267,25 +280,25 @@ spec:
   configuration:
     velero:
       defaultPlugins:
-        - kubevirt <1>
-        - gcp <2>
-        - csi <3>
-        - openshift <4>
-      resourceTimeout: 10m <5>
+        - kubevirt # <1>
+        - gcp # <2>
+        - csi # <3>
+        - openshift # <4>
+      resourceTimeout: 10m # <5>
     restic:
-      enable: true <6>
+      enable: true # <6>
       podConfig:
-        nodeSelector: <node_selector> <7>
+        nodeSelector: <node_selector> # <7>
   backupLocations:
     - velero:
-        provider: {provider} <8>
+        provider: {provider} # <8>
         default: true
         credential:
           key: cloud
-          name: <default_secret> <9>
+          name: <default_secret> # <9>
         objectStorage:
-          bucket: <bucket_name> <10>
-          prefix: <prefix> <11>
+          bucket: <bucket_name> # <10>
+          prefix: <prefix> # <11>
 ----
 <1> Optional: The `kubevirt` plugin is used with {VirtProductName}.
 <2> Specify the default plugin for the backup provider, for example, `gcp`, if appropriate.

--- a/modules/oadp-installing-dpa-1-3.adoc
+++ b/modules/oadp-installing-dpa-1-3.adoc
@@ -51,42 +51,45 @@ apiVersion: oadp.openshift.io/v1alpha1
 kind: DataProtectionApplication
 metadata:
   name: <dpa_sample>
-  namespace: openshift-adp <1>
+  namespace: openshift-adp # <1>
 spec:
   configuration:
     velero:
       defaultPlugins:
-        - openshift <2>
+        - openshift # <2>
         - aws
-      resourceTimeout: 10m <3>
-    nodeAgent: <4>
-      enable: true <5>
-      uploaderType: kopia <6>
+      resourceTimeout: 10m # <3>
+    nodeAgent: # <4>
+      enable: true # <5>
+      uploaderType: kopia # <6>
       podConfig:
-        nodeSelector: <node_selector> <7>
+        nodeSelector: <node_selector> # <7>
   backupLocations:
     - name: default
       velero:
         provider: {provider}
         default: true
         objectStorage:
-          bucket: <bucket_name> <8>
-          prefix: <prefix> <9>
+          bucket: <bucket_name> # <8>
+          prefix: <prefix> # <9>
         config:
           region: <region>
           profile: "default"
-          s3ForcePathStyle: "true" <10>
-          s3Url: <s3_url> <11>
+          s3ForcePathStyle: "true" # <10>
+          s3Url: <s3_url> # <11>
         credential:
           key: cloud
-          name: {credentials} <12>
-  snapshotLocations: <13>
+          name: {credentials} # <12>
+  snapshotLocations: # <13>
     - name: default
       velero:
         provider: {provider}
         config:
-          region: <region> <14>
+          region: <region> # <14>
           profile: "default"
+        credential:
+          key: cloud
+          name: {credentials} # <15>
 ----
 <1> The default namespace for OADP is `openshift-adp`. The namespace is a variable and is configurable.
 <2> The `openshift` plugin is mandatory.
@@ -102,6 +105,7 @@ spec:
 <12> Specify the name of the `Secret` object that you created. If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
 <13> Specify a snapshot location, unless you use CSI snapshots or a File System Backup (FSB) to back up PVs.
 <14> The snapshot location must be in the same region as the PVs.
+<15> Specify the name of the `Secret` object that you created. If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the snapshot location. If your backup and snapshot locations use different credentials, create separate profiles in the `credentials-velero` file.
 endif::[]
 
 ifdef::installing-oadp-azure[]
@@ -112,35 +116,35 @@ apiVersion: oadp.openshift.io/v1alpha1
 kind: DataProtectionApplication
 metadata:
   name: <dpa_sample>
-  namespace: openshift-adp <1>
+  namespace: openshift-adp # <1>
 spec:
   configuration:
     velero:
       defaultPlugins:
         - azure
-        - openshift <2>
-      resourceTimeout: 10m <3>
-    nodeAgent: <4>
-      enable: true <5>
-      uploaderType: kopia <6>
+        - openshift # <2>
+      resourceTimeout: 10m # <3>
+    nodeAgent: # <4>
+      enable: true # <5>
+      uploaderType: kopia # <6>
       podConfig:
-        nodeSelector: <node_selector> <7>
+        nodeSelector: <node_selector> # <7>
   backupLocations:
     - velero:
         config:
-          resourceGroup: <azure_resource_group> <8>
-          storageAccount: <azure_storage_account_id> <9>
-          subscriptionId: <azure_subscription_id> <10>
+          resourceGroup: <azure_resource_group> # <8>
+          storageAccount: <azure_storage_account_id> # <9>
+          subscriptionId: <azure_subscription_id> # <10>
           storageAccountKeyEnvVar: AZURE_STORAGE_ACCOUNT_ACCESS_KEY
         credential:
           key: cloud
-          name: {credentials}  <11>
+          name: {credentials}  # <11>
         provider: {provider}
         default: true
         objectStorage:
-          bucket: <bucket_name> <12>
-          prefix: <prefix> <13>
-  snapshotLocations: <14>
+          bucket: <bucket_name> # <12>
+          prefix: <prefix> # <13>
+  snapshotLocations: # <14>
     - velero:
         config:
           resourceGroup: <azure_resource_group>
@@ -148,6 +152,9 @@ spec:
           incremental: "true"
         name: default
         provider: {provider}
+        credential:
+          key: cloud
+          name: {credentials} # <15>
 ----
 <1> The default namespace for OADP is `openshift-adp`. The namespace is a variable and is configurable.
 <2> The `openshift` plugin is mandatory.
@@ -163,6 +170,7 @@ spec:
 <12> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
 <13> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
 <14> You do not need to specify a snapshot location if you use CSI snapshots or Restic to back up PVs.
+<15> Specify the name of the `Secret` object that you created. If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
 endif::[]
 
 ifdef::installing-oadp-gcp[]
@@ -173,37 +181,40 @@ apiVersion: oadp.openshift.io/v1alpha1
 kind: DataProtectionApplication
 metadata:
   name: <dpa_sample>
-  namespace: <OPERATOR_INSTALL_NS> <1>
+  namespace: <OPERATOR_INSTALL_NS> # <1>
 spec:
   configuration:
     velero:
       defaultPlugins:
         - gcp
-        - openshift <2>
-      resourceTimeout: 10m <3>
-    nodeAgent: <4>
-      enable: true <5>
-      uploaderType: kopia <6>
+        - openshift # <2>
+      resourceTimeout: 10m # <3>
+    nodeAgent: # <4>
+      enable: true # <5>
+      uploaderType: kopia # <6>
       podConfig:
-        nodeSelector: <node_selector> <7>
+        nodeSelector: <node_selector> # <7>
   backupLocations:
     - velero:
         provider: {provider}
         default: true
         credential:
-          key: cloud <8>
-          name: {credentials} <9>
+          key: cloud # <8>
+          name: {credentials} # <9>
         objectStorage:
-          bucket: <bucket_name> <10>
-          prefix: <prefix> <11>
-  snapshotLocations: <12>
+          bucket: <bucket_name> # <10>
+          prefix: <prefix> # <11>
+  snapshotLocations: # <12>
     - velero:
         provider: {provider}
         default: true
         config:
           project: <project>
-          snapshotLocation: us-west1 <13>
-  backupImages: true <14>
+          snapshotLocation: us-west1 # <13>
+        credential:
+          key: cloud
+          name: {credentials} # <14>
+  backupImages: true # <15>
 ----
 <1> The default namespace for OADP is `openshift-adp`. The namespace is a variable and is configurable.
 <2> The `openshift` plugin is mandatory.
@@ -218,7 +229,8 @@ spec:
 <11> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
 <12> Specify a snapshot location, unless you use CSI snapshots or Restic to back up PVs.
 <13> The snapshot location must be in the same region as the PVs.
-<14> Google workload identity federation supports internal image backup. Set this field to `false` if you do not want to use image backup.
+<14> Specify the name of the `Secret` object that you created. If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
+<15> Google workload identity federation supports internal image backup. Set this field to `false` if you do not want to use image backup.
 endif::[]
 
 ifdef::installing-oadp-mcg[]
@@ -229,35 +241,35 @@ apiVersion: oadp.openshift.io/v1alpha1
 kind: DataProtectionApplication
 metadata:
   name: <dpa_sample>
-  namespace: openshift-adp <1>
+  namespace: openshift-adp # <1>
 spec:
   configuration:
     velero:
       defaultPlugins:
         - aws
-        - openshift <2>
-      resourceTimeout: 10m <3>
-    nodeAgent: <4>
-      enable: true <5>
-      uploaderType: kopia <6>
+        - openshift # <2>
+      resourceTimeout: 10m # <3>
+    nodeAgent: # <4>
+      enable: true # <5>
+      uploaderType: kopia # <6>
       podConfig:
-        nodeSelector: <node_selector> <7>
+        nodeSelector: <node_selector> # <7>
   backupLocations:
     - velero:
         config:
           profile: "default"
           region: minio
-          s3Url: <url> <8>
+          s3Url: <url> # <8>
           insecureSkipTLSVerify: "true"
           s3ForcePathStyle: "true"
         provider: {provider}
         default: true
         credential:
           key: cloud
-          name: {credentials} <9>
+          name: {credentials} # <9>
         objectStorage:
-          bucket: <bucket_name> <10>
-          prefix: <prefix> <11>
+          bucket: <bucket_name> # <10>
+          prefix: <prefix> # <11>
 ----
 <1> The default namespace for OADP is `openshift-adp`. The namespace is a variable and is configurable.
 <2> The `openshift` plugin is mandatory.
@@ -280,31 +292,31 @@ apiVersion: oadp.openshift.io/v1alpha1
 kind: DataProtectionApplication
 metadata:
   name: <dpa_sample>
-  namespace: openshift-adp <1>
+  namespace: openshift-adp # <1>
 spec:
   configuration:
     velero:
       defaultPlugins:
-        - kubevirt <2>
-        - gcp <3>
-        - csi <4>
-        - openshift <5>
-      resourceTimeout: 10m <6>
-    nodeAgent: <7>
-      enable: true <8>
-      uploaderType: kopia <9>
+        - kubevirt # <2>
+        - gcp # <3>
+        - csi # <4>
+        - openshift # <5>
+      resourceTimeout: 10m # <6>
+    nodeAgent: # <7>
+      enable: true # <8>
+      uploaderType: kopia # <9>
       podConfig:
-        nodeSelector: <node_selector> <10>
+        nodeSelector: <node_selector> # <10>
   backupLocations:
     - velero:
-        provider: {provider} <11>
+        provider: {provider} # <11>
         default: true
         credential:
           key: cloud
-          name: <default_secret> <12>
+          name: <default_secret> # <12>
         objectStorage:
-          bucket: <bucket_name> <13>
-          prefix: <prefix> <14>
+          bucket: <bucket_name> # <13>
+          prefix: <prefix> # <14>
 ----
 <1> The default namespace for OADP is `openshift-adp`. The namespace is a variable and is configurable.
 <2> Optional: The `kubevirt` plugin is used with {VirtProductName}.
@@ -330,31 +342,31 @@ apiVersion: oadp.openshift.io/v1alpha1
 kind: DataProtectionApplication
 metadata:
   name: <dpa_sample>
-  namespace: openshift-adp <1>
+  namespace: openshift-adp # <1>
 spec:
   configuration:
     velero:
       defaultPlugins:
-        - kubevirt <2>
-        - gcp <3>
-        - csi <4>
-        - openshift <5>
-      resourceTimeout: 10m <6>
-    nodeAgent: <7>
-      enable: true <8>
-      uploaderType: kopia <9>
+        - kubevirt # <2>
+        - gcp # <3>
+        - csi # <4>
+        - openshift # <5>
+      resourceTimeout: 10m # <6>
+    nodeAgent: # <7>
+      enable: true # <8>
+      uploaderType: kopia # <9>
       podConfig:
-        nodeSelector: <node_selector> <10>
+        nodeSelector: <node_selector> # <10>
   backupLocations:
     - velero:
-        provider: {provider} <11>
+        provider: {provider} # <11>
         default: true
         credential:
           key: cloud
-          name: <default_secret> <12>
+          name: <default_secret> # <12>
         objectStorage:
-          bucket: <bucket_name> <13>
-          prefix: <prefix> <14>
+          bucket: <bucket_name> # <13>
+          prefix: <prefix> # <14>
 ----
 <1> The default namespace for OADP is `openshift-adp`. The namespace is a variable and is configurable.
 <2> The `kubevirt` plugin is mandatory for {VirtProductName}.


### PR DESCRIPTION
## Jira 

* [OADP-1443](https://issues.redhat.com/browse/OADP-1443)

Updated dpa for oadp 1.2 and 1.3 for volume snapshot credential. 
* Have not included volume snapshot credential for MCG, ODF, or Virt. Could you please check if this is correct? 
Commented out the callouts as per doc guidelines.

##  Version

* OCP 4.12 → OCP 4.17

## Preview

* [Installing DPA 1.2 on AWS](https://78934--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html#oadp-installing-dpa-1-2-and-earlier_installing-oadp-aws)

* [Installing DPA 1.3 on AWS](https://78934--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html#oadp-installing-dpa-1-3_installing-oadp-aws)

* [Installing DPA 1.2 on Azure](https://78934--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.html#oadp-installing-dpa-1-2-and-earlier_installing-oadp-azure)

* [Installing DPA 1.3 on Azure](https://78934--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.html#oadp-installing-dpa-1-3_installing-oadp-azure)

* [Installing DPA 1.2 on GCP](https://78934--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.html#oadp-installing-dpa-1-2-and-earlier_installing-oadp-gcp)

* [Installing DPA 1.3 on GCP](https://78934--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.html#oadp-installing-dpa-1-3_installing-oadp-gcp)


## QE Review

* [ X] QE has approved this change.

