### PR TITLE
Replace 'minio' with a generic term in sample YAML files

### DIFF
--- a/modules/oadp-installing-dpa-1-2-and-earlier.adoc
+++ b/modules/oadp-installing-dpa-1-2-and-earlier.adoc
@@ -245,27 +245,28 @@ spec:
     - velero:
         config:
           profile: "default"
-          region: minio
-          s3Url: <url> # <5>
+          region: <region_name> <5>
+          s3Url: <url> # <6>
           insecureSkipTLSVerify: "true"
           s3ForcePathStyle: "true"
         provider: {provider}
         default: true
         credential:
           key: cloud
-          name: {credentials} # <6>
+          name: {credentials} # <7>
         objectStorage:
-          bucket: <bucket_name> # <7>
-          prefix: <prefix> # <8>
+          bucket: <bucket_name> # <8>
+          prefix: <prefix> # <9>
 ----
 <1> The `openshift` plugin is mandatory.
 <2> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.
 <3> Set this value to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that Restic pods run on each working node. In OADP version 1.2 and later, you can configure Restic for backups by adding `spec.defaultVolumesToFsBackup: true` to the `Backup` CR. In OADP version 1.1, add `spec.defaultVolumesToRestic: true` to the `Backup` CR.
 <4> Specify on which nodes Restic is available. By default, Restic runs on all nodes.
-<5> Specify the URL of the S3 endpoint.
-<6> If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
-<7> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
-<8> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
+<5> Specify the region, following the naming convention of the documentation of your object storage server.
+<6> Specify the URL of the S3 endpoint.
+<7> If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
+<8> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
+<9> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
 endif::[]
 ifdef::installing-oadp-ocs[]
 +

--- a/modules/oadp-installing-dpa-1-3.adoc
+++ b/modules/oadp-installing-dpa-1-3.adoc
@@ -258,18 +258,18 @@ spec:
     - velero:
         config:
           profile: "default"
-          region: minio
-          s3Url: <url> # <8>
+          region: <region_name> <8>
+          s3Url: <url> # <9>
           insecureSkipTLSVerify: "true"
           s3ForcePathStyle: "true"
         provider: {provider}
         default: true
         credential:
           key: cloud
-          name: {credentials} # <9>
+          name: {credentials} # <10>
         objectStorage:
-          bucket: <bucket_name> # <10>
-          prefix: <prefix> # <11>
+          bucket: <bucket_name> # <11>
+          prefix: <prefix> # <12>
 ----
 <1> The default namespace for OADP is `openshift-adp`. The namespace is a variable and is configurable.
 <2> The `openshift` plugin is mandatory.
@@ -278,10 +278,11 @@ spec:
 <5> Set this value to `true` if you want to enable `nodeAgent` and perform File System Backup.
 <6> Enter `kopia` or `restic` as your uploader. You cannot change the selection after the installation. For the Built-in DataMover you must use Kopia. The `nodeAgent` deploys a daemon set, which means that the `nodeAgent` pods run on each working node. You can configure File System Backup by adding `spec.defaultVolumesToFsBackup: true` to the `Backup` CR.
 <7> Specify the nodes on which Kopia or Restic are available. By default, Kopia or Restic run on all nodes.
-<8> Specify the URL of the S3 endpoint.
-<9> If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
-<10> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
-<11> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
+<8> Specify the region, following the naming convention of the documentation of your object storage server.
+<9> Specify the URL of the S3 endpoint.
+<10> If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
+<11> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
+<12> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
 endif::[]
 
 ifdef::installing-oadp-ocs[]

--- a/modules/oadp-secrets-for-different-credentials.adoc
+++ b/modules/oadp-secrets-for-different-credentials.adoc
@@ -180,7 +180,7 @@ spec:
     - velero:
         config:
           profile: "default"
-          region: minio
+          region: <region_name> <1>
           s3Url: <url>
           insecureSkipTLSVerify: "true"
           s3ForcePathStyle: "true"
@@ -188,12 +188,13 @@ spec:
         default: true
         credential:
           key: cloud
-          name:  <custom_secret> <1>
+          name:  <custom_secret> <2>
         objectStorage:
           bucket: <bucket_name>
           prefix: <prefix>
 ----
-<1> Backup location `Secret` with custom name.
+<1> Specify the region, following the naming convention of the documentation of your object storage server.
+<2> Backup location `Secret` with custom name.
 endif::[]
 ifdef::installing-oadp-ocs[]
 +


### PR DESCRIPTION
OADP 1.4.1 (OK to merge and publish before GA), OCP 4.13+

Resolves https://issues.redhat.com/browse/OADP-1322 by replacing `minio` by a more generic term in 3 sample YAML files.

Previews:

- https://79342--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.html#oadp-secrets-for-different-credentials_installing-oadp-mcg [step 5]
- https://79342--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.html#oadp-installing-dpa-1-2-and-earlier_installing-oadp-mcg [step 3]
- https://79342--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.html#oadp-installing-dpa-1-3_installing-oadp-mcg [step 3]

Approved by OADP QA [PrasadJoshi12 below] 