### PR TITLE
Update nw-ovn-kubernetes-rollback-live.adoc

### DIFF
--- a/modules/nw-ovn-kubernetes-rollback-live.adoc
+++ b/modules/nw-ovn-kubernetes-rollback-live.adoc
@@ -71,9 +71,18 @@ The command prints the following information every second:
 * The conditions on the status of the `network.config.openshift.io/cluster` object, reporting the progress of the migration.
 * The status of different nodes with respect to the `machine-config-operator` resource, including whether they are upgrading or have been upgraded, as well as their current and desired configurations.
 
-. After the rollback procedure has completed, enter the following command to remove the `network.openshift.io/network-type-migration=` annotation from the `network.config` custom resource:
+. Complete the following steps only if the migration succeeds and your cluster is in a good state:
+
+.. To remove the `network.openshift.io/network-type-migration=` annotation from the `network.config` custom resource, enter the following command:
 +
 [source,terminal]
 ----
 $ oc annotate network.config cluster network.openshift.io/network-type-migration-
+----
+
+.. To remove the OVN-Kubernetes network provider namespace, enter the following command:
++
+[source,terminal]
+----
+$ oc delete namespace openshift-ovn-kubernetes
 ----


### PR DESCRIPTION
PR title format: Steps to be included in the doc to remove the openshift-ovn-kubernetes project after performing the live OVN to SDN migration

Version(s):  4.16

Link to docs preview:
https://github.com/anandrece/openshift-docs/blob/anandrece_live_migration_sdn_ovn_doc_bug/modules/nw-ovn-kubernetes-rollback-live.adoc

Issue Link:
https://issues.redhat.com/browse/OCPBUGS-37166
