### PR TITLE
ROX:14415: Update docs with port numbers for connections

### DIFF
--- a/architecture/acs-architecture.adoc
+++ b/architecture/acs-architecture.adoc
@@ -23,3 +23,10 @@ include::modules/acs-architecture-external-components.adoc[leveloffset=+1]
 include::modules/acs-architecture-differences-ocp-kube.adoc[leveloffset=+1]
 
 include::modules/acs-architecture-interaction-between-services.adoc[leveloffset=+1]
+
+include::modules/acs-architecture-connections.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../installing/installing_ocp/install-central-ocp.html#install-central-operator-external-db_install-central-ocp[Installing Central with an external database using the Operator method]
+* xref:../cli/command-reference/roxctl.adoc#roxctl-command-options_roxctl[roxctl command options]

--- a/modules/acs-architecture-connections.adoc
+++ b/modules/acs-architecture-connections.adoc
@@ -1,0 +1,73 @@
+// Module included in the following assemblies:
+//
+// * architecture/acs-architecture.adoc
+:_mod-docs-content-type: CONCEPT
+[id="acs-architecture-connections_{context}"]
+= {product-title-short} connection protocols and default ports
+
+Components of {product-title-short} use various default ports and connection protocols. Depending on your system and firewall configuration, you might need to configure your firewall to allow traffic on certain ports.
+
+The following table provides default ports and protocols for some connections within {product-title-short} and between {product-title-short} and external components. This is helpful for configuring your firewall to allow inbound and outbound cluster traffic.
+
+However, you might need more detailed information in some scenarios. For example, if your firewall is integrated in the cluster router, you might need to specify ports for connections that happen within one cluster but might be on different IP networks. In this scenario, you can use the {product-title-short} network policy YAML files in your {ocp} and Kubernetes clusters to determine connections and ports that you might need to configure.
+
+.{product-title-short} connections between components
+
+[cols="4",options="header"]
+|===
+| Component or external entity | Connection type | Port | Additional information
+
+| Central and Scanner V4 Indexer
+| gRPC
+| 8443
+|
+
+| Central and Sensor on secured cluster
+a| * TCP/HTTPS
+* gRPC
+| 443
+| Sensor and Central primarily communicate over a bidirectional gRPC stream, initiated by Sensor to Central's port 443.
+
+| Central and user (CLI)
+a| * gRPC
+* HTTPS (with `--force-http1` option)
+| 443
+| For more information about the `--force-http1` option, see the `roxctl` command options.
+
+| Central and vulnerability feeds
+| HTTPS
+| 443
+| Connects to `definitions.stackrox.io` by default.
+
+| Collector to Sensor
+| gRPC
+| 443
+| This is a bidirectional gRPC connection initiated by Collector to Sensor's port 443.
+
+| Collector (Compliance) to Sensor
+| gRPC
+| 8444
+| If node scanning is enabled on {ocp} release 4, this connection is initiated by Sensor to compliance running in the Collector pod.
+
+| Scanner to Scanner-DB
+| TCP
+| 5432
+|
+| Scanner V4 Indexer to Central
+| HTTPS
+| 443
+|
+
+| Scanner V4 Indexer and Matcher to Scanner V4 DB
+| TCP
+| 5432
+|
+
+| Sensor and Admission Controller
+| gRPC
+| 443
+| This is a bidirectional gRPC stream, initiated by Admission Controller to Sensor's port 443. This occurs in delegated scanning scenarios or in {ocp} secured clusters.
+
+|===
+
+//old graphic version: https://docs.openshift.com/acs/3.70/architecture/acs-architecture.html#external-components_acs-architecture

--- a/modules/default-requirements-central-services.adoc
+++ b/modules/default-requirements-central-services.adoc
@@ -28,12 +28,11 @@ Central DB requires persistent storage in the cluster where Central is installed
 [NOTE]
 ====
 You can use a hostPath volume for storage only if all your hosts (or a group of hosts) mount a shared file system, such as an NFS share or a storage appliance.
-Otherwise, your data is only saved on a single node. Red{nbsp}Hat does not
-recommend using a hostPath volume.
+Otherwise, your data is only saved on a single node. Red{nbsp}Hat does not recommend using a hostPath volume.
 ====
 * Use Solid-State Drives (SSD) for best performance.
 However, you can use another storage type if you do not have SSDs available.
-* If you use a web proxy or firewall, you must configure bypass rules to allow traffic for the `definitions.stackrox.io` domain and enable {product-title} to trust your web proxy or firewall. Otherwise, updates for vulnerabilities will fail.
+* If you use a web proxy or firewall, you must configure bypass rules to allow traffic for the `definitions.stackrox.io` domain and enable {product-title-short} to trust your web proxy or firewall. Otherwise, updates for vulnerabilities will fail. You must also ensure that incoming connections from Sensor on secured clusters to Central on port 443 are possible.
 +
 {product-title} requires access to:
 

--- a/modules/default-requirements-secured-cluster-services.adoc
+++ b/modules/default-requirements-secured-cluster-services.adoc
@@ -14,6 +14,8 @@ Secured cluster services contain the following components:
 * Scanner (optional)
 * Scanner V4 (optional)
 
+If you use a web proxy or firewall, you must ensure that secured clusters and Central can communicate on HTTPS port 443.
+
 [id="default-requirements-secured-cluster-services-sensor_{context}"]
 == Sensor
 


### PR DESCRIPTION
Version(s):
4.5+

Issues:

https://issues.redhat.com/browse/ROX-14415
https://issues.redhat.com/browse/ROX-24289

Link to docs preview:

[80322--ocpdocs-pr.netlify.app/openshift-acs/latest/architecture/acs-architecture.html](https://80322--ocpdocs-pr.netlify.app/openshift-acs/latest/architecture/acs-architecture.html)
[80322--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/acs-default-requirements.html](https://80322--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/acs-default-requirements.html)

QE review: **ACS has no QE, approved by SMEs**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
