### PR TITLE
OADP-4597: Fix build-errors in Prow local validation

### DIFF
--- a/modules/nw-traditional-sharding.adoc
+++ b/modules/nw-traditional-sharding.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="nw-traditional-sharding_{context}"]
-== Traditional sharding example
+= Traditional sharding example
 
 An example of a configured Ingress Controller `finops-router` that has the label selector `spec.namespaceSelector.matchExpressions` with key values set to `finance` and `ops`:
 

--- a/modules/olm-overriding-operator-pod-affinity.adoc
+++ b/modules/olm-overriding-operator-pod-affinity.adoc
@@ -188,6 +188,7 @@ To control the placement of an Operator pod, complete the following steps:
 . Edit the Operator `Subscription` object to add an affinity:
 +
 ifndef::pod[]
+ifdef::olm[]
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -211,13 +212,38 @@ spec:
               - ip-10-0-185-229.ec2.internal
 #...
 ----
-ifdef::olm[]
 <1> Add a `nodeAffinity`, `podAffinity`, or `podAntiAffinity`. See the Additional resources section that follows for information about creating the affinity.
-endif::[]
+endif::olm[]
+
 ifdef::node[]
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-custom-metrics-autoscaler-operator
+  namespace: openshift-keda
+spec:
+  name: my-package
+  source: my-operators
+  sourceNamespace: operator-registries
+  config:
+    affinity: <1>
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+              - ip-10-0-185-229.ec2.internal
+#...
+----
 <1> Add a `nodeAffinity`.
-endif::[]
+endif::node[]
+
 endif::pod[]
+
 ifdef::pod[]
 [source,yaml]
 ----


### PR DESCRIPTION
### JIRA 

* [OADP-4597](https://issues.redhat.com/browse/OADP-4597)

This is a small PR to fix two small errors are returned when using `./scripts/prow-smoke-test.sh --validate`: 

```
>>> Working on networking book in openshift-enterprise <<<
Transforming the AsciiDoc content to DocBook XML...
asciidoctor: WARNING: includes/nw-traditional-sharding.adoc: line 7: section title out of sequence: expected level 4, got level 5
asciidoctor: WARNING: includes/nw-overlapped-sharding.adoc: line 7: section title out of sequence: expected level 4, got level 5
```

```
`>>> Working on nodes book in openshift-enterprise <<<
Transforming the AsciiDoc content to DocBook XML...
asciidoctor: WARNING: includes/olm-overriding-operator-pod-affinity.adoc: line 214: callout list item index: expected 2, got 1
asciidoctor: WARNING: includes/olm-overriding-operator-pod-affinity.adoc: line 214: no callout found for <2>
```


### Link to docs preview:

* https://79600--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/scheduling/nodes-scheduler-node-affinity.html
* https://79600--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/scheduling/nodes-scheduler-pod-affinity.html
* https://79600--ocpdocs-pr.netlify.app/openshift-dedicated/latest/operators/admin/olm-adding-operators-to-cluster.html
* https://79600--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.html
* https://79600--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-affinity.html
* https://79600--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-pod-affinity.html
* https://79600--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/admin/olm-adding-operators-to-cluster.html
* https://79600--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/scheduling/nodes-scheduler-node-affinity.html
* https://79600--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/scheduling/nodes-scheduler-pod-affinity.html
* https://79600--ocpdocs-pr.netlify.app/openshift-rosa/latest/operators/admin/olm-adding-operators-to-cluster.html

### QE review:
- [ ] QE has approved this change. - **No** QE not required - See [K.Alexander comment](https://github.com/openshift/openshift-docs/pull/79600#issuecomment-2255764159)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
