### PR TITLE
OCPBUGS-29402: Adding safe sysctls

### DIFF
--- a/modules/nodes-safe-sysctls-list.adoc
+++ b/modules/nodes-safe-sysctls-list.adoc
@@ -49,6 +49,22 @@ a| This restricts `ICMP_PROTO` datagram sockets to users in the group range. The
 
 | `net.ipv4.ip_unprivileged_port_start`
 | This defines the first unprivileged port in the network namespace. To disable all privileged ports, set this to `0`. Privileged ports must not overlap with the `ip_local_port_range`. For more information, see link:https://docs.kernel.org/networking/ip-sysctl.html?highlight=ip_unprivileged_port_start#ip-variables#ip-variables[ip_unprivileged_port_start].
+
+|`net.ipv4.ip_local_reserved_ports`
+| Specify a range of comma-separated local ports that you want to reserve for applications or services.
+
+| `net.ipv4.tcp_keepalive_time`
+| Specify the interval in seconds before the first `keepalive` probe should be sent after a connection has become idle.
+
+| `net.ipv4.tcp_fin_timeout`
+| Specify the time in seconds that a connection remains in the `FIN-WAIT-2` state before it is aborted.
+
+| `net.ipv4.tcp_keepalive_intvl`
+| Specify the interval in seconds between the `keepalive` probes. This value is multiplied by the `tcp_keepalive_probes` value to determine the total time required before it is decided that the connection is broken.
+
+| `net.ipv4.tcp_keepalive_probes`
+| Specify how many `keepalive` probes to send until it is determined that the connection is broken.
+
 |===
 
 


### PR DESCRIPTION
OCPBUGS-29402: Adding missing safe sysctl parameters.

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OCPBUGS-29402

Link to docs preview:
https://78983--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-sysctls.html#safe_and_unsafe_sysctls_nodes-containers-using

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
