### PR TITLE
MCO add "Node configuration management with machine config pools" module to new book

### DIFF
--- a/machine_configuration/index.adoc
+++ b/machine_configuration/index.adoc
@@ -29,6 +29,7 @@ include::modules/understanding-machine-config-operator.adoc[leveloffset=+1]
 * xref:../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[About the OpenShift SDN network plugin]
 
 include::modules/machine-config-overview.adoc[leveloffset=+1]
+include::modules/architecture-machine-config-pools.adoc[leveloffset=+2]
 
 include::modules/machine-config-node-drain.adoc[leveloffset=+1]
 

--- a/modules/architecture-machine-config-pools.adoc
+++ b/modules/architecture-machine-config-pools.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * architecture/control-plane.adoc
+// * machine_configuration/index.adoc
 
 [id="architecture-machine-config-pools_{context}"]
 = Node configuration management with machine config pools


### PR DESCRIPTION
I noticed the [Node configuration management with machine config pools](https://docs.openshift.com/container-platform/4.16/architecture/control-plane.html#architecture-machine-config-pools_control-plane) module and wanted to add it to the [recently reorganized Machine Config docs](https://github.com/openshift/openshift-docs/pull/61580). 

Preview:
Machine configuration -> Machine config overview -> [Node configuration management with machine config pools](https://79513--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/index.html#architecture-machine-config-pools_machine-config-overview)

No QE required.