### PR TITLE
OCPBUGS-35405 Enabling cgroup v2 is not possible if you are using performance profiles.

### DIFF
--- a/modules/nodes-clusters-cgroups-2.adoc
+++ b/modules/nodes-clusters-cgroups-2.adoc
@@ -37,7 +37,7 @@ endif::nodes[]
 
 [NOTE]
 ====
-Currently, disabling CPU load balancing is not supported by cgroup v2. As a result, you might not get the desired behavior from performance profiles if you have cgroup v2 enabled. Enabling cgroup v2 is not recommended if you are using performance profiles.
+In Telco, clusters using `PerformanceProfile` for low latency, real-time, and Data Plane Development Kit (DPDK) workloads automatically revert to cgroups v1 due to the lack of cgroups v2 support. Enabling cgroup v2 is not supported if you are using `PerformanceProfile`. 
 ====
 
 .Prerequisites

--- a/scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
+++ b/scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
@@ -19,6 +19,11 @@ You can restrict CPUs for infra and application containers, configure huge pages
 
 Learn about the Performance Profile Creator (PPC) and how you can use it to create a performance profile.
 
+[NOTE]
+====
+In Telco, clusters using `PerformanceProfile` for low latency, real-time, and Data Plane Development Kit (DPDK) workloads automatically revert to cgroups v1 due to the lack of cgroups v2 support. Enabling cgroup v2 is not supported if you are using `PerformanceProfile`. 
+====
+
 include::modules/cnf-about-the-profile-creator-tool.adoc[leveloffset=+2]
 
 include::modules/cnf-gathering-data-about-cluster-using-must-gather.adoc[leveloffset=+2]


### PR DESCRIPTION
[OCPBUGS-35405 ]: Enabling cgroup v2 is not possible if you are using performance profiles
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-35405
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://80071--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-cgroups-2.html#nodes-clusters-cgroups-2_nodes-cluster-cgroups-2

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
