### PR TITLE
OCPBUGS-37699: Remove mode=6 balance-alb from networking docs

### DIFF
--- a/modules/ipi-install-configuring-host-dual-network-interfaces-in-the-install-config.yaml-file.adoc
+++ b/modules/ipi-install-configuring-host-dual-network-interfaces-in-the-install-config.yaml-file.adoc
@@ -6,10 +6,16 @@
 [id="configuring-host-dual-network-interfaces-in-the-install-config-yaml-file_{context}"]
 = Optional: Configuring host network interfaces for dual port NIC
 
+Before installation, you can set the `networkConfig` configuration setting in the `install-config.yaml` file to configure host network interfaces using NMState to support dual port NIC.
+
 :FeatureName: Support for Day 1 operations associated with enabling NIC partitioning for SR-IOV devices
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
-Before installation, you can set the `networkConfig` configuration setting in the `install-config.yaml` file to configure host network interfaces using NMState to support dual port NIC.
+{VirtProductName} only supports the following bond modes:
+
+* mode=1 active-backup +
+* mode=2 balance-xor +
+* mode=4 802.3ad +
 
 .Prerequisites
 

--- a/modules/virt-example-bond-nncp.adoc
+++ b/modules/virt-example-bond-nncp.adoc
@@ -15,8 +15,6 @@ to the cluster.
 * mode=1 active-backup +
 * mode=2 balance-xor +
 * mode=4 802.3ad +
-* mode=5 balance-tlb +
-* mode=6 balance-alb
 ====
 
 The following YAML file is an example of a manifest for a bond interface.

--- a/modules/virt-example-nmstate-multiple-interfaces.adoc
+++ b/modules/virt-example-nmstate-multiple-interfaces.adoc
@@ -25,7 +25,7 @@ spec:
       type: bond <6>
       state: up <7>
       link-aggregation:
-        mode: balance-rr <8>
+        mode: balance-xor <8>
         options:
           miimon: '140' <9>
         port: <10>


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-37699](https://issues.redhat.com/browse/OCPBUGS-37699)

Link to docs preview:
[Example: Bond interface node network configuration policy](https://79684--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#virt-example-bond-nncp_k8s_nmstate-updating-node-network-config)

- [x] SME has approved this change.
- [x] QE has approved this change.



