### PR TITLE
OCPBUGS-32225#podman error

### DIFF
--- a/modules/ipi-install-creating-an-rhcos-images-cache.adoc
+++ b/modules/ipi-install-creating-an-rhcos-images-cache.adoc
@@ -101,10 +101,10 @@ $ ls -Z /home/kni/rhcos_image_cache
 +
 [source,terminal]
 ----
-$ podman run -d --name rhcos_image_cache \// <1>
+$ podman run -d --name rhcos_image_cache \ <1>
 -v /home/kni/rhcos_image_cache:/var/www/html \
 -p 8080:8080/tcp \
-registry.access.redhat.com/ubi9/httpd-24
+quay.io/centos7/httpd-24-centos7:2.4
 ----
 +
 <1> Creates a caching webserver with the name `rhcos_image_cache`. This pod serves the `bootstrapOSImage` image in the `install-config.yaml` file for deployment.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Versions: 
4.13+


Issue:
https://issues.redhat.com/browse/OCPBUGS-32225

Link to docs preview:
https://79077--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#ipi-install-creating-an-rhcos-images-cache_ipi-install-installation-workflow

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
