### PR TITLE
OSDOCS-11521: removed caveat for 4.17+

### DIFF
--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -448,10 +448,6 @@ defaultNetwork:
       ipsecConfig:
         mode: Full
 ----
-[IMPORTANT]
-====
-Using OVNKubernetes can lead to a stack exhaustion problem on {ibm-power-name}.
-====
 
 [discrete]
 [id="nw-operator-cr-kubeproxyconfig_{context}"]


### PR DESCRIPTION
Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-11521

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ x ] QE has approved this change. Change confirmed by @mffiedler 