### PR TITLE
temporary owner access

### DIFF
--- a/OWNERS-ALIASES
+++ b/OWNERS-ALIASES
@@ -29,3 +29,10 @@ aliases:
   - kalexand-rh
   - ousleyp
   - sjhala-ccs
+  - jeana-redhat
+  - stevsmit
+  - skrthomas
+  - abrennan89
+  - michaelryanpeter
+  - mburke5678
+  - snarayan-redhat


### PR DESCRIPTION
Temporarily granting owner access to the merge review squad to bypass a stale prow job.

@jeana-redhat @stevsmit @skrthomas @abrennan89 @mburke5678 @michaelryanpeter @snarayan-redhat, please just use your expanded access to add `/override ci/prow/deploy-preview` to stuck PRs.

I will revert this PR at the end of the day, and we can re-evaluate further actions on Monday, if necessary.