### PR TITLE
TELCODOCS-1722: Wrong Workload Availability for Red Hat OpenShift link

### DIFF
--- a/nodes/nodes/nodes-remediating-fencing-maintaining-rhwa.adoc
+++ b/nodes/nodes/nodes-remediating-fencing-maintaining-rhwa.adoc
@@ -8,4 +8,4 @@ toc::[]
 
 When node-level failures occur, such as the kernel hangs or network interface controllers (NICs) fail, the work required from the cluster does not decrease, and workloads from affected nodes need to be restarted somewhere. Failures affecting these workloads risk data loss, corruption, or both. It is important to isolate the node, known as `fencing`, before initiating recovery of the workload, known as `remediation`, and recovery of the node.
 
-For more information on remediation, fencing, and maintaining nodes, see the link:https://access.redhat.com/documentation/en-us/workload_availability_for_red_hat_openshift/23.2/html-single/remediation_fencing_and_maintenance/index#about-remediation-fencing-maintenance[Workload Availability for Red Hat OpenShift] documentation.
+For more information on remediation, fencing, and maintaining nodes, see the link:https://access.redhat.com/documentation/en-us/workload_availability_for_red_hat_openshift[Workload Availability for Red Hat OpenShift] documentation.

--- a/virt/virtual_machines/advanced_vm_management/virt-high-availability-for-vms.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-high-availability-for-vms.adoc
@@ -24,4 +24,4 @@ endif::openshift-rosa,openshift-dedicated[]
 
 You can configure remediating nodes by installing the Self Node Remediation Operator from the OperatorHub and enabling machine health checks or node remediation checks.
 
-For more information on remediation, fencing, and maintaining nodes, see the link:https://access.redhat.com/documentation/en-us/workload_availability_for_red_hat_openshift/23.2/html-single/remediation_fencing_and_maintenance/index#about-remediation-fencing-maintenance[Workload Availability for Red Hat OpenShift] documentation.
+For more information on remediation, fencing, and maintaining nodes, see the link:https://access.redhat.com/documentation/en-us/workload_availability_for_red_hat_openshift[Workload Availability for Red Hat OpenShift] documentation.


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-1722: Wrong Workload Availability for Red Hat OpenShift link

Applies to OCP version : 4.14+

Preview:
[Remediating, fencing, and maintaining nodes](https://80278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-remediating-fencing-maintaining-rhwa.html)
[About high availability for virtual machines](https://80278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-high-availability-for-vms.html)

Reporter review completed by @anna-savina
QE review completed by @frajamomo
Peer review to be completed by @StephenJamesSmith

Thank you.