### PR TITLE
RHDEVDOCS-6101: DOC: Add a flag on controllers to configure resyncPeriod in openshift-pipelines

### DIFF
--- a/install_config/customizing-configurations-in-the-tektonconfig-cr.adoc
+++ b/install_config/customizing-configurations-in-the-tektonconfig-cr.adoc
@@ -35,6 +35,8 @@ include::modules/op-changing-default-service-account.adoc[leveloffset=+1]
 
 include::modules/op-setting-annotations-labels-namespace.adoc[leveloffset=+1]
 
+include::modules/op-setting-resync-period.adoc[leveloffset=+1]
+
 include::modules/op-disabling-the-service-monitor.adoc[leveloffset=+1]
 
 include::modules/op-configuring-pipeline-resolvers.adoc[leveloffset=+1]

--- a/modules/op-setting-resync-period.adoc
+++ b/modules/op-setting-resync-period.adoc
@@ -1,0 +1,39 @@
+// This module is included in the following assemblies:
+// * install_config/customizing-configurations-in-the-tektonconfig-cr.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="op-setting-resync-period_{context}"]
+= Setting the resync period for the pipelines controller
+
+You can configure the resync period for the pipelines controller. Once every resync period, the controller reconciles all pipeline runs and task runs, regardless of events. 
+
+The default resync period is 10 hours. If you have a large number of pipeline runs and task runs, a full reconciliation every 10 hours might consume too many resources. In this case, you can configure a longer resync period.
+
+.Prerequisites
+* You are logged in to your {OCP} cluster with `cluster-admin` privileges.
+
+.Procedure
+
+* In the `TektonConfig` custom resource, configure the resync period for the pipelines controller, as shown in the following example.
++
+.Example
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+  pipeline:
+    options:
+      deployments:
+        tekton-pipelines-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-pipelines-controller
+                  args:
+                    - "-resync-period=24h" #<1>
+----
+<1> This example sets the resync period to 24 hours.


### PR DESCRIPTION
Version(s): `pipelines-docs-1.16`

Issue: [RHDEVDOCS-6101](https://issues.redhat.com/browse/RHDEVDOCS-6101)

Link to docs preview:  https://79107--ocpdocs-pr.netlify.app/openshift-pipelines/latest/install_config/customizing-configurations-in-the-tektonconfig-cr.html#op-setting-resync-period_customizing-configurations-in-the-tektonconfig-cr

QE review:
- [x] QE has approved this change.

**Additional information:**

