### PR TITLE
OCPBUGS-35851#adding missing port details

### DIFF
--- a/modules/installation-about-custom-azure-vnet.adoc
+++ b/modules/installation-about-custom-azure-vnet.adoc
@@ -130,6 +130,73 @@ include::snippets/mcs-endpoint-limitation.adoc[]
 
 Because cluster components do not modify the user-provided network security groups, which the Kubernetes controllers update, a pseudo-network security group is created for the Kubernetes controller to modify without impacting the rest of the environment.
 
+.Ports used for all-machine to all-machine communications
+[cols="2a,2a,5a",options="header"]
+|===
+
+|Protocol
+|Port
+|Description
+
+|ICMP
+|N/A
+|Network reachability tests
+
+.3+|TCP
+|`1936`
+|Metrics
+
+|`9000`-`9999`
+|Host level services, including the node exporter on ports `9100`-`9101` and
+the Cluster Version Operator on port `9099`.
+
+|`10250`-`10259`
+|The default ports that Kubernetes reserves
+
+.6+|UDP
+|`4789`
+|VXLAN
+
+|`6081`
+|Geneve
+
+|`9000`-`9999`
+|Host level services, including the node exporter on ports `9100`-`9101`.
+
+|`500`
+|IPsec IKE packets
+
+|`4500`
+|IPsec NAT-T packets
+
+|`123`
+|Network Time Protocol (NTP) on UDP port `123`
+
+If you configure an external NTP time server, you must open UDP port `123`.
+
+|TCP/UDP
+|`30000`-`32767`
+|Kubernetes node port
+
+|ESP
+|N/A
+|IPsec Encapsulating Security Payload (ESP)
+
+|===
+
+.Ports used for control plane machine to control plane machine communications
+[cols="2a,2a,5a",options="header"]
+|===
+
+|Protocol
+|Port
+|Description
+
+|TCP
+|`2379`-`2380`
+|etcd server and peer ports
+
+|===
 
 [id="installation-about-custom-azure-permissions_{context}"]
 == Division of permissions


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version:
4.13+

Issue:
https://issues.redhat.com/browse/OCPBUGS-35851

Link to docs preview:
https://79494--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/ipi/installing-azure-government-region.html#installation-about-custom-azure-vnet-nsg-requirements_installing-azure-government-region

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
