### PR TITLE
OSDOCS-11135: adds 4.15.23 relnotes Microshift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -385,3 +385,12 @@ Issued: 2024-07-18
 The {product-title} release 4.15.22 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4476[RHBA-2024:4476] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4474[RHSA-2024:4474] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-15-23-dp_{context}"]
+=== RHBA-2024:4701 - {microshift-short} 4.15.23 bug fix and enhancement advisory
+
+Issued: 2024-07-25
+
+The {product-title} release 4.15.23 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4701[RHBA-2024:4701] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4699[RHSA-2024:4699] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-11135](https://issues.redhat.com/browse/OSDOCS-11135)

Link to docs preview:
[4.15.23 async relnote](https://79260--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-23-dp_release-notes)

QE review:
- NA stock text