### PR TITLE
OADP-3920 added review section for backup and restore

### DIFF
--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
@@ -31,6 +31,8 @@ The `CloudStorage` API supports manually creating a `BackupStorageLocation` obje
 The {oadp-first} does not support backing up volume snapshots that were created by other software.
 ====
 
+include::modules/oadp-review-backup-restore.adoc[leveloffset=+1]
+
 You can create backup hooks to run commands before or after the backup operation. See xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-hooks-doc.adoc#oadp-creating-backup-hooks-doc[Creating backup hooks].
 
 You can schedule backups by creating a `Schedule` CR instead of a `Backup` CR. See xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-scheduling-backups-doc.adoc#oadp-scheduling-backups-doc[Scheduling backups using Schedule CR]].

--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc
@@ -10,5 +10,6 @@ You restore application backups by creating a `Restore` custom resource (CR). Se
 
 You can create restore hooks to run commands in a container in a pod by editing the `Restore` CR. See xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc#oadp-creating-restore-hooks_restoring-applications[Creating restore hooks].
 
+include::modules/oadp-review-backup-restore.adoc[leveloffset=+1]
 include::modules/oadp-creating-restore-cr.adoc[leveloffset=+1]
 include::modules/oadp-creating-restore-hooks.adoc[leveloffset=+1]

--- a/modules/oadp-review-backup-restore.adoc
+++ b/modules/oadp-review-backup-restore.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc
+// * backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="oadp-review-backup-restore_{context}"]
+= Previewing resources before running backup and restore
+
+{oadp-short} backs up application resources based on the type, namespace, or label. This means that you can view the resources after the backup is complete. Similarly, you can view the restored objects based on the namespace, persistent volume (PV), or label after a restore operation is complete. To preview the resources in advance, you can do a dry run of the backup and restore operations.
+
+.Prerequisites
+
+* You have installed the OADP Operator.
+
+.Procedure
+
+. To preview the resources included in the backup before running the actual backup, run the following command:
++
+[source,terminal]
+----
+$ velero backup create <backup-name> --snapshot-volumes false # <1>
+----
+<1> Specify the value of `--snapshot-volumes` parameter as `false`.
++
+. To know more details about the backup resources, run the following command:
++
+[source,terminal]
+----
+$ velero describe backup <backup_name> --details # <1>
+----
+<1> Specify the name of the backup.
++
+. To preview the resources included in the restore before running the actual restore, run the following command:
++
+[source,terminal]
+----
+$ velero restore create --from-backup <backup-name> # <1>
+----
+<1> Specify the name of the backup created to review the backup resources.
++
+[IMPORTANT]
+====
+The `velero restore create` command creates restore resources in the cluster. You must delete the resources created as part of the restore, after you review the resources.
+====
++
+. To know more details about the restore resources, run the following command:
++
+[source,terminal]
+----
+$ velero describe restore <restore_name> --details # <1>
+----
+<1> Specify the name of the restore.


### PR DESCRIPTION
## Jira 

* [OADP-3920](https://issues.redhat.com/browse/OADP-3920)

Added a section to review resources for backup and restore

##  Version

* OCP 4.13 → OCP 4.17

## Preview

* [Backing up - Review Backup and restore](https://79808--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html#oadp-review-backup-restore_backing-up-applications)

* [Restoring - Review Backup and restore](https://79808--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.html#oadp-review-backup-restore_restoring-applications)


## QE Review

* [x] QE has approved this change.
