### PR TITLE
OCPBUGS-35405-414 Enabling cgroup v2 is not possible if you are using 

### DIFF
--- a/modules/nodes-clusters-cgroups-2.adoc
+++ b/modules/nodes-clusters-cgroups-2.adoc
@@ -37,7 +37,7 @@ endif::nodes[]
 
 [NOTE]
 ====
-Currently, disabling CPU load balancing is not supported by cgroup v2. As a result, you might not get the desired behavior from performance profiles if you have cgroup v2 enabled. Enabling cgroup v2 is not recommended if you are using performance profiles.
+In Telco, clusters using `PerformanceProfile` for low latency, real-time, and Data Plane Development Kit (DPDK) workloads automatically revert to cgroups v1 due to the lack of cgroups v2 support. Enabling cgroup v2 is not supported if you are using `PerformanceProfile`.
 ====
 
 .Prerequisites

--- a/scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
+++ b/scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
@@ -19,6 +19,11 @@ You can restrict CPUs for infra and application containers, configure huge pages
 
 Learn about the Performance Profile Creator (PPC) and how you can use it to create a performance profile.
 
+[NOTE]
+====
+In Telco, clusters using `PerformanceProfile` for low latency, real-time, and Data Plane Development Kit (DPDK) workloads automatically revert to cgroups v1 due to the lack of cgroups v2 support. Enabling cgroup v2 is not supported if you are using `PerformanceProfile`. 
+====
+
 include::modules/cnf-about-the-profile-creator-tool.adoc[leveloffset=+2]
 
 include::modules/cnf-gathering-data-about-cluster-using-must-gather.adoc[leveloffset=+2]


### PR DESCRIPTION
[OCPBUGS-35405 ]: Enabling cgroup v2 is not possible if you are using performance profiles

Version(s): 4.14

Issue: https://issues.redhat.com/browse/OCPBUGS-35405

Link to docs preview:

- https://80214--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-cgroups-2.html
- https://80214--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html
- https://80214--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.html 

QE review:

 QE has approved this change.