### PR TITLE
OSDOCS-11355 Removing outdated service log sections from ROSA and OSD

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -362,12 +362,6 @@ Topics:
     File: osd-managing-worker-nodes
   - Name: About autoscaling nodes on a cluster
     File: osd-nodes-about-autoscaling-nodes
-- Name: Logging
-  Dir: osd_logging
-  Distros: openshift-dedicated
-  Topics:
-  - Name: Accessing the service logs
-    File: osd-accessing-the-service-logs
 ---
 Name: Security and compliance
 Dir: security
@@ -1259,8 +1253,6 @@ Topics:
       File: cluster-logging-dashboards
     - Name: Log visualization with Kibana
       File: logging-kibana
-  - Name: Accessing the service logs
-    File: sd-accessing-the-service-logs
   - Name: Configuring your Logging deployment
     Dir: config
     Topics:

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1526,10 +1526,6 @@ Topics:
       File: cluster-logging-dashboards
     - Name: Log visualization with Kibana
       File: logging-kibana
-  - Name: Accessing the service logs
-    File: sd-accessing-the-service-logs
-  - Name: Viewing cluster logs in the AWS Console
-    File: rosa-viewing-logs
   - Name: Configuring your Logging deployment
     Dir: config
     Topics:

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -1447,10 +1447,6 @@ Topics:
 #     File: cluster-logging-dashboards
 #   - Name: Log visualization with Kibana
 #     File: logging-kibana
-# - Name: Accessing the service logs
-#   File: sd-accessing-the-service-logs
-# - Name: Viewing cluster logs in the AWS Console
-#   File: rosa-viewing-logs
 # - Name: Configuring your Logging deployment
 #   Dir: config
 #   Topics:

--- a/ocm/ocm-overview.adoc
+++ b/ocm/ocm-overview.adoc
@@ -68,7 +68,10 @@ include::modules/ocm-settings-tab.adoc[leveloffset=+2]
 == Additional resources
 
 * For the complete documentation for {cluster-manager}, see link:https://access.redhat.com/documentation/en-us/openshift_cluster_manager/2022/html-single/managing_clusters/index[{cluster-manager} documentation].
-ifdef::openshift-dedicated,openshift-rosa[]
-* For steps to add cluster notification contacts, see xref:../observability/logging/sd-accessing-the-service-logs.adoc#adding-cluster-notification-contacts_sd-accessing-the-service-logs[Adding cluster notification contacts].
+ifdef::openshift-rosa,openshift-rosa-hcp,openshift-rosa-classic[]
+* For steps to add cluster notification contacts, see xref:../rosa_cluster_admin/rosa-cluster-notifications.adoc#add-notification-contact_rosa-cluster-notifications[Adding cluster notification contacts]
+endif::[]
+ifdef::openshift-dedicated[]
+* For steps to add cluster notification contacts, see xref:../osd_cluster_admin/osd-cluster-notifications.adoc#add-notification-contact_osd-cluster-notifications[Adding cluster notification contacts]
 endif::[]
 

--- a/rosa_planning/rosa-limits-scalability.adoc
+++ b/rosa_planning/rosa-limits-scalability.adoc
@@ -22,4 +22,4 @@ include::modules/sd-planning-considerations.adoc[leveloffset=+1]
 [id="additional-resources_rosa-limits-scalability"]
 == Additional resources
 
-* xref:../observability/logging/sd-accessing-the-service-logs.adoc#sd-accessing-the-service-logs[Accessing the service logs for ROSA clusters]
+* xref:../rosa_cluster_admin/rosa-cluster-notifications.adoc#managed-cluster-notification-view-hcc_rosa-cluster-notifications[Viewing cluster notifications using the {hybrid-console}]

--- a/upgrading/osd-upgrades.adoc
+++ b/upgrading/osd-upgrades.adoc
@@ -16,7 +16,7 @@ include::modules/upgrade.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* For more information about the service log and adding cluster notification contacts, see xref:../osd_cluster_admin/osd_logging/osd-accessing-the-service-logs.adoc#osd-accessing-the-service-logs[Accessing the service logs for {product-title} clusters].
+* For more information about the service log and adding cluster notification contacts, see xref:../osd_cluster_admin/osd-cluster-notifications.adoc#managed-cluster-notification-view-hcc_osd-cluster-notifications[Accessing cluster notifications in {hybrid-console}].
 
 include::modules/upgrade-auto.adoc[leveloffset=+1]
 include::modules/upgrade-manual.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-11355

Link to docs preview:
Section no longer appears under Logging in OSD or ROSA:
https://79160--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/logging_release_notes/logging-5-9-release-notes
https://79160--ocpdocs-pr.netlify.app/openshift-rosa/latest/observability/logging/logging_release_notes/logging-5-9-release-notes

QE review:
- [x] QE has approved this change.

Additional information:
The removed sections are superseded by the cluster notifications documentation in ROSA and OSD.

https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/policies-and-service-definition#review-action-notifications_rosa-policy-responsibility-matrix

https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/rosa-cluster-notifications