### PR TITLE
[enterprise-4.15] OSDOCS-40769: Corrected SCSI type in LUN disk sharing section

### DIFF
--- a/modules/virt-configuring-disk-sharing-lun.adoc
+++ b/modules/virt-configuring-disk-sharing-lun.adoc
@@ -6,11 +6,14 @@
 [id="virt-configuring-disk-sharing-lun_{context}"]
 = Configuring disk sharing by using LUN
 
-You can configure a LUN-backed virtual machine disk to be shared among multiple virtual machines by enabling SCSI persistent reservation. Enabling the shared option allows you to use advanced SCSI commands, such as those required for a Windows failover clustering implementation, against the underlying storage. Any disk to be shared must be in block mode.
+To secure data on your VM from outside access, you can enable SCSI persistent reservation and configure a LUN-backed virtual machine disk to be shared among multiple virtual machines. By enabling the shared option, you can use advanced SCSI commands, such as those required for a Windows failover clustering implementation, for managing the underlying storage.
 
-A disk of type `LUN` exposes the volume as a LUN device to the VM. This allows the VM to execute arbitrary iSCSI command passthrough on the disk.
+When a storage volume is configured as the `LUN` disk type, a VM can use the volume as a logical unit number (LUN) device. As a result, the VM can deploy and manage the disk by using SCSI commands.
 
-You reserve a LUN through the SCSI persistent reserve options to protect data on the VM from outside access. To enable the reservation, you configure the feature gate option. You then activate the option on the LUN disk to issue SCSI device-specific input and output controls (IOCTLs) that the VM requires.
+You reserve a LUN through the SCSI persistent reserve options. To enable the reservation: 
+
+. Configure the feature gate option
+. Activate the feature gate option on the LUN disk to issue SCSI device-specific input and output controls (IOCTLs) that the VM requires.
 
 .Prerequisites
 
@@ -19,8 +22,12 @@ You reserve a LUN through the SCSI persistent reserve options to protect data on
 * The volume access mode must be `ReadWriteMany` (RWX) if the VMs that are sharing disks are running on different nodes.
 +
 If the VMs that are sharing disks are running on the same node, `ReadWriteOnce` (RWO) volume access mode is sufficient.
+
 * The storage provider must support a Container Storage Interface (CSI) driver that uses the SCSI protocol.
+
 * If you are a cluster administrator and intend to configure disk sharing by using LUN, you must enable the cluster's feature gate on the `HyperConverged` custom resource (CR).
+
+* Disks that you want to share must be in block mode.
 
 .Procedure
 

--- a/virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc
@@ -10,8 +10,10 @@ You can configure shared disks to allow multiple virtual machines (VMs) to share
 
 You configure disk sharing by exposing the storage as either of these types:
 
-* An ordinary virtual machine disk
-* A logical unit number (LUN) device with an iSCSi connection and raw device mapping, as required for Windows Failover Clustering for shared volumes
+* An ordinary VM disk
+* A logical unit number (LUN) disk with an SCSI connection and raw device mapping, as required for Windows Failover Clustering for shared volumes
+
+In addition to configuring disk sharing, you can also set an error policy for each ordinary VM disk or LUN disk. The error policy controls how the hypervisor behaves when an input/output error occurs on a disk Read or Write.
 
 include::modules/virt-configuring-vm-disk-sharing.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.15

Issue:
https://issues.redhat.com/browse/CNV-40769

Link to docs preview:
https://80081--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.html

QE review:

[ ]  QE has approved this change.

Additional information:
Cherry-picked from https://github.com/openshift/openshift-docs/commit/b00af204a71649045c5fcd083eb89b1cc4080299 xref:https://github.com/openshift/openshift-docs/pull/78487