### PR TITLE
[enterprise-4.12] OBSDOCS-1173: Remove 'Next Steps' section from the Monitoring docs

### DIFF
--- a/observability/monitoring/application-monitoring.adoc
+++ b/observability/monitoring/application-monitoring.adoc
@@ -14,7 +14,3 @@ include::snippets/technology-preview.adoc[leveloffset=+0]
 include::modules/monitoring-configuring-cluster-for-application-monitoring.adoc[leveloffset=+1]
 include::modules/monitoring-configuring-monitoring-for-an-application.adoc[leveloffset=+1]
 include::modules/monitoring-exposing-custom-application-metrics-for-horizontal-pod-autoscaling.adoc[leveloffset=+1]
-
-== Next steps
-
-* To automatically adjust the number of pods in which the application runs, xref:../../observability/monitoring/application-monitoring.adoc#application-monitoring[configure Horizontal Pod Autoscaling for the application.]

--- a/observability/monitoring/configuring-the-monitoring-stack.adoc
+++ b/observability/monitoring/configuring-the-monitoring-stack.adoc
@@ -233,7 +233,3 @@ include::modules/monitoring-disabling-the-local-alertmanager.adoc[leveloffset=+1
 * link:https://prometheus.io/docs/alerting/latest/alertmanager/[Prometheus Alertmanager documentation]
 * xref:../../observability/monitoring/managing-alerts.adoc#[Managing alerts]
 
-== Next steps
-
-* xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
-* Learn about xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[remote health reporting] and, if necessary, opt out of it.

--- a/observability/monitoring/enabling-alert-routing-for-user-defined-projects.adoc
+++ b/observability/monitoring/enabling-alert-routing-for-user-defined-projects.adoc
@@ -31,7 +31,3 @@ include::modules/monitoring-granting-users-permission-to-configure-alert-routing
 
 * xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user defined projects]
 * xref:../../observability/monitoring/managing-alerts.adoc#creating-alert-routing-for-user-defined-projects_managing-alerts[Creating alert routing for user-defined projects]
-
-== Next steps
-
-* xref:../../observability/monitoring/managing-alerts.adoc#managing-alerts[Managing alerts]

--- a/observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc
+++ b/observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc
@@ -41,7 +41,3 @@ include::modules/monitoring-excluding-a-user-defined-project-from-monitoring.ado
 
 // Disabling monitoring for user-defined projects
 include::modules/monitoring-disabling-monitoring-for-user-defined-projects.adoc[leveloffset=+1]
-
-== Next steps
-
-* xref:../../observability/monitoring/managing-metrics.adoc#managing-metrics[Managing metrics]

--- a/observability/monitoring/managing-alerts.adoc
+++ b/observability/monitoring/managing-alerts.adoc
@@ -113,9 +113,4 @@ include::modules/monitoring-applying-a-custom-configuration-to-alertmanager-for-
 * See link:https://prometheus.io/docs/alerting/configuration/[Alertmanager configuration] for configuring alerting through different alert receivers.
 ifndef::openshift-rosa,openshift-dedicated[]
 * See xref:../../observability/monitoring/enabling-alert-routing-for-user-defined-projects.adoc#enabling-alert-routing-for-user-defined-projects[Enabling alert routing for user-defined projects] to learn how to enable a dedicated instance of Alertmanager for user-defined alert routing.
-
-
-== Next steps
-
-* xref:../../observability/monitoring/reviewing-monitoring-dashboards.adoc#reviewing-monitoring-dashboards[Reviewing monitoring dashboards]
 endif::[]

--- a/observability/monitoring/managing-metrics-targets.adoc
+++ b/observability/monitoring/managing-metrics-targets.adoc
@@ -22,6 +22,3 @@ include::modules/monitoring-searching-and-filtering-metrics-targets.adoc[levelof
 // Getting detailed information about metrics targets
 include::modules/monitoring-getting-detailed-information-about-a-target.adoc[leveloffset=+1]
 
-== Next steps
-
-* xref:../../observability/monitoring/managing-alerts.adoc#managing-alerts[Managing alerts]

--- a/observability/monitoring/managing-metrics.adoc
+++ b/observability/monitoring/managing-metrics.adoc
@@ -33,8 +33,3 @@ include::modules/monitoring-example-service-endpoint-authentication-settings.ado
 
 // Viewing a list of available metrics for a cluster
 include::modules/monitoring-viewing-a-list-of-available-metrics.adoc[leveloffset=+1]
-
-[id="next-steps_querying-metrics"]
-== Next steps
-
-* xref:../../observability/monitoring/querying-metrics.adoc#querying-metrics[Querying metrics]

--- a/observability/monitoring/monitoring-overview.adoc
+++ b/observability/monitoring/monitoring-overview.adoc
@@ -41,7 +41,3 @@ include::modules/monitoring-common-terms.adoc[leveloffset=+1]
 * xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#granting-users-permission-to-monitor-user-defined-projects_enabling-monitoring-for-user-defined-projects[Granting users permission to monitor user-defined projects]
 * xref:../../security/tls-security-profiles.adoc#tls-security-profiles[Configuring TLS security profiles]
 
-[id="next-steps_monitoring-overview"]
-== Next steps
-
-* xref:../../observability/monitoring/configuring-the-monitoring-stack.adoc#configuring-the-monitoring-stack[Configuring the monitoring stack]

--- a/observability/monitoring/osd-accessing-monitoring-for-user-defined-projects.adoc
+++ b/observability/monitoring/osd-accessing-monitoring-for-user-defined-projects.adoc
@@ -16,8 +16,3 @@ Custom Prometheus instances and the Prometheus Operator installed through Operat
 ====
 
 Optionally, you can disable monitoring for user-defined projects during or after a cluster installation.
-
-[id="accessing-user-defined-monitoring-next-steps"]
-== Next steps
-
-* xref:../../observability/monitoring/osd-configuring-the-monitoring-stack.adoc#osd-configuring-the-monitoring-stack[Configuring the monitoring stack]

--- a/observability/monitoring/osd-configuring-the-monitoring-stack.adoc
+++ b/observability/monitoring/osd-configuring-the-monitoring-stack.adoc
@@ -76,7 +76,3 @@ include::modules/osd-monitoring-setting-a-scrape-sample-limit-for-user-defined-p
 // Setting log levels for monitoring components
 include::modules/osd-monitoring-setting-log-levels-for-monitoring-components.adoc[leveloffset=+1]
 
-[id="configuring-the-monitoring-stack-next-steps"]
-== Next steps
-
-* xref:../../observability/monitoring/osd-managing-metrics.adoc#osd-managing-metrics[Managing metrics]

--- a/observability/monitoring/osd-managing-alerts.adoc
+++ b/observability/monitoring/osd-managing-alerts.adoc
@@ -71,7 +71,3 @@ include::modules/monitoring-applying-a-custom-configuration-to-alertmanager-for-
 * See link:https://www.pagerduty.com/[the PagerDuty official site] for more information on PagerDuty.
 * See link:https://www.pagerduty.com/docs/guides/prometheus-integration-guide/[the PagerDuty Prometheus Integration Guide] to learn how to retrieve the `service_key`.
 * See link:https://prometheus.io/docs/alerting/configuration/[Alertmanager configuration] for configuring alerting through different alert receivers.
-
-[id="alerts-next-steps"]
-== Next steps
-* xref:../../observability/monitoring/osd-reviewing-monitoring-dashboards.adoc#osd-reviewing-monitoring-dashboards[Reviewing monitoring dashboards]

--- a/observability/monitoring/osd-managing-metrics.adoc
+++ b/observability/monitoring/osd-managing-metrics.adoc
@@ -42,7 +42,4 @@ include::modules/osd-monitoring-exploring-the-visualized-metrics.adoc[leveloffse
 * See the xref:../../observability/monitoring/osd-managing-metrics.adoc#querying-metrics_osd-managing-metrics[Querying metrics] section on using the PromQL interface
 * xref:../../observability/monitoring/osd-troubleshooting-monitoring-issues.adoc#osd-troubleshooting-monitoring-issues[Troubleshooting monitoring issues]
 
-[id="managing-metrics-next-steps"]
-== Next steps
-* xref:../../observability/monitoring/managing-alerts.adoc#managing-alerts[Alerts]
 

--- a/observability/monitoring/osd-reviewing-monitoring-dashboards.adoc
+++ b/observability/monitoring/osd-reviewing-monitoring-dashboards.adoc
@@ -26,7 +26,3 @@ In the *Developer* perspective, you can view dashboards for only one project at 
 // Reviewing monitoring dashboards as a developer
 include::modules/osd-monitoring-reviewing-monitoring-dashboards-developer.adoc[leveloffset=+1]
 
-[id="monitoring-dashboards-next-steps"]
-== Next steps
-
-* xref:../../observability/monitoring/osd-troubleshooting-monitoring-issues.adoc#osd-troubleshooting-monitoring-issues[Troubleshooting monitoring issues]

--- a/observability/monitoring/osd-understanding-the-monitoring-stack.adoc
+++ b/observability/monitoring/osd-understanding-the-monitoring-stack.adoc
@@ -26,8 +26,3 @@ include::modules/osd-monitoring-targets-for-user-defined-projects.adoc[leveloffs
 * link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.7/html/monitoring/monitoring-overview#default-monitoring-components_monitoring-overview[Default monitoring components]
 * link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.7/html/monitoring/monitoring-overview#default-monitoring-targets_monitoring-overview[Default monitoring targets]
 // TODO: When there is a link to the OCP docs, should that be explicit, so they're not surprised when they find themselves in another doc set?
-
-[id="understanding-the-monitoring-stack-next-steps"]
-== Next steps
-
-* xref:../../observability/monitoring/osd-accessing-monitoring-for-user-defined-projects.adoc#osd-accessing-monitoring-for-user-defined-projects[Accessing monitoring for user-defined projects]

--- a/observability/monitoring/querying-metrics.adoc
+++ b/observability/monitoring/querying-metrics.adoc
@@ -34,7 +34,3 @@ include::modules/monitoring-exploring-the-visualized-metrics.adoc[leveloffset=+2
 * See xref:../../observability/monitoring/querying-metrics.adoc#querying-metrics-for-all-projects-as-an-administrator_querying-metrics[Querying metrics for all projects as an administrator] for details on accessing metrics for all projects as an administrator.
 * See xref:../../observability/monitoring/querying-metrics.adoc#querying-metrics-for-user-defined-projects-as-a-developer_querying-metrics[Querying metrics for user-defined projects as a developer] for details on accessing non-cluster metrics as a developer or a privileged user.
 
-[id="next-steps_managing-metrics-targets"]
-== Next steps
-
-* xref:../../observability/monitoring/managing-metrics-targets.adoc#managing-metrics-targets[Managing metrics targets]

--- a/observability/monitoring/reviewing-monitoring-dashboards.adoc
+++ b/observability/monitoring/reviewing-monitoring-dashboards.adoc
@@ -46,8 +46,3 @@ include::modules/monitoring-reviewing-monitoring-dashboards-developer.adoc[level
 .Additional resources
 
 * xref:../../applications/odc-monitoring-project-and-application-metrics-using-developer-perspective.adoc#monitoring-project-and-application-metrics-using-developer-perspective[Monitoring project and application metrics using the Developer perspective]
-
-[id="next-steps_reviewing-monitoring-dashboards"]
-== Next steps
-
-* xref:../../observability/monitoring/accessing-third-party-monitoring-apis.adoc#accessing-third-party-monitoring-apis[Accessing monitoring APIs by using the CLI]

--- a/observability/monitoring/rosa-accessing-monitoring-for-user-defined-projects.adoc
+++ b/observability/monitoring/rosa-accessing-monitoring-for-user-defined-projects.adoc
@@ -16,8 +16,3 @@ Custom Prometheus instances and the Prometheus Operator installed through Operat
 ====
 
 Optionally, you can disable monitoring for user-defined projects during or after a cluster installation.
-
-[id="accessing-user-defined-monitoring-next-steps"]
-== Next steps
-
-* xref:../../observability/monitoring/rosa-configuring-the-monitoring-stack.adoc#rosa-configuring-the-monitoring-stack[Configuring the monitoring stack]

--- a/observability/monitoring/rosa-configuring-the-monitoring-stack.adoc
+++ b/observability/monitoring/rosa-configuring-the-monitoring-stack.adoc
@@ -77,7 +77,3 @@ include::modules/osd-monitoring-setting-a-scrape-sample-limit-for-user-defined-p
 // Setting log levels for monitoring components
 include::modules/osd-monitoring-setting-log-levels-for-monitoring-components.adoc[leveloffset=+1]
 
-[id="configuring-the-monitoring-stack-next-steps"]
-== Next steps
-
-* xref:../../observability/monitoring/rosa-managing-metrics.adoc#rosa-managing-metrics[Managing metrics]

--- a/observability/monitoring/rosa-managing-alerts.adoc
+++ b/observability/monitoring/rosa-managing-alerts.adoc
@@ -71,7 +71,3 @@ include::modules/monitoring-applying-a-custom-configuration-to-alertmanager-for-
 * See link:https://www.pagerduty.com/[the PagerDuty official site] for more information on PagerDuty.
 * See link:https://www.pagerduty.com/docs/guides/prometheus-integration-guide/[the PagerDuty Prometheus Integration Guide] to learn how to retrieve the `service_key`.
 * See link:https://prometheus.io/docs/alerting/configuration/[Alertmanager configuration] for configuring alerting through different alert receivers.
-
-[id="alerts-next-steps"]
-== Next steps
-* xref:../../observability/monitoring/rosa-reviewing-monitoring-dashboards.adoc#rosa-reviewing-monitoring-dashboards[Reviewing monitoring dashboards]

--- a/observability/monitoring/rosa-managing-metrics.adoc
+++ b/observability/monitoring/rosa-managing-metrics.adoc
@@ -39,8 +39,4 @@ include::modules/osd-monitoring-exploring-the-visualized-metrics.adoc[leveloffse
 * See the xref:../../observability/monitoring/rosa-managing-metrics.adoc#querying-metrics_rosa-managing-metrics[Querying metrics] section on using the PromQL interface
 * xref:../../observability/monitoring/rosa-troubleshooting-monitoring-issues.adoc#rosa-troubleshooting-monitoring-issues[Troubleshooting monitoring issues]
 
-[id="managing-metrics-next-steps"]
-== Next steps
-* xref:../../observability/monitoring/managing-alerts.adoc#managing-alerts[Alerts]
-
 // TODO: Why is alerts a next step if alerts aren't supported? Can this be removed?

--- a/observability/monitoring/rosa-reviewing-monitoring-dashboards.adoc
+++ b/observability/monitoring/rosa-reviewing-monitoring-dashboards.adoc
@@ -26,7 +26,3 @@ In the *Developer* perspective, you can view dashboards for only one project at 
 // Reviewing monitoring dashboards as a developer
 include::modules/osd-monitoring-reviewing-monitoring-dashboards-developer.adoc[leveloffset=+1]
 
-[id="monitoring-dashboards-next-steps"]
-== Next steps
-
-* xref:../../observability/monitoring/rosa-troubleshooting-monitoring-issues.adoc#rosa-troubleshooting-monitoring-issues[Troubleshooting monitoring issues]

--- a/observability/monitoring/rosa-understanding-the-monitoring-stack.adoc
+++ b/observability/monitoring/rosa-understanding-the-monitoring-stack.adoc
@@ -28,7 +28,3 @@ include::modules/osd-monitoring-targets-for-user-defined-projects.adoc[leveloffs
 * link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html-single/monitoring/index#default-monitoring-targets_monitoring-overview[Default monitoring targets]
 // TODO: When there is a link to the OCP docs, should that be explicit, so they're not surprised when they find themselves in another doc set?
 
-[id="understanding-the-monitoring-stack-next-steps"]
-== Next steps
-
-* xref:../../observability/monitoring/rosa-accessing-monitoring-for-user-defined-projects.adoc#rosa-accessing-monitoring-for-user-defined-projects[Accessing monitoring for user-defined projects]


### PR DESCRIPTION
Manual CP from #78549 to 4.12