### PR TITLE
OCPBUGS#29600: Add comment for contributors adding content to the module

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -3,6 +3,12 @@
 // * disaster_recovery/scenario-2-restoring-cluster-state.adoc
 // * post_installation_configuration/cluster-tasks.adoc
 
+// Contributors: Some changes for the `etcd` restore procedure are only valid for 4.14+. 
+// In the 4.14+ documentation, OVN-K requires different steps because there is no centralized OVN 
+// control plane to be converted. For more information, see PR #64939. 
+// Do not cherry pick from "main" to "enterprise-4.12" or "enterprise-4.13" because the cherry pick
+// procedure is different for these versions. Instead, open a separate PR for 4.13 and 
+// cherry pick to 4.12 or make the updates directly in 4.12.  
 
 :_mod-docs-content-type: PROCEDURE
 [id="dr-scenario-2-restoring-cluster-state_{context}"]


### PR DESCRIPTION
Version(s):
4.13+

Issue:
[OCPBUGS-29600](https://issues.redhat.com/browse/OCPBUGS-29600url)

Link to docs preview:
N/A

QE review:
- [ ] QE has approved this change.
N/A (the submitter approved the comments)

Additional information:
This change adds a comment in 'dr-restoring-cluster-state' for contributors to ensure certain steps for 4.14 are not changed for 3 steps in the procedure. See OCPBUGS-29600 for details. The work to fix the cherry-issues issues was completed, however the submitter wanted comments added to alert contributors about any updates.
