### PR TITLE
RHDEVDOCS 6121 correct table formatting for chains

### DIFF
--- a/modules/op-supported-parameters-tekton-chains-configuration.adoc
+++ b/modules/op-supported-parameters-tekton-chains-configuration.adoc
@@ -267,19 +267,31 @@ If you configure the `kms` signature backend, set the KMS configuration, includi
 
 | `signers.kms.auth.address`
 | URI of the KMS server (the value of `VAULT_ADDR`).
+|
+|
 
 | `signers.kms.auth.token`
 | Authentication token for the KMS server (the value of `VAULT_TOKEN`).
+|
+|
 
 | `signers.kms.auth.oidc.path`
 | The path for OIDC authentication (for example, `jwt` for Vault).
+|
+|
 
 | `signers.kms.auth.oidc.role`
 | The role for OIDC authentication.
+|
+|
 
 | `signers.kms.auth.spire.sock`
 | The URI of the Spire socket for the KMS token (for example, `unix:///tmp/spire-agent/public/api.sock`).
+|
+|
 
 | `signers.kms.auth.spire.audience`
 | The audience for requesting a SVID from Spire.
+|
+|
 |===


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
please cp to pipelines-docs-1.11, pipelines-docs-1.12, pipelines-docs-1.13, pipelines-docs-1.14, pipelines-docs-1.15, pipelines-docs-1.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
RHDEVDOCS 6121

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://79151--ocpdocs-pr.netlify.app/openshift-pipelines/latest/secure/using-tekton-chains-for-openshift-pipelines-supply-chain-security.html#supported-parameters-tekton-chains-configuration_using-tekton-chains-for-openshift-pipelines-supply-chain-security Table 10

QE review:
n/a
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
This is a fix for a mistake in table formatting. No documentation content is changed so no SME or QE review is needed.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
