### PR TITLE
[enterprise-4.13] OCPBUGS#31297: Fixed typos

### DIFF
--- a/modules/cnf-checking-numa-aware-scheduler-logs.adoc
+++ b/modules/cnf-checking-numa-aware-scheduler-logs.adoc
@@ -79,7 +79,7 @@ numaresourcesscheduler.nodetopology.openshift.io/numaresourcesscheduler created
 
 . Check that the NUMA-aware scheduler was successfully deployed:
 
-.. Run the following command to check that the CRD is created succesfully:
+.. Run the following command to check that the CRD is created successfully:
 +
 [source,terminal]
 ----

--- a/modules/cnf-reporting-more-exact-reource-availability.adoc
+++ b/modules/cnf-reporting-more-exact-reource-availability.adoc
@@ -76,7 +76,7 @@ numaresourcesscheduler.nodetopology.openshift.io/numaresourcesscheduler created
 
 . Check that the NUMA-aware scheduler was successfully deployed:
 
-.. Run the following command to check that the CRD is created succesfully:
+.. Run the following command to check that the CRD is created successfully:
 +
 [source,terminal]
 ----

--- a/modules/cnf-troubleshooting-numa-aware-workloads.adoc
+++ b/modules/cnf-troubleshooting-numa-aware-workloads.adoc
@@ -45,7 +45,7 @@ $ oc get numaresourcesschedulers.nodetopology.openshift.io numaresourcesschedule
 topo-aware-scheduler
 ----
 
-. Verify that NUMA-aware scheduable nodes have the `noderesourcetopologies` CR applied to them. Run the following command:
+. Verify that NUMA-aware schedulable nodes have the `noderesourcetopologies` CR applied to them. Run the following command:
 +
 [source,terminal]
 ----
@@ -65,7 +65,7 @@ compute-1.example.com   17h
 The number of nodes should equal the number of worker nodes that are configured by the machine config pool (`mcp`) worker definition.
 ====
 
-. Verify the NUMA zone granularity for all scheduable nodes by running the following command:
+. Verify the NUMA zone granularity for all schedulable nodes by running the following command:
 +
 [source,terminal]
 ----

--- a/rest_api/console_apis/consolequickstart-console-openshift-io-v1.adoc
+++ b/rest_api/console_apis/consolequickstart-console-openshift-io-v1.adoc
@@ -285,7 +285,7 @@ Required::
 
 | `success`
 | `string`
-| success describes the succesfully passed task.
+| success describes the successfully passed task.
 
 |===
 


### PR DESCRIPTION
Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.13

Cherry-picked from: a6830b061d6f3cc6b3e14a8f8e5a944501c59c02

xref: https://github.com/openshift/openshift-docs/pull/79611