### PR TITLE
OSDOCS#11160: New max-unavailable and max-surge parameters

### DIFF
--- a/modules/rosa-create-objects.adoc
+++ b/modules/rosa-create-objects.adoc
@@ -744,6 +744,21 @@ a|--kubelet-configs <kubeletconfig_name>
 |--min-replicas
 |Specifies the minimum number of compute nodes when enabling autoscaling.
 
+//OSDOCS-11160: HCP only, but need to wait on separate HCP publishing
+//ifdef::openshift-rosa-hcp[]
+|--max-surge
+a| For {hcp-title-first} clusters, the `max-surge` parameter defines the number of new nodes that can be provisioned in excess of the desired number of replicas for the machine pool, as configured using the `--replicas` parameter, or as determined by the autoscaler when autoscaling is enabled. This can be an absolute number (for example, `2`) or a percentage of the machine pool size (for example, `20%`), but must use the same unit as the `max-unavailable` parameter.
+
+The default value is `1`, meaning that the maximum number of nodes in the machine pool during an upgrade is 1 plus the desired number of replicas for the machine pool. In this situation, one excess node can be provisioned before existing nodes need to be made unavailable. The number of nodes that can be provisioned simultaneously during an upgrade is `max-surge` plus `max-unavailable`.
+
+|--max-unavailable
+a|For {hcp-title-first} clusters, the `max-unavailable` parameter defines the number of nodes that can be made unavailable in a machine pool during an upgrade, before new nodes are provisioned. This can be an absolute number (for example, `2`) or a percentage of the current replica count in the machine pool (for example, `20%`), but must use the same unit as the `max-surge` parameter.
+
+The default value is `0`, meaning that no outdated nodes are removed before new nodes are provisioned. The valid range for this value is from `0` to the current machine pool size, or from `0%` to `100%`. The total number of nodes that can be upgraded simultaneously during an upgrade is `max-surge` plus `max-unavailable`.
+
+//endif::openshift-rosa-hcp[]
+// end OSDOCS-11160: HCP only, when separate docs are available
+
 |--name
 |Required: The name (string) for the machine pool.
 
@@ -795,6 +810,16 @@ Add a machine pool that is named `mp-1` with 3 replicas of `m5.xlarge` to a clus
 [source,terminal]
 ----
 $ rosa create machinepool --cluster=mycluster --replicas=3 --instance-type=m5.xlarge --name=mp-1
+----
+
+Add a machine pool (`mp-1`) to a {hcp-title-first} cluster, configuring 6 replicas and the following upgrade behavior:
+
+* Allow up to 2 excess nodes to be provisioned during an upgrade.
+* Ensure that no more than 3 nodes are unavailable during an upgrade.
+
+[source,terminal]
+----
+$ rosa create machinepool --cluster=mycluster --replicas=6 --name=mp-1 --max-surge=2 --max-unavailable=3
 ----
 
 Add a machine pool with labels to a cluster.

--- a/modules/rosa-edit-objects.adoc
+++ b/modules/rosa-edit-objects.adoc
@@ -234,7 +234,7 @@ Allows edits to the machine pool in a cluster.
 .Syntax
 [source,terminal]
 ----
-$ rosa edit machinepool --cluster=<cluster_name> | <cluster_id> <machinepool_ID> [arguments]
+$ rosa edit machinepool --cluster=<cluster_name_or_id> <machinepool_ID> [arguments]
 ----
 
 .Arguments
@@ -262,6 +262,20 @@ a|--kubelet-configs <kubeletconfig_name>
 
 |--min-replicas
 |Specifies the minimum number of compute nodes when enabling autoscaling.
+
+//OSDOCS-11160: HCP only, but need to wait on separate HCP publishing
+//ifdef::openshift-rosa-hcp[]
+|--max-surge
+a| For {hcp-title-first} clusters, the `max-surge` parameter defines the number of new nodes that can be provisioned in excess of the desired number of replicas for the machine pool, as configured using the `--replicas` parameter, or as determined by the autoscaler when autoscaling is enabled. This can be an absolute number (for example, `2`) or a percentage of the machine pool size (for example, `20%`), but must use the same unit as the `max-unavailable` parameter.
+
+The default value is `1`, meaning that the maximum number of nodes in the machine pool during an upgrade is 1 plus the desired number of replicas for the machine pool. In this situation, one excess node can be provisioned before existing nodes need to be made unavailable. The number of nodes that can be provisioned simultaneously during an upgrade is `max-surge` plus `max-unavailable`.
+
+|--max-unavailable
+a|For {hcp-title-first} clusters, the `max-unavailable` parameter defines the number of nodes that can be made unavailable in a machine pool during an upgrade, before new nodes are provisioned. This can be an absolute number (for example, `2`) or a percentage of the current replica count in the machine pool (for example, `20%`), but must use the same unit as the `max-surge` parameter.
+
+The default value is `0`, meaning that no outdated nodes are removed before new nodes are provisioned. The valid range for this value is from `0` to the current machine pool size, or from `0%` to `100%`. The total number of nodes that can be upgraded simultaneously during an upgrade is `max-surge` plus `max-unavailable`.
+//endif::openshift-rosa-hcp[]
+// end OSDOCS-11160: HCP only, when separate docs are available
 
 |--node-drain-grace-period
 |Specifies the node drain grace period when upgrading or replacing the machine pool. (This is for {hcp-title} clusters only.)
@@ -297,33 +311,43 @@ Set 4 replicas on a machine pool named `mp1` on a cluster named `mycluster`.
 
 [source,terminal]
 ----
-$ rosa edit machinepool --cluster=mycluster --replicas=4 --name=mp1
+$ rosa edit machinepool --cluster=mycluster --replicas=4 mp1
 ----
 
 Enable autoscaling on a machine pool named `mp1` on a cluster named `mycluster`.
 
 [source,terminal]
 ----
-$ rosa edit machinepool --cluster=mycluster --enable-autoscaling --min-replicas=3 --max-replicas=5 --name=mp1
+$ rosa edit machinepool --cluster=mycluster --enable-autoscaling --min-replicas=3 --max-replicas=5 mp1
 ----
 
 Disable autoscaling on a machine pool named `mp1` on a cluster named `mycluster`.
 
 [source,terminal]
 ----
-$ rosa edit machinepool --cluster=mycluster  --enable-autoscaling=false --replicas=3 --name=mp1
+$ rosa edit machinepool --cluster=mycluster  --enable-autoscaling=false --replicas=3 mp1
 ----
 
 Modify the autoscaling range on a machine pool named `mp1` on a cluster named `mycluster`.
 
 [source,terminal]
 ----
-$ rosa edit machinepool --max-replicas=9 --cluster=mycluster --name=mp1
+$ rosa edit machinepool --max-replicas=9 --cluster=mycluster mp1
 ----
 
-Associate a `KubeletConfig` object with an existing machine pool on a {hcp-title-first} cluster.
+On {hcp-title-first} clusters, edit the `mp1` machine pool to add the following behavior during upgrades:
+
+* Allow up to 2 excess nodes to be provisioned during an upgrade.
+* Ensure that no more than 3 nodes are unavailable during an upgrade.
 
 [source,terminal]
 ----
-$ rosa edit machinepool -c mycluster --kubelet-configs=set-high-pids --name high-pid-pool
+$ rosa edit machinepool --cluster=mycluster mp1 --max-surge=2 --max-unavailable=3
+----
+
+Associate a `KubeletConfig` object with an existing `high-pid-pool` machine pool on a {hcp-title} cluster.
+
+[source,terminal]
+----
+$ rosa edit machinepool -c mycluster --kubelet-configs=set-high-pids high-pid-pool
 ----

--- a/modules/rosa-hcp-upgrade-options.adoc
+++ b/modules/rosa-hcp-upgrade-options.adoc
@@ -1,0 +1,34 @@
+:_mod-docs-content-type: CONCEPT
+[id="rosa-upgrade-options_{context}"]
+= Upgrade options for {hcp-title} clusters
+
+In OpenShift, upgrading means provisioning a new component with updated software and using it to replace an existing component that has outdated software.
+
+You can control the impact of upgrades to your workload by controlling which parts of the cluster are upgraded, for example:
+
+Upgrade only the hosted control plane:: This does not impact your worker nodes.
+
+Upgrade nodes in a single machine pool:: This initiates a rolling replacement of nodes in the specified machine pool, and temporarily impacts the worker nodes on that machine pool. This does not impact nodes on other machine pools in the cluster.
+
+Upgrade nodes in multiple machine pools simultaneously:: This initiates a rolling replacement of nodes in the specified machine pools, and temporarily impacts the worker nodes on those machine pools. You can run this type of upgrade as a single command, or as multiple commands.
+
+Upgrade the whole cluster in sequence:: This initiates upgrade of the hosted control plane, followed by a rolling replacement of nodes in the specified machine pools. These upgrades occur in sequence because the hosted control plane and the machine pools cannot be upgraded at the same time. When an upgrade of the hosted control plane is in progress, nodes in the machine pools cannot be upgraded. When upgrade is in progress for nodes in the machine pools, the hosted control plane cannot be upgraded.
++
+[IMPORTANT]
+====
+To maintain compatibility between nodes in the cluster, nodes in machine pools cannot use a newer version than the hosted control plane. This means that the hosted control plane should always be upgraded to a given version before any machine pools are upgraded to the same version.
+====
+
+The time required to upgrade the hosted control plane varies depending on your workload configuration.
+
+The time required to upgrade a machine pool varies according to the number of worker nodes in the machine pool (`--replicas` or `--max-replicas`).
+
+You can further control the time required for an upgrade, and the impact of an upgrade to your workload, by editing the `--max-surge` and `--max-unavailable` values for each machine pool. These options control the number of nodes that can be upgraded simultaneously, and whether an upgrade provisions excess nodes or makes some existing nodes unavailable or both, for example:
+
+* **To prioritize high workload availability**, you can provision excess nodes instead of making existing nodes unavailable by setting a higher value for `--max-surge` and setting `--max-unavailable` to `0`.
+* **To prioritize lower infrastructure costs**, you can make some existing nodes unavailable and avoid provisioning excess nodes by setting a higher value for `--max-unavailable` and setting `--max-surge` to `0`.
+* **To prioritize upgrade speed by upgrading multiple nodes simultaneously**, you can provision excess nodes and allow some existing nodes to be made unavailable by configuring moderate values for both `--max-surge` and `--max-unavailable`.
+
+For more information about these parameters and their usage, see the _ROSA CLI reference_ for `rosa edit machinepool`.
+
+//Additional resources included in assembly.

--- a/modules/rosa-hcp-upgrading-cli-control-plane.adoc
+++ b/modules/rosa-hcp-upgrading-cli-control-plane.adoc
@@ -1,0 +1,94 @@
+// Module included in the following assemblies:
+//
+// * upgrading/rosa-hcp-upgrading.adoc
+
+// NOTE: This module is included several times in the same upgrade assembly.
+
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-hcp-upgrading-cli-control-plane_{context}"]
+// HCP-ONLY: Conditions for upgrading the hosted control plane WITHOUT upgrading any machine pools
+ifeval::["{context}" != "rosa-hcp-upgrading-whole-cluster"]
+= Upgrading the hosted control plane with the ROSA CLI
+
+You can manually upgrade the hosted control plane of a {hcp-title} cluster by using the ROSA CLI. This method schedules the control plane for an upgrade if a more recent version is available, either immediately, or at a specified future time.
+
+[NOTE]
+====
+Your control plane only supports machine pools within two minor Y-stream versions. For example, a {hcp-title} cluster with a control plane using version 4.15.z supports machine pools with version 4.13.z and 4.14.z, but the control plane does not support machine pools using version 4.12.z.
+====
+
+endif::[]
+//END HCP-ONLY conditions
+
+// WHOLE CLUSTER: Condition for upgrading hosted control plane as part of upgrading the whole cluster in sequence
+ifeval::["{context}" == "rosa-hcp-upgrading-whole-cluster"]
+= Upgrading the hosted control plane
+
+When you need to upgrade the whole cluster, upgrade the hosted control plane first.
+endif::[]
+
+
+.Prerequisites
+* You have installed and configured the latest version of the ROSA CLI.
+* No machine pool upgrades are in progress or scheduled to take place at the same time as the hosted control plane upgrade.
+
+//END WHOLE CLUSTER conditions
+
+.Procedure
+
+. Verify the current version of your cluster by running the following command:
++
+[source,terminal]
+----
+$ rosa describe cluster --cluster=<cluster_name_or_id> <1>
+----
+<1> Replace `<cluster_name_or_id>` with the cluster name or the cluster ID.
+
+. List the versions that you can upgrade your control plane to by running the following command:
++
+[source,terminal]
+----
+$ rosa list upgrade --cluster=<cluster_name_or_id>
+----
++
+The command returns a list of available updates, including the recommended version.
++
+.Example output
++
+[source,terminal]
+----
+VERSION  NOTES
+4.14.8   recommended
+4.14.7
+4.14.6
+----
+
+. Upgrade the cluster's hosted control plane by running the following command:
++
+[source,terminal]
+----
+$ rosa upgrade cluster -c <cluster_name_or_id> --control-plane [--schedule-date=<yyyy-mm-dd> --schedule-time=<HH:mm>] --version <version_number>
+----
+
+** To schedule an immediate upgrade to the specified version, run the following command:
++
+[source,terminal]
+----
+$ rosa upgrade cluster -c <cluster_name_or_id> --control-plane --version <version_number>
+----
++
+Your hosted control plane is scheduled for an immediate upgrade.
+
+** To schedule an upgrade to the the specified version at a future date, run the following command:
++
+[source,terminal]
+----
+$ rosa upgrade cluster -c <cluster_name_or_id> --control-plane --schedule-date=<yyyy-mm-dd> --schedule-time=<HH:mm> --version=<version_number>
+----
++
+Your hosted control plane is scheduled for an upgrade at the specified time in Coordinated Universal Time (UTC).
+
+ifeval::["{context}" != "rosa-hcp-upgrading-whole-cluster"]
+.Troubleshooting
+* Sometimes a scheduled upgrade does not initiate. See link:https://access.redhat.com/solutions/6648291[Upgrade maintenance canceled] for more information.
+endif::[]

--- a/modules/rosa-hcp-upgrading-cli-machinepool.adoc
+++ b/modules/rosa-hcp-upgrading-cli-machinepool.adoc
@@ -1,0 +1,133 @@
+// Module included in the following assemblies:
+//
+// * upgrading/rosa-hcp-upgrading.adoc
+
+// NOTE: This module is included several times in the same upgrade assembly.
+
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-hcp-upgrading-cli-machinepool_{context}"]
+// POOL-ONLY: Conditions for upgrading machine pools WITHOUT upgrading hosted control planes
+ifeval::["{context}" != "rosa-hcp-upgrading-whole-cluster"]
+= Upgrading machine pools with the ROSA CLI
+
+You can manually upgrade one or more machine pools in a {hcp-title} cluster by using the ROSA CLI. This method schedules the specified machine pools for an upgrade if a more recent version is available, either immediately, or at a specified future time.
+
+[NOTE]
+====
+Your control plane only supports machine pools within two minor Y-stream versions. For example, a {hcp-title} cluster with a control plane using version 4.15.z supports machine pools with version 4.13.z and 4.14.z, but the control plane does not support machine pools using version 4.12.z.
+====
+
+.Prerequisites
+* You have installed and configured the latest version of the ROSA CLI.
+* No upgrades for the hosted control plane are in progress on the cluster, or scheduled to occur at the same time as the machine pool upgrade.
+endif::[]
+//END POOL-ONLY condition
+
+// WHOLE CLUSTER: Conditions for upgrading machine pools as part of upgrading the whole cluster in sequence
+ifeval::["{context}" == "rosa-hcp-upgrading-whole-cluster"]
+= Upgrading machine pools
+
+When your hosted control plane upgrade is complete, you can upgrade one or more machine pools simultaneously.
+endif::[]
+//END WHOLE CLUSTER condition
+
+.Procedure
+. Verify the current version of your cluster by running the following command:
++
+[source,terminal]
+----
+$ rosa describe cluster --cluster=<cluster_name_or_id> <1>
+----
+<1> Replace `<cluster_name_or_id>` with the cluster name or the cluster ID.
++
+ifeval::["{context}" != "rosa-hcp-upgrading-whole-cluster"]
+.Example output
+[source,terminal]
+----
+OpenShift Version:     4.14.0
+----
+endif::[]
+ifeval::["{context}" == "rosa-hcp-upgrading-whole-cluster"]
+.Example output
+[source,terminal]
+----
+OpenShift Version:     4.14.8
+----
+//WHOLE CLUSTER: updating the version here to show after hcp upgrade in whole cluster section
+endif::[]
+
+. List the versions that you can upgrade your machine pools to by running the following command:
++
+[source,terminal]
+----
+$ rosa list upgrade --cluster <cluster-name> --machinepool <machinepool_name>
+----
++
+The command returns a list of available updates, including the recommended version.
++
+.Example output
++
+[source,terminal]
+----
+VERSION  NOTES
+4.14.5   recommended
+4.14.4
+4.14.3
+----
++
+[IMPORTANT]
+====
+Do not upgrade your machine pool to a version higher than your control plane. If you want to move to a higher version, upgrade the control plane to that version first.
+====
+//Is it even possible to do this? Will a higher version display? Can you specify a higher version even if it doesn't display?
+
+. Verify the upgrade behavior of the machine pools you intend to upgrade by running the following command:
++
+[source,terminal]
+----
+$ rosa describe machinepool --cluster=<cluster_name_or_id> <machine_pool_name> 
+----
++
+.Example output
+[source,terminal]
+----
+Replicas: 5
+Node drain grace period:   30 minutes
+
+Management upgrade:
+- Type: Replace
+- Max surge: 20%
+- Max unavailable: 20%
+----
++
+In the example, these settings allow the machine pool to provision one excess node (`max-surge` of 20% of `replicas`) and to have up to one node unavailable (`max-unavailable` of 20% of `replicas`) during an upgrade. This machine pool can therefore upgrade two nodes at a time, by provisioning one new node in excess of the replica count, and by making one node unavailable and replacing it. Node upgrades may be delayed by up to 30 minutes (`node-drain-grace-period` of 30 minutes) if necessary to protect workloads that have a pod disruption budget.
+
+. Upgrade one or more of your machine pools by running the following command:
++
+[source,terminal]
+----
+$ rosa upgrade machinepool -c <cluster_name> <first_machine_pool_id> <second_machine_pool_id> [--schedule-date=<yyyy-mm-dd> --schedule-time=<HH:mm>] --version <version_number>
+----
++
+Multiple machine pools can be upgraded simultaneously. You can schedule machine pool upgrades individually or schedule multiple upgrades in a single command.
+
+** To schedule the immediate upgrade of a specific machine pool on your cluster, run the following command:
++
+[source,terminal]
+----
+$ rosa upgrade machinepool -c <cluster_name> <your_machine_pool_id> --version <version_number>
+----
++
+Your machine pool is scheduled for immediate upgrade, which initiates a rolling replacement of all nodes in the specified machine pool.
+
+** To schedule an upgrade of multiple machine pools to start at a future date, run the following command:
++
+[source,terminal]
+----
+$ rosa upgrade machinepool -c <cluster_name> <first_machine_pool_id> <second_machine_pool_id> --schedule-date=<yyyy-mm-dd> --schedule-time=<HH:mm> --version <version_number>
+----
++
+Your machine pools are scheduled to begin an upgrade at the specified time and date in Coordinated Universal Time (UTC). This will initiate a rolling replacement of all nodes in the specified machine pools, beginning at the specified time.
+
+.Troubleshooting
+* Sometimes a scheduled upgrade does not initiate. See link:https://access.redhat.com/solutions/6648291[Upgrade maintenance canceled] for more information.

--- a/modules/rosa-upgrade-cluster-cli.adoc
+++ b/modules/rosa-upgrade-cluster-cli.adoc
@@ -34,10 +34,10 @@ $ rosa upgrade cluster --cluster=<cluster_name> | <cluster_id> [arguments]
 |The version (string) of OpenShift Container Platform that the cluster will be upgraded to.
 
 |--schedule-date
-|The next date (string) when the upgrade will run at the specified time. Format: `yyyy-mm-dd`
+|The next date (string) when the upgrade will run at the specified time in Coordinated Universal Time (UTC). Format: `yyyy-mm-dd`
 
 |--schedule-time
-|The next time the upgrade will run on the specified date. Format: `HH:mm`
+|The next time the upgrade will run on the specified date in Coordinated Universal Time (UTC). Format: `HH:mm`
 
 |--node-drain-grace-period ^[1]^
 |Sets a grace period (string) for how long the pod disruption budget-protected workloads are respected during upgrades. After this grace period, any workloads protected by pod disruption budgets that have not been successfully drained from a node will be forcibly evicted. Default: `1 hour`
@@ -133,6 +133,13 @@ $ rosa upgrade machinepool --cluster=<cluster_name> <machinepool_name>
 
 |--cluster
 |Required: The name or ID (string) of the cluster.
+
+|--schedule-date
+|The next date (string) when the upgrade will run at the specified time in Coordinated Universal Time (UTC). Format: `yyyy-mm-dd`
+
+|--schedule-time
+|The next time the upgrade will run on the specified date in Coordinated Universal Time (UTC). Format: `HH:mm`
+
 |===
 
 .Optional arguments inherited from parent commands
@@ -192,6 +199,8 @@ $ rosa delete upgrade --cluster=<cluster_name> <machinepool_name>
 |Specifies an AWS profile (string) from your credentials file.
 |===
 
+//Per wgordon, rosa upgrade roles is not needed for HCP clusters
+ifndef::openshift-rosa-hcp[]
 [id="rosa-upgrade-roles_{context}"]
 == upgrade roles
 Upgrades roles configured on a cluster.
@@ -233,8 +242,7 @@ Upgrade roles on a cluster named `mycluster`.
 ----
 $ rosa upgrade roles --cluster=mycluster
 ----
-
-
+endif::openshift-rosa-hcp[]
 
 
 

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -16,6 +16,8 @@ toc::[]
 [id="rosa-q3-2024_{context}"]
 === Q3 2024
 
+* **Upgrade multiple nodes simultaneously.** You can now configure a machine pool to upgrade multiple nodes simultaneously. Two new machine pool parameters, `max-surge` and `max-unavailable`, give you greater control over how machine pool upgrades occur. For more information, see xref:../upgrading/rosa-hcp-upgrading.adoc#rosa-hcp-upgrading[Upgrading ROSA with HCP clusters].
+
 * **{hcp-title} Graviton (ARM) instance types.** You can now use {AWS} Arm-based Graviton instance types for your workloads in {hcp-title-first} clusters created after 24 July, 2024, see xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-instance-types.adoc#rosa-sdpolicy-aws-instance-types-graviton_rosa-hcp-instance-types[AWS Graviton (ARM) instance types].
 
 * **ROSA CLI update.** The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/tag/v1.2.42[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-about_rosa-getting-started-cli[About the ROSA CLI].

--- a/upgrading/rosa-hcp-upgrading.adoc
+++ b/upgrading/rosa-hcp-upgrading.adoc
@@ -6,25 +6,56 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-You can upgrade {hcp-title-first} clusters by individually upgrading the hosted control plane and the machine pools with the ROSA command line interface (CLI), `rosa`.
+include::modules/rosa-hcp-upgrade-options.adoc[leveloffset=+1]
 
-Use one of the following methods to upgrade your HCP clusters:
+.Additional resources
+* xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-edit-machinepool_rosa-managing-objects-cli[ROSA CLI reference: `rosa edit machinepool`]
 
-* Upgrade only your hosted control plane. This does not impact your worker nodes.
-* Upgrade only your machine pool. This initiates a rolling reboot of a specific machine pool and temporarily impacts the worker nodes on the specific machine pool. It does not impact all your worker nodes if you have multiple machine pools.
-* Upgrade multiple machine pools simultaneously. This initiates a rolling reboot of worker nodes in the updated machine pools. This allows for updating multiple nodes simultaneously within a cluster.
-* Upgrade your hosted control plane first and then your machine pool.
-+
-[NOTE]
-====
-If you want to upgrade both your hosted control plane and your machine pool to the same version, you must upgrade the hosted control plane first.
-====
+//This cannot be a module if we want to use the xrefs
+[id="rosa-lifecycle-policy_{context}"]
+== Life cycle policies and planning
 
-To plan an upgrade, review the xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.adoc#rosa-hcp-life-cycle[{hcp-title} update life cycle] documentation. The life cycle page includes release definitions, support and upgrade requirements, installation policy information, and life cycle dates.
+To plan an upgrade, review the
+ifdef::openshift-rosa,openshift-rosa-classic[]
+xref:../rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc#rosa-life-cycle[{product-title} update life cycle].
+endif::openshift-rosa,openshift-rosa-classic[]
+ifdef::openshift-rosa-hcp[]
+xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.adoc#rosa-hcp-life-cycle[{hcp-title} update life cycle].
+endif::openshift-rosa-hcp[]
 
-[NOTE]
-====
-Hosted control plane upgrade duration varies based on your workload configuration, and machine pool upgrade duration varies based on the number of worker nodes.
-====
+The life cycle page includes release definitions, support and upgrade requirements, installation policy information and life cycle dates.
 
-include::modules/rosa-hcp-upgrading-cli-tutorial.adoc[leveloffset=+1]
+Upgrades are manually initiated or automatically scheduled. Red Hat Site Reliability Engineers (SREs) monitor upgrade progress and remedy any issues encountered.
+
+include::modules/rosa-hcp-upgrading-cli-control-plane.adoc[leveloffset=+1]
+
+include::modules/rosa-hcp-upgrading-cli-machinepool.adoc[leveloffset=+1]
+
+[id="rosa-hcp-upgrading-cli-cluster_{context}"]
+== Upgrading the whole cluster with the ROSA CLI
+
+Upgrading the entire cluster involves upgrading both the hosted control plane and nodes in the machine pools. However, these components cannot be upgraded at the same time. They must be upgraded in sequence. This can be done in any order. However, to maintain compatibility between nodes in the cluster, nodes in machine pools cannot use a newer version than the hosted control plane. Therefore, if both the hosted control plane and the nodes in your machine pools require upgrade to the same OpenShift version, you must upgrade the hosted control plane first, followed by the machine pools.
+
+[discrete]
+=== Prerequisites
+* You have installed and configured the latest version of the ROSA CLI.
+* No other upgrades are in progress or scheduled to take place at the same time as this upgrade.
+
+ifdef::context[:prevcontext: {context}]
+
+:context: rosa-hcp-upgrading-whole-cluster
+
+include::modules/rosa-hcp-upgrading-cli-control-plane.adoc[leveloffset=+2]
+
+ifdef::prevcontext[:context: {prevcontext}]
+
+ifdef::context[:prevcontext: {context}]
+
+:context: rosa-hcp-upgrading-whole-cluster
+
+include::modules/rosa-hcp-upgrading-cli-machinepool.adoc[leveloffset=+2]
+
+ifdef::prevcontext[:context: {prevcontext}]
+ifndef::prevcontext[:!context:]
+
+//include::modules/rosa-hcp-upgrading-cli-tutorial.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-11160

Link to docs preview:
- [Upgrading ROSA with HCP clusters](https://79038--ocpdocs-pr.netlify.app/openshift-rosa/latest/upgrading/rosa-hcp-upgrading.html)
  - most of this content has been reworked, recommend reviewing all of it, not just the parts relating to new parameters
- [ROSA CLI reference: create machinepool](https://79038--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli.html#rosa-create-machinepool_rosa-managing-objects-cli) - see parameter definitions and example usage after table of parameters
- [ROSA CLI reference: edit machinepool](https://79038--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli.html#rosa-edit-machinepool_rosa-managing-objects-cli) - see parameter definitions and example usage after table of parameters
- I've also updated the syntax for the schedule-time and schedule-date parameters for "rosa upgrade cluster" and "rosa upgrade machinepool" since these weren't clear from the previous doc: [ROSA CLI reference: rosa upgrade](https://79038--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli#rosa-upgrade-cluster_rosa-managing-objects-cli)

QE review:
- [x] QE has approved this change.
