### PR TITLE
Added additional NOTE, for syslog ingressaccess logging

### DIFF
--- a/modules/nw-configure-ingress-access-logging.adoc
+++ b/modules/nw-configure-ingress-access-logging.adoc
@@ -75,6 +75,8 @@ spec:
 [NOTE]
 ====
 The `syslog` destination port must be UDP.
+
+The `syslog` destination address must be an IP address. It does not support DNS hostname.
 ====
 
 Configure Ingress access logging with a specific log format.


### PR DESCRIPTION
Added additional NOTE, for syslog ingressaccess logging.

Where the Syslog destination address should always be IPv4, it does not support using DNS hostnames.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
OPC 4.16+

Issue:
Updating syslog ingress access logging doc for clarification about Syslog destination address 

Link to docs preview:
https://79188--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress-operator#nw-configure-ingress-access-logging_configuring-ingress

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
