### PR TITLE
OCPBUGS-37364-12: Cherry-pick for OCPBUGS-37364

### DIFF
--- a/networking/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.adoc
+++ b/networking/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.adoc
@@ -9,6 +9,11 @@ toc::[]
 
 The AWS Load Balancer (ALB) Operator deploys and manages an instance of the `AWSLoadBalancerController` resource.
 
+[IMPORTANT]
+====
+The AWS Load Balancer (ALB) Operator is only supported on the `x86_64` architecture.
+====
+
 These release notes track the development of the AWS Load Balancer Operator in {product-title}.
 
 For an overview of the AWS Load Balancer Operator, see xref:../../networking/aws_load_balancer_operator/understanding-aws-load-balancer-operator.adoc#aws-load-balancer-operator[AWS Load Balancer Operator in {product-title}].

--- a/networking/external_dns_operator/nw-creating-dns-records-on-azure.adoc
+++ b/networking/external_dns_operator/nw-creating-dns-records-on-azure.adoc
@@ -8,4 +8,9 @@ toc::[]
 
 You can create DNS records on Azure by using the External DNS Operator.
 
+[IMPORTANT]
+====
+Using the External DNS Operator on a {entra-first}-enabled cluster or a cluster that runs in {azure-full} Government (MAG) regions is not supported.
+====
+
 include::modules/nw-control-dns-records-public-hosted-zone-azure.adoc[leveloffset=+1]

--- a/networking/external_dns_operator/nw-creating-dns-records-on-gcp.adoc
+++ b/networking/external_dns_operator/nw-creating-dns-records-on-gcp.adoc
@@ -6,6 +6,11 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can create DNS records on GCP by using the External DNS Operator.
+You can create DNS records on {gcp-first} by using the External DNS Operator.
+
+[IMPORTANT]
+====
+Using the External DNS Operator on a cluster with {gcp-short} Workload Identity enabled is not supported. For more information about the {gcp-short} Workload Identity, see xref:../../authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc#cco-mode-gcp-workload-identity[Using manual mode with {gcp-short} Workload Identity].
+====
 
 include::modules/nw-control-dns-records-public-managed-zone-gcp.adoc[leveloffset=+1]


### PR DESCRIPTION
Cherry pick from #79724 with commit 2b7f6118b81283c545e573fa7f4ddab84e1b9b9e

Version(s):
4.12

Link to docs preview:
* [AWS Load Balancer Operator release notes](https://79830--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.html)
* [Creating DNS records on Azure](https://79830--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/external_dns_operator/nw-creating-dns-records-on-azure.html)
* [Creating DNS records on GCP](https://79830--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/external_dns_operator/nw-creating-dns-records-on-gcp.html)
