### PR TITLE
[RHACS] Added a note auto-generated registries are disabled in ACS

### DIFF
--- a/modules/automatic-configuration-image-registry.adoc
+++ b/modules/automatic-configuration-image-registry.adoc
@@ -3,14 +3,15 @@
 // * integration/integrate-with-image-registries.adoc
 :_mod-docs-content-type: CONCEPT
 [id="automatic-configuration-image-registry_{context}"]
-= Automatic Configuration
+= Automatic configuration
 
 [role="_abstract"]
 {product-title} includes default integrations with standard registries, such as Docker Hub and others. It can also automatically configure integrations based on artifacts found in the monitored clusters, such as image pull secrets. Usually, you do not need to configure registry integrations manually.
 
 [IMPORTANT]
 ====
-If you are using a GCR registry, {product-title} does not create a registry integration automatically.
+* If you use a Google Container Registry (GCR), {product-title} does not create a registry integration automatically.
+* If you use {product-title-managed}, automatic configuration is unavailable, and you must manually create registry integrations.
 ====
 
 [id="amazon_ecr_{context}"]


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-25058

Added a note.

Preview: https://79031--ocpdocs-pr.netlify.app/openshift-acs/latest/integration/integrate-with-image-registries.html#automatic-configuration-image-registry_integrate-with-image-registries

Cherry-pick into:
- `rhacs-docs-4.4`
- `rhacs-docs-4.5`

