### PR TITLE
OSDOCS-11484: Fix CMPS YAML for capacity res

### DIFF
--- a/modules/machineset-azure-capacity-reservation.adoc
+++ b/modules/machineset-azure-capacity-reservation.adoc
@@ -55,10 +55,19 @@ endif::cpmso[]
 # ...
 spec:
   template:
+ifndef::cpmso[]
     spec:
       providerSpec:
         value:
-          capacityReservationGroupID: <capacity-reservation-group> # <1>
+          capacityReservationGroupID: <capacity_reservation_group> # <1>
+endif::cpmso[]
+ifdef::cpmso[]
+    machines_v1beta1_machine_openshift_io:
+      spec:
+        providerSpec:
+          value:
+            capacityReservationGroupID: <capacity_reservation_group> # <1>
+endif::cpmso[]
 # ...
 ----
 <1> Specify the ID of the Capacity Reservation group that you want the machine set to deploy machines on.


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-11484](https://issues.redhat.com//browse/OSDOCS-11484)

Link to docs preview:

- [Compute](https://79638--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure.html#machineset-azure-capacity-reservation_creating-machineset-azure)
- [Control plane](https://79638--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.html#machineset-azure-capacity-reservation_cpmso-config-options-azure)

QE review:
- [x] QE has approved this change.

Additional information: