### PR TITLE
HCIDOCS-397: Remove "Optional" from headers

### DIFF
--- a/modules/creating-manifest-file-customized-br-ex-bridge.adoc
+++ b/modules/creating-manifest-file-customized-br-ex-bridge.adoc
@@ -18,7 +18,7 @@ endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="creating-manifest-file-customized-br-ex-bridge_{context}"]
-== Optional: Creating a manifest object that includes a customized `br-ex` bridge
+== Creating a manifest object that includes a customized `br-ex` bridge
 
 ifndef::postinstall-bare-metal-ipi,postinstall-bare-metal-upi[]
 As an alternative to using the `configure-ovs.sh` shell script to set a customized `br-ex` bridge on a bare-metal platform, you can create a `MachineConfig` object that includes a customized `br-ex` bridge network configuration.

--- a/modules/creating-scaling-machine-sets-compute-nodes-networking.adoc
+++ b/modules/creating-scaling-machine-sets-compute-nodes-networking.adoc
@@ -9,7 +9,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="creating-scaling-machine-sets-compute-nodes-networking_{context}"]
-= Optional: Scaling each machine set to compute nodes
+= Scaling each machine set to compute nodes
 
 To apply a customized `br-ex` bridge configuration to all compute nodes in your {product-title} cluster, you must edit your `MachineConfig` custom resource (CR) and modify its roles. Additionally, you must create a `BareMetalHost` CR that defines information for your bare-metal machine, such as hostname, credentials, and so on.
 

--- a/modules/ipi-install-configuring-host-dual-network-interfaces-in-the-install-config.yaml-file.adoc
+++ b/modules/ipi-install-configuring-host-dual-network-interfaces-in-the-install-config.yaml-file.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="configuring-host-dual-network-interfaces-in-the-install-config-yaml-file_{context}"]
-= Optional: Configuring host network interfaces for dual port NIC
+= Configuring host network interfaces for dual port NIC
 
 :FeatureName: Support for Day 1 operations associated with enabling NIC partitioning for SR-IOV devices
 include::snippets/technology-preview.adoc[leveloffset=+1]

--- a/modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc
+++ b/modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="configuring-host-network-interfaces-in-the-install-config-yaml-file_{context}"]
-= Optional: Configuring host network interfaces
+= Configuring host network interfaces
 
 Before installation, you can set the `networkConfig` configuration setting in the `install-config.yaml` file to configure host network interfaces using NMState.
 

--- a/modules/ipi-install-configuring-managed-secure-boot-in-the-install-config-file.adoc
+++ b/modules/ipi-install-configuring-managed-secure-boot-in-the-install-config-file.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="configuring-managed-secure-boot-in-the-install-config-file_{context}"]
-= Optional: Configuring managed Secure Boot
+= Configuring managed Secure Boot
 
 You can enable managed Secure Boot when deploying an installer-provisioned cluster using Redfish BMC addressing, such as `redfish`, `redfish-virtualmedia`, or `idrac-virtualmedia`. To enable managed Secure Boot, add the `bootMode` configuration setting to each node:
 

--- a/modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc
+++ b/modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc
@@ -5,7 +5,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="configuring-ntp-for-disconnected-clusters_{context}"]
-= Optional: Configuring NTP for disconnected clusters
+= Configuring NTP for disconnected clusters
 
 //This procedure can be executed as a day 1 or day 2 operation with minor differences.
 //The conditional text picks up the context and displays the appropriate alternate steps.

--- a/modules/ipi-install-configuring-storage-on-nodes.adoc
+++ b/modules/ipi-install-configuring-storage-on-nodes.adoc
@@ -5,7 +5,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="configuring-storage-on-nodes_{context}"]
-= Optional: Configuring storage on nodes
+= Configuring storage on nodes
 
 You can make changes to operating systems on {product-title} nodes by creating `MachineConfig` objects that are managed by the Machine Config Operator (MCO).
 

--- a/modules/ipi-install-configuring-the-bios.adoc
+++ b/modules/ipi-install-configuring-the-bios.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="configuring-the-bios_{context}"]
-= Optional: Configuring the BIOS
+= Configuring the BIOS
 
 The following procedure configures the BIOS during the installation process.
 

--- a/modules/ipi-install-configuring-the-raid.adoc
+++ b/modules/ipi-install-configuring-the-raid.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="configuring-the-raid_{context}"]
-= Optional: Configuring the RAID
+= Configuring the RAID
 
 The following procedure configures a redundant array of independent disks (RAID) using baseboard management controllers (BMCs) during the installation process.
 

--- a/modules/ipi-install-creating-an-rhcos-images-cache.adoc
+++ b/modules/ipi-install-creating-an-rhcos-images-cache.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="ipi-install-creating-an-rhcos-images-cache_{context}"]
-= Optional: Creating an {op-system} images cache
+= Creating an {op-system} images cache
 
 To employ image caching, you must download the {op-system-first} image used by the bootstrap VM to provision the cluster nodes. Image caching is optional, but it is especially useful when running the installation program on a network with limited bandwidth.
 

--- a/modules/ipi-install-deploying-routers-on-worker-nodes.adoc
+++ b/modules/ipi-install-deploying-routers-on-worker-nodes.adoc
@@ -5,7 +5,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="deploying-routers-on-worker-nodes_{context}"]
-= Optional: Deploying routers on compute nodes
+= Deploying routers on compute nodes
 
 During installation, the installation program deploys router pods on compute nodes. By default, the installation program installs two router pods. If a deployed cluster requires additional routers to handle external traffic loads destined for services within the {product-title} cluster, you can create a `yaml` file to set an appropriate number of router replicas.
 

--- a/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
@@ -9,7 +9,7 @@ endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id='modifying-install-config-for-dual-stack-network_{context}']
-= Optional: Deploying with dual-stack networking
+= Deploying with dual-stack networking
 
 For dual-stack networking in {product-title} clusters, you can configure IPv4 and IPv6 address endpoints for cluster nodes. To configure IPv4 and IPv6 address endpoints for cluster nodes, edit the `machineNetwork`, `clusterNetwork`, and `serviceNetwork` configuration settings in the `install-config.yaml` file. Each setting must have two CIDR entries each. For a cluster with the IPv4 family as the primary address family, specify the IPv4 setting first. For a cluster with the IPv6 family as the primary address family, specify the IPv6 setting first.
 

--- a/modules/ipi-install-modifying-install-config-for-no-provisioning-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-no-provisioning-network.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id='modifying-install-config-for-no-provisioning-network_{context}']
-= Optional: Deploying with no provisioning network
+= Deploying with no provisioning network
 
 To deploy an {product-title} cluster without a `provisioning` network, make the following changes to the `install-config.yaml` file.
 

--- a/modules/ipi-install-modifying-install-config-for-slaac-dual-stack-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-slaac-dual-stack-network.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id='ipi-install-modifying-install-config-for-slaac-dual-stack-network_{context}']
-= Optional: Configuring address generation modes for SLAAC in dual-stack networks
+= Configuring address generation modes for SLAAC in dual-stack networks
 
 For dual-stack clusters that use Stateless Address AutoConfiguration (SLAAC), you must specify a global value for the `ipv6.addr-gen-mode` network setting. You can set this value using NMState to configure the RAM disk and the cluster configuration files. If you do not configure a consistent `ipv6.addr-gen-mode` in these locations, IPv6 address mismatches can occur between CSR resources and `BareMetalHost` resources in the cluster.
 

--- a/modules/ipi-install-setting-proxy-settings-within-install-config.adoc
+++ b/modules/ipi-install-setting-proxy-settings-within-install-config.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id='ipi-install-setting-proxy-settings-within-install-config_{context}']
-= Optional: Setting proxy settings
+= Setting proxy settings
 
 To deploy an {product-title} cluster using a proxy, make the following changes to the `install-config.yaml` file.
 


### PR DESCRIPTION
Removed "Optional" from module titles per ContentX.

Fixes: [HCIDOCS-397](https://issues.redhat.com//browse/HCIDOCS-397)

See https://issues.redhat.com/browse/HCIDOCS-397 for additional details.

Preview URL: https://79601--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html
https://79601--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal-network-customizations.html
https://79601--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-restricted-networks-bare-metal.html
https://79601--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html
https://79601--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.html
https://79601--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations.html
https://79601--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/post-install-bare-metal-configuration.html

For release(s): 4.17
QE Review: 

- [ ] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
