### PR TITLE
OSDOCS-11564 Core OCP 4.16.6 Release Notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3306,8 +3306,8 @@ data:
 +
 (link:https://issues.redhat.com//browse/OCPBUGS-35316[*OCPBUGS-35316*])
 
-* Low-latency applications that rely on high-resolution timers to wake up their threads might experience higher wake up latencies than expected. 
-Although the expected wake up latency is under 20μs, latencies exceeding this time can occasionally be seen when running the `cyclictest` tool for long durations. 
+* Low-latency applications that rely on high-resolution timers to wake up their threads might experience higher wake up latencies than expected.
+Although the expected wake up latency is under 20μs, latencies exceeding this time can occasionally be seen when running the `cyclictest` tool for long durations.
 Testing has shown that wake up latencies are under 20μs for over 99.99999% of the samples.
 (link:https://issues.redhat.com/browse/OCPBUGS-34022[*OCPBUGS-34022*])
 
@@ -3330,6 +3330,82 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+[id="ocp-4-16-6_{context}"]
+=== RHSA-2024:4965 - {product-title} {product-version}.6 bug fix
+
+Issued: 6 August 2024
+
+{product-title} release {product-version}.6 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:4965[RHSA-2024:4965] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:4968[RHBA-2024:4968] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.6 --pullspecs
+----
+
+[id="ocp-4-16-6-enhancements_{context}"]
+==== Enhancements
+
+The following enhancements are included in this z-stream release:
+
+[id="ocp-4-16-6-enhancements-_{context}"]
+===== Ingress Controller certificate expiration dates collected
+
+* The Insights Operator now collects information about all Ingress Controller certificate expiration dates. The information is put into a JSON file in the path `aggregated/ingress_controllers_certs.json`. (link:https://issues.redhat.com/browse/OCPBUGS-37671[*OCPBUGS-37671*])
+
+[id="ocp-4-16-6-enhancements-debug-log_{context}"]
+===== Enabling debug log levels
+
+* Previously, you could not control log levels for the internal component that selects IP addresses for cluster nodes. With this release, you can now enable debug log levels so that you can either increase or decrease log levels on demand. To adjust log levels, you must create a config map manifest file with a configuration similar to the following:
++
+[source,yaml]
+----
+apiVersion: v1
+data:
+  enable-nodeip-debug: "true"
+kind: ConfigMap
+metadata:
+  name: logging
+  namespace: openshift-vsphere-infra
+# ...
+----
+(link:https://issues.redhat.com/browse/OCPBUGS-35891[*OCPBUGS-35891*])
+
+
+[id="ocp-4-16-6-enhancements-ironic-inspector-htpasswd_{context}"]
+===== Ironic and Inspector `htpasswd` improvement
+
+* Previously, the Ironic and Inspector `htpasswd` were provided to the `ironic-image` using environment variables, which is not secure. From this release, the Ironic `htpasswd` is provided to `ironic-image` using the `/auth/ironic/htpasswd` file, and the Inspector `htpasswd` is provided to `ironic-image` using the `/auth/inspector/htpasswd` file for better security. (link:https://issues.redhat.com/browse/OCPBUGS-36285[*OCPBUGS-36285*])
+
+[id="ocp-4-16-6-bug-fixes_{context}"]
+==== Bug fixes
+
+*  Previously, installer-created subnets were being tagged with `kubernetes.io/cluster/<clusterID>: shared`. With this release, subnets are now tagged with `kubernetes.io/cluster/<clusterID>: owned`. (link:https://issues.redhat.com/browse/OCPBUGS-37510[*OCPBUGS-37510*])
+
+* Previously, the same node was queued multiple times in the draining controller, which caused the the same node to be drained twice. With this release, a node will only be drained once. (link:https://issues.redhat.com/browse/OCPBUGS-37470[*OCPBUGS-37470*])
+
+* Previously, cordoned nodes in machine config pools (MCPs) with higher `maxUnavailable` than unavailable nodes might be selected as an update candidate. With this release, cordoned nodes will never be queued for an update. (link:https://issues.redhat.com/browse/OCPBUGS-37460[*OCPBUGS-37460*])
+
+* Previously, oc-mirror plugin v2, when running behind proxy with the system proxy configuration set, would attempt to recover signatures for releases without using the system proxy configuration. With this release, the system proxy configuration is taken into account during signature recovery as well and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-37445[*OCPBUGS-37445*])
+
+* Previously, an alert for `OVNKubernetesNorthdInactive` would not fire in circumstances where it should fire. With this release, the issue is fixed so that the alert for `OVNKubernetesNorthdInactive` fires as expected. (link:https://issues.redhat.com/browse/OCPBUGS-37362[*OCPBUGS-37362*])
+
+* Previously, the Load Balancer ingress rules were continuously revoked and  authorized, causing unnecessary Amazon Web Services (AWS) Application Programming Interface (API) calls and cluster provision delays. With this release, the Load Balancer checks for ingress rules that need to be applied and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-36968[*OCPBUGS-36968*])
+
+* Previously, in the {product-title} web console, one inactive or idle browser tab caused the session to expire for all other tabs. With this release, activity in any tab will prevent session expiration. (link:https://issues.redhat.com/browse/OCPBUGS-36864[*OCPBUGS-36864*])
+
+* Previously, the Open vSwitch (OVS) pinning procedure set the CPU affinity of the main thread, but other CPU threads did not pick up this affinity if they had already been created. As a consequence, some OVS threads did not run on the correct CPU set, which might interfere with the performance of pods with a Quality of Service (QoS) class of `Guaranteed`. With this update, the OVS pinning procedure updates the affinity of all the OVS threads, ensuring that all OVS threads run on the correct CPU set. (link:https://issues.redhat.com/browse/OCPBUGS-36608[*OCPBUGS-36608*])
+
+* Previously, the etcd Operator checked the health of etcd members in serial with an all-member timeout that matched the single-member timeout. That allowed one slow member check to consume the entire timeout, and cause later member checks to fail with the error `deadline-exceeded`, regardless of the health of that later member. Now, etcd checks the health of members in parallel so the health and speed of one member's check doesn't affect the other members' checks. (link:https://issues.redhat.com/browse/OCPBUGS-36489[*OCPBUGS-36489*])
+
+[id="ocp-4-16-6-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.16.5
 [id="ocp-4-16-5_{context}"]
 === RHBA-2024:4855 - {product-title} {product-version}.5 bug fix
@@ -3344,7 +3420,7 @@ You can view the container images in this release by running the following comma
 
 [source,terminal]
 ----
-$ oc adm release info 4.16.4 --pullspecs
+$ oc adm release info 4.16.5 --pullspecs
 ----
 
 [id="ocp-4-16-5-bug-fixes_{context}"]


### PR DESCRIPTION
Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-11564](https://issues.redhat.com/browse/OSDOCS-11564)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to [docs preview](https://80038--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-6_release-notes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Not needed
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: **MERGE REVIEWER**: Since peer review I removed a bug that was dropped from the release, and added the Ironic and Inspector enhancement since the security level was changed. 

Advisory links will not work until after release on August 6th.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
