### PR TITLE
TELCODOCS-1907 : RN Tuning CNI- ALLMULTI flag (GA, 4.14.z backport)

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -861,6 +861,13 @@ Admin Network Policy is available as a Technology Preview feature. You can enabl
 
 With this release, the ability to create a MAC-VLAN, IP-VLAN, and VLAN subinterface based on a master interface in a container namespace is generally available. You can use this feature to create the master interfaces as part of the pod network configuration in a separate network attachment definition. You can then base the VLAN, MACVLAN or IPVLAN on this interface without knowing the network configuration of the node. For more information, see xref:../networking/multiple_networks/configuring-additional-network.html#nw-about-configuring-master-interface-container_configuring-additional-network[About configuring the master interface in the container network namespace].
 
+[id="ocp-4-14-all-multicast"]
+==== Supporting all-multicast mode
+
+{product-title} release now supports configuring the all-multicast mode by using the tuning CNI plugin. This update eliminates the need to grant the `NET_ADMIN` capability to the pod's Security Context Constraints (SCC), enhancing security by minimizing potential vulnerabilities for your pods.
+
+For further information about all-multicast mode, see xref:../networking/hardware_networks/configuring-interface-sysctl-sriov-device.adoc#nw-about-all-multi-cast-mode_configuring-sysctl-interface-sriov-device[About all-multicast mode].
+
 [id="ocp-4-14-tap-device-plugin"]
 ==== Enhance network flexibility by using the TAP device plugin
 


### PR DESCRIPTION
[TELCODOCS-1511,[TELCODOCS-1907](https://issues.redhat.com//browse/TELCODOCS-1907)]: Enabling ALLMULTI flag

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-1907
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://80045--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-all-multicast

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: RN for https://issues.redhat.com//browse/TELCODOCS-1907 now tested and verified on 4.14

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
