### PR TITLE
OSDOCS-11655 OCP 4.12.63 RNs + date format change

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -3398,7 +3398,7 @@ For any {product-title} release, always review the instructions on xref:../updat
 [id="ocp-4-12-0-ga"]
 === RHSA-2022:7399 - {product-title} 4.12.0 image release, bug fix, and security update advisory
 
-Issued: 2023-01-17
+Issued: 17 January 2023
 
 {product-title} release 4.12.0, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2022:7399[RHSA-2022:7399] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:7398[RHSA-2022:7398] advisory.
 
@@ -3423,7 +3423,7 @@ With this update, xref:../networking/hardware_networks/using-pod-level-bonding.a
 [id="ocp-4-12-1"]
 === RHSA-2023:0449 - {product-title} 4.12.1 bug fix and security update
 
-Issued: 2023-01-30
+Issued: 30 January 2023
 
 {product-title} release 4.12.1, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:0449[RHSA-2023:0449] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:0448[RHBA-2023:0448] advisory.
 
@@ -3449,7 +3449,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-2"]
 === RHSA-2023:0569 - {product-title} 4.12.2 bug fix and security update
 
-Issued: 2023-02-07
+Issued: 7 February 2023
 
 {product-title} release 4.12.2, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:0569[RHSA-2023:0569] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:0568[RHBA-2023:0568] advisory.
 
@@ -3468,7 +3468,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-3"]
 === RHSA-2023:0728 - {product-title} 4.12.3 bug fix and security update
 
-Issued: 2023-02-16
+Issued: 16 February 2023
 
 {product-title} release 4.12.3, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:0728[RHSA-2023:0728] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:0727[RHSA-2023:0727] advisory.
 
@@ -3492,7 +3492,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-4"]
 === RHSA-2023:0769 - {product-title} 4.12.4 bug fix and security update
 
-Issued: 2023-02-20
+Issued: 20 February 2023
 
 {product-title} release 4.12.4, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:0769[RHSA-2023:0769] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:0768[RHBA-2023:0768] advisory.
 
@@ -3511,7 +3511,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-5"]
 === RHSA-2023:0890 - {product-title} 4.12.5 bug fix and security update
 
-Issued: 2023-02-28
+Issued: 28 February 2023
 
 {product-title} release 4.12.5, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:0890[RHSA-2023:0890] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:0889[RHBA-2023:0889] advisory.
 
@@ -3541,7 +3541,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-6"]
 === RHSA-2023:1034 - {product-title} 4.12.6 bug fix and security update
 
-Issued: 2023-03-07
+Issued: 7 March 2023
 
 {product-title} release 4.12.6, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1034[RHBA-2023:1034] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:1033[RHSA-2023:1033] advisory.
 
@@ -3560,7 +3560,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-7"]
 === RHBA-2023:1163 - {product-title} 4.12.7 bug fix update
 
-Issued: 2023-03-13
+Issued: 13 March 2023
 
 {product-title} release 4.12.7 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1163[RHBA-2023:1163] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1162[RHBA-2023:1162] advisory.
 
@@ -3579,7 +3579,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-8"]
 === RHBA-2023:1269 - {product-title} 4.12.8 bug fix and security update
 
-Issued: 2023-03-21
+Issued: 21 March 2023
 
 {product-title} release 4.12.8, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1269[RHBA-2023:1269] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:1268[RHSA-2023:1268] advisory.
 
@@ -3598,7 +3598,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-9"]
 === RHSA-2023:1409 - {product-title} 4.12.9 bug fix and security update
 
-Issued: 2023-03-27
+Issued: 27 March 2023
 
 {product-title} release 4.12.9, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:1409[RHSA-2023:1409] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:1408[RHSA-2023:1408] advisory.
 
@@ -3624,7 +3624,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-10"]
 === RHBA-2023:1508 - {product-title} 4.12.10 bug fix update
 
-Issued: 2023-04-03
+Issued: 3 April 2023
 
 {product-title} release 4.12.10 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1508[RHBA-2023:1508] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1507[RHBA-2023:1507] advisory.
 
@@ -3643,7 +3643,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-11"]
 === RHSA-2023:1645 - {product-title} 4.12.11 bug fix and security update
 
-Issued: 2023-04-11
+Issued: 11 April 2023
 
 {product-title} release 4.12.11, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1645[RHBA-2023:1645] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1644[RHBA-2023:1644] advisory.
 
@@ -3682,7 +3682,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-12"]
 === RHBA-2023:1734 - {product-title} 4.12.12 bug fix
 
-Issued: 2023-04-13
+Issued: 13 April 2023
 
 {product-title} release 4.12.12 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1734[RHBA-2023:1734] advisory. There are no RPM packages for this update.
 
@@ -3701,7 +3701,7 @@ All {product-title} 4.12 users are advised that the only defect fixed in this re
 [id="ocp-4-12-13"]
 === RHBA-2023:1750 - {product-title} 4.12.13 bug fix update
 
-Issued: 2023-04-19
+Issued: 19 April 2023
 
 {product-title} release 4.12.13 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1750[RHBA-2023:1750] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1749[RHBA-2023:1749] advisory.
 
@@ -3735,7 +3735,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-14"]
 === RHBA-2023:1858 - {product-title} 4.12.14 bug fix update
 
-Issued: 2023-04-24
+Issued: 24 April 2023
 
 {product-title} release 4.12.14 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1858[RHBA-2023:1858] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1857[RHBA-2023:1857] advisory.
 
@@ -3762,7 +3762,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-15"]
 === RHBA-2023:2037 - {product-title} 4.12.15 bug fix update
 
-Issued: 2023-05-03
+Issued: 3 May 2023
 
 {product-title} release 4.12.15 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:2037[RHBA-2023:2037] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:2036[RHBA-2023:2036] advisory.
 
@@ -3786,7 +3786,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-16"]
 === RHSA-2023:2110 - {product-title} 4.12.16 bug fix and security update
 
-Issued: 2023-05-10
+Issued: 10 May 2023
 
 {product-title} release 4.12.16, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:2110[RHSA-2023:2110] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:2109[RHBA-2023:2109] advisory.
 
@@ -3810,7 +3810,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-17"]
 === RHBA-2023:2699 - {product-title} 4.12.17 bug fix update
 
-Issued: 2023-05-18
+Issued: 18 May 2023
 
 {product-title} release 4.12.17 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:2699[RHBA-2023:2699] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:2698[RHBA-2023:2698] advisory.
 
@@ -3834,7 +3834,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-18"]
 === RHBA-2023:3208 - {product-title} 4.12.18 bug fix update
 
-Issued: 2023-05-23
+Issued: 23 May 2023
 
 {product-title} release 4.12.18 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:3208[RHBA-2023:3208] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:3207[RHBA-2023:3207] advisory.
 
@@ -3860,7 +3860,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-19"]
 === RHSA-2023:3287 - {product-title} 4.12.19 bug fix and security update
 
-Issued: 2023-05-31
+Issued: 31 May 2023
 
 {product-title} release 4.12.19 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:3287[RHSA-2023:3287] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:3286[RHBA-2023:3286] advisory.
 
@@ -3879,7 +3879,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-20"]
 === RHSA-2023:3410 - {product-title} 4.12.20 bug fix update
 
-Issued: 2023-06-07
+Issued: 7 June 2023
 
 {product-title} release 4.12.20 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:3410[RHSA-2023:3410] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3409[RHSA-2023:3409] advisory.
 
@@ -3903,7 +3903,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-21"]
 === RHBA-2023:3546 - {product-title} 4.12.21 bug fix and security update
 
-Issued: 2023-06-14
+Issued: 14 June 2023
 
 {product-title} release 4.12.21, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:3546[RHBA-2023:3546] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3545[RHSA-2023:3545] advisory.
 
@@ -3929,7 +3929,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-22"]
 === RHSA-2023:3615 - {product-title} 4.12.22 bug fix and security update
 
-Issued: 2023-06-26
+Issued: 26 June 2023
 
 {product-title} release 4.12.22, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:3615[RHSA-2023:3615] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3613[RHSA-2023:3613] advisory.
 
@@ -3955,7 +3955,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-23"]
 === RHSA-2023:3925 - {product-title} 4.12.23 bug fix and security update
 
-Issued: 2023-07-06
+Issued: 6 July 2023
 
 {product-title} release 4.12.23, which includes security updates, is now available.This update includes a Red Hat security bulletin for customers who run {product-title} in FIPS mode. For more information, see link:https://access.redhat.com/security/vulnerabilities/RHSB-2023-001[RHSB-2023:001].
 
@@ -3976,7 +3976,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-24"]
 === RHBA-2023:3977 - {product-title} 4.12.24 bug fix and security update
 
-Issued: 2023-07-12
+Issued: 12 July 2023
 
 {product-title} release 4.12.24, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:3977[RHBA-2023:3977] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3976[RHSA-2023:3976] advisory.
 
@@ -4017,7 +4017,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-25"]
 === RHBA-2023:4048 - {product-title} 4.12.25 bug fix update
 
-Issued: 2023-07-19
+Issued: 19 July 2023
 
 {product-title} release 4.12.25 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4048[RHBA-2023:4048] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4047[RHBA-2023:4047] advisory.
 
@@ -4036,7 +4036,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-26"]
 === RHBA-2023:4221 - {product-title} 4.12.26 bug fix update
 
-Issued: 2023-07-26
+Issued: 26 July 2023
 
 {product-title} release 4.12.26 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4221[RHBA-2023:4221] advisory. There are no RPM packages for this update.
 
@@ -4055,7 +4055,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-27"]
 === RHBA-2023:4319 - {product-title} 4.12.27 bug fix update
 
-Issued: 2023-08-02
+Issued: 2 August 2023
 
 {product-title} release 4.12.27 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4319[RHBA-2023:4319] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4322[RHBA-2023:4322] advisory.
 
@@ -4074,7 +4074,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-28"]
 === RHBA-2023:4440 - {product-title} 4.12.28 bug fix update
 
-Issued: 2023-08-09
+Issued: 9 August 2023
 
 {product-title} release 4.12.28 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4440[RHBA-2023:4440] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4443[RHBA-2023:4443] advisory.
 
@@ -4093,7 +4093,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-29"]
 === RHBA-2023:4608 - {product-title} 4.12.29 bug fix update
 
-Issued: 2023-08-16
+Issued: 16 August 2023
 
 {product-title} release 4.12.29 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4608[RHBA-2023:4608] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4611[RHBA-2023:4611] advisory.
 
@@ -4124,7 +4124,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-30"]
 === RHSA-2023:4671 - {product-title} 4.12.30 bug fix update
 
-Issued: 2023-08-23
+Issued: 23 August 2023
 
 {product-title} release 4.12.30, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:4671[RHSA-2023:4671] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:4674[RHSA-2023:4674] advisory.
 
@@ -4144,7 +4144,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-31"]
 === RHBA-2023:4756 - {product-title} 4.12.31 bug fix update
 
-Issued: 2023-08-31
+Issued: 31 August 2023
 
 {product-title} release 4.12.31 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4756[RHBA-2023:4756] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4759[RHBA-2023:4759] advisory.
 
@@ -4163,7 +4163,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-32"]
 === RHBA-2023:4900 - {product-title} 4.12.32 bug fix update
 
-Issued: 2023-09-06
+Issued: 6 September 2023
 
 {product-title} release 4.12.32 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4900[RHBA-2023:4900] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4903[RHBA-2023:4903] advisory.
 
@@ -4188,7 +4188,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-33"]
 === RHBA-2023:5016 - {product-title} 4.12.33 bug fix update
 
-Issued: 2023-09-12
+Issued: 12 September 2023
 
 {product-title} release 4.12.33 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:5016[RHBA-2023:5016] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:5018[RHBA-2023:5018] advisory.
 
@@ -4207,7 +4207,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-34"]
 === RHBA-2023:5151 - {product-title} 4.12.34 bug fix update
 
-Issued: 2023-09-20
+Issued: 20 September 2023
 
 {product-title} release 4.12.34 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:5151[RHBA-2023:5151] advisory. There are no RPM packages for this release.
 
@@ -4235,7 +4235,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-35"]
 === RHBA-2023:5321 - {product-title} 4.12.35 bug fix update
 
-Issued: 2023-09-27
+Issued: 27 September 2023
 
 {product-title} release 4.12.35 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:5321[RHBA-2023:5321] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:5323[RHBA-2023:5323] advisory.
 
@@ -4254,7 +4254,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-36"]
 === RHSA-2023:5390 - {product-title} 4.12.36 bug fix and security update
 
-Issued: 2023-10-04
+Issued: 4 October 2023
 
 {product-title} release 4.12.36, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:5390[RHSA-2023:5390] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:5392[RHBA-2023:5392] advisory.
 
@@ -4273,7 +4273,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-37"]
 === RHBA-2023:5450 - {product-title} 4.12.37 bug fix update
 
-Issued: 2023-10-11
+Issued: 11 October 2023
 
 {product-title} release 4.12.37 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:5450[RHBA-2023:5450] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:5452[RHBA-2023:5452] advisory.
 
@@ -4292,7 +4292,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-39"]
 === RHSA-2023:5677 - {product-title} 4.12.39 bug fix and security update
 
-Issued: 2023-10-18
+Issued: 18 October 2023
 
 {product-title} release 4.12.39, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:5677[RHSA-2023:5677] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:5679[RHSA-2023:5679] advisory.
 
@@ -4318,7 +4318,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-40"]
 === RHSA-2023:5896 - {product-title} 4.12.40 bug fix and security update
 
-Issued: 2023-10-25
+Issued: 25 October 2023
 
 {product-title} release 4.12.40, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:5896[RHSA-2023:5896] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:5898[RHBA-2023:5898] advisory.
 
@@ -4337,7 +4337,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-41"]
 === RHSA-2023:6126 - {product-title} 4.12.41 bug fix and security update
 
-Issued: 2023-11-02
+Issued: 2 November 2023
 
 {product-title} release 4.12.41, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:6126[RHSA-2023:6126] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:6128[RHSA-2023:6128] advisory.
 
@@ -4356,7 +4356,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-42"]
 === RHSA-2023:6276 - {product-title} 4.12.42 bug fix and security update
 
-Issued: 2023-11-08
+Issued: 8 November 2023
 
 {product-title} release 4.12.42, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:6276[RHSA-2023:6276] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:6278[RHBA-2023:6278] advisory.
 
@@ -4392,7 +4392,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-43"]
 === RHSA-2023:6842 - {product-title} 4.12.43 bug fix and security update
 
-Issued: 2023-11-16
+Issued: 16 November 2023
 
 {product-title} release 4.12.43, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:6842[RHSA-2023:6842] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:6844[RHBA-2023:6844] advisory.
 
@@ -4411,7 +4411,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-44"]
 === RHSA-2023:6894 - {product-title} 4.12.44 bug fix and security update
 
-Issued: 2023-11-21
+Issued: 21 November 2023
 
 {product-title} release 4.12.44, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:6894[RHSA-2023:6894] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:6896[RHBA-2023:6896] advisory.
 
@@ -4430,7 +4430,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-45"]
 === RHSA-2023:7608 - {product-title} 4.12.45 bug fix and security update
 
-Issued: 2023-12-06
+Issued: 6 December 2023
 
 {product-title} release 4.12.45, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:7608[RHSA-2023:7608] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:7610[RHSA-2023:7610] advisory.
 
@@ -4458,7 +4458,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-46"]
 === RHSA-2023:7823 - {product-title} 4.12.46 bug fix and security update
 
-Issued: 2024-01-04
+Issued: 4 January 2024
 
 {product-title} release 4.12.46, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:7823[RHSA-2023:7823] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:7825[RHBA-2023:7825] advisory.
 
@@ -4483,7 +4483,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-47"]
 === RHSA-2024:0198 - {product-title} 4.12.47 bug fix and security update
 
-Issued: 2024-01-17
+Issued: 17 January 2024
 
 {product-title} release 4.12.47, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:0198[RHSA-2024:0198] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0200[RHSA-2024:0200] advisory.
 
@@ -4508,7 +4508,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-48"]
 === RHSA-2024:0485 - {product-title} 4.12.48 bug fix and security update
 
-Issued: 2024-01-31
+Issued: 31 January 2024
 
 {product-title} release 4.12.48, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:0485[RHSA-2024:0485] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0489[RHSA-2024:0489] advisory.
 
@@ -4528,7 +4528,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-49"]
 === RHSA-2024:0664 - {product-title} 4.12.49 bug fix and security update
 
-Issued: 2024-02-09
+Issued: 9 February 2024
 
 {product-title} release 4.12.49, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:0664[RHSA-2024:0664] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0666[RHSA-2024:0666] advisory.
 
@@ -4552,7 +4552,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-50"]
 === RHSA-2024:0833 - {product-title} 4.12.50 bug fix and security update
 
-Issued: 2024-02-21
+Issued: 21 February 2024
 
 {product-title} release 4.12.50, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:0833[RHSA-2024:0833] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:0835[RHBA-2024:0835] advisory.
 
@@ -4576,7 +4576,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-51"]
 === RHSA-2024:1052 - {product-title} 4.12.51 bug fix and security update
 
-Issued: 2024-03-06
+Issued: 6 March 2024
 
 {product-title} release 4.12.51, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:1052[RHSA-2024:1052] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:1054[RHBA-2024:1054] advisory.
 
@@ -4602,7 +4602,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-53"]
 === RHSA-2024:1265 - {product-title} 4.12.53 bug fix update
 
-Issued: 2024-03-20
+Issued: 20 March 2024
 
 {product-title} release 4.12.53 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:1265[RHSA-2024:1265] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1267[RHSA-2024:1267] advisory.
 
@@ -4621,7 +4621,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-54"]
 === RHSA-2024:1572 - {product-title} 4.12.54 bug fix and security update
 
-Issued: 2024-04-03
+Issued: 3 April 2024
 
 {product-title} release 4.12.54, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:1572[RHSA-2024:1572] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1574[RHSA-2024:1574] advisory.
 
@@ -4640,7 +4640,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-55"]
 === RHSA-2024:1679 - {product-title} 4.12.55 bug fix and security update
 
-Issued: 2024-04-08
+Issued: 8 April 2024
 
 {product-title} release 4.12.55, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:1679[RHSA-2024:1679] advisory. There are no RPM packages for this update.
 
@@ -4664,7 +4664,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-56"]
 === RHSA-2024:1896 - {product-title} 4.12.56 bug fix and security update
 
-Issued: 2024-04-25
+Issued: 25 April 2024
 
 {product-title} release 4.12.56, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:1896[RHSA-2024:1896] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:1899[RHSA-2024:1899] advisory.
 
@@ -4688,7 +4688,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-57"]
 === RHSA-2024:2782 - {product-title} 4.12.57 bug fix and security update
 
-Issued: 2024-05-16
+Issued: 16 May 2024
 
 {product-title} release 4.12.57, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:2782[RHSA-2024:2782] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:2784[RHSA-2024:2784] advisory.
 
@@ -4714,7 +4714,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-58"]
 === RHSA-2024:3349 - {product-title} 4.12.58 bug fix and security update
 
-Issued: 2024-05-30
+Issued: 30 May 2024
 
 {product-title} release 4.12.58, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:3349[RHSA-2024:3349] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:3351[RHSA-2024:3351] advisory.
 
@@ -4756,7 +4756,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-59"]
 === RHSA-2024:3713 - {product-title} 4.12.59 bug fix and security update
 
-Issued: 2024-06-12
+Issued: 12 June 2024
 
 {product-title} release 4.12.59, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:3713[RHSA-2024:3713] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:3715[RHSA-2024:3715] advisory.
 
@@ -4786,7 +4786,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-60"]
 === RHSA-2024:4006 - {product-title} 4.12.60 bug fix and security update
 
-Issued: 2024-06-27
+Issued: 27 June 2024
 
 {product-title} release 4.12.60, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:4006[RHSA-2024:4006] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4008[RHSA-2024:4008] advisory.
 
@@ -4817,7 +4817,7 @@ To update an existing {product-title} 4.12 cluster to this latest release, see x
 [id="ocp-4-12-61"]
 === RHSA-2024:4677 - {product-title} 4.12.61 bug fix and security update
 
-Issued: 2024-07-25
+Issued: 25 July 2024
 
 {product-title} release 4.12.61, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:4677[RHSA-2024:4677] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:4679[RHBA-2024:4679] advisory.
 
@@ -4843,6 +4843,25 @@ $ oc adm release info 4.12.61 --pullspecs
 * Previously, the installation program failed to install a cluster on IBM Cloud VPC on the "eu-es" region, although it is supported. With this update, the installation program successfully installs a cluster on IBM Cloud VPC on the "eu-es" region. (link:https://issues.redhat.com/browse/OCPBUGS-22981[*OCPBUGS-22981*])
 
 [id="ocp-4-12-61-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-12-63"]
+=== RHSA-2024:5200 - {product-title} 4.12.63 bug fix and security update
+
+Issued: 19 August 2024
+
+{product-title} release 4.12.63, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:5200[RHSA-2024:5200] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:5202[RHSA-2024:5202] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.63 --pullspecs
+----
+
+[id="ocp-4-12-63-updating"]
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-11655](https://issues.redhat.com/browse/OSDOCS-11655)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to [docs preview](https://80321--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-63)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
Not needed
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: I'm changing the date format to match the IBM Style Guide. Advisory links will not work until release day (19 August 2024).
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
