### PR TITLE
[OSDOCS-11260] "Enable FIPS cryptography" option 

### DIFF
--- a/modules/osd-create-cluster-ccs.adoc
+++ b/modules/osd-create-cluster-ccs.adoc
@@ -168,17 +168,21 @@ With *Use Custom KMS keys* selected:
 ... Select a key name from the *Key name* drop-down menu.
 ... Provide the *KMS Service Account*.
 +
+
+.. Optional: Select *Enable FIPS cryptography* if you require your cluster to be FIPS validated.
++
+[NOTE]
+====
+If *Enable FIPS cryptography* is selected, *Enable additional etcd encryption* is enabled by default and cannot be disabled. You can select *Enable additional etcd encryption* without selecting *Enable FIPS cryptography*.
+====
 endif::osd-on-gcp[]
-.. Optional: Select *Enable additional etcd encryption* if you require etcd key value encryption. With this option, the etcd key values are encrypted, but not the keys. This option is in addition to the control plane storage encryption that encrypts the etcd volumes in {product-title} clusters by default.
+.. Optional: Select *Enable additional etcd encryption* if you require etcd key value encryption. With this option, the etcd key values are encrypted, but the keys are not. This option is in addition to the control plane storage encryption that encrypts the etcd volumes in {product-title} clusters by default.
 +
 [NOTE]
 ====
 By enabling etcd encryption for the key values in etcd, you will incur a performance overhead of approximately 20%. The overhead is a result of introducing this second layer of encryption, in addition to the default control plane storage encryption that encrypts the etcd volumes. Consider enabling etcd encryption only if you specifically require it for your use case.
 ====
 +
-ifdef::osd-on-gcp[]
-.. Optional: Select *Enable FIPS cryptography* if you require your cluster to be FIPS validated.
-endif::osd-on-gcp[]
 ifdef::osd-on-aws[]
 .. Optional: Select *Encrypt persistent volumes with customer keys* if you want to provide your own
 AWS Key Management Service (KMS) key Amazon Resource Name (ARN).

--- a/modules/osd-create-cluster-gcp-account.adoc
+++ b/modules/osd-create-cluster-gcp-account.adoc
@@ -64,15 +64,18 @@ With *Use Custom KMS keys* selected:
 ... Provide the *KMS Service Account*.
 
 +
-.. Optional: Select *Enable additional etcd encryption* if you require etcd key value encryption.
-With this option, the etcd key values are encrypted, but not the keys. This option is in addition to the control plane storage encryption that encrypts the etcd volumes in {product-title} clusters by default.
+.. Optional: Select *Enable FIPS cryptography* if you require your cluster to be FIPS validated.
++
+[NOTE]
+====
+If *Enable FIPS cryptography* is selected, *Enable additional etcd encryption* is enabled by default and cannot be disabled. You can select *Enable additional etcd encryption* without selecting *Enable FIPS cryptography*.
+====
+.. Optional: Select *Enable additional etcd encryption* if you require etcd key value encryption. With this option, the etcd key values are encrypted, but the keys are not. This option is in addition to the control plane storage encryption that encrypts the etcd volumes in {product-title} clusters by default.
 +
 [NOTE]
 ====
 By enabling etcd encryption for the key values in etcd, you incur a performance overhead of approximately 20%. The overhead is a result of introducing this second layer of encryption, in addition to the default control plane storage encryption that encrypts the etcd volumes. Consider enabling etcd encryption only if you specifically require it for your use case.
 ====
-+
-.. Optional: Select *Enable FIPS cryptography* if you require your cluster to be FIPS validated.
 +
 . Click *Next*.
 

--- a/modules/osd-create-cluster-red-hat-account.adoc
+++ b/modules/osd-create-cluster-red-hat-account.adoc
@@ -64,6 +64,8 @@ To customize the subdomain, select the *Create custom domain prefix* checkbox, a
 .. Select a cluster version from the *Version* drop-down menu.
 .. Select a cloud provider region from the *Region* drop-down menu.
 .. Select a *Single zone* or *Multi-zone* configuration.
+.. Select a *Persistent storage* capacity for the cluster. For more information, see the _Storage_ section in the {product-title} service definition.
+.. Specify the number of *Load balancers* that you require for your cluster. For more information, see the _Load balancers_ section in the {product-title} service definition.
 +
 ifdef::osd-on-gcp[]
 .. Optional: Select *Enable Secure Boot for Shielded VMs* to use Shielded VMs when installing your cluster. For more information, see link:https://cloud.google.com/security/products/shielded-vm[Shielded VMs].
@@ -74,15 +76,24 @@ To successfully create a cluster, you must select *Enable Secure Boot support fo
 ====
 +
 endif::osd-on-gcp[]
-.. Select a *Persistent storage* capacity for the cluster. For more information, see the _Storage_ section in the {product-title} service definition.
-.. Specify the number of *Load balancers* that you require for your cluster. For more information, see the _Load balancers_ section in the {product-title} service definition.
 .. Leave *Enable user workload monitoring* selected to monitor your own projects in isolation from Red Hat Site Reliability Engineer (SRE) platform metrics. This option is enabled by default.
+ifdef::osd-on-gcp[]
+. Optional: Expand *Advanced Encryption* to make changes to encryption settings.
++
+.. Optional: Select *Enable FIPS cryptography* if you require your cluster to be FIPS validated.
++
+[NOTE]
+====
+If *Enable FIPS cryptography* is selected, *Enable additional etcd encryption* is enabled by default and cannot be disabled. You can select *Enable additional etcd encryption* without selecting *Enable FIPS cryptography*.
+====
+endif::osd-on-gcp[]
 .. Optional: Select *Enable additional etcd encryption* if you require etcd key value encryption. With this option, the etcd key values are encrypted, but not the keys. This option is in addition to the control plane storage encryption that encrypts the etcd volumes in {product-title} clusters by default.
 +
 [NOTE]
 ====
 By enabling etcd encryption for the key values in etcd, you will incur a performance overhead of approximately 20%. The overhead is a result of introducing this second layer of encryption, in addition to the default control plane storage encryption that encrypts the etcd volumes. Consider enabling etcd encryption only if you specifically require it for your use case.
 ====
++
 .. Click *Next*.
 
 . On the *Default machine pool* page, select a *Compute node instance type* and a *Compute node count*. The number and types of nodes that are available depend on your {product-title} subscription. If you are using multiple availability zones, the compute node count is per zone.

--- a/modules/osd-create-cluster-rhm-gcp-account.adoc
+++ b/modules/osd-create-cluster-rhm-gcp-account.adoc
@@ -64,15 +64,18 @@ With *Use Custom KMS keys* selected:
 ... Provide the *KMS Service Account*.
 
 +
-.. Optional: Select *Enable additional etcd encryption* if you require etcd key value encryption.
-With this option, the etcd key values are encrypted, but not the keys. This option is in addition to the control plane storage encryption that encrypts the etcd volumes in {product-title} clusters by default.
+.. Optional: Select *Enable FIPS cryptography* if you require your cluster to be FIPS validated.
++
+[NOTE]
+====
+If *Enable FIPS cryptography* is selected, *Enable additional etcd encryption* is enabled by default and cannot be disabled. You can select *Enable additional etcd encryption* without selecting *Enable FIPS cryptography*.
+====
+.. Optional: Select *Enable additional etcd encryption* if you require etcd key value encryption. With this option, the etcd key values are encrypted, but not the keys. This option is in addition to the control plane storage encryption that encrypts the etcd volumes in {product-title} clusters by default.
 +
 [NOTE]
 ====
 By enabling etcd encryption for the key values in etcd, you incur a performance overhead of approximately 20%. The overhead is a result of introducing this second layer of encryption, in addition to the default control plane storage encryption that encrypts the etcd volumes. Consider enabling etcd encryption only if you specifically require it for your use case.
 ====
-+
-.. Optional: Select *Enable FIPS cryptography* if you require your cluster to be FIPS validated.
 +
 . Click *Next*.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.16+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-11260
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

**Creating  a cluster on GCP with CCS**
https://79375--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-a-gcp-cluster.html#osd-create-gcp-cluster-ccs_osd-creating-a-cluster-on-gcp

**Creating  a cluster on GCP with Google Cloud Marketplace**
https://79375--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-a-gcp-cluster.html#osd-create-cluster-gcp-account_osd-creating-a-cluster-on-gcp

**Creating  a cluster on GCP with a Red Hat cloud account**
https://79375--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-a-gcp-cluster.html#osd-create-aws-cluster-ccs_osd-creating-a-cluster-on-gcp

**Creating  a cluster on GCP with with Red Hat Marketplace**
https://79375--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-a-gcp-cluster.html#osd-create-cluster-rhm-gcp-account_osd-creating-a-cluster-on-gcp


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
**Will be sent to review for QE once code merge is complete that shows changes to UI.** 
Additional information:
<!--- Optional: Include additional context or expand the description here.--->
****Reviewers: The changes to these docs consists of re-ordering some steps in the creation of an OSD cluster on GCP, as well as adding new information that came with the design changes. 
Specifically, the order of the optional steps for "Select Enable FIPS cryptography" and "Select Enable additional etcd encryption" were switched, and a note was added explaining that enabling additional etcd encryption was dependent on whether enabling FIPS cryptography was selected or not, but not the other way around (see attached image).** 

**These changes were applied to the various methods (based on billing model/infrastructure) used when creating the cluster, and are duplicated for each method. The scope of this ticket DOES NOT apply to OSD on AWS.**** 

![image](https://github.com/user-attachments/assets/39ec8ec7-254d-40fd-82a4-979c8487ea9c)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
