### PR TITLE
OCPBUGS-37364: Detail unsupported routes for the External DNS Operator

### DIFF
--- a/networking/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.adoc
+++ b/networking/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.adoc
@@ -9,6 +9,11 @@ toc::[]
 
 The AWS Load Balancer (ALB) Operator deploys and manages an instance of the `AWSLoadBalancerController` resource.
 
+[IMPORTANT]
+====
+The AWS Load Balancer (ALB) Operator is only supported on the `x86_64` architecture.
+====
+
 These release notes track the development of the AWS Load Balancer Operator in {product-title}.
 
 For an overview of the AWS Load Balancer Operator, see xref:../../networking/aws_load_balancer_operator/understanding-aws-load-balancer-operator.adoc#aws-load-balancer-operator[AWS Load Balancer Operator in {product-title}].

--- a/networking/external_dns_operator/external-dns-operator-release-notes.adoc
+++ b/networking/external_dns_operator/external-dns-operator-release-notes.adoc
@@ -6,7 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The External DNS Operator deploys and manages `ExternalDNS` to provide name resolution for services and routes from the external DNS provider to {product-title}.
+The External DNS Operator deploys and manages `ExternalDNS` to provide name resolution for services and routes from the external DNS provider to {product-title}. 
+
+[IMPORTANT]
+====
+The External DNS Operator is only supported on the `x86_64` architecture.
+====
 
 These release notes track the development of the External DNS Operator in {product-title}.
 

--- a/networking/external_dns_operator/nw-creating-dns-records-on-azure.adoc
+++ b/networking/external_dns_operator/nw-creating-dns-records-on-azure.adoc
@@ -8,4 +8,9 @@ toc::[]
 
 You can create DNS records on Azure by using the External DNS Operator.
 
+[IMPORTANT]
+====
+Using the External DNS Operator on a {entra-first}-enabled cluster or a cluster that runs in {azure-full} Government (MAG) regions is not supported.
+====
+
 include::modules/nw-control-dns-records-public-hosted-zone-azure.adoc[leveloffset=+1]

--- a/networking/external_dns_operator/nw-creating-dns-records-on-gcp.adoc
+++ b/networking/external_dns_operator/nw-creating-dns-records-on-gcp.adoc
@@ -6,6 +6,11 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can create DNS records on GCP by using the External DNS Operator.
+You can create DNS records on {gcp-first} by using the External DNS Operator.
+
+[IMPORTANT]
+====
+Using the External DNS Operator on a cluster with {gcp-short} Workload Identity enabled is not supported. For more information about the {gcp-short} Workload Identity, see xref:../../authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc#cco-short-term-creds-gcp_cco-short-term-creds[{gcp-short} Workload Identity].
+====
 
 include::modules/nw-control-dns-records-public-managed-zone-gcp.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.12+

Issues:
* https://issues.redhat.com/browse/OCPBUGS-37635
* https://issues.redhat.com/browse/OCPBUGS-37364
* https://issues.redhat.com/browse/OCPBUGS-37636
* https://issues.redhat.com/browse/OCPBUGS-37443
* https://issues.redhat.com/browse/OCPBUGS-37440

Link to docs preview:
* [AWS Load Balancer Operator release notes](https://79724--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.html)
* [External DNS Operator release notes](https://79724--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/external_dns_operator/external-dns-operator-release-notes.html)
* [Creating DNS records on Azure](https://79724--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/external_dns_operator/nw-creating-dns-records-on-azure.html)
* [Creating DNS records on GCP](https://79724--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/external_dns_operator/nw-creating-dns-records-on-gcp.html)

- [x] SME has approved this change.
- [x] QE has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
