### PR TITLE
OSDOCS-11592 OCP 4.16 RNs updating date format

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3306,8 +3306,8 @@ data:
 +
 (link:https://issues.redhat.com//browse/OCPBUGS-35316[*OCPBUGS-35316*])
 
-* Low-latency applications that rely on high-resolution timers to wake up their threads might experience higher wake up latencies than expected. 
-Although the expected wake up latency is under 20μs, latencies exceeding this time can occasionally be seen when running the `cyclictest` tool for long durations. 
+* Low-latency applications that rely on high-resolution timers to wake up their threads might experience higher wake up latencies than expected.
+Although the expected wake up latency is under 20μs, latencies exceeding this time can occasionally be seen when running the `cyclictest` tool for long durations.
 Testing has shown that wake up latencies are under 20μs for over 99.99999% of the samples.
 (link:https://issues.redhat.com/browse/OCPBUGS-34022[*OCPBUGS-34022*])
 
@@ -3334,7 +3334,7 @@ For any {product-title} release, always review the instructions on xref:../updat
 [id="ocp-4-16-5_{context}"]
 === RHBA-2024:4855 - {product-title} {product-version}.5 bug fix
 
-Issued: 2024-07-31
+Issued: 31 July 2024
 
 {product-title} release {product-version}.5 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4855[RHBA-2024:4855] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4858[RHSA-2024:4858] advisory.
 
@@ -3388,7 +3388,7 @@ To update an existing {product-title} 4.16 cluster to this latest release, see x
 [id="ocp-4-16-4_{context}"]
 === RHSA-2024:4613 - {product-title} {product-version}.4 bug fix and security update
 
-Issued: 2024-07-24
+Issued: 24 July 2024
 
 {product-title} release {product-version}.4, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:4613[RHSA-2024:4613] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4616[RHSA-2024:4616] advisory.
 
@@ -3445,7 +3445,7 @@ To update an existing {product-title} 4.16 cluster to this latest release, see x
 [id="ocp-4-16-3_{context}"]
 === RHSA-2024:4469 - {product-title} {product-version}.3 bug fix and security update
 
-Issued: 2024-07-16
+Issued: 16 July 2024
 
 {product-title} release {product-version}.3, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:4469[RHSA-2024:4469] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:4472[RHBA-2024:4472] advisory.
 
@@ -3504,7 +3504,7 @@ To update an existing {product-title} 4.16 cluster to this latest release, see x
 [id="ocp-4-16-2_{context}"]
 === RHSA-2024:4316 - {product-title} {product-version}.2 bug fix and security update
 
-Issued: 2024-07-09
+Issued: 9 July 2024
 
 {product-title} release {product-version}.2, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:4316[RHSA-2024:4316] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:4319[RHBA-2024:4319] advisory.
 
@@ -3575,7 +3575,7 @@ To update an existing {product-title} 4.16 cluster to this latest release, see x
 [id="ocp-4-16-1_{context}"]
 === RHSA-2024:4156 - {product-title} {product-version}.1 bug fix and security update
 
-Issued: 2024-07-03
+Issued: 3 July 2024
 
 {product-title} release {product-version}.1, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:4156[RHSA-2024:4156] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4159[RHSA-2024:4159] advisory.
 
@@ -3622,7 +3622,7 @@ To update an existing {product-title} 4.16 cluster to this latest release, see x
 [id="ocp-4-16-0-ga_{context}"]
 === RHSA-2024:0041 - {product-title} {product-version}.0 image release, bug fix, and security update advisory
 
-Issued: 2024-06-27
+Issued: 27 June 2024
 
 {product-title} release {product-version}.0, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:0041[RHSA-2024:0041] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0045[RHSA-2024:0045] advisory.
 


### PR DESCRIPTION
Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-11592](https://issues.redhat.com/browse/OSDOCS-11592)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to [docs preview:](https://80094--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Not needed
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Changing the date format to match the IBM Style Guide.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
