### PR TITLE
CNV#44295: Document: Enabling preallocation for a data volume

### DIFF
--- a/modules/virt-enabling-preallocation-for-dv.adoc
+++ b/modules/virt-enabling-preallocation-for-dv.adoc
@@ -28,6 +28,7 @@ spec:
     resources:
       requests:
         storage: 1Gi
+  preallocation: true
 # ...
 ----
 <1> All CDI source types support preallocation. However, preallocation is ignored for cloning operations.


### PR DESCRIPTION
Version(s): 4.15+

Issue: [CNV-44295](https://issues.redhat.com/browse/CNV-44295)

Link to docs preview: [Enabling preallocation for a data volume](https://78962--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-using-preallocation-for-datavolumes.html#virt-enabling-preallocation-for-dv_virt-using-preallocation-for-datavolumes) 

QE review:
- [x] Jenia Peimer has approved this change.


