### PR TITLE
OBSDOCS-1207: Fix two unrendered name attributes in docs.redhat.com

### DIFF
--- a/observability/distr_tracing/distr-tracing-rn.adoc
+++ b/observability/distr_tracing/distr-tracing-rn.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="distr-tracing-rn"]
 = Release notes for the {DTProductName}
-include::_attributes/common-attributes.adoc[]
 :context: distr-tracing-rn
 
 toc::[]

--- a/observability/otel/otel-rn.adoc
+++ b/observability/otel/otel-rn.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="otel_rn"]
 = Release notes for the {OTELName}
-include::_attributes/common-attributes.adoc[]
 :context: otel-rn
 
 toc::[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12, 4.13, 4.14, 4.15, 4.16, 4.17

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OBSDOCS-1207

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://78986--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/distr_tracing/distr-tracing-rn.html
https://78986--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-rn.html

QE review:
- N/A
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
