### PR TITLE
OBSDOCS-1211-Logging 5.8.10 release notes

### DIFF
--- a/modules/logging-release-notes-5-8-10.adoc
+++ b/modules/logging-release-notes-5-8-10.adoc
@@ -1,0 +1,30 @@
+// module included in /logging/logging-5-8-release-notes
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-5-8-10_{context}"]
+= Logging 5.8.10
+This release includes link:https://access.redhat.com/errata/RHBA-2024:4629[OpenShift Logging Bug Fix Release 5.8.10] and link:https://access.redhat.com/errata/RHBA-2024:4665[OpenShift Logging Bug Fix Release 5.8.10].
+
+[id="logging-release-notes-5-8-10-known-issues"]
+== Known issues
+
+* Before this update, when enabling retention, the Loki Operator produced an invalid configuration. As a result, Loki did not start properly. With this update, Loki pods can set retention. (link:https://issues.redhat.com/browse/LOG-5821[LOG-5821])
+
+[id="logging-release-notes-5-8-10-bug-fixes"]
+== Bug fixes
+
+* Before this update, the `ClusterLogForwarder` introduced an extra space in the message payload that did not follow the `RFC3164` specification. With this update, the extra space has been removed, fixing the issue. (link:https://issues.redhat.com/browse/LOG-5647[LOG-5647])
+
+[id="logging-release-notes-5-8-10-CVEs"]
+== CVEs
+
+*link:https://access.redhat.com/security/cve/CVE-2023-6597[CVE-2023-6597]
+*link:https://access.redhat.com/security/cve/CVE-2024-0450[CVE-2024-0450]
+*link:https://access.redhat.com/security/cve/CVE-2024-3651[CVE-2024-3651]
+*link:https://access.redhat.com/security/cve/CVE-2024-6387[CVE-2024-6387]
+*link:https://access.redhat.com/security/cve/CVE-2024-26735[CVE-2024-26735]
+*link:https://access.redhat.com/security/cve/CVE-2024-26993[CVE-2024-26993]
+*link:https://access.redhat.com/security/cve/CVE-2024-32002[CVE-2024-32002]
+*link:https://access.redhat.com/security/cve/CVE-2024-32004[CVE-2024-32004]
+*link:https://access.redhat.com/security/cve/CVE-2024-32020[CVE-2024-32020]
+*link:https://access.redhat.com/security/cve/CVE-2024-32021[CVE-2024-32021]
+*link:https://access.redhat.com/security/cve/CVE-2024-32465[CVE-2024-32465]

--- a/observability/logging/logging_release_notes/logging-5-8-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-8-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-8-10.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-8-9.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-8-8.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Logging Z-Stream Release Notes - 5.8.10
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1211

Fix Version: 4.12, 4.13, 4.14, 4.15

Doc Preview: https://79100--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging_release_notes/logging-5-8-release-notes.html

SME Review: @periklis 
QE Review: @anpingli 
Peer Review: @ShaunaDiaz 