### PR TITLE
[enterprise-4.15] OBSDOCS-1235: Removed 5.7z from 4.15

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2711,8 +2711,6 @@ Topics:
       File: logging-5-9-release-notes
     - Name: Logging 5.8
       File: logging-5-8-release-notes
-    - Name: Logging 5.7
-      File: logging-5-7-release-notes
   - Name: Support
     File: cluster-logging-support
   - Name: Troubleshooting logging

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -1245,8 +1245,6 @@ Topics:
       File: logging-5-9-release-notes
     - Name: Logging 5.8
       File: logging-5-8-release-notes
-    - Name: Logging 5.7
-      File: logging-5-7-release-notes
   - Name: Support
     File: cluster-logging-support
   - Name: Troubleshooting logging

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1501,8 +1501,6 @@ Topics:
       File: logging-5-9-release-notes
     - Name: Logging 5.8
       File: logging-5-8-release-notes
-    - Name: Logging 5.7
-      File: logging-5-7-release-notes
   - Name: Support
     File: cluster-logging-support
   - Name: Troubleshooting logging


### PR DESCRIPTION
Change type: Doc update; Logging Z-Stream Release Notes - Content Improvement
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1235

Fix Version: 4.15

Doc Preview: https://79963--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging_release_notes/logging-5-9-release-notes#logging-release-notes-5-9-4_logging-5-9-release-notes

QE Review: @anpingli 
Peer Review: @lpettyjo 