### PR TITLE
OADP-4502: adding snippet to cover the .snapshot on some NFS servers

### DIFF
--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
@@ -26,6 +26,8 @@ The `CloudStorage` API supports manually creating a `BackupStorageLocation` obje
 
 * If your cloud provider does not support snapshots or if your applications are on NFS data volumes, you can create backups by using Kopia or Restic. See xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#oadp-backing-up-applications-restic-doc[Backing up applications with File System Backup: Kopia or Restic].
 
+include::snippets/pod-volume-restore-snapshot-read-only.adoc[]
+
 [IMPORTANT]
 ====
 The {oadp-first} does not support backing up volume snapshots that were created by other software.

--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc
@@ -36,6 +36,8 @@ In OADP version 1.2 and earlier, you can only use Restic for backing up applicat
 FSB does not support backing up `hostPath` volumes. For more information, see link:https://velero.io/docs/v1.12/file-system-backup/#limitations[FSB limitations].
 ====
 
+include::snippets/pod-volume-restore-snapshot-read-only.adoc[]
+
 .Prerequisites
 
 * You must install the OpenShift API for Data Protection (OADP) Operator.

--- a/snippets/pod-volume-restore-snapshot-read-only.adoc
+++ b/snippets/pod-volume-restore-snapshot-read-only.adoc
@@ -1,0 +1,20 @@
+// Text snippet included in the following modules:
+//
+// * openshift-docs/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+// * openshift-docs/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+[IMPORTANT]
+.PodVolumeRestore fails with a `.../.snapshot: read-only file system` error
+====
+The `.../.snapshot` directory is a snapshot copy directory, which is used by several NFS servers. This directory has read-only access by default, so Velero cannot restore to this directory.
+
+Do not give Velero write access to the `.snapshot` directory, and disable client access to this directory.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.netapp.com/us-en/ontap/enable-snapshot-dir-access-task.html#enable-or-disable-client-access-to-snapshot-copy-directory-by-editing-a-share[Enable or disable client access to Snapshot copy directory by editing a share]
+* link:https://docs.portworx.com/portworx-backup-on-prem/reference/restore-with-fb#prerequisites-for-backup-and-restore-with-flashblade[Prerequisites for backup and restore with FlashBlade]
+====


### PR DESCRIPTION
### Jira

* [OADP-4502](https://issues.redhat.com/browse/OADP-4502)

### Version(s):

* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16
* OCP 4.17 → branch/enterprise-4.17

### Link to docs preview:

* [ Backing up applications with File System Backup: Kopia or Restic ](https://github.com/user-attachments/assets/f463d2c9-b69d-4729-a89e-5e4da2871263)


| Snippet |
| --------- |
| 
![image](https://github.com/user-attachments/assets/a4c46f68-01bd-43d9-93a7-5f04602db69b)   |


QE review:
- [X ] QE has approved this change. *Reviewed by QE and Dev*
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
