### PR TITLE
TELCODOCS-1879 - PTP grandmaster leap second docs

### DIFF
--- a/modules/ptp-configuring-dynamic-leap-seconds-handling-for-tgm.adoc
+++ b/modules/ptp-configuring-dynamic-leap-seconds-handling-for-tgm.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// *
+
+:_mod-docs-content-type: PROCEDURE
+[id="ptp-configuring-dynamic-leap-seconds-handling-for-tgm_{context}"]
+= Configuring dynamic leap seconds handling for PTP grandmaster clocks
+
+The PTP Operator container image includes the latest `leap-seconds.list` file at the time of release.
+You can configure the PTP Operator to automatically update the leap second file by using GPS announcements.
+Leap second information is stored in a `leap-configmap` custom resource (CR) in the `openshift-ptp` namespace.
+The PTP Operator mounts the `leap-configmap` CR as a volume in the `linuxptp-daemon` pod.
+The `ts2phc` process can access the local copy of the `leap-seconds.list` file.
+If the GPS satellite broadcasts new leap second data, the PTP Operator updates the local copy with the new data.
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+
+* You have logged in as a user with `cluster-admin` privileges.
+
+.Procedure
+//Start each step with an active verb. Use an unnumbered bullet (*) if the procedure includes only one step.
+
+.Verification
+//Provide the user with verification methods for the procedure, such as expected output or commands that confirm success or failure.

--- a/modules/ptp-overview-of-gnss-grandmaster-clock.adoc
+++ b/modules/ptp-overview-of-gnss-grandmaster-clock.adoc
@@ -28,3 +28,14 @@ Digital Phase-Locked Loop (DPLL)::
 DPLL provides clock synchronization between different PTP nodes in the network.
 DPLL compares the phase of the local system clock signal with the phase of the incoming synchronization signal, for example, PTP messages from the PTP grandmaster clock.
 The DPLL continuously adjusts the local clock frequency and phase to minimize the phase difference between the local clock and the reference clock.
+
+[discrete]
+[id="handling-leap-second-events-in-gnss_{context}"]
+== Handling leap second events in GNSS-synced PTP grandmaster clocks
+
+A leap second is a one-second adjustment that is occasionally applied to Coordinated Universal Time (UTC) to keep it synchronized with International Atomic Time (TAI).
+UTC leap seconds are unpredictable.
+Internationally agreed leap seconds are listed in https://hpiers.obspm.fr/iers/bul/bulc/ntp/leap-seconds.list[].
+This file is regularly updated by the International Earth Rotation and Reference Systems Service (IERS).
+An unhandled leap second can have a significant impact on far edge RAN networks.
+It can cause the far edge RAN application to immediately disconnect voice calls and data sessions.

--- a/networking/ptp/configuring-ptp.adoc
+++ b/networking/ptp/configuring-ptp.adoc
@@ -35,6 +35,8 @@ include::modules/nw-ptp-e810-hardware-configuration-reference.adoc[leveloffset=+
 
 include::modules/nw-ptp-dual-wpc-hardware-config-reference.adoc[leveloffset=+2]
 
+include::modules/ptp-configuring-dynamic-leap-seconds-handling-for-tgm.adoc[leveloffset=+1]
+
 include::modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Adding leap second config procedure

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
