### PR TITLE
PR for SRVLOGIC-369: Add a new procedure for kn-workflow plugin using the binary download. 

### DIFF
--- a/install/serverless-logic-install-kn-workflow-plugin-cli.adoc
+++ b/install/serverless-logic-install-kn-workflow-plugin-cli.adoc
@@ -1,12 +1,15 @@
 :_content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-logic-install-kn-workflow-plugin-cli"]
 = Installing the OpenShift Serverless Logic Knative Workflow plugin
-:context: serverless-logic-install-kn-workflow-artifact-images
+include::_attributes/common-attributes.adoc[]
+:context: serverless-logic-install-kn-workflow-plugin-cli
 
 toc::[]
 
 OpenShift Serverless Logic provides a plugin named `kn-workflow` for the Knative CLI, enabling you to set up a local workflow project using the command line.
 
 //install doc
+include::modules/serverless-logic-install-kn-workflow-binary-file-linux.adoc[leveloffset=+1]
+include::modules/serverless-logic-install-kn-workflow-binary-file-macos.adoc[leveloffset=+1]
+include::modules/serverless-logic-install-kn-workflow-binary-file-windows.adoc[leveloffset=+1]
 include::modules/serverless-logic-install-kn-workflow-artifact-images.adoc[leveloffset=+1]

--- a/modules/serverless-logic-install-kn-workflow-binary-file-linux.adoc
+++ b/modules/serverless-logic-install-kn-workflow-binary-file-linux.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * /serverless/install/serverless-logic-install-kn-workflow-plugin-cli.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-logic-install-kn-workflow-binary-file-linux_{context}"]
+= Installing the {ServerlessLogicProductName} Knative Workflow plugin for Linux
+
+If you are using a Linux distribution that does not have RPM or another package manager installed, you can install the Knative Workflow plugin.
+
+.Prerequisites
+
+* You have installed the Knative (`kn`) command-line interface (CLI).
+
+* If you are not using {op-system-base} or Fedora, ensure that the *libc* library is installed in a directory on your path.
++
+[IMPORTANT]
+====
+If the *libc* library is not available, you might see the following error when you run commands:
+
+[source,terminal]
+----
+$ kn: No such file or directory
+----
+====
+
+.Procedure
+
+. Download the latest `tar` archive suitable for your environment, from the link:https://mirror.openshift.com/pub/cgw/serverless-logic/latest/[Serverless Logic download mirror] page.
+
+. Extract the Knative Workflow plugin binary file by running the following command:
++
+[source,terminal]
+----
+$ tar xvzf <tar_archive>
+----
+
+. Rename the extracted Knative Workflow plugin binary file to `kn-workflow` by running the following command:
++
+[source,terminal]
+----
+$ mv <filename> kn-workflow
+----
+
+. Install the `kn-workflow` command as the Knative CLI plugin:
+
+.. Make the binary file executable by running the following command:
++
+[source,terminal]
+----
+$ chmod +x /usr/local/bin/kn-workflow
+----
+
+.. Copy the `kn-workflow` binary file to a directory in the `/usr/local/bin` path by running the following command:
++
+[source,terminal]
+----
+$ cp <path/to/downloaded/kn-workflow> /usr/local/bin/kn-workflow
+----
+
+.Verification
+
+* Run the following command to verify that the `kn-workflow` plugin is installed successfully:
++
+[source,terminal]
+----
+$ kn plugin list
+----

--- a/modules/serverless-logic-install-kn-workflow-binary-file-macos.adoc
+++ b/modules/serverless-logic-install-kn-workflow-binary-file-macos.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies:
+//
+// * /serverless/install/serverless-logic-install-kn-workflow-plugin-cli.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-logic-install-kn-workflow-binary-file-macos_{context}"]
+= Installing the {ServerlessLogicProductName} Knative Workflow plugin for macOS
+
+If you are using macOS, you can install the Knative Workflow plugin as a binary file.
+
+[IMPORTANT]
+====
+On macOS, some systems might block the application from running due to security policies. To fix this issue, click *System Preferences* -> *Security & Privacy* -> *General* to approve the application to run. For more information, see the link:https://support.apple.com/en-in/guide/mac-help/mh40616/mac[Open a Mac app from an unidentified developer] Apple support article.
+====
+
+.Prerequisites
+
+* You have installed the Knative (`kn`) command-line interface (CLI).
+
+.Procedure
+
+. Download the latest `tar` archive suitable for your environment, from the link:https://mirror.openshift.com/pub/cgw/serverless-logic/latest/[Serverless Logic download mirror] page.
+
+. Extract the Knative Workflow plugin binary file by running the following command:
++
+[source,terminal]
+----
+$ tar xvzf <tar_archive>
+----
+
+. Rename the extracted Knative Workflow plugin binary file to `kn-workflow` by running the following command:
++
+[source,terminal]
+----
+$ mv <filename> kn-workflow
+----
+
+. Install the `kn-workflow` command as the Knative CLI plugin:
+
+.. Make the binary file executable by running the following command:
++
+[source,terminal]
+----
+$ chmod +x /usr/local/bin/kn-workflow
+----
+
+.. Copy the `kn-workflow` binary file to a directory in the `/usr/local/bin` path by running the following command:
++
+[source,terminal]
+----
+$ cp <path/to/downloaded/kn-workflow> /usr/local/bin/kn-workflow
+----
+
+.Verification
+
+* Run the following command to verify that the `kn-workflow` plugin is installed successfully:
++
+[source,terminal]
+----
+$ kn plugin list
+----

--- a/modules/serverless-logic-install-kn-workflow-binary-file-windows.adoc
+++ b/modules/serverless-logic-install-kn-workflow-binary-file-windows.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assemblies:
+//
+// * /serverless/install/serverless-logic-install-kn-workflow-plugin-cli.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-logic-install-kn-workflow-binary-file-windows_{context}"]
+= Installing the {ServerlessLogicProductName} Knative Workflow plugin for Windows
+
+If you are using Windows, you can install the Knative Workflow plugin.
+
+.Prerequisites
+
+* You have installed the Knative (`kn`) command-line interface (CLI).
+
+.Procedure
+
+. Download the latest `zip` archive suitable for your environment, from the link:https://mirror.openshift.com/pub/cgw/serverless-logic/latest/[Serverless Logic download mirror] page.
+
+. Extract the Knative Workflow plugin binary file using PowerShell by running the following command:
++
+[source,terminal]
+----
+$ Expand-Archive -Path <filename>.zip -DestinationPath <destination>
+----
+
+. Rename the extracted Knative Workflow plugin binary file to `kn-workflow` by running the following command:
++
+[source,terminal]
+----
+$ Rename-Item -Path <destination>\<filename>.exe -NewName kn-workflow.exe
+----
+
+. Install the `kn-workflow` command as the Knative CLI plugin:
++
+On Windows, files with a `.exe` extension are treated as executable by default, so you do not need to change permissions.
+
+.. Move the `kn-workflow.exe` file to a directory in your `PATH` by running the following command:
++
+[source,terminal]
+----
+$ move C:\path\to\kn-workflow.exe "C:\Program Files"
+----
+
+.. Copy the `kn-workflow` binary file to a directory in your `PATH` by running the following command:
++
+[source,terminal]
+----
+$ Copy-Item -Path <destination>\kn-workflow.exe -Destination "C:\Program Files\kn-workflow.exe"
+----
+
+.Verification
+* Run the following command to verify that the `kn-workflow` plugin is installed successfully:
++
+[source,terminal]
+----
+$ kn plugin list
+----


### PR DESCRIPTION
**Affecting version:** `serverless-docs-1.33`, `serverless-docs-1.34`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVLOGIC-369

**Doc previews:** 

- [Installing the OpenShift Serverless Logic Knative Workflow plugin for Linux](https://80122--ocpdocs-pr.netlify.app/openshift-serverless/latest/install/serverless-logic-install-kn-workflow-plugin-cli.html#serverless-logic-install-kn-workflow-binary-file-linux_serverless-logic-install-kn-workflow-artifact-images)
- [Installing the OpenShift Serverless Logic Knative Workflow plugin for macOS](https://80122--ocpdocs-pr.netlify.app/openshift-serverless/latest/install/serverless-logic-install-kn-workflow-plugin-cli.html#serverless-logic-install-kn-workflow-binary-file-macos_serverless-logic-install-kn-workflow-artifact-images)
- [Installing the OpenShift Serverless Logic Knative Workflow plugin for Windows](https://80122--ocpdocs-pr.netlify.app/openshift-serverless/latest/install/serverless-logic-install-kn-workflow-plugin-cli.html#serverless-logic-install-kn-workflow-binary-file-windows_serverless-logic-install-kn-workflow-artifact-images)