### PR TITLE
OCPBUGS-37822: Add new permission required for forwarding rules labels

### DIFF
--- a/modules/minimum-required-permissions-ipi-gcp.adoc
+++ b/modules/minimum-required-permissions-ipi-gcp.adoc
@@ -33,6 +33,7 @@ If your organization’s security policies require a more restrictive set of per
 * `compute.globalAddresses.use`
 * `compute.globalForwardingRules.create`
 * `compute.globalForwardingRules.get`
+* `compute.globalForwardingRules.setLabels`
 * `compute.networks.create`
 * `compute.networks.get`
 * `compute.networks.list`

--- a/modules/minimum-required-permissions-upi-gcp.adoc
+++ b/modules/minimum-required-permissions-upi-gcp.adoc
@@ -34,6 +34,7 @@ If your organization’s security policies require a more restrictive set of per
 * `compute.globalAddresses.use`
 * `compute.globalForwardingRules.create`
 * `compute.globalForwardingRules.get`
+* `compute.globalForwardingRules.setLabels`
 * `compute.networks.create`
 * `compute.networks.get`
 * `compute.networks.list`


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

CAPG additions require the addition of compute.globalForwardingRules.setLabels by default.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.17

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-37822
https://issues.redhat.com/browse/OCPBUGS-33947
https://github.com/kubernetes-sigs/cluster-api-provider-gcp/issues/1276
https://github.com/kubernetes-sigs/cluster-api-provider-gcp/issues/1274

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
