### PR TITLE
OSDOCS-11377: Updated the mtu parameter for the bridge add. network p…

### DIFF
--- a/modules/nw-multus-bridge-object.adoc
+++ b/modules/nw-multus-bridge-object.adoc
@@ -81,7 +81,7 @@ ifndef::microshift[]
 endif::microshift[]
 
 |`mtu`
-|`string`
+|`integer`
 |Optional: Set the maximum transmission unit (MTU) to the specified value. The default value is automatically set by the kernel.
 
 |`enabledad`

--- a/networking/multiple_networks/configuring-additional-network.adoc
+++ b/networking/multiple_networks/configuring-additional-network.adoc
@@ -127,11 +127,22 @@ creating.
 
 The specific configuration fields for additional networks is described in the following sections.
 
+// Configuration for a bridge additional network
 include::modules/nw-multus-bridge-object.adoc[leveloffset=+2]
+
+// Configuration for a host device additional network
 include::modules/nw-multus-host-device-object.adoc[leveloffset=+2]
+
+// Configuration for an VLAN additional network
 include::modules/nw-multus-vlan-object.adoc[leveloffset=+2]
+
+// Configuration for an ipvlan additional network
 include::modules/nw-multus-ipvlan-object.adoc[leveloffset=+2]
+
+// Configuration for a macvlan additional network
 include::modules/nw-multus-macvlan-object.adoc[leveloffset=+2]
+
+// Configuration for a TAP additional network
 include::modules/nw-multus-tap-object.adoc[leveloffset=+2]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
(https://issues.redhat.com/browse/OSDOCS-11377)

Link to docs preview:
* [Configuration for a bridge additional network (ent)](https://79276--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html#nw-multus-bridge-object_configuring-additional-network)
* [Configuration for a bridge additional network (MShift)](https://79276--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift_multiple_networks/microshift-cni-multus.html#nw-multus-bridge-object_microshift-cni-multus)


- [x] SME has approved this change.
- [x] QE has approved this change.
