### PR TITLE
Highlight the command mentioned under step 5

### DIFF
--- a/modules/virt-troubleshooting-incorrect-policy-config.adoc
+++ b/modules/virt-troubleshooting-incorrect-policy-config.adoc
@@ -190,6 +190,7 @@ The `NmstateVerificationError` lists the `desired` policy configuration, the `cu
 
 . To ensure that the policy is configured properly, view the network configuration for one or all of the nodes by requesting the `NodeNetworkState` object. The following command returns the network configuration for the `control-plane-1` node:
 +
+[source,terminal]
 ----
 $ oc get nns control-plane-1 -o yaml
 ----


### PR DESCRIPTION
The command `oc get nns control-plane-1 -o yaml` in the step 5 was not highlited.

[source,terminal]
----
$ oc get nns control-plane-1 -o yaml
---

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
OCP 4.16+

Issue:
The command `oc get nns control-plane-1 -o yaml` in the step 5 was not highlighted.


Link to docs preview:

https://79483--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-troubleshooting-node-network.html#virt-troubleshooting-incorrect-policy-config_k8s-nmstate-troubleshooting-node-network

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
