### PR TITLE
OSDOCS-10060: Documented Support for migrating from SDN to OVN with N…

### DIFF
--- a/modules/checking-cluster-resources-before-initiating-limited-live-migration.adoc
+++ b/modules/checking-cluster-resources-before-initiating-limited-live-migration.adoc
@@ -6,9 +6,9 @@
 [id="checking-cluster-resources-before-initiating-limited-live-migration_{context}"]
 = Checking cluster resources before initiating the limited live migration
 
-Before migrating to OVN-Kubernetes by using the limited live migration, you should check for egress IP resources, egress firewall resources, and multicast enabled namespaces on your OpenShift SDN deployment. You should also review any network policies in your deployment. If you find that your cluster has these resources before migration, you should check their behavior after migration to ensure that they are working as intended.
+Before migrating to OVN-Kubernetes by using the limited live migration, you should check for egress IP resources, egress firewall resources, and multicast-enabled namespaces on your OpenShift SDN deployment. You should also review any network policies in your deployment. If you find that your cluster has these resources before migration, you should check their behavior after migration to ensure that they are working as intended.
 
-The following procedure shows you how to check for egress IP resources, egress firewall resources, multicast enabled namespaces, and network policies. No action is necessary after checking for these resources.
+The following procedure shows you how to check for egress IP resources, egress firewall resources, multicast-enabled namespaces, network policies, and an NNCP. No action is necessary after checking for these resources.
 
 .Prerequisites
 

--- a/modules/nw-ovn-kubernetes-live-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-live-migration-about.adoc
@@ -60,6 +60,8 @@ Before using the limited live migration method to the OVN-Kubernetes network plu
 
 * OpenShift SDN does not support IPv6. After the migration, cluster administrators can enable dual-stack.
 
+* The OpenShift SDN plugin allows application of the `NodeNetworkConfigurationPolicy` (NNCP) custom resource (CR) to the primary interface on a node. The OVN-Kubernetes network plugin does not have this capability.
+
 * The cluster MTU is the MTU value for pod interfaces. It is always less than your hardware MTU to account for the cluster network overlay overhead. The overhead is 100 bytes for OVN-Kubernetes and 50 bytes for OpenShift SDN.
 +
 During the limited live migration, both OVN-Kubernetes and OpenShift SDN run in parallel. OVN-Kubernetes manages the cluster network of some nodes, while OpenShift SDN manages the cluster network of others. To ensure that cross-CNI traffic remains functional, the Cluster Network Operator updates the routable MTU to ensure that both CNIs share the same overlay MTU. As a result, after the migration has completed, the cluster MTU is 50 bytes less.

--- a/modules/nw-ovn-kubernetes-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-migration-about.adoc
@@ -61,6 +61,14 @@ While the OVN-Kubernetes network plugin implements many of the capabilities pres
 The following sections highlight the differences in configuration between the aforementioned capabilities in OVN-Kubernetes and OpenShift SDN network plugins.
 
 [discrete]
+[id="migrating-sdn-primary-interface_{context}"]
+=== Primary network interface
+
+The OpenShift SDN plugin allows application of the `NodeNetworkConfigurationPolicy` (NNCP) custom resource (CR) to the primary interface on a node. The OVN-Kubernetes network plugin does not have this capability.
+
+If you have an NNCP applied to the primary interface, you must delete the NNCP before migrating to the OVN-Kubernetes network plugin. Deleting the NNCP does not remove the configuration from the primary interface, but the Kubernetes-NMState cannot manage this configuration. Instead, the `configure-ovs.sh` shell script manages the primary interface and the configuration attached to it.
+
+[discrete]
 [id="namespace-isolation_{context}"]
 === Namespace isolation
 

--- a/modules/nw-ovn-kubernetes-migration.adoc
+++ b/modules/nw-ovn-kubernetes-migration.adoc
@@ -7,25 +7,23 @@
 [id="nw-ovn-kubernetes-migration_{context}"]
 = Migrating to the OVN-Kubernetes network plugin by using the offline migration method
 
-As a cluster administrator, you can change the network plugin for your cluster to OVN-Kubernetes.
-During the migration, you must reboot every node in your cluster.
+As a cluster administrator, you can change the network plugin for your cluster to OVN-Kubernetes. During the migration, you must reboot every node in your cluster.
 
 [IMPORTANT]
 ====
-While performing the migration, your cluster is unavailable and workloads might be interrupted.
-Perform the migration only when an interruption in service is acceptable.
+While performing the migration, your cluster is unavailable and workloads might be interrupted. Perform the migration only when an interruption in service is acceptable.
 ====
 
 .Prerequisites
 
-* A cluster configured with the OpenShift SDN CNI network plugin in the network policy isolation mode.
-* Install the OpenShift CLI (`oc`).
-* Access to the cluster as a user with the `cluster-admin` role.
-* A recent backup of the etcd database is available.
-* A reboot can be triggered manually for each node.
-* The cluster is in a known good state, without any errors.
-* Before migration to the OVN-Kubernetes plugin, a security group rule must be in place to allow UDP packets on port `6081` for all nodes on all cloud platforms.
-* Before migration to the OVN-Kubernetes plugin, you must either set all timeouts for webhooks to `3` seconds or remove the webhooks.
+* You have a cluster configured with the OpenShift SDN CNI network plugin in the network policy isolation mode.
+* You installed the {oc-first}.
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have a recent backup of the etcd database is available.
+* You can manually reboot each node.
+* You checked that your cluster is in a known good state without any errors.
+* You created a security group rule that allows User Datagram Protocol (UDP) packets on port `6081` for all nodes on all cloud platforms.
+* You set all timeouts for webhooks to `3` seconds or removed the webhooks.
 
 .Procedure
 
@@ -66,6 +64,31 @@ EOT
 [source,terminal]
 ----
 $ oc patch Network.operator.openshift.io cluster --type='merge' \ --patch '{"spec":{"migration":null}}'
+----
+
+. Delete the `NodeNetworkConfigurationPolicy` (NNCP) custom resource (CR) that defines the primary network interface for the OpenShift SDN network plugin by completing the following steps:
++
+.. Check that the existing NNCP CR bonded the primary interface to your cluster by entering the following command: 
++
+[source,terminal]
+----
+$ oc get nncp
+----
++
+.Example output
+[source,terminal]
+----
+NAME          STATUS      REASON
+bondmaster0   Available   SuccessfullyConfigured
+----
++
+Network Manager stores the connection profile for the bonded primary interface in the `/etc/NetworkManager/system-connections` system path.
++
+.. Remove the NNCP from your cluster:
++
+[source,terminal]
+----
+$ oc delete nncp <nncp_manifest_filename>
 ----
 
 . To prepare all the nodes for the migration, set the `migration` field on the CNO configuration object by running the following command:

--- a/modules/removing-nncp-initiating-limited-live-migration.adoc
+++ b/modules/removing-nncp-initiating-limited-live-migration.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="removing-nncp-initiating-limited-live-migration_{context}"]
+= Removing the `NodeNetworkConfigurationPolicy` (NNCP) custom resource (CR)
+
+The OpenShift SDN plugin allows application of the NodeNetworkConfigurationPolicy (NNCP) custom resource (CR) to the primary interface on a node. The OVN-Kubernetes network plugin does not have this capability.
+
+If you have an NNCP applied to the primary interface, you must delete the NNCP before migrating to the OVN-Kubernetes network plugin. Deleting the NNCP does not remove the configuration from the primary interface, but the Kubernetes-NMState cannot manage this configuration. Instead, the `configure-ovs.sh` shell script manages the primary interface and the configuration attached to it.
+
+.Prerequisties
+
+
+.Procedure
+
+. Remove the configuration from the Cluster Network Operator (CNO) configuration object by running the following command:
++
+[source,terminal]
+----
+$ oc patch Network.operator.openshift.io cluster --type='merge' \ --patch '{"spec":{"migration":null}}'
+----
+
+. Delete the `NodeNetworkConfigurationPolicy` (NNCP) custom resource (CR) that defines the primary network interface for the OpenShift SDN network plugin by completing the following steps:
++
+.. Check that the existing NNCP CR bonded the primary interface to your cluster by entering the following command: 
++
+[source,terminal]
+----
+$ oc get nncp
+----
++
+.Example output
+[source,terminal]
+----
+NAME          STATUS      REASON
+bondmaster0   Available   SuccessfullyConfigured
+----
++
+Network Manager stores the connection profile for the bonded primary interface in the `/etc/NetworkManager/system-connections` system path.
++
+.. Remove the NNCP from your cluster:
++
+[source,terminal]
+----
+$ oc delete nncp <nncp_manifest_filename>
+----

--- a/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
@@ -10,19 +10,46 @@ As a cluster administrator, you can migrate to the OVN-Kubernetes network plugin
 
 To learn more about OVN-Kubernetes, read xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes#about-ovn-kubernetes[About the OVN-Kubernetes network plugin].
 
+// Offline migration to the OVN-Kubernetes network plugin overview
 include::modules/nw-ovn-kubernetes-migration-about.adoc[leveloffset=+1]
+
+// How the offline migration process works
 include::modules/nw-network-plugin-migration-process.adoc[leveloffset=+2]
+
+// Migrating to the OVN-Kubernetes network plugin by using the offline migration method
 include::modules/nw-ovn-kubernetes-migration.adoc[leveloffset=+2]
 
+// Limited live migration to the OVN-Kubernetes network plugin overview
 include::modules/nw-ovn-kubernetes-live-migration-about.adoc[leveloffset=+1]
+
+// How the live migration process works
 include::modules/how-the-live-migration-process-works.adoc[leveloffset=+2]
+
+// Migrating to the OVN-Kubernetes network plugin by using the limited live migration method
 include::modules/nw-ovn-kubernetes-live-migration.adoc[leveloffset=+2]
+
+// Checking cluster resources before initiating the limited live migration
 include::modules/checking-cluster-resources-before-initiating-limited-live-migration.adoc[leveloffset=+3]
+
+// Removing egress router pods before initiating the limited live migration
 include::modules/removing-egress-router-pods-before-initiating-limited-live-migration.adoc[leveloffset=+3]
+
+// Removing the NodeNetworkConfigurationPolicy (NNCP) custom resource (CR)
+include::modules/removing-nncp-initiating-limited-live-migration.adoc[leveloffset=+3]
+
+// Initiating the limited live migration process
 include::modules/initiating-limited-live-migration.adoc[leveloffset=+3]
+
+// Patching OVN-Kubernetes address ranges
 include::modules/patching-ovnk-address-ranges.adoc[leveloffset=+3]
+
+// Checking cluster resources after initiating the limited live migration
 include::modules/checking-cluster-resources-after-initiating-limited-live-migration.adoc[leveloffset=+3]
+
+// Checking limited live migration metrics
 include::modules/nw-ovn-kubernetes-checking-live-migration-metrics.adoc[leveloffset=+2]
+
+// Information about limited live migration metrics
 include::modules/live-migration-metrics-information.adoc[leveloffset=+3]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-10060](https://issues.redhat.com/browse/OSDOCS-10060)

Link to docs preview:
* [Considerations for offline migration to the OVN-Kubernetes network plugin](https://79807--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#considerations-migrating-ovn-kubernetes-network-provider_migrate-from-openshift-sdn)
* [Migrating to the OVN-Kubernetes network plugin by using the offline migration method](https://79807--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#nw-ovn-kubernetes-migration_migrate-from-openshift-sdn)
* [Removing the NodeNetworkConfigurationPolicy (NNCP) custom resource (CR)](https://79807--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#removing-nncp-initiating-limited-live-migration_migrate-from-openshift-sdn)

- [ ] SME has approved this change.
- [ ] QE has approved this change.

Additional information:
* [NP-1036](https://issues.redhat.com/browse/NP-1036)
* [OPNET-499](https://issues.redhat.com/browse/OPNET-499)
* [Migrating from the OpenShift SDN network plugin](https://docs.openshift.com/container-platform/4.16/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#how-the-migration-process-works_migrate-from-openshift-sdn)
* [Installing the Kubernetes NMState Operator](https://docs.openshift.com/container-platform/4.16/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.html#installing-the-kubernetes-nmstate-operator-cli)
* [BM Install doc](https://docs.openshift.com/container-platform/4.16/installing/installing_bare_metal/installing-bare-metal-network-customizations.html#creating-manifest-file-customized-br-ex-bridge_installing-bare-metal-network-customizations)
