### PR TITLE
OSDOCS-10920: adds 4.16.4 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -223,4 +223,14 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-16-3-bug-fixes_{context}"]
 ==== Bug fixes
 
-* A mistake in validation allowed empty entries in the `listenAddress` configuration parameter. The empty entries prevented {microshift-short} from starting and rendered a difficult-to-understand error message. Empty entries in the list are now filtered.
+* An error in validation allowed empty entries in the `listenAddress` configuration parameter. The empty entries prevented {microshift-short} from starting and rendered a difficult-to-understand error message. Empty entries in the list are now filtered.
+
+[id="microshift-4-16-4-dp_{context}"]
+=== RHBA-2024:4615 - {microshift-short} 4.16.4 bug fix and enhancement advisory
+
+Issued: 2024-07-24
+
+{product-title} release 4.16.4 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4615[RHBA-2024:4615] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4613[RHSA-2024:4613] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16

Issue:
[OSDOCS-10920](https://issues.redhat.com/browse/OSDOCS-10920)

Link to docs preview:
[4-16-4 release notes](https://79176--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-4-dp_release-notes)

QE review:
- N/A stock text

<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
