### PR TITLE
Correct the hyperlink in the OCP doc for verifying image signatures link

### DIFF
--- a/machine_configuration/machine-configs-configure.adoc
+++ b/machine_configuration/machine-configs-configure.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can use the tasks in this section to create `MachineConfig` objects that modify files, systemd unit files, and other operating system features running on {product-title} nodes. For more ideas on working with machine configs, see content related to link:https://access.redhat.com/solutions/3868301[updating] SSH authorized keys, link:https://access.redhat.com/verify-images-ocp4[verifying image signatures], link:https://access.redhat.com/solutions/4727321[enabling SCTP], and link:https://access.redhat.com/solutions/5170251[configuring iSCSI initiatornames] for {product-title}.
+You can use the tasks in this section to create `MachineConfig` objects that modify files, systemd unit files, and other operating system features running on {product-title} nodes. For more ideas on working with machine configs, see content related to link:https://access.redhat.com/solutions/3868301[updating] SSH authorized keys, xref:../security/container_security/security-container-signature.adoc#security-container-signature[verifying image signatures], link:https://access.redhat.com/solutions/4727321[enabling SCTP], and link:https://access.redhat.com/solutions/5170251[configuring iSCSI initiatornames] for {product-title}.
 
 {product-title} supports link:https://coreos.github.io/ignition/configuration-v3_2/[Ignition specification version 3.2]. All new machine configs you create going forward should be based on Ignition specification version 3.2. If you are upgrading your {product-title} cluster, any existing Ignition specification version 2.x machine configs will be translated automatically to specification version 3.2.
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-11658

Update the doc for redirecting to the correct OCP doc page while clicking on `[verifying image signatures](https://docs.openshift.com/container-platform/4.16/machine_configuration/machine-configs-configure.html)`. Currently, it redirects to a [KCS](https://access.redhat.com/verify-images-ocp4) which then redirects to the [official OCP doc page](https://docs.openshift.com/container-platform/4.12/security/container_security/security-container-signature.html?extIdCarryOver=true&sc_cid=701f2000001Css5AAC).

Applies to 4.12+, but will need manual CP 4.12 to 4.15.

No QE

Preview:
[Using machine config objects to configure node](https://80263--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-configs-configure.html)  -- Updated _verifying image signatures_ link in first paragraph.
