### PR TITLE
OADP-4517: Adding Performance Section to OADP docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3384,6 +3384,8 @@ Topics:
   - Name: OADP performance
     Dir: oadp-performance
     Topics:
+    - Name: OADP 1.4 performance
+      File: oadp-1-4-performance
     - Name: OADP recommended network settings
       File: oadp-recommended-network-settings
   - Name: OADP features and plugins

--- a/backup_and_restore/application_backup_and_restore/oadp-performance/modules
+++ b/backup_and_restore/application_backup_and_restore/oadp-performance/modules
@@ -1,1 +1,1 @@
-../../modules/
+../../../modules

--- a/backup_and_restore/application_backup_and_restore/oadp-performance/oadp-1-4-performance.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-performance/oadp-1-4-performance.adoc
@@ -1,0 +1,19 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="oadp-1-4-performance"]
+= {oadp-short} 1.4 performance and use cases
+include::_attributes/common-attributes.adoc[]
+:context: oadp-performance-1-4
+
+toc::[]
+
+The objective of this performance testing was to run regression test cases for backup and restore performance of {oadp-first} 1.4 using File System Backup (FSB) and  Container Storage Interface (CSI).
+
+The majority of CSI and FSB flows showed comparable performance with the previous {oadp-short} 1.3, including the Velero built-in DataMover. In the majority of cases tested, the main performance-related difference for this release was related to FSB flows, which showed a significant improvement in the duration of results compared to {oadp-short} versions 1.3.
+
+include::modules/oadp-1-4-data-utilization.adoc[leveloffset=+1]
+
+include::modules/oadp-1-4-transfer-rate.adoc[leveloffset=+1]
+
+include::modules/oadp-1-4-0-performance.adoc[leveloffset=+1]
+
+include::modules/oadp-1-4-1-performance.adoc[leveloffset=+1]

--- a/modules/oadp-1-4-0-performance.adoc
+++ b/modules/oadp-1-4-0-performance.adoc
@@ -1,0 +1,1016 @@
+// This module is included in the following assembly:
+//
+// * backup_and_restore/application_backup_and_restore/oadp-performance/oadp-1-4-performance.adoc
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-1-4-0-performance_{context}"]
+= {oadp-short} 1.4.0 scale and performance
+
+
+[width="100%",cols="20%,55%,25%",options="header",]
+|===
+|Test
+|Result
+|Performance as a percentage
+
+.2+|Restore a namespace with 33K secrets
+| Restore without the `+update+` flag took 11 minutes compared to 55 minutes when using {oadp-short} 1.3.0.
+| 80% performance improvement
+
+| Restore with the `+update+` flag took 6 minutes compared to 28 minutes when using {oadp-short} 1.3.0.
+|78.57% performance improvement
+
+|Backup using File System Backup (FSB) of 4 s logical unit number (LUN) of which, 3 TB is used as data on CephRBD storage class.footnote:[Application backed up with Kopia as File System Backup (FSB)]
+|The backup took 37 minutes and 4 seconds compared to 2 hours 22 minutes and 12 seconds on {oadp-short} 1.3.1.
+|76.20% performance improvement
+
+.2+|Backup using FSB of a single namespace with 5000 pods, including 499MB amount of data per pod.
+| The backup took 4:28:11 compared to 14 hours 13 minutes and 33 seconds on {oadp-short} 1.3.1.
+| 68.51% performance improvement
+
+| The restore took 2 hours 23 minutes and 50 seconds compared to 5 hours 32 minutes and 03 seconds on {oadp-short} 1.3.1.
+|56.70% performance improvement
+
+|Backup using FSB of a single namespace with 1000 pods, including 499 MB of data per pod.
+|The backup took 18 minutes and 42 seconds compared to 1 hour 11 minutes and 39 seconds on {oadp-short} 1.3.0.
+|73.92% performance improvement
+GB
+|Backup using FSB of a single namespace with 2000 pods, including 499 MB of data per pod.
+|The backup took 36 minutes and 43 seconds compared to 3 hours 5 minutes and 28 seconds on {oadp-short} 1.3.1.
+|80.21% performance improvement
+
+|Restore using Data Mover on a single namespace with 100 pods, including 2 GB of data per pod.
+|The restore took 10 minutes and 24 minutes compared to 29 minutes and 27 seconds on {oadp-short} 1.3.0.
+|64.66% performance improvement
+
+|Backup using FSB using a single namespace with one file sized 1 TB using duplicate data (dd).
+|The backup took 17 minutes and 51 seconds compared to 46 minutes and 07 seconds on {oadp-short} 1.3.1.
+|61.3% performance improvement
+
+|Restore using FSB of a single namespace with 100 files, each sized 10GB.
+|The restore took 51 minutes and 17 seconds compared to 13 minutes 53 minutes on {oadp-short} 1.3.1.
+|269.34% performance degredation footnote:[This performance degredation is possibly related to file size and count. While the new Kopia version shows improvements in other cases with smaller file sizes, there is observable degradation with larger files compared to previous {oadp-short} versions 1.3.0 to 1.3.1.]
+
+|===
+
+[id="oadp-1-4-0-performance-test-cases_{context}"]
+== {oadp-short} 1.4.0 performance test cases
+
+[width="100%",cols="7%,7%,7%,7%,7%,7%,7%,7%,7%,7%,8%,8%,8%,8%,8%",options="header",]
+|===
+|
+|Action
+|Storage
+|Version
+|Duration
+|Version
+|Duration
+|Version
+|Duration
+|Bucket
+|Velero spec limits
+|node-agent spec limits
+|File System Backup (Kopia or Restic) Timeout
+|{oadp-short} version
+|{odf-short} version
+
+|Kopia
+|Backup
+|Ceph-RBD
+|1.4.0
+|0:20:12
+|1.3.1-54
+|0:20:33
+|1.3.0-152
+|0:36:15
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Restore
+|Ceph-RBD
+|1.4.0
+|1:10:30
+|1.3.1-54
+|1:03:08
+|1.3.0-152
+|1:15:18
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Container Storage Interface (CSI)
+|Backup
+|Ceph-FS
+|1.4.0
+|0:00:07
+|1.3.1-54
+|0:00:12
+|1.3.0-117
+|0:00:12
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|CSI
+|Restore
+|Ceph-FS
+|1.4.0
+|FAILED
+|1.3.1-54
+|0:00:19
+|1.3.0-117
+|0:00:19
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Backup
+|Ceph-RBD
+|1.4.0
+|0:34:18
+|1.3.1-54
+|0:41:34
+|1.3.0-156
+|1:10:26
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.16.0
+|4.15.3
+
+|Kopia
+|Restore
+|Ceph-RBD
+|1.4.0
+|2:44:33
+|1.3.1-54
+|2:32:51
+|1.3.0-156
+|2:50:55
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.16.0
+|4.15.3
+
+|Kopia
+|Backup
+|Ceph-FS
+|1.4.0
+|0:33:48
+|1.3.1-54
+|2:22:12
+|1.3.0-156
+|1:01:11
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.16.0
+|4.15.3
+
+|Kopia
+|Restore
+|Ceph-FS
+|1.4.0
+|FAILED
+|1.3.1-54
+|2:38:57
+|1.3.0-156
+|2:57:42
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.16.0
+|4.15.3
+
+|Kopia
+|Backup
+|Ceph-RBD
+|1.4.0
+|0:42:23
+|1.3.1-54
+|0:41:34
+|1.3.0-156
+|1:10:26
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Restore
+|Ceph-RBD
+|1.4.0
+|FAILED
+|1.3.1-54
+|2:32:51
+|1.3.0-156
+|2:50:55
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Backup
+|Ceph-FS
+|1.4.0
+|0:37:04
+|1.3.1-54
+|2:22:12
+|1.3.0-156
+|1:01:11
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Restore
+|Ceph-FS
+|1.4.0
+|2:28:22
+|1.3.1-54
+|2:38:57
+|1.3.0-156
+|2:57:42
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Backup
+|Ceph-RBD
+|1.4.0
+|0:17:51
+|1.3.1-54
+|0:46:07
+|1.3.0-147
+|0:40:21
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Restore
+|Ceph-RBD
+|1.4.0
+|1:45:52
+|1.3.1-54
+|1:45:30
+|1.3.0-147
+|1:31:54
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Backup
+|Ceph-RBD
+|1.4.0
+|0:13:29
+|1.3.1-54
+|0:15:02
+|1.3.0-117
+|0:17:24
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Restore
+|Ceph-RBD
+|1.4.0
+|0:50:35
+|1.3.1-54
+|0:13:53
+|1.3.0-117
+|0:18:51
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Data Mover
+|Backup
+|Ceph-RBD
+|1.4.0
+|0:08:49
+|1.3.1-54
+|0:09:10
+|1.3.0-117
+|0:10:05
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Data Mover
+|Restore
+|Ceph-RBD
+|1.4.0
+|0:10:24
+|1.3.1-54
+|0:28:51
+|1.3.0-117
+|0:29:27
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Data Mover
+|Backup
+|Ceph-FS
+|1.4.0
+|0:23:18
+|1.3.1-54
+|
+|1.3.0-117
+|0:38:01
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Data Mover
+|Restore
+|Ceph-FS
+|1.4.0
+|0:24:25
+|1.3.1-54
+|N/A
+|1.3.0-117
+|0:30:32
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Data Mover
+|Backup
+|Ceph-RBD
+|1.4.0
+|0:08:12
+|1.3.1-54
+|0:08:17
+|1.3.0-117
+|0:15:03
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Data Mover
+|Restore
+|Ceph-RBD
+|1.4.0
+|0:19:27
+|1.3.1-54
+|0:15:05
+|1.3.0-117
+|0:21:15
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|CSI
+|Backup
+|Ceph-RBD
+|1.4.0
+|0:11:07
+|1.3.1-54
+|0:09:03
+|1.3.0-156
+|0:09:11
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|CSI
+|Restore
+|Ceph-RBD
+|1.4.0
+|0:03:36
+|1.3.1-54
+|0:02:47
+|1.3.0-156
+|0:02:41
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Backup
+|Ceph-RBD
+|1.4.0
+|0:03:08
+|1.3.1-59
+|0:04:28
+|1.3.0-156
+|0:04:38
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Restore
+|Ceph-RBD
+|1.4.0
+|0:03:37
+|1.3.1-59
+|0:11:13
+|1.3.0-156
+|0:11:21
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Backup
+|Ceph-FS
+|1.4.0
+|0:01:56
+|N/A
+|N/A
+|N/A
+|N/A
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Restore
+|Ceph-FS
+|1.4.0
+|0:02:53
+|N/A
+|N/A
+|N/A
+|N/A
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+
+|CSI
+|Backup
+|Ceph-RBD
+|1.4.0
+|9:17:14
+|1.3.1-59
+|9:40:17
+|1.3.1-42
+|9:57:11
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.16.0
+|4.15.3
+
+|CSI
+|Restore
+|Ceph-RBD
+|1.4.0
+|1:25:28
+|1.3.1-59
+|2:07:58
+|1.3.1-42
+|FAIL
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.16.0
+|4.15.3
+
+|Kopia
+|Backup
+|Ceph-RBD
+|1.4.0
+|4:28:11
+|1.3.1-59
+|14:13:33
+|N/A
+|N/A
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.16.0
+|4.15.3
+
+|Kopia
+|Restore
+|Ceph-RBD
+|1.4.0
+|2:23:50
+|1.3.1-59
+|5:32:03
+|N/A |N/A
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.16.0
+|4.15.3
+
+|CSI
+|Backup
+|Ceph-FS
+|1.4.0
+|1:38:07
+|1.3.1-59
+|1:35:21
+|1.3.1-54
+|1:33:58
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.16.0
+|4.15.3
+
+|CSI
+|Restore
+|Ceph-FS
+|1.4.0
+|FAILED
+|1.3.1-59
+|0:22:20
+|1.3.1-54
+|0:25:49
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.16.0
+|4.15.3
+
+|Kopia
+|Backup
+|Ceph-FS
+|1.4.0
+|0:18:42
+|1.3.1-59
+|1:05:59
+|1.3.0-156
+|1:11:39
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.16.0
+|4.15.3
+
+|Kopia
+|Restore
+|Ceph-FS
+|1.4.0
+|0:27:28
+|1.3.1-59
+|0:31:16
+|1.3.0-156
+|0:39:20
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|CSI
+|Backup
+|Ceph-RBD
+|1.4.0
+|1:37:59
+|1.3.1-59
+|1:34:00
+|1.3.0-156
+|1:52:10
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|CSI
+|Restore
+|Ceph-RBD
+|1.4.0
+|0:26:59
+|1.3.1-59
+|0:22:23
+|1.3.0-156
+|0:42:06
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|CSI
+|Backup
+|Ceph-RBD
+|1.4.0
+|3:22:25
+|
+|
+|
+|
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|CSI
+|Restore
+|Ceph-RBD
+|1.4.0
+|0:54:06
+|
+|
+|
+|
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Backup
+|Ceph-RBD
+|1.4.0
+|0:16:22
+|1.3.1-59
+|1:02:19
+|1.3.0-156
+|1:05:51
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Restore
+|Ceph-RBD
+|1.4.0
+|0:24:50
+|1.3.1-59
+|0:46:02
+|1.3.0-156
+|0:42:29
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Backup
+|Ceph-RBD
+|1.4.0
+|0:38:12
+|1.3.1-59
+|3:05:28
+|1.3.0-156
+|2:58:52
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Restore
+|Ceph-RBD
+|1.4.0
+|0:57:31
+|1.3.1-59
+|1:45:46
+|1.3.0-156
+|2:56:53
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Backup
+|Ceph-RBD
+|1.4.0
+|0:36:43
+|1.3.1-59
+|3:05:28
+|1.3.0-156
+|2:58:52
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Restore
+|Ceph-RBD
+|1.4.0
+|0:56:28
+|1.3.1-59
+|1:45:46
+|1.3.0-156
+|2:56:53
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Backup
+|Ceph-RBD
+|1.4.0
+|0:16:35
+|1.3.1-59
+|3:05:28
+|1.3.0-156
+|2:58:52
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Restore
+|Ceph-RBD
+|1.4.0
+|0:19:03
+|1.3.1-59
+|1:45:46
+|1.3.0-156
+|2:56:53
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Backup
+|Ceph-RBD
+|1.4.0
+|0:00:38
+|1.3.1-59
+|
+|1.3.0-156
+|0:00:24
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Restore
+|Ceph-RBD
+|1.4.0
+|
+restore: 0:11:11 +
+restore+update flag: 0:05:45
+|1.3.1-59
+|
+|1.3.0-156
+|
+restore: 0:55:28 +
+restore+update flag: 0:27:59
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Backup
+|Ceph-RBD
+|1.4.0
+|0:13:59
+|
+|
+|
+|
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+
+|Kopia
+|Restore
+|Ceph-RBD
+|1.4.0
+|0:01:31
+|
+|
+|
+|
+|MinIO-PVC
+|No limits
+|
+CPU:20 +
+Memory: 32GB
+|900m
+|4.15.11
+|4.15.3
+|===

--- a/modules/oadp-1-4-1-performance.adoc
+++ b/modules/oadp-1-4-1-performance.adoc
@@ -1,0 +1,115 @@
+// This module is included in the following assembly:
+//
+// * backup_and_restore/application_backup_and_restore/oadp-performance/oadp-1-4-performance.adoc
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-1-4-1-performance_{context}"]
+= {oadp-short} 1.4.1 scale and performance
+
+The objective of this testing was to run regression tests for backup and restore of {oadp-first} using CSI, File System Backup (FSB) using Kopia, native DataMover, and incremental backup using DataMover.
+
+Also tested was FSB with Kopia using the new feature of setting the Kopia algorithm in the Data Protection Application (DPA). (hashing, encryption, and splitter). An alternative hashing algorithm could provide an improvement of up to 10%
+
+Other test cases show the same results as {oadp-short} 1.4.0.
+
+[NOTE]
+====
+All testing was conducted on bare metal OpenShift clusters operating within the RDU2 scale laboratory, with isolated hardware, networking, and storage.
+====
+
+.Changing the Kopia Algorithm: up to 10% improvement
+
+The implementation of a new hashing value, BLAKE3-256-128, in place of the default Kopia algorithm configuration results in an enhancement of backup results of up to 10%.
+
+.33k secret (ACM) matches improved results from {oadp-short} 1.4.0   
+
+Restore a namespace with 33K secrets. The restore ran, both with and without the `--existing-resource-policy update` flag. The results show a major improvement in both cases compared to {oadp-short} 1.3.0 and the same results as {oadp-short} 1.4.0
+
+.Filesystem restore using Kopia of a single namespace with 100 files, each sized 10 GB
+
+Filesystem restore using Kopia of a single namespace with 100 files, each sized 10 GB. This flow requires requests and limits for the `ephemeral-storage` configuration (DPA), see link:https://issues.redhat.com/browse/OADP-4855[OADP-4855], is found, and as a workaround, NodeAgent pods are restarted to clean the cache.
+
+[NOTE]
+====
+The issue of Kopia leaving the cache on the worker node is scheduled to be resolved in {oadp-short} 1.5.0.
+====
+
+.DataMover
+
+DataMover backup shows the same results as {oadp-short} 1.3.0 and 1.3.1. DataMover restore shows the same results as {oadp-short} 1.3.0 and similar slowness regarding {oadp-short} 1.3.1:
+
+.DataMover Incremental backup
+
+DataMover Incremental Backup shows similar results as (oadp-short) 1.3.0 and 1.3.1:
+
+.DataMover Incremental backup
+[width="100%",cols="9%,25%,34%,32%",options="header",]
+|===
+|Test |OADP 1.3.0 |OADP 1.3.1 |OADP 1.4.1
+|backup-vbd-datagen-single-ns-100pods-2gb-cephrbd |00:09:20 |00:09:07 |00:08:51
+
+|restore-vbd-datagen-single-ns-100pods-2gb-cephrbd |00:24:27 |00:34:11 |00:13:23
+
+|backup-vbd-datagen-single-ns-1pod-500gb-cephrbd |00:09:27 |00:09:11 |00:08:32
+
+|restore-vbd-datagen-single-ns-1pod-500gb-cephrbd |00:26:14 |00:17:35 |00:26:10
+|===
+
+.Duration of the CephFS restore compared to the CephRBD restore
+
+Restoring a large Container Storage Interface (CSI) snapshot on Ceph RBD is substantially faster when compared to CephFS:
+
+.Duration of the CephFS restore compared to the CephRBD restore
+[width="100%",cols="9%,25%,34%,32%",options="header",]
+|===
+|Test |OADP 1.3.0 |OADP 1.3.1 |OADP 1.4.1
+|backup-vbd-datagen-single-ns-100pods-2gb-cephrbd |00:09:20 |00:09:07 |00:08:51
+
+|restore-vbd-datagen-single-ns-100pods-2gb-cephrbd |00:24:27 |00:34:11 |00:13:23
+
+|backup-vbd-datagen-single-ns-1pod-500gb-cephrbd |00:09:27 |00:09:11 |00:08:32
+
+|restore-vbd-datagen-single-ns-1pod-500gb-cephrbd |00:26:14 |00:17:35 |00:26:10
+|===
+
+.PVC compared to PV create time
+
+The following commands show the gap between PersistentVolumeClaim (PVC) create time and  PersistentVolume (PV) create time.
+
+Once the PV is created and the restore-CR is in `finalizing` status, the restore-CR status is changed to `Completed`.
+
+. Verify that the persistent volume claim is bound:
++
+[source,terminal]
+----
+$ oc get pvc -ndatagen-1pod-3000g-fs
+----
+
++
+Example output:
+
++
+[source,terminal]
+----
+pvc-busy-data-fs-1pod-3000g-1   Bound
+pvc-25682db5-1da6-46f9-8e48-13332eaca35e   4000Gi     RWO
+ocs-storagecluster-cephfs   <unset>                 45h
+----
+
+. Verify that the persistent volume is bound:
++
+[source,terminal]
+----
+$ oc get pv | grep datagen-1pod-3000g-fs
+----
+
++
+Example output:
+
++
+[source,terminal]
+----
+pvc-25682db5-1da6-46f9-8e48-13332eaca35e   4000Gi     RWO            Delete
+Bound    datagen-1pod-3000g-fs/pvc-busy-data-fs-1pod-3000g-1
+ocs-storagecluster-cephfs     <unset>              29h
+----

--- a/modules/oadp-1-4-data-utilization.adoc
+++ b/modules/oadp-1-4-data-utilization.adoc
@@ -1,0 +1,72 @@
+//
+// * backup_and_restore/application_backup_and_restore/oadp-performance/oadp-1-4-performance.adoc
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-1-4-data-utilization_{context}"]
+= OADP 1.4 data utilization
+
+The following is an example of observed performance when running {oadp-short} backup and restore with different plugins in an isolated environment. Your experiences with {oadp-short} may differ from these outcomes based on the types of resources in their cluster, including CPU (cores), storage, network, and the content of the data utilized for backup and restores. These numbers are not intended to represent a minimum expected rate, but rather the transfer rate when performing backups and restores in an isolated environment with optimal conditions and dedicated hardware.
+
+.Transfer Rate
+
+The calculated throughput rate denotes the quantity of non-zero data contained within persistent volumes (PVs) utilized in the backup or restore process, divided by the duration required to process a backup or restore.
+
+This rate assists in your understanding of {oadp-short}.
+
+[id="oadp-1-4-data-utilization-single-backup_{context}"]
+== Backups for single pod and PV
+
+The transfer rate for File System Backup (FSB) with Kopia and Container Storage Interface (CSI) Snapshot data movement is around 1 GB per second, depending on storage type.
+
+.Examples in numbers
+
+* FSB with Kopia on Single PV on Ceph RBD
+** 2 TB PV containing 1.5 TB of data transferred 1.34 GB per second
+** 4 TB PV containing 3 TB of data transferred 1.35 GB per second
+
+* FSB with Kopia on Single PV on Ceph RBD compared to Ceph FS: RBD was faster:
+** 4 TB PV containing 3T of data backup
+*** Ceph RBD: transferred 1.35 GB per second
+*** CephFS: transferred  980 MB per second
+
+* CSI Snapshot data movement compared to FSB with Kopia Single PV on Ceph RBD:
+** 1 TB PV containing 0.5 TB of data transferred 1 GB per second
+** 2 TB PV containing 1.5 TB of data transferred 1.34 GB per second
+
+CSI Snapshot data movement rates shown represent the initial backup and match the rates seen on FSB with Kopia using Ceph RBD.
+
+[id="oadp-1-4-data-utilization-single-restore_{context}"]
+== Restores for single pod and PV
+
+The transfer rates for restoring a single pod containing data on a single PV are around 230–350 MB per second, depending on storage type.
+
+.Examples in numbers
+
+* Restore from FSB with Kopia Single PV on Ceph RBD:
+** 2 TB PV containing 1.5 TB of data transferred 280 MB per second
+** 4 TB PV containing 3 TB of data transferred 240 MB per second
+
+* Restore from FSB with Kopia Single PV on Ceph RBD compared to Ceph FS: the transfer rate is about the same:
+** FSB with Kopia CephRBD: 4 TB PV containing  3 TB of data transferred at 240 MB per second
+** FSB with Kopia CephFS: 4 TB PV containing  3 TB of data transferred at 230 MB per second
+
+* Restore from CSI Snapshot data movement compared to Restore from FSB with Kopia on Single PV on Ceph RBD
+** Restore from CSI Snapshot data movement CephRBD:  1 TB PV containing 0.5 TB of data transferred 350 MB per second
+** Restore from FSB with Kopia CephRBD:  2 TB PV containing 1.5 TB of data transferred 280 MB per second
+
+[id="oadp-1-4-data-utilization-comparinf-csi-fsb_{context}"]
+== Comparing CSI & FSB with Kopia
+
+Comparing CSI & FSB with Kopia, many PVs in a single namespace with 6 workers.
+
+.Backup: CSI Snapshot compared to FSB with Kopia
+
+* 500 GB of data spread equally across 1,000 pods and PVs in a single namespace using 6 workers:
+** CSI: Data transferred 80 MB per second (rate was the same for CephFS and CephRBD).
+** FSB with Kopia: Data transferred 520 MB per second on RBD and 420 MB per second on CephFS.
+
+.Restore: CSI Snapshot compared to FSB with Kopia
+
+* 500 GB of data spread equally across 1,000 pods and PVs in a single namespace using 6 workers:
+** CSI:   data transferred 40 MB per second on CephFS and 350 MB per second on CephRBD
+** FSB with Kopia: data transferred 260 MB per second on CephFS and 240 MB per second on CephRBD

--- a/modules/oadp-1-4-transfer-rate.adoc
+++ b/modules/oadp-1-4-transfer-rate.adoc
@@ -1,0 +1,78 @@
+
+// This module is included in the following assembly:
+//
+// * backup_and_restore/application_backup_and_restore/oadp-performance/oadp-1-4-performance.adoc
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-1-4-transfer-rate_{context}"]
+= {oadp-short} 1.4 transfer rate
+
+The following depicts the observed performance during the execution of {oadp-first} backup and restore with diverse plugins within an isolated environment.
+
+You may have different experiences with {oadp-short} depending on the types of resources in their cluster, such as CPU (core), storage, network, and the type of data that is used for backups and restores. These numbers are not intended to represent a minimum expected rate, but rather represent the transfer rate when performing backups and restores in an isolated environment with optimal conditions and dedicated hardware.
+
+[id="oadp-1-4-transfer-rate-def_{context}"]
+== Transfer rate definition
+
+The calculated throughput rate is the amount of non-zero data contained in a persistent volume (PV), divided by the time taken to process a backup or restore.
+
+This rate allows you to understand the performance of {oadp-short}.
+
+[id="oadp-1-4-backup-singlepod-pv_{context}"]
+=== Backups for single pod and PV
+
+The transfer rates for File System Backup (FSB) with Kopia are approximately 1 GB/s, based on the storage type.
+
+.Examples
+
+* FSB with Kopia on Single PV on Ceph RBD:
+** 2 TB PV containing 1.5 TB of data transferred 1.34 GB/s
+** 4TB PV containing 3TB of data transferred 1.35 GB/s
+
+* FSB with Kopia on Single PV on Ceph RBD compared to Ceph FS RBD is faster:
+** 4 TB PV containing 3 TB of data backup
+*** Ceph RBD: transferred 1.35 GB/s
+*** CephFS: transferred 980 MB/s
+
+* Container Storage Interface (CSI) Snapshot Data Movement compared to FSB with Kopia Single PV on Ceph RBD:
+** 1 TB PV containing 0.5TB of data transferred 530 MB/s
+** 2 TB PV containing 1.5TB of data transferred 1.34 GB/s
+
+The CSI snapshot data movement represents the initial backup upload to a minIO S3 bucket located within the same cluster.
+
+The rate of upload for the CSI Snapshot Data movement backup was observed to be 650 MB/s for a single PV backup.
+
+[id="oadp-1-4-restore-singlepod-pv_{context}"]
+=== Restores for single pod and PV
+
+Restores are performed for single pods containing data on a single PV, with a non-zero data transfer rate ranging from 230 to 350 MB/s, depending on the storage type.
+
+.Examples
+
+* Restore from FSB with Kopia Single PV on Ceph RBD:
+** 2 TB PV containing 1.5TB of data transferred 280 MB/s
+** 4 TB PV containing 3TB of data transferred 240 MB/s
+
+* Restore from FSB with Kopia Single PV on Ceph RBD compared to Ceph FS had a similar transfer rate:
+** FSB with Kopia CephRBD: 4 TB PV containing 3 TB of data transferred 240 MB/s
+** FSB with Kopia CephFS: 4TB PV containing 3 TB of data transferred 230 MB/s
+
+
+* Restore from CSI Snapshot Data Movement compared to Restore from FSB with Kopia on Single PV on Ceph RBD:
+** Restore from CSI Snapshot Data Movement CephRBD: 1 TB PV containing 0.5 TB of data transferred 350 MB/s
+** Restore from FSB with Kopia CephRBD: 2 TB PV containing 1.5 TB of data transferred 280 MB/s
+
+The CSI Snapshot data movement represents a restoration from an initial backup that is obtained from the minIO S3 bucket located within the same cluster. The download rate for the CSI Snapshot Data movement restore was observed as 300 MB/s to 450 MB/s for a single PV restore.
+
+[id="oadp-1-4-csi-fsb-kopia-comparisom_{context}"]
+=== Comparing CSI and FSB with Kopia with many PVs in single namespaces with 6 workers
+
+* Backup: CSI Snapshot VS FSB with Kopia:
+** 500 GB of data spread equally across 1,000 pods and PVs in a single namespace using 6 workers:
+** CSI data transfer rate of 80 MB/s was the same for CephFS and CephRBD.
+** FSB with Kopia data transferred: 520 MB/s on RBD and 420 MB/s on CephFS
+
+* Restore: CSI Snapshot VS FSB with Kopia:
+** 500 GB of data spread equally across 1,000 pods and PVs in a single namespace using 6 workers:
+** CSI data transferred 40 MB/s on CephFS and 350 MB/s on CephRBD
+** FSB with Kopia data transferred 260 MB/s on CephFS and 240 MB/s on CephRBD


### PR DESCRIPTION
### Jira

* [OADP-4517](https://issues.redhat.com//browse/OADP-4517)

### Version(s):



### Link to docs preview:

* [OADP 1.4 performance and use cases](https://78956--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-performance/oadp-1-4-performance.html)


### QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
