### PR TITLE
Highlight the `oc patch etcd/cluster` command

### DIFF
--- a/modules/etcd-tuning-parameters.adoc
+++ b/modules/etcd-tuning-parameters.adoc
@@ -42,7 +42,7 @@ If the output is empty, the field has not been set and should be considered as t
 +
 [source,terminal]
 ----
-oc patch etcd/cluster --type=merge -p '{"spec": {"controlPlaneHardwareSpeed": "<value>"}}'
+$ oc patch etcd/cluster --type=merge -p '{"spec": {"controlPlaneHardwareSpeed": "<value>"}}'
 ----
 +
 The following table indicates the heartbeat interval and leader election timeout for each profile. These values are subject to change.
@@ -87,7 +87,7 @@ Control Plane Hardware Speed:  ""
 +
 [source,terminal]
 ----
-oc get pods -n openshift-etcd -w
+$ oc get pods -n openshift-etcd -w
 ----
 +
 The following output shows the expected entries for master-0. Before you continue, wait until all masters show a status of `4/4 Running`.


### PR DESCRIPTION
Highlight the `oc patch etcd/cluster` command

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
OCP 4.14+

Issue:
Highlight the `oc patch etcd/cluster` command

Link to docs preview:

https://79972--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.html#etcd-changing-hardware-speed-tolerance_recommended-etcd-practices

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
