### PR TITLE
OSDOCS-10856: Add release note for bpfman Operator

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -852,6 +852,16 @@ For more information, see xref:../networking/multiple_networks/understanding-use
 
 {product-title} {product-version} now includes CoreDNS version 1.11.3.
 
+[id="ocp-4-17-ebpf-manager-operator-technology-preview_{context}"]
+==== eBPF manager Operator (Tech Preview)
+
+The eBPF manager Operator, available as a Technology Preview, allows you to securely deploy and manage eBPF programs. It facilitates the secure loading, unloading, modifying, and monitoring of eBPF programs in {product-title} clusters. For more information about deploying the bpfman Operator, see xref:../networking/network_security/ebpf_manager/ebpf-manager-operator-about.adoc#bpfman-operator-about[About the eBPF manager Operator].
+
+[id="ocp-4-17-ebpf-program-support-ingress-node-firewall-operator_{context}"]
+==== eBPF program support for Ingress Node Firewall Operator (Technology Preview)
+
+Secure management of eBPF programs for the Ingress Node Firewall Operator is available as a Technology Preview. Use of this feature requires installation of the eBPF manager Operator, also available as a Technology Preview. For more information, see xref:../networking/network_security/ingress-node-firewall-operator.adoc#ingress-node-firewall-operator_ingress-node-firewall-operator[Ingress Node Firewall Operator integration].
+
 [id="ocp-4-17-nw-metallb"]
 ==== Changes to MetalLB
 
@@ -2046,7 +2056,17 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.15 |4.16 |4.17
 
-|Advertise using L2 mode the MetalLB service from a subset of nodes, using a specific pool of IP addresses
+|Ingress Node Firewall Operator
+|General Availability
+|General Availability
+|General Availability
+
+|eBPF manager Operator
+|N/A
+|N/A
+|Technology Preview
+
+|Advertise by using L2 mode the MetalLB service from a subset of nodes, using a specific pool of IP addresses
 |Technology Preview
 |Technology Preview
 |Technology Preview


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-10856

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://79943--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-ebpf-program-support-ingress-node-firewall-operator_release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
