### PR TITLE
OSDOCS#10853: Remove unsupported overcommit methods from Managed docs

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1446,6 +1446,7 @@ Topics:
   - Name: Configuring cluster memory to meet container memory and risk requirements
     File: nodes-cluster-resource-configure
     Distros: openshift-rosa
+# TODO: Remove the whole nodes-cluster-overcommit file for OSDOCS-10853?
   - Name: Configuring your cluster to place pods on overcommited nodes
     File: nodes-cluster-overcommit
     Distros: openshift-rosa

--- a/modules/nodes-cluster-overcommit-project-disable.adoc
+++ b/modules/nodes-cluster-overcommit-project-disable.adoc
@@ -7,21 +7,52 @@
 [id="nodes-cluster-overcommit-project-disable_{context}"]
 = Disabling overcommitment for a project
 
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 When enabled, overcommitment can be disabled per-project. For example, you can allow infrastructure components to be configured independently of overcommitment.
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+
+ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+If required by your use case, you can disable overcommitment on any project that is not managed by Red Hat. For a list of projects that cannot be modified, see "Red Hat Managed resources" in _Support_.
+
+.Prerequisites
+* You are logged in to the cluster using an account with cluster administrator or cluster editor permissions.
+
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 .Procedure
-
-To disable overcommitment in a project:
-
-ifndef::openshift-rosa,openshift-dedicated[]
+//For OCP and Origin:
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 . Create or edit the namespace object file.
-endif::openshift-rosa,openshift-dedicated[]
-// Invalid value: "false": field is immutable, try updating the namespace
-ifdef::openshift-rosa,openshift-dedicated[]
-. Edit the namespace object file.
-endif::openshift-rosa,openshift-dedicated[]
-
 . Add the following annotation:
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+//For ROSA, ROSA-HCP, OSD:
+ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+. Edit the namespace object file:
+.. If you are using the web console:
+... Click *Administration* -> *Namespaces* and click the namespace for the project.
+... In the *Annotations* section, click the *Edit* button.
+... Click *Add more* and enter a new annotation that uses a *Key* of `quota.openshift.io/cluster-resource-override-enabled` and a *Value* of `false`.
+... Click *Save*.
+ifndef::openshift-rosa,openshift-rosa-hcp[]
+.. If you are using the {oc-first}:
+... Edit the namespace:
++
+[source,terminal]
+----
+$ oc edit namespace/<project_name>
+----
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+.. If you are using the ROSA CLI (`rosa`):
+... Edit the namespace:
++
+[source,terminal]
+----
+$ rosa edit namespace/<project_name>
+----
+endif::openshift-rosa,openshift-rosa-hcp[]
+... Add the following annotation:
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 +
 [source,yaml]
 ----
@@ -29,7 +60,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
-    quota.openshift.io/cluster-resource-override-enabled: "false" <1>
+    quota.openshift.io/cluster-resource-override-enabled: "false" <.>
 # ...
 ----
-<1> Setting this annotation to `false` disables overcommit for this namespace.
+<.> Setting this annotation to `false` disables overcommit for this namespace.

--- a/modules/nodes-cluster-project-overcommit.adoc
+++ b/modules/nodes-cluster-project-overcommit.adoc
@@ -6,6 +6,7 @@
 [id="nodes-cluster-project-overcommit_{context}"]
 = Project-level limits
 
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 To help control overcommit, you can set per-project resource limit ranges,
 specifying memory and CPU limits and defaults for a project that overcommit
 cannot exceed.
@@ -13,3 +14,11 @@ cannot exceed.
 For information on project-level resource limits, see Additional resources.
 
 Alternatively, you can disable overcommitment for specific projects.
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+
+ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+In {product-title}, overcommitment of project-level resources is enabled by default.
+If required by your use case, you can disable overcommitment on projects that are not managed by Red Hat.
+
+For the list of projects that are managed by Red Hat and cannot be modified, see "Red Hat Managed resources" in _Support_.
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]

--- a/nodes/clusters/nodes-cluster-overcommit.adoc
+++ b/nodes/clusters/nodes-cluster-overcommit.adoc
@@ -6,11 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-
-
-
-
-
 In an _overcommitted_ state, the sum of the container compute resource requests
 and limits exceeds the resources available on the system. For example, you might
 want to use overcommitment in development environments where a trade-off of
@@ -24,33 +19,32 @@ The scheduler attempts to optimize the compute resource use across all nodes
 in your cluster. It places pods onto specific nodes, taking the pods' compute
 resource requests and nodes' available capacity into consideration.
 
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 {product-title} administrators can control the level of overcommit and manage
 container density on nodes. You can configure cluster-level overcommit using
 the xref:#nodes-cluster-resource-override_nodes-cluster-overcommit[ClusterResourceOverride Operator]
 to override the ratio between requests and limits set on developer containers.
 In conjunction with xref:#nodes-cluster-node-overcommit_nodes-cluster-overcommit[node overcommit] and
 xref:../../applications/deployments/managing-deployment-processes.adoc#deployments-setting-resources_deployment-operations[project memory and CPU limits and defaults], you can adjust the resource limit and request to achieve the desired level of overcommit.
-endif::openshift-rosa,openshift-dedicated[]
-ifdef::openshift-rosa,openshift-dedicated[]
-{product-title} administrators can control the level of overcommit and manage
-container density on nodes. You can configure cluster-level overcommit using
-the xref:#nodes-cluster-resource-override_nodes-cluster-overcommit[ClusterResourceOverride Operator]
-to override the ratio between requests and limits set on developer containers.
-In conjunction with xref:#nodes-cluster-node-overcommit_nodes-cluster-overcommit[node overcommit], you can adjust the resource limit and request to achieve the desired level of overcommit.
-endif::openshift-rosa,openshift-dedicated[]
 
 [NOTE]
 ====
 In {product-title}, you must enable cluster-level overcommit. Node overcommitment is enabled by default.
 See xref:#nodes-cluster-overcommit-node-disable_nodes-cluster-overcommit[Disabling overcommitment for a node].
 ====
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
-// The following include statements pull in the module files that comprise
-// the assembly. Include any combination of concept, procedure, or reference
-// modules required to cover the user story. You can also include other
-// assemblies.
+//ROSA and Dedicated intro
+ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+{product-title} administrators can manage container density on nodes by configuring pod placement behavior and per-project resource limits that overcommit cannot exceed.
 
+Alternatively, administrators can disable project-level resource overcommitment on customer-created namespaces that are not managed by Red Hat.
+
+For more information about container resource management, see Additional resources.
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+
+//core openshift content
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 include::modules/nodes-cluster-overcommit-resource-requests.adoc[leveloffset=+1]
 
@@ -100,15 +94,21 @@ include::modules/nodes-cluster-overcommit-node-resources.adoc[leveloffset=+2]
 
 include::modules/nodes-cluster-overcommit-node-disable.adoc[leveloffset=+2]
 
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+
+//ROSA and Dedicated can only do the following, so no ifndef on these
 include::modules/nodes-cluster-project-overcommit.adoc[leveloffset=+1]
 
 include::modules/nodes-cluster-overcommit-project-disable.adoc[leveloffset=+2]
 
-ifndef::openshift-rosa,openshift-dedicated[]
 [role="_additional-resources"]
 [id="nodes-cluster-overcommit-addtl-resources"]
 == Additional resources
-
-* xref:../../applications/deployments/managing-deployment-processes.adoc#deployments-triggers_deployment-operations[Setting deployment resources].
-* xref:../../nodes/nodes/nodes-nodes-resources-configuring.adoc#nodes-nodes-resources-configuring-setting_nodes-nodes-resources-configuring[Allocating resources for nodes].
-endif::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+* xref:../../applications/deployments/managing-deployment-processes.adoc#deployments-triggers_deployment-operations[Setting deployment resources]
+* xref:../../nodes/nodes/nodes-nodes-resources-configuring.adoc#nodes-nodes-resources-configuring-setting_nodes-nodes-resources-configuring[Allocating resources for nodes]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+* xref:../../nodes/clusters/nodes-cluster-limit-ranges.adoc#nodes-cluster-limit-ranges[Restrict resource consumption with limit ranges]
+* xref:../../support/troubleshooting/sd-managed-resources.adoc#sd-managed-resources[Red Hat Managed resources]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]

--- a/support/troubleshooting/sd-managed-resources.adoc
+++ b/support/troubleshooting/sd-managed-resources.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="sd-managed-resources"]
-= {product-title} managed resources
+= Red{nbsp}Hat managed resources
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: sd-managed-resources
 
@@ -9,7 +9,7 @@ toc::[]
 [id="sd-managed-resources-overview_{context}"]
 == Overview
 
-The following covers all resources managed or protected by the Service Reliability Engineering Platform (SRE-P) Team.  Customers should not attempt to modify these resources because doing so can lead to cluster instability.
+The following covers all {product-title} resources that are managed or protected by the Service Reliability Engineering Platform (SRE-P) Team.  Customers should not attempt to modify these resources because doing so can lead to cluster instability.
 
 [id="sd-managed-resources-all_{context}"]
 == Hive managed resources


### PR DESCRIPTION
Version(s): 4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-10853

Link to docs preview:
OSD: https://80040--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/clusters/nodes-cluster-overcommit.html
OCP: https://80040--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-overcommit.html
ROSA: https://80040--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/clusters/nodes-cluster-overcommit.html

QE review:
- [x] QE has approved this change.

Additional information: N/A