### PR TITLE
ROX-25060: Update info for admission controller timeout

### DIFF
--- a/cloud_service/installing_cloud_ocp/install-secured-cluster-cloud-ocp.adoc
+++ b/cloud_service/installing_cloud_ocp/install-secured-cluster-cloud-ocp.adoc
@@ -7,7 +7,7 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-You can install {product-title-managed-short} on your secured clusters by using the the Operator or Helm charts. You can also use the `roxctl` CLI to install it, but do not use this method unless you have a specific installation need that requires using it.
+You can install {product-title-managed-short} on your secured clusters by using the Operator or Helm charts. You can also use the `roxctl` CLI to install it, but do not use this method unless you have a specific installation need that requires using it.
 
 .Prerequisites
 

--- a/modules/secured-cluster-configuration-options-operator.adoc
+++ b/modules/secured-cluster-configuration-options-operator.adoc
@@ -79,8 +79,7 @@ a| Use one of the following values to specify if the admission controller must c
 The default value is `DoNotScanInline`.
 
 | `admissionControl.timeoutSeconds`
-| Use this parameter to specify the maximum number of seconds {product-title} must wait for an admission review before marking it as fail open.
-
+| Use this parameter to specify the maximum number of seconds {product-title-short} must wait for an admission review before marking it as fail open. If the admission webhook does not receive information that it is requesting before the end of the timeout period, it fails, but in fail open status, it still allows the operation to succeed. For example, the admission controller would allow a deployment to be created even if a scan had timed out and {product-title-short} could not determine if the deployment violated a policy. For example, the admission controller would allow a deployment to be created even if the scan had timed out. Beginning in release 4.5, Red{nbsp}Hat reduced the default timeout setting for the {product-title-short} admission controller webhooks from 20 seconds to 10 seconds, resulting in an effective timeout of 12 seconds within the `ValidatingWebhookConfiguration`. This change does not negatively affect {ocp} users because {ocp} caps the timeout at 13 seconds.
 |===
 
 [id="scanner-configuration-settings_{context}"]

--- a/modules/secured-cluster-services-config.adoc
+++ b/modules/secured-cluster-services-config.adoc
@@ -8,6 +8,23 @@
 [id="secured-cluster-services-config_{context}"]
 = Configuration parameters
 
+ifeval::["{context}" == "install-secured-cluster-cloud-ocp"]
+:openshift:
+endif::[]
+
+ifeval::["{context}" == "install-secured-cluster-cloud-other"]
+:kube:
+endif::[]
+
+ifeval::["{context}" == "install-secured-cluster-ocp"]
+:openshift:
+endif::[]
+
+ifeval::["{context}" == "install-secured-cluster-other"]
+:kube:
+endif::[]
+
+
 |===
 | Parameter | Description
 
@@ -155,9 +172,13 @@ This option corresponds to the *Contact image scanners* option in the {product-t
 //TODO: Link to admission controller docs
 
 | `admissionControl.dynamic.timeout`
-| The maximum time, in seconds, {product-title} should wait while evaluating admission review requests.
-Use this to set request timeouts when you enable image scanning.
-If the image scan runs longer than the specified time, {product-title} accepts the request.
+| Use this parameter to specify the maximum number of seconds {product-title-short} must wait for an admission review before marking it as fail open. If the admission webhook does not receive information that it is requesting before the end of the timeout period, it fails, but in fail open status, it still allows the operation to succeed. For example, the admission controller would allow a deployment to be created even if a scan had timed out and {product-title-short} could not determine if the deployment violated a policy. Beginning in release 4.5, Red{nbsp}Hat reduced the default timeout setting for the {product-title-short} admission controller webhooks from 20 seconds to 10 seconds, resulting in an effective timeout of 12 seconds within the `ValidatingWebhookConfiguration`.
+ifndef::kube[]
+This change does not negatively affect {ocp} users because {ocp} caps the timeout at 13 seconds.
+endif::kube[]
+ifndef::openshift[]
+For Kubernetes clusters, image scanning and pulling that are done as part of the webhook execution might require you to configure a longer timeout value.
+endif::openshift[]
 
 | `admissionControl.resources.requests.memory`
 | The memory request for the Admission Control container. Use this parameter to override the default value.


### PR DESCRIPTION
Version(s):
4.5+

[Issue](https://issues.redhat.com/browse/ROX-25060)

Links to docs previews:

[79149--ocpdocs-pr.netlify.app](https://79149--ocpdocs-pr.netlify.app/)
[79149--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_ocp/install-secured-cluster-cloud-ocp.html](https://79149--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_ocp/install-secured-cluster-cloud-ocp.html)
[79149--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_other/install-secured-cluster-cloud-other.html](https://79149--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_other/install-secured-cluster-cloud-other.html)
[79149--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-config-options-ocp.html](https://79149--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-config-options-ocp.html)
[79149--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-ocp.html](https://79149--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-ocp.html)
[79149--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_other/install-secured-cluster-other.html](https://79149--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_other/install-secured-cluster-other.html)


QE review: (**ACS has no QE, reviewed/approved by SME**)
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
