### PR TITLE
[SRVKS-1182] Add the new kourier bootstrap documentation

### DIFF
--- a/knative-serving/config-applications/configuring-kourier.adoc
+++ b/knative-serving/config-applications/configuring-kourier.adoc
@@ -8,4 +8,6 @@ toc::[]
 
 Kourier is a lightweight Kubernetes-native Ingress for Knative Serving. Kourier acts as a gateway for Knative, routing HTTP traffic to Knative services.
 
+include::modules/accessing-the-current-envoy-bootstrap-configuration.adoc[leveloffset=+1]
 include::modules/customizing-kourier-bootstrap-for-kourier-getaways.adoc[leveloffset=+1]
+include::modules/enabling-administrator-interface-access.adoc[leveloffset=+1]

--- a/modules/accessing-the-current-envoy-bootstrap-configuration.adoc
+++ b/modules/accessing-the-current-envoy-bootstrap-configuration.adoc
@@ -1,0 +1,140 @@
+// Module included in the following assemblies:
+//
+// * config-applications/configuring-kourier.adoc
+:_content-type: PROCEDURE
+[id="accessing-the-current-envoy-bootstrap-configuration_{context}"]
+= Accessing the current Envoy bootstrap configuration
+
+The Envoy proxy component in Kourier handles inbound and outbound HTTP traffic for the Knative services. By default, Kourier contains an Envoy bootstrap configuration in the `kourier-bootstrap` configuration map in the `knative-serving-ingress` namespace.
+
+.Procedure
+
+* To get the current Envoy bootstrap configuration, run the following command:
++
+.Example command
+[source,terminal]
+----
+$ oc get cm kourier-bootstrap -n knative-serving-ingress -o yaml
+----
++
+For example, with the default configuration, the example command produces the output that contains the following excerpts:
++
+.Example output
+[source,terminal]
+----
+Name:         kourier-bootstrap
+Namespace:    knative-serving-ingress
+Labels:       app.kubernetes.io/component=net-kourier
+              app.kubernetes.io/name=knative-serving
+              app.kubernetes.io/version=release-v1.10
+              networking.knative.dev/ingress-provider=kourier
+              serving.knative.openshift.io/ownerName=knative-serving
+              serving.knative.openshift.io/ownerNamespace=knative-serving
+Annotations:  manifestival: new
+----
++
+.Example `Data` output
+[source,terminal]
+----
+dynamic_resources:
+  ads_config:
+    transport_api_version: V3
+    api_type: GRPC
+    rate_limit_settings: {}
+    grpc_services:
+    - envoy_grpc: {cluster_name: xds_cluster}
+  cds_config:
+    resource_api_version: V3
+    ads: {}
+  lds_config:
+    resource_api_version: V3
+    ads: {}
+node:
+  cluster: kourier-knative
+  id: 3scale-kourier-gateway
+static_resources:
+  listeners:
+    - name: stats_listener
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 9000
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: stats_server
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                route_config:
+                  virtual_hosts:
+                    - name: admin_interface
+                      domains:
+                        - "*"
+                      routes:
+                        - match:
+                            safe_regex:
+                              regex: '/(certs|stats(/prometheus)?|server_info|clusters|listeners|ready)?'
+                            headers:
+                              - name: ':method'
+                                string_match:
+                                  exact: GET
+                          route:
+                            cluster: service_stats
+  clusters:
+    - name: service_stats
+      connect_timeout: 0.250s
+      type: static
+      load_assignment:
+        cluster_name: service_stats
+        endpoints:
+          lb_endpoints:
+            endpoint:
+              address:
+                pipe:
+                  path: /tmp/envoy.admin
+    - name: xds_cluster
+      # This keepalive is recommended by envoy docs.
+      # https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options:
+              connection_keepalive:
+                interval: 30s
+                timeout: 5s
+      connect_timeout: 1s
+      load_assignment:
+        cluster_name: xds_cluster
+        endpoints:
+          lb_endpoints:
+            endpoint:
+              address:
+                socket_address:
+                  address: "net-kourier-controller.knative-serving-ingress.svc.cluster.local."
+                  port_value: 18000
+      type: STRICT_DNS
+admin:
+  access_log:
+  - name: envoy.access_loggers.stdout
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+  address:
+    pipe:
+      path: /tmp/envoy.admin
+layered_runtime:
+  layers:
+    - name: static-layer
+      static_layer:
+        envoy.reloadable_features.override_request_timeout_by_gateway_timeout: false
+----
++
+.Example `BinaryData` output
+[source,terminal]
+----
+Events:  <none>
+----

--- a/modules/customizing-kourier-bootstrap-for-kourier-getaways.adoc
+++ b/modules/customizing-kourier-bootstrap-for-kourier-getaways.adoc
@@ -1,8 +1,11 @@
+// Module included in the following assemblies:
+//
+// * config-applications/configuring-kourier.adoc
 :_content-type: PROCEDURE
 [id="customizing-kourier-bootstrap-for-kourier-getaways_{context}"]
 = Customizing kourier-bootstrap for Kourier getaways
 
-The Envoy proxy component in Kourier handles inbound and outbound HTTP traffic for the Knative services. By default, Kourier contains an Envoy bootstrap configuration in the `kourier-bootstrap` configuration map in the `knative-serving-ingress` namespace. You can change this configuration.
+The Envoy proxy component in Kourier handles inbound and outbound HTTP traffic for the Knative services. By default, Kourier contains an Envoy bootstrap configuration in the `kourier-bootstrap` configuration map in the `knative-serving-ingress` namespace. You can change this configuration map to a custom one.
 
 .Prerequisites
 

--- a/modules/enabling-administrator-interface-access.adoc
+++ b/modules/enabling-administrator-interface-access.adoc
@@ -1,0 +1,73 @@
+// Module included in the following assemblies:
+//
+// * config-applications/configuring-kourier.adoc
+:_content-type: PROCEDURE
+[id="enabling-administrator-interface-access_{context}"]
+= Enabling administrator interface access
+
+You can change the envoy bootstrap configuration to enable access to the administrator interface.
+
+[IMPORTANT]
+====
+This procedure assumes sufficient knowledge of Knative, as changing envoy bootstrap configuration might result in Knative failure. Red Hat does not support custom configurations that are not tested or shipped with the product.
+====
+
+.Prerequisites
+
+* You have installed the {ServerlessOperatorName} and Knative Serving.
+* You have cluster administrator permissions on {ocp-product-title}, or you have cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
+
+.Procedure
+
+. To enable administrator interface access, locate this configuration in your bootstrapping configuration map:
++
+[source,terminal]
+----
+pipe:
+  path: /tmp/envoy.admin
+----
++
+Substitute it with the following configuration:
++
+[source,terminal]
+----
+socket_address: <1>
+  address: 127.0.0.1
+  port_value: 9901
+----
+<1> This configuration enables access to the Envoy admin interface on the loopback address (127.0.0.1) and port 9901.
++
+. Apply the `socket_address` configuration in the `service_stats` cluster configuration and in the `admin` configuration:
+.. The first is in the `service_stats` cluster configuration:
++
+[source,terminal]
+----
+clusters:
+  - name: service_stats
+    connect_timeout: 0.250s
+    type: static
+    load_assignment:
+      cluster_name: service_stats
+      endpoints:
+        lb_endpoints:
+          endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 9901
+----
++
+.. The second is in the `admin` configuration:
++
+[source,terminal]
+----
+admin:
+  access_log:
+    - name: envoy.access_loggers.stdout
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 9901
+----


### PR DESCRIPTION
Version(s):
`serverless-docs-1.34`+

Issue:
https://issues.redhat.com/browse/SRVKS-1182

Link to docs preview:
https://79689--ocpdocs-pr.netlify.app/openshift-serverless/latest/knative-serving/config-applications/configuring-kourier.html

QE review:
- [ ] QE has approved this change.