### PR TITLE
HCIDOCS-400: Wrong title for baremetal installation section

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -399,7 +399,7 @@ Topics:
   - Name: Setting up the environment for an OpenShift installation
     File: ipi-install-installation-workflow
   - Name: Installing a cluster
-    File: ipi-install-installation
+    File: ipi-install-installing-a-cluster
   - Name: Postinstallation configuration
     File: ipi-install-post-installation-configuration
   - Name: Expanding the cluster

--- a/installing/installing_bare_metal_ipi/ipi-install-installing-a-cluster.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installing-a-cluster.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="ipi-install-installation"]
-= Installing OpenShift
+[id="ipi-install-installing-a-cluster"]
+= Installing a cluster
 include::_attributes/common-attributes.adoc[]
-:context: ipi-install-installation
+:context: ipi-install-installing-a-cluster
 
 toc::[]
 
@@ -10,7 +10,7 @@ toc::[]
 include::modules/ipi-install-deploying-the-cluster-via-the-openshift-installer.adoc[leveloffset=+1]
 
 // Following the installation
-include::modules/ipi-install-following-the-installation.adoc[leveloffset=+1]
+include::modules/ipi-install-following-the-progress-of-the-installation.adoc[leveloffset=+1]
 
 // Verifying static IP address configuration
 include::modules/ipi-install-verifying-static-ip-address-configuration.adoc[leveloffset=+1]

--- a/installing/installing_ibm_cloud/install-ibm-cloud-installation-workflow.adoc
+++ b/installing/installing_ibm_cloud/install-ibm-cloud-installation-workflow.adoc
@@ -24,4 +24,4 @@ include::modules/ipi-install-creating-the-openshift-manifests.adoc[leveloffset=+
 
 include::modules/ipi-install-deploying-the-cluster-via-the-openshift-installer.adoc[leveloffset=+1]
 
-include::modules/ipi-install-following-the-installation.adoc[leveloffset=+1]
+include::modules/ipi-install-following-the-progress-of-the-installation.adoc[leveloffset=+1]

--- a/installing/overview/index.adoc
+++ b/installing/overview/index.adoc
@@ -25,7 +25,7 @@ include::modules/ipi-verifying-nodes-after-installation.adoc[leveloffset=+2]
 
 * xref:../../post_installation_configuration/post-install-bare-metal-configuration.adoc#getting-the-baremetalhost-resource_post-install-bare-metal-configuration[Getting the BareMetalHost resource]
 
-* xref:../../installing/installing_bare_metal_ipi/ipi-install-installation.adoc#ipi-install-troubleshooting-following-the-installation_ipi-install-installation[Following the installation]
+* xref:../../installing/installing_bare_metal_ipi/ipi-install-installing-a-cluster.adoc#ipi-install-following-the-progress-of-the-installation_ipi-install-installing-a-cluster[Following the progress of the installation]
 
 * xref:../../installing/validation_and_troubleshooting/validating-an-installation.adoc#validating-an-installation[Validating an installation]
 

--- a/modules/ipi-install-following-the-progress-of-the-installation.adoc
+++ b/modules/ipi-install-following-the-progress-of-the-installation.adoc
@@ -3,8 +3,8 @@
 //installing/installing_bare_metal_ipi/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="ipi-install-troubleshooting-following-the-installation_{context}"]
-= Following the installation
+[id="ipi-install-following-the-progress-of-the-installation_{context}"]
+= Following the progress of the installation
 
 During the deployment process, you can check the installation's overall status by issuing the `tail` command to the `.openshift_install.log` log file in the install directory folder:
 


### PR DESCRIPTION
Changed file names as requested by reviewers. This is in relation to https://github.com/openshift/openshift-docs/pull/79078

Fixes: [HCIDOCS-400](https://issues.redhat.com//browse/HCIDOCS-400)

See https://issues.redhat.com/browse/HCIDOCS-400 for additional details.

Preview URL: https://79771--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installing-a-cluster.html
https://79771--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud/install-ibm-cloud-installation-workflow.html
https://79771--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/overview/index.html

For release(s): 4.17, 4.16
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
