### PR TITLE
Update customize-certificates-api-add-named.adoc

### DIFF
--- a/modules/customize-certificates-api-add-named.adoc
+++ b/modules/customize-certificates-api-add-named.adoc
@@ -93,6 +93,11 @@ spec:
         name: <secret>
 ...
 ----
++
+[NOTE]
+====
+Do not include the port number along with the API server FQDN. Misconfiguration in this file will fail to add the API server named certificate.
+====
 
 . Check the `kube-apiserver` operator, and verify that a new revision of the Kubernetes API server rolls out.
 It may take a minute for the operator to detect the configuration change and trigger a new deployment.


### PR DESCRIPTION
Updating API server FQDN with port number fails to update API server named certificate

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Add a note in the documentation to not to use port number along with FQDN in apiserver/cluster to update API server named certificate.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->
There must be a note in official Red Hat documentation to make customers understand the implications of misconfiguration in the `apiserver/cluster` file.
KCS created for the issue where the customer put API server port number along with the API server FQDN . This failed to update the API server named certificate : https://access.redhat.com/solutions/7079870

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-11611

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://docs.openshift.com/container-platform/4.16/security/certificates/api-server.html#customize-certificates-api-add-named_api-server-certificates

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
