### PR TITLE
Update rosa-sdpolicy-am-limited-support.adoc

### DIFF
--- a/modules/rosa-sdpolicy-am-limited-support.adoc
+++ b/modules/rosa-sdpolicy-am-limited-support.adoc
@@ -25,6 +25,7 @@ endif::rosa-with-hcp[]
 If you remove or replace any native {product-title} components or any other component that is installed and managed by Red{nbsp}Hat:: If cluster administrator permissions were used, Red{nbsp}Hat is not responsible for any of your or your authorized users’ actions, including those that affect infrastructure services, service availability, or data loss. If Red{nbsp}Hat detects any such actions, the cluster might transition to a Limited Support status. Red{nbsp}Hat notifies you of the status change and you should either revert the action or create a support case to explore remediation steps that might require you to delete and recreate the cluster.
 
 If you have questions about a specific action that might cause a cluster to move to a Limited Support status or need further assistance, open a support ticket.
+
 ifeval::["{context}" == "rosa-hcp-service-definition"]
 :!rosa-with-hcp:
 endif::[]


### PR DESCRIPTION
Fixed a conditional that was showing up in the live build:
![image](https://github.com/user-attachments/assets/876e7f42-c539-4fc6-9500-7123b7b3f4e9)

- [**ROSA Classic**](https://80083--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-limited-support_rosa-service-definition)
- [**ROSA with HCP**](https://80083--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-limited-support_rosa-hcp-service-definition)
