### PR TITLE
Updated the correct command  for accessing Cluster Samples Operator…

### DIFF
--- a/modules/samples-operator-crd.adoc
+++ b/modules/samples-operator-crd.adoc
@@ -19,7 +19,7 @@ You can configure the Cluster Samples Operator by editing the file with the prov
 +
 [source,terminal]
 ----
-$ oc edit configs.samples.operator.openshift.io/cluster -o yaml
+$ oc edit configs.samples.operator.openshift.io/cluster
 ----
 +
 The Cluster Samples Operator configuration resembles the following example:


### PR DESCRIPTION
Removed `-o yaml` under `Accessing the Cluster Samples Operator configuration`

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
OCP 4.16+

Issue:
Updated the correct command to for accessing Cluster Samples Operator…

Link to docs preview: https://79269--ocpdocs-pr.netlify.app/openshift-enterprise/latest/openshift_images/configuring-samples-operator.html#samples-operator-crd_configuring-samples-operator
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
