### PR TITLE
 OCPBUGS-36365: LPAR updates to ABI docs

### DIFF
--- a/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.adoc
+++ b/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.adoc
@@ -42,9 +42,18 @@ include::modules/installing-ocp-agent-ibm-z.adoc[leveloffset=+1]
 include::modules/installing-ocp-agent-ibm-z-zvm.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-.Additional resources
 
 * xref:../../installing/installing_ibm_z/installing-ibm-z.adoc#installing-ibm-z[Installing a cluster with z/VM on {ibm-z-title} and {ibm-linuxone-title}]
 
 // Adding {ibm-z-name} agents with {op-system-base} KVM
 include::modules/installing-ocp-agent-ibm-z-kvm.adoc[leveloffset=+2]
+
+// Adding {ibm-z-title} Logical Partition (LPAR) as agents
+include::modules/adding-ibmz-lpar-agent.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing_ibm_z/installing-ibm-z.adoc#installing-ibm-z[Installing a cluster with z/VM on {ibm-z-title} and {ibm-linuxone-title}]
+
+

--- a/modules/adding-ibmz-lpar-agent.adoc
+++ b/modules/adding-ibmz-lpar-agent.adoc
@@ -1,0 +1,93 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_with_agent_based_installer/prepare-pxe-infra-agent.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="adding-ibmz-lpar-agents_{context}"]
+= Adding {ibm-z-title} agents in a Logical Partition (LPAR)
+
+Use the following procedure to manually add {ibm-z-name} agents to your cluster that runs in an LPAR environment. Use this procedure only for {ibm-z-name} clusters running in an LPAR.
+
+.Prerequisites
+* You have Python 3 installed.
+
+.Procedure
+
+. Create a boot parameter file for the agents.
++
+.Example parameter file
+[source,terminal]
+----
+rd.neednet=1 cio_ignore=all,!condev \
+console=ttysclp0 \
+ignition.firstboot ignition.platform.id=metal
+coreos.live.rootfs_url=http://<http_server>/rhcos-<version>-live-rootfs.<architecture>.img \// <1>
+coreos.inst.persistent-kargs=console=ttysclp0
+ip=<ip>::<gateway>:<netmask>:<hostname>::none nameserver=<dns> \// <2>
+rd.znet=qeth,<network_adaptor_range>,layer2=1
+rd.<disk_type>=<adapter> \// <3>
+zfcp.allow_lun_scan=0
+ai.ip_cfg_override=1 \// <4>
+random.trust_cpu=on rd.luks.options=discard
+----
+<1> For the `coreos.live.rootfs_url` artifact, specify the matching `rootfs` artifact for the `kernel` and `initramfs` that you are starting. Only HTTP and HTTPS protocols are supported.
+<2> For the `ip` parameter, manually assign the IP address, as described in _Installing a cluster with z/VM on IBM Z and IBM LinuxONE_.
+<3> For installations on DASD-type disks, use `rd.dasd` to specify the DASD where {op-system-first} is to be installed. For installations on FCP-type disks, use `rd.zfcp=<adapter>,<wwpn>,<lun>` to specify the FCP disk where {op-system} is to be installed.
+<4> Specify this parameter when you use an Open Systems Adapter (OSA) or HiperSockets.
+
+. Generate the `.ins` and `initrd.img.addrsize` files by running the following Python script:
++
+The `.ins` file is a special file that includes installation data and is present on the FTP server. It can be accessed from the HMC system.
+This file contains details such as mapping of the location of installation data on the disk or FTP server, the memory locations where the data is to be copied.
++
+[NOTE]
+====
+The `.ins` and `initrd.img.addrsize` files are not automatically generated as part of boot-artifacts from the installer. You must manually generate these files.
+====
+
+.. Save the following script to a file, such as `generate-files.py`:
++
+.Example of a Python file named `generate-files.py` file
+[source,python]
+----
+# The following commands retrieve the size of the `kernel` and `initrd`:
+KERNEL_IMG_PATH='./kernel.img'
+INITRD_IMG_PATH='./initrd.img'
+CMDLINE_PATH='./generic.prm'
+kernel_size=(stat -c%s KERNEL_IMG_PATH)
+initrd_size=(stat -c%s INITRD_IMG_PATH)
+# The following command rounds the `kernel` size up to the next megabytes (MB) boundary.
+# This value is the starting address of `initrd.img`.
+offset=(( (kernel_size + 1048575) / 1048576 * 1048576 ))
+INITRD_IMG_NAME=(echo INITRD_IMG_PATH | rev | cut -d '/' -f 1 | rev)
+# The following commands create the kernel binary patch file that contains the `initrd` address and size:
+KERNEL_OFFSET=0x00000000
+KERNEL_CMDLINE_OFFSET=0x00010480
+INITRD_ADDR_SIZE_OFFSET=0x00010408
+OFFSET_HEX=(printf '0x%08x\n' offset)
+# The following command converts the address and size to binary format:
+printf "(printf '%016x\n' $initrd_size)" | xxd -r -p > temp_size.bin
+# The following command concatenates the address and size binaries:
+cat temp_address.bin temp_size.bin > "$INITRD_IMG_NAME.addrsize"
+# The following command deletes temporary files:
+rm -rf temp_address.bin temp_size.bin
+# The following commands create the `.ins` file.
+# The file is based on the paths of the `kernel.img`, `initrd.img`, `initrd.img.addrsize`, and `cmdline` files and the memory locations where the data is to be copied.
+KERNEL_IMG_PATH KERNEL_OFFSET
+INITRD_IMG_PATH OFFSET_HEX
+INITRD_IMG_NAME.addrsize INITRD_ADDR_SIZE_OFFSET
+CMDLINE_PATH KERNEL_CMDLINE_OFFSET
+----
+
+.. Execute the script by running the following command:
++
+[source,terminal]
+----
+$ python3 <file_name>.py
+----
+
+. Transfer the `initrd`, `kernel`, `generic.ins`, and `initrd.img.addrsize` parameter files to the file server. For more information, see link:https://www.ibm.com/docs/en/linux-on-systems?topic=bl-booting-linux-in-lpar-mode[Booting Linux in LPAR mode] (IBM documentation).
+
+. Start the machine.
+
+. Repeat the procedure for all other machines in the cluster.

--- a/modules/installing-ocp-agent-ibm-z-kvm.adoc
+++ b/modules/installing-ocp-agent-ibm-z-kvm.adoc
@@ -9,16 +9,11 @@ endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="installing-ocp-agent-ibm-z-kvm_{context}"]
-= Adding {ibm-z-name} agents with {op-system-base} KVM
+= Adding {ibm-z-title} agents with {op-system-base} KVM
 
 Use the following procedure to manually add {ibm-z-name} agents with {op-system-base} KVM.
 Only use this procedure for {ibm-z-name} clusters with {op-system-base} KVM.
 
-[NOTE]
-====
-Currently, ISO boot support on {ibm-z-name} (`s390x`) is available only for {op-system-base} KVM, which provides the flexibility to choose either PXE or ISO-based installation.
-For installations with z/VM, only PXE boot is supported.
-====
 .Procedure
 
 . Boot your {op-system-base} KVM machine.

--- a/modules/installing-ocp-agent-ibm-z.adoc
+++ b/modules/installing-ocp-agent-ibm-z.adoc
@@ -13,3 +13,9 @@ Depending on your {ibm-z-name} environment, you can choose from the following op
 
 * Adding {ibm-z-name} agents with z/VM
 * Adding {ibm-z-name} agents with {op-system-base} KVM
+* Adding {ibm-z-name} agents with Logical Partition (LPAR)
+
+[NOTE]
+====
+Currently, ISO boot support on {ibm-z-name} (`s390x``) is available only for {op-system-base-full} KVM, which provides the flexibility to choose either PXE or ISO-based installation. For installations with z/VM and Logical Partition (LPAR), only PXE boot is supported.
+====

--- a/modules/understanding-agent-install.adoc
+++ b/modules/understanding-agent-install.adoc
@@ -9,6 +9,11 @@ As an {product-title} user, you can leverage the advantages of the Assisted Inst
 
 The Agent-based installation comprises a bootable ISO that contains the Assisted discovery agent and the Assisted Service. Both are required to perform the cluster installation, but the latter runs on only one of the hosts.
 
+[NOTE]
+====
+Currently, ISO boot support on {ibm-z-name} (`s390x``) is available only for {op-system-base-full} KVM, which provides the flexibility to choose either PXE or ISO-based installation. For installations with z/VM and Logical Partition (LPAR), only PXE boot is supported.
+====
+
 The `openshift-install agent create image` subcommand generates an ephemeral ISO based on the inputs that you provide. You can choose to provide inputs through the following manifests:
 
 Preferred:


### PR DESCRIPTION
Version(s): 4.16+

Issues: https://issues.redhat.com/browse/OCPBUGS-36365
Links to doc preview:
https://79373--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html#adding-ibmz-lpar-agents_installing-with-agent-based-installer 

https://79373--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent#installing-ocp-agent-ibm-z_prepare-pxe-assets-agent 

https://79373--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer#understanding-agent-install_preparing-to-install-with-agent-based-installer 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Link to Gdoc: https://ibm.ent.box.com/notes/1457790308609
