### PR TITLE
HCIDOCS-400: Wrong title for baremetal installation section

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -392,6 +392,8 @@ Topics:
     File: ipi-install-prerequisites
   - Name: Setting up the environment for an OpenShift installation
     File: ipi-install-installation-workflow
+  - Name: Installing a cluster
+    File: ipi-install-installation
   - Name: Postinstallation configuration
     File: ipi-install-post-installation-configuration
   - Name: Expanding the cluster

--- a/installing/index.adoc
+++ b/installing/index.adoc
@@ -25,7 +25,7 @@ include::modules/ipi-verifying-nodes-after-installation.adoc[leveloffset=+2]
 
 * xref:../post_installation_configuration/bare-metal-configuration.adoc#getting-the-baremetalhost-resource_post-install-bare-metal-configuration[Getting the BareMetalHost resource]
 
-* xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#ipi-install-troubleshooting-following-the-installation_ipi-install-installation-workflow[Following the installation]
+* xref:../installing/installing_bare_metal_ipi/ipi-install-installation.adoc#ipi-install-troubleshooting-following-the-installation_ipi-install-installation[Following the installation]
 
 * xref:../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation]
 

--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -170,20 +170,3 @@ include::modules/ipi-modify-install-config-for-a-disconnected-registry.adoc[leve
 // Validation checklist for installation
 include::modules/ipi-install-validation-checklist-for-installation.adoc[leveloffset=+1]
 
-// Deploying the cluster via the {product-title} installer
-include::modules/ipi-install-deploying-the-cluster-via-the-openshift-installer.adoc[leveloffset=+1]
-
-// Following the installation
-include::modules/ipi-install-following-the-installation.adoc[leveloffset=+1]
-
-// Verifying static IP address configuration
-include::modules/ipi-install-verifying-static-ip-address-configuration.adoc[leveloffset=+1]
-
-// Preparing to reinstall a cluster on bare metal
-include::modules/ipi-preparing-reinstall-cluster-bare-metal.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-[id="additional-resources_creating_manifest_ignition"]
-== Additional resources
-* xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installation-user-infra-generate-k8s-manifest-ignition_installing-bare-metal[{product-title} Creating the Kubernetes manifest and Ignition config files]
-* xref:../../updating/understanding_updates/understanding-update-channels-release.adoc#understanding-update-channels-releases[Understanding update channels and releases]

--- a/installing/installing_bare_metal_ipi/ipi-install-installation.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation.adoc
@@ -1,0 +1,25 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="ipi-install-installation"]
+= Installing OpenShift
+include::_attributes/common-attributes.adoc[]
+:context: ipi-install-installation
+
+toc::[]
+
+// Deploying the cluster via the {product-title} installer
+include::modules/ipi-install-deploying-the-cluster-via-the-openshift-installer.adoc[leveloffset=+1]
+
+// Following the installation
+include::modules/ipi-install-following-the-installation.adoc[leveloffset=+1]
+
+// Verifying static IP address configuration
+include::modules/ipi-install-verifying-static-ip-address-configuration.adoc[leveloffset=+1]
+
+// Preparing to reinstall a cluster on bare metal
+include::modules/ipi-preparing-reinstall-cluster-bare-metal.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_creating_manifest_ignition"]
+== Additional resources
+* xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installation-user-infra-generate-k8s-manifest-ignition_installing-bare-metal[Creating the Kubernetes manifest and Ignition config files]
+* xref:../../updating/understanding_updates/understanding-update-channels-release.adoc#understanding-update-channels-releases[Understanding update channels and releases]


### PR DESCRIPTION
Created a separate assembly for the installation steps.

Fixes: [HCIDOCS-400](https://issues.redhat.com//browse/HCIDOCS-400)

See https://issues.redhat.com/browse/HCIDOCS-400 for additional details.

Preview URL: https://79078--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation.html
https://79078--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html

For release(s): 4.12-4.17
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
