### PR TITLE
RHDEVDOCS-5983: DOC: Records/Logs retention configuration in Tekton R…

### DIFF
--- a/modules/op-configuring-retention-policy-results.adoc
+++ b/modules/op-configuring-retention-policy-results.adoc
@@ -1,0 +1,37 @@
+// This module is included in the following assembly:
+//
+// * cicd/pipelines/using-tekton-results-for-openshift-pipelines-observability.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-retention-policy-results_{context}"]
+= Configuring the retention policy for {tekton-results}
+
+By default, {tekton-results} stores pipeline runs, task runs, events, and logs indefinitely. This leads to an unnecesary use of storage resources and can affect your database performance.
+
+You can configure the retention policy for {tekton-results} at the cluster level to remove older results and their associated records and logs. You can achieve this by editing the `TektonResult` custom resource (CR).
+
+.Prerequisites
+
+* You installed {tekton-results}.
+
+.Procedure
+
+* In the `TektonResult` CR, configure the retention policy for {tekton-results}, as shown in the following example:
++
+.Example retention policy for {tekton-results}
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonResult
+metadata:
+  name: result
+spec:
+  options:
+    configMaps:
+      config-results-retention-policy:
+        data:
+          runAt: "3 5 * * 0" #<1>
+          maxRetention: "30" #<2>
+----
+<1> Specify, in cron format, when to run the pruning job in the database. This example runs the job at 5:03 AM every Sunday.
+<2> Specify how many days to keep the data in the database. This example retains the data for 30 days.

--- a/records/using-tekton-results-for-openshift-pipelines-observability.adoc
+++ b/records/using-tekton-results-for-openshift-pipelines-observability.adoc
@@ -23,8 +23,9 @@ include::modules/op-results-cert.adoc[leveloffset=+2]
 include::modules/op-results-db.adoc[leveloffset=+2]
 include::modules/op-results-storage.adoc[leveloffset=+2]
 
-
+//Install and configure Tekton Results
 include::modules/op-installing-results.adoc[leveloffset=+1]
+include::modules/op-configuring-retention-policy-results.adoc[leveloffset=+1]
 
 [id="querying-using-opc_using-tekton-results-for-openshift-pipelines-observability"]
 == Querying {tekton-results} using the opc command line utility


### PR DESCRIPTION
Version(s): `pipelines-docs-1.16`

Issue: [RHDEVDOCS-5983](https://issues.redhat.com/browse/RHDEVDOCS-5983)

Link to docs preview:  https://80048--ocpdocs-pr.netlify.app/openshift-pipelines/latest/records/using-tekton-results-for-openshift-pipelines-observability.html#configuring-retention-policy-results_using-tekton-results-for-openshift-pipelines-observability

QE review:
- [x] QE has approved this change.

**Additional information:**