### PR TITLE
Update CO version for oc get clusteroperator/network command

### DIFF
--- a/modules/nw-cluster-network-operator.adoc
+++ b/modules/nw-cluster-network-operator.adoc
@@ -38,7 +38,7 @@ $ oc get clusteroperator/network
 [source,terminal]
 ----
 NAME      VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE
-network   4.5.4     True        False         False      50m
+network   4.16.1     True        False         False      50m
 ----
 +
 The following fields provide information about the status of the operator:


### PR DESCRIPTION
Update CO version for oc get co/network command

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
OCP 4.16

Issue:
Update CO version for oc get co/network command

Link to docs preview:

https://79472--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/cluster-network-operator.html#nw-cluster-network-operator_cluster-network-operator

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
