### PR TITLE
enterprise-4.13 OADP-4657: Release Notes for 1.4.0 for OCP 4.13

### DIFF
--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
@@ -7,7 +7,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-The release notes for OpenShift API for Data Protection (OADP) describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
+The release notes for {oadp-first} describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
 
 include::modules/oadp-1-4-0-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-backing-up-dpa-configuration-1-4-0.adoc[leveloffset=+3]
@@ -24,4 +24,4 @@ To upgrade from OADP 1.3 to 1.4, no Data Protection Application (DPA) changes ar
 [id="verifying-upgrade-1-4-0_{context}"]
 === Verifying the upgrade
 
-Verify the installation by following steps from the link:https://docs.openshift.com/container-platform/4.15/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-2.html#verifying-upgrade-1-2-0_oadp-release-notes[Verifying the upgrade] section.
+Verify the installation by following steps from the xref:../../../backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-2.adoc#verifying-upgrade-1-2-0_oadp-release-notes[Verifying the upgrade] section.

--- a/modules/oadp-1-4-0-release-notes.adoc
+++ b/modules/oadp-1-4-0-release-notes.adoc
@@ -22,8 +22,8 @@ link:https://issues.redhat.com/browse/OADP-4075[OADP-4075]
 
 .Data Mover backups work properly in the {product-title} 4.16 cluster
 
-Previously, Velero was using the earlier version of SDK where the `Spec.SourceVolumeMode` field did not exist. As a consequence, Data Mover backups failed in the {product-title} 4.16 cluster on the external snapshotter with v4.2 version. 
-With this update, external snapshotter is upgraded to v7.0 version and later. As a result, backups do not fail in the {product-title} 4.16 cluster.
+Previously, Velero was using the earlier version of SDK where the `Spec.SourceVolumeMode` field did not exist. As a consequence, Data Mover backups failed in the {product-title} 4.16 cluster on the external snapshotter with version 4.2. 
+With this update, external snapshotter is upgraded to version 7.0 and later. As a result, backups do not fail in the {product-title} 4.16 cluster.
 link:https://issues.redhat.com/browse/OADP-3922[OADP-3922]
 
 For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12438505[OADP 1.4.0 resolved issues] in Jira.
@@ -52,15 +52,15 @@ Always upgrade to the next minor version. *Do not* skip versions. To update to a
 [id="changes-oadp-1-3-to-1-4_{context}"]
 === Changes from OADP 1.3 to 1.4
 
-The Velero server has been updated from version 1.12 to 1.14. Note that, there are no changes in the Data Protection Application (DPA).
+The Velero server has been updated from version 1.12 to 1.14. Note that there are no changes in the Data Protection Application (DPA).
 
 This changes the following:
 
-* The `velero-plugin-for-csi` code is now available in the Velero code, which means no `init` container is needed for the plugin anymore.
+* The `velero-plugin-for-csi` code is now available in the Velero code, which means an `init` container is no longer required for the plugin.
 
-* Velero changed client Burst and QPS defaults from 30 and 20 to 100 and 100 respectively.
+* Velero changed client Burst and QPS defaults from 30 and 20 to 100 and 100, respectively.
 
-* The `velero-plugin-for-aws` plugin updated default value of the `spec.config.checksumAlgorithm` field in BackupStorageLocations (BSLs) from `""` (no checksum calculation) to the `CRC32` algorithm. For more information, see link:https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/release-1.10/backupstoragelocation.md[Velero plugins for AWS Backup Storage Location]. The checksum algorithm types are known to work only with AWS. 
+* The `velero-plugin-for-aws` plugin updated default value of the `spec.config.checksumAlgorithm` field in `BackupStorageLocation` objects (BSLs) from `""` (no checksum calculation) to the `CRC32` algorithm. For more information, see link:https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/release-1.10/backupstoragelocation.md[Velero plugins for AWS Backup Storage Location]. The checksum algorithm types are known to work only with AWS. 
 Several S3 providers require the `md5sum` to be disabled by setting the checksum algorithm to `""`. Confirm `md5sum` algorithm support and configuration with your storage provider. 
 +
-In  OADP 1.4, the default value for BSLs created within DPA for this configuration is `""`. This default value means that the `md5sum` is not checked, which is consistent with OADP 1.3. For BSLs created within DPA, update it by using the `spec.backupLocations[].velero.config.checksumAlgorithm` field in the DPA. If your BSLs are created outside DPA, you can update this configuration by using `spec.config.checksumAlgorithm` in the BSLs.
+In OADP 1.4, the default value for BSLs created within DPA for this configuration is `""`. This default value means that the `md5sum` is not checked, which is consistent with OADP 1.3. For BSLs created within DPA, update it by using the `spec.backupLocations[].velero.config.checksumAlgorithm` field in the DPA. If your BSLs are created outside DPA, you can update this configuration by using `spec.config.checksumAlgorithm` in the BSLs.

--- a/modules/oadp-backing-up-dpa-configuration-1-4-0.adoc
+++ b/modules/oadp-backing-up-dpa-configuration-1-4-0.adoc
@@ -12,7 +12,7 @@ You must back up your current `DataProtectionApplication` (DPA) configuration.
 .Procedure
 * Save your current DPA configuration by running the following command:
 +
-.Example
+.Example command
 [source,terminal]
 ----
 $ oc get dpa -n openshift-adp -o yaml > dpa.orig.backup

--- a/modules/oadp-upgrading-oadp-operator-1-4-0.adoc
+++ b/modules/oadp-upgrading-oadp-operator-1-4-0.adoc
@@ -12,5 +12,5 @@ Use the following procedure when upgrading the {oadp-first} Operator.
 .Procedure
 
 . Change your subscription channel for the OADP Operator from `stable-1.3` to `stable-1.4`.
-. Wait for the operator and containers to update and restart.
+. Wait for the Operator and containers to update and restart.
 


### PR DESCRIPTION
### Jira

* [OADP-4657](https://issues.redhat.com/browse/OADP-4657) - [DOC] Release Notes for OADP 1.4.0 for OCP 4.13
    * Release notes added to 4.13 to address the ACM issue. However, when @adellape was reviewing, there were so many corrections, rather than make them for just 4.13, I created this PR for the sake of uniformity. 

See [this PR](https://github.com/openshift/openshift-docs/pull/79411) for further details.

### Version(s):

* OCP 4.13 + 

### Link to docs preview:

* [OADP 1.4.0 release notes in OCP 4.13](https://80253--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.html)

### QE review:
- [X] [QE has approved this change](https://github.com/openshift/openshift-docs/pull/79411#issuecomment-2273286724).