### PR TITLE
TELCODOCS-1869 -  CNF-11995 MetalLB: configurable BGP connect time (GA)

### DIFF
--- a/modules/nw-metallb-bgppeer-cr.adoc
+++ b/modules/nw-metallb-bgppeer-cr.adoc
@@ -90,6 +90,10 @@ If the BGP peer is not directly connected to the same network, the speaker canno
 This field applies to _external BGP_.
 External BGP is the term that is used to describe when a BGP peer belongs to a different Autonomous System.
 
+|`connectTime`
+|`duration`
+|Specifies how long BGP waits between connection attempts to a neighbor.
+
 |===
 
 [NOTE]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
[TELCODOCS-1869](https://issues.redhat.com//browse/TELCODOCS-1869) - [CNF-11995](https://issues.redhat.com//browse/CNF-11995) MetalLB: configurable BGP connect time (GA)
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-1869
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [About the BGP peer custom resource](https://80280--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-configure-bgp-peers.html#nw-metallb-bgppeer-cr_configure-metallb-bgp-peers)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
