### PR TITLE
Highlighted the verification command

### DIFF
--- a/modules/etcd-increase-db.adoc
+++ b/modules/etcd-increase-db.adoc
@@ -67,7 +67,7 @@ The etcd Operator automatically rolls out the etcd instances with the new values
 +
 [source,terminal]
 ----
-oc get pods -n openshift-etcd
+$ oc get pods -n openshift-etcd
 ----
 +
 The following output shows the expected entries.


### PR DESCRIPTION
Highlighted the verification command for etcd disk quota 

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
OCP 4.16+

Issue: The verification command for etcd disk quota was not highlighted correctly.

Link to docs preview:
 https://79971--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.html#etcd-change-db-size_recommended-etcd-practices

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
