### PR TITLE
OSDOCS-11563: Documented the 4.15.25 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2733,6 +2733,40 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.15.25
+[id="ocp-4-15-25_{context}"]
+=== RHSA-2024:4955 - {product-title} 4.15.25 bug fix and security update
+
+Issued: 2024-08-07
+
+{product-title} release 4.15.25, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2024:4955[RHSA-2024:4955] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4958[RHSA-2024:4958] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.25 --pullspecs
+----
+
+[id="ocp-4-15-25-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, a machine config pool (MCP) with a higher `maxUnavailable` value than the amount of unavailable nodes would cause cordoned nodes to receive updates if they were in a certain position on the node list. With this release, a fix ensures that cordoned nodes are not added to a queue to receive updates. (link:https://issues.redhat.com/browse/OCPBUGS-37629[*OCPBUGS-37629*])
+
+* Prevously, an errant code change resulted in a duplicated `oauth.config.openshift.io` item on the Global Configuration page. With this release, the duplicated item is removed. (link:https://issues.redhat.com/browse/OCPBUGS-37458[*OCPBUGS-37458*])
+
+* Previously, the Cluster Network Operator (CNO) IPsec mechanism incorrectly behaved on a cluster that had multiple worker machine config pools. With this release, CNO Ipsec mechanism works as intended for a cluster with multiple worker machine config pools. This fix does not apply to updating an IPsec-enabled cluster with multiple paused machine config pools. (link:https://issues.redhat.com/browse/OCPBUGS-37205[*OCPBUGS-37205*])
+
+* Previously, the Open vSwitch (OVS) pinning procedure set the CPU affinity of the main thread, but other CPU threads did not pick up this affinity if they had already been created. As a consequence, some OVS threads did not run on the correct CPU set, which might interfere with the performance of pods with a Quality of Service (QoS) class of `Guaranteed`. With this release, the OVS pinning procedure updates the affinity of all the OVS threads, ensuring that all OVS threads run on the correct CPU set. (link:https://issues.redhat.com/browse/OCPBUGS-37196[*OCPBUGS-37196*])
+
+* Previously, when you created or deleted large volumes of service objects simultaneously, the service controller's ability to process each service sequentially would slow down. This caused short timeout issues for the service controller and backlog issues for the objects. With this release, the service controller can now process up to 10 service objects simultaneously to reduce the backlog and timeout issues. (link:https://issues.redhat.com/browse/OCPBUGS-36821[*OCPBUGS-36821*])
+
+[id="ocp-4-15-25-updating_{context}"]
+==== Updating
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 [id="ocp-4-15-24_{context}"]
 === RHSA-2024:4850 - {product-title} 4.15.24 bug fix and security update
 


### PR DESCRIPTION
Version(s):
4.15

Issue:
(https://issues.redhat.com/browse/OSDOCS-11563)

Link to docs preview:
[RHSA-2024:4955 - OpenShift Container Platform 4.15.25 bug fix and security update](https://79934--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-25_release-notes)

