### PR TITLE
ROX:25607: disable RHACS default network policies option

### DIFF
--- a/modules/central-configuration-options-operator.adoc
+++ b/modules/central-configuration-options-operator.adoc
@@ -278,14 +278,6 @@ If no PVC with the given name exists, it is created. The default value is `scann
 |===
 | Parameter | Description
 
-| `tls.additionalCAs`
-| Additional Trusted CA certificates for the secured cluster to trust.
-These certificates are typically used when integrating with services using a private certificate authority.
-
-| `misc.createSCCs`
-| Specify `true` to create `SecurityContextConstraints` (SCCs) for Central.
-Setting to `true` might cause issues in some environments.
-
 | `customize.annotations`
 | Allows specifying custom annotations for the Central deployment.
 
@@ -296,10 +288,26 @@ Setting to `true` might cause issues in some environments.
 
 | Configures whether {product-title-short} should run in online or offline mode. In offline mode, automatic updates of vulnerability definitions and kernel modules are disabled.
 
+| `misc.createSCCs`
+| Specify `true` to create `SecurityContextConstraints` (SCCs) for Central.
+Setting to `true` might cause issues in some environments.
+
 | `monitoring.openshift.enabled`
 | If you set this option to `false`, {product-title} will not set up {osp} monitoring. Defaults to `true` on {osp} 4.
 
+|`network.policies`
+a| To provide security at the network level, {product-title-short} creates default `NetworkPolicy` resources in the namespace where Central is installed. These network policies allow ingress to specific components on specific ports. If you do not want {product-title-short} to create these policies, set this parameter to `Disabled`. The default value is `Enabled`.
+
+[WARNING]
+====
+Disabling creation of default network policies can break communication between {product-title-short} components. If you disable creation of default policies, you must create your own network policies to allow this communication.
+====
+
 | `overlays`
-| See Customizing the installation using the operator with overlays
+| See "Customizing the installation using the Operator with overlays".
+
+| `tls.additionalCAs`
+| Additional Trusted CA certificates for the secured cluster to trust.
+These certificates are typically used when integrating with services using a private certificate authority.
 
 |===

--- a/modules/central-services-public-config.adoc
+++ b/modules/central-services-public-config.adoc
@@ -76,6 +76,24 @@ When Central, the StackRox Scanner, or Scanner V4 must reach out to services tha
 
 |===
 
+[id="default-network-policy-creation_{context}"]
+== Default network policies
+
+To provide security at the network level, {product-title-short} creates default `NetworkPolicy` resources in the namespace where Central is installed. These network policies allow ingress to specific components on specific ports. If you do not want {product-title-short} to create these policies, set this parameter to `Disabled`. The default value is `Enabled`.
+
+[WARNING]
+====
+Disabling creation of default network policies can break communication between {product-title-short} components. If you disable creation of default policies, you must create your own network policies to allow this communication.
+====
+
+|===
+| Parameter | Description
+
+|`network.enableNetworkPolicies`
+| Specify if {product-title-short} creates default network policies to allow communication between components. To create your own network policies, set this parameter to `False`. The default value is `True`.
+
+|===
+
 [id="central-services-public-configuration-file-central_{context}"]
 == Central
 Configurable parameters for Central.

--- a/modules/install-central-operator.adoc
+++ b/modules/install-central-operator.adoc
@@ -98,6 +98,12 @@ When Scanner V4 is enabled, you can configure the following options:
 |===
 * *Egress*: Settings for outgoing network traffic, including whether {product-title-short} should run in online (connected) or offline (disconnected) mode.
 * *TLS*: Use this field to add additional trusted root certificate authorities (CAs).
+* *network*: To provide security at the network level, {product-title-short} creates default `NetworkPolicy` resources in the namespace where Central is installed. To create and manage your own network policies, in the *policies* section, select *Disabled*. By default, this option is *Enabled*.
++
+[WARNING]
+====
+Disabling creation of default network policies can break communication between {product-title-short} components. If you disable creation of default policies, you must create your own network policies to allow this communication.
+====
 * *Advanced configuration*: You can use these fields to perform the following actions:
 ** Specify additional image pull secrets
 ** Add custom environment variables to set for managed pods' containers

--- a/modules/secured-cluster-configuration-options-operator.adoc
+++ b/modules/secured-cluster-configuration-options-operator.adoc
@@ -284,14 +284,6 @@ This configuration defines the settings of the Sensor components, which runs on 
 |===
 | Parameter | Description
 
-| `tls.additionalCAs`
-| Additional trusted CA certificates for the secured cluster.
-These certificates are used when integrating with services using a private certificate authority.
-
-| `misc.createSCCs`
-| Set this to `true` to create SCCs for Central.
-It may cause issues in some environments.
-
 | `customize.annotations`
 | Allows specifying custom annotations for the Central deployment.
 
@@ -302,7 +294,23 @@ It may cause issues in some environments.
 | Configures whether {product-title} should run in online or offline mode.
 In offline mode, automatic updates of vulnerability definitions and kernel modules are disabled.
 
+| `misc.createSCCs`
+| Set this to `true` to create SCCs for Central.
+It may cause issues in some environments.
+
+|`network.policies`
+a| To provide security at the network level, {product-title-short} creates default `NetworkPolicy` resources in the namespace where secured cluster resources are installed. These network policies allow ingress to specific components on specific ports. If you do not want {product-title-short} to create these policies, set this parameter to `Disabled`. The default value is `Enabled`.
+
+[WARNING]
+====
+Disabling creation of default network policies can break communication between {product-title-short} components. If you disable creation of default policies, you must create your own network policies to allow this communication.
+====
+
 | `overlays`
-| See Customizing the installation using the operator with overlays
+| See "Customizing the installation using the Operator with overlays".
+
+| `tls.additionalCAs`
+| Additional trusted CA certificates for the secured cluster.
+These certificates are used when integrating with services using a private certificate authority.
 
 |===

--- a/modules/secured-cluster-services-config.adoc
+++ b/modules/secured-cluster-services-config.adoc
@@ -303,6 +303,13 @@ If you do not create this account, you must complete future upgrades manually if
 | `monitoring.openshift.enabled`
 | If you set this option to `false`, {product-title} will not set up {osp} monitoring. Defaults to `true` on {osp} 4.
 
+| `network.enableNetworkPolicies`
+a| To provide security at the network level, {product-title-short} creates default `NetworkPolicy` resources in the namespace where secured cluster resources are installed. These network policies allow ingress to specific components on specific ports. If you do not want {product-title-short} to create these policies, set this parameter to `False`. This is a Boolean value. The default value is `True`, which means the default policies are automatically created.
+
+[WARNING]
+====
+Disabling creation of default network policies can break communication between {product-title-short} components. If you disable creation of default policies, you must create your own network policies to allow this communication.
+====
 |===
 
 [id="secured-cluster-services-environment-variables_{context}"]


### PR DESCRIPTION
Version(s):
4.5+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

[Issue](https://issues.redhat.com/browse/ROX-25607)

Link to docs previews:

[secured cluster options, OCP - Helm](https://80234--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_ocp/install-secured-cluster-cloud-ocp.html#configure-secured-cluster-services-helm-chart-customizations-cloud-ocp) - see "network.enableNetworkPolicies" in table

[secured cluster options, K8s - Helm](https://80234--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_other/install-secured-cluster-cloud-other.html#secured-cluster-services-config_install-secured-cluster-cloud-other) - see "network.enableNetworkPolicies" in table

[secured cluster options, OCP - Operator](https://80234--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-config-options-ocp.html#general-and-miscellaneous-settings-secured-cluster_install-secured-cluster-config-options-ocp) - see "network.policies" in table

[secured cluster options, Cloud Service, OCP](https://80234--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_ocp/install-secured-cluster-cloud-ocp.html#secured-cluster-services-config_install-secured-cluster-cloud-ocp) - see "network.enableNetworkPolicies" in table

[secured cluster options, Cloud Service, K8s](https://80234--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_other/install-secured-cluster-cloud-other.html#secured-cluster-services-config_install-secured-cluster-cloud-other) - see "network.enableNetworkPolicies" in table

[installing Central on OCP - Operator](https://80234--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-ocp.html#install-central-operator_install-central-ocp) - See Step 8, "network"

[Central options, OCP - Operator](https://80234--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-config-options-ocp.html#general-and-miscellaneous-settings_install-central-config-options-ocp) - see "network.policies" in table

[installing Central on K8s - Helm](https://80234--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_other/install-central-other.html#default-network-policy-creation_install-central-other)

QE review:
- [x] QE has approved this change. (**ACS has no QE, approved by SME**)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
