### PR TITLE
PR for SRVCOM-3238: Add release notes entries about "SRVCOM-3200" and "SRVCOM-3203" in Serverless version 1.33.2

### DIFF
--- a/about/serverless-release-notes.adoc
+++ b/about/serverless-release-notes.adoc
@@ -1,7 +1,7 @@
 :_content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-release-notes"]
 = Release notes
+include::_attributes/common-attributes.adoc[]
 :context: serverless-release-notes
 
 toc::[]
@@ -28,6 +28,7 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 
 // Release notes included, most to least recent
 // OCP + OSD + ROSA
+include::modules/serverless-rn-1-33-2.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-33-0.adoc[leveloffset=+1]
 
 // OCP + OSD + ROSA

--- a/modules/serverless-rn-1-33-2.adoc
+++ b/modules/serverless-rn-1-33-2.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies
+//
+// * about/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-33-2_{context}"]
+= Red Hat {ServerlessProductName} 1.33.2
+
+{ServerlessProductName} 1.33.2 is now available. Fixed issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes:
+
+[id="fixed-issues-1-33-2_{context}"]
+== Fixed issues
+
+* Previously, creating Knative installation resources like `KnativeServing` or `KnativeEventing` in a user namespace triggered an infinite reconciliation loop in the {ServerlessOperatorName}. This issue has been resolved by reintroducing an admission webhook that prevents the creation of Knative installation resources in any namespace other than `knative-serving` or `knative-eventing`.
+
+* Previously, post-install batch jobs were removed after a certain period, leaving privileged service accounts unbound. This caused compliance systems to flag the issue. The problem has been resolved by retaining completed jobs, ensuring that service accounts remain bound.


### PR DESCRIPTION
**Affecting version:** 
- `serverless-docs-1.33`
- `serverless-docs-1.34`

**Tracking JIRAs:** 
- https://issues.redhat.com/browse/SRVCOM-3235
- sub-task: https://issues.redhat.com/browse/SRVCOM-3238

**Doc previews:** [Red Hat OpenShift Serverless 1.33.2](https://80282--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-rn-1-33-2_serverless-release-notes)