### PR TITLE
HCIDOCS-401: Need "Minimum resource requirements for cluster installation" information for IPI on bare metal

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-prerequisites.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-prerequisites.adoc
@@ -21,6 +21,8 @@ Before starting an installer-provisioned installation of {product-title}, ensure
 
 include::modules/ipi-install-node-requirements.adoc[leveloffset=+1]
 
+include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+1]
+
 include::modules/virt-planning-bare-metal-cluster-for-ocp-virt.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/modules/installation-minimum-resource-requirements.adoc
+++ b/modules/installation-minimum-resource-requirements.adoc
@@ -47,6 +47,7 @@
 // * installing/installing-restricted-networks-azure-installer-provisioned.adoc
 // * installing/installing_azure/installing-restricted-networks-azure-user-provisioned.adoc
 // * installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc
+// * installing/intalling_bare_metal_ipi/ipi-install-prerequisites.adoc
 
 ifeval::["{context}" == "installing-azure-customizations"]
 :azure:
@@ -74,6 +75,9 @@ ifeval::["{context}" == "installing-restricted-networks-azure-user-provisioned"]
 endif::[]
 ifeval::["{context}" == "installing-bare-metal"]
 :bare-metal:
+endif::[]
+ifeval::["{context}" == "ipi-install-prerequisites"]
+:ipi-bare-metal:
 endif::[]
 ifeval::["{context}" == "installing-bare-metal-network-customizations"]
 :bare-metal:
@@ -136,7 +140,7 @@ Each cluster machine must meet the following minimum requirements:
 
 |Machine
 |Operating System
-ifndef::bare-metal[]
+ifndef::bare-metal,ipi-bare-metal[]
 ifndef::ibm-cloud-vpc,vsphere[]
 |vCPU ^[1]^
 endif::ibm-cloud-vpc,vsphere[]
@@ -144,11 +148,11 @@ ifdef::ibm-cloud-vpc,vsphere[]
 |vCPU
 endif::ibm-cloud-vpc,vsphere[]
 |Virtual RAM
-endif::bare-metal[]
-ifdef::bare-metal[]
+endif::bare-metal,ipi-bare-metal[]
+ifdef::bare-metal,ipi-bare-metal[]
 |CPU ^[1]^
 |RAM
-endif::bare-metal[]
+endif::bare-metal,ipi-bare-metal[]
 |Storage
 ifndef::ibm-z,ibm-cloud-vpc,vsphere[]
 |Input/Output Per Second (IOPS)^[2]^
@@ -161,7 +165,8 @@ ifdef::ibm-z,ibm-cloud-vpc[]
 endif::ibm-z,ibm-cloud-vpc[]
 
 |Bootstrap
-|{op-system}
+ifndef::ipi-bare-metal[|{op-system}]
+ifdef::ipi-bare-metal[|{op-system-base}]
 ifdef::ibm-power[|2]
 ifndef::ibm-power[|4]
 |16 GB
@@ -189,8 +194,8 @@ endif::ibm-z[]
 
 ifndef::openshift-origin[]
 |Compute
-ifdef::ibm-z,ibm-power,ibm-cloud-vpc[|{op-system}]
-ifndef::ibm-z,ibm-power,ibm-cloud-vpc,vsphere[|{op-system}, {op-system-base} 8.6 and later ^[3]^]
+ifdef::ibm-z,ibm-power,ibm-cloud-vpc,ipi-bare-metal[|{op-system}]
+ifndef::ibm-z,ibm-power,ibm-cloud-vpc,vsphere,ipi-bare-metal[|{op-system}, {op-system-base} 8.6 and later ^[3]^]
 ifdef::vsphere[|{op-system}, {op-system-base} 8.6 and later ^[2]^]
 |2
 |8 GB
@@ -222,19 +227,19 @@ endif::openshift-origin[]
 ifdef::ibm-z[]
 1. One physical core (IFL) provides two logical cores (threads) when SMT-2 is enabled. The hypervisor can provide two or more vCPUs.
 endif::ibm-z[]
-ifdef::bare-metal[]
-1. One CPU is equivalent to one physical core when simultaneous multithreading (SMT), or hyperthreading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio: (threads per core × cores) × sockets = CPUs.
-endif::bare-metal[]
-ifndef::ibm-z,bare-metal,ibm-cloud-vpc,vsphere[]
-1. One vCPU is equivalent to one physical core when simultaneous multithreading (SMT), or hyperthreading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio: (threads per core × cores) × sockets = vCPUs.
-endif::ibm-z,bare-metal,ibm-cloud-vpc,vsphere[]
-ifndef::ibm-z,ibm-power,ibm-cloud-vpc,vsphere[]
+ifdef::bare-metal,ipi-bare-metal[]
+1. One CPU is equivalent to one physical core when simultaneous multithreading (SMT), or Hyper-Threading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio: (threads per core × cores) × sockets = CPUs.
+endif::bare-metal,ipi-bare-metal[]
+ifndef::ibm-z,bare-metal,ibm-cloud-vpc,vsphere,ipi-bare-metal[]
+1. One vCPU is equivalent to one physical core when simultaneous multithreading (SMT), or Hyper-Threading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio: (threads per core × cores) × sockets = vCPUs.
+endif::ibm-z,bare-metal,ibm-cloud-vpc,vsphere,ipi-bare-metal[]
+ifndef::ibm-z,ibm-power,ibm-cloud-vpc,vsphere,ipi-bare-metal[]
 2. {product-title} and Kubernetes are sensitive to disk performance, and faster storage is recommended, particularly for etcd on the control plane nodes which require a 10 ms p99 fsync duration. Note that on many cloud platforms, storage size and IOPS scale together, so you might need to over-allocate storage volume to obtain sufficient performance.
 3. As with all user-provisioned installations, if you choose to use {op-system-base} compute machines in your cluster, you take responsibility for all operating system life cycle management and maintenance, including performing system updates, applying patches, and completing all other required tasks. Use of {op-system-base} 7 compute machines is deprecated and has been removed in {product-title} 4.10 and later.
-endif::ibm-z,ibm-power,ibm-cloud-vpc,vsphere[]
-ifdef::ibm-power[]
+endif::ibm-z,ibm-power,ibm-cloud-vpc,vsphere,ipi-bare-metal[]
+ifdef::ibm-power,ipi-bare-metal[]
 2. {product-title} and Kubernetes are sensitive to disk performance, and faster storage is recommended, particularly for etcd on the control plane nodes. Note that on many cloud platforms, storage size and IOPS scale together, so you might need to over-allocate storage volume to obtain sufficient performance.
-endif::ibm-power[]
+endif::ibm-power,ipi-bare-metal[]
 ifdef::vsphere[]
 1. {product-title} and Kubernetes are sensitive to disk performance, and faster storage is recommended, particularly for etcd on the control plane nodes which require a 10 ms p99 fsync duration. Note that on many cloud platforms, storage size and IOPS scale together, so you might need to over-allocate storage volume to obtain sufficient performance.
 2. As with all user-provisioned installations, if you choose to use {op-system-base} compute machines in your cluster, you take responsibility for all operating system life cycle management and maintenance, including performing system updates, applying patches, and completing all other required tasks. Use of {op-system-base} 7 compute machines is deprecated and has been removed in {product-title} 4.10 and later.
@@ -287,6 +292,9 @@ ifeval::["{context}" == "installing-restricted-networks-azure-user-provisioned"]
 endif::[]
 ifeval::["{context}" == "installing-bare-metal"]
 :!bare-metal:
+endif::[]
+ifeval::["{context}" == "ipi-install-prerequisites"]
+:!ipi-bare-metal:
 endif::[]
 ifeval::["{context}" == "installing-bare-metal-network-customizations"]
 :!bare-metal:


### PR DESCRIPTION
Added the minimum requirements module to the IPI docs. The module has already been extensively reviewed and is included in many documents. Please ensure the include is working, and note that I have included a comment in the module to the additional assembly. This is a module reuse use case.

I did add an ipi-bare-metal context to ensure the right values appear. That could use a peer review. Vale flags potential for unbalanced if statements, but they are balanced and working fine for me.

Fixes: [HCIDOCS-401](https://issues.redhat.com//browse/HCIDOCS-401)

See https://issues.redhat.com/browse/HCIDOCS-401 for additional details.

Preview URL: https://79030--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites#installation-minimum-resource-requirements_ipi-install-prerequisites

For release(s): 4.13-4.17
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
