### PR TITLE
[OSDOCS-11556]Document Support A2 (NVIDIA A100 80 GB) GCP nodes

### DIFF
--- a/modules/sdpolicy-am-gcp-compute-types.adoc
+++ b/modules/sdpolicy-am-gcp-compute-types.adoc
@@ -90,4 +90,9 @@
 * a2-highgpu-4g (48 vCPU, 340 GiB)
 * a2-highgpu-8g (96 vCPU, 680 GiB)
 * a2-megagpu-16g (96 vCPU, 1.33 TiB)
+* a2-ultragpu-1g (12 vCPU, 170 GiB)
+* a2-ultragpu-2g (24 vCPU, 340 GiB)
+* a2-ultragpu-4g (48 vCPU, 680 GiB)
+* a2-ultragpu-8g (96 vCPU, 1360 GiB)
+
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.16+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-11556
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://79782--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-service-definition.html#gcp-compute-types_osd-service-definition
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
