### PR TITLE
[SRVKS-1053] Add the step for specifying non-default certificate name

### DIFF
--- a/modules/serverless-enabling-tls-internal-traffic.adoc
+++ b/modules/serverless-enabling-tls-internal-traffic.adoc
@@ -41,3 +41,16 @@ spec:
 ----
 $ oc delete pod -n knative-serving --selector app=activator
 ----
+
+. After you change `defaultCertificate` in the Ingress Controller, you need to specify the custom certificate name in the `openshift-ingress-default-certificate` field in the `KnativeServing` custom resource. For example, if the custom certificate name is `ca-ingress-cert`, add the following configuration:
++
+[source,yaml]
+----
+...
+spec:
+  config:
+    network:
+      internal-encryption: "true"
+      openshift-ingress-default-certificate: "ca-ingress-cert"
+...
+----

--- a/modules/serverless-enabling-tls-internal-traffic.adoc
+++ b/modules/serverless-enabling-tls-internal-traffic.adoc
@@ -23,7 +23,7 @@ include::snippets/technology-preview.adoc[]
 
 .Procedure
 
-. Create or update your `KnativeServing` resource and make sure that it includes the `internal-encryption: "true"` field in the spec:
+. Create or update your `KnativeServing` resource and make sure that it includes the `system-internal-tls: Enabled` field in the spec:
 +
 [source,yaml]
 ----
@@ -31,7 +31,7 @@ include::snippets/technology-preview.adoc[]
 spec:
   config:
     network:
-      internal-encryption: "true"
+      system-internal-tls: Enabled
 ...
 ----
 
@@ -42,7 +42,19 @@ spec:
 $ oc delete pod -n knative-serving --selector app=activator
 ----
 
-. After you change `defaultCertificate` in the Ingress Controller, you need to specify the custom certificate name in the `openshift-ingress-default-certificate` field in the `KnativeServing` custom resource. For example, if the custom certificate name is `ca-ingress-cert`, add the following configuration:
+. Optionally, change the `defaultCertificate` in the Ingress Controller:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+ ...
+spec:
+  defaultCertificate:
+    name: ca-ingress-cert
+----
+
+. If you changed the `defaultCertificate`, you need to specify the custom certificate name in the `openshift-ingress-default-certificate` field in the `KnativeServing` custom resource. For example, if the custom certificate name is `ca-ingress-cert`, add the following configuration:
 +
 [source,yaml]
 ----
@@ -50,7 +62,7 @@ $ oc delete pod -n knative-serving --selector app=activator
 spec:
   config:
     network:
-      internal-encryption: "true"
+      system-internal-tls: Enabled
       openshift-ingress-default-certificate: "ca-ingress-cert"
 ...
 ----


### PR DESCRIPTION
Version(s):
`serverless-docs-1.34`+

Issue:
https://issues.redhat.com/browse/SRVKS-1053

Link to docs preview:
https://79108--ocpdocs-pr.netlify.app/openshift-serverless/latest/knative-serving/config-applications/serverless-config-tls.html

QE review:
- [ ] QE has approved this change.