### PR TITLE
OCPBUGS-37812: Removing erroneous mention of MTU

### DIFF
--- a/modules/virt-example-vf-host-services.adoc
+++ b/modules/virt-example-vf-host-services.adoc
@@ -13,7 +13,7 @@ include::snippets/technology-preview.adoc[leveloffset=+1]
 
 You can apply a `NodeNetworkConfigurationPolicy` manifest to an existing cluster to complete the following tasks:
 
-* Configure QoS or MTU host network settings for VFs to optimize performance.
+* Configure QoS host network settings for VFs to optimize performance.
 * Add, remove, or update VFs for a network interface.
 * Manage VF bonding configurations.
 


### PR DESCRIPTION
OCPBUGS-37812: Removing erroneous mention of MTU

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OCPBUGS-37812

Link to docs preview:
https://79839--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html

Additional information:
Typo - does not change any YAML examples - no QE required


