### PR TITLE
OCPBUGS-13688: Use of pidsLimit is deprecated as of 4.11 and new default is 4096

### DIFF
--- a/modules/create-a-containerruntimeconfig-crd.adoc
+++ b/modules/create-a-containerruntimeconfig-crd.adoc
@@ -15,7 +15,7 @@ To revert the changes implemented by using a `ContainerRuntimeConfig` CR, you mu
 
 You can modify the following settings by using a `ContainerRuntimeConfig` CR:
 
-* **PIDs limit**: Setting the PIDs limit in the `ContainerRuntimeConfig` is expected to be deprecated. If PIDs limits are required, it is recommended to use the `podPidsLimit` field in the `KubeletConfig` CR instead. The default value of the `podPidsLimit` field is `4096`.
+* **PIDs limit**: Setting the PIDs limit in the `ContainerRuntimeConfig` is expected to be deprecated. If PIDs limits are required, it is recommended to use the `podPidsLimit` field in the `KubeletConfig` CR instead. The default `podPidsLimit` value is `4096` and the default `pids_limit` value is `0`. If `podPidsLimit` is lower than `pids_limit` then the effective container PIDs limit is defined by the value set in `podPidsLimit`.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-13688

Link to docs preview:
https://79713--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-configs-custom.html#create-a-containerruntimeconfig_machine-configs-custom

QE review:
- [x] QE has approved this change.
@sunilcio previously signed off on https://github.com/openshift/openshift-docs/pull/60080 but the PR was closed as stale due to commits not being squashed. This PR is just to include the previously approved content.
cc @mrVectorz 
