### PR TITLE
OADP-4357: AWS plugin required for all S3 storage

### DIFF
--- a/modules/oadp-installing-dpa-1-2-and-earlier.adoc
+++ b/modules/oadp-installing-dpa-1-2-and-earlier.adoc
@@ -93,7 +93,6 @@ spec:
         credential:
           key: cloud
           name: {credentials} # <12>
-          
 ----
 <1> The `openshift` plugin is mandatory.
 <2> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.
@@ -234,39 +233,40 @@ spec:
   configuration:
     velero:
       defaultPlugins:
-        - aws
-        - openshift # <1>
-      resourceTimeout: 10m # <2>
+        - aws # <1>
+        - openshift # <2>
+      resourceTimeout: 10m # <3>
     restic:
-      enable: true # <3>
+      enable: true # <4>
       podConfig:
-        nodeSelector: <node_selector> # <4>
+        nodeSelector: <node_selector> # <5>
   backupLocations:
     - velero:
         config:
           profile: "default"
-          region: <region_name> <5>
-          s3Url: <url> # <6>
+          region: <region_name> <6>
+          s3Url: <url> # <7>
           insecureSkipTLSVerify: "true"
           s3ForcePathStyle: "true"
         provider: {provider}
         default: true
         credential:
           key: cloud
-          name: {credentials} # <7>
+          name: {credentials} # <8>
         objectStorage:
-          bucket: <bucket_name> # <8>
-          prefix: <prefix> # <9>
+          bucket: <bucket_name> # <9>
+          prefix: <prefix> # <10>
 ----
-<1> The `openshift` plugin is mandatory.
-<2> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.
-<3> Set this value to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that Restic pods run on each working node. In OADP version 1.2 and later, you can configure Restic for backups by adding `spec.defaultVolumesToFsBackup: true` to the `Backup` CR. In OADP version 1.1, add `spec.defaultVolumesToRestic: true` to the `Backup` CR.
-<4> Specify on which nodes Restic is available. By default, Restic runs on all nodes.
-<5> Specify the region, following the naming convention of the documentation of your object storage server.
-<6> Specify the URL of the S3 endpoint.
-<7> If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
-<8> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
-<9> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
+<1> An object store plugin corresponding to your storage locations is required. For all S3 providers, the required plugin is `aws`. For {azure-short} and {gcp-short} object stores, the `azure` or `gcp` plugin is required.
+<2> The `openshift` plugin is mandatory.
+<3> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.
+<4> Set this value to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that Restic pods run on each working node. In OADP version 1.2 and later, you can configure Restic for backups by adding `spec.defaultVolumesToFsBackup: true` to the `Backup` CR. In OADP version 1.1, add `spec.defaultVolumesToRestic: true` to the `Backup` CR.
+<5> Specify on which nodes Restic is available. By default, Restic runs on all nodes.
+<6> Specify the region, following the naming convention of the documentation of your object storage server.
+<7> Specify the URL of the S3 endpoint.
+<8> If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
+<9> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
+<10> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
 endif::[]
 ifdef::installing-oadp-ocs[]
 +
@@ -281,8 +281,8 @@ spec:
   configuration:
     velero:
       defaultPlugins:
-        - kubevirt # <1>
-        - gcp # <2>
+        - aws # <1>
+        - kubevirt # <2>
         - csi # <3>
         - openshift # <4>
       resourceTimeout: 10m # <5>
@@ -301,8 +301,8 @@ spec:
           bucket: <bucket_name> # <10>
           prefix: <prefix> # <11>
 ----
-<1> Optional: The `kubevirt` plugin is used with {VirtProductName}.
-<2> Specify the default plugin for the backup provider, for example, `gcp`, if appropriate.
+<1> An object store plugin corresponding to your storage locations is required. For all S3 providers, the required plugin is `aws`. For {azure-short} and {gcp-short} object stores, the `azure` or `gcp` plugin is required.
+<2> Optional: The `kubevirt` plugin is used with {VirtProductName}.
 <3> Specify the `csi` default plugin if you use CSI snapshots to back up PVs. The `csi` plugin uses the link:https://{velero-domain}/docs/main/csi/[Velero CSI beta snapshot APIs]. You do not need to configure a snapshot location.
 <4> The `openshift` plugin is mandatory.
 <5> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.

--- a/modules/oadp-installing-dpa-1-3.adoc
+++ b/modules/oadp-installing-dpa-1-3.adoc
@@ -246,43 +246,44 @@ spec:
   configuration:
     velero:
       defaultPlugins:
-        - aws
-        - openshift # <2>
-      resourceTimeout: 10m # <3>
-    nodeAgent: # <4>
-      enable: true # <5>
-      uploaderType: kopia # <6>
+        - aws # <2>
+        - openshift # <3>
+      resourceTimeout: 10m # <4>
+    nodeAgent: # <5>
+      enable: true # <6>
+      uploaderType: kopia # <7>
       podConfig:
-        nodeSelector: <node_selector> # <7>
+        nodeSelector: <node_selector> # <8>
   backupLocations:
     - velero:
         config:
           profile: "default"
-          region: <region_name> <8>
-          s3Url: <url> # <9>
+          region: <region_name> <9>
+          s3Url: <url> # <10>
           insecureSkipTLSVerify: "true"
           s3ForcePathStyle: "true"
         provider: {provider}
         default: true
         credential:
           key: cloud
-          name: {credentials} # <10>
+          name: {credentials} # <11>
         objectStorage:
-          bucket: <bucket_name> # <11>
-          prefix: <prefix> # <12>
+          bucket: <bucket_name> # <12>
+          prefix: <prefix> # <13>
 ----
 <1> The default namespace for OADP is `openshift-adp`. The namespace is a variable and is configurable.
-<2> The `openshift` plugin is mandatory.
-<3> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.
-<4> The administrative agent that routes the administrative requests to servers.
-<5> Set this value to `true` if you want to enable `nodeAgent` and perform File System Backup.
-<6> Enter `kopia` or `restic` as your uploader. You cannot change the selection after the installation. For the Built-in DataMover you must use Kopia. The `nodeAgent` deploys a daemon set, which means that the `nodeAgent` pods run on each working node. You can configure File System Backup by adding `spec.defaultVolumesToFsBackup: true` to the `Backup` CR.
-<7> Specify the nodes on which Kopia or Restic are available. By default, Kopia or Restic run on all nodes.
-<8> Specify the region, following the naming convention of the documentation of your object storage server.
-<9> Specify the URL of the S3 endpoint.
-<10> If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
-<11> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
-<12> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
+<2> An object store plugin corresponding to your storage locations is required. For all S3 providers, the required plugin is `aws`. For {azure-short} and {gcp-short} object stores, the `azure` or `gcp` plugin is required.
+<3> The `openshift` plugin is mandatory.
+<4> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.
+<5> The administrative agent that routes the administrative requests to servers.
+<6> Set this value to `true` if you want to enable `nodeAgent` and perform File System Backup.
+<7> Enter `kopia` or `restic` as your uploader. You cannot change the selection after the installation. For the Built-in DataMover you must use Kopia. The `nodeAgent` deploys a daemon set, which means that the `nodeAgent` pods run on each working node. You can configure File System Backup by adding `spec.defaultVolumesToFsBackup: true` to the `Backup` CR.
+<8> Specify the nodes on which Kopia or Restic are available. By default, Kopia or Restic run on all nodes.
+<9> Specify the region, following the naming convention of the documentation of your object storage server.
+<10> Specify the URL of the S3 endpoint.
+<11> Specify the name of the `Secret` object that you created. If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
+<12> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
+<13> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
 endif::[]
 
 ifdef::installing-oadp-ocs[]
@@ -298,8 +299,8 @@ spec:
   configuration:
     velero:
       defaultPlugins:
-        - kubevirt # <2>
-        - gcp # <3>
+        - aws # <2>
+        - kubevirt # <3>
         - csi # <4>
         - openshift # <5>
       resourceTimeout: 10m # <6>
@@ -320,8 +321,8 @@ spec:
           prefix: <prefix> # <14>
 ----
 <1> The default namespace for OADP is `openshift-adp`. The namespace is a variable and is configurable.
-<2> Optional: The `kubevirt` plugin is used with {VirtProductName}.
-<3> Specify the default plugin for the backup provider, for example, `gcp`, if appropriate.
+<2> An object store plugin corresponding to your storage locations is required. For all S3 providers, the required plugin is `aws`. For {azure-short} and {gcp-short} object stores, the `azure` or `gcp` plugin is required.
+<3> Optional: The `kubevirt` plugin is used with {VirtProductName}.
 <4> Specify the `csi` default plugin if you use CSI snapshots to back up PVs. The `csi` plugin uses the link:https://{velero-domain}/docs/main/csi/[Velero CSI beta snapshot APIs]. You do not need to configure a snapshot location.
 <5> The `openshift` plugin is mandatory.
 <6> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.


### PR DESCRIPTION
### Jira

* [OADP-4357](https://issues.redhat.com/browse/OADP-4357)

### Version(s):

* OCP 4.13 → branch/enterprise-4.13
*  OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16
* OCP 4.17 → branch/enterprise-4.17

### Link to docs preview:

* MCG
    * [DPA 1.2 and earlier](https://79455--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.html#oadp-installing-dpa-1-2-and-earlier_installing-oadp-mcg)
    * [DPA 1.3](https://79455--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.html#oadp-installing-dpa-1-3_installing-oadp-mcg)
* ODF
    * [DPA 1.2 and earlier](https://79455--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.html#oadp-installing-dpa-1-2-and-earlier_installing-oadp-ocs)
    * [DPA 1.3](https://79455--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.html#oadp-installing-dpa-1-3_installing-oadp-ocs)

### QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
