### PR TITLE
Adds chunksize MiB to s3 storage docs

### DIFF
--- a/modules/registry-operator-configuration-resource-overview-aws-s3.adoc
+++ b/modules/registry-operator-configuration-resource-overview-aws-s3.adoc
@@ -17,6 +17,10 @@ The image registry `spec.storage.s3` configuration parameter holds the informati
 |Bucket is the bucket name in which you want to store the registry's data.
 It is optional and is generated if not provided.
 
+|`chunkSizeMiB`
+|ChunkSizeMiB is the size of the multipart upload chunks of the S3 API.
+The default is `10` MiB with a minimum of `5` MiB. 
+
 |`region`
 |Region is the AWS region in which your bucket exists. It is optional and is
 set based on the installed AWS Region.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17+
Issue:
https://issues.redhat.com/browse/OSDOCS-11612

Link to docs preview:
https://79998--ocpdocs-pr.netlify.app/openshift-enterprise/latest/registry/configuring_registry_storage/configuring-registry-storage-aws-user-infrastructure.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
