### PR TITLE
Incorrect apiVersion for imagestream

### DIFF
--- a/modules/templates-creating-from-console.adoc
+++ b/modules/templates-creating-from-console.adoc
@@ -28,7 +28,7 @@ appear in this list, as demonstrated here:
 [source,yaml]
 ----
 kind: "ImageStream"
-apiVersion: "v1"
+apiVersion: "image.openshift.io/v1"
 metadata:
   name: "ruby"
   creationTimestamp: null


### PR DESCRIPTION
apiVersion for imagestream was set to "v1".

Updated it to replace the correct apiVersion i.e., "image.openshift.io/v1"

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):  

OCP 4.16+
Issue:

Incorrect apiVersion mentioned in the official doc for imagestream.

Link to docs preview:

https://79409--ocpdocs-pr.netlify.app/openshift-enterprise/latest/openshift_images/using-templates.html#templates-creating-from-console_using-templates

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
