### PR TITLE
OCPBUGS-30568 - Inheritance for canary Machine Config Pools

### DIFF
--- a/modules/update-using-custom-machine-config-pools-inheritance.adoc
+++ b/modules/update-using-custom-machine-config-pools-inheritance.adoc
@@ -1,0 +1,170 @@
+// Module included in the following assemblies:
+//
+// * updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="update-using-custom-machine-config-pools-mcp-inheritance_{context}"]
+= Managing machine configuration inheritance for a worker pool canary
+
+You can configure a machine config pool (MCP) canary to inherit any `MachineConfig` assigned to an existing MCP. 
+This is useful if, for example, you want to use a canary MCP to test as you update the nodes of an existing MCP, one at a time.
+
+
+.Prerequisites
+
+* You have created one or more custom machine config pools (MCP).
+
+.Procedure
+
+. Create a secondary MCP. 
+.. Save the following file as `machineConfigPool.yaml`.
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-perf
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - {
+         key: machineconfiguration.openshift.io/role,
+         operator: In,
+         values: [worker,worker-perf]
+        }
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-perf: "" 
+----
++
+.. Create the new machine config pool by running the following command:
++
+[source,terminal]
+----
+$ oc create -f machineConfigPool.yaml
+----
++
+.Example output
+[source,terminal]
+----
+machineconfigpool.machineconfiguration.openshift.io/worker-perf created
+----
+
+. Add some machines to the secondary MCP.
+This example labels the worker nodes, `worker-b` and `worker-c` to the MCP `worker-perf`:
++
+[source,terminal]
+----
+$ oc label node worker-b node-role.kubernetes.io/worker-perf=''
+$ oc label node worker-c node-role.kubernetes.io/worker-perf=''
+----
+
+. Create a new `MachineConfig` for the MCP `worker-perf`.
+.. Save the following `MachineConfig` example as `new-machineconfig.yaml`.
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 06-kdump-enable-master
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+      - enabled: true
+        name: kdump.service
+  kernelArguments:
+    - crashkernel=512M
+----
+
+.. Apply the `MachineCOnfig` by running the following command:
+[source,terminal]
+----
+oc create -f new-machineconfig.yaml
+----
+
+. Create the new canary MCP and add machines from the MCP you created above.
+This example creates the an MCP called `worker-perf-canary` MCP, and adds machines from the `worker-perf` to it. 
+
+.. Label the canary worker node `worker-a` by running the following command: 
++
+[source,terminal]
+----
+$ oc label node worker-a node-role.kubernetes.io/worker-perf-canary=''
+----
+
+.. Save the following file as `machineConfigPool-Canary.yaml`.
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-perf-canary
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - {
+         key: machineconfiguration.openshift.io/role,
+         operator: In,
+         values: [worker-perf,worker-perf-canary] <1>
+        }
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-perf-canary: ""
+----
+<1> This exmaple includes `worker-perf-canary` as an optional value. You can use a value in this way to configure members of an additional `MachineConfig`.
+
+.. Create the new worker-perf-canary by running the following command:
++
+[source,terminal]
+----
+$ oc create -f machineConfigPool-Canary.yaml
+----
++
+.Example output
+[source,terminal]
+----
+machineconfigpool.machineconfiguration.openshift.io/worker-perf-canary created
+----
+
+. Check if the `MachineConfig` is inherited in `worker-perf-canary`. 
+.. Verify that no MCP is degraded by running the following command:
++
+[source,terminal]
+----
+$ oc get mcp
+----
++
+.Example output
+[source,terminal]
+----
+NAME                  CONFIG                                                          UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
+master                rendered-master-2bf1379b39e22bae858ea1a3ff54b2ac                True      False      False      3              3                   3                     0                      5d16h
+worker                rendered-worker-b9576d51e030413cfab12eb5b9841f34                True      False      False      0              0                   0                     0                      5d16h
+workers-perf          rendered-workers-perf-b98a1f62485fa702c4329d17d9364f6a          True      False      False      2              2                   2                     0                      56m
+workers-perf-canary   rendered-workers-perf-canary-b98a1f62485fa702c4329d17d9364f6a   True      False      False      1              1                   1                     0                      44m
+----
+
+.. Verify that the MCs are inherited from `worker-perf` into `worker-perf-canary`.
++
+[source,terminal]
+----
+$ oc get nodes
+----
++
+.Example output
+[source,terminal]
+----
+NAME       STATUS   ROLES                        AGE     VERSION
+...
+worker-a   Ready    worker,worker-perf-canary   5d15h   v1.27.13+e709aa5
+worker-b   Ready    worker,worker-perf          5d15h   v1.27.13+e709aa5
+worker-c   Ready    worker,worker-perf          5d15h   v1.27.13+e709aa5
+----

--- a/modules/update-using-custom-machine-config-pools-mcp-remove.adoc
+++ b/modules/update-using-custom-machine-config-pools-mcp-remove.adoc
@@ -22,7 +22,7 @@ A node must have a role to be properly functioning in the cluster.
 $ oc label node ci-ln-0qv1yp2-f76d1-kl2tq-worker-a-j2ssz node-role.kubernetes.io/worker=
 ----
 +
-.Example output if the `worker` label is present
+.Example output if the `worker` label is present:
 +
 [source,terminal]
 ----

--- a/updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc
+++ b/updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc
@@ -135,6 +135,9 @@ include::modules/update-using-custom-machine-config-pools-about.adoc[leveloffset
 // Creating machine config pools to perform a canary rollout update
 include::modules/update-using-custom-machine-config-pools-mcp.adoc[leveloffset=+1]
 
+// Managing machine configuration inheritance for a worker pool canary
+include::modules/update-using-custom-machine-config-pools-inheritance.adoc[leveloffset=+1]
+
 // Pausing the machine config pools
 include::modules/update-using-custom-machine-config-pools-pause.adoc[leveloffset=+1]
 
@@ -153,3 +156,4 @@ include::modules/update-using-custom-machine-config-pools-unpause.adoc[leveloffs
 
 // Moving a node to the original machine config pool
 include::modules/update-using-custom-machine-config-pools-mcp-remove.adoc[leveloffset=+1]
+


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-30568
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Managing machine configuration inheritance for a worker pool canary](https://79755--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/update-using-custom-machine-config-pools.html#update-using-custom-machine-config-pools-mcp-inheritance_update-using-custom-machine-config-pools)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
