### PR TITLE
RHDEVDOCS 6095 enable openshift-lightspeed distr display

### DIFF
--- a/_javascripts/page-loader.js
+++ b/_javascripts/page-loader.js
@@ -8,6 +8,7 @@ const urlMappings = {
   "openshift-builds": "https://docs.openshift.com/builds/",
   "openshift-enterprise": "https://docs.openshift.com/container-platform/",
   "openshift-gitops": "https://docs.openshift.com/gitops/",
+  "openshift-lightspeed": "https://docs.openshift.com/lightspeed/",
   "openshift-origin": "https://docs.okd.io/",
   "openshift-pipelines": "https://docs.openshift.com/pipelines/",
   "openshift-serverless": "https://docs.openshift.com/serverless/",


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
Please cherrypick to main

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
RHDEVDOCS 6095

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
n/a

QE review:
n/a
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

This PR adds build and display facilities for the openshift-lightspeed distro to docs.openshift.com . It does not affect any documentation text, so QA review does not apply. The targeting to enterprise-4.1 with cherry-pick to main is not an error, it is caused by how d.o.c code works.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
