### PR TITLE
Added information regarding impacts of frequent backups

### DIFF
--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
@@ -7,7 +7,12 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-You back up applications by creating a `Backup` custom resource (CR). See xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr.adoc#oadp-creating-backup-cr-doc[Creating a Backup CR].
+Frequent backups might consume storage on the backup storage location. Check the frequency of backups, retention time, and the amount of data of the persistent volumes (PVs) if using non-local backups, for example, S3 buckets.
+Since all taken backup remains until expired, also check the time to live (TTL) setting of the schedule.
+
+Note that that there might be known issues with supported storage classes, for example, CSI backups might fail due to a Ceph limitation. For more information, see xref:modules/oadp-release-notes-1-1-2.adoc#known-issues_oadp-release-notes[Known issues].
+
+You can back up applications by creating a `Backup` custom resource (CR). For moreinformation, see xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr.adoc#oadp-creating-backup-cr-doc[Creating a Backup CR].
 
 * The `Backup` CR creates backup files for Kubernetes resources and internal images on S3 object storage.
 * If your cloud provider has a native snapshot API or supports CSI snapshots, the `Backup` CR backs up persistent volumes (PVs) by creating snapshots. For more information about working with CSI snapshots, see xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-pvs-csi-doc.adoc#oadp-backing-up-pvs-csi-doc[Backing up persistent volumes with CSI snapshots].
@@ -33,7 +38,7 @@ The {oadp-first} does not support backing up volume snapshots that were created 
 
 You can create backup hooks to run commands before or after the backup operation. See xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-hooks-doc.adoc#oadp-creating-backup-hooks-doc[Creating backup hooks].
 
-You can schedule backups by creating a `Schedule` CR instead of a `Backup` CR. See xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-scheduling-backups-doc.adoc#oadp-scheduling-backups-doc[Scheduling backups using Schedule CR]].
+You can schedule backups by creating a `Schedule` CR instead of a `Backup` CR. See xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-scheduling-backups-doc.adoc#oadp-scheduling-backups-doc[Scheduling backups using Schedule CR].
 
 // include::modules/oadp-creating-backup-cr.adoc[leveloffset=+1]
 // include::modules/oadp-backing-up-pvs-csi.adoc[leveloffset=+1]

--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
@@ -12,7 +12,7 @@ Because all taken backup remains until expired, also check the time to live (TTL
 
 [NOTE]
 ====
-There might be known issues with supported storage classes, for example, CSI backups might fail due to a Ceph limitation. For more information, see xref:xref:../../../backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-1.adoc#known-issues_oadp-release-notes[Known issues].
+There might be known issues with supported storage classes, for example, CSI backups might fail due to a Ceph limitation. For more information, see xref:../../../backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-1.adoc#known-issues_oadp-release-notes[Known issues].
 ====
 
 You can back up applications by creating a `Backup` custom resource (CR). For more information, see xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr.adoc#oadp-creating-backup-cr-doc[Creating a Backup CR].

--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
@@ -8,11 +8,14 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 Frequent backups might consume storage on the backup storage location. Check the frequency of backups, retention time, and the amount of data of the persistent volumes (PVs) if using non-local backups, for example, S3 buckets.
-Since all taken backup remains until expired, also check the time to live (TTL) setting of the schedule.
+Because all taken backup remains until expired, also check the time to live (TTL) setting of the schedule.
 
-Note that that there might be known issues with supported storage classes, for example, CSI backups might fail due to a Ceph limitation. For more information, see xref:modules/oadp-release-notes-1-1-2.adoc#known-issues_oadp-release-notes[Known issues].
+[NOTE]
+====
+There might be known issues with supported storage classes, for example, CSI backups might fail due to a Ceph limitation. For more information, see xref:xref:../../../backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-1.adoc#known-issues_oadp-release-notes[Known issues].
+====
 
-You can back up applications by creating a `Backup` custom resource (CR). For moreinformation, see xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr.adoc#oadp-creating-backup-cr-doc[Creating a Backup CR].
+You can back up applications by creating a `Backup` custom resource (CR). For more information, see xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-creating-backup-cr.adoc#oadp-creating-backup-cr-doc[Creating a Backup CR].
 
 * The `Backup` CR creates backup files for Kubernetes resources and internal images on S3 object storage.
 * If your cloud provider has a native snapshot API or supports CSI snapshots, the `Backup` CR backs up persistent volumes (PVs) by creating snapshots. For more information about working with CSI snapshots, see xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-pvs-csi-doc.adoc#oadp-backing-up-pvs-csi-doc[Backing up persistent volumes with CSI snapshots].


### PR DESCRIPTION
Version(s):
OADP 1.4.1
OCP 4.13 → OCP 4.16

Issue:
[OADP-1793](https://issues.redhat.com/browse/OADP-1793)

Link to docs preview:
https://80245--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Apart from adding content regarding frequent backups and its impact, I've added a minor fix in the orignal abstract and fixed the syntax for link - See [Scheduling backups using Schedule CR](https://docs.redhat.com/en/documentation/openshift_container_platform/4.12/html-single/backup_and_restore/index#oadp-scheduling-backups-doc)]

