### PR TITLE
[SRVCOM-3149] Change sidecar injection from annotations to labels

### DIFF
--- a/modules/serverless-ossm-installing-and-configuring-openshift-serverless.adoc
+++ b/modules/serverless-ossm-installing-and-configuring-openshift-serverless.adoc
@@ -22,12 +22,14 @@ spec:
       enabled: true <1>
   deployments: <2>
   - name: activator
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
   - name: autoscaler
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
   config:
     istio: <3>
@@ -61,20 +63,24 @@ spec:
       istio: enabled <1>
   workloads: <2>
   - name: pingsource-mt-adapter
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
   - name: imc-dispatcher
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
   - name: mt-broker-ingress
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
   - name: mt-broker-filter
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
 ----
 <1> Enable Eventing Istio controller to create a `DestinationRule` for each `InMemoryChannel` or `KafkaChannel` service.
@@ -113,32 +119,39 @@ spec:
       enabled: true
   workloads: <2>
   - name: kafka-controller
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
   - name: kafka-broker-receiver
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
   - name: kafka-broker-dispatcher
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
   - name: kafka-channel-receiver
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
   - name: kafka-channel-dispatcher
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
   - name: kafka-source-dispatcher
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
   - name: kafka-sink-receiver
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
 ----
 <1> The Apache Kafka cluster URL, for example `my-cluster-kafka-bootstrap.kafka:9092`.

--- a/modules/serverless-ossm-setup.adoc
+++ b/modules/serverless-ossm-setup.adoc
@@ -160,12 +160,14 @@ spec:
       enabled: true <1>
   deployments: <2>
   - name: activator
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
   - name: autoscaler
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
 ----
 <1> Enables Istio integration.
@@ -193,20 +195,24 @@ spec:
       istio: enabled <1>
   workloads:
   - name: pingsource-mt-adapter
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true" <2>
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
   - name: imc-dispatcher
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
   - name: mt-broker-ingress
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
   - name: mt-broker-filter
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
 ----
 <1> Enables Eventing istio controller to create a `DestinationRule` for each InMemoryChannel or KafkaChannel service.
@@ -247,32 +253,39 @@ spec:
     enabled: true
   workloads: <2>
   - name: kafka-controller
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
   - name: kafka-broker-receiver
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
   - name: kafka-broker-dispatcher
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
   - name: kafka-channel-receiver
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
   - name: kafka-channel-dispatcher
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
   - name: kafka-source-dispatcher
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
   - name: kafka-sink-receiver
-    annotations:
+    labels:
       "sidecar.istio.io/inject": "true"
+    annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
 ----
 <1> The Apache Kafka cluster URL, for example: `my-cluster-kafka-bootstrap.kafka:9092`.


### PR DESCRIPTION
Version(s):
`serverless-docs-1.34`+

Issue:
https://issues.redhat.com/browse/SRVCOM-3149

Link to docs preview:
https://79344--ocpdocs-pr.netlify.app/openshift-serverless/latest/integrations/serverless-ossm-setup.html

QE review:
- [x] QE has approved this change.