### PR TITLE
OCPBUGS-28795: removed featuregate warning to perfscale docs

### DIFF
--- a/modules/etcd-tuning-parameters.adoc
+++ b/modules/etcd-tuning-parameters.adoc
@@ -21,7 +21,7 @@ include::snippets/technology-preview.adoc[]
 To change the hardware speed tolerance for etcd, complete the following steps.
 
 .Prerequisites
-* You have edited the cluster instance to enable Technology Preview features. For more information, see "Understanding feature gates".
+* You have edited the cluster instance to enable `TechPreviewNoUpgrade` features. For more information, see "Understanding feature gates" in the _Additional resources_.
 
 .Procedure
 


### PR DESCRIPTION
Version(s):
4.14, 4.15

Issue:
https://issues.redhat.com/browse/OCPBUGS-28795

Link to docs preview:
[Changing hardware speed tolerance](https://79688--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.html#etcd-changing-hardware-speed-tolerance_recommended-etcd-practices)

QE review:
This clarifies the documentation without changing the meaning; no QE required. 

Additional information:
A tech preview feature in 4.14 and 4.15 required `TechPreviewNoUpgrade` enabled. Adding clarification to the docs. 
