### PR TITLE
RHDEVDOCS-6036: Adding a host attribute to the keycloak instance

### DIFF
--- a/modules/gitops-creating-a-new-client-using-keycloak.adoc
+++ b/modules/gitops-creating-a-new-client-using-keycloak.adoc
@@ -73,6 +73,80 @@ spec:
       rootCA: ""
 ----
 
+* Optional: Customize the `spec.sso.keycloak` field to add the route name for the `keycloak` provider in the `ArgoCD` CR. Use this feature to support advanced routing use cases, such as balancing incoming traffic load among multiple link:https://docs.openshift.com/container-platform/latest/networking/ingress-sharding.html#nw-ingress-sharding_ingress-sharding[Ingress Controller shards].
++
+** Add a `host` parameter in the `ArgoCD` CR by using the following example YAML:
++
+.Example `ArgoCD` CR
+[source,yaml]
+----
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: <resource_name> #<1>
+  labels:
+    example: route
+spec:
+  sso:
+    provider: keycloak
+    keycloak:
+     host: <hostname> #<2>
+  server:
+    ingress:
+      enabled: true
+    insecure: true
+----
+<1> Replace `<resource_name>` with the name of the `ArgoCD` CR.
+<2> Replace `<hostname>` with the name of the host key, for example, `sso.test.example.com`.
++
+** To create the `ArgoCD CR`, run the following command:
++
+[source,terminal]
+----
+$ oc create -f <argocd_filename>.yaml -n <your-namespace>
+----
++
+** To edit the `ArgoCD CR`, run the following command:
++
+[source,terminal]
+----
+$ oc edit -f <argocd_filename>.yaml -n <your_namespace>
+----
++
+** Save the file to apply the changes.
++
+** To apply the `ArgoCD` CR, run the following command:
++
+[source,terminal]
+----
+$ oc apply -f <argocd_filename>.yaml -n <your_namespace>
+----
++
+** Verify that the `host` attribute is added by running the following command:
++
+[source,terminal]
+----
+$ oc get route keycloak -n <your_namespace> -o yaml
+----
++
+.Example output
++
+[source,yaml]
+----
+kind: Route
+metadata:
+  name: keycloak #<1>
+  labels:
+    application: keycloak
+spec:
+  host: sso.test.example.com
+status:
+  ingress:
+    - host: sso.test.example.com #<2>
+----
+<1> Specifies the name of the route.
+<2> Specifies the name of the host key.
+
 [NOTE]
 ====
 The Keycloak instance takes 2-3 minutes to install and run.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

GitOps 1.13, GitOps 1.14

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/RHDEVDOCS-6036

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Customizing the route name in Keycloak](https://79429--ocpdocs-pr.netlify.app/openshift-gitops/latest/accesscontrol_usermanagement/configuring-sso-for-argo-cd-using-keycloak.html#gitops-customizing-the-route-name-in-keycloak_configuring-sso-for-argo-cd-using-keycloak)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: @Rizwana777 
QE review: @varshab1210 
Peer review: 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
