### PR TITLE
TELCODOCS-1868: Moving feature host network settings for SR-IOV network VFs to GA with minor functionality updates

### DIFF
--- a/modules/virt-example-vf-host-services.adoc
+++ b/modules/virt-example-vf-host-services.adoc
@@ -4,12 +4,9 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="virt-example-vf-host-services_{context}"]
-= Example: Node network configuration policy for virtual functions (Technology Preview)
+= Example: Node network configuration policy for virtual functions
 
 Update host network settings for Single Root I/O Virtualization (SR-IOV) network virtual functions (VF) in an existing cluster by applying a `NodeNetworkConfigurationPolicy` manifest.
-
-:FeatureName: Updating host network settings for SR-IOV network VFs
-include::snippets/technology-preview.adoc[leveloffset=+1]
 
 You can apply a `NodeNetworkConfigurationPolicy` manifest to an existing cluster to complete the following tasks:
 
@@ -23,7 +20,7 @@ To update host network settings for SR-IOV VFs by using NMState on physical func
 ====
 
 The following YAML file is an example of a manifest that defines QoS policies for a VF.
-This file includes samples values that you must replace with your own information.
+This YAML includes samples values that you must replace with your own information.
 
 [source,yaml]
 ----
@@ -59,12 +56,12 @@ spec:
 <9> Identifies the VF with an ID of `0`.
 <10> Sets a maximum transmission rate, in Mbps, for the VF. This sample value sets a rate of 200 Mbps.
 
-The following YAML file is an example of a manifest that creates a VLAN interface on top of a VF and adds it to a bonded network interface.
-It includes samples values that you must replace with your own information.
+The following YAML file is an example of a manifest that adds a VF for a network interface. 
+
+In this sample configuration, the `ens1f1v0` VF is created on the `ens1f1` physical interface, and this VF is added to a bonded network interface `bond0`. The bond uses `active-backup` mode for redundancy. In this example, the VF is configured to use hardware offloading to manage the VLAN directly on the physical interface.
 
 [source,yaml]
 ----
-
 apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
 metadata:
@@ -75,39 +72,40 @@ spec:
   maxUnavailable: 3
   desiredState:
     interfaces:
-      - name: ens1f0v1 <4>
+      - name: ens1f1 <4>
         type: ethernet
         state: up
-      - name: ens1f0v1.477 <5>
-        type: vlan
-        state: up
-        vlan:
-          base-iface: ens1f0v1 <6>
-          id: 477
-      - name: bond0 <7>
-        description: Add vf <8>
-        type: bond <9>
-        state: up <10>
+        ethernet:
+            sr-iov:
+              total-vfs: 1 <5>
+              vfs:
+                - id: 0
+                  trust: true <6>
+                  vlan-id: 477 <7>
+      - name: bond0 <8>
+        description: Attach VFs to bond <9>
+        type: bond <10>
+        state: up <11>
         link-aggregation:
-          mode: active-backup <11>
+          mode: active-backup <12>
           options:
-            primary: ens1f1v0.477 <12>
-          port: <13>
-            - ens1f1v0.477
-            - ens1f0v0.477
-            - ens1f0v1.477 <14>
+            primary: ens1f0v0 <13>
+          port: <14>
+            - ens1f0v0
+            - ens1f1v0 <15>
 ----
 <1> Name of the policy.
 <2> Optional: If you do not include the `nodeSelector` parameter, the policy applies to all nodes in the cluster.
-<3> This example applies to all nodes with the `worker` role.
+<3> The example applies to all nodes with the `worker` role.
 <4> Name of the VF network interface.
-<5> Name of the VLAN network interface.
-<6> The VF network interface to which the VLAN interface is attached.
-<7> Name of the bonding network interface.
-<8> Optional: Human-readable description of the interface.
-<9> The type of interface.
-<10> The requested state for the interface after configuration.
-<11> The bonding policy for the bond.
-<12> The primary attached bonding port.
-<13> The ports for the bonded network interface.
-<14> In this example, this VLAN network interface is added as an additional interface to the bonded network interface.
+<5> Number of VFs to create.
+<6> Setting to allow failover bonding between the active and backup VFs.
+<7> ID of the VLAN. The example uses hardward offloading to define a VLAN directly on the VF.
+<8> Name of the bonding network interface.
+<9> Optional: Human-readable description of the interface.
+<10> The type of interface.
+<11> The requested state for the interface after configuration.
+<12> The bonding policy for the bond.
+<13> The primary attached bonding port.
+<14> The ports for the bonded network interface.
+<15> In this example, the VLAN network interface is added as an additional interface to the bonded network interface.

--- a/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
@@ -60,6 +60,8 @@ include::modules/virt-example-vf-host-services.adoc[leveloffset=+2]
 .Additional resources
 * xref:../../networking/hardware_networks/configuring-sriov-device.adoc#configuring-sriov-device[Configuring an SR-IOV network device]
 
+* xref:../../networking/hardware_networks/configuring-hardware-offloading.adoc#configuring-hardware-offloading[Configuring hardware offloading]
+
 include::modules/virt-example-bond-nncp.adoc[leveloffset=+2]
 
 include::modules/virt-example-ethernet-nncp.adoc[leveloffset=+2]


### PR DESCRIPTION
[TELCODOCS-1868](https://issues.redhat.com//browse/TELCODOCS-1868): Moving feature host network settings for SR-IOV network VFs to GA with minor functionality updates

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1868

Link to docs preview:
https://80046--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#virt-example-vf-host-services_k8s_nmstate-updating-node-network-config

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
