### PR TITLE
Add feature gate prerequisite for machine config nodes feature

### DIFF
--- a/machine_configuration/index.adoc
+++ b/machine_configuration/index.adoc
@@ -44,6 +44,11 @@ include::modules/machine-config-drift-detection.adoc[leveloffset=+1]
 include::modules/checking-mco-status.adoc[leveloffset=+1]
 include::modules/checking-mco-node-status.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about feature gates, see xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-console_nodes-cluster-enabling[Enabling feature sets using the web console].
+
 [id="machine-config-operator-certificates_{context}"]
 == Understanding Machine Config Operator certificates
 

--- a/modules/checking-mco-node-status.adoc
+++ b/modules/checking-mco-node-status.adoc
@@ -13,6 +13,9 @@ To see the status of the Machine Config Operator (MCO) updates to your cluster, 
 :FeatureName: Improved MCO state reporting
 include::snippets/technology-preview.adoc[]
 
+.Prerequisites
+* You set `featureSet: TechPreviewNoUpgrade` in your `FeatureGate` custom resource (CR) to enable the feature set capability for your cluster.
+
 .Procedure
 . Get a summary of update statuses for all nodes in all machine config pools by running the following command:
 +


### PR DESCRIPTION
Added feature gate in the prerequisites section

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. --> 

Issue: [OCPBUGS-37434](https://issues.redhat.com/browse/OCPBUGS-37434)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:  [Checking machine config node status](https://79682--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/index.html#checking-mco-node-status_machine-config-overview)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: 
https://docs.openshift.com/container-platform/4.16/machine_configuration/index.html#checking-mco-node-status_machine-config-overview

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
