### PR TITLE
TELCODOCS-1953: adding policy for pulling images from ECR on SNO

### DIFF
--- a/modules/installation-aws-iam-policies-about.adoc
+++ b/modules/installation-aws-iam-policies-about.adoc
@@ -8,6 +8,11 @@
 
 By default, the installation program creates instance profiles for the bootstrap, control plane, and compute instances with the necessary permissions for the cluster to operate.
 
+[NOTE]
+====
+To enable pulling images from the Amazon Elastic Container Registry (ECR) as a postinstallation task in a {sno} cluster, you must add the `AmazonEC2ContainerRegistryReadOnly` policy to the IAM role associated with the cluster's control plane role.
+====
+
 However, you can create your own IAM roles and specify them as part of the installation process. You might need to specify your own roles to deploy the cluster or to manage the cluster after installation. For example:
 
 * Your organization's security policies require that you use a more restrictive set of permissions to install the cluster.


### PR DESCRIPTION
[TELCODOCS-1953](https://issues.redhat.com//browse/TELCODOCS-1953): Adding note about policy required for pulling images from ECR post-install.

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1953

Link to docs preview:
https://79419--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#iam-policies-and-aws-authentication_installing-aws-account

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
