### PR TITLE
OSDOCS-10921: adds 4.16.5 async relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -234,3 +234,12 @@ Issued: 2024-07-24
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
+[id="microshift-4-16-5-dp_{context}"]
+=== RHBA-2024:4857 - {microshift-short} 4.16.5 bug fix and enhancement advisory
+
+Issued: 2024-07-31
+
+{product-title} release 4.16.5 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4857[RHBA-2024:4857] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:4855[RHBA-2024:4855] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-1092](https://issues.redhat.com/browse/OSDOCS-10921)

Link to docs preview:
[MicroShift async release note 4-16-5](https://79550--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-5-dp_release-notes)

QE review:
- N/A stock text, no new technical content

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
