### PR TITLE
OCPBUGS-38002: Updated EggressIPconfig object to match API description

### DIFF
--- a/modules/nw-egress-ips-config-object.adoc
+++ b/modules/nw-egress-ips-config-object.adoc
@@ -3,12 +3,15 @@
 // * networking/ovn_kubernetes_network_provider/assigning-egress-ips-ovn.adoc
 
 [id="nw-egress-ips-config-object_{context}"]
-= EgressIPconfig object
-As a feature of egress IP, the `reachabilityTotalTimeoutSeconds` parameter configures the total timeout for checks that are sent by probes to egress IP nodes. The `egressIPConfig` object allows users to set the `reachabilityTotalTimeoutSeconds` `spec`. If the EgressIP node cannot be reached within this timeout, the node is declared down.
+= The egressIPConfig object
 
-You can increase this value if your network is not stable enough to handle the current default value of 1 second.
+As a feature of egress IP, the `reachabilityTotalTimeoutSeconds` parameter configures the EgressIP node reachability check total timeout in seconds. If the EgressIP node cannot be reached within this timeout, the node is declared down.
 
-The following YAML describes changing the `reachabilityTotalTimeoutSeconds` from the default 1 second probes to 5 second probes:
+You can set a value for the `reachabilityTotalTimeoutSeconds` in the configuration file for the `egressIPConfig` object. Setting a large value might cause the EgressIP implementation to react slowly to node changes. The implementation reacts slowly for EgressIP nodes that have an issue and are unreachable. 
+
+If you omit the `reachabilityTotalTimeoutSeconds` parameter from the `egressIPConfig` object, the platform chooses a reasonable default value, which is subject to change over time. The current default is `1` second. A value of `0` disables the reachability check for the EgressIP node.
+
+The following `egressIPConfig` object describes changing the `reachabilityTotalTimeoutSeconds` from the default `1` second probes to `5` second probes:
 
 [source,yaml]
 ----
@@ -28,8 +31,5 @@ spec:
         routingViaHost: false
       genevePort: 6081
 ----
-<1> The `egressIPConfig` holds the configurations for the options of the `EgressIP` object. Changing these configurations allows you to extend the `EgressIP` object.
-
-<2> The value for `reachabilityTotalTimeoutSeconds` accepts integer values from `0` to `60`. A value of 0 disables the reachability check of the egressIP node. Values of `1` to `60` correspond to the duration in seconds between probes sending the reachability check for the node.
-
-
+<1> The `egressIPConfig` holds the configurations for the options of the `EgressIP` object. By changing these configurations, you can extend the `EgressIP` object.
+<2> The value for `reachabilityTotalTimeoutSeconds` accepts integer values from `0` to `60`. A value of `0` disables the reachability check of the egressIP node. Setting a value from `1` to `60` corresponds to the timeout in seconds for a probe to send the reachability check to the node.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-38002](https://issues.redhat.com/browse/OCPBUGS-38002)

Link to docs preview:
[EgressIPconfig object](https://80138--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html#nw-egress-ips-config-object_configuring-egress-ips-ovn)

- [x] SME has approved this change (Martin Kennelly).
- [x] QE has approved this change (Zhanqi, huiran0826, or jechen0648 ).

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
