### PR TITLE
Update ai-adding-worker-nodes-to-cluster.adoc

### DIFF
--- a/modules/ai-adding-worker-nodes-to-cluster.adoc
+++ b/modules/ai-adding-worker-nodes-to-cluster.adoc
@@ -68,7 +68,7 @@ $ CLUSTER_ID=$(curl "$API_URL/api/assisted-install/v2/clusters/import" -H "Autho
 +
 [source,terminal]
 ----
-export INFRA_ENV_REQUEST=$(jq --null-input \
+$ export INFRA_ENV_REQUEST=$(jq --null-input \
     --slurpfile pull_secret <path_to_pull_secret_file> \//<1>
     --arg ssh_pub_key "$(cat <path_to_ssh_pub_key>)" \//<2>
     --arg cluster_id "$CLUSTER_ID" '{


### PR DESCRIPTION
The export command is missing a $ at the beginning.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
In the documentation , Under point 4 b , the export command is missing a $ at the beginning 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
The export command is missing a $ at the beginning 

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://docs.openshift.com/container-platform/4.14/nodes/nodes/nodes-sno-worker-nodes.html#ai-adding-worker-nodes-to-cluster_add-workers

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
