### PR TITLE
[RHACS] ROX-25421: Document troubleshooting for secured cluster upgrader

### DIFF
--- a/modules/troubleshooting-cluster-upgrader.adoc
+++ b/modules/troubleshooting-cluster-upgrader.adoc
@@ -1,0 +1,76 @@
+// Module included in the following assemblies:
+//
+// * upgrade/upgrade-roxctl.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="troubleshooting-upgrader_{context}"]
+= Troubleshooting the cluster upgrader
+
+[role="_abstract"]
+If you encounter problems when using the legacy installation method for the secured cluster and enabling the automated updates, you can try troubleshooting the problem.
+The following errors can be found in the clusters view when the upgrader fails.
+
+[id="upgrader-missing-permissions_{context}"]
+== Upgrader is missing permissions
+
+.Symptom
+
+The following error is displayed in the cluster page:
+
+[source,text]
+----
+Upgrader failed to execute PreflightStage of the roll-forward workflow: executing stage "Run preflight checks": preflight check "Kubernetes authorization" reported errors. This usually means that access is denied. Have you configured this Secured Cluster for automatically receiving upgrades?"
+----
+
+.Procedure
+
+. Ensure that the bundle for the secured cluster was generated with future upgrades enabled before clicking *Download YAML file and keys*.
+. If possible, remove that secured cluster and generate a new bundle making sure that future upgrades are enabled.
+. If you cannot re-create the cluster, you can take these actions:
+.. Ensure that the service account `sensor-upgrader` exists in the same namespace as Sensor.
+.. Ensure that a ClusterRoleBinding exists (default name: `<namespace>:upgrade-sensors`) that grants the `cluster-admin` ClusterRole to the `sensor-upgrader` service account.
+
+[id="upgrader-cannot-start-missing-image_{context}"]
+== Upgrader cannot start due to missing image
+
+.Symptom
+
+The following error is displayed in the cluster page:
+
+[source,text]
+----
+"Upgrade initialization error: The upgrader pods have trouble pulling the new image: Error pulling image: (...) (<image_reference:tag>: not found)"
+----
+
+.Procedure
+
+. Ensure that the Secured Cluster can access the registry and pull the image `<image_reference:tag>`.
+. Ensure that the image pull secrets are configured correctly in the secured cluster.
+
+[id="upgrader-cannot-start-unknown-reason_{context}"]
+== Upgrader cannot start due to an unknown reason
+
+.Symptom
+
+The following error is displayed in the cluster page:
+
+[source,text]
+----
+"Upgrade initialization error: Pod terminated: (Error)"
+----
+
+.Procedure
+
+. Ensure that the upgrader has enough permissions for accessing the cluster objects. For more information, see "Upgrader is missing permissions".
+. Check the upgrader logs for more insights.
+
+[id="obtainig-upgrader-logs_{context}"]
+=== Obtaining upgrader logs
+
+The logs can be accessed by running the following command:
+[source,terminal,subs="+quotes"]
+----
+$ kubectl -n <namespace> logs deploy/sensor-upgrader <1>
+----
+<1> For `_<namespace>_`, specify the namespace in which Sensor is running.
+
+Usually, the upgrader deployment is only running in the cluster for a short time while doing the upgrades. It is removed later, so accessing its logs using the orchestrator CLI can require proper timing.

--- a/upgrading/upgrade-roxctl.adoc
+++ b/upgrading/upgrade-roxctl.adoc
@@ -64,6 +64,7 @@ After upgrading Central services, you must upgrade all secured clusters.
 ====
 * If you are using automatic upgrades:
 ** Update all your secured clusters by using automatic upgrades.
+** For information about troubleshooting problems with the automatic cluster upgrader, see xref:../upgrading/upgrade-roxctl.adoc#troubleshooting-upgrader_{context}[Troubleshooting the cluster upgrader].
 ** Skip the instructions in this section and follow the instructions in the xref:../upgrading/upgrade-roxctl.adoc#verify-upgrades_{context}[Verify upgrades] and xref:../upgrading/upgrade-roxctl.adoc#revoke-the-api-token_{context}[Revoking the API token] sections.
 * If you are not using automatic upgrades, you must run the instructions in this section on all secured clusters including the Central cluster.
 ** To ensure optimal functionality, use the same {product-title-short} version for your secured clusters and the cluster on which Central is installed.
@@ -113,3 +114,5 @@ include::modules/rollback-central-forced.adoc[leveloffset=+2]
 include::modules/verify-upgrades.adoc[leveloffset=+1]
 
 include::modules/revoke-the-api-token.adoc[leveloffset=+1]
+
+include::modules/troubleshooting-cluster-upgrader.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

We are enabling the auto-cluster upgrader for legacy-installed secured clusters working with managed central. We want to make sure that users understand the potential errors that the upgrader may return.
The upgrader is not a new thing and it has been used for a long time, we are just enabling it for a small group of new users and want to make sure that it works as expected.

Version(s):
- All ACS versions

Issue:
- Epic: https://issues.redhat.com/browse/ROX-22312
- Task: https://issues.redhat.com/browse/ROX-25421
- GH backend implementation that will link to this docs: https://github.com/stackrox/stackrox/pull/12280

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
- https://80296--ocpdocs-pr.netlify.app/openshift-acs/latest/upgrading/upgrade-roxctl.html

QE review: **(ACS has no QE; approved by SMEs)**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
- Work continued under [ROX-26273](https://issues.redhat.com/browse/ROX-26273) 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
