### PR TITLE
OADP-3913: Fixing technology preview snippet OADP 1.3.0 release notes  and fixing weird erroneous header

### DIFF
--- a/modules/oadp-release-notes-1-3-0.adoc
+++ b/modules/oadp-release-notes-1-3-0.adoc
@@ -13,11 +13,10 @@ The {oadp-first} 1.3.0 release notes lists new features, resolved issues and bug
 
 .Velero built-in DataMover
 
+:FeatureName: Velero built-in DataMover
+include::snippets/technology-preview.adoc[]
+
 OADP 1.3 includes a built-in Data Mover that you can use to move Container Storage Interface (CSI) volume snapshots to a remote object store. The built-in Data Mover allows you to restore stateful applications from the remote object store if a failure, accidental deletion, or corruption of the cluster occurs. It uses Kopia as the uploader mechanism to read the snapshot data and to write to the Unified Repository.
-
-
-//:FeatureName: Velero built-in DataMover
-Velero built-in DataMover is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
 
 .Backing up applications with File System Backup: Kopia or Restic
 
@@ -152,5 +151,3 @@ spec:
 In a future OADP release, it is planned that the `kopia` tool will become the default `uploaderType` value.
 ====
 
-[id="upgrade-steps-1-3-0_{context}"]
-=== Upgrading steps


### PR DESCRIPTION
### JIRA

* [OADP-3913](https://issues.redhat.com/browse/OADP-3913) 

### Version(s):

* OCP 4.12 → OCP 4.16

### Link to docs preview:

* [OADP 1.3.0 release notes](https://79290--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.html#oadp-release-notes-1-3-0_oadp-release-notes)

QE review:
- [ ] QE has approved this change. 

* No change made to the text of the documentation. Only the removal of a weird extra header and changing a tech preview from text to a snippet


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
