### PR TITLE
TRACING-4204 | Document forwarding logs to lokiStack

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2920,7 +2920,7 @@ Topics:
     File: otel-configuring-metrics-for-monitoring-stack
   - Name: Forwarding traces to a TempoStack
     File: otel-forwarding
-  - Name: Forwarding logs to a LikiStack
+  - Name: Forwarding logs to a LokiStack
     File: otel-forwarding-logs
   - Name: Configuring the Collector metrics
     File: otel-configuring-otelcol-metrics

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2920,6 +2920,8 @@ Topics:
     File: otel-configuring-metrics-for-monitoring-stack
   - Name: Forwarding traces to a TempoStack
     File: otel-forwarding
+  - Name: Forwarding logs to a LikiStack
+    File: otel-forwarding-logs
   - Name: Configuring the Collector metrics
     File: otel-configuring-otelcol-metrics
   - Name: Gathering the observability data from multiple clusters

--- a/observability/otel/otel-forwarding-logs.adoc
+++ b/observability/otel/otel-forwarding-logs.adoc
@@ -4,12 +4,12 @@
 include::_attributes/common-attributes.adoc[]
 :context: otel-forwarding-logs
 
-To configure forwarding logs to a LokiStack instance, you can deploy and configure the OpenTelemetry Collector. You can deploy the OpenTelemetry Collector in the deployment mode by using the specified processors, receivers, and exporters. For other modes, see the OpenTelemetry Collector documentation linked in _Additional resources_.
+To configure forwarding logs to a LokiStack instance, you can deploy and configure the OpenTelemetry Collector. You can deploy the OpenTelemetry Collector in the deployment mode by using the specified processors, receivers, and exporters.
 
 .Prerequisites
 
 * The {OTELOperator} is installed.
-* The {LokiOperator} is installed.
+* The {LokiOperator} is installed. See _Additional resources_ on how to install LokiStack.
 * A supported LokiStack instance is deployed on the cluster.
 
 TODO add dev-preview note and that the `lokipush` exporter will be removed in future release in favour of OTLP.
@@ -27,7 +27,7 @@ metadata:
   name: otel-collector-deployment
 ----
 
-. Create a cluster role that gives collector service account permissions to push logs to the LokiStack application tenant.
+. Create a cluster role that gives collector service account permissions to push logs to the LokiStack application tenant. The cluster role has also permissions for `k8sattributes` processor.
 +
 .Example ClusterRole
 [source,yaml]
@@ -37,14 +37,16 @@ kind: ClusterRole
 metadata:
   name: otel-collector-logs-writer
 rules:
- - apiGroups:
-   - loki.grafana.com
-   resourceNames:
-   - logs
-   resources:
-   - application
-   verbs:
-   - create
+ - apiGroups: ["loki.grafana.com"]
+   resourceNames: ["logs"]
+   resources: ["application"]
+   verbs: ["create"]
+ - apiGroups: [""]
+   resources: ["pods", "namespaces", "nodes"]
+   verbs: ["get", "watch", "list"]
+ - apiGroups: ["apps"]
+   resources: ["replicasets"]
+   verbs: ["get", "list", "watch"]
 ----
 <2> The `resourcedetectionprocessor` requires permissions for infrastructures and status.
 
@@ -90,13 +92,10 @@ spec:
           http: {}
     processors:
       resource:
-        attributes:
-          - key: collector_type
-            value: otel
+        attributes: <1>
+          - key: loki.format <2>
             action: insert
-          - key: loki.format
-            action: insert
-            value: logfmt
+            value: json
           - key:  kubernetes_namespace_name
             from_attribute: k8s.namespace.name
             action: upsert
@@ -109,8 +108,8 @@ spec:
           - key: log_type
             value: application
             action: upsert
-          - key: loki.resource.labels
-            value: log_type, kubernetes_namespace_name, kubernetes_pod_name, kubernetes_container_name, collector_type
+          - key: loki.resource.labels <3>
+            value: log_type, kubernetes_namespace_name, kubernetes_pod_name, kubernetes_container_name
             action: insert
       transform:
         log_statements:
@@ -120,28 +119,26 @@ spec:
 
     exporters:
       loki:
-        endpoint: https://logging-loki-gateway-http.openshift-logging.svc.cluster.local:8080/api/logs/v1/application/loki/api/v1/push <1>
-        default_labels_enabled:
-          exporter: true
-          job: true
-        headers:
-          "X-Scope-OrgID": application
+        endpoint: https://logging-loki-gateway-http.openshift-logging.svc.cluster.local:8080/api/logs/v1/application/loki/api/v1/push <4>
         tls:
           ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
         auth:
           authenticator: bearertokenauth
 
     service:
-      extensions: [bearertokenauth] <2>
+      extensions: [bearertokenauth] <5>
       pipelines:
         logs:
           receivers: [otlp]
           processors: [transform, resource]
-          exporters: [loki] <3>
+          exporters: [loki] <6>
 ----
-<1> The Loki exporter that points to the gateway of LokiStack `logging-loki` instance and uses `application` tenant.
-<2> Enables `bearertokenauth` extension that is used by the Loki exporter.
-<3> Enables Loki exporter in for exporting logs from the collector.
+<1> Resource attributes `kubernetes_namespace_name`, `kubernetes_pod_name`, `kubernetes_container_name`, `log_type` are used by OpenShift console. The Loki exporter considers them as labels if they are present in
+<2> Resource attribute `loki.format` configures the format of Loki logs. Possible values are `json`, `logfmt` and `raw`.
+<3> Resource attribute `loki.resource.labels` configures which resource attributes are considered as Loki labels.
+<4> The Loki exporter that points to the gateway of LokiStack `logging-loki` instance and uses `application` tenant.
+<5> Enables `bearertokenauth` extension that is used by the Loki exporter.
+<6> Enables Loki exporter in for exporting logs from the collector.
 
 [TIP]
 ====
@@ -160,7 +157,7 @@ spec:
           image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:latest
           args:
             - logs
-            - --otlp-endpoint=otel-collector:4317
+            - --otlp-endpoint=otel-collector.openshift-logging.svc.cluster.local:4317
             - --otlp-insecure
             - --duration=30s
             - --workers=1
@@ -172,6 +169,4 @@ spec:
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://opentelemetry.io/docs/collector/[OpenTelemetry Collector documentation]
-* link:https://github.com/os-observability/redhat-rhosdt-samples[Deployment examples on GitHub]
-* TODO add link to OCP Loki docs
+* xref:../logging/log_storage/installing-log-storage.adoc[Installing LokiStack log storage]

--- a/observability/otel/otel-forwarding-logs.adoc
+++ b/observability/otel/otel-forwarding-logs.adoc
@@ -9,7 +9,7 @@ To configure forwarding logs to a LokiStack instance, you can deploy and configu
 .Prerequisites
 
 * The {OTELOperator} is installed.
-* The {LokiOperator} is installed. See _Additional resources_ on how to install LokiStack.
+* The {loki-op} is installed. See _Additional resources_ on how to install LokiStack.
 * A supported LokiStack instance is deployed on the cluster.
 
 TODO add dev-preview note and that the `lokipush` exporter will be removed in future release in favour of OTLPHTTP.

--- a/observability/otel/otel-forwarding-logs.adoc
+++ b/observability/otel/otel-forwarding-logs.adoc
@@ -12,7 +12,7 @@ To configure forwarding logs to a LokiStack instance, you can deploy and configu
 * The {LokiOperator} is installed. See _Additional resources_ on how to install LokiStack.
 * A supported LokiStack instance is deployed on the cluster.
 
-TODO add dev-preview note and that the `lokipush` exporter will be removed in future release in favour of OTLP.
+TODO add dev-preview note and that the `lokipush` exporter will be removed in future release in favour of OTLPHTTP.
 
 .Procedure
 

--- a/observability/otel/otel-forwarding-logs.adoc
+++ b/observability/otel/otel-forwarding-logs.adoc
@@ -1,0 +1,177 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="otel-forwarding-logs"]
+= Forwarding Logs to a LokiStack instance
+include::_attributes/common-attributes.adoc[]
+:context: otel-forwarding-logs
+
+To configure forwarding logs to a LokiStack instance, you can deploy and configure the OpenTelemetry Collector. You can deploy the OpenTelemetry Collector in the deployment mode by using the specified processors, receivers, and exporters. For other modes, see the OpenTelemetry Collector documentation linked in _Additional resources_.
+
+.Prerequisites
+
+* The {OTELOperator} is installed.
+* The {LokiOperator} is installed.
+* A supported LokiStack instance is deployed on the cluster.
+
+TODO add dev-preview note and that the `lokipush` exporter will be removed in future release in favour of OTLP.
+
+.Procedure
+
+. Create a service account for the OpenTelemetry Collector.
++
+.Example ServiceAccount
+[source,yaml]
+----
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-collector-deployment
+----
+
+. Create a cluster role that gives collector service account permissions to push logs to the LokiStack application tenant.
++
+.Example ClusterRole
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otel-collector-logs-writer
+rules:
+ - apiGroups:
+   - loki.grafana.com
+   resourceNames:
+   - logs
+   resources:
+   - application
+   verbs:
+   - create
+----
+<2> The `resourcedetectionprocessor` requires permissions for infrastructures and status.
+
+. Bind the cluster role to the service account.
++
+.Example ClusterRoleBinding
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otel-collector-logs-writer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: otel-collector-logs-writer
+subjects:
+  - kind: ServiceAccount
+    name: otel-collector-deployment
+    namespace: openshift-logging
+----
+
+. Create the YAML file to define the `OpenTelemetryCollector` custom resource (CR).
++
+.Example OpenTelemetryCollector
+[source,yaml]
+----
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel
+  namespace: openshift-logging
+spec:
+  serviceAccount: otel-collector-deployment
+  config:
+    extensions:
+      bearertokenauth:
+        filename: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    receivers:
+      otlp:
+        protocols:
+          grpc: {}
+          http: {}
+    processors:
+      resource:
+        attributes:
+          - key: collector_type
+            value: otel
+            action: insert
+          - key: loki.format
+            action: insert
+            value: logfmt
+          - key:  kubernetes_namespace_name
+            from_attribute: k8s.namespace.name
+            action: upsert
+          - key:  kubernetes_pod_name
+            from_attribute: k8s.pod.name
+            action: upsert
+          - key: kubernetes_container_name
+            from_attribute: k8s.container.name
+            action: upsert
+          - key: log_type
+            value: application
+            action: upsert
+          - key: loki.resource.labels
+            value: log_type, kubernetes_namespace_name, kubernetes_pod_name, kubernetes_container_name, collector_type
+            action: insert
+      transform:
+        log_statements:
+          - context: log
+            statements:
+              - set(attributes["level"], ConvertCase(severity_text, "lower"))
+
+    exporters:
+      loki:
+        endpoint: https://logging-loki-gateway-http.openshift-logging.svc.cluster.local:8080/api/logs/v1/application/loki/api/v1/push <1>
+        default_labels_enabled:
+          exporter: true
+          job: true
+        headers:
+          "X-Scope-OrgID": application
+        tls:
+          ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+        auth:
+          authenticator: bearertokenauth
+
+    service:
+      extensions: [bearertokenauth] <2>
+      pipelines:
+        logs:
+          receivers: [otlp]
+          processors: [transform, resource]
+          exporters: [loki] <3>
+----
+<1> The Loki exporter that points to the gateway of LokiStack `logging-loki` instance and uses `application` tenant.
+<2> Enables `bearertokenauth` extension that is used by the Loki exporter.
+<3> Enables Loki exporter in for exporting logs from the collector.
+
+[TIP]
+====
+You can deploy `telemetrygen` as a test:
+[source,yaml]
+----
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: telemetrygen
+spec:
+  template:
+    spec:
+      containers:
+        - name: telemetrygen
+          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:latest
+          args:
+            - logs
+            - --otlp-endpoint=otel-collector:4317
+            - --otlp-insecure
+            - --duration=30s
+            - --workers=1
+      restartPolicy: Never
+  backoffLimit: 4
+----
+====
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://opentelemetry.io/docs/collector/[OpenTelemetry Collector documentation]
+* link:https://github.com/os-observability/redhat-rhosdt-samples[Deployment examples on GitHub]
+* TODO add link to OCP Loki docs


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12-4.17

This should be published with RHOSDT 3.3 release. 

There will be change to this docs once the LokiStack releases support for OTLP ingestions (most likely in 6.0.z, ~after mid September)

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/TRACING-4204

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://80200--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-forwarding-logs.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
