### PR TITLE
OSDOCS-11404: fix minor typo

### DIFF
--- a/modules/machineset-azure-capacity-reservation.adoc
+++ b/modules/machineset-azure-capacity-reservation.adoc
@@ -71,7 +71,7 @@ spec:
 [source,terminal]
 ----
 ifndef::cpmso[]
-$ oc oc get machines.machine.openshift.io \
+$ oc get machines.machine.openshift.io \
   -n openshift-machine-api \
   -l machine.openshift.io/cluster-api-machineset=<machine_set_name>
 endif::cpmso[]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-11404](https://issues.redhat.com//browse/OSDOCS-11404)

Link to docs preview:
https://79208--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure.html#machineset-azure-capacity-reservation_creating-machineset-azure

QE review:
N/A

Additional information: