### PR TITLE
OCPBUGS-37195: Clarify which OADP manifests are for target clusters in IBU docs

### DIFF
--- a/modules/ztp-image-based-upgrade-installing-oadp.adoc
+++ b/modules/ztp-image-based-upgrade-installing-oadp.adoc
@@ -13,7 +13,7 @@ Install and configure the OADP Operator with {ztp} before starting the upgrade.
 
 .Procedure
 
-. Create the following CRs in the `openshift-adp` namespace and push them to the `source-crs/custom-crs` directory:
+. Create the following CRs in the `openshift-adp` namespace for both the seed and target clusters, then push the CRs to the `source-crs/custom-crs` directory:
 +
 --
 .Example `OadpSubscriptionNS.yaml` file
@@ -138,7 +138,7 @@ spec:
 [...]
 ----
 
-. Create the `DataProtectionApplication` CR and the S3 secret:
+. Create the `DataProtectionApplication` CR and the S3 secret only for the target cluster:
 
 .. Create the following CRs in your `source-crs/custom-crs` directory:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16, 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-37195
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://79533--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/cnf-image-based-upgrade-install-operators.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
