### PR TITLE
OSDOCS-10967: Update responsibility matrix

### DIFF
--- a/modules/rosa-policy-change-management.adoc
+++ b/modules/rosa-policy-change-management.adoc
@@ -114,7 +114,8 @@ You can review the history of all cluster upgrade events in the {cluster-manager
 
 - Set up internal networking components required for internal cluster communication between worker, infrastructure, and control plane nodes.
 
-|- Provide optional non-default IP address ranges for machine CIDR, service CIDR, and pod CIDR if needed through {cluster-manager} when the cluster is provisioned.
+|- Configure your firewall to grant access to the required OpenShift and AWS domains and ports before the cluster is provisioned. For more information, see "AWS firewall prerequisites".
+- Provide optional non-default IP address ranges for machine CIDR, service CIDR, and pod CIDR if needed through {cluster-manager} when the cluster is provisioned.
 - Request that the API service endpoint be made public or private on cluster creation or after cluster creation through {cluster-manager}.
 
 |Virtual networking management

--- a/modules/rosa-policy-responsibilities.adoc
+++ b/modules/rosa-policy-responsibilities.adoc
@@ -36,7 +36,7 @@ If the `cluster-admin` role is added to a user, see the responsibilities and exc
 
 |Application networking |Red{nbsp}Hat and Customer |Red{nbsp}Hat and Customer |Red{nbsp}Hat and Customer |Red{nbsp}Hat |Red{nbsp}Hat
 
-|Cluster networking |Red{nbsp}Hat |Red{nbsp}Hat and Customer |Red{nbsp}Hat and Customer |Red{nbsp}Hat |Red{nbsp}Hat
+|Cluster networking |Red{nbsp}Hat |Red{nbsp}Hat and Customer ^[1]^ |Red{nbsp}Hat and Customer |Red{nbsp}Hat |Red{nbsp}Hat
 
 |Virtual networking management |Red{nbsp}Hat and Customer |Red{nbsp}Hat and Customer |Red{nbsp}Hat and Customer |Red{nbsp}Hat and Customer |Red{nbsp}Hat and Customer
 
@@ -54,3 +54,4 @@ If the `cluster-admin` role is added to a user, see the responsibilities and exc
 |Hardware/AWS global infrastructure |AWS |AWS |AWS |AWS |AWS
 
 |===
+. The customer must configure their firewall to grant access to the required OpenShift and AWS domains and ports before the cluster is provisioned. For more information, see "AWS firewall prerequisites".

--- a/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.adoc
@@ -9,6 +9,13 @@ toc::[]
 This documentation outlines Red{nbsp}Hat, Amazon Web Services (AWS), and customer responsibilities for the {product-title} (ROSA) managed service.
 
 include::modules/rosa-policy-responsibilities.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../rosa_planning/rosa-sts-aws-prereqs.adoc#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs[AWS firewall prerequisites]
+
+
 include::modules/rosa-policy-shared-responsibility.adoc[leveloffset=+1]
 
 [id="review-action-notifications_{context}"]
@@ -21,6 +28,12 @@ include::modules/managed-cluster-notification-policy.adoc[leveloffset=+2]
 
 include::modules/rosa-policy-incident.adoc[leveloffset=+1]
 include::modules/rosa-policy-change-management.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../rosa_planning/rosa-sts-aws-prereqs.adoc#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs[AWS firewall prerequisites]
+
 include::modules/rosa-policy-security-and-compliance.adoc[leveloffset=+1]
 include::modules/rosa-policy-disaster-recovery.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
* enterprise-4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-10967

Link to docs preview:
* Responsibility matrix: https://79796--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.html
* Release management table: https://79796--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.html#rosa-policy-release-management_rosa-policy-responsibility-matrix

QE review:
* Not required
