### PR TITLE
Add "oc delete" command with flag "--interactive" in RHOCP4 document

### DIFF
--- a/modules/oc-by-example-content.adoc
+++ b/modules/oc-by-example-content.adoc
@@ -1318,6 +1318,10 @@ Delete resources by file names, stdin, resources and names, or by resources and 
   
   # Delete all pods
   oc delete pods --all
+
+  # Delete all resources with a warning prompt
+  # When the --interactive flag is set to true, the resource is deleted only if the user confirms the deletion
+  oc delete all --all --interactive
 ----
 
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Add "oc delete" command with flag "--interactive" in RHOCP4 documentation

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->
A new flag "--interactive" is introduced in RHOCP version 4.16
The RHOCP documentation currently does not include the "oc delete" command with this new flag.

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
RHOCP 4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-11471

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
A new flag "--interactive" is introduced in RHOCP version 4.16 [1]
The RHOCP documentation [2] currently does not include the "oc delete" command with this new flag.
[1] https://docs.openshift.com/container-platform/4.16/release_notes/ocp-4-16-release-notes.html#ocp-4-16-interactive-flag_release-notes 
[2] https://docs.openshift.com/container-platform/4.16/cli_reference/openshift_cli/developer-cli-commands.html#oc-delete

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
