### PR TITLE
CNV#44566: workloadUpdateMethods is backed up in an environment variable

### DIFF
--- a/modules/virt-preventing-workload-updates-during-eus-update.adoc
+++ b/modules/virt-preventing-workload-updates-during-eus-update.adoc
@@ -20,12 +20,12 @@ When you update from one Extended Update Support (EUS) version to the next, you 
 
 .Procedure
 
-. Back up the current `workloadUpdateMethods` configuration by running the following command:
+. Run the following command and record the `workloadUpdateMethods` configuration:
 +
 [source,terminal,subs="attributes+"]
 ----
-$ WORKLOAD_UPDATE_METHODS=$(oc get kv kubevirt-kubevirt-hyperconverged \
-  -n {CNVNamespace} -o jsonpath='{.spec.workloadUpdateStrategy.workloadUpdateMethods}')
+$ oc get kv kubevirt-kubevirt-hyperconverged \
+  -n {CNVNamespace} -o jsonpath='{.spec.workloadUpdateStrategy.workloadUpdateMethods}'
 ----
 
 . Turn off all workload update methods by running the following command:
@@ -181,12 +181,12 @@ $ oc get csv -n {CNVNamespace}
 +
 The update completes when the `VERSION` field matches the target EUS version and the `PHASE` field reads `Succeeded`.
 
-. Restore the workload update methods configuration that you backed up:
+. Restore the `workloadUpdateMethods` configuration that you recorded from step 1 with the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
 $ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} --type json -p \
-  "[{\"op\":\"add\",\"path\":\"/spec/workloadUpdateStrategy/workloadUpdateMethods\", \"value\":$WORKLOAD_UPDATE_METHODS}]"
+  "[{\"op\":\"add\",\"path\":\"/spec/workloadUpdateStrategy/workloadUpdateMethods\", \"value\":{WorkloadUpdateMethodConfig}}]"
 ----
 +
 .Example output


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/CNV-44566

Link to docs preview:
https://79235--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/updating/upgrading-virt.html#virt-preventing-workload-updates-during-eus-update_upgrading-virt

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
