### PR TITLE
OSDOCS-11466: 4.13.46 RN

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -4265,3 +4265,33 @@ $ oc adm release info 4.13.45 --pullspecs
 [id="ocp-4-13-45-updating"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-13-46"]
+=== RHSA-2024:4846 - {product-title} 4.13.46 bug fix and security updates
+
+Issued: 2024-07-31
+
+{product-title} release 4.13.46, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:4846[RHSA-2024:4846] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4848[RHSA-2024:4848] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.46 --pullspecs
+----
+
+[id="ocp-4-13-46-bug-fixes"]
+==== Bug fixes
+
+* Previously, the DNS Operator did not verify that a cluster had ready nodes with available CPU in at least two availability zones, and the DNS daemon set did not use surge for rolling updates. As a result, clusters in which all nodes were in the same availability zone would repeatedly emit TopologyAwareHintsDisabled events for the cluster DNS service. With this release, the `TopologyAwareHintsDisabled` events are no longer emitted on clusters that do not have nodes in multiple availability zones and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-11449[*OCPBUGS-11449*])
+
+* Previously, nodes that were booted by using 4.1 and 4.2 boot images for {product-title} got stuck during provisioning because the `machine-config-daemon-firstboot.service` had incompatible `machine-config-daemon` binary code. With this release, binary code has been updated and the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-36782[*OCPBUGS-36782*])
+
+* Previously, a change of dependency targets was introduced in {product-title} 4.14 that prevented disconnected Azure Red Hat OpenShift (ARO) installs from scaling up new nodes after they upgraded to affected versions. With this release, disconnected ARO installs can scale up new nodes after upgrading to {product-title} 4.14. (link:https://issues.redhat.com/browse/OCPBUGS-37160[*OCPBUGS-37160*])
+
+[id="ocp-4-13-46-updating"]
+==== Updating
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OSDOCS-11466](https://issues.redhat.com/browse/OSDOCS-11466)

Link to docs preview:
https://79578--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-46

QE review:
N/A

Additional information:
Errata URLs will return 404 until go-live (7/31)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
