### PR TITLE
OLS-880: Create redirect from OCP stub page to OLS standalone content

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -351,6 +351,16 @@ AddType text/vtt                            vtt
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/collecting-debugging-data-for-support.html /gitops/latest/understanding_openshift_gitops/gathering-gitops-diagnostic-information-for-support.html [L,R=302]
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/cicd/gitops/troubleshooting-issues-in-GitOps.html /gitops/latest/troubleshooting_gitops_issues/auto-reboot-during-argo-cd-sync-with-machine-configurations.html [L,R=302]
 
+
+# Lightspeed handling unversioned and latest links
+    RewriteRule ^lightspeed/?$ /lightspeed/latest [R=302]
+    RewriteRule ^lightspeed/latest/?(.*)$ /lightspeed/1\.0tp1/$1 [NE,R=302]
+
+    # Lightspeed landing page
+
+    RewriteRule ^container-platform/(4\.9|4\.10|4\.11|4\.12|4\.13|4\.14|4\.15|4\.16|4\.17|4\.18)/lightspeed/about/ols-openshift-lightspeed-overview.html /lightspeed/latest/about/ols-about-openshift-lightspeed.html [NE,R=302]
+
+
     # Pipelines handling unversioned and latest links
     RewriteRule ^pipelines/?$ /pipelines/latest [R=302]
     RewriteRule ^pipelines/latest/?(.*)$ /pipelines/1\.15/$1 [NE,R=302]

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -264,6 +264,13 @@
               <option value="1.9">1.9</option>
               <option value="1.8">1.8</option>
             </select>
+        <% elsif (distro_key == "openshift-lightspeed") %>
+            <a href="https://docs.openshift.com/lightspeed/<%= version %>/about/ols-openshift-lightspeed-overview.html">
+              <%= distro %>
+            </a>
+            <select id="version-selector" onchange="versionSelector(this);">
+              <option value="1.0tp1">1.0tp1</option>
+            </select>
         <% elsif (distro_key == "openshift-telco") %>
             <a href="https://docs.openshift.com/container-platform-telco/<%= version %>/welcome/index.html">
               <%= distro %>


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): OCP 4.15+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OLS-880
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
