### PR TITLE
HCIDOCS-403: Fix typo in IPI/bare metal install

### DIFF
--- a/modules/ipi-install-setting-cluster-node-hostnames-dhcp.adoc
+++ b/modules/ipi-install-setting-cluster-node-hostnames-dhcp.adoc
@@ -6,13 +6,15 @@
 [id="ipi-install-setting-cluster-node-hostnames-dhcp_{context}"]
 = Setting the cluster node hostnames through DHCP
 
-On {op-system-first} machines, hostnames are is set through `NetworkManager`. 
-By default, the machines obtain their hostnames through DHCP. 
-If hostnames are not provided by DHCP, set statically through kernel arguments, or another method, they are obtained through a reverse DNS lookup. 
-Reverse DNS lookup occurs after the network has been initialized on a node and can take time to resolve. 
-Other system services can start prior to this and detect hostnames as `localhost` or similar. 
-You can avoid this delay in assigning hostnames by using DHCP to provide the hostname for each cluster node.
+On {op-system-first} machines, `NetworkManager` sets the hostnames. By default, DHCP provides the hostnames to `NetworkManager`, which is the recommended method. `NetworkManager` gets the hostnames through a reverse DNS lookup in the following cases:
 
-Additionally, setting the hostnames through DHCP can bypass any manual DNS record name configuration errors in environments that have a DNS split-horizon implementation.
+* If DHCP does not provide the hostnames
+* If you use kernel arguments to set the hostnames
+* If you use another method to set the hostnames
 
+Reverse DNS lookup occurs after the network has been initialized on a node, and can increase the time it takes `NetworkManager` to set the hostname. Other system services can start prior to `NetworkManager` setting the hostname, which can cause those services to use a default hostname such as `localhost`.
 
+[TIP]
+====
+You can avoid the delay in setting hostnames by using DHCP to provide the hostname for each cluster node. Additionally, setting the hostnames through DHCP can bypass manual DNS record name configuration errors in environments that have a DNS split-horizon implementation.
+====


### PR DESCRIPTION
This bug required fixing a typo, which I did. After re-reading it, I decided it could use a rewrite mostly due to overuse of pronouns, making it more difficult to understand the point of the module.

Fixes: [HCIDOCS-403](https://issues.redhat.com//browse/HCIDOCS-403)

See https://issues.redhat.com/browse/HCIDOCS-403 for additional details.

Preview URL: https://80275--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#ipi-install-setting-cluster-node-hostnames-dhcp_ipi-install-installation-workflow

For release(s): 4.12-4.17
QE Review: 

- [ ] QE has approved this change. 

Signed-off-by:  <jowilkin@redhat.com>
