### PR TITLE
OSDOCS#11576: Adding note to not use memory ballooning

### DIFF
--- a/modules/installation-minimum-resource-requirements.adoc
+++ b/modules/installation-minimum-resource-requirements.adoc
@@ -47,7 +47,7 @@
 // * installing/installing-restricted-networks-azure-installer-provisioned.adoc
 // * installing/installing_azure/installing-restricted-networks-azure-user-provisioned.adoc
 // * installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc
-// * installing/intalling_bare_metal_ipi/ipi-install-prerequisites.adoc
+// * installing/installing_bare_metal_ipi/ipi-install-prerequisites.adoc
 
 ifeval::["{context}" == "installing-azure-customizations"]
 :azure:
@@ -265,6 +265,10 @@ You are required to use Azure virtual machines that have the `premiumIO` paramet
 endif::azure[]
 
 If an instance type for your platform meets the minimum requirements for cluster machines, it is supported to use in {product-title}.
+
+ifdef::vsphere[]
+include::snippets/memory-ballooning.adoc[]
+endif::vsphere[]
 
 ifeval::["{context}" == "installing-azure-customizations"]
 :!azure:

--- a/snippets/memory-ballooning.adoc
+++ b/snippets/memory-ballooning.adoc
@@ -1,0 +1,18 @@
+// Text snippet included in the following modules:
+//
+// * modules/installation-minimum-resource-requirements.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+[IMPORTANT]
+====
+Do not use memory ballooning in {product-title} clusters. Memory ballooning can cause cluster-wide instabilities, service degradation, or other undefined behaviors.
+
+* Control plane machines should have committed memory equal to or greater than the published minimum resource requirements for a cluster installation.
+
+* Compute machines should have a minimum reservation equal to or greater than the published minimum resource requirements for a cluster installation.
+
+These minimum CPU and memory requirements do not account for resources required by user workloads.
+
+For more information, see the Red Hat Knowledgebase article link:https://access.redhat.com/articles/7074533[Memory Ballooning and OpenShift].
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-11576

Link to docs preview:
* https://80237--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/upi-vsphere-installation-reqs.html#installation-minimum-resource-requirements_upi-vsphere-installation-reqs

Also, here is an example of another assembly that uses this module, to show that this note only appears for vSphere: https://80237--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites#installation-minimum-resource-requirements_ipi-install-prerequisites

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
