### PR TITLE
OSDOCS-11377: Updated the mtu parameter for the bridge add. network p…

### DIFF
--- a/modules/nw-multus-bridge-object.adoc
+++ b/modules/nw-multus-bridge-object.adoc
@@ -70,7 +70,7 @@ plugin:
 |Optional: Assign a VLAN trunk tag. The default value is `none`.
 
 |`mtu`
-|`string`
+|`integer`
 |Optional: Set the maximum transmission unit (MTU) to the specified value. The default value is automatically set by the kernel.
 
 |`enabledad`

--- a/networking/multiple_networks/configuring-additional-network.adoc
+++ b/networking/multiple_networks/configuring-additional-network.adoc
@@ -124,9 +124,14 @@ creating.
 
 The specific configuration fields for additional networks is described in the following sections.
 
+// Configuration for a bridge additional network
 include::modules/nw-multus-bridge-object.adoc[leveloffset=+2]
+
+// Configuration for a host device additional network
 include::modules/nw-multus-host-device-object.adoc[leveloffset=+2]
 include::modules/nw-multus-ipvlan-object.adoc[leveloffset=+2]
+
+// Configuration for a macvlan additional network
 include::modules/nw-multus-macvlan-object.adoc[leveloffset=+2]
 
 include::modules/nw-multus-ipam-object.adoc[leveloffset=+1]


### PR DESCRIPTION
CP of #79276 with commit 2122ed0b1a890db12f8384d32c164bdae1b64a5c

Version(s):
4.12

Link to docs preview:
[Configuration for a bridge additional network](https://79371--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html#nw-multus-bridge-object_configuring-additional-network)


