### PR TITLE
OSDOCS-11170: Adding workload partitioning notes in microshift releas…

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -56,6 +56,10 @@ This release adds improvements related to the following components and concepts.
 //[id="microshift-4-17-certificates-cleaning_{context}"]
 //==== Support for cleaning up certificates
 
+[id="microshift-4-17-workload-partitioning_{context}"]
+==== Support for workload partitioning
+With this release, workload partitioning is supported in {microshift-short}. For more information, see xref:../microshift_configuring/microshift-workload-partitioning.adoc#microshift-workload-partitioning[Workload partitioning].
+
 [id="microshift-4-17-networking_{context}"]
 === Networking
 


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-11170](https://issues.redhat.com/browse/OSDOCS-11170)

Link to docs preview:
[workload partitioning](https://80281--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-configuring_release-notes)

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.

Additional Information:
related to https://github.com/openshift/openshift-docs/pull/80198