### PR TITLE
CNV_36963: Fixing broken xrefs in CNV 4.14 (cherrypick OCPBUGS_24463 to 4.14)

### DIFF
--- a/virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc
+++ b/virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc
@@ -10,9 +10,9 @@ By default, {VirtProductName} is installed with a single, internal pod network.
 
 You can create a Linux bridge network and attach a virtual machine (VM) to the network by performing the following steps:
 
-. xref:../../virt-connecting-vm-to-linux-bridge.adoc#virt-creating-linux-bridge-nncp_virt-connecting-vm-to-linux-bridge[Create a Linux bridge node network configuration policy (NNCP)].
-. Create a Linux bridge network attachment definition (NAD) by using the xref:../../virt-connecting-vm-to-linux-bridge.adoc#virt-creating-linux-bridge-nad-web_virt-connecting-vm-to-linux-bridge[web console] or the xref:../../virt-connecting-vm-to-linux-bridge.adoc#virt-creating-linux-bridge-nad-cli_virt-connecting-vm-to-linux-bridge[command line].
-. Configure the VM to recognize the NAD by using the xref:../../virt-connecting-vm-to-linux-bridge.adoc#virt-vm-creating-nic-web_virt-connecting-vm-to-linux-bridge[web console] or the xref:../../virt-connecting-vm-to-linux-bridge.adoc#virt-attaching-vm-secondary-network-cli_virt-connecting-vm-to-linux-bridge[command line].
+. xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-creating-linux-bridge-nncp_virt-connecting-vm-to-linux-bridge[Create a Linux bridge node network configuration policy (NNCP)].
+. Create a Linux bridge network attachment definition (NAD) by using the xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-creating-linux-bridge-nad-web_virt-connecting-vm-to-linux-bridge[web console] or the xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-creating-linux-bridge-nad-cli_virt-connecting-vm-to-linux-bridge[command line].
+. Configure the VM to recognize the NAD by using the xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-vm-creating-nic-web_virt-connecting-vm-to-linux-bridge[web console] or the xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-attaching-vm-secondary-network-cli_virt-connecting-vm-to-linux-bridge[command line].
 
 include::modules/virt-creating-linux-bridge-nncp.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/CNV-36963

CNV 4.14
OCP 4.14

Preview: https://80112--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-linux-bridge.html