### PR TITLE
OCPBUG 19873: Created Cri-O default capabilities section

### DIFF
--- a/modules/checking-mco-node-status.adoc
+++ b/modules/checking-mco-node-status.adoc
@@ -71,7 +71,7 @@ ip-10-0-74-108.ec2.internal   True      False            False            False 
 $ oc describe machineconfignode/<node_name> <1>
 ----
 <1> The name of the node is the `MachineConfigNode` object name.
-+
+
 .Example output
 [source,text]
 ----

--- a/modules/create-crio-default-capabilities.adoc
+++ b/modules/create-crio-default-capabilities.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/machine-configuration-tasks.adoc
+
+
+:_mod-docs-content-type: PROCEDURE
+[id="create-crio-default-capabilities_{context}"]
+= Creating a drop-in file for CRI-O's default capabilities
+
+
+You can change some of the settings associated with the {product-title} CRI-O runtime for the nodes associated with a specific machine config pool (MCP). Using a controller custom resource (CR), you set the configuration values and add a label to match the MCP. The MCO then rebuilds the `crio.conf` and `default.conf` configuration files on the associated nodes with the updated values.
+
+Machine Configs that once were a default in older {product-title} versions have not been removed by updating to newer {product-title} versions which do not include these Machine Configs as default. In order to ensure that clusters running on the same {product-title} version have the same default Machine Configs included.
+
+You can create multiple `ContainerRuntimeConfig` CRs, as needed, with a limit of 10 per cluster. For the first `ContainerRuntimeConfig` CR, the MCO creates a machine config appended with `containerruntime`. With each subsequent CR, the controller creates a new `containerruntime` machine config with a numeric suffix. For example, if you have a `containerruntime` machine config with a `-2` suffix, the next `containerruntime` machine config is appended with `-3`.
+
+If you want to delete the machine configs, you should delete them in reverse order to avoid exceeding the limit. For example, you should delete the `containerruntime-3` machine config before deleting the `containerruntime-2` machine config.
+
+[NOTE]
+====
+If you have a machine config with a `containerruntime-9` suffix, and you create another `ContainerRuntimeConfig` CR, a new machine config is not created, even if there are fewer than 10 `containerruntime` machine configs.
+====
+
+.Example showing multiple `ContainerRuntimeConfig` CRs
+[source,terminal]
+----
+$ oc get ctrcfg
+----
+
+.Example output
+[source,terminal]
+----
+NAME         AGE
+ctr-overlay  15m
+ctr-level    5m45s
+----
+
+.Example showing multiple containerruntime related system configs
+[source,terminal]
+----
+$ cat /proc/1/status | grep Cap
+$ capsh --decode=<decode_CapBnd_value>
+----

--- a/post_installation_configuration/machine-configuration-tasks.adoc
+++ b/post_installation_configuration/machine-configuration-tasks.adoc
@@ -85,5 +85,4 @@ Besides managing `MachineConfig` objects, the MCO manages two custom resources (
 include::modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc[leveloffset=+2]
 include::modules/create-a-containerruntimeconfig-crd.adoc[leveloffset=+2]
 include::modules/set-the-default-max-container-root-partition-size-for-overlay-with-crio.adoc[leveloffset=+2]
-
-
+include::modules/create-crio-default-capabilities.adoc[leveloffset=+2]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13-4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUG 19873](https://issues.redhat.com/browse/OCPBUGS-19873)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
