### PR TITLE
OSDOCS-10901 Deprecating AWS Outposts

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -121,6 +121,13 @@ You can now move etcd from a root volume (Cinder) to a dedicated ephemeral local
 
 For more information, see xref:../installing/installing_openstack/deploying-openstack-with-rootVolume-etcd-on-local-disk.adoc#deploying-openstack-with-rootvolume-etcd-on-local-disk[Deploying on OpenStack with rootVolume and etcd on local disk].
 
+[id="ocp-4-17-installation-aws-outposts-deprecated_{context}"]
+==== Announcement of the deprecation of extending compute nodes into AWS Outposts for clusters deployed on AWS Public Cloud
+
+With this release, extending compute nodes into AWS Outposts for clusters deployed on AWS Public Cloud is deprecated. The ability to deploy compute nodes into AWS Outposts after installation, as an extension of an existing {product-title} cluster operating in a public AWS region, will be removed with the release of {product-title} version 4.20.
+
+For more information, see xref:../installing/installing_aws/ipi/installing-aws-outposts.html#installing-aws-outposts[Extending an AWS VPC cluster into an AWS Outpost].
+
 [id="ocp-4-17-postinstallation-configuration_{context}"]
 === Postinstallation configuration
 
@@ -1084,6 +1091,11 @@ In the following tables, features are marked with the following statuses:
 |Removed
 |Removed
 
+|Installing a cluster on {aws-short} with compute nodes in {aws-short} Outposts
+|Deprecated
+|Deprecated
+|Deprecated
+
 |====
 
 [discrete]
@@ -1331,7 +1343,7 @@ Starting in {product-title} 4.17, RukPak is now removed and relevant functionali
 
 * Previously, an optional internal function of the cluster autoscaler caused repeated log entries when it was not implemented. The issue is resolved in this release. (link:https://issues.redhat.com/browse/OCPBUGS-33932[*OCPBUGS-33932*])
 
-* Previously, a node associated with a restarting machine briefly having a status of `Ready=Unknown` triggered the `UnavailableReplicas` condition in the Control Plane Machine Set Operator. This condition caused the Operator to enter the `Available=False` state and trigger alerts because that state indicates a nonfunctional component that requires immediate administrator intervention. This alert should not have been triggered for the brief and expected unavailabilty during a restart. With this release, a grace period for node unreadiness is added to avoid triggering unnecessary alerts. (link:https://issues.redhat.com/browse/OCPBUGS-20061[*OCPBUGS-20061*]) 
+* Previously, a node associated with a restarting machine briefly having a status of `Ready=Unknown` triggered the `UnavailableReplicas` condition in the Control Plane Machine Set Operator. This condition caused the Operator to enter the `Available=False` state and trigger alerts because that state indicates a nonfunctional component that requires immediate administrator intervention. This alert should not have been triggered for the brief and expected unavailabilty during a restart. With this release, a grace period for node unreadiness is added to avoid triggering unnecessary alerts. (link:https://issues.redhat.com/browse/OCPBUGS-20061[*OCPBUGS-20061*])
 
 * Previously, when an {product-title} cluster was installed with no capabilities and later enabled the Build capability, the related Build cluster configuration custom resource definition (CRD) was not created. With this release, the Build cluster configuration CRD and its default instance are created. This allows the Build capability to be fully configured and customized. (link:https://issues.redhat.com/browse/OCPBUGS-34395[*OCPBUGS-34395*])
 
@@ -1551,7 +1563,7 @@ metadata:
 [id="ocp-4-17-node-tuning-operator-bug-fixes_{context}"]
 ==== Node Tuning Operator (NTO)
 
-* Previously, due to an internal bug, the Node Tuning Operator incorrectly computed CPU masks for interrupt and network-handling CPU affinity if a machine had more than 256 CPUs. This prevented proper CPU isolation on those machines and resulted in `systemd` unit failures. With this release, the Node Tuning Operator computes the masks correctly. (link:https://issues.redhat.com/browse/OCPBUGS-39164[*OCPBUGS-39164*]) 
+* Previously, due to an internal bug, the Node Tuning Operator incorrectly computed CPU masks for interrupt and network-handling CPU affinity if a machine had more than 256 CPUs. This prevented proper CPU isolation on those machines and resulted in `systemd` unit failures. With this release, the Node Tuning Operator computes the masks correctly. (link:https://issues.redhat.com/browse/OCPBUGS-39164[*OCPBUGS-39164*])
 
 * Previously, the Open vSwitch (OVS) pinning procedure set the CPU affinity of the main thread, but other CPU threads did not pick up this affinity if they had already been created. As a consequence, some OVS threads did not run on the correct CPU set, which might interfere with the performance of pods with a Quality of Service (QoS) class of `Guaranteed`. With this update, the OVS pinning procedure updates the affinity of all the OVS threads, ensuring that all OVS threads run on the correct CPU set. (link:https://issues.redhat.com/browse/OCPBUGS-35347[*OCPBUGS-35347*])
 


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-10901

Link to docs preview:
https://79880--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-installation-aws-outposts-deprecated_release-notes

QE review:
- [x] QE has approved this change.
