### PR TITLE
OSDOCS#10361: Removed Configuring AWS security groups to access the API.

### DIFF
--- a/_unused_topics/rosa-hcp-aws-private-security-groups.adoc
+++ b/_unused_topics/rosa-hcp-aws-private-security-groups.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc
+
 [id="rosa-hcp-aws-private-security-groups_{context}"]
 :_mod-docs-content-type: PROCEDURE
 = Configuring AWS security groups to access the API

--- a/rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc
+++ b/rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc
@@ -11,7 +11,6 @@ For {hcp-title-first} workloads that do not require public internet access, you 
 //include::modules/osd-aws-privatelink-about.adoc[leveloffset=+1]
 //include::modules/osd-aws-privatelink-required-resources.adoc[leveloffset=+1]
 include::modules/rosa-hcp-aws-private-create-cluster.adoc[leveloffset=+1]
-include::modules/rosa-hcp-aws-private-security-groups.adoc[leveloffset=+1]
 include::modules/rosa-additional-principals-overview.adoc[leveloffset=+1]
 include::modules/rosa-additional-principals-create.adoc[leveloffset=+2]
 include::modules/rosa-additional-principals-edit.adoc[leveloffset=+2]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
openshift-4.16.z+

Issue:
[OSDOCS-10361](https://issues.redhat.com/browse/OSDOCS-10361)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[Creating a private cluster on ROSA with HCP](https://79720--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-aws-private-creating-cluster.html) - The "Configuring AWS security groups to access the API" section has been removed.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
