### PR TITLE
RHDEVDOCS-6092: Minor changes in Sizing requirements section

### DIFF
--- a/modules/sizing-requirements-for-gitops.adoc
+++ b/modules/sizing-requirements-for-gitops.adoc
@@ -13,13 +13,13 @@ Every time you install the {gitops-title} Operator, the resources on the namespa
 [cols="2,2,2,2,2",options="header"]
 |===
 |Workload |CPU requests |CPU limits |Memory requests |Memory limits
-|argocd-application-controller |1 |2 |1024M |2048M
-|applicationset-controller |1 |2 |512M |1024M
-|argocd-server |0.125 |0.5 |128M |256M
-|argocd-repo-server |0.5 |1 |256M |1024M
-|argocd-redis |0.25 |0.5 |128M |256M
-|argocd-dex |0.25 |0.5 |128M |256M
-|HAProxy |0.25 |0.5 |128M |256M
+|argocd-application-controller |1 |2 |1024Mi |2048Mi
+|applicationset-controller |1 |2 |512Mi |1024Mi
+|argocd-server |0.125 |0.5 |128Mi |256Mi
+|argocd-repo-server |0.5 |1 |256Mi |1024Mi
+|argocd-redis |0.25 |0.5 |128Mi |256Mi
+|argocd-dex |0.25 |0.5 |128Mi |256Mi
+|HAProxy |0.25 |0.5 |128Mi |256Mi
 |===
 
 Optionally, you can also use the ArgoCD custom resource with the `oc` command to see the specifics and modify them:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

GitOps 1.13

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/RHDEVDOCS-6092

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Sizing requirements for GitOps](https://78989--ocpdocs-pr.netlify.app/openshift-gitops/latest/installing_gitops/preparing-gitops-install.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: cfang@redhat.com
QE review: @varshab1210 
Peer review:

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
