### PR TITLE
increase timeout for docker startup on codespace

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "image":"mcr.microsoft.com/devcontainers/universal:2",
-  "postCreateCommand": "sleep 30 && docker run --rm -it -v `pwd`:/docs:Z quay.io/openshift-cs/asciibinder sh -c \"git config --global --add safe.directory /docs && asciibinder build --distro openshift-rosa && asciibinder build --distro openshift-enterprise\" && python3 -m http.server -d ./_preview",
+  "postCreateCommand": "sleep 60  && docker run --rm -it -v `pwd`:/docs:Z quay.io/openshift-cs/asciibinder sh -c \"git config --global --add safe.directory /docs && asciibinder build --distro openshift-rosa && asciibinder build --distro openshift-enterprise\" && python3 -m http.server -d ./_preview",
   "customizations": {
     "vscode": {
       "settings": {


### PR DESCRIPTION
Version(s):
main only - just a fix for codespaces

Issue:
n/a

Link to docs preview:
no impact of docs

QE review:
n/a

Additional information:
Docker seems slower to startup on codepsaces for some reason, so increasing sleep to 60 seconds