### PR TITLE
OSDOCS-10292: 4.17 and future versioning

### DIFF
--- a/modules/machineset-azure-capacity-reservation.adoc
+++ b/modules/machineset-azure-capacity-reservation.adoc
@@ -11,9 +11,8 @@ endif::[]
 [id="machineset-azure-capacity-reservation_{context}"]
 = Configuring Capacity Reservation by using machine sets
 
-//Note: This is in 4.16.3, and might be backported through 4.14.z at a later date.
-//Earlier versions of OCP should get an update .z version here. OCP 4.17 docs should use {product-version}.
-{product-title} version 4.16.3 and later supports on-demand Capacity Reservation with Capacity Reservation groups on {azure-full} clusters.
+//If backported to earlier versions, must replace {product-version} with the correct .z
+{product-title} version {product-version} and later supports on-demand Capacity Reservation with Capacity Reservation groups on {azure-full} clusters.
 
 You can configure a machine set to deploy machines on any available resources that match the parameters of a capacity request that you define.
 These parameters specify the VM size, region, and number of instances that you want to reserve.


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OSDOCS-10292](https://issues.redhat.com//browse/OSDOCS-10292)

Link to docs preview:
* [Configuring Capacity Reservation by using machine sets](https://78954--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure.html#machineset-azure-capacity-reservation_creating-machineset-azure) (compute)
* [Configuring Capacity Reservation by using machine sets](https://78954--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.html#machineset-azure-capacity-reservation_cpmso-config-options-azure) (control plane)

QE review:
N/A

Additional information:
This initially went in for a 4.16 backport, but 4.17+ should use `{product-version}`