### PR TITLE
OSDOCS-11661:user-defined network OVN-K

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1433,6 +1433,8 @@ Topics:
     File: understanding-multiple-networks
   - Name: Configuring an additional network
     File: configuring-additional-network
+  - Name: Understanding user defined networks
+    File: understanding-user-defined-networks
   - Name: About virtual routing and forwarding
     File: about-virtual-routing-and-forwarding
   - Name: Configuring multi-network policy

--- a/modules/nw-udn-best-practices.adoc
+++ b/modules/nw-udn-best-practices.adoc
@@ -1,0 +1,30 @@
+//module included in the following assembly:
+//
+// *networkking/multiple_networks/understanding-user-defined-networks.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="considerations-for-udn_{context}"]
+= Best practices for UserDefinedNetwork
+
+Before setting up a `UserDefinedNetwork` (UDN) resource, users should consider the following information:
+
+* To eliminate errors and ensure connectivity to services, you should create a namespace scoped UDN CR, create pods in the namespace and then create services in that namespace.
+
+* `Openshift-*` namespaces should not be used to set up a udn.
+
+* You might want to allow access to any Kubernetes services on the cluster default  network. By default, KAPI and DNS are accessible.
+
+// May be something that is downstream only.
+//* No active primary UDN managed pod can also be a candidate for `v1.multus-cni.io/default-network`
+
+* Ensure tenants are using the `UserDefinedNetwork` resource and not `network-attachement-definitions` resource.This can create security risks between tenants.
+
+* When configuring pod IP addresses the CIDR cannot overlap with the default cluster CIDR used by the cluster default network. OVN-Kubernetes network plugin uses the following address for the default network: 100.64.0.0/16, 169.254.169.0/29, 100.88.0.0/16, fd98::/64, fd69::/125, and fd97::/64.
+
+* The default network’s podsubnet cannot be reused for any UDN.
+
+* The default network’s joinsubnet cannot be reused for any UDN.
+
+* You should not change pod IPAM annotations.
+
+* The `Primary` network `role` is supported for UDN in {product-version}.

--- a/modules/nw-udn-best-practices.adoc
+++ b/modules/nw-udn-best-practices.adoc
@@ -8,22 +8,22 @@
 
 Before setting up a `UserDefinedNetwork` (UDN) resource, users should consider the following information:
 
-* To eliminate errors and ensure connectivity to services, you should create a namespace scoped UDN CR, create pods in the namespace and then create services in that namespace.
+* To eliminate errors and ensure connectivity to services, you should create a namespace scoped UDN CR, create pods in the namespace, and then create services in that namespace.
 
-* `Openshift-*` namespaces should not be used to set up a udn.
+* `Openshift-*` namespaces should not be used to set up a UDN.
 
 * You might want to allow access to any Kubernetes services on the cluster default  network. By default, KAPI and DNS are accessible.
+
+* You must reconfigure your masquerade subnet to be large enough to hold the desired number of networks. For more information, see xref:../../networking/cluster-network-operator.adoc#nw-operator-cr-cno-object_cluster-network-operator[Cluster Network Operator configuration object].
 
 // May be something that is downstream only.
 //* No active primary UDN managed pod can also be a candidate for `v1.multus-cni.io/default-network`
 
-* Ensure tenants are using the `UserDefinedNetwork` resource and not `network-attachement-definitions` resource.This can create security risks between tenants.
+* Ensure tenants are using the `UserDefinedNetwork` resource and not `network-attachement-definitions` resource. This can create security risks between tenants.
 
-* When configuring pod IP addresses the CIDR cannot overlap with the default cluster CIDR used by the cluster default network. OVN-Kubernetes network plugin uses the following address for the default network: 100.64.0.0/16, 169.254.169.0/29, 100.88.0.0/16, fd98::/64, fd69::/125, and fd97::/64.
+* When configuring pod IP addresses the CIDR cannot overlap with the default cluster CIDR used by the cluster default network. OVN-Kubernetes network plugin uses the following address for the default network: `100.64.0.0/16`, `169.254.169.0/29`, `100.88.0.0/16`, `fd98::/64`, `fd69::/125`, and `fd97::/64`.
 
-* The default network’s podsubnet cannot be reused for any UDN.
-
-* The default network’s joinsubnet cannot be reused for any UDN.
+* The default network’s `PodSubnets` and `JoinSubnets` fields cannot be reused for any UDN.
 
 * You should not change pod IPAM annotations.
 

--- a/modules/nw-udn-cr.adoc
+++ b/modules/nw-udn-cr.adoc
@@ -21,32 +21,36 @@ If any cluster default networked pods exist before the user-defined network is c
 . Create a request for a user-defined network:
 
 .. Create a yaml file, such as `my-udn-request.yaml`, to define your request with content like the following example:
-
++
 [source, yaml]
 ----
-apiVersion: policy.networking.k8s.io/v1alpha1
+apiVersion: k8s.ovn.org/v1
 kind: UserDefinedNetwork
 metadata:
-name: <example_network> # <1>
-namespace: <my_namespace>
+  name: udn-1 # <1>
+  namespace: default
 spec:
-topology: Layer2 # <2>
-role: Primary # <3>
-mtu: 9000 <4>
-subnets: ["10.0.0.0/24"] # <5>
-excludeSubnets: ["10.0.0.0/26"] <6>
-JoinSubnets: <7>
-IPAMLifecycle: Persistent # <8>
+  topology: Layer2 # <2>
+  layer2:
+    role: Primary # <3>
+    mtu: 9000 # <4>
+    subnets:
+      - "10.0.0.0/24"
+      - "2001:db8::/64" # <5>
+    excludeSubnets:
+      - "10.0.0.0/26"
+      - "2001:db8::/80" # <6>
+    JoinSubnets: [] # <7>
+    IPAMLifecycle: Persistent # <8>
 ----
 <1> Name of your `UserDefinedNetwork` resource. This should not be `default`.
 <2> The layer you wish to create the network on. The `topology` field accepts values of `Layer2` and `Layer3`.
 <3> Specifies `Primary` or `Secondary`. `Primary` is the only `role` specification supported in {product-version}.
 <4> The maximum transmission units (MTU) the default value is `1400`.
-<5> Specifies the subnet to be used for the network across the cluster. Supports both IPv6 and dual-stack. For example, `192.168.100.0/24`,`2001:DBB::/64`. If omitted the network only provides `Layer2` communication and you must configure IP addresses.
+<5> Specifies the subnet to be used for the network across the cluster. Supports both IPv6 and dual-stack. For example, `192.168.100.0/24`,`2001:DBB::/64`. Dual-stack may set two subnets otherwise only one is allowed. When the `topology` field is set to `Layer3`, the subnet is split into smaller subnets for every node. Accepted format for subnets when `Layer3` is set are: `10.128.0.0/16/24`. For `Layer2` values in `topology` field, standard CIDR ranges are accepted. If omitted the network only provides `Layer2` communication and you must configure IP addresses.
 <6> Specifies the CIDR range to remove from the assignable IP address pool excluding them from being assigned to pods.
 <7> Specifies the `subnets` used inside the OVN-Kubernetes network topology. If omitted, the OVN-Kubernetes network plugin assigns one, which is subject to change over time.
 <8> Specifies the IP address management system (IPAM). The `Persistent` value specifies that workloads have persistent IP addresses. Assigned by the container network interface (CNI) and used by OVN-Kubernetes to program pod IP addresses. You must not change this for pod annotations.
-
 
 .. Apply your request by running the following command:
 +
@@ -55,10 +59,39 @@ IPAMLifecycle: Persistent # <8>
 $ oc apply -f my-udn-request.yaml
 ----
 
-.Verify that your request is successful by running the following command:
+. Verify that your request is successful by running the following command:
++
 [source, terminal]
 ----
-$ oc
+$ oc get userdefinednetworks udn-1 -n default -o yaml
 ----
-
-
++
+.Example output
+[source,terminal]
+----
+apiVersion: k8s.ovn.org/v1
+kind: UserDefinedNetwork
+metadata:
+  creationTimestamp: "2024-08-28T17:18:47Z"
+  finalizers:
+  - k8s.ovn.org/user-defined-network-protection
+  generation: 1
+  name: udn-1
+  namespace: default
+  resourceVersion: "53313"
+  uid: f483626d-6846-48a1-b88e-6bbeb8bcde8c
+spec:
+  layer2:
+    mtu: 9000
+    role: Primary
+    subnets:
+    - 10.0.0.0/24
+  topology: Layer2
+status:
+  conditions:
+  - lastTransitionTime: "2024-08-28T17:18:47Z"
+    message: NetworkAttachmentDefinition has been created
+    reason: NetworkAttachmentDefinitionReady
+    status: "True"
+    type: NetworkReady
+----

--- a/modules/nw-udn-cr.adoc
+++ b/modules/nw-udn-cr.adoc
@@ -1,0 +1,64 @@
+//module included in the following assembly:
+//
+// *networking/multiple_networks/understanding-user-defined-networks.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-udn-cr_{context}"]
+= Creating a UserDefinedNetwork custom resource
+
+The following procedure sets up a user-defined network that is namespace scoped.
+
+.Prerequisites
+* You must
+
+.Procedure
+
+[NOTE]
+====
+If any cluster default networked pods exist before the user-defined network is created, any further pods created in this namespace will return an error message: `What_is_this`.
+====
+
+. Create a request for a user-defined network:
+
+.. Create a yaml file, such as `my-udn-request.yaml`, to define your request with content like the following example:
+
+[source, yaml]
+----
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: UserDefinedNetwork
+metadata:
+name: <example_network> # <1>
+namespace: <my_namespace>
+spec:
+topology: Layer2 # <2>
+role: Primary # <3>
+mtu: 9000 <4>
+subnets: ["10.0.0.0/24"] # <5>
+excludeSubnets: ["10.0.0.0/26"] <6>
+JoinSubnets: <7>
+IPAMLifecycle: Persistent # <8>
+----
+<1> Name of your `UserDefinedNetwork` resource. This should not be `default`.
+<2> The layer you wish to create the network on. The `topology` field accepts values of `Layer2` and `Layer3`.
+<3> Specifies `Primary` or `Secondary`. `Primary` is the only `role` specification supported in {product-version}.
+<4> The maximum transmission units (MTU) the default value is `1400`.
+<5> Specifies the subnet to be used for the network across the cluster. Supports both IPv6 and dual-stack. For example, `192.168.100.0/24`,`2001:DBB::/64`. If omitted the network only provides `Layer2` communication and you must configure IP addresses.
+<6> Specifies the CIDR range to remove from the assignable IP address pool excluding them from being assigned to pods.
+<7> Specifies the `subnets` used inside the OVN-Kubernetes network topology. If omitted, the OVN-Kubernetes network plugin assigns one, which is subject to change over time.
+<8> Specifies the IP address management system (IPAM). The `Persistent` value specifies that workloads have persistent IP addresses. Assigned by the container network interface (CNI) and used by OVN-Kubernetes to program pod IP addresses. You must not change this for pod annotations.
+
+
+.. Apply your request by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f my-udn-request.yaml
+----
+
+.Verify that your request is successful by running the following command:
+[source, terminal]
+----
+$ oc
+----
+
+

--- a/modules/nw-udn-limitations.adoc
+++ b/modules/nw-udn-limitations.adoc
@@ -1,0 +1,26 @@
+//module included in the following assembly:
+//
+// *networkking/multiple_networks/understanding-user-defined-networks.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="limitations-for-udn_{context}"]
+= Limitations for UserDefinedNetwork custom resource
+
+While user-defined networks (UDN) offer highly customizable network configuration options, there are limitations that cluster administrators should be aware of when implementing and managing these networks. Consider the following limitations before implementing a user-defined network.
+
+* *Scale limitations*: The number of internal OVN-Kubernetes objects, such as kernel devices, rules, and VRFs, multiply as the number of namespaces and networks increase. As a result, user-defined networks might cause potential performance issues and scalability challenges for some {product-title} deployments.
+
+* *Complex network configurations*: User-defined networks reduce the complexity of isolation policies. However, setting up and managing multiple networking, wherein each have their own gateway router and load balancer, might require advanced networking knowledge.
+
+* *Interference with secondary projects*: User-defined networks increase the risk of breaking secondary projects that integrated with OVN-Kubernetes, such as MetalLB or Submariner.
+
+* *DNS limitations*: DNS lookups for pods resolve to the pod's IP address on the cluster default network. Even if a pod is part of a user-defined network, DNS lookups will not resolve to the pod's IP address on that user-defined network.
+
+* *Initial network assignment*: If a namespace is assigned to a new network, it cannot have existing pods, or else the new network assignment will not be accepted by OVN-Kubernetes.
+
+* *Service reachability*: Services created in namespaces that are served by the UDN are only accessible by namespaces connected to the UDN. Services in a UDN are reachable by other namespaces in that share the same network.
+//Services created in namespaces without user-defined networks using the default network are only accessible by other namespaces also using the default network. This can limit the flexibility of services across different networks.
+
+* *Health check limitations*: Kubelet health checks are performed by the cluster default network, which does not confirm the network connectivity of the primary interface on the pod. Consequently, scenarios where a pod appears healthy by the default network, but has broken connectivity on the primary interface, are possible with user-defined networks.
+
+* *Network policy limitations*: Network policies that enable traffic between namespaces connected to different user-defined primary networks are not effective. This traffic policies do not take effect because there is no connectivity between these isolated networks.

--- a/modules/nw-udn-limitations.adoc
+++ b/modules/nw-udn-limitations.adoc
@@ -6,19 +6,21 @@
 [id="limitations-for-udn_{context}"]
 = Limitations for UserDefinedNetwork custom resource
 
-While user-defined networks (UDN) offer highly customizable network configuration options, there are limitations that cluster administrators should be aware of when implementing and managing these networks. Consider the following limitations before implementing a user-defined network.
+While user-defined networks (UDN) offer highly customizable network configuration options, there are limitations that cluster administrators and developers should be aware of when implementing and managing these networks. Consider the following limitations before implementing a user-defined network.
 
 * *Scale limitations*: The number of internal OVN-Kubernetes objects, such as kernel devices, rules, and VRFs, multiply as the number of namespaces and networks increase. As a result, user-defined networks might cause potential performance issues and scalability challenges for some {product-title} deployments.
 
-* *Complex network configurations*: User-defined networks reduce the complexity of isolation policies. However, setting up and managing multiple networking, wherein each have their own gateway router and load balancer, might require advanced networking knowledge.
+* *Complex network configurations*: User-defined networks reduce the complexity of isolation policies. However, setting up and managing multiple networking, wherein each have their own gateway router and load balancer, requires advanced networking knowledge.
 
-* *Interference with secondary projects*: User-defined networks increase the risk of breaking secondary projects that integrated with OVN-Kubernetes, such as MetalLB or Submariner.
+* *Interference with secondary projects*: User-defined networks increase the risk of breaking secondary projects that integrate with OVN-Kubernetes, such as MetalLB or Submariner.
 
 * *DNS limitations*: DNS lookups for pods resolve to the pod's IP address on the cluster default network. Even if a pod is part of a user-defined network, DNS lookups will not resolve to the pod's IP address on that user-defined network.
 
 * *Initial network assignment*: If a namespace is assigned to a new network, it cannot have existing pods, or else the new network assignment will not be accepted by OVN-Kubernetes.
 
-* *Service reachability*: Services created in namespaces that are served by the UDN are only accessible by namespaces connected to the UDN. Services in a UDN are reachable by other namespaces in that share the same network.
+* *Service reachability*: Services created in namespaces that are served by the UDN are only accessible by namespaces connected to the UDN. Services in a UDN are reachable by other namespaces that share the same network. This can limit the flexibility of services across different networks.
+
+
 //Services created in namespaces without user-defined networks using the default network are only accessible by other namespaces also using the default network. This can limit the flexibility of services across different networks.
 
 * *Health check limitations*: Kubelet health checks are performed by the cluster default network, which does not confirm the network connectivity of the primary interface on the pod. Consequently, scenarios where a pod appears healthy by the default network, but has broken connectivity on the primary interface, are possible with user-defined networks.

--- a/networking/multiple_networks/understanding-user-defined-networks.adoc
+++ b/networking/multiple_networks/understanding-user-defined-networks.adoc
@@ -1,0 +1,62 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="understanding-user-defined-networks"]
+= Understanding user-defined networks
+include::_attributes/common-attributes.adoc[]
+:context: understanding-user-defined-networks
+
+toc::[]
+
+The OVN-Kubernetes network plugin has traditionally supported layer 2, layer 3, and localnet network types for secondary interfaces, but limited primary networks to a single layer 3 topology. This allowed for network models where all pods shared the same network topology, but restricted the ability to customize primary network configurations.
+
+With user-defined networks, cluster administrators and users are offered highly customizable network configuration options that provide users with the ability to define their own network topologies, ensure network isolation, manage IP addressing, and leverage advanced networking features. User-defined networks help enhance networking flexibility, security, and scalability.
+
+User-defined networks provide the following benefits:
+
+. Enhanced network isolation
++
+* **Tenant isolation**: Namespaces can have their own isolated primary network, similar to how tenants are isolated in {rh-openstack-first}. This improves security by reducing the risk of cross-tenant traffic.
+* **Layer 2 and layer 3 support**: Cluster administrators can configure primary networks as layer 2 or layer 3 network types. This provides the flexibility of a secondary network to the primary network.
+
+. Simplified network management
++
+* **Reduced network configuration complexity**: With user-defined networks, complex network isolation policies are eliminated, making it easier for cluster administrators to scale and manage networks.
+
+* **Consistent and selectable IP addressing**: Users can specify and reuse IP subnets across different namespaces and clusters, providing a consistent networking environment.
+
+. Improved network security
++
+* **Native isolation**: Provides a native way to isolate network tenants, which reduces the reliance on complex network policies.
+
+. Simplification of application migration from {rh-openstack-first}
++
+* **Network parity**: With user-defined networking, the migration of applications from OpenStack to {product-title} is simplified by providing similar network isolation and configuration options.
+
+. Scalability
++
+* **Support for multiple networks**: The user-defined networking feature allows administrators to connect multiple namespaces to a single network, or to create distinct networks for different sets of namespaces.
+
+. Optimized traffic handling
++
+* **Enhanced routing efficiency**: With
+* **North/south network traffic support**: Improves connectivity with services outside of the cluster by adding support for external traffic to and from pods.
+
+// Looks like this may be out for 4.17, but in for 4.18 as of 8/19/24
+//. Ingress and egress support
+//+
+//* **Support for ingress and egress traffic**: Cluster ingress and egress traffic is supported for both primary and secondary networks.
+//* **Support for ingress and egress features**: User-defined networks support support the following ingress and egress features:
+//+
+//** EgressQoS
+//** EgressService
+//** EgressIP
+//** Load balancer and NodePort services, as well as services with external IPs.
+
+//Limitations that users should consider for UDN.
+include::modules/nw-udn-limitations.adoc[leveloffset=+1]
+
+//Describes best practices users should follow. Has the gotchas.
+include::modules/nw-udn-best-practices.adoc[leveloffset=+1]
+
+//How to implement the UDN API on a cluster.
+include::modules/nw-udn-cr.adoc[leveloffset=+1]
+


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-11661
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://80266--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/understanding-user-defined-networks.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
