### PR TITLE
OBSDOCS-1079: Create a table listing and describing all RBAC permissi…

### DIFF
--- a/modules/monitoring-granting-user-permissions-using-the-cli.adoc
+++ b/modules/monitoring-granting-user-permissions-using-the-cli.adoc
@@ -6,7 +6,12 @@
 [id="granting-user-permissions-using-the-cli_{context}"]
 = Granting user permissions by using the CLI
 
-You can grant users permissions to monitor their own projects, by using the OpenShift CLI (`oc`).
+You can grant users permissions for the `openshift-monitoring` project or their own projects, by using the OpenShift CLI (`oc`).
+
+[IMPORTANT]
+====
+Whichever role or cluster role you choose, you must bind it against a specific project as a cluster administrator.
+====
 
 .Prerequisites
 
@@ -16,17 +21,18 @@ You can grant users permissions to monitor their own projects, by using the Open
 
 .Procedure
 
-* Assign a monitoring role to a user for a project:
+* To assign a monitoring role to a user for a project, enter the following command:
 +
 [source,terminal]
 ----
-$ oc policy add-role-to-user <role> <user> -n <namespace> <1>
+$ oc adm policy add-role-to-user <role> <user> -n <namespace> --role-namespace <namespace> <1>
 ----
-<1> Substitute `<role>` with `monitoring-rules-view`, `monitoring-rules-edit`, or `monitoring-edit`.
+<1> Substitute `<role>` with the wanted monitoring role, `<user>` with the user to whom you want to assign the role, and `<namespace>` with the project where you want to grant the access.
+
+* To assign a monitoring cluster role to a user for a project, enter the following command:
 +
-[IMPORTANT]
-====
-Whichever role you choose, you must bind it against a specific project as a cluster administrator.
-====
-+
-As an example, substitute `<role>` with `monitoring-edit`, `<user>` with `johnsmith`, and `<namespace>` with `ns1`. This assigns the user `johnsmith` permission to set up metrics collection and to create alerting rules in the `ns1` namespace.
+[source,terminal]
+----
+$ oc adm policy add-cluster-role-to-user <cluster-role> <user> -n <namespace> <1>
+----
+<1> Substitute `<cluster-role>` with the wanted monitoring cluster role, `<user>` with the user to whom you want to assign the cluster role, and `<namespace>` with the project where you want to grant the access.

--- a/modules/monitoring-granting-user-permissions-using-the-web-console.adoc
+++ b/modules/monitoring-granting-user-permissions-using-the-web-console.adoc
@@ -6,7 +6,7 @@
 [id="granting-user-permissions-using-the-web-console_{context}"]
 = Granting user permissions by using the web console
 
-You can grant users permissions to monitor their own projects, by using the {product-title} web console.
+You can grant users permissions for the `openshift-monitoring` project or their own projects, by using the {product-title} web console.
 
 .Prerequisites
 
@@ -15,20 +15,20 @@ You can grant users permissions to monitor their own projects, by using the {pro
 
 .Procedure
 
-. In the *Administrator* perspective within the {product-title} web console, navigate to *User Management* -> *RoleBindings* -> *Create binding*.
+. In the *Administrator* perspective of the {product-title} web console, go to *User Management* -> *RoleBindings* -> *Create binding*.
 
-. In the *Binding Type* section, select the "Namespace Role Binding" type.
+. In the *Binding Type* section, select the *Namespace Role Binding* type.
 
 . In the *Name* field, enter a name for the role binding.
 
-. In the *Namespace* field, select the user-defined project where you want to grant the access.
+. In the *Namespace* field, select the project where you want to grant the access.
 +
 [IMPORTANT]
 ====
-The monitoring role will be bound to the project that you apply in the *Namespace* field. The permissions that you grant to a user by using this procedure will apply only to the selected project.
+The monitoring role or cluster role permissions that you grant to a user by using this procedure apply only to the project that you select in the *Namespace* field.
 ====
 
-. Select `monitoring-rules-view`, `monitoring-rules-edit`, or `monitoring-edit` in the *Role Name* list.
+. Select a monitoring role or cluster role from the *Role Name* list.
 
 . In the *Subject* section, select *User*.
 

--- a/modules/monitoring-granting-users-permission-to-monitor-user-defined-projects.adoc
+++ b/modules/monitoring-granting-users-permission-to-monitor-user-defined-projects.adoc
@@ -10,24 +10,48 @@ As a cluster administrator, you can monitor all core {product-title} and user-de
 
 You can also grant developers and other users different permissions:
 
-* To monitor user-defined projects.
-* To configure the components that monitor user-defined projects.
-* To configure alert routing for user-defined projects.
+* Monitoring user-defined projects
+* Configuring the components that monitor user-defined projects
+* Configuring alert routing for user-defined projects
+* Managing alerts and silences for user-defined projects
 
-You can grant the permissions by assigning one of the following monitoring roles:
+You can grant the permissions by assigning one of the following monitoring roles or cluster roles:
 
+.Monitoring roles
 |===
-|Role name |Description
+|Role name |Description |Project
 
-|`monitoring-rules-view` | Users with this cluster role have read access to `PrometheusRule` custom resources for a user-defined project. They can also view the alerts in the *Developer* perspective of the {product-title} web console.
+|`user-workload-monitoring-config-edit` 
+|Users with this role can edit the `user-workload-monitoring-config` `ConfigMap` object to configure Prometheus, Prometheus Operator, Alertmanager, and Thanos Ruler for user-defined workload monitoring. 
+|`openshift-user-workload-monitoring`
 
-|`monitoring-rules-edit` | Users with this cluster role can create, modify, and delete `PrometheusRule` custom resources for a user-defined project. They can also create and silence alerts in the *Developer* perspective of the {product-title} web console.
+|`monitoring-alertmanager-api-reader` 
+|Users with this role have read access to the user-defined Alertmanager API for all projects, if the user-defined Alertmanager is enabled.
+|`openshift-user-workload-monitoring`
 
-|`monitoring-edit` | Users with this cluster role have the same privileges as users with the `monitoring-rules-edit` cluster role. Additionally, users can create, modify, and delete `ServiceMonitor` and `PodMonitor` resources to scrape metrics from services and pods.
-
-|`user-workload-monitoring-config-edit` | This role is given in the `openshift-user-workload-monitoring` project. Users with this role can edit the `user-workload-monitoring-config` `ConfigMap` object to configure Prometheus, Prometheus Operator, Alertmanager, and Thanos Ruler for user-defined workload monitoring.
-
-|`alert-routing-edit` | Users with this cluster role can create, update, and delete `AlertmanagerConfig` custom resources for a user-defined project.
+|`monitoring-alertmanager-api-writer` 
+|Users with this role have read and write access to the user-defined Alertmanager API for all projects, if the user-defined Alertmanager is enabled.
+|`openshift-user-workload-monitoring`
 |===
 
-The following sections provide details on how to assign these roles by using the {product-title} web console or the CLI.
+.Monitoring cluster roles
+|===
+|Cluster role name |Description |Project
+
+|`monitoring-rules-view` 
+|Users with this cluster role have read access to `PrometheusRule` custom resources (CRs) for user-defined projects. They can also view the alerts and silences in the *Developer* perspective of the {product-title} web console.
+|Can be bound with `RoleBinding` to any user project.
+
+|`monitoring-rules-edit` 
+|Users with this cluster role can create, modify, and delete `PrometheusRule` CRs for user-defined projects. They can also manage alerts and silences in the *Developer* perspective of the {product-title} web console.
+|Can be bound with `RoleBinding` to any user project.
+
+|`monitoring-edit` 
+|Users with this cluster role have the same privileges as users with the `monitoring-rules-edit` cluster role. Additionally, users can create, read, modify, and delete `ServiceMonitor` and `PodMonitor` resources to scrape metrics from services and pods.
+|Can be bound with `RoleBinding` to any user project.
+
+|`alert-routing-edit` 
+|Users with this cluster role can create, update, and delete `AlertmanagerConfig` CRs for user-defined projects.
+|Can be bound with `RoleBinding` to any user project.
+|===
+

--- a/modules/monitoring-granting-users-permissions-for-core-platform-monitoring.adoc
+++ b/modules/monitoring-granting-users-permissions-for-core-platform-monitoring.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * observability/monitoring/configuring-the-monitoring-stack.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="granting-users-permissions-for-core-platform-monitoring_{context}"]
+= Granting users permissions for core platform monitoring
+
+As a cluster administrator, you can monitor all core {product-title} and user-defined projects.
+
+You can also grant developers and other users different permissions for core platform monitoring. You can grant the permissions by assigning one of the following monitoring roles or cluster roles:
+
+|===
+|Name |Description |Project
+
+|`cluster-monitoring-metrics-api` 
+|Users with this role have the ability to access Thanos Querier API endpoints. Additionally, it grants access to the core platform Prometheus API and user-defined Thanos Ruler API endpoints.
+|`openshift-monitoring`
+
+|`cluster-monitoring-operator-alert-customization` 
+|Users with this role can manage `AlertingRule` and `AlertRelabelConfig` resources for core platform monitoring. These permissions are required for the alert customization feature. 
+|`openshift-monitoring`
+
+|`monitoring-alertmanager-edit` 
+|Users with this role can manage the Alertmanager API for core platform monitoring. They can also manage alert silences in the *Administrator* perspective of the {product-title} web console.
+|`openshift-monitoring`
+
+|`monitoring-alertmanager-view` 
+|Users with this role can monitor the Alertmanager API for core platform monitoring. They can also view alert silences in the *Administrator* perspective of the {product-title} web console. 
+|`openshift-monitoring`
+
+|`cluster-monitoring-view` 
+|Users with this cluster role have the same access rights as `cluster-monitoring-metrics-api` role, with additional permissions, providing access to the `/federate` endpoint for the user-defined Prometheus.
+|Must be bound with `ClusterRoleBinding` to gain access to the `/federate` endpoint for the user-defined Prometheus.
+|===
+

--- a/observability/monitoring/configuring-the-monitoring-stack.adoc
+++ b/observability/monitoring/configuring-the-monitoring-stack.adoc
@@ -74,6 +74,19 @@ include::modules/monitoring-creating-user-defined-workload-monitoring-configmap.
 * xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
 endif::openshift-dedicated,openshift-rosa[]
 
+ifndef::openshift-dedicated,openshift-rosa[]
+// Granting users permissions for core platform monitoring
+include::modules/monitoring-granting-users-permissions-for-core-platform-monitoring.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#granting-user-permissions-using-the-web-console_enabling-monitoring-for-user-defined-projects[Granting user permissions by using the web console] 
+* xref:../../observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc#granting-user-permissions-using-the-cli_enabling-monitoring-for-user-defined-projects[Granting user permissions by using the CLI]
+* xref:../../observability/monitoring/accessing-third-party-monitoring-apis.adoc#resources-reference-for-the-cluster-monitoring-operator[Resources reference for the {cmo-full}]
+* xref:../../observability/monitoring/accessing-third-party-monitoring-apis.adoc#cmo-services-resources[CMO services resources]
+
+endif::openshift-dedicated,openshift-rosa[]
+
 // Configuring the monitoring stack
 include::modules/monitoring-configuring-the-monitoring-stack.adoc[leveloffset=+1]
 

--- a/observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc
+++ b/observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc
@@ -22,6 +22,11 @@ include::modules/monitoring-enabling-monitoring-for-user-defined-projects.adoc[l
 
 // Granting users permission to monitor user-defined projects
 include::modules/monitoring-granting-users-permission-to-monitor-user-defined-projects.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../observability/monitoring/accessing-third-party-monitoring-apis.adoc#cmo-services-resources[CMO services resources]
+
 include::modules/monitoring-granting-user-permissions-using-the-web-console.adoc[leveloffset=+2]
 include::modules/monitoring-granting-user-permissions-using-the-cli.adoc[leveloffset=+2]
 

--- a/observability/monitoring/managing-alerts.adoc
+++ b/observability/monitoring/managing-alerts.adoc
@@ -15,12 +15,6 @@ In {product-title} {product-version}, the Alerting UI enables you to manage aler
 [NOTE]
 ====
 The alerts, silences, and alerting rules that are available in the Alerting UI relate to the projects that you have access to. For example, if you are logged in as a user with the `cluster-admin` role, you can access all alerts, silences, and alerting rules.
-
-If you are a non-administrator user, you can create and silence alerts if you are assigned the following user roles:
-
-* The `cluster-monitoring-view` cluster role, which allows you to access Alertmanager
-* The `monitoring-alertmanager-edit` role, which permits you to create and silence alerts in the *Administrator* perspective in the web console
-* The `monitoring-rules-edit` cluster role, which permits you to create and silence alerts in the *Developer* perspective in the web console
 ====
 
 // Accessing the Alerting UI in the Administrator and Developer perspectives


### PR DESCRIPTION
Version(s): `enterprise-4.12` and later

Issue: [OBSDOCS-1079](https://issues.redhat.com/browse/OBSDOCS-1079)

Link to docs preview: 

* https://80127--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-the-monitoring-stack.html#granting-users-permissions-for-core-platform-monitoring_configuring-the-monitoring-stack

* https://80127--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/enabling-monitoring-for-user-defined-projects.html#granting-users-permission-to-monitor-user-defined-projects_enabling-monitoring-for-user-defined-projects

QE review:
- [x] QE has approved this change.

**Additional information:**