### PR TITLE
OADP-4622 Multiple BSL and VSL

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3272,6 +3272,10 @@ Topics:
       File: installing-oadp-ocs
     - Name: Configuring OADP with OpenShift Virtualization
       File: installing-oadp-kubevirt
+    - Name: Configuring OADP with multiple backup storage locations
+      File: configuring-oadp-multiple-bsl
+    - Name: Configuring OADP with multiple Volume Snapshot Locations
+      File: configuring-oadp-multiple-vsl
   - Name: Uninstalling OADP
     Dir: installing
     Topics:

--- a/backup_and_restore/application_backup_and_restore/installing/configuring-oadp-multiple-bsl.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/configuring-oadp-multiple-bsl.adoc
@@ -1,0 +1,29 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="configuring-oadp-multiple-bsl"]
+= Configuring the {oadp-first} with more than one Backup Storage Location
+include::_attributes/common-attributes.adoc[]
+:context: configuring-oadp-multiple-bsl
+:configuring-oadp-multiple-bsl:
+
+
+toc::[]
+
+
+You can configure one or more backup storage locations (BSLs) in the Data Protection Application (DPA). You can also select the location to store the backup in when you create the backup. With this configuration, you can store your backups in the following ways:
+
+* To different regions
+* To a different storage provider
+
+{oadp-short} supports multiple credentials for configuring more than one BSL, so that you can specify the credentials to use with any BSL.
+
+// module for configuring the DPA with multiple BSLs.
+include::modules/oadp-configuring-dpa-multiple-bsl.adoc[leveloffset=+1]
+// module for multiple BSL use case.
+include::modules/oadp-multiple-bsl-use-case.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc#oadp-secrets-for-different-credentials_installing-oadp-aws[Creating profiles for different credentials]
+
+:!configuring-oadp-multiple-bsl:

--- a/backup_and_restore/application_backup_and_restore/installing/configuring-oadp-multiple-vsl.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/configuring-oadp-multiple-vsl.adoc
@@ -1,0 +1,17 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="configuring-oadp-multiple-vsl"]
+= Configuring the {oadp-first} with more than one Volume Snapshot Location
+include::_attributes/common-attributes.adoc[]
+:context: configuring-oadp-multiple-vsl
+:configuring-oadp-multiple-vsl:
+
+toc::[]
+
+
+You can configure one or more Volume Snapshot Locations (VSLs) to store the snapshots in different cloud provider regions.
+
+// module for configuring the DPA with multiple VSLs.
+include::modules/oadp-configuring-dpa-multiple-vsl.adoc[leveloffset=+1]
+
+
+:!configuring-oadp-multiple-vsl:

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
@@ -36,6 +36,7 @@ include::modules/oadp-self-signed-certificate.adoc[leveloffset=+2]
 
 include::modules/oadp-installing-dpa-1-2-and-earlier.adoc[leveloffset=+1]
 include::modules/oadp-installing-dpa-1-3.adoc[leveloffset=+1]
+include::modules/oadp-configuring-dpa-multiple-bsl.adoc[leveloffset=+1]
 include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc
@@ -40,4 +40,6 @@ include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
 
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc#oadp-installing-dpa-1-3_installing-oadp-kubevirt[Installing the Data Protection Application with the `kubevirt` and `openshift` plugins]
 
+* xref:../../../backup_and_restore/application_backup_and_restore/installing/configuring-oadp-multiple-bsl.adoc#configuring-oadp-multiple-bsl[Configuring the {oadp-first} with multiple backup storage locations]
+
 :installing-oadp-azure!:

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc
@@ -41,4 +41,6 @@ include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
 
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc#oadp-installing-dpa-1-3_installing-oadp-kubevirt[Installing the Data Protection Application with the `kubevirt` and `openshift` plugins]
 
+* xref:../../../backup_and_restore/application_backup_and_restore/installing/configuring-oadp-multiple-bsl.adoc#configuring-oadp-multiple-bsl[Configuring the {oadp-first} with multiple backup storage locations]
+
 :installing-oadp-gcp!:

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
@@ -50,4 +50,6 @@ include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
 
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc#oadp-installing-dpa-1-3_installing-oadp-kubevirt[Installing the Data Protection Application with the `kubevirt` and `openshift` plugins]
 
+* xref:../../../backup_and_restore/application_backup_and_restore/installing/configuring-oadp-multiple-bsl.adoc#configuring-oadp-multiple-bsl[Configuring the {oadp-first} with multiple backup storage locations]
+
 :installing-oadp-mcg!:

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
@@ -51,4 +51,6 @@ include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
 
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc#oadp-installing-dpa-1-3_installing-oadp-kubevirt[Installing the Data Protection Application with the `kubevirt` and `openshift` plugins]
 
+* xref:../../../backup_and_restore/application_backup_and_restore/installing/configuring-oadp-multiple-bsl.adoc#configuring-oadp-multiple-bsl[Configuring the {oadp-first} with multiple backup storage locations]
+
 :installing-oadp-ocs!:

--- a/modules/oadp-configuring-dpa-multiple-bsl.adoc
+++ b/modules/oadp-configuring-dpa-multiple-bsl.adoc
@@ -1,0 +1,84 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/installing/configuring-oadp-multiple-bsl.adoc
+
+
+:_mod-docs-content-type: PROCEDURE
+[id="oadp-configuring-dpa-multiple-bsl_{context}"]
+= Configuring the DPA with more than one BSL
+
+You can configure the DPA with more than one BSL and specify the credentials provided by the cloud provider.  
+
+.Prerequisites
+
+* You must install the {oadp-short} Operator.
+* You must create the secrets by using the credentials provided by the cloud provider.
+
+.Procedure
+
+. Configure the DPA with more than one BSL. See the following example.
++
+.Example DPA
+[source,yaml]
+----
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+#...
+backupLocations:
+  - name: aws # <1>
+    velero:
+      provider: aws
+      default: true # <2>
+      objectStorage:
+        bucket: <bucket_name> # <3>
+        prefix: <prefix> # <4>
+      config:
+        region: <region_name> # <5>
+        profile: "default"
+      credential:
+        key: cloud
+        name: cloud-credentials # <6>
+  - name: odf # <7>
+    velero:
+      provider: aws
+      default: false
+      objectStorage:
+        bucket: <bucket_name> 
+        prefix: <prefix> 
+      config:
+        profile: "default" 
+        region: <region_name>
+        s3Url: <url> # <8>
+        insecureSkipTLSVerify: "true"
+        s3ForcePathStyle: "true"
+      credential:
+        key: cloud
+        name: <custom_secret_name_odf> # <9>
+#...
+----
+<1> Specify a name for the first BSL.
+<2> This parameter indicates that this BSL is the default BSL. If a BSL is not set in the `Backup CR`, the default BSL is used. You can set only one BSL as the default.
+<3> Specify the bucket name.
+<4> Specify a prefix for Velero backups; for example, `velero`.
+<5> Specify the AWS region for the bucket.
+<6> Specify the name of the default `Secret` object that you created.
+<7> Specify a name for the second BSL.
+<8> Specify the URL of the S3 endpoint.
+<9> Specify the correct name for the `Secret`; for example, `custom_secret_name_odf`. If you do not specify a `Secret` name, the default name is used.
+
+. Specify the BSL to be used in the backup CR. See the following example.
++
+.Example backup CR
+[source,yaml]
+----
+apiVersion: velero.io/v1
+kind: Backup
+# ...
+spec:
+  includedNamespaces:
+  - <namespace> # <1>
+  storageLocation: <backup_storage_location> # <2> 
+  defaultVolumesToFsBackup: true 
+----
+<1> Specify the namespace to back up.
+<2> Specify the storage location.

--- a/modules/oadp-configuring-dpa-multiple-vsl.adoc
+++ b/modules/oadp-configuring-dpa-multiple-vsl.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/installing/configuring-oadp-multiple-vsl.adoc
+
+
+:_mod-docs-content-type: CONCEPT
+[id="oadp-configuring-dpa-multiple-vsl_{context}"]
+= Configuring the DPA with more than one VSL
+
+You configure the DPA with more than one VSL and specify the credentials provided by the cloud provider. Make sure that you configure the snapshot location in the same region as the persistent volumes. See the following example.
+
+.Example DPA
+[source,yaml]
+----
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+#...
+snapshotLocations:
+  - velero:
+      config:
+        profile: default
+        region: <region> # <1>
+      credential:
+        key: cloud
+        name: cloud-credentials
+      provider: aws
+  - velero:
+      config:
+        profile: default
+        region: <region>
+      credential:
+        key: cloud
+        name: <custom_credential> # <2>
+      provider: aws
+#...
+----
+<1> Specify the region. The snapshot location must be in the same region as the persistent volumes.
+<2> Specify the custom credential name.

--- a/modules/oadp-multiple-bsl-use-case.adoc
+++ b/modules/oadp-multiple-bsl-use-case.adoc
@@ -1,0 +1,194 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/installing/configuring-oadp-multiple-bsl.adoc
+
+
+:_mod-docs-content-type: PROCEDURE
+[id="oadp-multiple-bsl-use-case_{context}"]
+= {oadp-short} use case for two BSLs
+
+In this use case, you configure the DPA with two storage locations by using two cloud credentials. You back up an application with a database by using the default BSL. {oadp-short} stores the backup resources in the default BSL. You then backup the application again by using the second BSL.
+
+.Prerequisites
+
+* You must install the {oadp-short} Operator.
+* You must configure two backup storage locations: AWS S3 and Multicloud Object Gateway (MCG).
+* You must have an application with a database deployed on a Red Hat OpenShift cluster.
+
+.Procedure
+
+. Create the first `Secret` for the AWS S3 storage provider with the default name by running the following command:
++
+[source,terminal]
+----
+$ oc create secret generic cloud-credentials -n openshift-adp --from-file cloud=<aws_credentials_file_name> # <1>
+----
+<1> Specify the name of the cloud credentials file for AWS S3.
+
+. Create the second `Secret` for MCG with a custom name by running the following command:
++
+[source,terminal]
+----
+$ oc create secret generic mcg-secret -n openshift-adp --from-file cloud=<MCG_credentials_file_name> # <1>
+----
+<1> Specify the name of the cloud credentials file for MCG. Note the name of the `mcg-secret` custom secret.
+
+. Configure the DPA with the two BSLs as shown in the following example.
++
+.Example DPA
+[source,yaml]
+----
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+metadata:
+  name: two-bsl-dpa
+  namespace: openshift-adp  
+spec:
+  backupLocations:
+  - name: aws
+    velero:
+      config:
+        profile: default
+        region: <region_name> # <1>
+      credential:
+        key: cloud
+        name: cloud-credentials
+      default: true
+      objectStorage:
+        bucket: <bucket_name> # <2>
+        prefix: velero
+      provider: aws
+  - name: mcg
+    velero:
+      config:
+        insecureSkipTLSVerify: "true"
+        profile: noobaa
+        region: <region_name> # <3>
+        s3ForcePathStyle: "true"
+        s3Url: <s3_url> # <4>
+      credential:
+        key: cloud
+        name: mcg-secret # <5>
+      objectStorage:
+        bucket: <bucket_name_mcg> # <6>
+        prefix: velero
+      provider: aws
+  configuration:
+    nodeAgent:
+      enable: true
+      uploaderType: kopia
+    velero:
+      defaultPlugins:
+      - openshift
+      - aws
+----
+<1> Specify the AWS region for the bucket.
+<2> Specify the AWS S3 bucket name.
+<3> Specify the region, following the naming convention of the documentation of MCG.
+<4> Specify the URL of the S3 endpoint for MCG.
+<5> Specify the name of the custom secret for MCG storage.
+<6> Specify the MCG bucket name.
+
+. Create the DPA by running the following command:
++
+[source,terminal]
+----
+$ oc create -f <dpa_file_name> # <1>
+----
+<1> Specify the file name of the DPA you configured.
+
+. Verify that the DPA has reconciled by running the following command:
++
+[source,terminal]
+----
+$ oc get dpa -o yaml
+----
+
+. Verify that the BSLs are available by running the following command:
++
+[source,terminal]
+----
+$ oc get bsl
+----
++
+.Example output
+[source,terminal]
+----
+NAME   PHASE       LAST VALIDATED   AGE     DEFAULT
+aws    Available   5s               3m28s   true
+mcg    Available   5s               3m28s   
+----
+
+. Create a backup CR with the default BSL. 
++
+[NOTE]
+====
+In the following example, the `storageLocation` field is not specified in the backup CR.
+====
++
+.Example backup CR
+[source,yaml]
+----
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: test-backup1
+  namespace: openshift-adp
+spec:
+  includedNamespaces:
+  - <mysql_namespace> # <1>
+  defaultVolumesToFsBackup: true
+----
+<1> Specify the namespace for the application installed in the cluster.
+
+. Create a backup by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <backup_file_name> # <1>
+----
+<1> Specify the name of the backup CR file.
+
+. Verify that the backup completed with the default BSL by running the following command:
++
+[source,terminal]
+----
+$ oc get backup <backup_name> -o yaml # <1>
+----
+<1> Specify the name of the backup.
+
+. Create a backup CR by using MCG as the BSL. In the following example, note that the second `storageLocation` value is specified at the time of backup CR creation.
++
+.Example backup `CR`
+[source,yaml]
+----
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: test-backup1
+  namespace: openshift-adp
+spec:
+  includedNamespaces:
+  - <mysql_namespace> # <1>
+  storageLocation: mcg # <2>
+  defaultVolumesToFsBackup: true
+----
+<1> Specify the namespace for the application installed in the cluster.
+<2> Specify the second storage location.
+
+. Create a second backup by running the following command:
++
+[source, terminal]
+----
+$ oc apply -f <backup_file_name> # <1>
+----
+<1> Specify the name of the backup CR file.
+
+
+. Verify that the backup completed with the storage location as MCG by running the following command:
++
+[source, terminal]
+----
+$ oc get backup <backup_name> -o yaml # <1>
+----
+<1> Specify the name of the backup.


### PR DESCRIPTION
## Jira 

* [OADP-4622](https://issues.redhat.com/browse/OADP-4622)

Adding a section for configuring DPA with multiple BSLs and VSLs

##  Version

* OCP 4.13 → OCP 4.17

## Preview

* [Configuring OADP with more than one Backup Storage Location](https://80125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/configuring-oadp-multiple-bsl.html)

* [Configuring OADP with more than one Volume Snapshot Location](https://80125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/configuring-oadp-multiple-vsl.html)

* [Configuring multiple BSL in AWS DPA](https://80125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html#oadp-configuring-dpa-multiple-bsl_installing-oadp-aws) 

## QE Review

* [x] QE has approved this change
