### PR TITLE
OSDOCS-9350-deepdive-2: Configuring ingress cluster traffic using a N…

### DIFF
--- a/modules/nw-create-load-balancer-service.adoc
+++ b/modules/nw-create-load-balancer-service.adoc
@@ -10,24 +10,20 @@ Use the following procedure to create a load balancer service.
 
 .Prerequisites
 
-* Make sure that the project and service you want to expose exist.
-* Your cloud provider supports load balancers.
+* You logged in to {product-title}.
+* You ensured that the project and service you want to expose exist.
+* You ensured that your cloud provider supports load balancers.
 
 .Procedure
-
-To create a load balancer service:
-
-. Log in to  {product-title}.
 
 . Load the project where the service you want to expose is located.
 +
 [source,terminal]
 ----
-$ oc project project1
+$ oc project <project_name>
 ----
 
-. Open a text file on the control plane node and paste the following text, editing the
-file as needed:
+. Open a text file on the control plane node and paste the following text into the file. Edit the text as needed.
 +
 .Sample load balancer configuration file
 ----
@@ -49,14 +45,15 @@ spec:
 ----
 <1> Enter a descriptive name for the load balancer service.
 <2> Enter the same port that the service you want to expose is listening on.
-<3> Enter a list of specific IP addresses to restrict traffic through the load balancer. This field is ignored if the cloud-provider does not support the feature.
+<3> Enter a list of specific IP addresses to restrict traffic through the load balancer. This field is ignored if the cloud provider does not support the feature.
 <4> Enter `Loadbalancer` as the type.
 <5> Enter the name of the service.
 +
 [NOTE]
 ====
-To restrict the traffic through the load balancer to specific IP addresses, it is recommended to use the Ingress Controller field `spec.endpointPublishingStrategy.loadBalancer.allowedSourceRanges`. Do not set the `loadBalancerSourceRanges` field.
+To restrict the traffic through the load balancer to specific IP addresses, consider using the Ingress Controller field `spec.endpointPublishingStrategy.loadBalancer.allowedSourceRanges`. Do not set the `loadBalancerSourceRanges` field.
 ====
+
 . Save and exit the file.
 
 . Run the following command to create the service:
@@ -73,7 +70,7 @@ For example:
 $ oc create -f mysql-lb.yaml
 ----
 
-. Execute the following command to view the new service:
+. Enter the following command to view the new service:
 +
 [source,terminal]
 ----
@@ -87,11 +84,9 @@ NAME       TYPE           CLUSTER-IP      EXTERNAL-IP                           
 egress-2   LoadBalancer   172.30.22.226   ad42f5d8b303045-487804948.example.com   3306:30357/TCP   15m
 ----
 +
-The service has an external IP address automatically assigned if there is a cloud
-provider enabled.
+The service has an external IP address automatically assigned if there is a cloud provider enabled.
 
-. On the master, use a tool, such as cURL, to make sure you can reach the service
-using the public IP address:
+. On the control plane node, use a tool, such as `curl`, to make sure you can reach the service by using the public IP address:
 +
 [source,terminal]
 ----
@@ -105,11 +100,9 @@ For example:
 $ curl 172.29.121.74:3306
 ----
 +
-The examples in this section use a MySQL service, which requires a client application.
-If you get a string of characters with the `Got packets out of order` message,
-you are connecting with the service:
+The following examples use a MySQL service, which requires a client application. If you get a string of characters with the `Got packets out of order` message, you are connecting with the service:
 +
-If you have a MySQL client, log in with the standard CLI command:
+If you have a MySQL client, log in by entering the standard CLI command:
 +
 [source,terminal]
 ----

--- a/modules/nw-creating-project-and-service.adoc
+++ b/modules/nw-creating-project-and-service.adoc
@@ -6,44 +6,59 @@
 [id="nw-creating-project-and-service_{context}"]
 = Creating a project and service
 
-If the project and service that you want to expose do not exist, first create
-the project, then the service.
+If the project and service that you want to expose do not exist, you must create the project and then the service.
 
-If the project and service already exist, skip to the procedure on exposing the
-service to create a route.
+If the project and service already exist, go the "Exposing the service by creating a route" procedure.
 
 .Prerequisites
 
-* Install the `oc` CLI and log in as a cluster administrator.
+* You installed the {oc-first} and logged in as a cluster administrator.
 
 .Procedure
 
-. Create a new project for your service by running the `oc new-project` command:
+. Create a new project for your service by entering the following `oc new-project` command in your CLI:
 +
 [source,terminal]
 ----
-$ oc new-project myproject
+$ oc new-project <service_project_name> <1>
 ----
 
-. Use the `oc new-app` command to create your service:
+. Enter the `oc new-app` command to create your service:
 +
 [source,terminal]
 ----
-$ oc new-app nodejs:12~https://github.com/sclorg/nodejs-ex.git
+$ oc new-app <service_name>
 ----
 
-. To verify that the service was created, run the following command:
+. To patch the created `NodePort` service as a service that selects an available port on each node in your cluster, enter the following command. The command does not require that you define a route, router, or ingress controller for a cluster.
 +
 [source,terminal]
 ----
-$ oc get svc -n myproject
+$ oc patch svc/<service_name> --type='merge' -p='{"spec":{"type":"NodePort"}}' -n <service_project_name>
+service/<service_name> patched
 ----
 +
 .Example output
 [source,terminal]
 ----
-NAME        TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
-nodejs-ex   ClusterIP   172.30.197.157   <none>        8080/TCP   70s
+NAME                     TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                        AGE
+<service_project_name>   NodePort    172.30.231.25    <none>        8080:32171/TCP,8888:30515/TCP  7m17s
+----
+
+.Verification
+
+. To verify that the new service exists enter the following command:
++
+[source,terminal]
+----
+$ oc get svc -n <service_project_name>
+----
++
+.Example output
+[source,terminal]
+----
+NAME                    TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
+<service_project_name>  ClusterIP   172.30.231.25    <none>        8080/TCP,8888/TCP   6m25s
 ----
 +
 By default, the new service does not have an external IP address.

--- a/modules/nw-exposing-service.adoc
+++ b/modules/nw-exposing-service.adoc
@@ -12,23 +12,26 @@ endif::[]
 
 You can expose the service as a route by using the `oc expose` command.
 
+ifdef::nodeport[]
+After as service is available on a node port, traffic received on any node in your cluster redirects to a node with the running service.
+endif::nodeport[]
+
+.Prerequisites
+
+* You logged in to {product-title}.
+
 .Procedure
-
-To expose the service:
-
-. Log in to {product-title}.
 
 . Log in to the project where the service you want to expose is located:
 +
 [source,terminal]
 ----
-$ oc project myproject
+$ oc project <project_name>
 ----
 
 ifndef::nodeport[]
 . Run the `oc expose service` command to expose the route:
 +
-
 [source,terminal]
 ----
 $ oc expose service nodejs-ex
@@ -40,9 +43,9 @@ $ oc expose service nodejs-ex
 route.route.openshift.io/nodejs-ex exposed
 ----
 
-. To verify that the service is exposed, you can use a tool, such as cURL, to make sure the service is accessible from outside the cluster.
+. To verify that the service is exposed, you can use a tool, such as `curl`, to make sure the service is accessible from outside the cluster.
 
-.. Use the `oc get route` command to find the route's host name:
+.. Use the `oc get route` command to find the route's hostname:
 +
 [source,terminal]
 ----
@@ -56,7 +59,7 @@ NAME        HOST/PORT                        PATH   SERVICES    PORT       TERMI
 nodejs-ex   nodejs-ex-myproject.example.com         nodejs-ex   8080-tcp                 None
 ----
 
-.. Use cURL to check that the host responds to a GET request:
+.. Use `curl` to check that the host responds to a `GET` request:
 +
 [source,terminal]
 ----
@@ -69,8 +72,8 @@ $ curl --head nodejs-ex-myproject.example.com
 HTTP/1.1 200 OK
 ...
 ----
-
 endif::nodeport[]
+
 ifdef::nodeport[]
 . To expose a node port for the application, modify the custom resource definition (CRD) of a service by entering the following command:
 +
@@ -92,14 +95,14 @@ spec:
   sessionAffinity: None
   type: NodePort <2>
 ----
-<1> Optional: Specify the node port range for the application. By default, {product-title} selects an available port in the `30000-32767` range.
+<1> Optional: Specify a node port range that is within the `30000-32767` range for the application. By default, {product-title} automatically selects an available port in the `30000-32767` range.
 <2> Define the service type.
 
 . Optional: To confirm the service is available with a node port exposed, enter the following command:
 +
 [source,terminal]
 ----
-$ oc get svc -n myproject
+$ oc get svc -n <project_name>
 ----
 +
 .Example output
@@ -136,6 +139,7 @@ httpd   NodePort   172.xx.xx.xx    <none>        8443:30327/TCP   109s
 ----
 endif::nodeport[]
 
+// Should we do this?
 //Potentially add verification step, "If a verification step is needed, it would
 //look something like oc get route mysql-55-rhel7 and curl with the host from the
 //output of the oc get route command."

--- a/modules/nw-using-load-balancer-getting-traffic.adoc
+++ b/modules/nw-using-load-balancer-getting-traffic.adoc
@@ -1,19 +1,15 @@
 // Module included in the following assemblies:
 //
-// * ingress/getting-traffic-cluster.adoc
+// * networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-nodeport.adoc
 
 [id="nw-using-load-balancer-getting-traffic_{context}"]
-= Using a load balancer to get traffic into the cluster
+= Using a load balancer to get traffic into a cluster
 
-If you do not need a specific external IP address, you can configure a load
-balancer service to allow external access to an {product-title} cluster.
+If you do not need a specific external IP address, you can configure a load balancer service to allow external access to an {product-title} cluster.
 
-A load balancer service allocates a unique IP. The load balancer has a single
-edge router IP, which can be a virtual IP (VIP), but is still a single machine
-for initial load balancing.
+A load balancer service allocates a unique IP. The load balancer has a single edge router IP, which can be a virtual IP (VIP), but is still a single machine for initial load balancing.
 
 [NOTE]
 ====
-If a pool is configured, it is done at the infrastructure level, not by a cluster
-administrator.
+A pool must be configured at the infrastructure level and not by a cluster administrator.
 ====

--- a/modules/nw-using-nodeport.adoc
+++ b/modules/nw-using-nodeport.adoc
@@ -5,21 +5,13 @@
 [id="nw-using-nodeport_{context}"]
 = Using a NodePort to get traffic into the cluster
 
-Use a `NodePort`-type `Service` resource to expose a service on a specific port
-on all nodes in the cluster. The port is specified in the `Service` resource's
-`.spec.ports[*].nodePort` field.
+Use a `NodePort`-type `Service` resource to expose a service on a specific port on all nodes in the cluster. The port is specified in the `.spec.ports[*].nodePort` field of the `Service` resource. 
 
 [IMPORTANT]
 ====
 Using a node port requires additional port resources.
 ====
 
-A `NodePort` exposes the service on a static port on the node's IP address.
-``NodePort``s are in the `30000` to `32767` range by default, which means a
-`NodePort` is unlikely to match a service's intended port. For example, port
-`8080` may be exposed as port `31020` on the node.
+A `NodePort` exposes the service as a static port on the node's IP address. A `NodePort` service operates in the `30000` to `32767` range by default, which means a `NodePort` is unlikely to match an intended port on a default service. For example, port `8080` might be exposed as port `31020` on the node.
 
-The administrator must ensure the external IP addresses are routed to the nodes.
-
-``NodePort``s and external IPs are independent and both can be used
-concurrently.
+The administrator must ensure the external IP addresses are routed to the nodes. A `NodePort` service and external IP addresses are independent and both can be used concurrently.

--- a/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer.adoc
+++ b/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer.adoc
@@ -6,40 +6,30 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{product-title} provides methods for communicating from
-outside the cluster with services running in the cluster. This method uses a
-load balancer.
+{product-title} provides methods for communicating from outside the cluster with services running in the cluster. The method outlined in this document describes manually setting your own ports for your load balancer that runs on supported cloud-based infrastructure.
 
+// Using a load balancer to get traffic into a cluster
 include::modules/nw-using-load-balancer-getting-traffic.adoc[leveloffset=+1]
-
-[NOTE]
-====
-The procedures in this section require prerequisites performed by the cluster
-administrator.
-====
 
 == Prerequisites
 
-Before starting the following procedures, the administrator must:
+Before starting the following procedures, the administrator must complete the following tasks:
 
-* Set up the external port to the cluster networking environment so that requests
-can reach the cluster.
+* Set up the external port to the cluster networking environment so that requests can reach the cluster.
 
-* Make sure there is at least one user with cluster admin role. To add this role
-to a user, run the following command:
+* Ensure you have at least one user with cluster admin role. To add this role to a user, run the following command:
 +
 ----
 $ oc adm policy add-cluster-role-to-user cluster-admin username
 ----
 
-* Have an {product-title} cluster with at least one master and at least one node
-and a system outside the cluster that has network access to the cluster. This
-procedure assumes that the external system is on the same subnet as the cluster.
-The additional networking required for external systems on a different subnet is
-out-of-scope for this topic.
+* Ensure your {product-title} cluster has at least one control plane node and one node, and a system outside the cluster that has network access to the cluster. This procedure assumes that the external system is on the same subnet as the cluster. The additional networking required for external systems on a different subnet is out-of-scope for this document.
 
+// Creating a project and service
 include::modules/nw-creating-project-and-service.adoc[leveloffset=+1]
 
+// Exposing the service by creating a route
 include::modules/nw-exposing-service.adoc[leveloffset=+1]
 
+// Creating a load balancer service
 include::modules/nw-create-load-balancer-service.adoc[leveloffset=+1]

--- a/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-nodeport.adoc
+++ b/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-nodeport.adoc
@@ -6,16 +6,14 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{product-title} provides methods for communicating from
-outside the cluster with services running in the cluster. This method uses a
-`NodePort`.
+{product-title} provides methods for communicating from outside the cluster with services running in the cluster. This method uses a `NodePort`.
 
+// Using a NodePort to get traffic into the cluste
 include::modules/nw-using-nodeport.adoc[leveloffset=+1]
 
 [NOTE]
 ====
-The procedures in this section require prerequisites performed by the cluster
-administrator.
+The procedures in this section require prerequisites performed by the cluster administrator.
 ====
 
 == Prerequisites
@@ -32,16 +30,13 @@ to a user, run the following command:
 $ oc adm policy add-cluster-role-to-user cluster-admin <user_name>
 ----
 
-* Have an {product-title} cluster with at least one master and at least one node
-and a system outside the cluster that has network access to the cluster. This
-procedure assumes that the external system is on the same subnet as the cluster.
-The additional networking required for external systems on a different subnet is
-out-of-scope for this topic.
+* Ensure your {product-title} cluster has at least one control plane node and one node, and a system outside the cluster that has network access to the cluster. This procedure assumes that the external system is on the same subnet as the cluster. The additional networking required for external systems on a different subnet is out-of-scope for this document.
 
+// Creating a project and service
 include::modules/nw-creating-project-and-service.adoc[leveloffset=+1]
 
+// Exposing the service by creating a route
 include::modules/nw-exposing-service.adoc[leveloffset=+1]
-
 
 [role="_additional-resources"]
 [id="configuring-ingress-cluster-traffic-nodeport-additional-resources"]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
(https://issues.redhat.com/browse/OSDOCS-9350)

Link to docs preview:
* [Configuring ingress cluster traffic using an Ingress Controller](https://79812--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.html)
* [Configuring ingress cluster traffic using a load balancer](https://79812--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer.html)
* [Configuring ingress cluster traffic using a NodePort](https://79812--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-nodeport.html)

- [ ] SME has approved this change.
- [ ] QE has approved this change.

Additional information:
* [SME doc](https://docs.google.com/document/d/13w_tqS-xFFFrb74jF_rcgApUuXwrBsjVaEQGY2mE0KI/edit#heading=h.nn1hdtqlfcrd)
