### PR TITLE
OSDOCS-11652 : Add missing  "machines_v1beta1_machine_openshift_io: " in spec.template for sample yaml file provided in 'Configuring trusted launch for Azure virtual machines by using machine sets'

### DIFF
--- a/modules/machineset-azure-trusted-launch.adoc
+++ b/modules/machineset-azure-trusted-launch.adoc
@@ -85,16 +85,17 @@ endif::cpmso[]
 # ...
 spec:
   template:
-    spec:
-      providerSpec:
-        value:
-          securityProfile:
-            settings:
-              securityType: TrustedLaunch # <1>
-              trustedLaunch:
-                uefiSettings: # <2>
-                  secureBoot: Enabled # <3>
-                  virtualizedTrustedPlatformModule: Enabled # <4>
+    machines_v1beta1_machine_openshift_io:
+      spec:
+        providerSpec:
+          value:
+            securityProfile:
+              settings:
+                securityType: TrustedLaunch # <1>
+                trustedLaunch:
+                  uefiSettings: # <2>
+                    secureBoot: Enabled # <3>
+                    virtualizedTrustedPlatformModule: Enabled # <4>
 # ...
 ----
 <1> Enables the use of trusted launch for Azure virtual machines. This value is required for all valid configurations.


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-11652

Link to docs preview:
https://80199--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.html

https://80199--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure.html

**Additional information:**


Sample yaml configuration mentioned in [procedure](https://docs.openshift.com/container-platform/4.16/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.html#machineset-azure-trusted-launch_cpmso-config-options-azure)  step no. 2  for Configuring trusted launch for Azure virtual machines by using machine sets seems to be incorrect: 

Sample configuration as per documentation :

apiVersion: machine.openshift.io/v1
kind: ControlPlaneMachineSet
```
# ...
spec:
  template:
    spec:
      providerSpec:
        value:
          securityProfile:
            settings:
              securityType: TrustedLaunch 
              trustedLaunch:
                uefiSettings: 
                  secureBoot: Enabled 
                  virtualizedTrustedPlatformModule: Enabled 
# ...

```
Sample configuration should be as below : 

```
apiVersion: machine.openshift.io/v1
kind: ControlPlaneMachineSet
# ...
spec:
  template:
    machines_v1beta1_machine_openshift_io:    
      spec:
        providerSpec:
          value:
            securityProfile:
              settings:
                securityType: TrustedLaunch 
                trustedLaunch:
                  uefiSettings: 
                    secureBoot: Enabled 
                    virtualizedTrustedPlatformModule: Enabled 
# ...  

```

Doc Link:  https://docs.openshift.com/container-platform/4.16/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.html#machineset-azure-trusted-launch_cpmso-config-options-azure

