### PR TITLE
OCPBUGS-37415: Added a note to the Troubleshooting node network confi…

### DIFF
--- a/modules/k8s-nmstate-troubleshooting-dns-disconnected-env.adoc
+++ b/modules/k8s-nmstate-troubleshooting-dns-disconnected-env.adoc
@@ -8,6 +8,11 @@
 
 If you experience DNS connectivity issues when configuring `nmstate` in a disconnected environment, you can configure the DNS server to resolve the list of name servers for the domain `root-servers.net`.
 
+[IMPORTANT]
+====
+Ensure that the DNS server includes a name server (NS) entry for the `root-servers.net` zone. The DNS server does not need to forward a query to an upstream resolver, but the server must return a correct answer for the NS query.
+====
+
 == Configuring the bind9 DNS named server  
 
 For a cluster configured to query a `bind9` DNS server, you can add the `root-servers.net` zone to a configuration file that contains at least one NS record.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-37415](https://issues.redhat.com/browse/OCPBUGS-37415)

Link to docs preview:
[Troubleshooting DNS connectivity issues in a disconnected environment](https://80201--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-troubleshooting-node-network.html)


- [X] SME has approved this change.
- [x] QE has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
