### PR TITLE
OCPBUGS-34815: Fix CAS expander example

### DIFF
--- a/modules/cluster-autoscaler-config-priority-expander.adoc
+++ b/modules/cluster-autoscaler-config-priority-expander.adoc
@@ -58,10 +58,10 @@ metadata:
 data:
   priorities: |- # <3>
     10:
-      - *fast*
-      - *archive*
+      - .*fast.*
+      - .*archive.*
     40:
-      - *prod*
+      - .*prod.*
 ----
 <1> You must name config map `cluster-autoscaler-priority-expander`.
 <2> You must create the config map in the same namespace as cluster autoscaler pod, which is the `openshift-machine-api` namespace.


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-34815](https://issues.redhat.com/browse/OCPBUGS-34815)

Link to docs preview:
[Configuring a priority expander for the cluster autoscaler](https://79219--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/applying-autoscaling.html#cluster-autoscaler-config-priority-expander_applying-autoscaling)

QE review:
- [x] QE has approved this change.