### PR TITLE
OADP-4360 added troubleshooting info for PVR fail

### DIFF
--- a/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
@@ -55,6 +55,45 @@ requests:
 ----
 ====
 
+[id="podvolumerestore-fails_{context}"]
+== PodVolumeRestore fails to complete when StorageClass is NFS
+
+The restore operation fails when there is more than one volume during a NFS restore by using `Restic` or `Kopia`. `PodVolumeRestore` either fails with the following error or keeps trying to restore before finally failing.
+
+.Error message
+
+[source,terminal]
+----
+Velero: pod volume restore failed: data path restore failed: \
+Failed to run kopia restore: Failed to copy snapshot data to the target: \
+restore error: copy file: error creating file: \
+open /host_pods/b4d...6/volumes/kubernetes.io~nfs/pvc-53...4e5/userdata/base/13493/2681: \
+no such file or directory
+----
+
+.Cause
+
+The NFS mount path is not unique for the two volumes to restore. As a result, the `velero` lock files use the same file on the NFS server during the restore, causing the `PodVolumeRestore` to fail.
+
+.Solution
+
+You can resolve this issue by setting up a unique `pathPattern` for each volume, while defining the `StorageClass` for `nfs-subdir-external-provisioner` in the `deploy/class.yaml` file. Use the following `nfs-subdir-external-provisioner` `StorageClass` example:
+
+
+[source,yaml]
+----
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: nfs-client
+provisioner: k8s-sigs.io/nfs-subdir-external-provisioner 
+parameters:
+  pathPattern: "${.PVC.namespace}/${.PVC.annotations.nfs.io/storage-path}" # <1>
+  onDelete: delete
+----
+
+<1> Specifies a template for creating a directory path by using `PVC` metadata such as labels, annotations, name, or namespace. To specify metadata, use `${.PVC.<metadata>}`. For example, to name a folder: `<pvc-namespace>-<pvc-name>`, use `${.PVC.namespace}-${.PVC.name}` as `pathPattern`.
+
 [id="issues-with-velero-and-admission-workbooks"]
 == Issues with Velero and admission webhooks
 


### PR DESCRIPTION
## Jira 

* [OADP-4360](https://issues.redhat.com/browse/OADP-4360)

Added a section under Troubleshooting to give information about the cause and solution for the PVR fail issue.

##  Version

* OCP 4.12 → OCP 4.17

## Preview

* [PodVolumeRestore fails to complete](https://79245--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting.html#podvolumerestore-fails_oadp-troubleshooting)

## QE Review

* [x] QE has approved this change.
