### PR TITLE
CNV#44182: Document: Enable PersistentReservation feature gates by using the command line

### DIFF
--- a/modules/virt-enabling-persistentreservation-feature-gate-cli.adoc
+++ b/modules/virt-enabling-persistentreservation-feature-gate-cli.adoc
@@ -14,6 +14,6 @@ You enable the `persistentReservation` feature gate by using the command line. E
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
-  --type json -p '[{"op":"replace","path":"/spec/featureGates/persistentReservation", "value": true}]'
+$ oc patch hyperconverged kubevirt-hyperconverged -n openshift-cnv --type json -p \
+'[{"op":"replace","path":"/spec/featureGates/persistentReservation", "value": true}]'
 ----


### PR DESCRIPTION
Version(s): 4.15+

Issue: [CNV-44182](https://issues.redhat.com/browse/CNV-44182)

Link to docs preview: [Enabling the persistent reservation feature gate by using the command line](https://78958--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.html#virt-enabling-persistentreservation-feature-gate-cli_virt-configuring-shared-volumes-for-vms)

QE review:
- [x] QE has approved this change.

Additional information:


  
