### PR TITLE
OSDOCS#10721: Disaster recovery - add a step to wait for redeployment to complete

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -628,7 +628,18 @@ $ oc patch etcd cluster -p='{"spec": {"forceRedeploymentReason": "recovery-'"$( 
 ----
 <1> The `forceRedeploymentReason` value must be unique, which is why a timestamp is appended.
 +
+The `etcd` redeployment starts.
++
 When the `etcd` cluster Operator performs a redeployment, the existing nodes are started with new pods similar to the initial bootstrap scale up.
+
+. Monitor the `etcd` instances by running:
++
+[source,terminal]
+----
+$ oc adm wait-for-stable-cluster
+----
++
+This process can take up to 15 minutes.
 
 . Turn the quorum guard back on by entering:
 +


### PR DESCRIPTION
Version(s):
4.16+

[Link](https://79802--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html#dr-scenario-2-restoring-cluster-state_dr-restoring-cluster-state) to docs preview: (updated 8/1)
Changes on Steps 18 and 19.

QE review:
- [x ] QE has approved this change.