### PR TITLE
[SRVKS-1260] Correct field name in HTTP/1 sample

### DIFF
--- a/knative-serving/http-configuration/http1-full-duplex-support.adoc
+++ b/knative-serving/http-configuration/http1-full-duplex-support.adoc
@@ -23,7 +23,7 @@ metadata:
   namespace: default
 spec:
   template:
-    spec:
+    metadata:
       annotations:
         features.knative.dev/http-full-duplex: "Enabled"
 ...


### PR DESCRIPTION
Version(s):
serverless-docs-1.33+

Issue:
https://issues.redhat.com/browse/SRVKS-1260

Link to docs preview:
https://79738--ocpdocs-pr.netlify.app/openshift-serverless/latest/knative-serving/http-configuration/http1-full-duplex-support.html

QE review:
- [x] QE has approved this change.
