### PR TITLE
OSDOCS-11236: Add guidance about dual-stack networking limitations

### DIFF
--- a/installing/installing_bare_metal/installation-config-parameters-bare-metal.adoc
+++ b/installing/installing_bare_metal/installation-config-parameters-bare-metal.adoc
@@ -10,3 +10,10 @@ toc::[]
 Before you deploy an {product-title} cluster, you provide a customized `install-config.yaml` installation configuration file that describes the details for your environment.
 
 include::modules/installation-configuration-parameters.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#nw-ovn-kubernetes-limitations_about-ovn-kubernetes[OVN-Kubernetes IPv6 and dual-stack limitations]
+
+

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -192,7 +192,12 @@ Only IPv4 addresses are supported.
 endif::agent,bare,ibm-power,ibm-z,vsphere[]
 
 ifdef::agent,bare,ibm-power,ibm-z,vsphere[]
+Consider the following information before you configure network parameters for your cluster:
+
 * If you use the {openshift-networking} OVN-Kubernetes network plugin, both IPv4 and IPv6 address families are supported.
+* If you deployed nodes in an {product-title} cluster with a network that supports both IPv4 and non-link-local IPv6 addresses, configure your cluster to use a dual-stack network.
+** For clusters configured for dual-stack networking, both IPv4 and IPv6 traffic must use the same network interface as the default gateway. This ensures that in a multiple network interface controller (NIC) environment, a cluster can detect what NIC to use based on the available network interface. For more information, see "OVN-Kubernetes IPv6 and dual-stack limitations" in _About the OVN-Kubernetes network plugin_.
+** To prevent network connectivity issues, do not install a single-stack IPv4 cluster on a host that supports dual-stack networking.
 
 ifdef::ibm-cloud[]
 [NOTE]
@@ -631,7 +636,12 @@ endif::agent[]
 
 |credentialsMode:
 |The Cloud Credential Operator (CCO) mode. If no mode is specified, the CCO dynamically tries to determine the capabilities of the provided credentials, with a preference for mint mode on the platforms where multiple modes are supported.
-|`Mint`, `Passthrough`, `Manual` or an empty string (`""`). ^[1]^
+
+[NOTE]
+====
+Not all CCO modes are supported for all cloud providers. For more information about CCO modes, see the "Managing cloud provider credentials" entry in the _Authentication and authorization_ content.
+====
+|`Mint`, `Passthrough`, `Manual` or an empty string (`""`).
 
 ifndef::openshift-origin,ibm-power-vs[]
 |fips:
@@ -762,9 +772,7 @@ ifdef::ibm-power-vs[]
 |The system type must be either `e980` or `s922`.
 endif::ibm-power-vs[]
 |====
-[.small]
---
-1. Not all CCO modes are supported for all cloud providers. For more information about CCO modes, see the "Managing cloud provider credentials" entry in the _Authentication and authorization_ content.
+
 ifdef::aws,gcp[]
 +
 [NOTE]
@@ -780,7 +788,6 @@ ifdef::aws,gcp,azure[]
 Setting this parameter to `Manual` enables alternatives to storing administrator-level secrets in the `kube-system` project, which require additional configuration steps. For more information, see "Alternatives to storing administrator-level secrets in the kube-system project".
 ====
 endif::aws,gcp,azure[]
---
 
 ifdef::aws[]
 [id="installation-configuration-parameters-optional-aws_{context}"]


### PR DESCRIPTION
Version(s):
4.16 + 

Issue:
[OSDOCS-11236](https://issues.redhat.com/browse/OSDOCS-11236)

Link to docs preview:
[Network configuration parameters](https://79422--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installation-config-parameters-bare-metal#installation-configuration-parameters-network_installation-config-parameters-bare-metal)

- [x] SME has approved this change.
- [x] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
