### PR TITLE
CMP-2666: Added SPO 0.8.4 release notes

### DIFF
--- a/modules/spo-binding-workloads.adoc
+++ b/modules/spo-binding-workloads.adoc
@@ -35,10 +35,16 @@ spec:
   profileRef:
     kind: {kind} <1>
     name: profile <2>
-  image: quay.io/security-profiles-operator/test-nginx-unprivileged:1.21
+  image: quay.io/security-profiles-operator/test-nginx-unprivileged:1.21 <3>
 ----
-<1> The `kind:` variable refers to the name of the profile.
+<1> The `kind:` variable refers to the kind of the profile.
 <2> The `name:` variable refers to the name of the profile.
+<3> You can enable a default security profile by using a wildcard in the image attribute: `image: "*"`
++
+[IMPORTANT]
+====
+Using the `image: "*"` wildcard attribute binds all new pods with a default security profile in a given namespace.
+====
 
 . Label the namespace with `enable-binding=true` by running the following command:
 +

--- a/security/security_profiles_operator/spo-release-notes.adoc
+++ b/security/security_profiles_operator/spo-release-notes.adoc
@@ -12,6 +12,20 @@ These release notes track the development of the Security Profiles Operator in {
 
 For an overview of the Security Profiles Operator, see xref:../../security/security_profiles_operator/spo-overview.adoc#[Security Profiles Operator Overview].
 
+[id="spo-release-notes-0-8-4"]
+== Security Profiles Operator 0.8.4
+
+The following advisory is available for the Security Profiles Operator 0.8.4:
+
+* link:https://access.redhat.com/errata/RHBA-2024:4781[RHBA-2024:4781 - OpenShift Security Profiles Operator bug fix update]
+
+This update addresses CVEs in underlying dependencies.
+
+[id="spo-0-8-4-new-features-and-enhancements"]
+=== New features and enhancements
+
+* You can now specify a default security profile in the `image` attribute of a `ProfileBinding` object by setting a wildcard. For more information, see xref:../../security/security_profiles_operator/spo-selinux.adoc#spo-binding-workloads_spo-selinux[Binding workloads to profiles with ProfileBindings (SELinux)] and xref:../../security/security_profiles_operator/spo-seccomp.adoc#spo-binding-workloads_spo-seccomp[Binding workloads to profiles with ProfileBindings (Seccomp)].
+
 [id="spo-release-notes-0-8-2"]
 == Security Profiles Operator 0.8.2
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/CMP-2666

Link to docs preview:
[Security Profiles Operator 0.8.4](https://79305--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/security_profiles_operator/spo-release-notes.html#spo-release-notes-0-8-4)
[79305--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/security_profiles_operator/spo-seccomp.html](https://79305--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/security_profiles_operator/spo-seccomp.html)
[79305--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/security_profiles_operator/spo-selinux.html](https://79305--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/security_profiles_operator/spo-selinux.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
None
