### PR TITLE
OCPBUGS-37808-413 removing vlanTrunk from  bridge CNI 

### DIFF
--- a/modules/nw-multus-bridge-object.adoc
+++ b/modules/nw-multus-bridge-object.adoc
@@ -65,10 +65,6 @@ plugin:
 |`string`
 |Optional: Indicates whether the default vlan must be preserved on the `veth` end connected to the bridge. Defaults to true.
 
-|`vlanTrunk`
-|`list`
-|Optional: Assign a VLAN trunk tag. The default value is `none`.
-
 |`mtu`
 |`string`
 |Optional: Set the maximum transmission unit (MTU) to the specified value. The default value is automatically set by the kernel.


### PR DESCRIPTION
[OCPBUGS-37808]: Remove vlanTrunk from bridge CNI table for all version before 4.14

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 413
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-37808
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://79828--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
