### PR TITLE
[enterprise-4.15] TELCODOCS-1976: Adding content for improved SR-IOV Network Operator node draining

### DIFF
--- a/modules/nw-sriov-configuring-multiple-nodes.adoc
+++ b/modules/nw-sriov-configuring-multiple-nodes.adoc
@@ -1,0 +1,171 @@
+:_mod-docs-content-type: PROCEDURE
+[id="configure-sr-iov-operator-parallel-nodes_{context}"]
+= Configuring parallel node draining during SR-IOV network policy updates
+
+By default, the SR-IOV Network Operator drains workloads from a node before every policy change.
+The Operator completes this action, one node at a time, to ensure that no workloads are affected by the reconfiguration.
+
+In large clusters, draining nodes sequentially can be time-consuming, taking hours or even days. In time-sensitive environments, you can enable parallel node draining in an `SriovNetworkPoolConfig` custom resource (CR) for faster rollouts of SR-IOV network configurations. 
+
+To configure parallel draining, use the `SriovNetworkPoolConfig` CR to create a node pool. You can then add nodes to the pool and define the maximum number of nodes in the pool that the Operator can drain in parallel. With this approach, you can enable parallel draining for faster reconfiguration while ensuring you still have enough nodes remaining in the pool to handle any running workloads.
+
+[NOTE]
+====
+A node can belong to only one SR-IOV network pool configuration. If a node is not part of a pool, it is added to a virtual, default pool that is configured to drain one node at a time only.
+
+The node might restart during the draining process.
+====
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+* Install the SR-IOV Network Operator.
+* Ensure that nodes have hardware that supports SR-IOV.
+
+.Procedure
+
+. Create a `SriovNetworkPoolConfig` resource:
+
+.. Create a YAML file that defines the `SriovNetworkPoolConfig` resource:
++
+.Example `sriov-nw-pool.yaml` file
+[source,yaml]
+----
+apiVersion: v1
+kind: SriovNetworkPoolConfig
+metadata:
+  name: pool-1 <1>
+  namespace: openshift-sriov-network-operator <2>
+spec:
+  maxUnavailable: 2 <3>
+  nodeSelector: <4>
+    matchLabels:
+      node-role.kubernetes.io/worker: ""
+----
+<1> Specify the name of the `SriovNetworkPoolConfig` object.
+<2> Specify namespace where the SR-IOV Network Operator is installed.
+<3> Specify an integer number or percentage value for nodes that can be unavailable in the pool during an update. For example, if you have 10 nodes and you set the maximum unavailable value to 2, then only 2 nodes can be drained in parallel at any time, leaving 8 nodes for handling workloads.
+<4> Specify the nodes to add the pool by using the node selector. This example adds all nodes with the `worker` role to the pool.
+
+.. Create the `SriovNetworkPoolConfig` resource by running the following command:
++
+[source,terminal]
+----
+$ oc create -f sriov-nw-pool.yaml
+----
+
+. Create the `sriov-test` namespace by running the following comand:
++
+[source,terminal]
+----
+$ oc create namespace sriov-test
+----
+
+. Create a `SriovNetworkNodePolicy` resource:
+
+..  Create a YAML file that defines the `SriovNetworkNodePolicy` resource:
++
+.Example `sriov-node-policy.yaml` file
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: sriov-nic-1
+  namespace: openshift-sriov-network-operator
+spec:
+  deviceType: netdevice
+  nicSelector:
+    pfNames: ["ens1"]
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+  numVfs: 5
+  priority: 99
+  resourceName: sriov_nic_1
+----
+
+.. Create the `SriovNetworkNodePolicy` resource by running the following command:
++
+[source,terminal]
+----
+$ oc create -f sriov-node-policy.yaml
+----
+
+. Create a `SriovNetwork` resource:
+
+.. Create a YAML file that defines the `SriovNetwork` resource:
++
+.Example `sriov-network.yaml` file
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: sriov-nic-1
+  namespace: openshift-sriov-network-operator
+spec:
+  linkState: auto
+  networkNamespace: sriov-test
+  resourceName: sriov_nic_1
+  capabilities: '{ "mac": true, "ips": true }'
+  ipam: '{ "type": "static" }'
+----
+
+.. Create the `SriovNetwork` resource by running the following command:
++
+[source,terminal]
+----
+$ oc create -f sriov-network.yaml
+----
+
+.Verification 
+
+* View the node pool you created by running the following command:
++
+[source,terminal]
+----
+$ oc get sriovNetworkpoolConfig -n openshift-sriov-network-operator
+----
++
+.Example output
+[source,terminal]
+----
+NAME     AGE
+pool-1   67s <1>
+----
+<1> In this example, `pool-1` contains all the nodes with the `worker` role.
+
+To demonstrate the node draining process by using the example scenario from the previous procedure, complete the following steps:
+
+. Update the number of virtual functions in the `SriovNetworkNodePolicy` resource to trigger workload draining in the cluster:
++
+[source,terminal]
+----
+$ oc patch SriovNetworkNodePolicy sriov-nic-1 -n openshift-sriov-network-operator --type merge -p '{"spec": {"numVfs": 4}}'
+----
+
+. Monitor the draining status on the target cluster by running the following command:
++
+[source,terminal]
+----
+$ oc get sriovNetworkNodeState -n openshift-sriov-network-operator
+----
++
+.Example output
+[source,terminal]
+----
+NAMESPACE                          NAME       SYNC STATUS   DESIRED SYNC STATE   CURRENT SYNC STATE   AGE
+openshift-sriov-network-operator   worker-0   InProgress    Drain_Required       DrainComplete        3d10h
+openshift-sriov-network-operator   worker-1   InProgress    Drain_Required       DrainComplete        3d10h
+----
++
+When the draining process is complete, the `SYNC STATUS` changes to `Succeeded`, and the `DESIRED SYNC STATE` and `CURRENT SYNC STATE` values return to `IDLE`.
++
+.Example output
+[source,terminal]
+----
+NAMESPACE                          NAME       SYNC STATUS   DESIRED SYNC STATE   CURRENT SYNC STATE   AGE
+openshift-sriov-network-operator   worker-0   Succeeded     Idle                 Idle                 3d10h
+openshift-sriov-network-operator   worker-1   Succeeded     Idle                 Idle                 3d10h
+----

--- a/networking/hardware_networks/configuring-sriov-device.adoc
+++ b/networking/hardware_networks/configuring-sriov-device.adoc
@@ -14,13 +14,14 @@ include::modules/nw-sriov-networknodepolicy-object.adoc[leveloffset=+1]
 
 include::modules/nw-sriov-nic-partitioning.adoc[leveloffset=+2]
 
-
 include::modules/nw-sriov-configuring-device.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-updating_nodes-nodes-working[Understanding how to update labels on nodes].
+
+include::modules/nw-sriov-configuring-multiple-nodes.adoc[leveloffset=+2]
 
 include::modules/nw-sriov-troubleshooting.adoc[leveloffset=+1]
 

--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -706,6 +706,13 @@ With this release, you can use the `NodeNetworkConfigurationPolicy` resource to 
 
 For example, you can configure a host network Quality of Service (QoS) policy to manage network access to host resources by an attached SR-IOV network VF. For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc#virt-example-vf-host-services_k8s_nmstate-updating-node-network-config[Node network configuration policy for virtual functions].
 
+[id="ocp-4-15-networking-sriov-draining"]
+==== Parallel node draining during SR-IOV network policy updates
+
+With this update, you can configure the SR-IOV Network Operator to drain nodes in parallel during network policy updates. The option to drain nodes in parallel enables faster rollouts of SR-IOV network configurations. You can use the `SriovNetworkPoolConfig` custom resource to configure parallel node draining and define the maximum number of nodes in the pool that the Operator can drain in parallel.
+
+For more information, see xref:../networking/hardware_networks/configuring-sriov-device.adoc#configure-sr-iov-operator-parallel-nodes_configuring-sriov-device[Configuring parallel node draining during SR-IOV network policy updates].
+
 [id="ocp-4-15-registry"]
 === Registry
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-1976
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

- https://79757--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-device.html
- https://79757--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-networking-sriov-draining

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Cherrypicked from the original main and RN PRs:
* [Main](https://github.com/openshift/openshift-docs/pull/74464)
* [RN](https://github.com/openshift/openshift-docs/pull/75620)
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
