### PR TITLE
OADP-4657: velero relationship table to include 4.13

### DIFF
--- a/modules/velero-oadp-version-relationship.adoc
+++ b/modules/velero-oadp-version-relationship.adoc
@@ -20,5 +20,5 @@
 | 1.3.0 | link:https://{velero-domain}/docs/v1.12/[1.12] | 4.10 - 4.15
 | 1.3.1 | link:https://{velero-domain}/docs/v1.12/[1.12] | 4.10 - 4.15
 | 1.3.2 | link:https://{velero-domain}/docs/v1.12/[1.12] | 4.10 - 4.15
-| 1.4.0 | link:https://{velero-domain}/docs/v1.14/[1.14] | 4.14 and later
+| 1.4.0 | link:https://{velero-domain}/docs/v1.14/[1.14] | 4.13 and later
 |===


### PR DESCRIPTION
### Jira

* [OADP-4657](https://issues.redhat.com/browse/OADP-4657)

    * Adding that 4.13 now supports OADP 1.4 to address the ACM issues. This is included in the Velero relationship table. 

### Version(s):

* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16
* OCP 4.17 → branch/enterprise-4.17

### Link to docs preview:

* [OADP-Velero-OpenShift Container Platform version relationship](https://79836--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.html#velero-oadp-version-relationship_installing-oadp-operator)
* [Troubleshooting - OADP-Velero-OpenShift Container Platform version relationship](https://79836--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting.html#velero-oadp-version-relationship_oadp-troubleshooting)

QE review:
- [X] [QE has approved this change.](https://github.com/openshift/openshift-docs/pull/79836#issuecomment-2273283500)

<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
