### PR TITLE
OCPBUGS-36646 - Adding clarifications for PTP HA docs

### DIFF
--- a/modules/ptp-configuring-linuxptp-services-as-ha-bc-for-dual-nic.adoc
+++ b/modules/ptp-configuring-linuxptp-services-as-ha-bc-for-dual-nic.adoc
@@ -16,7 +16,9 @@ Create two `PtpConfig` custom resource (CR) objects that configure the NICs as T
 
 [IMPORTANT]
 ====
-When you create the `PtpConfig` CRs, ensure that the `phc2sysOpts` field is an empty string to prevent setting up the `phc2sys` processes on these two profiles.
+You set `phc2SysOpts` options once in the `PtpConfig` CR that configures HA.
+Set the `phc2sysOpts` field to an empty string in the `PtpConfig` CRs that configure the two NICs.
+This prevents individual `phc2sys` processes from being set up for the two profiles.
 ====
 
 The third `PtpConfig` CR configures a highly available system clock service.
@@ -24,6 +26,11 @@ The CR sets the `ptp4lOpts` field to an empty string to prevent the `ptp4l` proc
 The CR adds profiles for the `ptp4l` configurations under the `spec.profile.ptpSettings.haProfiles` key and passes the kernel socket path of those profiles to the `phc2sys` service.
 When a `ptp4l` failure occurs, the `phc2sys` service switches to the backup `ptp4l` configuration.
 When the primary profile becomes active again, the `phc2sys` service reverts to the original state.
+
+[IMPORTANT]
+====
+Ensure that you set `spec.recommend.priority` to the same value for all three `PtpConfig` CRs that you use to configure HA.
+====
 
 .Prerequisites
 
@@ -105,12 +112,17 @@ $ oc create -f ha-ptp-config-nic2.yaml
 . Create the `PtpConfig` CR that configures the HA system clock.
 For example:
 
-.. Create the `ptp-config-for-ha.yaml` file:
+.. Create the `ptp-config-for-ha.yaml` file.
+Set `haProfiles` to match the `metadata.name` fields that are set in the `PtpConfig` CRs that configure the two NICs.
+For example: `haProfiles: ha-ptp-config-nic1,ha-ptp-config-nic2`
 +
 [source,yaml]
 ----
 include::snippets/ztp_PtpConfigForHA.yaml[]
 ----
+<1> Set the `ptp4lOpts` field to an empty string.
+If it is not empty, the `p4ptl` process starts with a critical error.
+
 +
 [IMPORTANT]
 ====

--- a/snippets/ztp_PtpConfigForHA.yaml
+++ b/snippets/ztp_PtpConfigForHA.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   profile:
     - name: "boundary-ha"
-      ptp4lOpts: ""
+      ptp4lOpts: "" # <1>
       phc2sysOpts: "-a -r -n 24"
       ptpSchedulingPolicy: SCHED_FIFO
       ptpSchedulingPriority: 10


### PR DESCRIPTION
Adding clarifications for PTP T-BC HA docs

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OCPBUGS-36646

Link to docs preview:
https://79908--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ptp/configuring-ptp.html#ptp-configuring-linuxptp-services-as-ha-bc-for-dual-nic_configuring-ptp

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
