### PR TITLE
OSDOCS-11136: adds 4.15.24 async relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -394,3 +394,13 @@ Issued: 2024-07-25
 The {product-title} release 4.15.23 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4701[RHBA-2024:4701] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4699[RHSA-2024:4699] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-15-24-dp_{context}"]
+=== RHBA-2024:4852 - {microshift-short} 4.15.24 bug fix and enhancement advisory
+
+Issued: 2024-07-31
+
+The {product-title} release 4.15.24 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4852[RHBA-2024:4852] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4850[RHSA-2024:4850] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-11136](https://issues.redhat.com/browse/OSDOCS-11136)

Link to docs preview:
[MicroShift 4-15-24 release note](https://79564--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-24-dp_release-notes)

QE review:
- N/A stock text

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
