### PR TITLE
OADP-2493 created new PR without attributes include

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
@@ -37,10 +37,12 @@ include::modules/oadp-self-signed-certificate.adoc[leveloffset=+2]
 include::modules/oadp-installing-dpa-1-2-and-earlier.adoc[leveloffset=+1]
 include::modules/oadp-installing-dpa-1-3.adoc[leveloffset=+1]
 include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
+include::modules/oadp-about-disable-node-agent-dpa.adoc[leveloffset=+2] 
 
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc#oadp-installing-dpa-1-3_installing-oadp-kubevirt[Installing the Data Protection Application with the `kubevirt` and `openshift` plugins]
+* xref:../../../nodes/jobs/nodes-nodes-jobs.adoc#nodes-nodes-jobs[Running tasks in pods using jobs].
 
 :!installing-oadp-aws:

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc
@@ -34,10 +34,12 @@ include::modules/oadp-self-signed-certificate.adoc[leveloffset=+2]
 include::modules/oadp-installing-dpa-1-2-and-earlier.adoc[leveloffset=+1]
 include::modules/oadp-installing-dpa-1-3.adoc[leveloffset=+1]
 include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
+include::modules/oadp-about-disable-node-agent-dpa.adoc[leveloffset=+2] 
 
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc#oadp-installing-dpa-1-3_installing-oadp-kubevirt[Installing the Data Protection Application with the `kubevirt` and `openshift` plugins]
+* xref:../../../nodes/jobs/nodes-nodes-jobs.adoc#nodes-nodes-jobs[Running tasks in pods using jobs].
 
 :installing-oadp-azure!:

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc
@@ -35,10 +35,12 @@ include::modules/oadp-installing-dpa-1-2-and-earlier.adoc[leveloffset=+1]
 include::modules/oadp-gcp-wif-cloud-authentication.adoc[leveloffset=+1]
 include::modules/oadp-installing-dpa-1-3.adoc[leveloffset=+1]
 include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
+include::modules/oadp-about-disable-node-agent-dpa.adoc[leveloffset=+2] 
 
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc#oadp-installing-dpa-1-3_installing-oadp-kubevirt[Installing the Data Protection Application with the `kubevirt` and `openshift` plugins]
+* xref:../../../nodes/jobs/nodes-nodes-jobs.adoc#nodes-nodes-jobs[Running tasks in pods using jobs].
 
 :installing-oadp-gcp!:

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
@@ -41,6 +41,7 @@ include::modules/oadp-self-signed-certificate.adoc[leveloffset=+2]
 include::modules/oadp-installing-dpa-1-2-and-earlier.adoc[leveloffset=+1]
 include::modules/oadp-installing-dpa-1-3.adoc[leveloffset=+1]
 include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
+include::modules/oadp-about-disable-node-agent-dpa.adoc[leveloffset=+2] 
 
 [discrete]
 [role="_additional-resources"]
@@ -49,5 +50,6 @@ include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
 * link:https://access.redhat.com/solutions/6719951[Performance tuning guide for Multicloud Object Gateway].
 
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc#oadp-installing-dpa-1-3_installing-oadp-kubevirt[Installing the Data Protection Application with the `kubevirt` and `openshift` plugins]
+* xref:../../../nodes/jobs/nodes-nodes-jobs.adoc#nodes-nodes-jobs[Running tasks in pods using jobs].
 
 :installing-oadp-mcg!:

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
@@ -45,10 +45,12 @@ include::modules/oadp-installing-dpa-1-2-and-earlier.adoc[leveloffset=+1]
 include::modules/oadp-installing-dpa-1-3.adoc[leveloffset=+1]
 include::modules/oadp-creating-object-bucket-claim.adoc[leveloffset=+2]
 include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
+include::modules/oadp-about-disable-node-agent-dpa.adoc[leveloffset=+2] 
 
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc#oadp-installing-dpa-1-3_installing-oadp-kubevirt[Installing the Data Protection Application with the `kubevirt` and `openshift` plugins]
+* xref:../../../nodes/jobs/nodes-nodes-jobs.adoc#nodes-nodes-jobs[Running tasks in pods using jobs].
 
 :installing-oadp-ocs!:

--- a/modules/oadp-about-disable-node-agent-dpa.adoc
+++ b/modules/oadp-about-disable-node-agent-dpa.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="oadp-about-disable-node-agent-dpa_{context}"]
+= Disabling the node agent in DataProtectionApplication
+
+If you are not using `Restic`, `Kopia`, or `DataMover` for your backups, you can disable the `nodeAgent` field in the `DataProtectionApplication` custom resource (CR). Before you disable `nodeAgent`, ensure the {oadp-short} Operator is idle and not running any backups.
+
+.Procedure
+
+. To disable the `nodeAgent`, set the `enable` flag to `false`. See the following example:
++
+.Example `DataProtectionApplication` CR
+[source, yaml]
+----
+# ...
+configuration:
+  nodeAgent:
+    enable: false  # <1>
+    uploaderType: kopia
+# ...
+----
+<1> Disables the node agent.
+
+. To enable the `nodeAgent`, set the `enable` flag to `true`. See the following example:
++
+.Example `DataProtectionApplication` CR
+[source, yaml]
+----
+# ...
+configuration:
+  nodeAgent:
+    enable: true  # <1>
+    uploaderType: kopia
+# ...
+----
+<1> Enables the node agent.
+
+You can set up a job to enable and disable the `nodeAgent` field in the `DataProtectionApplication` CR. For more information, see "Running tasks in pods using jobs".


### PR DESCRIPTION
## Jira 

* [OADP-2493](https://issues.redhat.com/browse/OADP-2493)

Created this PR because the original [PR](https://github.com/openshift/openshift-docs/pull/79683) was failing during merge.
I have removed include::_attributes/common-attributes.adoc[] from the module oadp-about-disable-node-agent-dpa.adoc which was causing the merge to fail.
This PR is approved by QE and has gone through OCP peer review.  Resubmitting the PR again for merging. 

##  Version

* OCP 4.13 → OCP 4.17

## Preview

[AWS - About disabling node agent in the DataProtectionApplication](https://80039--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html#oadp-about-disable-node-agent-dpa_installing-oadp-aws)

[Azure - About disabling node agent in the DataProtectionApplication](https://80039--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure#oadp-about-disable-node-agent-dpa_installing-oadp-azure)

[GCP - About disabling node agent in the DataProtectionApplication](https://80039--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp#oadp-about-disable-node-agent-dpa_installing-oadp-gcp)

[MCG - About disabling node agent in the DataProtectionApplication](https://80039--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg#oadp-about-disable-node-agent-dpa_installing-oadp-mcg)

[ODF - About disabling node agent in the DataProtectionApplication](https://80039--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs#oadp-about-disable-node-agent-dpa_installing-oadp-ocs)

## QE Review

* [x] QE has approved this change.
