### PR TITLE
[enterprise-4.16] OSDOCS-9469: Documented the configure-ovs alternative

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -576,7 +576,7 @@ Topics:
   Distros: openshift-enterprise,openshift-origin
   File: configuring-private-cluster
 - Name: Bare metal configuration
-  File: bare-metal-configuration
+  File: post-install-bare-metal-configuration
 - Name: Configuring multi-architecture compute machines on an OpenShift cluster
   Dir: configuring-multi-arch-compute-machines
   Distros: openshift-enterprise

--- a/installing/cluster-capabilities.adoc
+++ b/installing/cluster-capabilities.adoc
@@ -35,7 +35,7 @@ include::modules/cluster-bare-metal-operator.adoc[leveloffset=+2]
 .Additional resources
 * xref:../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[Deploying installer-provisioned clusters on bare metal]
 * xref:../installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc#preparing-to-install-on-bare-metal[Preparing for bare metal cluster installation]
-* xref:../post_installation_configuration/bare-metal-configuration.adoc#post-install-bare-metal-configuration[Bare metal configuration]
+* xref:../post_installation_configuration/post-install-bare-metal-configuration.adoc#post-install-bare-metal-configuration[Bare metal configuration]
 
 // Build capability
 include::modules/build-config-capability.adoc[leveloffset=+2]

--- a/installing/index.adoc
+++ b/installing/index.adoc
@@ -23,7 +23,7 @@ include::modules/ipi-verifying-nodes-after-installation.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../post_installation_configuration/bare-metal-configuration.adoc#getting-the-baremetalhost-resource_post-install-bare-metal-configuration[Getting the BareMetalHost resource]
+* xref:../post_installation_configuration/post-install-bare-metal-configuration.adoc#getting-the-baremetalhost-resource_post-install-bare-metal-configuration[Getting the BareMetalHost resource]
 
 * xref:../installing/installing_bare_metal_ipi/ipi-install-installation.adoc#ipi-install-troubleshooting-following-the-installation_ipi-install-installation[Following the installation]
 

--- a/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
@@ -52,6 +52,7 @@ include::modules/csr-management.adoc[leveloffset=+2]
 * See xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installation-three-node-cluster_installing-bare-metal[Configuring a three-node cluster] for details about deploying three-node clusters in bare metal environments.
 * See xref:../../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-approve-csrs_installing-bare-metal-network-customizations[Approving the certificate signing requests for your machines] for more information about approving cluster certificate signing requests after installation.
 
+// Networking requirements for user-provisioned infrastructure
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -64,6 +65,12 @@ include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
 * xref:../../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-user-provisioned-validating-dns_installing-bare-metal-network-customizations[Validating DNS resolution for user-provisioned infrastructure]
 
 include::modules/installation-load-balancing-user-infra.adoc[leveloffset=+2]
+
+// Creating a manifest object that includes a customized `br-ex` bridge
+include::modules/creating-manifest-file-customized-br-ex-bridge.adoc[leveloffset=+1]
+
+// Scale each machine set to compute nodes
+include::modules/creating-scaling-machine-sets-compute-nodes-networking.adoc[leveloffset=+2]
 
 include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
 

--- a/installing/installing_bare_metal/installing-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal.adoc
@@ -70,6 +70,7 @@ Ensure you enable the `disk.EnableUUID` parameter on all virtual machines in you
 
 * See xref:../../installing/installing_vsphere/upi/installing-vsphere.adoc#installation-vsphere-machines_installing-vsphere[Installing RHCOS and starting the OpenShift Container Platform bootstrap process] for details on setting the `disk.EnableUUID` parameter's value to `TRUE` on VMware vSphere for user-provisioned infrastructure.
 
+// Networking requirements for user-provisioned infrastructure
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -85,6 +86,12 @@ include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
 * xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installation-user-provisioned-validating-dns_installing-bare-metal[Validating DNS resolution for user-provisioned infrastructure]
 
 include::modules/installation-load-balancing-user-infra.adoc[leveloffset=+2]
+
+// Creating a manifest object that includes a customized `br-ex` bridge
+include::modules/creating-manifest-file-customized-br-ex-bridge.adoc[leveloffset=+1]
+
+// Scale each machine set to compute nodes
+include::modules/creating-scaling-machine-sets-compute-nodes-networking.adoc[leveloffset=+2]
 
 include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
 

--- a/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
@@ -64,6 +64,7 @@ include::modules/csr-management.adoc[leveloffset=+2]
 * See xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-three-node-cluster_installing-restricted-networks-bare-metal[Configuring a three-node cluster] for details about deploying three-node clusters in bare metal environments.
 * See xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-approve-csrs_installing-restricted-networks-bare-metal[Approving the certificate signing requests for your machines] for more information about approving cluster certificate signing requests after installation.
 
+// Networking requirements for user-provisioned infrastructure
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -79,6 +80,12 @@ include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
 * xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-user-provisioned-validating-dns_installing-restricted-networks-bare-metal[Validating DNS resolution for user-provisioned infrastructure]
 
 include::modules/installation-load-balancing-user-infra.adoc[leveloffset=+2]
+
+// Creating a manifest object that includes a customized `br-ex` bridge
+include::modules/creating-manifest-file-customized-br-ex-bridge.adoc[leveloffset=+1]
+
+// Scale each machine set to compute nodes
+include::modules/creating-scaling-machine-sets-compute-nodes-networking.adoc[leveloffset=+2]
 
 include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
 

--- a/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
@@ -30,7 +30,7 @@ include::modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc[leve
 
 * xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backing-up-etcd-data_backup-etcd[Backing up etcd]
 
-* xref:../../post_installation_configuration/bare-metal-configuration.adoc#post-install-bare-metal-configuration[Bare metal configuration]
+* xref:../../post_installation_configuration/post-install-bare-metal-configuration.adoc#post-install-bare-metal-configuration[Bare metal configuration]
 
 * xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#bmc-addressing_ipi-install-installation-workflow[BMC addressing]
 

--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -25,6 +25,12 @@ include::modules/ipi-install-checking-ntp-sync.adoc[leveloffset=+1]
 // Configuring networking
 include::modules/ipi-install-configuring-networking.adoc[leveloffset=+1]
 
+// Creating a manifest object that includes a customized `br-ex` bridge
+include::modules/creating-manifest-file-customized-br-ex-bridge.adoc[leveloffset=+1]
+
+// Scale each machine set to compute nodes
+include::modules/creating-scaling-machine-sets-compute-nodes-networking.adoc[leveloffset=+2]
+
 // Establishing communication between subnets
 include::modules/ipi-install-establishing-communication-between-subnets.adoc[leveloffset=+1]
 
@@ -62,7 +68,7 @@ include::modules/ipi-install-bmc-addressing.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../post_installation_configuration/bare-metal-configuration.adoc#editing-a-baremetalhost-resource_post-install-bare-metal-configuration[Editing a BareMetalHost resource]
+* xref:../../post_installation_configuration/post-install-bare-metal-configuration.adoc#editing-a-baremetalhost-resource_post-install-bare-metal-configuration[Editing a BareMetalHost resource]
 
 // Verifying support for the Redfish API
 include::modules/ipi-install-verifying-support-for-redfish-apis.adoc[leveloffset=+2]
@@ -133,7 +139,7 @@ include::modules/ipi-install-configuring-the-bios.adoc[leveloffset=+2]
 [id="additional-resources_bare_metal_config"]
 .Additional resources
 
-* xref:../../post_installation_configuration/bare-metal-configuration.adoc#post-install-bare-metal-configuration[Bare metal configuration]
+* xref:../../post_installation_configuration/post-install-bare-metal-configuration.adoc#post-install-bare-metal-configuration[Bare metal configuration]
 
 // Optional: Configuring the RAID
 include::modules/ipi-install-configuring-the-raid.adoc[leveloffset=+2]
@@ -145,7 +151,7 @@ include::modules/ipi-install-configuring-storage-on-nodes.adoc[leveloffset=+2]
 [id="additional-resources_raid_config"]
 .Additional resources
 
-* xref:../../post_installation_configuration/bare-metal-configuration.adoc#post-install-bare-metal-configuration[Bare metal configuration]
+* xref:../../post_installation_configuration/post-install-bare-metal-configuration.adoc#post-install-bare-metal-configuration[Bare metal configuration]
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/managing_storage_devices/index#partition-naming-scheme_disk-partitions[Partition naming scheme]
 

--- a/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
@@ -12,3 +12,6 @@ include::modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc[leve
 
 include::modules/nw-enabling-a-provisioning-network-after-installation.adoc[leveloffset=+1]
 
+// Creating a manifest object that includes a customized `br-ex` bridge
+include::modules/creating-manifest-file-customized-br-ex-bridge.adoc[leveloffset=+1]
+

--- a/modules/bmo-about-the-bare-metal-operator.adoc
+++ b/modules/bmo-about-the-bare-metal-operator.adoc
@@ -1,25 +1,25 @@
 // This is included in the following assemblies:
 //
-// post_installation_configuration/bare-metal-configuration.adoc
+// post_installation_configuration/post-install-bare-metal-configuration.adoc
 
 :_module-type: CONCEPT
 [id="bmo-about-the-bare-metal-operator_{context}"]
 = About the Bare Metal Operator
 
-Use the Bare Metal Operator (BMO) to provision, manage, and inspect bare-metal hosts in your cluster. 
- 
-The BMO uses the following resources to complete these tasks: 
+Use the Bare Metal Operator (BMO) to provision, manage, and inspect bare-metal hosts in your cluster.
+
+The BMO uses the following resources to complete these tasks:
 
 * `BareMetalHost`
 * `HostFirmwareSettings`
 * `FirmwareSchema`
 * `HostFirmwareComponents`
 
-The BMO maintains an inventory of the physical hosts in the cluster by mapping each bare-metal host to an instance of the `BareMetalHost` custom resource definition. Each `BareMetalHost` resource features hardware, software, and firmware details. The BMO continually inspects the bare-metal hosts in the cluster to ensure each `BareMetalHost` resource accurately details the components of the corresponding host. 
+The BMO maintains an inventory of the physical hosts in the cluster by mapping each bare-metal host to an instance of the `BareMetalHost` custom resource definition. Each `BareMetalHost` resource features hardware, software, and firmware details. The BMO continually inspects the bare-metal hosts in the cluster to ensure each `BareMetalHost` resource accurately details the components of the corresponding host.
 
-The BMO also uses the `HostFirmwareSettings` resource, the `FirmwareSchema` resource, and the `HostFirmwareComponents` resource to detail firmware specifications and upgrade or downgrade firmware for the bare-metal host. 
+The BMO also uses the `HostFirmwareSettings` resource, the `FirmwareSchema` resource, and the `HostFirmwareComponents` resource to detail firmware specifications and upgrade or downgrade firmware for the bare-metal host.
 
-The BMO interfaces with bare-metal hosts in the cluster by using the Ironic API service. The Ironic service uses the Baseboard Management Controller (BMC) on the host to interface with the machine. 
+The BMO interfaces with bare-metal hosts in the cluster by using the Ironic API service. The Ironic service uses the Baseboard Management Controller (BMC) on the host to interface with the machine.
 
 Some common tasks you can complete by using the BMO include the following:
 

--- a/modules/bmo-about-the-baremetalhost-resource.adoc
+++ b/modules/bmo-about-the-baremetalhost-resource.adoc
@@ -1,6 +1,6 @@
 // This is included in the following assemblies:
 //
-// post_installation_configuration/bare-metal-configuration.adoc
+// post_installation_configuration/post-install-bare-metal-configuration.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="about-the-baremetalhost-resource_{context}"]
@@ -96,7 +96,7 @@ a|  (Optional) Contains the information about the RAID configuration for bare me
 ====
 {product-title} {product-version} supports hardware RAID for BMCs, including:
 
-* Fujitsu iRMC with support for RAID levels 0, 1, 5, 6, and 10 
+* Fujitsu iRMC with support for RAID levels 0, 1, 5, 6, and 10
 * Dell iDRAC using the Redfish API with firmware version 6.10.30.20 or later and RAID levels 0, 1, and 5
 
 {product-title} {product-version} does not support software RAID.

--- a/modules/bmo-about-the-firmwareschema-resource.adoc
+++ b/modules/bmo-about-the-firmwareschema-resource.adoc
@@ -1,6 +1,6 @@
 // This is included in the following assemblies:
 //
-// post_installation_configuration/bare-metal-configuration.adoc
+// post_installation_configuration/post-install-bare-metal-configuration.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="about-the-firmwareschema-resource_{context}"]

--- a/modules/bmo-about-the-hostfirmwarecomponents-resource.adoc
+++ b/modules/bmo-about-the-hostfirmwarecomponents-resource.adoc
@@ -1,6 +1,6 @@
 // This is included in the following assemblies:
 //
-// post_installation_configuration/bare-metal-configuration.adoc
+// post_installation_configuration/post-install-bare-metal-configuration.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="about-the-hostfirmwarecomponents-resource_{context}"]

--- a/modules/bmo-about-the-hostfirmwaresettings-resource.adoc
+++ b/modules/bmo-about-the-hostfirmwaresettings-resource.adoc
@@ -1,6 +1,6 @@
 // This is included in the following assemblies:
 //
-// post_installation_configuration/bare-metal-configuration.adoc
+// post_installation_configuration/post-install-bare-metal-configuration.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="about-the-hostfirmwaresettings-resource_{context}"]

--- a/modules/bmo-attaching-a-non-bootable-iso-to-a-bare-metal-node.adoc
+++ b/modules/bmo-attaching-a-non-bootable-iso-to-a-bare-metal-node.adoc
@@ -1,6 +1,6 @@
-// This module is included in the following assemblies: 
+// This module is included in the following assemblies:
 //
-// * post_installation_configuration/bare-metal-configuration.adoc
+// * post_installation_configuration/post-install-bare-metal-configuration.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="attaching-a-non-bootable-iso-to-a-bare-metal-node_{context}"]
@@ -46,7 +46,7 @@ $ oc apply -f <node_name>-dataimage.yaml -n <node_namespace> <1>
 ----
 <1> Replace `<node_namespace>` so that the namespace matches the namespace for the `BareMetalHost` resource. For example, `openshift-machine-api`.
 
-. Reboot the node. 
+. Reboot the node.
 +
 [NOTE]
 ====

--- a/modules/bmo-editing-a-baremetalhost-resource.adoc
+++ b/modules/bmo-editing-a-baremetalhost-resource.adoc
@@ -1,6 +1,6 @@
-// This module is included in the following assemblies: 
+// This module is included in the following assemblies:
 //
-// post_installation_configuration/bare-metal-configuration.adoc
+// post_installation_configuration/post-install-bare-metal-configuration.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="editing-a-baremetalhost-resource_{context}"]

--- a/modules/bmo-editing-the-hostfirmwarecomponents-resource.adoc
+++ b/modules/bmo-editing-the-hostfirmwarecomponents-resource.adoc
@@ -1,6 +1,6 @@
 // This is included in the following assemblies:
 //
-// post_installation_configuration/bare-metal-configuration.adoc
+// post_installation_configuration/post-install-bare-metal-configuration.adoc
 
 [id="editing-the-hostfirmwarecomponents-resource_{context}"]
 = Editing the HostFirmwareComponents resource

--- a/modules/bmo-editing-the-hostfirmwaresettings-resource.adoc
+++ b/modules/bmo-editing-the-hostfirmwaresettings-resource.adoc
@@ -1,6 +1,6 @@
 // This is included in the following assemblies:
 //
-// post_installation_configuration/bare-metal-configuration.adoc
+// post_installation_configuration/post-install-bare-metal-configuration.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="editing-the-hostfirmwaresettings-resource_{context}"]

--- a/modules/bmo-getting-the-baremetalhost-resource.adoc
+++ b/modules/bmo-getting-the-baremetalhost-resource.adoc
@@ -1,6 +1,7 @@
 // This is included in the following assemblies:
 //
-// post_installation_configuration/bare-metal-configuration.adoc
+// post_installation_configuration/post-install-bare-metal-configuration.adoc
+
 :_mod-docs-content-type: PROCEDURE
 [id="getting-the-baremetalhost-resource_{context}"]
 = Getting the BareMetalHost resource

--- a/modules/bmo-getting-the-firmwareschema-resource.adoc
+++ b/modules/bmo-getting-the-firmwareschema-resource.adoc
@@ -1,6 +1,6 @@
 // This is included in the following assemblies:
 //
-// post_installation_configuration/bare-metal-configuration.adoc
+// post_installation_configuration/post-install-bare-metal-configuration.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="getting-the-firmwareschema-resource_{context}"]

--- a/modules/bmo-getting-the-hostfirmwarecomponents-resource.adoc
+++ b/modules/bmo-getting-the-hostfirmwarecomponents-resource.adoc
@@ -1,6 +1,6 @@
 // This is included in the following assemblies:
 //
-// post_installation_configuration/bare-metal-configuration.adoc
+// post_installation_configuration/post-install-bare-metal-configuration.adoc
 
 [id="getting-the-hostfirmwarecomponents-resource_{context}"]
 = Getting the HostFirmwareComponents resource
@@ -76,5 +76,5 @@ status:
     status: "False"
     type: ChangeDetected
   lastUpdated: "2024-04-25T20:32:06Z"
-  updates: [] 
+  updates: []
 ----

--- a/modules/bmo-getting-the-hostfirmwaresettings-resource.adoc
+++ b/modules/bmo-getting-the-hostfirmwaresettings-resource.adoc
@@ -1,6 +1,6 @@
 // This is included in the following assemblies:
 //
-// post_installation_configuration/bare-metal-configuration.adoc
+// post_installation_configuration/post-install-bare-metal-configuration.adoc
 
 [id="getting-the-hostfirmwaresettings-resource_{context}"]
 = Getting the HostFirmwareSettings resource

--- a/modules/bmo-verifying-the-hostfirmware-settings-resource-is-valid.adoc
+++ b/modules/bmo-verifying-the-hostfirmware-settings-resource-is-valid.adoc
@@ -1,6 +1,6 @@
 // This is included in the following assemblies:
 //
-// post_installation_configuration/bare-metal-configuration.adoc
+// post_installation_configuration/post-install-bare-metal-configuration.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="verifying-the-hostfirmware-settings-resource-is-valid_{context}"]

--- a/modules/con_bmo-bare-metal-operator-architecture.adoc
+++ b/modules/con_bmo-bare-metal-operator-architecture.adoc
@@ -1,6 +1,6 @@
 // This is included in the following assemblies:
 //
-// post_installation_configuration/bare-metal-configuration.adoc
+// post_installation_configuration/post-install-bare-metal-configuration.adoc
 :_mod-docs-content-type: CONCEPT
 [id="bmo-bare-metal-operator-architecture_{context}"]
 = Bare Metal Operator architecture

--- a/modules/creating-manifest-file-customized-br-ex-bridge.adoc
+++ b/modules/creating-manifest-file-customized-br-ex-bridge.adoc
@@ -1,0 +1,218 @@
+// Module included in the following assemblies:
+//
+// IPI
+// * installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+// * installing/ipi-install-post-installation-configuration.adoc
+// UPI
+// * installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+// * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+// * installing/installing_bare_metal/installing-bare-metal.adoc
+// * post_installation_configuration/post-install-bare-metal-configuration.adoc
+
+ifeval::["{context}" == "ipi-install-post-installation-configuration"]
+:postinstall-bare-metal-ipi:
+endif::[]
+ifeval::["{context}" == "post-install-bare-metal-configuration"]
+:postinstall-bare-metal-upi:
+endif::[]
+
+:_mod-docs-content-type: PROCEDURE
+[id="creating-manifest-file-customized-br-ex-bridge_{context}"]
+== Optional: Creating a manifest object that includes a customized `br-ex` bridge
+
+ifndef::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
+As an alternative to using the `configure-ovs.sh` shell script to set a customized `br-ex` bridge on a bare-metal platform, you can create a `MachineConfig` object that includes a customized `br-ex` bridge network configuration.
+
+:FeatureName: Creating a `MachineConfig` object that includes a customized `br-ex` bridge
+include::snippets/technology-preview.adoc[]
+endif::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
+
+ifdef::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
+As an alternative to using the `configure-ovs.sh` shell script to set a customized `br-ex` bridge on a bare-metal platform, you can create a `NodeNetworkConfigurationPolicy` custom resource (CR) that includes a customized `br-ex` bridge network configuration.
+
+:FeatureName: Creating a `NodeNetworkConfigurationPolicy` CR that includes a customized `br-ex` bridge
+include::snippets/technology-preview.adoc[]
+
+This feature supports the following tasks:
+
+* Modifying the maximum transmission unit (MTU) for your cluster.
+* Modifying attributes of a different bond interface, such as MIImon (Media Independent Interface Monitor), bonding mode, or Quality of Service (QoS).
+* Updating DNS values.
+endif::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
+
+Consider the following use cases for creating a manifest object that includes a customized `br-ex` bridge:
+
+* You want to make postinstallation changes to the bridge, such as changing the Open vSwitch (OVS) or OVN-Kubernetes `br-ex` bridge network. The `configure-ovs.sh` shell script does not support making postinstallation changes to the bridge.
+* You want to deploy the bridge on a different interface than the interface available on a host or server IP address.
+* You want to make advanced configurations to the bridge that are not possible with the `configure-ovs.sh` shell script. Using the script for these configurations might result in the bridge failing to connect multiple network interfaces and facilitating data forwarding between the interfaces.
+
+ifndef::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
+
+[NOTE]
+====
+If you require an environment with a single network interface controller (NIC) and default network settings, use the `configure-ovs.sh` shell script.
+====
+
+After you install {op-system-first} and the system reboots, the Machine Config Operator injects Ignition configuration files into each node in your cluster, so that each node received the `br-ex` bridge network configuration. To prevent configuration conflicts, the `configure-ovs.sh` shell script receives a signal to not configure the `br-ex` bridge.
+endif::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
+
+.Prerequisites
+ifndef::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
+* Optional: You have installed the link:https://nmstate.io/[`nmstate`] API so that you can validate the NMState configuration.
+endif::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
+
+ifdef::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
+* You set a customized `br-ex` by using the alternative method to `configure-ovs`.
+* You installed the Kubernetes NMState Operator.
+endif::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
+
+.Procedure
+
+ifndef::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
+. Create a NMState configuration file that has decoded base64 information for your customized `br-ex` bridge network:
++
+.Example of an NMState configuration for a customized `br-ex` bridge network
+[source,yaml]
+----
+interfaces:
+- name: enp2s0 <1>
+  type: ethernet <2>
+  state: up <3>
+  ipv4:
+    enabled: false <4>
+  ipv6:
+    enabled: false
+- name: br-ex
+  type: ovs-bridge
+  state: up
+  ipv4:
+    enabled: false
+    dhcp: false
+  ipv6:
+    enabled: false
+    dhcp: false
+  bridge:
+    port:
+    - name: enp2s0 <5>
+    - name: br-ex
+- name: br-ex
+  type: ovs-interface
+  state: up
+  copy-mac-from: enp2s0
+  ipv4:
+    enabled: true
+    dhcp: true
+  ipv6:
+    enabled: false
+    dhcp: false
+# ...
+----
+<1> Name of the interface.
+<2> The type of ethernet.
+<3> The requested state for the interface after creation.
+<4> Disables IPv4 and IPv6 in this example.
+<5> The node NIC to which the bridge attaches.
+
+. Use the `cat` command to base64-encode the contents of the NMState configuration:
++
+[source,terminal]
+----
+$ cat <nmstate_configuration>.yaml | base64 <1>
+----
+<1> Replace `<nmstate_configuration>` with the name of your NMState resource YAML file.
+
+. Create a `MachineConfig` manifest file and define a customized `br-ex` bridge network configuration analogous to the following example:
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker <1>
+  name: 10-br-ex-worker <2>
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,<base64_encoded_nmstate_configuration> <3>
+        mode: 0644
+        overwrite: true
+        path: /etc/nmstate/openshift/cluster.yml
+# ...
+----
+<1> For each node in your cluster, specify the hostname path to your node and the base-64 encoded Ignition configuration file data for the machine type. If you have a single global configuration specified in an `/etc/nmstate/openshift/cluster.yml` configuration file that you want to apply to all nodes in your cluster, you do not need to specify the hostname path for each node. The `worker` role is the default role for nodes in your cluster. The `.yaml` extension does not work when specifying the hostname path for each node or all nodes in the `MachineConfig` manifest file.
+<2> The name of the policy.
+<3> Writes the encoded base64 information to the specified path. 
+endif::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
+
+ifdef::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
+. Create a `NodeNetworkConfigurationPolicy` (NNCP) CR and define a customized `br-ex` bridge network configuration. Depending on your needs, ensure that you set a masquerade IP for either the `ipv4.address.ip`, `ipv6.address.ip`, or both parameters. A masquerade IP address must match an in-use IP address block.
++
+.Example of an NNCP CR that sets IPv6 and IPv4 masquerade IP addresses
+[source,yaml]
+----
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: worker-0-br-ex <1>
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: worker-0
+    desiredState:
+    interfaces:
+    - name: enp2s0 <2>
+      type: ethernet <3>
+      state: up <4>
+      ipv4:
+        enabled: false <5>
+      ipv6:
+        enabled: false
+    - name: br-ex
+      type: ovs-bridge
+      state: up
+      ipv4:
+        enabled: false
+        dhcp: false
+      ipv6:
+        enabled: false
+        dhcp: false
+      bridge:
+        port:
+        - name: enp2s0 <6>
+        - name: br-ex
+    - name: br-ex
+      type: ovs-interface
+      state: up
+      copy-mac-from: enp2s0
+      ipv4:
+        enabled: true
+        dhcp: true
+        address:
+        - ip: "169.254.169.2"
+          prefix-length: 29
+      ipv6:
+        enabled: false
+        dhcp: false
+        address:
+        - ip: "fd69::2"
+        prefix-length: 125
+----
+<1> Name of the policy.
+<2> Name of the interface.
+<3> The type of ethernet.
+<4> The requested state for the interface after creation.
+<5> Disables IPv4 and IPv6 in this example.
+<6> The node NIC to which the bridge is attached.
+endif::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
+
+ifeval::["{context}" == "ipi-install-post-installation-configuration"]
+:!postinstall-bare-metal:
+endif::[]
+ifeval::["{context}" == "bare-metal-configuration"]
+:!postinstall-bare-metal:
+endif::[]
+

--- a/modules/creating-scaling-machine-sets-compute-nodes-networking.adoc
+++ b/modules/creating-scaling-machine-sets-compute-nodes-networking.adoc
@@ -1,0 +1,76 @@
+// Module included in the following assemblies:
+//
+// IPI
+// * installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+// UPI
+// * installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+// * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+// * installing/installing_bare_metal/installing-bare-metal.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="creating-scaling-machine-sets-compute-nodes-networking_{context}"]
+= Optional: Scaling each machine set to compute nodes
+
+To apply a customized `br-ex` bridge configuration to all compute nodes in your {product-title} cluster, you must edit your `MachineConfig` custom resource (CR) and modify its roles. Additionally, you must create a `BareMetalHost` CR that defines information for your bare-metal machine, such as hostname, credentials, and so on.
+
+After you configure these resources, you must scale machine sets, so that the machine sets can apply the resource configuration to each compute node and reboot the nodes.
+
+.Prerequisites
+
+* You created a `MachineConfig` manifest object that includes a customized `br-ex` bridge configuration.
+
+.Procedure
+
+. Edit the `MachineConfig` CR by entering the following command:
++
+[source,terminal]
+----
+$ oc edit mc <machineconfig_custom_resource_name>
+----
+
+. Add each compute node configuration to the CR, so that the CR can manage roles for each defined compute node in your cluster.
+
+. Create a `Secret` object named `extraworker-secret` that has a minimal static IP configuration.
+
+. Apply the `extraworker-secret` secret to each node in your cluster by entering the following command. This step provides each compute node access to the Ignition config file.
++
+[source,terminal]
+----
+$ oc apply -f ./extraworker-secret.yaml
+----
+
+. Create a `BareMetalHost` resource and specify the network secret in the `preprovisioningNetworkDataName` parameter:
++
+.Example `BareMetalHost` resource with an attached network secret
+[source,yaml]
+----
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+spec:
+# ...
+  preprovisioningNetworkDataName: ostest-extraworker-0-network-config-secret
+# ...
+----
+
+. To mange the `BareMetalHost` object within the `openshift-machine-api` namespace of your cluster, change to the namespace by entering the following command:
++
+[source,terminal]
+----
+$ oc project openshift-machine-api
+----
+
+. Get the machine sets:
++
+[source,terminal]
+----
+$ oc get machinesets
+----
+
+. Scale each machine set by entering the following command. You must run this command for each machine set.
++
+[source,terminal]
+----
+$ oc scale machineset <machineset_name> --replicas=<n> <1>
+----
+<1> Where `<machineset_name>` is the name of the machine set and `<n>` is the number of compute nodes.
+

--- a/modules/nw-modifying-operator-install-config.adoc
+++ b/modules/nw-modifying-operator-install-config.adoc
@@ -23,6 +23,7 @@ endif::[]
 = Specifying advanced network configuration
 
 You can use advanced network configuration for your network plugin to integrate your cluster into your existing network environment.
+
 You can specify advanced network configuration only before you install the cluster.
 
 [IMPORTANT]

--- a/modules/nw-ovn-kubernetes-migration.adoc
+++ b/modules/nw-ovn-kubernetes-migration.adoc
@@ -234,7 +234,7 @@ $ oc get machineconfig <config_name> -o yaml | grep ExecStart
 +
 where `<config_name>` is the name of the machine config from the `machineconfiguration.openshift.io/currentConfig` field.
 +
-The machine config must include the following update to the systemd configuration:
+The machine config can include the following update to the systemd configuration:
 +
 [source,plain]
 ----

--- a/modules/virt-example-nmstate-IP-management.adoc
+++ b/modules/virt-example-nmstate-IP-management.adoc
@@ -91,16 +91,20 @@ The following snippet configures an Ethernet interface that uses a dynamic IP ad
 [id="virt-example-nmstate-IP-management-dns_{context}"]
 == DNS
 
-By default, the `nmstate` API stores DNS values globally as against storing them in a network interface. For certain situations, you must configure a network interface to store DNS values. To define a DNS configuration for a network interface, you must initially specify the `dns-resolver` section in the network interface's YAML configuration file.
+By default, the `nmstate` API stores DNS values globally as against storing them in a network interface. For certain situations, you must configure a network interface to store DNS values.
 
 [TIP]
 ====
 Setting a DNS configuration is comparable to modifying the `/etc/resolv.conf` file.
 ====
 
+To define a DNS configuration for a network interface, you must initially specify the `dns-resolver` section in the network interface's YAML configuration file.
+
 [IMPORTANT]
 ====
-You cannot use `br-ex` bridge, an OVNKubernetes-managed Open vSwitch bridge, as the interface when configuring DNS resolvers.
+You cannot use `br-ex` bridge, an OVNKubernetes-managed Open vSwitch bridge, as the interface when configuring DNS resolvers unless you manually configured a customized `br-ex` bridge.
+
+For more information, see "Creating a manifest object that includes a customized br-ex bridge" in the _Deploying installer-provisioned clusters on bare metal_ document or the _Installing a user-provisioned cluster on bare metal_ document.
 ====
 
 The following example shows a default situation that stores DNS values globally:

--- a/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
@@ -18,7 +18,9 @@ Before you can use NMState with {product-title}, you must install the Kubernetes
 
 [NOTE]
 ====
-The Kubernetes NMState Operator updates the network configuration of a secondary NIC. It cannot update the network configuration of the primary NIC or the `br-ex` bridge.
+The Kubernetes NMState Operator updates the network configuration of a secondary NIC. The Operator cannot update the network configuration of the primary NIC, or update the `br-ex` bridge on most on-premise networks.
+
+On a bare-metal platform, using the Kubernetes NMState Operator to update the `br-ex` bridge network configuration is only supported if you set the `br-ex` bridge as the interface in a machine config manifest file. To update the `br-ex` bridge as a postinstallation task, you must set the `br-ex` bridge as the interface in the NMState configuration of the `NodeNetworkConfigurationPolicy` custom resource (CR) for your cluster.
 ====
 
 {product-title} uses link:https://nmstate.github.io/[`nmstate`] to report on and configure the state of the node network. This makes it possible to modify the network policy configuration, such as by creating a Linux bridge on all nodes, by applying a single configuration manifest to the cluster.
@@ -26,7 +28,7 @@ The Kubernetes NMState Operator updates the network configuration of a secondary
 Node networking is monitored and updated by the following objects:
 
 `NodeNetworkState`:: Reports the state of the network on that node.
-`NodeNetworkConfigurationPolicy`:: Describes the requested network configuration on nodes. You update the node network configuration, including adding and removing interfaces, by applying a `NodeNetworkConfigurationPolicy` manifest to the cluster.
+`NodeNetworkConfigurationPolicy`:: Describes the requested network configuration on nodes. You update the node network configuration, including adding and removing interfaces, by applying a `NodeNetworkConfigurationPolicy` CR to the cluster.
 `NodeNetworkConfigurationEnactment`:: Reports the network policies enacted upon each node.
 
 [id="installing-the-kubernetes-nmstate-operator-cli"]

--- a/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
@@ -90,3 +90,10 @@ include::modules/virt-example-inherit-static-ip-from-nic.adoc[leveloffset=+2]
 
 // Examples: IP management
 include::modules/virt-example-nmstate-IP-management.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#creating-manifest-file-customized-br-ex-bridge_ipi-install-installation-workflow[Creating a manifest object that includes a customized br-ex bridge (Installer-provisioned infrastructure)]
+
+* xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#creating-manifest-file-customized-br-ex-bridge_installing-bare-metal[Creating a manifest object that includes a customized br-ex bridge (User-provisioned infrastructure)]

--- a/post_installation_configuration/index.adoc
+++ b/post_installation_configuration/index.adoc
@@ -26,7 +26,7 @@ The following lists details these configurations:
 
 * xref:../machine_configuration/index.adoc#machine-config-overview[Configure operating system features]: The Machine Config Operator (MCO) manages `MachineConfig` objects. By using the MCO, you can configure nodes and custom resources.
 
-* xref:../post_installation_configuration/bare-metal-configuration.adoc#post-install-bare-metal-configuration[Configure bare metal nodes]: You can use the Bare Metal Operator (BMO) to manage bare metal hosts. The BMO can complete the following operations:
+* xref:../post_installation_configuration/post-install-bare-metal-configuration.adoc#post-install-bare-metal-configuration[Configure bare metal nodes]: You can use the Bare Metal Operator (BMO) to manage bare metal hosts. The BMO can complete the following operations:
 
 ** Inspects hardware details of the host and report them to the bare metal host.
 ** Inspect firmware and configure BIOS settings.

--- a/post_installation_configuration/post-install-bare-metal-configuration.adoc
+++ b/post_installation_configuration/post-install-bare-metal-configuration.adoc
@@ -8,22 +8,50 @@ toc::[]
 
 When deploying {product-title} on bare metal hosts, there are times when you need to make changes to the host either before or after provisioning. This can include inspecting the host's hardware, firmware, and firmware details. It can also include formatting disks or changing modifiable firmware settings.
 
+// About the Bare Metal Operator
 include::modules/bmo-about-the-bare-metal-operator.adoc[leveloffset=+1]
+
+// Bare Metal Operator architecture
 include::modules/con_bmo-bare-metal-operator-architecture.adoc[leveloffset=+2]
+
+// Creating a manifest object that includes a customized `br-ex` bridge
+include::modules/creating-manifest-file-customized-br-ex-bridge.adoc[leveloffset=+1]
+
+// About the BareMetalHost resource
 include::modules/bmo-about-the-baremetalhost-resource.adoc[leveloffset=+1]
+
+// Getting the BareMetalHost resource
 include::modules/bmo-getting-the-baremetalhost-resource.adoc[leveloffset=+1]
+
+// Editing a BareMetalHost resource
 include::modules/bmo-editing-a-baremetalhost-resource.adoc[leveloffset=+1]
 
+// Attaching a non-bootable ISO to a bare-metal node
 include::modules/bmo-attaching-a-non-bootable-iso-to-a-bare-metal-node.adoc[leveloffset=+1]
 
+// About the HostFirmwareSettings resource
 include::modules/bmo-about-the-hostfirmwaresettings-resource.adoc[leveloffset=+1]
+
+// Getting the HostFirmwareSettings resource
 include::modules/bmo-getting-the-hostfirmwaresettings-resource.adoc[leveloffset=+1]
+
+// Editing the HostFirmwareSettings resource
 include::modules/bmo-editing-the-hostfirmwaresettings-resource.adoc[leveloffset=+1]
+
+// Verifying the HostFirmware Settings resource is valid
 include::modules/bmo-verifying-the-hostfirmware-settings-resource-is-valid.adoc[leveloffset=+1]
 
+// About the FirmwareSchema resource
 include::modules/bmo-about-the-firmwareschema-resource.adoc[leveloffset=+1]
+
+// Getting the FirmwareSchema resource
 include::modules/bmo-getting-the-firmwareschema-resource.adoc[leveloffset=+1]
 
+// About the HostFirmwareComponents resource
 include::modules/bmo-about-the-hostfirmwarecomponents-resource.adoc[leveloffset=+1]
+
+// Getting the HostFirmwareComponents resource
 include::modules/bmo-getting-the-hostfirmwarecomponents-resource.adoc[leveloffset=+1]
+
+// Editing the HostFirmwareComponents resource
 include::modules/bmo-editing-the-hostfirmwarecomponents-resource.adoc[leveloffset=+1]

--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -1126,18 +1126,18 @@ For more information, see xref:../support/gathering-cluster-data.adoc#about-must
 // [id="ocp-4-16-upgrading-or-downgrading-host-firmware_{context}"]
 // ==== Upgrading or downgrading host firmware
 
-// Beginning with {product-title} {product-version}, you can upgrade or downgrade the firmware for a bare-metal node to a specific version. Metal^3^ provides the `HostFirmwareComponents` resource, which describes BIOS and baseboard management controller (BMC) firmware versions. Upgrading or downgrading firmware is useful when deploying an {product-title} cluster on bare metal with validated patterns that have been tested against specific firmware versions. See xref:../post_installation_configuration/bare-metal-configuration.adoc#about-the-hostfirmwarecomponents-resource_post-install-bare-metal-configuration[About the HostFirmwareComponents resource] for additional details.
+// Beginning with {product-title} {product-version}, you can upgrade or downgrade the firmware for a bare-metal node to a specific version. Metal^3^ provides the `HostFirmwareComponents` resource, which describes BIOS and baseboard management controller (BMC) firmware versions. Upgrading or downgrading firmware is useful when deploying an {product-title} cluster on bare metal with validated patterns that have been tested against specific firmware versions. See xref:../post_installation_configuration/post-install-bare-metal-configuration.adoc#about-the-hostfirmwarecomponents-resource_post-install-bare-metal-configuration[About the HostFirmwareComponents resource] for additional details.
 
 [id="ocp-4-16-editing-the-baremetalhost-resource_{context}"]
 ==== Editing the BareMetalHost resource
 
-In {product-title} {product-version} and later, you can edit the baseboard management controller (BMC) address in the `BareMetalHost` resource of a bare-metal node. The node must be in the `Provisioned`, `ExternallyProvisioned`, `Registering`, or `Available` state. Editing the BMC address in the `BareMetalHost` resource will not result in deprovisioning the node. See xref:../post_installation_configuration/bare-metal-configuration.adoc#editing-a-baremetalhost-resource_post-install-bare-metal-configuration[Editing a BareMetalHost resource] for additional details.
+In {product-title} {product-version} and later, you can edit the baseboard management controller (BMC) address in the `BareMetalHost` resource of a bare-metal node. The node must be in the `Provisioned`, `ExternallyProvisioned`, `Registering`, or `Available` state. Editing the BMC address in the `BareMetalHost` resource will not result in deprovisioning the node. See xref:../post_installation_configuration/post-install-bare-metal-configuration.adoc#editing-a-baremetalhost-resource_post-install-bare-metal-configuration[Editing a BareMetalHost resource] for additional details.
 
 [id="ocp-4-16-attaching-a-non-bootable-iso_{context}"]
 ==== Attaching a non-bootable ISO
 
 In {product-title} {product-version} and later, you can attach a generic, non-bootable ISO virtual media image to a provisioned node by using the `DataImage` resource. After you apply the resource, the ISO image becomes accessible to the operating system on the next reboot.
-The node must use Redfish or drivers derived from it to support this feature. The node must be in the `Provisioned` or `ExternallyProvisioned` state. See xref:../post_installation_configuration/bare-metal-configuration.adoc#attaching-a-non-bootable-iso-to-a-bare-metal-node_post-install-bare-metal-configuration[Attaching a non-bootable ISO to a bare-metal node] for additional details.
+The node must use Redfish or drivers derived from it to support this feature. The node must be in the `Provisioned` or `ExternallyProvisioned` state. See xref:../post_installation_configuration/post-install-bare-metal-configuration.adoc#attaching-a-non-bootable-iso-to-a-bare-metal-node_post-install-bare-metal-configuration[Attaching a non-bootable ISO to a bare-metal node] for additional details.
 
 [id="ocp-4-16-monitoring_{context}"]
 === Monitoring


### PR DESCRIPTION
Cherry pick of #76548 with commit ID 32a85983e3d03f9b974c186e453505544d98d43c

Version(s):
4.16

Link to docs preview:
[4.16 Release Notes](https://79340--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes#ocp-4-16-bug-fixes_release-notes)
