### PR TITLE
CNV-37647: 4.16-specific table comparing bridge CNI and OVN-K localnet

### DIFF
--- a/virt/vm_networking/virt-networking-overview.adoc
+++ b/virt/vm_networking/virt-networking-overview.adoc
@@ -90,6 +90,43 @@ endif::openshift-rosa,openshift-dedicated[]
 
 . xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#attaching-vm-to-ovn-secondary-nw[Connect the VM to the OVN-Kubernetes secondary network] by adding the network details to the VM specification.
 
+// Hiding from ROSA/OSD as Linux Bridge is not supported
+ifndef::openshift-rosa,openshift-dedicated[]
+[id="comparing-bridge-localnet"]
+=== Comparing Linux bridge CNI and OVN-Kubernetes localnet topology
+
+The following table provides a comparison of features available when using the Linux bridge CNI versus the localnet topology for an OVN-Kubernetes plugin:
+
+.Linux bridge CNI compared to an OVN-Kubernetes localnet topology
+[cols="1,1,1",options="header"]
+|===
+|Feature
+|Available on Linux bridge CNI
+|Available on OVN-Kubernetes localnet
+
+|Layer 2 access to the underlay native network	
+|Only on secondary network interface controllers (NICs)
+|Yes
+
+|Layer 2 access to underlay VLANs
+|Yes
+|Yes
+
+|Network policies
+|No
+|Yes
+
+|Managed IP pools
+|No
+|No
+
+|MAC spoof filtering
+|Yes
+|Yes
+
+|===
+endif::openshift-rosa,openshift-dedicated[]
+
 // Hiding in ROSA/OSD as not supported
 ifndef::openshift-rosa,openshift-dedicated[]
 xref:../../virt/vm_networking/virt-hot-plugging-network-interfaces.adoc#virt-hot-plugging-network-interfaces[Hot plugging secondary network interfaces]::


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-37647](https://issues.redhat.com//browse/CNV-37647)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://79377--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-networking-overview.html#comparing-bridge-localnet
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Same table as in https://github.com/openshift/openshift-docs/pull/79192 except that Managed IP pools are not supported on OVN-K localnet for 4.16.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
