### PR TITLE
Replace script in 'Creating a Restore CR'

### DIFF
--- a/modules/oadp-creating-restore-cr.adoc
+++ b/modules/oadp-creating-restore-cr.adoc
@@ -93,21 +93,18 @@ label_name () {
     echo "${1:0:57}${sha:0:6}"
 }
 
-OADP_NAMESPACE=${OADP_NAMESPACE:=openshift-adp}
-
 if [[ $# -ne 1 ]]; then
     echo "usage: ${BASH_SOURCE} restore-name"
     exit 1
 fi
 
-echo using OADP Namespace $OADP_NAMESPACE
-echo restore: $1
+echo "restore: $1"
 
 label=$(label_name $1)
-echo label: $label
+echo "label:   $label"
 
 echo Deleting disconnected restore pods
-oc delete pods -l oadp.openshift.io/disconnected-from-dc=$label
+oc delete pods --all-namespaces -l oadp.openshift.io/disconnected-from-dc=$label
 
 for dc in $(oc get dc --all-namespaces -l oadp.openshift.io/replicas-modified=$label -o jsonpath='{range .items[*]}{.metadata.namespace}{","}{.metadata.name}{","}{.metadata.annotations.oadp\.openshift\.io/original-replicas}{","}{.metadata.annotations.oadp\.openshift\.io/original-paused}{"\n"}')
 do
@@ -122,5 +119,4 @@ EOF
     fi
 done
 ----
-
 ====


### PR DESCRIPTION
OADP 1.4.1, OCP 4.13+

Resolves [OADP-2926](https://issues.redhat.com//browse/OADP-2926) by replacing the script that appears in https://docs.openshift.com/container-platform/4.16/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.html#oadp-creating-restore-cr_restoring-applications .

Preview: https://79374--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.html [example script after step 4]



Note:  As per the comments in the Jira, I replaced the existing script with the script in https://github.com/openshift/oadp-operator/blob/oadp-1.4/docs/scripts/dc-post-restore.sh . GitHub interpreted this single copy-paste action as a number of additions and deletions, rather than one large replacement. 
