### PR TITLE
OSDOCS-10292: 4.17 rel notes

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -465,6 +465,12 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 [id="ocp-4-17-machine-management_{context}"]
 === Machine management
 
+[id="ocp-4-17-enhancements-azure-res-cap_{context}"]
+==== Configuring Capacity Reservation by using machine sets
+
+{product-title} release {product-version} introduces support for on-demand Capacity Reservation with Capacity Reservation groups on {azure-full} clusters.
+For more information, see _Configuring Capacity Reservation by using machine sets_ for xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#machineset-azure-capacity-reservation_creating-machineset-azure[compute] or xref:../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc#machineset-azure-capacity-reservation_cpmso-config-options-azure[control plane] machine sets.
+
 [id="ocp-4-17-nodes_{context}"]
 === Nodes
 


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-10292](https://issues.redhat.com//browse/OSDOCS-10292)

Link to docs preview:
[Configuring Capacity Reservation by using machine sets](https://78955--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-enhancements-azure-res-cap_release-notes)

QE review:
- [x] QE has approved this change.

Additional information: