### PR TITLE
Add peer review squads for Prow reviews

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,5 +21,8 @@ QE review:
 Additional information:
 <!--- Optional: Include additional context or expand the description here.--->
 
-<!--- After you open your PR, ask for review from the OpenShift docs team:
+<!--- After you open your PR, reviewers and approvers are assigned automatically.
+
+  You can also use /assign, /cc @user, /unassign, or /uncc commands to change or modify the reviewer assignment.
+
   For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,101 @@
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#OWNERS_ALIASES
+# Do not change indents
+# Incorrect indents break the Prow CI
+
+aliases:
+  peer-reviewers-a:
+  - bergerhoffer
+  - stevsmit
+  - snarayan-redhat
+  - JoeAldinger
+  - michaelryanpeter
+  - skrthomas
+  - GroceryBoyJr
+  - eohartman
+  - agantony
+  - mletalie
+  - mramendi
+  - aspauldi
+  - abrennan89
+  - mpandya15
+
+  peer-reviewers-b:
+  - bmcelvee
+  - mburke5678
+  - jldohmann
+  - kcarmichael08
+  - ousleyp
+  - opayne1
+  - Srivaralakshmi
+  - dfitzmau
+  - sabrinajess
+  - cbippley
+  - kowen-rh
+  - jmanthei
+  - max-cx
+
+  peer-reviewers-c:
+  - adellape
+  - lpettyjo
+  - jeana-redhat
+  - sheriff-rh
+  - bscott-rh
+  - skopacz1
+  - gaurav-nelson
+  - aldiazRH
+  - tmalove
+  - xenolinux
+  - gwynnemonahan
+  - smunje1
+  - obrown1205
+
+  peer-reviewers-d:
+  - jab-rh
+  - maxwelldb
+  - EricPonvelle
+  - sjhala-ccs
+  - bburt-rh
+  - aireilly
+  - lahinson
+  - ShaunaDiaz
+  - DCChadwick
+  - shipsing
+  - rh-tokeefe
+  - bhardesty
+  - jneczypor
+
+  merge-reviewers:
+  - abhatt-rh
+  - abrennan89
+  - adellape
+  - aireilly
+  - bburt-rh
+  - bergerhoffer
+  - bscott-rh
+  - gabriel-rh
+  - jab-rh
+  - jeana-redhat
+  - JoeAldinger
+  - kalexand-rh
+  - kcarmichael08
+  - mburke5678
+  - michaelryanpeter
+  - opayne1
+  - ousleyp
+  - sjhala-ccs
+  - snarayan-redhat
+  - Srivaralakshmi
+
+  scripts-reviewers:
+  - aireilly
+  - mramendi
+  - gaurav-nelson
+  - rohennes
+  - kalexand-rh
+  - gabriel-rh
+
+  scripts-approvers:
+  - aireilly
+  - gaurav-nelson
+  - kalexand-rh
+  - gabriel-rh

--- a/scripts/OWNERS
+++ b/scripts/OWNERS
@@ -3,11 +3,7 @@
 # Do not change indents
 # Incorrect indents break the Prow CI
 
-# Uncomment to enable review squads
 reviewers:
-- peer-reviewers-a
-# - peer-reviewers-b
-# - peer-reviewers-c
-# - peer-reviewers-d
+- scripts-reviewers
 approvers:
-- merge-reviewers
+- scripts-approvers


### PR DESCRIPTION
Add peer review squads to OWNERS file for automatic Prow review assignment. 

This follows the [code review process](https://www.kubernetes.dev/docs/guide/owners/#the-code-review-process) for docs that is used by the rest of the OpenShift Engineering org.

The OWNERS file is used to designate reviewers and merge approvers. It specifies individuals or teams responsible for specific code areas, facilitating automated assignment of reviewers and approvers for PRs. 

Review assignment is automated. You can also `/assign` or `/cc @user`, or `/unassign`, `/uncc`.

Will need to be reviewed and merged in conjunction with https://github.com/openshift/release/pull/54945

* Every branch, folder, sub-folder can have an OWNERS file. Teams can freely create their own reviewers pool to target specific content.