### PR TITLE
TELCODOCS-1867 FRR-k8s GA

### DIFF
--- a/networking/metallb/metallb-frr-k8s.adoc
+++ b/networking/metallb/metallb-frr-k8s.adoc
@@ -6,9 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: The `FRRConfiguration` custom resource
-include::snippets/technology-preview.adoc[]
-
 FRRouting (FRR) is a free, open source internet routing protocol suite for Linux and UNIX platforms.
 `FRR-K8s` is a Kubernetes based DaemonSet that exposes a subset of the `FRR` API in a Kubernetes-compliant manner.
 As a cluster administrator, you can use the `FRRConfiguration` custom resource (CR) to configure `MetalLB` to use `FRR-K8s` as the backend.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

[TELCODOCS-1867](https://issues.redhat.com//browse/TELCODOCS-1867) - [CNF-11914](https://issues.redhat.com//browse/CNF-11914) [GA] MetalLB - moving `FRR-k8s` from Tech Preview to GA
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-1867
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Configuring the integration of MetalLB and FRR-K8s ](https://80279--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-frr-k8s.html)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
