### PR TITLE
OCPBUGS#16663: Remove provisioning with `new-master-machine.yaml`

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -465,90 +465,6 @@ clustername-8qw5l-worker-us-east-1c-pkg26   Running   m4.large    us-east-1   us
 ----
 <1> This is the control plane machine for the lost control plane host, `ip-10-0-131-183.ec2.internal`.
 
-.. Save the machine configuration to a file on your file system by running:
-+
-[source,terminal]
-----
-$ oc get machine clustername-8qw5l-master-0 \ <1>
-    -n openshift-machine-api \
-    -o yaml \
-    > new-master-machine.yaml
-----
-<1> Specify the name of the control plane machine for the lost control plane host.
-
-.. Edit the `new-master-machine.yaml` file that was created in the previous step to assign a new name and remove unnecessary fields.
-
-... Remove the entire `status` section by running:
-+
-[source,terminal]
-----
-status:
-  addresses:
-  - address: 10.0.131.183
-    type: InternalIP
-  - address: ip-10-0-131-183.ec2.internal
-    type: InternalDNS
-  - address: ip-10-0-131-183.ec2.internal
-    type: Hostname
-  lastUpdated: "2020-04-20T17:44:29Z"
-  nodeRef:
-    kind: Node
-    name: ip-10-0-131-183.ec2.internal
-    uid: acca4411-af0d-4387-b73e-52b2484295ad
-  phase: Running
-  providerStatus:
-    apiVersion: awsproviderconfig.openshift.io/v1beta1
-    conditions:
-    - lastProbeTime: "2020-04-20T16:53:50Z"
-      lastTransitionTime: "2020-04-20T16:53:50Z"
-      message: machine successfully created
-      reason: MachineCreationSucceeded
-      status: "True"
-      type: MachineCreation
-    instanceId: i-0fdb85790d76d0c3f
-    instanceState: stopped
-    kind: AWSMachineProviderStatus
-----
-
-... Change the `metadata.name` field to a new name by running:
-+
-It is recommended to keep the same base name as the old machine and change the ending number to the next available number. In this example, `clustername-8qw5l-master-0` is changed to `clustername-8qw5l-master-3`:
-+
-[source,terminal]
-----
-apiVersion: machine.openshift.io/v1beta1
-kind: Machine
-metadata:
-  ...
-  name: clustername-8qw5l-master-3
-  ...
-----
-
-... Remove the `spec.providerID` field by running:
-+
-[source,terminal]
-----
-providerID: aws:///us-east-1a/i-0fdb85790d76d0c3f
-----
-
-... Remove the `metadata.annotations` and `metadata.generation` fields by running:
-+
-[source,terminal]
-----
-annotations:
-  machine.openshift.io/instance-state: running
-...
-generation: 2
-----
-
-... Remove the `metadata.resourceVersion` and `metadata.uid` fields by running:
-+
-[source,terminal]
-----
-resourceVersion: "13291"
-uid: a282eb70-40a2-4e89-8009-d05dd420d31a
-----
-
 .. Delete the machine of the lost control plane host by running:
 +
 [source,terminal]
@@ -556,34 +472,10 @@ uid: a282eb70-40a2-4e89-8009-d05dd420d31a
 $ oc delete machine -n openshift-machine-api clustername-8qw5l-master-0 <1>
 ----
 <1> Specify the name of the control plane machine for the lost control plane host.
++
+A new machine is automatically provisioned after deleting the machine of the lost control plane host.
 
-.. Verify that the machine was deleted by running:
-+
-[source,terminal]
-----
-$ oc get machines -n openshift-machine-api -o wide
-----
-+
-Example output:
-+
-[source,terminal]
-----
-NAME                                        PHASE     TYPE        REGION      ZONE         AGE     NODE                           PROVIDERID                              STATE
-clustername-8qw5l-master-1                  Running   m4.xlarge   us-east-1   us-east-1b   3h37m   ip-10-0-143-125.ec2.internal   aws:///us-east-1b/i-096c349b700a19631   running
-clustername-8qw5l-master-2                  Running   m4.xlarge   us-east-1   us-east-1c   3h37m   ip-10-0-154-194.ec2.internal   aws:///us-east-1c/i-02626f1dba9ed5bba  running
-clustername-8qw5l-worker-us-east-1a-wbtgd   Running   m4.large    us-east-1   us-east-1a   3h28m   ip-10-0-129-226.ec2.internal   aws:///us-east-1a/i-010ef6279b4662ced   running
-clustername-8qw5l-worker-us-east-1b-lrdxb   Running   m4.large    us-east-1   us-east-1b   3h28m   ip-10-0-144-248.ec2.internal   aws:///us-east-1b/i-0cb45ac45a166173b   running
-clustername-8qw5l-worker-us-east-1c-pkg26   Running   m4.large    us-east-1   us-east-1c   3h28m   ip-10-0-170-181.ec2.internal   aws:///us-east-1c/i-06861c00007751b0a   running
-----
-
-.. Create a machine by using the `new-master-machine.yaml` file by running:
-+
-[source,terminal]
-----
-$ oc apply -f new-master-machine.yaml
-----
-
-.. Verify that the new machine has been created by running:
+.. Verify that a new machine has been created by running:
 +
 [source,terminal]
 ----

--- a/modules/restore-replace-stopped-baremetal-etcd-member.adoc
+++ b/modules/restore-replace-stopped-baremetal-etcd-member.adoc
@@ -173,11 +173,7 @@ $ oc delete secret etcd-serving-openshift-control-plane-2 -n openshift-etcd
 secret "etcd-serving-openshift-control-plane-2" deleted
 ----
 
-. Delete the control plane machine.
-+
-If you are running installer-provisioned infrastructure, or you used the Machine API to create your machines, follow these steps. Otherwise, you must create the new control plane node using the same method that was used to originally create it.
-
-.. Obtain the machine for the unhealthy member.
+. Obtain the machine for the unhealthy member.
 +
 In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
 +
@@ -197,110 +193,6 @@ examplecluster-compute-0          Running                          165m    opens
 examplecluster-compute-1          Running                          165m    openshift-compute-1         baremetalhost:///openshift-machine-api/openshift-compute-1/0fdae6eb-2066-4241-91dc-e7ea72ab13b9         provisioned
 ----
 <1> This is the control plane machine for the unhealthy node, `examplecluster-control-plane-2`.
-
-.. Save the machine configuration to a file on your file system:
-+
-[source,terminal]
-----
-$ oc get machine examplecluster-control-plane-2 \ <1>
-    -n openshift-machine-api \
-    -o yaml \
-    > new-master-machine.yaml
-----
-<1> Specify the name of the control plane machine for the unhealthy node.
-
-.. Edit the `new-master-machine.yaml` file that was created in the previous step to assign a new name and remove unnecessary fields.
-
-... Remove the entire `status` section:
-+
-[source,yaml]
-----
-status:
-  addresses:
-  - address: ""
-    type: InternalIP
-  - address: fe80::4adf:37ff:feb0:8aa1%ens1f1.373
-    type: InternalDNS
-  - address: fe80::4adf:37ff:feb0:8aa1%ens1f1.371
-    type: Hostname
-  lastUpdated: "2020-04-20T17:44:29Z"
-  nodeRef:
-    kind: Machine
-    name: fe80::4adf:37ff:feb0:8aa1%ens1f1.372
-    uid: acca4411-af0d-4387-b73e-52b2484295ad
-  phase: Running
-  providerStatus:
-    apiVersion: machine.openshift.io/v1beta1
-    conditions:
-    - lastProbeTime: "2020-04-20T16:53:50Z"
-      lastTransitionTime: "2020-04-20T16:53:50Z"
-      message: machine successfully created
-      reason: MachineCreationSucceeded
-      status: "True"
-      type: MachineCreation
-    instanceId: i-0fdb85790d76d0c3f
-    instanceState: stopped
-    kind: Machine
-----
-
-. Change the `metadata.name` field to a new name.
-+
-It is recommended to keep the same base name as the old machine and change the ending number to the next available number. In this example, `examplecluster-control-plane-2` is changed to `examplecluster-control-plane-3`.
-+
-For example:
-+
-[source,yaml]
-----
-apiVersion: machine.openshift.io/v1beta1
-kind: Machine
-metadata:
-  ...
-  name: examplecluster-control-plane-3
-  ...
-----
-
-.. Remove the `spec.providerID` field:
-+
-[source,yaml]
-----
-  providerID: baremetalhost:///openshift-machine-api/openshift-control-plane-2/3354bdac-61d8-410f-be5b-6a395b056135
-----
-
-.. Remove the `metadata.annotations` and `metadata.generation` fields:
-+
-[source,yaml]
-----
-  annotations:
-    machine.openshift.io/instance-state: externally provisioned
-  ...
-  generation: 2
-----
-
-.. Remove the `spec.conditions`, `spec.lastUpdated`, `spec.nodeRef` and `spec.phase` fields:
-+
-[source,yaml]
-----
-  lastTransitionTime: "2022-08-03T08:40:36Z"
-message: 'Drain operation currently blocked by: [{Name:EtcdQuorumOperator Owner:clusteroperator/etcd}]'
-reason: HookPresent
-severity: Warning
-status: "False"
-
-type: Drainable
-lastTransitionTime: "2022-08-03T08:39:55Z"
-status: "True"
-type: InstanceExists
-
-lastTransitionTime: "2022-08-03T08:36:37Z"
-status: "True"
-type: Terminable
-lastUpdated: "2022-08-03T08:40:36Z"
-nodeRef:
-kind: Node
-name: openshift-control-plane-2
-uid: 788df282-6507-4ea2-9a43-24f237ccbc3c
-phase: Running
-----
 
 . Ensure that the Bare Metal Operator is available by running the following command:
 +
@@ -344,6 +236,8 @@ If deletion of the machine is delayed for any reason or the command is obstructe
 ====
 Do not interrupt machine deletion by pressing `Ctrl+c`. You must allow the command to proceed to completion. Open a new terminal window to edit and delete the finalizer fields.
 ====
++
+A new machine is automatically provisioned after deleting the machine of the unhealthy member.
 +
 .. Edit the machine configuration by running the following command:
 +
@@ -463,16 +357,9 @@ openshift-control-plane-2 available              examplecluster-control-plane-3 
 openshift-compute-0       provisioned            examplecluster-compute-0       true         4h48m
 openshift-compute-1       provisioned            examplecluster-compute-1       true         4h48m
 ----
-+
-.. Create the new control plane machine using the `new-master-machine.yaml` file:
-+
-[source,terminal]
-----
-$ oc apply -f new-master-machine.yaml
-----
 
 
-.. Verify that the new machine has been created:
+.. Verify that a new machine has been created:
 +
 [source,terminal]
 ----

--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -210,74 +210,6 @@ clustername-8qw5l-worker-us-east-1c-pkg26   Running   m4.large    us-east-1   us
 ----
 <1> This is the control plane machine for the unhealthy node, `ip-10-0-131-183.ec2.internal`.
 
-.. Save the machine configuration to a file on your file system:
-+
-[source,terminal]
-----
-$ oc get machine clustername-8qw5l-master-0 \ <1>
-    -n openshift-machine-api \
-    -o yaml \
-    > new-master-machine.yaml
-----
-<1> Specify the name of the control plane machine for the unhealthy node.
-
-.. Edit the `new-master-machine.yaml` file that was created in the previous step to assign a new name and remove unnecessary fields.
-
-... Remove the entire `status` section:
-+
-[source,yaml]
-----
-status:
-  addresses:
-  - address: 10.0.131.183
-    type: InternalIP
-  - address: ip-10-0-131-183.ec2.internal
-    type: InternalDNS
-  - address: ip-10-0-131-183.ec2.internal
-    type: Hostname
-  lastUpdated: "2020-04-20T17:44:29Z"
-  nodeRef:
-    kind: Node
-    name: ip-10-0-131-183.ec2.internal
-    uid: acca4411-af0d-4387-b73e-52b2484295ad
-  phase: Running
-  providerStatus:
-    apiVersion: awsproviderconfig.openshift.io/v1beta1
-    conditions:
-    - lastProbeTime: "2020-04-20T16:53:50Z"
-      lastTransitionTime: "2020-04-20T16:53:50Z"
-      message: machine successfully created
-      reason: MachineCreationSucceeded
-      status: "True"
-      type: MachineCreation
-    instanceId: i-0fdb85790d76d0c3f
-    instanceState: stopped
-    kind: AWSMachineProviderStatus
-----
-
-... Change the `metadata.name` field to a new name.
-+
-It is recommended to keep the same base name as the old machine and change the ending number to the next available number. In this example, `clustername-8qw5l-master-0` is changed to `clustername-8qw5l-master-3`.
-+
-For example:
-+
-[source,yaml]
-----
-apiVersion: machine.openshift.io/v1beta1
-kind: Machine
-metadata:
-  ...
-  name: clustername-8qw5l-master-3
-  ...
-----
-
-... Remove the `spec.providerID` field:
-+
-[source,yaml]
-----
-  providerID: aws:///us-east-1a/i-0fdb85790d76d0c3f
-----
-
 .. Delete the machine of the unhealthy member:
 +
 [source,terminal]
@@ -285,33 +217,10 @@ metadata:
 $ oc delete machine -n openshift-machine-api clustername-8qw5l-master-0 <1>
 ----
 <1> Specify the name of the control plane machine for the unhealthy node.
-
-.. Verify that the machine was deleted:
 +
-[source,terminal]
-----
-$ oc get machines -n openshift-machine-api -o wide
-----
-+
-.Example output
-[source,terminal]
-----
-NAME                                        PHASE     TYPE        REGION      ZONE         AGE     NODE                           PROVIDERID                              STATE
-clustername-8qw5l-master-1                  Running   m4.xlarge   us-east-1   us-east-1b   3h37m   ip-10-0-154-204.ec2.internal   aws:///us-east-1b/i-096c349b700a19631   running
-clustername-8qw5l-master-2                  Running   m4.xlarge   us-east-1   us-east-1c   3h37m   ip-10-0-164-97.ec2.internal    aws:///us-east-1c/i-02626f1dba9ed5bba   running
-clustername-8qw5l-worker-us-east-1a-wbtgd   Running   m4.large    us-east-1   us-east-1a   3h28m   ip-10-0-129-226.ec2.internal   aws:///us-east-1a/i-010ef6279b4662ced   running
-clustername-8qw5l-worker-us-east-1b-lrdxb   Running   m4.large    us-east-1   us-east-1b   3h28m   ip-10-0-144-248.ec2.internal   aws:///us-east-1b/i-0cb45ac45a166173b   running
-clustername-8qw5l-worker-us-east-1c-pkg26   Running   m4.large    us-east-1   us-east-1c   3h28m   ip-10-0-170-181.ec2.internal   aws:///us-east-1c/i-06861c00007751b0a   running
-----
+A new machine is automatically provisioned after deleting the machine of the unhealthy member.
 
-.. Create the new machine using the `new-master-machine.yaml` file:
-+
-[source,terminal]
-----
-$ oc apply -f new-master-machine.yaml
-----
-
-.. Verify that the new machine has been created:
+.. Verify that a new machine has been created:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-16663](https://issues.redhat.com/browse/OCPBUGS-16663)

Link to docs preview:
[Restoring to a previous cluster state](https://80267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html#dr-scenario-2-restoring-cluster-state_dr-restoring-cluster-state)
[Replacing an unhealthy etcd member whose machine is not running or whose node is not ready](https://80267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html#restore-replace-stopped-etcd-member_replacing-unhealthy-etcd-member)
[Replacing an unhealthy bare metal etcd member whose machine is not running or whose node is not ready](https://80267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html#restore-replace-stopped-baremetal-etcd-member_replacing-unhealthy-etcd-member)

QE review:
- [x] QE has approved this change.

Additional information:
N/A