### PR TITLE
Update the dns clusteroperator version in nw-dns-operator.adoc

### DIFF
--- a/modules/nw-dns-operator.adoc
+++ b/modules/nw-dns-operator.adoc
@@ -39,7 +39,7 @@ $ oc get clusteroperator/dns
 [source,terminal]
 ----
 NAME      VERSION     AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
-dns       4.16        True        False         False      92m
+dns       4.16.0        True        False         False      92m
 ----
 +
 `AVAILABLE`, `PROGRESSING`, and `DEGRADED` provide information about the status of the Operator. `AVAILABLE` is `True` when at least 1 pod from the CoreDNS daemon set reports an `Available` status condition, and the DNS service has a cluster IP address.

--- a/modules/nw-dns-operator.adoc
+++ b/modules/nw-dns-operator.adoc
@@ -39,7 +39,7 @@ $ oc get clusteroperator/dns
 [source,terminal]
 ----
 NAME      VERSION     AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
-dns       4.1.15-0.11  True        False         False      92m
+dns       4.16        True        False         False      92m
 ----
 +
 `AVAILABLE`, `PROGRESSING`, and `DEGRADED` provide information about the status of the Operator. `AVAILABLE` is `True` when at least 1 pod from the CoreDNS daemon set reports an `Available` status condition, and the DNS service has a cluster IP address.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Update the dns clusteroperator version in nw-dns-operator.adoc

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->
The current version of dns cluster operator is old :
~~~
$ oc get clusteroperator/dns
NAME      VERSION     AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
dns       4.1.15-0.11  True        False         False      92m
~~~

Correct the version of DNS cluster operator like below :
~~~
$ oc get clusteroperator/dns
NAME      VERSION     AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
dns       4.16.0        True        False         False      92m
~~~

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
RHOCP 4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
Incorrect DNS cluster operator version mentioned in the command output

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://docs.openshift.com/container-platform/4.16/networking/dns-operator.html#nw-dns-operator_dns-operator

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
