### PR TITLE
OCPBUGS-34129: Update ipi gcp docs

### DIFF
--- a/modules/minimum-required-permissions-upi-gcp.adoc
+++ b/modules/minimum-required-permissions-upi-gcp.adoc
@@ -31,7 +31,6 @@ If your organization’s security policies require a more restrictive set of per
 * `compute.forwardingRules.setLabels`
 * `compute.globalAddresses.create`
 * `compute.globalAddresses.get`
-* `compute.globalAddresses.setLabels`
 * `compute.globalAddresses.use`
 * `compute.globalForwardingRules.create`
 * `compute.globalForwardingRules.get`
@@ -156,7 +155,6 @@ If your organization’s security policies require a more restrictive set of per
 * `compute.httpHealthChecks.get`
 * `compute.httpHealthChecks.list`
 * `compute.httpHealthChecks.useReadOnly`
-* `compute.regionHealthCheckServices.list`
 * `compute.regionHealthChecks.create`
 * `compute.regionHealthChecks.get`
 * `compute.regionHealthChecks.useReadOnly`


### PR DESCRIPTION
Versions: 4.16 and 4.17

** Updates to ipi docs to match min permissions for upi:
  - compute.globalAddresses.setLabels
  - compute.regionHealthCheckServices.list

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
