### PR TITLE
TELCODOCS-1980: fixing broken link

### DIFF
--- a/modules/telco-core-ref-application-workloads.adoc
+++ b/modules/telco-core-ref-application-workloads.adoc
@@ -14,7 +14,7 @@ Pods running network functions that do not require the high throughput and low l
 
 Description of limits::
 
-* CNF applications should conform to the latest version of the link:https://test-network-function.github.io/cnf-best-practices-guide/[Red Hat Best Practices for Kubernetes] guide.
+* CNF applications should conform to the latest version of the link:https://test-network-function.github.io/k8s-best-practices-guide/[Red Hat Best Practices for Kubernetes] guide.
 * For a mix of best-effort and burstable QoS pods.
 ** Guaranteed QoS pods might be used but require correct configuration of reserved and isolated CPUs in the `PerformanceProfile`.
 ** Guaranteed QoS Pods must include annotations for fully isolating CPUs.

--- a/modules/telco-ran-du-application-workloads.adoc
+++ b/modules/telco-ran-du-application-workloads.adoc
@@ -10,7 +10,7 @@ DU worker nodes must have 3rd Generation Xeon (Ice Lake) 2.20 GHz or better CPUs
 
 5G RAN DU user applications and workloads should conform to the following best practices and application limits:
 
-* Develop cloud-native network functions (CNFs) that conform to the latest version of the link:https://test-network-function.github.io/cnf-best-practices-guide/[CNF best practices guide].
+* Develop cloud-native network functions (CNFs) that conform to the latest version of the link:https://test-network-function.github.io/k8s-best-practices-guide/[CNF best practices guide].
 
 * Use SR-IOV for high performance networking.
 


### PR DESCRIPTION
[TELCODOCS-1980](https://issues.redhat.com//browse/TELCODOCS-1980): fixing broken link

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1980

Link to docs preview:
- https://80107--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco_ref_design_specs/core/telco-core-rds-use-cases.html#telco-core-ref-application-workloads_ran-core-design-overview
- https://80107--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco_ref_design_specs/ran/telco-ran-du-overview.html#telco-du-workloads_ran-ref-design-overview

Additional information:
Fixing broken link, no QE required.