### PR TITLE
OSDOCS-10970: adds IPv6 relnote MicroShift 4.17

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -34,7 +34,7 @@ This release adds improvements related to the following components and concepts.
 
 [id="microshift-4-17-updating_{context}"]
 === Updating
-//Updating two minor versions in a single step is supported from 4.16. Updates for both single-version minor releases and patch releases are still supported.
+Updating two minor versions in a single step is supported in 4.17. Updates for both single-version minor releases and patch releases are still supported.
 
 //[id="microshift-4-17-updates-supported_{context}"]
 //==== Update two minor versions in a single step
@@ -59,14 +59,10 @@ This release adds improvements related to the following components and concepts.
 [id="microshift-4-17-networking_{context}"]
 === Networking
 
-//[id="microshift-4-17-multus_{context}"]
-//==== Multiple networks capability now available
-
-//[id="microshift-4-17-configure-ingress-router_{context}"]
-//==== Custom configurations for the ingress router are supported
-
-//[id="microshift-4-17-configure-route-admission-policy_{context}"]
-//==== Configuring the route admission policy now available
+[id="microshift-4-17-IPv6_{context}"]
+==== IPv6 single and dual-stack IPv6 networking now available
+With this release, you can run {microshift-short} and your workloads with either IPv6 only or IPv4 and IPv6 dual stack networking protocols. Ingress and egress traffic can be on either IPv4 or IPv6 traffic, mixed or parallel. See xref:../microshift_configuring/microshift-using-config-tools.adoc#microshift-using-config-tools[Configuring IPv6 networking].
+//crossref to be updated
 
 [id="microshift-4-17-storage_{context}"]
 === Storage


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-10970](https://issues.redhat.com/browse/OSDOCS-10970)

Link to docs preview:
[IPv6 release note](https://80202--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-IPv6_release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
