### PR TITLE
[WIP] OBSDOCS-71: [POC] Observability operators upgrade resource

### DIFF
--- a/modules/obs-support-version-matrix-for-observability-components.adoc
+++ b/modules/obs-support-version-matrix-for-observability-components.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * observability/index.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="obs-support-version-matrix-for-observability-components_{context}"]
+= Support version matrix for {ObservabilityShortName} components
+
+The following matrix contains information about supported versions of {ObservabilityShortName} components for {product-title} 4.12 and later releases.
+
+[NOTE]
+====
+The monitoring component is deployed by default in every {product-title} installation. Therefore, its version corresponds with the versions of {product-title}.
+====
+
+.{product-title} and component versions
+|===
+|{product-title} |{logging-uc} |Distributed tracing (Tempo)  |Distributed tracing (Jaeger) |{OTELName} |Network Observability |{PM-shortname-c}
+
+|4.16 |5.8, 5.9 |0.1.0, 0.3.1, 0.6.0, 0.8.0, 0.10.0 |1.30.2, 1.34.1, 1.42.0, 1.47.1, 1.51.0, 1.53.0, 1.57.0 |0.56.0, 0.60.0, 0.74.0, 0.81.1, 0.89.0, 0.93.0, 0.100.1, 0.102.0 |1.0.0, 1.1.0, 1.2.0, 1.3.0, 1.4.0, 1.4.1, 1.4.2, 1.5.0, 1.6.0 |0.1, 0.2
+
+|4.15 |5.8, 5.9 |0.1.0, 0.3.1, 0.6.0, 0.8.0, 0.10.0 |1.30.2, 1.34.1, 1.42.0, 1.47.1, 1.51.0, 1.53.0, 1.57.0 |0.56.0, 0.60.0, 0.74.0, 0.81.1, 0.89.0, 0.93.0, 0.100.1, 0.102.0 |1.0.0, 1.1.0, 1.2.0, 1.3.0, 1.4.0, 1.4.1, 1.4.2, 1.5.0, 1.6.0 |0.1, 0.2
+
+|4.14 |5.7, 5.8, 5.9 |0.1.0, 0.3.1, 0.6.0, 0.8.0, 0.10.0 |1.30.2, 1.34.1, 1.42.0, 1.47.1, 1.51.0, 1.53.0, 1.57.0 |0.56.0, 0.60.0, 0.74.0, 0.81.1, 0.89.0, 0.93.0, 0.100.1, 0.102.0 |1.0.0, 1.1.0, 1.2.0, 1.3.0, 1.4.0, 1.4.1, 1.4.2, 1.5.0, 1.6.0 |0.1, 0.2
+
+|4.13 |5.6, 5.7, 5.8, 5.9 |0.1.0, 0.3.1, 0.6.0, 0.8.0, 0.10.0 |1.30.2, 1.34.1, 1.42.0, 1.47.1, 1.51.0, 1.53.0, 1.57.0 |0.56.0, 0.60.0, 0.74.0, 0.81.1, 0.89.0, 0.93.0, 0.100.1, 0.102.0 |1.0.0, 1.1.0, 1.2.0, 1.3.0, 1.4.0, 1.4.1, 1.4.2, 1.5.0, 1.6.0 |N/A
+
+|4.12 |5.5, 5.6, 5.7, 5.8 |0.1.0, 0.3.1, 0.6.0, 0.8.0, 0.10.0 |1.30.2, 1.34.1, 1.42.0, 1.47.1, 1.51.0, 1.53.0, 1.57. |0.56.0, 0.60.0, 0.74.0, 0.81.1, 0.89.0, 0.93.0, 0.100.1, 0.102.0 |1.0.0, 1.1.0, 1.2.0, 1.3.0, 1.4.0, 1.4.1, 1.4.2, 1.5.0, 1.6.0 |N/A
+|===

--- a/observability/index.adoc
+++ b/observability/index.adoc
@@ -26,6 +26,10 @@ endif::openshift-dedicated,openshift-rosa[]
 
 {ObservabilityLongName} connects open-source observability tools and technologies to create a unified {ObservabilityShortName} solution. The components of {ObservabilityLongName} work together to help you collect, store, deliver, analyze, and visualize data.
 
+ifndef::openshift-dedicated,openshift-rosa[]
+include::modules/obs-support-version-matrix-for-observability-components.adoc[leveloffset=+1]
+endif::openshift-dedicated,openshift-rosa[]
+
 [id="monitoring-overview-index"]
 == Monitoring
 Monitor the in-cluster health and performance of your applications running on {product-title} with metrics and customized alerts for CPU and memory usage, network connectivity, and other resource usage. Monitoring stack components are deployed and managed by the {cmo-full}.


### PR DESCRIPTION
Version(s): `enterprise-4.12` and later

Issue: [OBSDOCS-71](https://issues.redhat.com/browse/OBSDOCS-71)

Link to docs preview: https://79103--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/index.html#obs-support-version-matrix-for-observability-components_observability-overview

QE review:
- [ ] QE has approved this change.

**Additional information:**