### PR TITLE
OSDOCS#11399: Added a release note for additional principals on ROSA with HCP cluster

### DIFF
--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -21,6 +21,8 @@ toc::[]
 [id="rosa-q2-2024_{context}"]
 === Q2 2024
 
+* **Approve additional principals for {hcp-title} clusters.** You can approve additional user-roles to connect to your cluster's private API server endpoint. For more information, see xref:../rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc#rosa-additional-principals-overview_rosa-hcp-aws-private-creating-cluster[Additional principals on your {hcp-title} cluster].
+
 * **ROSA CLI update.** The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/tag/v1.2.41[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-about_rosa-getting-started-cli[About the ROSA CLI].
 
 * **Approved Access for ROSA clusters.** Red{nbsp}Hat Site Reliability Engineering (SRE) managing and proactively supporting ROSA Clusters will typically not require elevated access to customer clusters as part of the normal operations. In the unlikely event should Red{nbsp}Hat SRE (Site Reliability Engineer) need elevated access, the _Approved Access_ functionality provides an interface for customers to review and _approve_ or _deny_ access requests.


### PR DESCRIPTION
Version(s):
`enterprise-4.16+`

Issue:
**[OSDOCS-11399](https://issues.redhat.com/browse/OSDOCS-11399)**

Link to docs preview:
- **[What's New in ROSA](https://79331--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html)**

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR adds a release note for the Additional principals feature.