### PR TITLE
[OCPBUGS-34875]: Adding note about hosted clusters to API server certificate docs

### DIFF
--- a/security/certificates/api-server.adoc
+++ b/security/certificates/api-server.adoc
@@ -11,4 +11,9 @@ cluster CA. Clients outside of the cluster will not be able to verify the
 API server's certificate by default. This certificate can be replaced
 by one that is issued by a CA that clients trust.
 
+[NOTE]
+====
+In hosted control plane clusters, you cannot replace self-signed certificates from the API.
+====
+
 include::modules/customize-certificates-api-add-named.adoc[leveloffset=+1]


### PR DESCRIPTION

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-34875
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://80148--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificates/api-server.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
