### PR TITLE
Reordering the steps to restart the cluster gracefully

### DIFF
--- a/modules/graceful-restart.adoc
+++ b/modules/graceful-restart.adoc
@@ -34,10 +34,10 @@ The control plane nodes are ready if the status is `Ready`, as shown in the foll
 +
 [source,terminal]
 ----
-NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-168-251.ec2.internal   Ready    master   75m   v1.29.4
-ip-10-0-170-223.ec2.internal   Ready    master   75m   v1.29.4
-ip-10-0-211-16.ec2.internal    Ready    master   75m   v1.29.4
+NAME                           STATUS   ROLES                  AGE   VERSION
+ip-10-0-168-251.ec2.internal   Ready    control-plane,master   75m   v1.29.4
+ip-10-0-170-223.ec2.internal   Ready    control-plane,master   75m   v1.29.4
+ip-10-0-211-16.ec2.internal    Ready    control-plane,master   75m   v1.29.4
 ----
 
 . If the control plane nodes are _not_ ready, then check whether there are any pending certificate signing requests (CSRs) that must be approved.
@@ -105,6 +105,14 @@ $ oc describe csr <csr_name> <1>
 $ oc adm certificate approve <csr_name>
 ----
 
+. After the control plane and worker nodes are ready, mark all the nodes in the cluster as schedulable.
+Run the following command:
++
+[source,terminal]
+----
+for node in $(oc get nodes -o jsonpath='{.items[*].metadata.name}'); do echo ${node} ; oc adm uncordon ${node} ; done
+----
+
 . Verify that the cluster started properly.
 
 .. Check that there are no degraded cluster Operators.
@@ -141,21 +149,13 @@ Check that the status for all nodes is `Ready`.
 +
 [source,terminal]
 ----
-NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-168-251.ec2.internal   Ready    master   82m   v1.29.4
-ip-10-0-170-223.ec2.internal   Ready    master   82m   v1.29.4
-ip-10-0-179-95.ec2.internal    Ready    worker   70m   v1.29.4
-ip-10-0-182-134.ec2.internal   Ready    worker   70m   v1.29.4
-ip-10-0-211-16.ec2.internal    Ready    master   82m   v1.29.4
-ip-10-0-250-100.ec2.internal   Ready    worker   69m   v1.29.4
+NAME                           STATUS   ROLES                  AGE   VERSION
+ip-10-0-168-251.ec2.internal   Ready    control-plane,master   82m   v1.29.4
+ip-10-0-170-223.ec2.internal   Ready    control-plane.master   82m   v1.29.4
+ip-10-0-179-95.ec2.internal    Ready    worker                 70m   v1.29.4
+ip-10-0-182-134.ec2.internal   Ready    worker                 70m   v1.29.4
+ip-10-0-211-16.ec2.internal    Ready    control-plane,master   82m   v1.29.4
+ip-10-0-250-100.ec2.internal   Ready    worker                 69m   v1.29.4
 ----
 +
 If the cluster did not start properly, you might need to restore your cluster using an etcd backup.
-
-. After the control plane and worker nodes are ready, mark all the nodes in the cluster as schedulable.
-Run the following command:
-+
-[source,terminal]
-----
-for node in $(oc get nodes -o jsonpath='{.items[*].metadata.name}'); do echo ${node} ; oc adm uncordon ${node} ; done
-----


### PR DESCRIPTION
Reorder the steps to restart the cluster gracefully 

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):

4.12+

Issue:

https://issues.redhat.com/browse/OSDOCS-11571

Link to docs preview:

https://79928--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/graceful-cluster-restart.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
