### PR TITLE
OSDOCS-11464 OCP 4.15.24 Release Notes

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2733,6 +2733,31 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+[id="ocp-4-15-24_{context}"]
+=== RHSA-2024:4850 - {product-title} 4.15.24 bug fix and security update
+
+Issued: 2024-07-31
+
+{product-title} release 4.15.24, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2024:4850[RHSA-2024:4850] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4853[RHSA-2024:4853] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.24 --pullspecs
+----
+
+[id="ocp-4-15-24-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the TuneD daemon could unnecessarily reload an additional time after a Tuned custom resource (CR) update. With this release, the Tuned object has been removed and the TuneD (daemon) profiles are carried directly in the Tuned Profile Kubernetes objects. As a result, the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-36870[*OCPBUGS-36870*])
+
+[id="ocp-4-15-24-updating_{context}"]
+==== Updating
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 [id="ocp-4-15-23_{context}"]
 === RHSA-2024:4699 - {product-title} 4.15.23 bug fix and security update
 
@@ -2762,7 +2787,7 @@ The following enhancement is included in this z-stream release:
 [id="ocp-4-15-23-bug-fixes_{context}"]
 ==== Bug fixes
 
-* Previously, the OpenSSL versions for the Machine Config Operator and the hosted  control plane were not the same. With this release, the FIPS cluster `NodePool` resource creation for {product-title} 4.14 and {product-title} 4.15 has been fixed and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-37266[*OCPBUGS-37266*])
+* Previously, the OpenSSL versions for the Machine Config Operator and the hosted control plane were not the same. With this release, the FIPS cluster `NodePool` resource creation for {product-title} 4.14 and {product-title} 4.15 has been fixed and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-37266[*OCPBUGS-37266*])
 
 * Previously, the operand details displayed information for the first custom resource definition (CRD) that matched by name. With this release, the operand details page displays information for the CRD that matches by name and the version of the operand. (link:https://issues.redhat.com/browse/OCPBUGS-36971[*OCPBUGS-36971*])
 


### PR DESCRIPTION
Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-11464](https://issues.redhat.com/browse/OSDOCS-11464)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to [docs preview](https://79595--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-24_release-notes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
Not needed
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Advisory links will not work until July 31.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
