### PR TITLE
OSDOCS-11381 OCP 4.15.23 Release Notes

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2733,6 +2733,51 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+[id="ocp-4-15-23_{context}"]
+=== RHSA-2024:4699 - {product-title} 4.15.23 bug fix and security update
+
+Issued: 2024-07-25
+
+{product-title} release 4.15.23 is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2024:4699[RHSA-2024:4699] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4702[RHSA-2024:4702] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.23 --pullspecs
+----
+
+[id="ocp-4-15-23-enhancements_{context}"]
+==== Enhancements
+
+The following enhancement is included in this z-stream release:
+
+[id="ocp-4-15-23-timeout-ingress_{context}"]
+===== Adding connectTimeout tuning option to Ingress Controller API
+
+* The IngressController API is updated with a new tuning option, `ingresscontroller.spec.tuningOptions.connectTimeout`, which defines how long the router will wait for a response when establishing a connection to a backend server. (link:https://issues.redhat.com/browse/OCPBUGS-36208[*OCPBUGS-36208*])
+
+[id="ocp-4-15-23-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the OpenSSL versions for the Machine Config Operator and the hosted  control plane were not the same. With this release, the FIPS cluster `NodePool` resource creation for {product-title} 4.14 and {product-title} 4.15 has been fixed and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-37266[*OCPBUGS-37266*])
+
+* Previously, the operand details displayed information for the first custom resource definition (CRD) that matched by name. With this release, the operand details page displays information for the CRD that matches by name and the version of the operand. (link:https://issues.redhat.com/browse/OCPBUGS-36971[*OCPBUGS-36971*])
+
+* Previously, the HyperShift hosted control plane (HCP) would fail to generate ignition because of mismatched versions of {op-system-base-full} OpenSSL versions used by the HyperShift Control Plane Operator and the Machine Config Operator. With this release, the versions of {op-system-base-full} OpenSSL match correctly and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-36863[*OCPBUGS-36863*])
+
+* Previously, the Ingress Operator could not successfully update the canary route because the Operator did not have permission to update `spec.host` or `spec.subdomain` on an existing route. With this release, the required permission is added to the cluster role for the Operator's `ServiceAccount` and the Ingress Operator can update the canary route. (link:https://issues.redhat.com/browse/OCPBUGS-36466[*OCPBUGS-36466*])
+
+* Previously, installing an Operator could sometimes fail if the same Operator had been previously installed and uninstalled. This was due to a caching issue. This bug fix updates {olm} to correctly install the Operator in this scenario, and as a result this issue no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-36451[*OCPBUGS-36451*])
+
+* Previously, after installing the Pipelines Operator, Pipeline templates took some time to become available in the cluster, but users were still able to create the Deployment. With this update, the *Create* button on the *Import from Git* page is disabled if there is no pipeline template present for the resource selected. (link:https://issues.redhat.com/browse/OCPBUGS-34477[*OCPBUGS-34477*])
+
+[id="ocp-4-15-23-updating_{context}"]
+==== Updating
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.15.22
 [id="ocp-4-15-22"]
 === RHSA-2024:4474 - {product-title} 4.15.22 bug fix and security update
@@ -2802,13 +2847,13 @@ $ oc adm release info 4.15.21 --pullspecs
 
 * Previously, the `alertmanager-trusted-ca-bundle` config map was not injected into the user-defined Alertmanager container, which prevented the verification of HTTPS web servers receiving alert notifications. With this update, the trusted CA bundle config map is mounted into the Alertmanager container at the `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` path. (link:https://issues.redhat.com/browse/OCPBUGS-36312[*OCPBUGS-36312*])
 
-* Previously, the internal image registry did not correctly authenticate users on clusters configured for `externalAWS` IAM OpenID Connect (OIDC) users. This causes issues for users when pushing or pulling images to and from the internal image registry. With this release, the internal image registry starts by using the `SelfSubjectReview` API instead of the OpenShift-specific user API. The OpenShift-specific user API is not compatible with external OIDC users. (link:https://issues.redhat.com/browse/OCPBUGS-36287[*OCPBUGS-36287*]) 
+* Previously, the internal image registry did not correctly authenticate users on clusters configured for `externalAWS` IAM OpenID Connect (OIDC) users. This causes issues for users when pushing or pulling images to and from the internal image registry. With this release, the internal image registry starts by using the `SelfSubjectReview` API instead of the OpenShift-specific user API. The OpenShift-specific user API is not compatible with external OIDC users. (link:https://issues.redhat.com/browse/OCPBUGS-36287[*OCPBUGS-36287*])
 
 * Previously, for clusters upgraded from earlier versions of {product-title}, enabling `kdump` on an OVN-enabled cluster sometimes prevented the node from rejoining the cluster or returning to the `Ready` state. With this release, stale data from earlier {product-title} versions are removed, so that nodes can now correctly start and rejoin the cluster. (link:https://issues.redhat.com/browse/OCPBUGS-36258[*OCPBUGS-36258*])
 
-* Previously, the {product-title} installation program included a pair of slashes (`//`) in a path to a resource pool for a cluster installed on {vmw-first}. This issue caused the ControlPlaneMachineSet (CPMS) Operator to create additional contol plane machines. With this release, the pair of slashes is removed to prevent this issue from occuring. (link:https://issues.redhat.com/browse/OCPBUGS-36225[*OCPBUGS-36225*]) 
+* Previously, the {product-title} installation program included a pair of slashes (`//`) in a path to a resource pool for a cluster installed on {vmw-first}. This issue caused the ControlPlaneMachineSet (CPMS) Operator to create additional contol plane machines. With this release, the pair of slashes is removed to prevent this issue from occuring. (link:https://issues.redhat.com/browse/OCPBUGS-36225[*OCPBUGS-36225*])
 
-* Previously, the GrowPart tool locked a device. This impacted Linux Unified Key Setup-on-disk-format (LUKS) devices from being opened and caused the operating system to boot into emergency mode. With this release, the call to the GrowPart tool is removed, so that LUKS devices are not unintentionally locked and the operating system can successfully boot. (link:https://issues.redhat.com/browse/OCPBUGS-35988[*OCPBUGS-35988*]) 
+* Previously, the GrowPart tool locked a device. This impacted Linux Unified Key Setup-on-disk-format (LUKS) devices from being opened and caused the operating system to boot into emergency mode. With this release, the call to the GrowPart tool is removed, so that LUKS devices are not unintentionally locked and the operating system can successfully boot. (link:https://issues.redhat.com/browse/OCPBUGS-35988[*OCPBUGS-35988*])
 
 * Previously, a bug in systemd might cause the `coreos-multipath-trigger.service` unit to hang forever. As a result, the system would never finish booting. With this release, the systemd unit was removed and the issue is fixed. (link:https://issues.redhat.com/browse/OCPBUGS-35749[*OCPBUGS-35749*])
 


### PR DESCRIPTION
Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-11381](https://issues.redhat.com/browse/OSDOCS-11381)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to [docs preview](https://79329--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-23_release-notes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
Not needed
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Advisory links will not work until July 25. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
