### PR TITLE
RHDEVDOCS-6037: Document disabling autoscraping ArgoCD metrics

### DIFF
--- a/modules/gitops-disabling-automatic-scraping-of-metrics-for-argo-cd-instances.adoc
+++ b/modules/gitops-disabling-automatic-scraping-of-metrics-for-argo-cd-instances.adoc
@@ -1,0 +1,91 @@
+// Module included in the following assemblies:
+//
+// * observability/monitoring/monitoring-argo-cd-instances.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="gitops-disabling-automatic-scraping-of-metrics-for-argo-cd-instances_{context}"]
+= Disabling automatic scraping of metrics for Argo CD instances
+
+By default, the {gitops-title} Operator automatically scrapes metrics for all Argo CD instances to measure the performance. As a result, the Operator creates the following resources and label to the namespace where the Argo CD instance is installed:
+
+* `gitops-operator-argocd-alerts` prometheus rule
+* `<argocd_namespace>-read` role
+* `<argocd_name>`, `<argocd_name>-repo-server`, and `<argocd_name>-server` service monitors
+* `<argocd_namespace>-prometheus-k8s-read-binding` role binding
+* `openshift.io/cluster-monitoring=true` label
+
+Scraping metrics for multiple Argo CD instances in a cluster might result in excessive storage usage. As a preventive measure, use the web console's YAML view and configure the `ArgoCD` custom resource (CR) to disable the automatic scraping of metrics for your Argo CD instance.
+
+As a cluster administrator, by disabling metric scraping for individual instances, you can give your users better control, flexibility, and stability to manage their defined namespaces.
+
+.Procedure
+
+. Log in to the {OCP} web console. 
+
+. In the *Administrator* perspective of the web console, click *Operators* -> *Installed Operators*.
+
+. From the *Project* list, select the project where the user-defined Argo CD instance is installed.
+
+. Select *{gitops-title}* from the installed Operators list and go to the *Argo CD* tab.
+
+. Click your user-defined Argo CD instance.
+
+. Configure the `ArgoCD` CR of your user-defined Argo CD instance to disable the automatic scraping of metrics:
+.. Click the *YAML* tab and edit the YAML file of the `ArgoCD` CR.
+.. In the `ArgoCD` CR, set the `spec.monitoring.disableMetrics` field value to `true`:
++
+.Example `ArgoCD` CR
+[source,YAML]
+----
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+ name: example  # <1>
+ namespace: spring-petclinic # <2>
+spec:
+ monitoring:
+   disableMetrics: true
+----
+<1> The name of the user-defined Argo CD instance.
+<2> The namespace where you want to run the user-defined Argo CD instance.
++
+[TIP]
+====
+Alternatively, use the following command to disable the automatic scraping of metrics in the {gitops-title} `argocd` CLI:
+
+.Example command
+[source,terminal]
+----
+$ oc patch argocd example -n spring-petclinic --type='json' -p='[{"op": "replace", "path": "/spec/monitoring/disableMetrics", "value": true}]'
+----
+
+.Example output
+[source,terminal]
+----
+argocd.argoproj.io/example patched
+----
+====
+
+. Verify that the Operator adds the `openshift.io/cluster-monitoring=false` label to your defined namespace:
+.. Go to *Administration* -> *Namespaces*.
++
+The *Namespaces* page displays the created namespaces.
+.. Click your defined namespace, go to the *YAML* tab, and verify that under the `metadata.labels` section, the `openshift.io/cluster-monitoring=false` label is added by the Operator.
+
+. Verify that the Operator deletes the following resources from your defined namespace:
+.. Go to *Home* -> *Search*.
+.. From the *Resources* list, select *PrometheusRule*, *Role*, *RoleBinding*, and *ServiceMonitors*.
++
+The *Search* page displays the selected resources.
+.. In the *Search* page, verify that under the *PrometheusRule* section, the `gitops-operator-argocd-alerts` prometheus rule is removed.
+.. Under the *Roles* section, from the *Filter* list, select *Namespace Roles*.
+.. Verify that the `<argocd_namespace>-read` role is removed.
+.. Under the *RoleBindings* section, from the *Filter* list, select *Namespace RoleBindings*.
+.. Verify that the `<argocd_namespace>-prometheus-k8s-read-binding` role binding is removed.
+.. Verify that under the *ServiceMonitors* section, the `<argocd_name>`, `<argocd_name>-repo-server`, and `<argocd_name>-server` service monitors are removed.
+
+[NOTE]
+====
+You can enable the metrics for your instance by modifying the `spec.monitoring.disableMetrics` field value to `false`. The Operator then creates the required role, role bindings, and service monitors and adds the `openshift.io/cluster-monitoring=true` label to your defined namespace. 
+====
+

--- a/observability/monitoring/monitoring-argo-cd-custom-resource-workloads.adoc
+++ b/observability/monitoring/monitoring-argo-cd-custom-resource-workloads.adoc
@@ -11,11 +11,11 @@ With {gitops-title}, you can monitor the availability of Argo CD custom resource
 You can enable and disable the setting for monitoring Argo CD custom resource workloads. 
 
 // Prerequisites for monitoring Argo CD custom resource workloads
-[id="prerequisites_monitoring-argo-cd-custom-resource-workloads"]
+[id="prerequisites_{context}"]
 == Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role. 
-* You have installed the {gitops-title} Operator on your {OCP} cluster.
+* {gitops-title} is installed in your cluster.
 * The monitoring stack is configured in your cluster in the `openshift-monitoring` project. In addition, the Argo CD instance is in a namespace that you can monitor through Prometheus.
 * The `kube-state-metrics` service is running on your cluster.
 * Optional: If you are enabling monitoring for an Argo CD instance already present in a user-defined project, ensure that the monitoring is link:https://docs.openshift.com/container-platform/latest/observability/monitoring/enabling-monitoring-for-user-defined-projects.html#enabling-monitoring-for-user-defined-projects_enabling-monitoring-for-user-defined-projects[enabled for user-defined projects] in your cluster.
@@ -32,6 +32,6 @@ include::modules/gitops-enabling-monitoring-for-argo-cd-custom-resource-workload
 include::modules/gitops-disabling-monitoring-for-argo-cd-custom-resource-workloads.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="additional-resources_monitoring-argo-cd-custom-resource-workloads"]
+[id="additional-resources_{context}"]
 == Additional resources
 * link:https://docs.openshift.com/container-platform/latest/observability/monitoring/enabling-monitoring-for-user-defined-projects.html#enabling-monitoring-for-user-defined-projects_enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]

--- a/observability/monitoring/monitoring-argo-cd-instances.adoc
+++ b/observability/monitoring/monitoring-argo-cd-instances.adoc
@@ -8,12 +8,20 @@ toc::[]
 
 By default, the {gitops-title} Operator automatically detects an installed Argo CD instance in your defined namespace, for example, `openshift-gitops`, and connects it to the monitoring stack of the cluster to provide alerts for out-of-sync applications.
 
-[id="prerequisites_monitoring-argo-cd-instances"]
+[id="prerequisites_{context}"]
 == Prerequisites
 * You have access to the cluster with `cluster-admin` privileges.
 * You have access to the {OCP} web console.
-* You have installed the {gitops-title} Operator on your {OCP} cluster.
+* You have installed the {gitops-title} Operator in your cluster.
 * You have installed an Argo CD application in your defined namespace, for example, `openshift-gitops`.
 
 // Monitoring Argo CD health using Prometheus metrics
 include::modules/gitops-monitoring-argo-cd-health-using-prometheus-metrics.adoc[leveloffset=+1]
+
+// Disabling automatic scraping of metrics for Argo CD instances
+include::modules/gitops-disabling-automatic-scraping-of-metrics-for-argo-cd-instances.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../../observability/monitoring/monitoring-argo-cd-custom-resource-workloads.adoc#monitoring-argo-cd-custom-resource-workloads[Monitoring Argo CD custom resource workloads]


### PR DESCRIPTION
Jira issue: [RHDEVDOCS-6037](https://issues.redhat.com/browse/RHDEVDOCS-6037) 

Aligned team: DevTools 
Cherry-pick to versions: `gitops-docs-1.13` and later

Docs preview:

- [Disabling automatic scraping of metrics for Argo CD instances](https://80126--ocpdocs-pr.netlify.app/openshift-gitops/latest/observability/monitoring/monitoring-argo-cd-instances#gitops-disabling-automatic-scraping-of-metrics-for-argo-cd-instances_monitoring-argo-cd-instances)

SME review: Completed by @skatyal

QE review: Completed by @varshab1210

Peer review:  Completed by @tmalove 

Additional information: N/A
