### PR TITLE
OCPBUGS-37304: vSphere CPMS template in FD note

### DIFF
--- a/modules/cpmso-yaml-provider-spec-vsphere.adoc
+++ b/modules/cpmso-yaml-provider-spec-vsphere.adoc
@@ -61,6 +61,12 @@ If you specify this value in the provider specification when using failure domai
 <6> Specifies the number of CPUs allocated for the control plane machines.
 <7> Specifies the number of cores for each control plane CPU.
 <8> Specifies the vSphere VM template to use, such as `user-5ddjd-rhcos`.
++
+[NOTE]
+====
+If the cluster is configured to use a failure domain, this parameter is configured in the failure domain.
+If you specify this value in the provider specification when using failure domains, the Control Plane Machine Set Operator ignores it.
+====
 <9> Specifies the control plane user data secret. Do not change this value.
 <10> Specifies the workspace details for the control plane.
 +


### PR DESCRIPTION
Version(s):
4.15+

Issue:
OCPBUGS-37304

Link to docs preview:
[Sample VMware vSphere provider specification](https://79597--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere#cpmso-yaml-provider-spec-vsphere_cpmso-config-options-vsphere)

QE review:
- [x] QE has approved this change.

Additional information: