### PR TITLE
OTA-1206: Reposition EUS-to-EUS as Applying Multiple Control Plane Up…

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -697,7 +697,7 @@ Topics:
     File: updating-cluster-cli
   - Name: Updating a cluster using the web console
     File: updating-cluster-web-console
-  - Name: Performing an EUS-to-EUS update
+  - Name: Applying Multiple Control Plane Updates
     File: eus-eus-update
     Distros: openshift-enterprise
   - Name: Performing a canary rollout update

--- a/modules/understanding-update-channels.adoc
+++ b/modules/understanding-update-channels.adoc
@@ -26,7 +26,7 @@ Newly installed clusters default to using stable channels.
 [id="eus-4y-channel_{context}"]
 == eus-4.y channel
 
-In addition to the stable channel, all even-numbered minor versions of {product-title} offer link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[Extended Update Support] (EUS). Releases promoted to the stable channel are also simultaneously promoted to the EUS channels. The primary purpose of the EUS channels is to serve as a convenience for clusters performing an EUS-to-EUS update.
+In addition to the stable channel, all even-numbered minor versions of {product-title} offer link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[Extended Update Support] (EUS). Releases promoted to the stable channel are also simultaneously promoted to the EUS channels. The primary purpose of the EUS channels is to serve as a convenience for clusters Applying Multiple Control Plane Updates update.
 
 [NOTE]
 ====

--- a/modules/update-availability-faq.adoc
+++ b/modules/update-availability-faq.adoc
@@ -23,7 +23,7 @@ For the latest z-stream releases, this delay may generally be a week or two. How
 ====
 
 * Releases promoted to the `stable` channel are simultaneously promoted to the `eus` channel.
-The primary purpose of the `eus` channel is to serve as a convenience for clusters performing an EUS-to-EUS update.
+The primary purpose of the `eus` channel is to serve as a convenience for clusters Applying Multiple Control Plane Updates update.
 
 [id="channel-safety_{context}"]
 *Is a release on the `stable` channel safer or more supported than a release on the `fast` channel?*

--- a/modules/updating-eus-to-eus-layered-products.adoc
+++ b/modules/updating-eus-to-eus-layered-products.adoc
@@ -4,9 +4,9 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="updating-eus-to-eus-olm-operators_{context}"]
-= EUS-to-EUS update for layered products and Operators installed through Operator Lifecycle Manager
+= Applying Multiple Control Plane Updates for layered products and Operators installed through Operator Lifecycle Manager
 
-In addition to the EUS-to-EUS update steps mentioned for the web console and CLI, there are additional steps to consider when performing EUS-to-EUS updates for clusters with the following:
+In addition to the Applying Multiple Control Plane Updates steps mentioned for the web console and CLI, there are additional steps to consider when Applying Multiple Control Plane Updates for clusters with the following:
 
 * Layered products
 * Operators installed through Operator Lifecycle Manager (OLM)
@@ -15,13 +15,13 @@ In addition to the EUS-to-EUS update steps mentioned for the web console and CLI
 
 Layered products refer to products that are made of multiple underlying products that are intended to be used together and cannot be broken into individual subscriptions. For examples of layered {product-title} products, see link:https://access.redhat.com/support/policy/updates/openshift/#layered[Layered Offering On OpenShift].
 
-As you perform an EUS-to-EUS update for the clusters of layered products and those of Operators that have been installed through OLM, you must complete the following:
+As you apply Multiple Control Plane Updates on clusters with layered products and those of Operators that have been installed through OLM, you must complete the following:
 
 . You have updated all Operators previously installed through Operator Lifecycle Manager (OLM) to a version that is compatible with your target release. Updating the Operators ensures they have a valid update path when the default OperatorHub catalogs switch from the current minor version to the next during a cluster update. See "Updating installed Operators" in the "Additional resources" section for more information on how to check compatibility and, if necessary, update the installed Operators.
 
 . Confirm the cluster version compatibility between the current and intended Operator versions. You can verify which versions your OLM Operators are compatible with by using the link:https://access.redhat.com/labs/ocpouic/?operator=logging&&ocp_versions=4.10,4.11,4.12[Red{nbsp}Hat {product-title} Operator Update Information Checker].
 
-As an example, here are the steps to perform an EUS-to-EUS update from <4.y> to <4.y+2> for OpenShift Data Foundation (ODF). This can be done through the CLI or web console. For information on how to update clusters through your desired interface, see _EUS-to-EUS update using the web console_ and "EUS-to-EUS update using the CLI" in "Additional resources".
+As an example, here are the steps to apply multiple Control Plane updates from <4.y> to <4.y+2> for OpenShift Data Foundation (ODF). This can be done through the CLI or web console. For information on how to update clusters through your desired interface, see _Applying Multiple Control Plane Updates using the web console_ and "Applying Multiple Control Plane Updates using the CLI" in "Additional resources".
 
 .Example workflow
 . Pause the worker machine pools.

--- a/modules/updating-eus-to-eus-upgrade-cli.adoc
+++ b/modules/updating-eus-to-eus-upgrade-cli.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="updating-eus-to-eus-upgrade-cli_{context}"]
-= EUS-to-EUS update using the CLI
+= Applying Multiple Control Plane Updates using the CLI
 
 .Prerequisites
 
@@ -37,7 +37,7 @@ master   rendered-master-ecbb9582781c1091e1c9f19d50cf836c       True  	  False
 worker   rendered-worker-00a3f0c68ae94e747193156b491553d5       True  	  False
 ----
 
-. Your current version is <4.y>, and your intended version to update is <4.y+2>. Change to the `eus-<4.y+2>` channel by running the following command:
+. Your current version is <4.y>, and your intended version to update is <4.y+2>. Change to `eus-<4.y+2>`, `stable-<4.y+2>`, or `fast-<4.y+2>` channel by running the following command:
 +
 [source,terminal]
 ----
@@ -48,7 +48,7 @@ $ oc adm upgrade channel eus-<4.y+2>
 ====
 
 If you receive an error message indicating that `eus-<4.y+2>` is not one of the
-available channels, this indicates that Red Hat is still rolling out EUS version updates.
+available channels, this indicates that Red Hat is still rolling out updates to your target version.
 This rollout process generally takes 45-90 days starting at the GA date.
 ====
 +
@@ -125,7 +125,7 @@ $ oc patch mcp/worker --type merge --patch '{"spec":{"paused":false}}'
 +
 [IMPORTANT]
 ====
-If pools are not unpaused, the cluster is not permitted to update to any future minor versions, and some maintenance tasks are inhibited. This puts the cluster at risk for future degradation.
+If pools are not unpaused, the cluster is not permitted to update to any future minor versions.
 ====
 
 . Verify that your previously paused pools are updated and that the update to version <4.y+2> is complete by running the following command:

--- a/modules/updating-eus-to-eus-upgrade-console.adoc
+++ b/modules/updating-eus-to-eus-upgrade-console.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="updating-eus-to-eus-upgrade-console_{context}"]
-= EUS-to-EUS update using the web console
+= Applying Multiple Control Plane Updates using the web console
 
 .Prerequisites
 
@@ -24,7 +24,7 @@ To view the status of all machine config pools, click *Compute* -> *MachineConfi
 If your machine config pools have an `Updating` status, please wait for this status to change to `Up to date`. This process could take several minutes.
 ====
 
-. Set your channel to `eus-<4.y+2>`.
+. Set your channel to `eus-<4.y+2>`, `stable-<4.y+2>`, or `fast-<4.y+2>`.
 +
 To set your channel, click *Administration* -> *Cluster Settings* -> *Channel*. You can edit your channel by clicking on the current hyperlinked channel.
 

--- a/modules/updating-eus-to-eus-upgrade.adoc
+++ b/modules/updating-eus-to-eus-upgrade.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="updating-eus-to-eus-upgrade_{context}"]
-= EUS-to-EUS update
+= Applying Multiple Control Plane Updates
 
 The following procedure pauses all non-master machine config pools and performs updates from {product-title} <4.y> to <4.y+1> to <4.y+2>, then unpauses the previously paused machine config pools.
 Following this procedure reduces the total update duration and the number of times worker nodes are restarted.
@@ -12,6 +12,6 @@ Following this procedure reduces the total update duration and the number of tim
 .Prerequisites
 
 * Review the release notes for {product-title} <4.y+1> and <4.y+2>
-* Review the release notes and product lifecycles for any layered products and Operator Lifecycle Manager (OLM) Operators. Some may require updates either before or during an EUS-to-EUS update.
+* Review the release notes and product lifecycles for any layered products and Operator Lifecycle Manager (OLM) Operators. Some may require updates either before or while applying multiple Control Plane updates.
 * Ensure that you are familiar with version-specific prerequisites, such as the removal of deprecated APIs, that are required prior to updating from {product-title} <4.y+1> to <4.y+2>.
 

--- a/updating/updating_a_cluster/eus-eus-update.adoc
+++ b/updating/updating_a_cluster/eus-eus-update.adoc
@@ -1,6 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="eus-eus-update"]
-= Performing an EUS-to-EUS update
+= Applying Multiple Control Plane Updates
+Previously called "EUS-to-EUS Updates"
 include::_attributes/common-attributes.adoc[]
 :context: eus-to-eus-update
 
@@ -13,28 +14,26 @@ To do: Remove this comment once 4.13 docs are EOL.
 ////
 
 Due to fundamental Kubernetes design, all {product-title} updates between minor versions must be serialized.
-You must update from {product-title} <4.y> to <4.y+1>, and then to <4.y+2>. You cannot update from {product-title} <4.y> to <4.y+2> directly.
-However, administrators who want to update between two Extended Update Support (EUS) versions can do so incurring only a single reboot of non-control plane hosts.
+Administrators who want to update across multiple minor versions quickly may perform multiple Control Plane Updates followed by a single Worker Node update.
 
-[IMPORTANT]
+[NOTE]
 ====
-EUS-to-EUS updates are only viable between *even-numbered minor versions* of {product-title}.
+Currently this is only supported between two EUS versions, however EUS subscriptions are not necessary. For instance clusters running 4.12 could apply the control plane update from 4.12 to 4.13, then the control plane update from 4.13 to 4.14 followed by updating workers directly from 4.12 to 4.14. A cluster running 4.15 cannot currently apply the same pattern when updating from 4.16 to 4.17. This may change in the future as we expand our tested version skew.
 ====
 
-There are a number of caveats to consider when attempting an EUS-to-EUS update.
 
-* EUS-to-EUS updates are only offered after updates between all versions involved have been made available in `stable` channels.
-* If you encounter issues during or after updating to the odd-numbered minor version but before updating to the next even-numbered version, then remediation of those issues may require that non-control plane hosts complete the update to the odd-numbered version before moving forward.
-* You can do a partial update by updating the worker or custom pool nodes to accommodate the time it takes for maintenance.
+There are a number of caveats to consider when applying multiple control plane updates.
 
-* Until the machine config pools are unpaused and the update is complete, some features and bugs fixes in <4.y+1> and <4.y+2> of {product-title} are not available.
+* If you encounter issues during or after applying the first control plane update remediation of those issues may require that non-control plane hosts complete the update to that version before applying a second control plane update.
 
-* All the clusters might update using EUS channels for a conventional update without pools paused, but only clusters with non control-plane `MachineConfigPools` objects can do EUS-to-EUS update with pools paused.
+* Until the machine config pools are unpaused and the update is complete, features and bugs fixes which depend on worker updates are not available.
 
-// EUS-to-EUS update
+* All the clusters may apply multiple control plane updates, but only clusters with non control-plane `MachineConfigPools` objects can benefit from skipping worker updates.
+
+// Applying Multiple Control Plane Updates
 include::modules/updating-eus-to-eus-upgrade.adoc[leveloffset=+1]
 
-// EUS-to-EUS update using the web console
+// Applying Multiple Control Plane Updates
 include::modules/updating-eus-to-eus-upgrade-console.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -45,7 +44,7 @@ include::modules/updating-eus-to-eus-upgrade-console.adoc[leveloffset=+2]
 * xref:../../updating/updating_a_cluster/updating-cluster-web-console.adoc#update-upgrading-web_updating-cluster-web-console[Updating a cluster by using the web console]
 * xref:../../updating/updating_a_cluster/updating-cluster-rhel-compute.adoc#updating-cluster-rhel-compute[Updating a cluster that includes RHEL compute machines]
 
-// EUS-to-EUS update using the CLI
+// Applying Multiple Control Plane Updates using the CLI
 include::modules/updating-eus-to-eus-upgrade-cli.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/updating/updating_a_cluster/updating-cluster-cli.adoc
+++ b/updating/updating_a_cluster/updating-cluster-cli.adoc
@@ -64,7 +64,7 @@ include::modules/update-upgrading-oc-adm-upgrade-status.adoc[leveloffset=+1]
 .Additional resources
 
 ifndef::openshift-origin[]
-* xref:../../updating/updating_a_cluster/eus-eus-update.adoc#eus-eus-update[Performing an EUS-to-EUS update]
+* xref:../../updating/updating_a_cluster/eus-eus-update.adoc#eus-eus-update[Applying Multiple Control Plane Updates update]
 endif::openshift-origin[]
 * xref:../../updating/updating_a_cluster/updating-cluster-cli.adoc#update-conditional-upgrade-pathupdating-cluster-cli[Updating along a conditional update path]
 ifndef::openshift-origin[]

--- a/updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update-osus.adoc
+++ b/updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update-osus.adoc
@@ -147,6 +147,6 @@ After you configure your cluster to use the installed OpenShift Update Service a
 
 ** xref:../../../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[Updating a cluster using the web console]
 ** xref:../../../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI]
-** xref:../../../updating/updating_a_cluster/eus-eus-update.adoc#eus-eus-update[Performing an EUS-to-EUS update]
+** xref:../../../updating/updating_a_cluster/eus-eus-update.adoc#eus-eus-update[Applying Multiple Control Plane Updates update]
 ** xref:../../../updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools[Performing a canary rollout update]
 ** xref:../../../updating/updating_a_cluster/updating-cluster-rhel-compute.adoc#updating-cluster-rhel-compute[Updating a cluster that includes RHEL compute machines]

--- a/virt/updating/upgrading-virt.adoc
+++ b/virt/updating/upgrading-virt.adoc
@@ -17,7 +17,7 @@ include::modules/virt-about-workload-updates.adoc[leveloffset=+2]
 ifndef::openshift-rosa,openshift-dedicated,openshift-origin[]
 include::modules/virt-about-eus-updates.adoc[leveloffset=+2]
 
-Learn more about xref:../../updating/updating_a_cluster/eus-eus-update.adoc#eus-eus-update[performing an EUS-to-EUS update].
+Learn more about xref:../../updating/updating_a_cluster/eus-eus-update.adoc#eus-eus-update[Applying Multiple Control Plane Updates update].
 
 include::modules/virt-preventing-workload-updates-during-eus-update.adoc[leveloffset=+1]
 endif::openshift-rosa,openshift-dedicated,openshift-origin[]
@@ -45,7 +45,7 @@ Configure workload updates to ensure that VMIs update automatically.
 [role="_additional-resources"]
 == Additional resources
 ifndef::openshift-rosa,openshift-dedicated,openshift-origin[]
-* xref:../../updating/updating_a_cluster/eus-eus-update.adoc#eus-eus-update[Performing an EUS-to-EUS update]
+* xref:../../updating/updating_a_cluster/eus-eus-update.adoc#eus-eus-update[Applying Multiple Control Plane Updates update]
 endif::openshift-rosa,openshift-dedicated,openshift-origin[]
 * xref:../../operators/understanding/olm-what-operators-are.adoc#olm-what-operators-are[What are Operators?]
 * xref:../../operators/understanding/olm/olm-understanding-olm.adoc#olm-understanding-olm[Operator Lifecycle Manager concepts and resources]


### PR DESCRIPTION
…dates

Just a quick update to align to that. Did not change any anchors or filenames though it'd be desirable to be able to do that in the future I don't know how we generally handle that in OpenShift Docs.

Version(s):
4.14+

Issue:
[OTA-1206](https://issues.redhat.com//browse/OTA-1206)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
While we are not currently changing the supported version skew we do wish to conceptually distance the pattern of applying multiple control plane updates and then a single rolling update to workers from the need to have EUS subscriptions. Once we apply these changes we will support this pattern in all channels, fast-X.Y, stable-X.Y, and eus-X.Y. At that point the only difference that will be present in the eus channel is that it will continue to receive z-stream updates after an EUS version transitions from Maintenance to EUS phase of its lifecycle.