### PR TITLE
TELCODOCS-1488: Outdated must gather images - 4.13

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -60,14 +60,11 @@ endif::openshift-dedicated[]
 |`registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel8:v<installed_version_sandboxed_containers>`
 |Data collection for {sandboxed-containers-first}.
 
-|`registry.redhat.io/workload-availability/self-node-remediation-must-gather-rhel8:v<installed-version-SNR>`
-|Data collection for the Self Node Remediation (SNR) Operator and the Node Health Check (NHC) Operator.
+|`registry.redhat.io/workload-availability/node-healthcheck-must-gather-rhel8:v<installed-version-NHC>`
+|Data collection for the Red{nbsp}Hat Workload Availability Operators, including the Self Node Remediation (SNR) Operator, the Fence Agents Remediation (FAR) Operator, the Machine Deletion Remediation (MDR) Operator, the Node Health Check Operator (NHC) Operator, and the Node Maintenance Operator (NMO) Operator.
 
 |`registry.redhat.io/openshift4/ptp-must-gather-rhel8:v<installed-version-ptp>`
 |Data collection for the PTP Operator.
-
-|`registry.redhat.io/workload-availability/node-maintenance-must-gather-rhel8:v<installed-version-NMO>`
-|Data collection for the Node Maintenance Operator (NMO).
 
 |`registry.redhat.io/openshift-gitops-1/must-gather-rhel8:v<installed_version_GitOps>`
 |Data collection for {gitops-title}.


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-1488: Outdated must gather images

Applies to OCP version : 4.13+

Preview: [Gathering data about specific features](https://79128--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data.html#gathering-data-specific-features_gathering-cluster-data)

Dev review completed by @slintes 
QE review completed by @anna-savina 
Peer review to be completed by @StephenJamesSmith 

Thank you.