### PR TITLE
GitOps 1.12.5 RN New PR

### DIFF
--- a/modules/gitops-release-notes-1-12-5.adoc
+++ b/modules/gitops-release-notes-1-12-5.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assembly:
+//
+// * release_notes/gitops-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="release-notes-for-gitops-1-12-5_{context}"]
+= Release Notes for {gitops-title} 1.12.5
+
+{gitops-title} 1.12.5 is now available on {OCP} 4.12, 4.13, 4.14, and 4.15.
+
+[id="errata-updates-1-12-5_{context}"]
+== Errata updates
+
+[id="rhsa-2024-4973-gitops-1-12-5-security-update-advisory_{context}"]
+=== RHSA-2024:4973 - {gitops-title} 1.12.5 security update advisory
+
+Issued: 2024-08-01
+
+The list of security fixes that are included in this release is documented in the following advisory:
+
+* link:https://access.redhat.com/errata/RHSA-2024:4973[RHSA-2024:4973]
+
+If you have installed the {gitops-title} Operator, run the following command to view the container images in this release:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-operators
+----

--- a/release_notes/gitops-release-notes.adoc
+++ b/release_notes/gitops-release-notes.adoc
@@ -38,6 +38,9 @@ include::modules/gitops-release-notes-1-13-1.adoc[leveloffset=+1]
 // Release notes for Red Hat OpenShift GitOps 1.13.0
 include::modules/gitops-release-notes-1-13-0.adoc[leveloffset=+1]
 
+// Release notes for Red Hat OpenShift GitOps 1.12.5
+include::modules/gitops-release-notes-1-12-5.adoc[leveloffset=+1]
+
 // Release notes for Red Hat OpenShift GitOps 1.12.4
 include::modules/gitops-release-notes-1-12-4.adoc[leveloffset=+1]
 


### PR DESCRIPTION
This new PR is an addition to the previous PR which included the changes for the [1.12.5 Release Notes](https://github.com/openshift/openshift-docs/pull/79804).

Version(s):

GitOps 1.12, GitOps 1.13, GitOps 1.14

Issue:

https://issues.redhat.com/browse/RHDEVDOCS-6139

Link to docs preview:

[Release Notes for Red Hat OpenShift GitOps 1.12.5](https://79829--ocpdocs-pr.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes.html#release-notes-for-gitops-1-12-5_gitops-release-notes)

QE review:

 QE has approved this change.
SME review: Completed by [anjoseph@redhat.com](mailto:anjoseph@redhat.com)
QE review: Completed by @varshab1210
Peer review: Completed by @Srivaralakshmi

Additional information: