### PR TITLE
RHDEVDOCS-6086: Enable Tekton Chains to operate only in selected name…

### DIFF
--- a/modules/op-enabling-tekton-chains-to-operate-only-in-selected-namespaces.adoc
+++ b/modules/op-enabling-tekton-chains-to-operate-only-in-selected-namespaces.adoc
@@ -1,0 +1,39 @@
+// This module is included in the following assemblies:
+// * secure/using-tekton-chains-for-openshift-pipelines-supply-chain-security.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="enabling-tekton-chains-to-operate-only-in-selected-namespaces_{context}"]
+= Enabling {tekton-chains} to operate only in selected namespaces
+
+By default, the {tekton-chains} controller monitors resources in all namespaces. You can customize {tekton-chains} to run only in specific namespaces, which provides granular control over its operation.
+
+.Prerequisites
+* You are logged in to your {OCP} cluster with `cluster-admin` privileges.
+
+.Procedure
+
+* In the `TektonConfig` CR, in the `chain` section, add the `--namespace=` argument to contain the namespaces that the controller should monitor.
++
+The following example shows the configuration for the {tekton-chains} controller to only monitor resources within the `dev` and `test` namespaces, filtering `PipelineRun` and `TaskRun` objects accordingly:
++
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+  chain:
+    disabled: false
+    options:
+      deployments:
+        tekton-chains-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - args:
+                  - --namespace=dev, test #<1>
+                  name: tekton-chains-controller
+----
+<1> If the `--namespace` argument is not provided or is left empty, the controller watches all namespaces by default.

--- a/secure/using-tekton-chains-for-openshift-pipelines-supply-chain-security.adoc
+++ b/secure/using-tekton-chains-for-openshift-pipelines-supply-chain-security.adoc
@@ -20,9 +20,8 @@ To capture information about task runs, {tekton-chains} uses `Result` objects. W
 * You can securely store signatures and signed artifacts using OCI repository as a storage backend.
 
 include::modules/op-configuring-tekton-chains.adoc[leveloffset=+1]
-
 include::modules/op-supported-parameters-tekton-chains-configuration.adoc[leveloffset=+2]
-
+include::modules/op-enabling-tekton-chains-to-operate-only-in-selected-namespaces.adoc[leveloffset=+2]
 include::modules/op-signing-secrets-in-tekton-chains.adoc[leveloffset=+1]
 include::modules/op-chains-signing-secrets-cosign.adoc[leveloffset=+2]
 include::modules/op-chains-signing-secrets-skopeo.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s): `pipelines-docs-1.16`

Issue: [RHDEVDOCS-6086](https://issues.redhat.com/browse/RHDEVDOCS-6086)

Link to docs preview: https://79163--ocpdocs-pr.netlify.app/openshift-pipelines/latest/secure/using-tekton-chains-for-openshift-pipelines-supply-chain-security.html#enabling-tekton-chains-to-operate-only-in-selected-namespaces_using-tekton-chains-for-openshift-pipelines-supply-chain-security

QE review:
- [x] QE has approved this change.

**Additional information:**