### PR TITLE
Fix typo in step3 bash cmd of sdn to ovn procedure

### DIFF
--- a/modules/nw-ovn-kubernetes-migration.adoc
+++ b/modules/nw-ovn-kubernetes-migration.adoc
@@ -65,7 +65,8 @@ EOT
 +
 [source,terminal]
 ----
-$ oc patch Network.operator.openshift.io cluster --type='merge' \ --patch '{"spec":{"migration":null}}'
+$ oc patch Network.operator.openshift.io cluster --type='merge' \
+  --patch '{"spec":{"migration":null}}'
 ----
 
 . To prepare all the nodes for the migration, set the `migration` field on the CNO configuration object by running the following command:


### PR DESCRIPTION
Version(s): 4.16+

Issue: Documentation has a typo in step 3 of migrate-from-openshift-sdn. It does not have a line break like others have. Then, a copy-paste-execute of that command will end up with an error.

Link to docs preview: https://docs.openshift.com/container-platform/4.16/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#nw-ovn-kubernetes-migration_migrate-from-openshift-sdn


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

