### PR TITLE
OSDOCS-11380: 4.16.4 RN

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3325,6 +3325,63 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.16.4
+[id="ocp-4-16-4_{context}"]
+=== RHSA-2024:4613 - {product-title} {product-version}.4 bug fix and security update
+
+Issued: 2024-07-24
+
+{product-title} release {product-version}.4, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:4613[RHSA-2024:4613] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4616[RHSA-2024:4616] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.4 --pullspecs
+----
+
+[id="ocp-4-16-4-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, a change to the Ingress Operator added logic to `clear spec.host` and set `spec.subdomain` on the canary route. However, the Operator's service account did not have the necessary `routes/custom-host` permission to update `spec.host` or `spec.subdomain` on an existing route. With this release, the permission is added to the `ClusterRole` resource for the Operator's service account and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-32887[*OCPBUGS-32887*])
+
+* Previously, the number of calls to the subscription's `fetchOrganization` endpoint from the Console Operator was too high, which caused issues with installation. With this release, the organization ID is cached and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-34012[*OCPBUGS-34012*])
+
+* Previously, role bindings related to the `ImageRegistry`, `Build`, and `DeploymentConfig` capabilities were created in every namespace, even if the respective capability was disabled. With this release, the role bindings are only created if the respective cluster capability is enabled on the cluster. (link:https://issues.redhat.com/browse/OCPBUGS-34384[*OCPBUGS-34384*])
+
+* Previously, the MetalLB Operator deployed the downstream image when deploying with FRR-K8s, the Border Gateway Protocol (BGP) backend for MetalLB. With this release, the MetalLB Operator deploys the upstream image instead of the dowstream one. (link:https://issues.redhat.com/browse/OCPBUGS-35864[*OCPBUGS-35864*])
+
+* Previously, when LUKS encryption was enabled on a system using 512 emulation (512e) disks, the encryption failed at the `ignition-ostree-growfs` step and reported an error because of an alignment issue. With this release, a workaround is added in the `ignition-ostree-growfs` step to detect this situation and resolve the alignment issue. (link:https://issues.redhat.com/browse/OCPBUGS-36147[*OCPBUGS-36147*])
+
+* Previously, the `--bind-address` parameter for localhost caused liveness test failure for {ibm-power-server-title} clusters. With this release, the `--bind-address` parameter for localhost is removed and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-36317[*OCPBUGS-36317*])
+
+* Previously, Operator bundle unpack jobs that had already been created were not found by the Operator Lifecycle Manager (OLM) when installing an Operator. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-36450[*OCPBUGS-36450*])
+
+* Previously, the etcd data store used for Cluster API-provisioned installations was only removed when either the bootstrap node or the cluster was destroyed. With this release, if there is an error during infrastructure provisioning, the data store is removed and does not take up unnecessary disk space. (link:https://issues.redhat.com/browse/OCPBUGS-36463[*OCPBUGS-36463*])
+
+* Previously, enabling custom feature gates could cause the installation to fail in AWS if the feature gate `ClusterAPIInstallAWS=true` was not enabled. With this release, the `ClusterAPIInstallAWS=true` feature gate is no longer required. (link:https://issues.redhat.com/browse/OCPBUGS-36720[*OCPBUGS-36720*])
+
+* Previously, if `create cluster` was run after the `destroy cluster` command, an error would report that local infrastructure provisioning artifacts already exist. With this release, leftover artifacts are removed with `destroy cluster` and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-36777[*OCPBUGS-36777*])
+
+* Previously, the **OperandDetails** page displayed information for the first custom resource definition (CRD) that matched by name. With this release, the **OperandDetails** page displays information for the CRD that matches by name and by the version of the operand. (link:https://issues.redhat.com/browse/OCPBUGS-36841[*OCPBUGS-36841*])
+
+* Previously, if the `openshift.io/internal-registry-pull-secret-ref` annotation was removed from a `ServiceAccount` resource, {product-title} re-created the deleted annotation and created a new managed image pull secret. This contention could cause the cluster to get overloaded with image pull secrets. With this release, {product-title} attempts to reclaim managed image pull secrets that were previously referenced and deletes managed image pull secrets that remain orphaned after reconciliation. (link:https://issues.redhat.com/browse/OCPBUGS-36862[*OCPBUGS-36862*])
+
+* Previously, some of the processes remained running after the installation program stopped due to setup failures. With this release, all installation processes stop when the installation program stops running. (link:https://issues.redhat.com/browse/OCPBUGS-36890[*OCPBUGS-36890*])
+
+* Previously, there was no runbook for the `ClusterMonitoringOperatorDeprecatedConfig` alert. With this release, the runbook for the `ClusterMonitoringOperatorDeprecatedConfig` alert is added and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-36907[*OCPBUGS-36907*])
+
+* Previously, the *Cluster overview page* included a _View all steps in documentation_ link that resulted in a 404 error for ROSA and OSD clusters. With this update, the link does not appear for ROSA and OSD clusters. (link:https://issues.redhat.com/browse/OCPBUGS-37063[*OCPBUGS-37063*])
+
+* Previously, there was a mismatch between OpenSSL versions of Machine Config Operator tools used by {product-title} and the OpenSSL version that runs on the hosted control plane. With this release, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-37241[*OCPBUGS-37241*])
+
+[id="ocp-4-16-4-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 //4.16.3
 [id="ocp-4-16-3_{context}"]
 === RHSA-2024:4469 - {product-title} {product-version}.3 bug fix and security update


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-11380](https://issues.redhat.com/browse/OSDOCS-11380)

Link to docs preview:
https://79296--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-4_release-notes

QE review:
N/A

Additional information:
URLs return 404 until go-live (7/24)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
