### PR TITLE
OCPBUGS#21125: Add scope and type to `allowedSourceRanges` example command

### DIFF
--- a/modules/nw-configuring-lb-allowed-source-ranges.adoc
+++ b/modules/nw-configuring-lb-allowed-source-ranges.adoc
@@ -25,6 +25,7 @@ If you have already set the `spec.loadBalancerSourceRanges` field or the load ba
 ----
 $ oc -n openshift-ingress-operator patch ingresscontroller/default \
     --type=merge --patch='{"spec":{"endpointPublishingStrategy": \
-    {"loadBalancer":{"allowedSourceRanges":["0.0.0.0/0"]}}}}' <1>
+    {"type":"LoadBalancerService", "loadbalancer": \
+    {"scope":"External", "allowedSourceRanges":["0.0.0.0/0"]}}}}' <1>
 ----
 <1> The example value `0.0.0.0/0` specifies the allowed source range.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-21125](https://issues.redhat.com/browse/OCPBUGS-21125)

Link to docs preview:
[Configuring ingress cluster traffic using load balancer allowed source ranges ](https://80145--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer-allowed-source-ranges.html)

QE review:
- [x] QE has approved this change.

Additional information:
N/A