### PR TITLE
OSDOCS#19873: Added crio capabilities section in machine configuration

### DIFF
--- a/machine_configuration/machine-configs-configure.adoc
+++ b/machine_configuration/machine-configs-configure.adoc
@@ -49,5 +49,16 @@ include::modules/rhcos-load-firmware-blobs.adoc[leveloffset=+1]
 
 * xref:../installing/install_config/installing-customizing.adoc#installation-special-config-butane_installing-customizing[Creating machine configs with Butane]
 
-include::modules/core-user-password.adoc[leveloffset=+1]
+include::modules/core-user-password.adoc[leveloffset=+2]
+
+[id="configuring-machines-with-custom-resources"]
+== Configuring MCO-related custom resources
+
+Besides managing `MachineConfig` objects, the MCO manages two custom resources (CRs): `KubeletConfig` and `ContainerRuntimeConfig`. Those CRs let you change node-level settings impacting how the Kubelet and CRI-O container runtime services behave.
+
+include::modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc[leveloffset=+2]
+include::modules/create-a-containerruntimeconfig-crd.adoc[leveloffset=+2]
+include::modules/set-the-default-max-container-root-partition-size-for-overlay-with-crio.adoc[leveloffset=+2]
+include::modules/create-crio-default-capabilities.adoc[leveloffset=+2]
+
 

--- a/modules/checking-mco-node-status.adoc
+++ b/modules/checking-mco-node-status.adoc
@@ -71,7 +71,7 @@ ip-10-0-74-108.ec2.internal   True      False            False            False 
 $ oc describe machineconfignode/<node_name> <1>
 ----
 <1> The name of the node is the `MachineConfigNode` object name.
-+
+
 .Example output
 [source,text]
 ----

--- a/modules/create-crio-default-capabilities.adoc
+++ b/modules/create-crio-default-capabilities.adoc
@@ -1,0 +1,38 @@
+:_mod-docs-content-type: CONCEPT
+[id="create-crio-default-capabilities_{context}"]
+= Creating a drop-in file for the default capabilities of CRI-O
+
+You can change some of the settings associated with the {product-title} CRI-O runtime for the nodes associated with a specific machine config pool (MCP). By using a controller custom resource (CR), you set the configuration values and add a label to match the MCP. The MCO then rebuilds the `crio.conf` and `default.conf` configuration files on the associated nodes with the updated values.
+
+Earlier versions of {product-title} included specific machine configs by default. If you updated to a later version of {product-title}, those machine configs were retained to ensure that clusters running on the same {product-title} version have the same machine configs.
+
+You can create multiple `ContainerRuntimeConfig` CRs, as needed, with a limit of 10 per cluster. For the first `ContainerRuntimeConfig` CR, the MCO creates a machine config appended with `containerruntime`. With each subsequent CR, the controller creates a `containerruntime` machine config with a numeric suffix. For example, if you have a `containerruntime` machine config with a `-2` suffix, the next `containerruntime` machine config is appended with `-3`.
+
+If you want to delete the machine configs, delete them in reverse order to avoid exceeding the limit. For example, delete the `containerruntime-3` machine config before you delete the `containerruntime-2` machine config.
+
+[NOTE]
+====
+If you have a machine config with a `containerruntime-9` suffix and you create another `ContainerRuntimeConfig` CR, a new machine config is not created, even if there are fewer than 10 `containerruntime` machine configs.
+====
+
+.Example of multiple `ContainerRuntimeConfig` CRs
+[source,terminal]
+----
+$ oc get ctrcfg
+----
+
+.Example output
+[source,terminal]
+----
+NAME         AGE
+ctr-overlay  15m
+ctr-level    5m45s
+----
+
+.Example of multiple `containerruntime` related system configs
+[source,terminal]
+----
+$ cat /proc/1/status | grep Cap
+$ capsh --decode=<decode_CapBnd_value> <1>
+----
+<1> Replace `<decode_CapBnd_value>` with the specific value you want to decode.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-19873
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
