### PR TITLE
Updates egress ip docs to provide proper command for return egess ip …

### DIFF
--- a/modules/nw-egress-ips-assign.adoc
+++ b/modules/nw-egress-ips-assign.adoc
@@ -49,7 +49,8 @@ $ oc apply -f <egressips_name>.yaml <1>
 egressips.k8s.ovn.org/<egressips_name> created
 ----
 
-. Optional: Save the `<egressips_name>.yaml` file so that you can make changes later.
+. Optional: Store the `<egressips_name>.yaml` file so that you can make changes later.
+
 . Add labels to the namespace that requires egress IP addresses. To add a label to the namespace of an `EgressIP` object defined in step 1, run the following command:
 +
 [source,terminal]
@@ -57,3 +58,29 @@ egressips.k8s.ovn.org/<egressips_name> created
 $ oc label ns <namespace> env=qa <1>
 ----
 <1> Replace `<namespace>` with the namespace that requires egress IP addresses.
+
+.Verification
+
+* To show all egress IPs that are in use in your cluster, enter the following command:
++
+[source,terminal]
+----
+$ oc get egressip -o yaml
+----
++
+[NOTE]
+====
+The command `oc get egressip` only returns one egress IP address regardless of how many are configured. This is not a bug and is a limitation of Kubernetes. As a workaround, you can pass in the `-o yaml` or `-o json` flags to return all egress IPs addresses in use.
+====
++
+.Example output
++
+[source,terminal]
+----
+# ...
+spec:
+  egressIPs:
+  - 192.168.127.10
+  - 192.168.127.11
+# ...
+----


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-19542

Link to docs preview:
https://79662--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/assigning-egress-ips-ovn.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
