### PR TITLE
OSDOCS-11516: Approved Access Spelling mistake

### DIFF
--- a/support/approved-access.adoc
+++ b/support/approved-access.adoc
@@ -9,7 +9,7 @@ endif::[]
 
 toc::[]
 
-Red{nbsp}Hat Site Reliability Engineering (SRE) typically does not require a elevated access to systems as part of normal operations to manage and support {product-title} clusters. In the unlikely event that SRE needs elevated access to systems, you can use the _Approved Access_ interface to review and _approve_ or _deny_ access to these systems.
+Red{nbsp}Hat Site Reliability Engineering (SRE) typically does not require an elevated access to systems as part of normal operations to manage and support {product-title} clusters. In the unlikely event that SRE needs elevated access to systems, you can use the _Approved Access_ interface to review and _approve_ or _deny_ access to these systems.
 
 Elevated access requests to clusters on {product-rosa} clusters and the corresponding cloud accounts can be created by SRE either in response to a customer-initiated support ticket or in response to alerts received by SRE as part of the standard incident response process.
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-11516

Link to docs preview:
