### PR TITLE
OCPBUGS-37574: Updated the network multiple interface mapping example

### DIFF
--- a/modules/configuring-localnet-switched-topology.adoc
+++ b/modules/configuring-localnet-switched-topology.adoc
@@ -69,8 +69,9 @@ spec:
       type: ovs-bridge
       state: up
       bridge:
+        allow-extra-patch-ports: true
         options:
-          stp: true
+          stp: false
         port:
         - name: eth1 <4>
     ovn:


### PR DESCRIPTION
Version(s):
4.14+

Issue:
* [OCPBUGS-37574](https://issues.redhat.com/browse/OCPBUGS-37574)
* [OCPBUGS-37542](https://issues.redhat.com/browse/OCPBUGS-37542)

Link to docs preview:
[Configuration for an OVN-Kubernetes additional network mapping](https://79456--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html#configuring-additional-network_configuration-additional-network-interface)

- [x] SME has approved this change.
- [x] QE has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
