### PR TITLE
OSDOCS-4782: Added HostNetwork note to Using the  network policy

### DIFF
--- a/modules/nw-networkpolicy-about.adoc
+++ b/modules/nw-networkpolicy-about.adoc
@@ -62,6 +62,11 @@ spec:
 
 * Only accept connections from pods within a project:
 +
+[IMPORTANT]
+====
+To allow ingress connections from `hostNetwork` pods in the same namespace, you need to apply the `allow-from-hostnetwork` policy together with the `allow-same-namespace` policy.
+====
++
 To make pods accept connections from other pods in the same project, but reject all other connections from pods in other projects, add the following `NetworkPolicy` object:
 +
 [source,yaml]
@@ -150,11 +155,10 @@ spec:
 ----
 <1> `policy-group.network.openshift.io/ingress:""` label supports both OpenShift-SDN and OVN-Kubernetes.
 
-
 [id="nw-networkpolicy-allow-from-hostnetwork_{context}"]
 == Using the allow-from-hostnetwork network policy
 
-Add the following `allow-from-hostnetwork` `NetworkPolicy` object to direct traffic from the host network pods:
+Add the following `allow-from-hostnetwork` `NetworkPolicy` object to direct traffic from the host network pods.
 
 [source,yaml]
 ----


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-4782](https://issues.redhat.com/browse/OSDOCS-4782)

Link to docs preview:
[Using the allow-from-hostnetwork network policy](https://80047--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/network_policy/about-network-policy.html#nw-networkpolicy-allow-from-hostnetwork_about-network-policy)

- [x] SME has approved this change. Ben Bennett
- [x] QE has approved this change.

