### PR TITLE
OCPBUGS-36255: Documented the failover VIP allowed_address_pairs

### DIFF
--- a/modules/migration-migrating-on-prem-to-cloud.adoc
+++ b/modules/migration-migrating-on-prem-to-cloud.adoc
@@ -42,7 +42,7 @@ $ oc config view
 
 . Establish a tunnel by entering the following command on the command system:
 +
-[source,terminal,sub="+quotes"]
+[source,terminal,subs="+quotes"]
 ----
 $ crane tunnel-api [--namespace <namespace>] \
       --destination-context <destination-cluster> \

--- a/modules/nw-ipfailover-configuration.adoc
+++ b/modules/nw-ipfailover-configuration.adoc
@@ -6,9 +6,9 @@
 [id="nw-ipfailover-configuration_{context}"]
 = Configuring IP failover in your cluster
 
-As a cluster administrator, you can configure IP failover on an entire cluster, or on a subset of nodes, as defined by the label selector. You can also configure multiple IP failover deployment configurations in your cluster, where each one is independent of the others.
+As a cluster administrator, you can configure IP failover on an entire cluster, or on a subset of nodes, as defined by the label selector. You can also configure multiple IP failover deployments in your cluster, where each one is independent of the others.
 
-The IP failover deployment configuration ensures that a failover pod runs on each of the nodes matching the constraints or the label used.
+The IP failover deployment ensures that a failover pod runs on each of the nodes matching the constraints or the label used.
 
 This pod runs Keepalived, which can monitor an endpoint and use Virtual Router Redundancy Protocol (VRRP) to fail over the virtual IP (VIP) from one node to another if the first node cannot reach the service or endpoint.
 
@@ -16,20 +16,21 @@ For production use, set a `selector` that selects at least two nodes, and set `r
 
 .Prerequisites
 
-* You are logged in to the cluster with a user with `cluster-admin` privileges.
+* You are logged in to the cluster as a user with `cluster-admin` privileges.
 * You created a pull secret.
+* {rh-openstack-first} only: 
+** You installed an link:https://docs.openstack.org/python-openstackclient/latest/[{rh-openstack} client ({op-system} documentation)] on the target environment.
+** You also downloaded the link:https://docs.openstack.org/zh_CN/user-guide/common/cli-set-environment-variables-using-openstack-rc.html[{rh-openstack} `openrc.sh` rc file ({op-system} documentation)].
 
 .Procedure
 
-//. Create an {product-title} pull secret
-//+
 . Create an IP failover service account:
 +
 [source,terminal]
 ----
 $ oc create sa ipfailover
 ----
-+
+
 . Update security context constraints (SCC) for `hostNetwork`:
 +
 [source,terminal]
@@ -41,8 +42,57 @@ $ oc adm policy add-scc-to-user privileged -z ipfailover
 ----
 $ oc adm policy add-scc-to-user hostnetwork -z ipfailover
 ----
+
+. {rh-openstack-first} only: Complete the following steps to make a failover VIP address reachable on {rh-openstack} ports.
 +
-. Create a deployment YAML file to configure IP failover:
+.. Use the {rh-openstack} CLI to show the default {rh-openstack} API and VIP addresses in the `allowed_address_pairs` parameter of your {rh-openstack} cluster:
++
+[source,terminal]
+----
+$ openstack port show <cluster_name> -c allowed_address_pairs
+----
++
+.Output example
+[source,terminal,subs="+attributes"]
+----
+*Field*                  *Value*
+allowed_address_pairs    ip_address='192.168.0.5', mac_address='fa:16:3e:31:f9:cb'
+                         ip_address='192.168.0.7', mac_address='fa:16:3e:31:f9:cb'
+----
++
+.. Set a different VIP address for the IP failover deployment and make the address reachable on {rh-openstack} ports by entering the following command in the {rh-openstack} CLI. Do not set any default {rh-openstack} API and VIP addresses as the failover VIP address for the IP failover deployment.
++
+.Example of adding the `1.1.1.1` failover IP address as an allowed address on {rh-openstack} ports.
+[source,terminal,subs="+attributes"]
+----
+$ openstack port set <cluster_name> --allowed-address ip-address=1.1.1.1,mac-address=fa:fa:16:3e:31:f9:cb
+----
++
+.. Create a deployment YAML file to configure IP failover for your deployment. See "Example deployment YAML for IP failover configuration" in a later step.
++
+.. Specify the following specification in the IP failover deployment so that you pass the failover VIP address to the `OPENSHIFT_HA_VIRTUAL_IPS` environment variable:
++
+.Example of adding the `1.1.1.1` VIP address to `OPENSHIFT_HA_VIRTUAL_IPS`
+[source,yaml,subs="attributes,quotes"]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ipfailover-keepalived
+# ...
+      spec:
+          env:
+          - name: OPENSHIFT_HA_VIRTUAL_IPS 
+          value: "1.1.1.1"
+# ...
+----
+
+. Create a deployment YAML file to configure IP failover.
++
+[NOTE]
+====
+For {rh-openstack-first}, you do not need to re-create the deployment YAML file. You already created this file as part of the earlier instructions.
+====
 +
 .Example deployment YAML for IP failover configuration
 [source,yaml]
@@ -159,27 +209,3 @@ spec:
 <11> The strategy for handling a new higher priority host. The default value is `preempt_delay 300`, which causes a Keepalived instance to take over a VIP after 5 minutes if a lower-priority master is holding the VIP.
 <12> The period, in seconds, that the check script is run. The default value is `2`.
 <13> Create the pull secret before creating the deployment, otherwise you will get an error when creating the deployment.
-////
-+
-.Example service YAML for IP failover configuration
-[source,yaml]
-----
-apiVersion: v1
-kind: Service
-metadata:
-  name: ipfailover-keepalived-service
-spec:
-  ports:
-    - port: 1985
-      targetPort: 1985
-      name: todo
-    - port: 112
-      targetPort: 112
-      name: vrrp
-  selector:
-    ipfailover: hello-openshift
-  externalIPs:
-  - 1.1.1.1
-  - 1.1.1.2
-----
-////


### PR DESCRIPTION
Version(s):
4.12+

Issue: [OCPBUGS-26255](https://issues.redhat.com/browse/OCPBUGS-36255)

Link to docs preview:
[Configuring IP failover in your cluster](https://80287--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring-ipfailover.html#nw-ipfailover-configuration_configuring-ipfailover)

- [x] SME has approved this change. (Bram Verschueren)
- [x] QE has approved this change. (Melvin Joseph)

Additional information:
* [openstack_networking_port_v2](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/networking_port_v2)
* [Configuring IP failover in your cluster](https://docs.openshift.com/container-platform/4.16/networking/configuring-ipfailover.html#nw-ipfailover-configuration_configuring-ipfailover)
* [ip Failover GH](https://github.com/openshift/openshift-docs/blob/67cbb8996517582f6f8d5fff8570b3f886e05110/modules/nw-ipfailover-configuration.adoc)
* [OpenStackClient](https://docs.openstack.org/python-openstackclient/latest/)
* [OpenStack RC file](https://docs.openstack.org/zh_CN/user-guide/common/cli-set-environment-variables-using-openstack-rc.html)
