### PR TITLE
OCPBUGS-36901: Add step to network observability installation for Lokiless option

### DIFF
--- a/modules/network-observability-operator-install.adoc
+++ b/modules/network-observability-operator-install.adoc
@@ -33,6 +33,7 @@ Additionally, this installation example uses the `netobserv` namespace, which is
 . Navigate to *Operators* -> *Installed Operators*. Under Provided APIs for Network Observability, select the *Flow Collector* link.
 . Navigate to the *Flow Collector* tab, and click *Create FlowCollector*. Make the following selections in the form view:
 .. *spec.agent.ebpf.Sampling*: Specify a sampling size for flows. Lower sampling sizes will have higher impact on resource utilization. For more information, see the "FlowCollector API reference", `spec.agent.ebpf`.
+.. If you are not using Loki, click *Loki client settings* and change *Enable* to *False*. The setting is *True* by default.
 .. If you are using Loki, set the following specifications:
 ... *spec.loki.mode*: Set this to the `LokiStack` mode, which automatically sets URLs, TLS, cluster roles and a cluster role binding, as well as the `authToken` value. Alternatively, the `Manual` mode allows more control over configuration of these settings.
 ... *spec.loki.lokistack.name*: Set this to the name of your `LokiStack` resource. In this documentation, `loki` is used.


### PR DESCRIPTION
…i-less option

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-36901
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
Step 5 b: https://79278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/installing-operators.html#network-observability-operator-installation_network_observability
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
