### PR TITLE
[enterprise-4.16] OBSDOCS-1235: Removed Logging 5.7z and 5.8z from 4.16

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2738,10 +2738,6 @@ Topics:
     Topics:
     - Name: Logging 5.9
       File: logging-5-9-release-notes
-    - Name: Logging 5.8
-      File: logging-5-8-release-notes
-    - Name: Logging 5.7
-      File: logging-5-7-release-notes
   - Name: Support
     File: cluster-logging-support
   - Name: Troubleshooting logging

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -1225,10 +1225,6 @@ Topics:
     Topics:
     - Name: Logging 5.9
       File: logging-5-9-release-notes
-    - Name: Logging 5.8
-      File: logging-5-8-release-notes
-    - Name: Logging 5.7
-      File: logging-5-7-release-notes
   - Name: Support
     File: cluster-logging-support
   - Name: Troubleshooting logging

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1496,10 +1496,6 @@ Topics:
     Topics:
     - Name: Logging 5.9
       File: logging-5-9-release-notes
-    - Name: Logging 5.8
-      File: logging-5-8-release-notes
-    - Name: Logging 5.7
-      File: logging-5-7-release-notes
   - Name: Support
     File: cluster-logging-support
   - Name: Troubleshooting logging


### PR DESCRIPTION
Change type: Doc update; Logging Z-Stream Release Notes - Content Improvement
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1235

Fix Version: 4.16

Doc Preview: https://79962--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging_release_notes/logging-5-9-release-notes

QE Review: @anpingli 
Peer Review: @xenolinux 