### PR TITLE
[OCPBUGS-38114]: Removing hypershift dump command from HCP troubleshooting docs

### DIFF
--- a/modules/hosted-control-planes-troubleshooting.adoc
+++ b/modules/hosted-control-planes-troubleshooting.adoc
@@ -6,7 +6,7 @@
 [id="hosted-control-planes-troubleshooting_{context}"]
 = Gathering information to troubleshoot {hcp}
 
-When you need to troubleshoot an issue with hosted control plane clusters, you can gather information by running the `hypershift dump cluster` command. The command generates output for the management cluster and the hosted cluster.
+When you need to troubleshoot an issue with hosted control plane clusters, you can gather information by running the `must-gather` command. The command generates output for the management cluster and the hosted cluster.
 
 The output for the management cluster contains the following content:
 
@@ -41,56 +41,13 @@ Although the output does not contain any secret objects from the cluster, it can
 +
 [source,terminal]
 ----
-$ hypershift dump cluster \
-    --name <hosted_cluster_name> \// <1>
-    --namespace <hosted_cluster_namespace> \ <2>
-    --dump-guest-cluster \
-    --artifact-dir clusterDump-<hosted_cluster_namespace>-<hosted_cluster_name>
+$ oc adm must-gather --image=registry.redhat.io/multicluster-engine/must-gather-rhel9:v<mce_version> \
+  /usr/bin/gather hosted-cluster-namespace=HOSTEDCLUSTERNAMESPACE hosted-cluster-name=HOSTEDCLUSTERNAME \
+  --dest-dir=NAME ; tar -cvzf NAME.tgz NAME
 ----
 +
-<1> Specify your hosted cluster name.
-<2> Specify your hosted cluster namespace, for example, `clusters`.
-+
-.Example output
-+
-[source,terminal]
-----
-2023-06-06T12:18:20+02:00   INFO    Archiving dump  {"command": "tar", "args": ["-cvzf", "hypershift-dump.tar.gz", "cluster-scoped-resources", "event-filter.html", "namespaces", "network_logs", "timestamp"]}
-2023-06-06T12:18:21+02:00   INFO    Successfully archived dump  {"duration": "1.519376292s"}
-----
+where:
 
-* To configure the command-line interface so that it impersonates all of the queries against the management cluster by using a username or service account, enter the `hypershift dump cluster` command with the `--as` flag.
-+
-The service account must have enough permissions to query all of the objects from the namespaces, so the `cluster-admin` role is recommended to make sure you have enough permissions. The service account must be located in or have permissions to query the namespace of the `HostedControlPlane` resource.
-+
-If your username or service account does not have enough permissions, the output contains only the objects that you have permissions to access. During that process, you might see `forbidden` errors.
-+
-** To use impersonation by using a service account, enter the following command:
-+
-[source,terminal]
-----
-$ hypershift dump cluster \
-    --name <hosted_cluster_name> \// <1>
-    --namespace <hosted_cluster_namespace> \// <2>
-    --dump-guest-cluster \
-    --as "system:serviceaccount:<service_account_namespace>:<service_account_name>" \ <3>
-    --artifact-dir clusterDump-<hosted_cluster_namespace>-<hosted_cluster_name>
-----
-<1> Specify your hosted cluster name.
-<2> Specify your hosted cluster namespace, for example, `clusters`.
-<3> Specify the `default` namespace and name, for example, `"system:serviceaccount:default:samplesa"`.
-
-** To use impersonation by using a username, enter the following command:
-+
-[source,terminal]
-----
-$ hypershift dump cluster \
-    --name <hosted_cluster_name> \// <1>
-    --namespace <hosted_cluster_namespace> \// <2>
-    --dump-guest-cluster \
-    --as "<cluster_user_name>" \ <3>
-    --artifact-dir clusterDump-<hosted_cluster_namespace>-<hosted_cluster_name>
-----
-<1> Specify your hosted cluster name.
-<2> Specify your hosted cluster namespace, for example, `clusters`.
-<3> Specify your cluster user name, for example, `cloud-admin`.
+** You replace `<mce_version>` with the version of {mce-short} that you are using; for example, `2.6`.
+** The `hosted-cluster-namespace=HOSTEDCLUSTERNAMESPACE` parameter is optional. If you do not include it, the command runs as though the hosted cluster is in the default namespace, which is `clusters`.
+** The `--dest-dir=NAME` parameter is optional. Specify that parameter if you want to save the results of the command to a compressed file, replacing `NAME` with the name of the directory where you want to save the results.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-38115
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://80230--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-troubleshooting.html#hosted-control-planes-troubleshooting_hcp-troubleshooting
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
