### PR TITLE
RHDEVDOCS-5837 Update _distro_map.yml

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -373,6 +373,9 @@ openshift-gitops:
     gitops-docs-1.13:
       name: '1.13'
       dir: gitops/1.13
+    gitops-docs-1.14:
+      name: '1.14'
+      dir: gitops/1.14
 openshift-pipelines:
   name: Red Hat OpenShift Pipelines
   author: OpenShift documentation team <openshift-docs@redhat.com>


### PR DESCRIPTION
**Version(s):** `main` only

**Issue:**
-  [RHDEVDOCS 5837](https://issues.redhat.com/browse/RHDEVDOCS-5837)

**Link to docs preview:** N/A
**SME and QE review:** Not applicable


**Additional information:** This PR updates the distro map in main for the 1.14 GitOps standalone doc. It does not alter documentation content, so no documentation preview is available.