### PR TITLE
Fix 404 logo image

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -2602,3 +2602,22 @@ b.conum * {
 .print-logo {
   display: none;
 }
+
+/*Override osh-nav-footer.css which has broken logo images */
+.navbar.navbar-default.navbar-openshift .navbar-brand {
+    background: url(https://www.redhat.com/rhdc/managed-files/Logo-Red_Hat-OpenShift-A-Reverse-RGB.svg) 100% no-repeat !important;
+    background-size: contain !important;
+    background-position: left center !important;
+    margin: 5px 15px !important;
+    padding: 0 !important;
+    width: 175px !important;
+    height: 70px !important;
+}
+
+.navbar.navbar-default.navbar-openshift .navbar-brand.brand-online {
+    background: url(https://www.redhat.com/rhdc/managed-files/Logo-Red_Hat-OpenShift-A-Reverse-RGB.svg) 100% no-repeat !important
+}
+
+.navbar.navbar-default.navbar-openshift .navbar-brand.brand-dedicated {
+    background: url(https://www.redhat.com/rhdc/managed-files/Logo-Red_Hat-OpenShift-A-Reverse-RGB.svg) 100% no-repeat !important
+}


### PR DESCRIPTION
Fixes missing navbar logo image.

Version(s):
enterprise-4.1

Link to docs preview:
https://file.emea.redhat.com/aireilly/fix-image/welcome/index.html