### PR TITLE
OSDOCS-11440: adds low latency release note MicroShift 4.17

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -74,8 +74,10 @@ This release adds improvements related to the following components and concepts.
 [id="microshift-4-17-running-apps_{context}"]
 === Running applications
 
-//[id="microshift-4-17-gitops_{context}"]
-//==== GitOps with Argo CD now available
+[id="microshift-4-17-low-latency_{context}"]
+====  Low-latency performance for applications now available
+You can now run a {microshift-short} cluster with low-latency response rates. Using a low-latency {microshift-short} configuration with operating system tuning results in reduced application response times and can include deterministic performance. Using workload partitioning is also recommended.
+//See (crossrefs here to ll and wp)
 
 [id="microshift-4-17-support_{context}"]
 === Support


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-11440](https://issues.redhat.com/browse/OSDOCS-11440)

Link to docs preview:
[Low latency release note](https://80235--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-low-latency_release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
