### PR TITLE
OBSDOCS-1136: Added a compatibility matrix table for the Logging 6.0 …

### DIFF
--- a/modules/log6x-logging-compatibility-support-matrix.adoc
+++ b/modules/log6x-logging-compatibility-support-matrix.adoc
@@ -1,0 +1,28 @@
+[id="log6x-logging-compatibility-support-matrix_{context}"]
+= Compatibility and support matrix
+
+In the table, components are marked with the following statuses:
+
+[horizontal]
+TP:: Technology Preview
+GA:: General Availability
+
+The components or features in link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] status are experimental and are not intended for production use.
+
+[NOTE]
+====
+To know about compatible {product-title} versions for {logging-uc} releases, see link:https://access.redhat.com/product-life-cycles?product=Red%20Hat%20OpenShift%20Logging[Product Life Cycles].
+====
+
+.Components support matrix
+[options="header"]
+|===
+
+| {logging-uc} Version 6+| Component Version
+
+| Operator | `eventrouter` | `logfilemetricexplorer` | `loki` | `lokistack-gateway` | `opa-openshift` | `vector`
+
+|6.0 | 0.4 (GA) | v1.1 (GA) | v3.1.0 (GA) | v0.1 (GA) | v0.1 (GA) | v0.37.x (GA)
+
+|===
+

--- a/observability/logging/cluster-logging.adoc
+++ b/observability/logging/cluster-logging.adoc
@@ -26,6 +26,10 @@ include::modules/logging-architecture-overview.adoc[leveloffset=+1]
 .Additional resources
 * xref:../../observability/logging/log_visualization/log-visualization-ocp-console.adoc#log-visualization-ocp-console[Log visualization with the web console]
 
+// this module is to be included in the Logging 6.0 Release Notes. See https://docs.openshift.com/pipelines/1.15/about/op-release-notes.html#compatibility-support-matrix_op-release-notes for reference.
+
+include::modules/log6x-logging-compatibility-support-matrix.adoc[leveloffset=+1]
+
 include::modules/cluster-logging-about.adoc[leveloffset=+1]
 
 ifdef::openshift-rosa,openshift-dedicated[]


### PR DESCRIPTION
**Purpose:** To resolve the issue: https://issues.redhat.com/browse/OBSDOCS-1136

**Aligned team:** Logging (ODiE)

**Content for preview:** https://79153--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/cluster-logging.html#log6x-logging-compatibility-support-matrix_cluster-logging

**SME review:**  @periklis 
**QE review:** @kabirbhartiRH 
**Peer review:** @mletalie 

**Additional info:** The table is current placed in an introduction assembly, but we would place it in the Logging 6.0 RN once that RN file is ready. 