### PR TITLE
Update VPC requirements for creating ROSA HCP clusters

### DIFF
--- a/modules/rosa-hcp-vpc-manual.adoc
+++ b/modules/rosa-hcp-vpc-manual.adoc
@@ -23,7 +23,10 @@ If you choose to manually create your Virtual Private Cloud (VPC) instead of usi
 | You need one availability zone for a single zone, and you need three for availability zones for multi-zone.
 
 | Public subnet
-| You must have one public subnet with a NAT gateway for public clusters. Private clusters do not need a public subnet.
+| You must have one public subnet with an internet gateway for public clusters.
+
+| Private subnet
+| You must have exactly one private subnet in each availability zone (AZ) for installing machine pools in ROSA HCP clusters. A NAT gateway may be associated with this subnet to allow outbound internet access for the instances. Private clusters do not need a public subnet.
 
 | DNS hostname and resolution
 | You must ensure that the DNS hostname and resolution are enabled.


### PR DESCRIPTION
**Version(s):**
Applies to all supported versions of ROSA HCP documentation.

**Issue:**
Clarified the requirements for VPC configuration, specifically the setup of public and private subnets for ROSA HCP clusters. Updated the instructions to accurately reflect that each availability zone (AZ) must have exactly **one private subnet for machine pools**. 

Public subnet should be associated with **an internet gateway, not a NAT gateway**.

**Additional information:**

- Created a test VPC `shawn-test-vpc` with **only one public subnet** in a single AZ
![image](https://github.com/user-attachments/assets/502703f9-90d7-42ce-bedb-aa3a52adb8e1)
- When creating a ROSA HCP cluster from OCM console to select the VPC `shawn-test-vpc` I created manually for installing machine pools:
![image](https://github.com/user-attachments/assets/0b2ffd0f-bbde-4673-90b7-83fecc1c3eae)
It shows the VPC doesn't have all necessary subnets (we should have private subnet for installing machine pools)

This update ensures that the documentation aligns with best practices for VPC configurations in AWS, particularly for ROSA HCP clusters. The revision clarifies the subnet requirements to prevent potential misconfigurations during cluster setup.

**QE review:**
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->