### PR TITLE
OSDOCS-11434: update route config MicroShift (remove project)

### DIFF
--- a/microshift_networking/microshift-configuring-routes.adoc
+++ b/microshift_networking/microshift-configuring-routes.adoc
@@ -9,13 +9,13 @@ toc::[]
 You can configure routes for {microshift-short} for clusters.
 
 //OCP module, edit with care; Creating an insecure/http route
-include::modules/nw-creating-a-route.adoc[leveloffset=+1]
+include::modules/microshift-nw-create-http-based-route.adoc[leveloffset=+1]
 
 //OCP module, edit with care; HTTP Strict Transport Security
-include::modules/nw-enabling-hsts.adoc[leveloffset=+2]
+include::modules/nw-enabling-hsts.adoc[leveloffset=+1]
 
 //OCP module, edit with care; Enabling HTTP strict transport security per-route
-include::modules/nw-enabling-hsts-per-route.adoc[leveloffset=+2]
+include::modules/nw-enabling-hsts-per-route.adoc[leveloffset=+1]
 
 //OCP module, edit with care; Disabling HTTP strict transport security per-route
 include::modules/nw-disabling-hsts.adoc[leveloffset=+2]

--- a/modules/microshift-nw-create-http-based-route.adoc
+++ b/modules/microshift-nw-create-http-based-route.adoc
@@ -1,0 +1,66 @@
+// Module included in the following assemblies:
+//
+// * microshift_networking/microshift-configuring-routes.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-nw-creating-a-route_{context}"]
+= Creating an HTTP-based route
+
+A route allows you to host your application at a public URL. It can either be secure or unsecured, depending on the network security configuration of your application. An HTTP-based route is an unsecured route that uses the basic HTTP routing protocol and exposes a service on an unsecured application port.
+
+The following procedure describes how to create a simple HTTP-based route to a web application, using the `hello-microshift` application as an example.
+
+.Prerequisites
+* You installed the OpenShift CLI (`oc`).
+* You have access to your {microshift-short} cluster.
+* You have a web application that exposes a port and a TCP endpoint listening for traffic on the port.
+
+.Procedure
+
+. Create a service called `hello-microshift` by running the following command:
++
+[source,terminal]
+----
+$ oc expose pod hello-microshift -n $namespace
+----
+
+. Create an unsecured route to the `hello-microshift` application by running the following command:
++
+[source,terminal]
+----
+$ oc expose svc/hello-microshift --hostname=microshift.com $namespace
+----
+
+.Verification
+
+* Verify that the `route` resource was created by running the following command:
++
+[source,terminal]
+----
+$ oc get routes -o yaml <name of resource> -n $namespace <1>
+----
+<1> In this example, the route is named `hello-microshift` and the namespace is named `hello-microshift`.
+
+.Sample YAML definition of the created unsecured route:
+[source,yaml]
+----
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: hello-microshift
+  namespace: hello-microshift
+spec:
+  host: microshift.com <1>
+  port:
+    targetPort: 8080 <2>
+  to:
+    kind: Service
+    name: hello-microshift
+----
+<1> Example hostname.
+<2> `targetPort` is required for the router to map the endpoint port in the service.
++
+[NOTE]
+====
+{microshift-short} does not a use an API that creates a default ingress domain, but instead provides a wildcard for automatically generated domains. Each route can also define a separate hostname.
+====


### PR DESCRIPTION
Version(s):
4.16, 4.17

Issue:
[OSDOCS-11434](https://issues.redhat.com/browse/OSDOCS-11434)

Link to docs preview:
[Configuring routes - http-based-route, no project](https://79312--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-configuring-routes.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
