### PR TITLE
[enterprise-4.12] TELCODOCS#1912: Added API endpoints for delete subscription and delete all subscriptions

### DIFF
--- a/modules/cnf-fast-event-notifications-api-refererence.adoc
+++ b/modules/cnf-fast-event-notifications-api-refererence.adoc
@@ -16,9 +16,11 @@ Use the following API endpoints to subscribe the `cloud-event-consumer` DU appli
 * `/api/ocloudNotifications/v1/subscriptions`
 - `POST`: Creates a new subscription
 - `GET`: Retrieves a list of subscriptions
+- `DELETE`: Deletes all subscriptions
 
 * `/api/ocloudNotifications/v1/subscriptions/<subscription_id>`
 - `GET`: Returns details for the specified subscription ID
+- `DELETE`: Deletes the subscription associated with the specified subscription ID
 
 * `/api/ocloudNotifications/v1/health`
 - `GET`: Returns the health status of `ocloudNotifications` API
@@ -26,7 +28,7 @@ Use the following API endpoints to subscribe the `cloud-event-consumer` DU appli
 * `api/ocloudNotifications/v1/publishers`
 - `GET`: Returns an array of `os-clock-sync-state`, `ptp-clock-class-change`, and `lock-state` messages for the cluster node
 
-* `/api/ocloudnotifications/v1/<resource_address>/CurrentState`
+* `/api/ocloudnotifications/v1/{resource_address}/CurrentState`
 -  `GET`: Returns the current state of one the following event types: `os-clock-sync-state`, `ptp-clock-class-change`, or `lock-state` events
 
 [NOTE]
@@ -86,25 +88,46 @@ Creates a new subscription. If a subscription is successfully created, or if it 
 }
 ----
 
-== api/ocloudNotifications/v1/subscriptions/<subscription_id>
-
 [discrete]
 === HTTP method
 
-`GET api/ocloudNotifications/v1/subscriptions/<subscription_id>`
+`DELETE api/ocloudNotifications/v1/subscriptions`
 
 [discrete]
 ==== Description
 
-Returns details for the subscription with ID `<subscription_id>`
+Deletes all subscriptions.
 
-.Query parameters
-|===
-| Parameter | Type
+.Example API response
+[source,json]
+----
+{
+"status": "deleted all subscriptions"
+}
+----
 
-| `<subscription_id>`
-| string
-|===
+[id="api-ocloud-notifications-v1-subscriptions-subscription_id_{context}"]
+== api/ocloudNotifications/v1/subscriptions/{subscription_id}
+
+[discrete]
+=== HTTP method
+
+`GET api/ocloudNotifications/v1/subscriptions/{subscription_id}`
+
+[discrete]
+=== Description
+
+Returns details for the subscription with ID `subscription_id`.
+
+.Global path parameters
+[cols=2*, width="60%", options="header"]
+|====
+|Parameter
+|Type
+
+|`subscription_id`
+|string
+|====
 
 .Example API response
 [source,json]
@@ -117,7 +140,36 @@ Returns details for the subscription with ID `<subscription_id>`
 }
 ----
 
-== api/ocloudNotifications/v1/health/
+[discrete]
+=== HTTP method
+
+`DELETE api/ocloudNotifications/v1/subscriptions/{subscription_id}`
+
+[discrete]
+=== Description
+
+Deletes the subscription with ID `subscription_id`.
+
+.Global path parameters
+[cols=2*, width="60%", options="header"]
+|====
+|Parameter
+|Type
+
+|`subscription_id`
+|string
+|====
+
+.Example API response
+[source,json]
+----
+{
+"status": "OK"
+}
+----
+
+[id="api-ocloudnotifications-v1-health_{context}"]
+== api/ocloudNotifications/v1/health
 
 [discrete]
 === HTTP method
@@ -264,7 +316,7 @@ $ oc logs -f linuxptp-daemon-cvgr6 -n openshift-ptp -c cloud-event-proxy
 }
 ----
 
-== /api/ocloudnotifications/v1/<resource_address>/CurrentState
+== /api/ocloudnotifications/v1/{resource_address}/CurrentState
 
 [discrete]
 === HTTP method
@@ -284,13 +336,15 @@ Configure the `CurrentState` API endpoint to return the current state of the `os
 * `ptp-clock-class-change` notifications describe the current state of the PTP clock class.
 * `lock-state` notifications describe the current status of the PTP equipment lock state. Can be in `LOCKED`, `HOLDOVER` or `FREERUN` state.
 
-.Query parameters
-|===
-| Parameter | Type
+.Global path parameters
+[cols=2*, width="60%", options="header"]
+|====
+|Parameter
+|Type
 
-| `<resource_address>`
-| string
-|===
+|`resource_address`
+|string
+|====
 
 .Example lock-state API response
 [source,json]


### PR DESCRIPTION
Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12

Cherry-picked from: 83232fbe96768296c12287be9d95a8430a8e413a

xref: https://github.com/openshift/openshift-docs/pull/78920

Doc preview:
- [Subscribing DU applications to PTP events REST API reference](https://79967--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#cnf-fast-event-notifications-api-refererence_using-ptp)