### PR TITLE
[ENTERPRISE-4.12] OCPBUGS-37699: Remove mode=6 balance-alb from networking docs

### DIFF
--- a/modules/virt-example-bond-nncp.adoc
+++ b/modules/virt-example-bond-nncp.adoc
@@ -15,8 +15,6 @@ to the cluster.
 * mode=1 active-backup +
 * mode=2 balance-xor +
 * mode=4 802.3ad +
-* mode=5 balance-tlb +
-* mode=6 balance-alb
 ====
 
 The following YAML file is an example of a manifest for a bond interface.

--- a/modules/virt-example-nmstate-multiple-interfaces.adoc
+++ b/modules/virt-example-nmstate-multiple-interfaces.adoc
@@ -25,7 +25,7 @@ spec:
       type: bond <6>
       state: up <7>
       link-aggregation:
-        mode: balance-rr <8>
+        mode: balance-xor <8>
         options:
           miimon: '140' <9>
         port: <10>


### PR DESCRIPTION
Cherry-picked from #79684 with commit ID ab4b33c6b6618ef391bbc99d7530819f98c4e13d

Version: 4.12

Link to docs preview:
* [Example: Bond interface node network configuration policy](https://79684--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#virt-example-bond-nncp_k8s_nmstate-updating-node-network-config)

Additional information

The (Optional: Configuring host network interfaces for dual port NIC)[https://79684--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow#configuring-host-dual-network-interfaces-in-the-install-config-yaml-file_ipi-install-installation-workflow] was already published with the first failed merge so this file is not part of the changes in this PR.

