### PR TITLE
OSDOCS-11656: Documented the 4.16.7 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3332,6 +3332,58 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+[id="ocp-4-16-7_{context}"]
+=== RHSA-2024:5107 - {product-title} {product-version}.7 bug fix and security update
+
+Issued: 13 August 2024
+
+{product-title} release {product-version}.7, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:5107[RHSA-2024:5107] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:5110[RHBA-2024:5110] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.7 --pullspecs
+----
+
+[id="ocp-4-16-7-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the `openshift-install` CLI sometimes failed to connect to the bootstrap node when collecting bootstrap gather logs. The installation program reported an error message such as `The bootstrap machine did not execute the release-image.service systemd unit`. With this release and after the bootstrap gather logs issue occurs, the installation program now reports `Invalid log bundle or the bootstrap machine could not be reached and bootstrap logs were not collected`, which is a more accurate error message. (link:https://issues.redhat.com/browse/OCPBUGS-37838[*OCPBUGS-37838*])
+
+* Previously, after a firmware update through the `HostFirmwareComponents` resource, the resource would not show the newer information about the installed firmware in `Status.Components`. With this release, after a firmware update is run and the `BareMetalHosts` (BMH) object moves to `provisioning`, the newer information about the firmware is populated in the `HostFirmwareComponents` resource under `Status.Components.` (link:https://issues.redhat.com/browse/OCPBUGS-37765[*OCPBUGS-37765*])
+
+* Previously, oc-mirror plugin v2 for tags were not created for the {product-title} release images. Some container registries depend on these tags as mandatory tags. With this release, these tags are added to all release images. (link:https://issues.redhat.com/browse/OCPBUGS-37757[*OCPBUGS-37757*])
+
+* Previously, extracting the IP address from the Cluster API Machine object only returned a single address. On {vmw-first}, the returned address would always be an IPv6 address and this caused issues with the `must-gather` implementation if the address was non-routable. With this release, the Cluster API Machine object returns all IP addresses, including IPv4, so that the `must-gather` issue no longer occurs on {vmw-full}. (link:https://issues.redhat.com/browse/OCPBUGS-37607[*OCPBUGS-37607*])
+
+* Previously, the installation program incorrectly required {aws-first} permissions for creating Identity and Access Management (IAM) roles for an {product-title} cluster that already had these roles. With this release, the installation program only requests permissions for roles not yet created. (link:https://issues.redhat.com/browse/OCPBUGS-37494[*OCPBUGS-37494*]) 
+
+* Previously, when you attempted to install a cluster on {rh-openstack-first} and you used special characters, such as the hash sign (`#`) in a cluster name, the Neutron API failed to tag a security group with the name of the cluster. This caused the installation of the cluster to fail. With this release, the installation program uses an alternative endpoint to tag security groups and this endpoint supports the use of special characters in tag names. (link:https://issues.redhat.com/browse/OCPBUGS-37492[*OCPBUGS-37492*])  
+
+* Previously, the Dell iDRAC baseboard management controller (BMC) with the Redfish protocol caused clusters to fail on the Dell iDRAC servers. With this release, an update to the `idrac-redfish` management interface to unset the `ipxe` parameter fixed this issue. (link:https://issues.redhat.com/browse/OCPBUGS-37262[*OCPBUGS-37262*])
+
+* Previously, the `assisted-installer` did not reload new data from the `assisted-service` when the `assisted-installer` checked control plane nodes for readiness and a conflict existed with a write operation from the `assisted-installer-controller`. This conflict prevented the `assisted-installer` from detecting a node that was marked by the `assisted-installer-controller` as `Ready` because the `assisted-installer` relied on older information. With this release, the `assisted-installer` can receive the newest information from the `assisted-service`, so that it the `assisted-installer` can accurately detect the status of each node. (link:https://issues.redhat.com/browse/OCPBUGS-37167[*OCPBUGS-37167*])
+
+* Previously, the DNS-based egress firewall incorrectly caused memory increases for nodes running in a cluster because of multiple retry operations. With this release, the retry logic is fixed so that DNS pods no longer leak excess memory to nodes. (link:https://issues.redhat.com/browse/OCPBUGS-37078[*OCPBUGS-37078*])
+
+////
+* Need to confirm with MCO team is OCPBUGS-37485 is a known issue or bug fix. 
+* OCPBUGS-37065 is internal and won't be documented. Confirmed with SME to drop the Jira
+* OCPBUGS-36937 is internal and won't be documented. Reporter is on PTO but Confirmed with assignee SME to drop it.
+* OCPBUGS-37621 is not something a customer needs to know. Confirmed with SME to drop the Jira.
+* OCPBUGS-34790 is not something a customer needs to know. Confirmed with SME to drop the Jira.
+////
+
+* Previously, `HostedClusterConfigOperator` resource did not delete the `ImageDigestMirrorSet` (IDMS) object after a user removed the `ImageContentSources` field from the `HostedCluster` object. This caused the IDMS object to remain in the `HostedCluster` object. With this release, `HostedClusterConfigOperator` removes all IDMS resources in the `HostedCluster` object so that this issue no longer exists. (link:https://issues.redhat.com/browse/OCPBUGS-36766[*OCPBUGS-36766*])
+
+[id="ocp-4-16-7-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 [id="ocp-4-16-6_{context}"]
 === RHSA-2024:4965 - {product-title} {product-version}.6 bug fix
 
@@ -3402,6 +3454,8 @@ metadata:
 * Previously, the Open vSwitch (OVS) pinning procedure set the CPU affinity of the main thread, but other CPU threads did not pick up this affinity if they had already been created. As a consequence, some OVS threads did not run on the correct CPU set, which might interfere with the performance of pods with a Quality of Service (QoS) class of `Guaranteed`. With this update, the OVS pinning procedure updates the affinity of all the OVS threads, ensuring that all OVS threads run on the correct CPU set. (link:https://issues.redhat.com/browse/OCPBUGS-36608[*OCPBUGS-36608*])
 
 * Previously, the etcd Operator checked the health of etcd members in serial with an all-member timeout that matched the single-member timeout. That allowed one slow member check to consume the entire timeout, and cause later member checks to fail with the error `deadline-exceeded`, regardless of the health of that later member. Now, etcd checks the health of members in parallel so the health and speed of one member's check doesn't affect the other members' checks. (link:https://issues.redhat.com/browse/OCPBUGS-36489[*OCPBUGS-36489*])
+
+* Previously, in a cluster that runs {product-title} 4.16 with the Telco RAN DU reference configuration, long duration `cyclictest` or `timerlat` tests could fail with maximum latencies detected above `20`us. This issue occured because the `psi` kernel command line argument was being set to `1` by default when cgroups v2 is enabled. With this release, the issue is fixed by setting `psi=0` in the kernel arguments when enabling cgroups v2. The `cyclictest` latency issue reported in link:https://issues.redhat.com/browse/OCPBUGS-34022[*OCPBUGS-34022*] is now also fixed. (link:https://issues.redhat.com/browse/OCPBUGS-37271[*OCPBUGS-37271*])
 
 [id="ocp-4-16-6-updating_{context}"]
 ==== Updating


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-11656](https://issues.redhat.com/browse/OSDOCS-11656)

Link to docs preview:
* [4.16.7](https://80295--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-7_release-notes)

