### PR TITLE
OCPBUGS-37993: List "Configuring MetalLB with an L2 advertisement and label" in "Next Steps"

### DIFF
--- a/networking/metallb/metallb-configure-address-pools.adoc
+++ b/networking/metallb/metallb-configure-address-pools.adoc
@@ -18,15 +18,12 @@ include::modules/nw-metallb-configure-address-pool.adoc[leveloffset=+1]
 // Examples
 include::modules/nw-metallb-example-addresspool.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-[id="additional-resources_metallb-configure-address-pools"]
-== Additional resources
-
-* xref:../../networking/metallb/about-advertising-ipaddresspool.adoc#nw-metallb-configure-with-L2-advertisement-label_about-advertising-ip-address-pool[Configuring MetalLB with an L2 advertisement and label].
 
 [id="next-steps_{context}"]
 == Next steps
 
-* For BGP mode, see xref:../../networking/metallb/metallb-configure-bgp-peers.adoc#metallb-configure-bgp-peers[Configuring MetalLB BGP peers].
+* xref:../../networking/metallb/about-advertising-ipaddresspool.adoc#nw-metallb-configure-with-L2-advertisement-label_about-advertising-ip-address-pool[Configuring MetalLB with an L2 advertisement and label]
 
-* xref:../../networking/metallb/metallb-configure-services.adoc#metallb-configure-services[Configuring services to use MetalLB].
+* xref:../../networking/metallb/metallb-configure-bgp-peers.adoc#metallb-configure-bgp-peers[Configuring MetalLB BGP peers]
+
+* xref:../../networking/metallb/metallb-configure-services.adoc#metallb-configure-services[Configuring services to use MetalLB]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-37993

Link to docs preview:
https://80084--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-configure-address-pools.html#next-steps_configure-metallb-address-pools

QE review:
No QE review required.
