### PR TITLE
OSDOCS-8455: Adding oc adm upgrade status to Troubleshooting cluster updates

### DIFF
--- a/modules/update-upgrading-oc-adm-upgrade-status.adoc
+++ b/modules/update-upgrading-oc-adm-upgrade-status.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="update-upgrading-oc-adm-upgrade-status_{context}"]
-= Retrieving information about a cluster update using oc adm upgrade status (Technology Preview)
+= Gathering cluster update status using oc adm upgrade status (Technology Preview)
 
 When updating your cluster, it is useful to understand how your update is progressing. While the `oc adm upgrade` command returns limited information about the status of your update, this release introduces the `oc adm upgrade status` command as a Technology Preview feature. This command decouples status information from the `oc adm upgrade` command and provides specific information regarding a cluster update, including the status of the control plane and worker node updates.
 

--- a/updating/troubleshooting_updates/gathering-data-cluster-update.adoc
+++ b/updating/troubleshooting_updates/gathering-data-cluster-update.adoc
@@ -15,6 +15,8 @@ endif::openshift-origin[]
 
 include::modules/gathering-log-data.adoc[leveloffset=+1]
 
+include::modules/update-upgrading-oc-adm-upgrade-status.adoc[leveloffset=+1]
+
 include::modules/gathering-clusterversion-history.adoc[leveloffset=+1]
 
 include::modules/gathering-clusterversion-history-console.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OSDOCS-8455](https://issues.redhat.com/browse/OSDOCS-8455)

Link to docs preview:
https://79593--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/troubleshooting_updates/gathering-data-cluster-update.html
https://79593--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-cluster-cli.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
