### PR TITLE
[enterprise-4.13] WMCO: 240.0.0.0 should not be used for clusters that will enable Windows workload

### DIFF
--- a/modules/windows-containers-release-notes-limitations.adoc
+++ b/modules/windows-containers-release-notes-limitations.adoc
@@ -35,6 +35,8 @@ Note the following limitations when working with Windows nodes managed by the WM
 
 * {productwinc} does not support any Windows operating system language other than English (United States). 
 
+* Due to a limitation within the Windows operating system, `clusterNetwork` CIDR addresses of class E, such as `240.0.0.0`, are not compatible with Windows nodes.
+
 * Kubernetes has identified the following link:https://kubernetes.io/docs/concepts/windows/intro/#limitations[node feature limitations] :
 ** Huge pages are not supported for Windows containers.
 ** Privileged containers are not supported for Windows containers.

--- a/windows_containers/enabling-windows-container-workloads.adoc
+++ b/windows_containers/enabling-windows-container-workloads.adoc
@@ -42,7 +42,9 @@ You can install the Windows Machine Config Operator using either the web console
 
 [NOTE]
 ====
-The WMCO is not supported in clusters that use a xref:../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide proxy] because the WMCO is not able to route traffic through the proxy connection for the workloads.
+* The WMCO is not supported in clusters that use a xref:../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide proxy] because the WMCO is not able to route traffic through the proxy connection for the workloads.
+
+* Due to a limitation within the Windows operating system, `clusterNetwork` CIDR addresses of class E, such as `240.0.0.0`, are not compatible with Windows nodes.
 ====
 
 include::modules/installing-wmco-using-web-console.adoc[leveloffset=+2]


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/77452