### PR TITLE
[enterprise-4.13] OSDOCS-11377-13: CPs for updated the mtu parameter for the bridge

### DIFF
--- a/modules/nw-multus-bridge-object.adoc
+++ b/modules/nw-multus-bridge-object.adoc
@@ -70,7 +70,7 @@ plugin:
 |Optional: Assign a VLAN trunk tag. The default value is `none`.
 
 |`mtu`
-|`string`
+|`integer`
 |Optional: Set the maximum transmission unit (MTU) to the specified value. The default value is automatically set by the kernel.
 
 |`enabledad`

--- a/networking/multiple_networks/configuring-additional-network.adoc
+++ b/networking/multiple_networks/configuring-additional-network.adoc
@@ -126,10 +126,19 @@ creating.
 
 The specific configuration fields for additional networks is described in the following sections.
 
+// Configuration for a bridge additional network
 include::modules/nw-multus-bridge-object.adoc[leveloffset=+2]
+
+// Configuration for a host device additional network
 include::modules/nw-multus-host-device-object.adoc[leveloffset=+2]
+
+// Configuration for an VLAN additional network
 include::modules/nw-multus-vlan-object.adoc[leveloffset=+2]
+
+// Configuration for an ipvlan additional network
 include::modules/nw-multus-ipvlan-object.adoc[leveloffset=+2]
+
+// Configuration for a macvlan additional network
 include::modules/nw-multus-macvlan-object.adoc[leveloffset=+2]
 include::modules/configuring-ovnk-additional-networks.adoc[leveloffset=+2]
 include::modules/configuration-ovnk-network-plugin-json-object.adoc[leveloffset=+3]


### PR DESCRIPTION
CP of #79276 with commit 2122ed0b1a890db12f8384d32c164bdae1b64a5c

Version(s):
4.13

Link to docs preview:
[Configuration for a bridge additional network](https://79366--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html#nw-multus-bridge-object_configuring-additional-network)

