### PR TITLE
RHDEVDOCS 5719 running Buildah as nonroot with user namespaces

### DIFF
--- a/modules/op-nonroot-buildah-user-namespaces.adoc
+++ b/modules/op-nonroot-buildah-user-namespaces.adoc
@@ -1,0 +1,72 @@
+// This module is included in the following assemblies:
+// * secure/unprivileged-building-of-container-images-using-buildah.adoc
+
+:_mod-docs-content-type: PROCEDURE
+
+[id="nonroot-buildah-user-namespaces_{context}"]
+= Running Buildah as a non-root user by configuring user namespaces
+
+Configuring user namespaces is the simplest way to run Buildah in a task as a non-root user. However, some images might not build using this option.
+
+.Prerequisites
+
+* You have installed the `oc` command-line utility.
+
+.Procedure
+
+. To create a copy of the `buildah` task, which is provided in the `openshift-pipelines` namespace, and to change the name of the copy to `buildah-as-user`, enter the following command:
++
+[source,terminal]
+----
+$ oc get task buildah -n openshift-pipelines -o yaml | yq '. |= (del .metadata |= with_entries(select(.key == "name" )))' | yq '.kind="Task"' | yq '.metadata.name="buildah-as-user"' | oc create -f -
+----
+
+. Edit the copied `buildah` task by entering the following command:
++
+[source,terminal]
+----
+$ oc edit task buildah-as-user
+----
++
+In the new task, create `annotations` and `stepTemplate` sections, as shown in the following example:
++
+.Example additions to the `buildah-as-user` task
+[source,yaml]
+----
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  annotations:
+    io.kubernetes.cri-o.userns-mode: 'auto:size=65536;map-to-root=true'
+    io.openshift.builder: 'true'
+  name: assemble-containerimage
+  namespace: pipeline-namespace
+spec:
+  description: This cluster task builds an image.
+#  ...
+  stepTemplate:
+    env:
+      - name: HOME
+        value: /tekton/home
+    image: $(params.builder-image)
+    imagePullPolicy: IfNotPresent
+    name: ''
+    resources:
+      limits:
+        cpu: '1'
+        memory: 4Gi
+      requests:
+        cpu: 100m
+        memory: 2Gi
+    securityContext:
+      capabilities:
+        add:
+          - SETFCAP
+      runAsNonRoot: true
+      runAsUser: 1000 # <1>
+    workingDir: $(workspaces.working-directory.path)
+#  ...
+----
+<1> The `runAsUser:` setting is not strictly necessary, because `podTemplate` is used.
+
+. Use the new `buildah-as-user` task to build the image in your pipeline.

--- a/secure/unprivileged-building-of-container-images-using-buildah.adoc
+++ b/secure/unprivileged-building-of-container-images-using-buildah.adoc
@@ -6,15 +6,27 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Running {pipelines-shortname} as the root user on a container can expose the container processes and the host to other potentially malicious resources. You can reduce this type of exposure by running the workload as a specific non-root user in the container. To run builds of container images using Buildah as a non-root user, you can perform the following steps:
+Running {pipelines-shortname} as the root user on a container can expose the container processes and the host to other potentially malicious resources. You can reduce this type of exposure by running the workload as a specific non-root user in the container.
+
+In most cases, you can run Buildah without root privileges by creating a custom task for building the image and configuring user namespaces in this task.
+
+If your image does not build successfully using this configuration, you can use custom service account (SA) and security context constraint (SCC) definitions; however, if you use this option, you must enable the Buildah step to raise its privileges (`allowPrivilegeEscalation: true`).
+
+include::modules/op-nonroot-buildah-user-namespaces.adoc[leveloffset=+1]
+
+[id="buildah-nonroot-sa-scc"]
+== Running Buildah as a non-root user by defining a custom SA and SCC
+
+To run builds of container images using Buildah as a non-root user, you can perform the following steps:
 
 * Define custom service account (SA) and security context constraint (SCC).
 * Configure Buildah to use the `build` user with id `1000`.
 * Start a task run with a custom config map, or integrate it with a pipeline run.
 
-include::modules/op-configuring-custom-sa-and-scc.adoc[leveloffset=+1]
-include::modules/op-configuring-buildah-to-use-build-user.adoc[leveloffset=+1]
-include::modules/op-starting-a-task-run-pipeline-run-build-user.adoc[leveloffset=+1]
+include::modules/op-configuring-custom-sa-and-scc.adoc[leveloffset=+2]
+include::modules/op-configuring-buildah-to-use-build-user.adoc[leveloffset=+2]
+include::modules/op-starting-a-task-run-pipeline-run-build-user.adoc[leveloffset=+2]
+
 include::modules/op-limitations-of-unprivileged-builds.adoc[leveloffset=+1]
 
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
pipelines-docs-1.15, pipelines-docs-1.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
RHDEVDOCS 5719

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://79325--ocpdocs-pr.netlify.app/openshift-pipelines/latest/secure/unprivileged-building-of-container-images-using-buildah.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
