### PR TITLE
OADP-4568 added snippet for xfs filesystem

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/oadp-using-data-mover-for-csi-snapshots-doc.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/oadp-using-data-mover-for-csi-snapshots-doc.adoc
@@ -68,6 +68,10 @@ The VolSync Operator is required for using OADP Data Mover.
 ====
 
 * You have installed the OADP operator by using OLM.
++
+--
+include::snippets/xfs-filesystem-snippet.adoc[]
+--
 
 .Procedure
 

--- a/modules/oadp-1-3-backing-csi-snapshots.adoc
+++ b/modules/oadp-1-3-backing-csi-snapshots.adoc
@@ -43,6 +43,11 @@ spec:
 <1> Set to `true` if you use Data Mover only for volumes that opt out of `fs-backup`. Set to `false` if you use Data Mover by default for volumes.
 <2> Set to `true` to enable movement of CSI snapshots to remote object storage.
 
++
+--
+include::snippets/xfs-filesystem-snippet.adoc[]
+--
+
 . Apply the manifest:
 +
 [source,terminal]

--- a/snippets/xfs-filesystem-snippet.adoc
+++ b/snippets/xfs-filesystem-snippet.adoc
@@ -1,0 +1,21 @@
+// Text snippet included in the following modules:
+//
+// * modules/oadp-1-3-backing-csi-snapshots.adoc
+// * backup_and_restore/application_backup_and_restore/installing/oadp-using-data-mover-for-csi-snapshots-doc.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+[NOTE]
+====
+If you format the volume by using XFS filesystem and the volume is at 100% capacity, the backup fails with a `no space left on device` error. For example:
+
+[source,terminal]
+----
+Error: relabel failed /var/lib/kubelet/pods/3ac..34/volumes/ \
+kubernetes.io~csi/pvc-684..12c/mount: lsetxattr /var/lib/kubelet/ \
+pods/3ac..34/volumes/kubernetes.io~csi/pvc-68..2c/mount/data-xfs-103: \
+no space left on device
+----
+  
+In this scenario, consider resizing the volume or using a different filesystem type, for example, `ext4`, so that the backup completes successfully.
+====


### PR DESCRIPTION
## Jira 

* [OADP-4568](https://issues.redhat.com/browse/OADP-4568)

Added a note for users when using XFS filesystem with the volume at 100% capacity.

##  Version

* OCP 4.12 → OCP 4.17

## Preview

* [Backing up and restoring CSI snapshots using OADP Data Mover 1.3](https://79413--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/oadp-backup-restore-csi-snapshots.html#oadp-1-3-backing-csi-snapshots_oadp-backup-restore-csi-snapshots)

* [Using OADP Data Mover 1.2 for CSI snapshots](https://79413--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/oadp-using-data-mover-for-csi-snapshots-doc.html)

## QE Review

* [x] QE has approved this change.
