### PR TITLE
SSE-C encryption backups

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
@@ -25,6 +25,14 @@ include::modules/migration-configuring-aws-s3.adoc[leveloffset=+1]
 include::modules/oadp-about-backup-snapshot-locations-secrets.adoc[leveloffset=+1]
 include::modules/oadp-creating-default-secret.adoc[leveloffset=+2]
 include::modules/oadp-secrets-for-different-credentials.adoc[leveloffset=+2]
+include::modules/oadp-ssec-encrypted-backups.adoc[leveloffset=+2]
+
+[role="_additional-resources_1"]
+.Additional resources
+
+You can also download the file with the additional encryption key backed up with Velcro by running a different command. See xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc#oadp-ssec-encrypted-backups-velero_installing-oadp-aws[Downloading a file with an SSE-C encryption key for files backed up by Velero].
+
+include::modules/oadp-ssec-encrypted-backups-velero.adoc[leveloffset=+3]
 
 [id="configuring-dpa-aws"]
 == Configuring the Data Protection Application
@@ -47,7 +55,7 @@ include::modules/oadp-configuring-dpa-multiple-bsl.adoc[leveloffset=+1]
 include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
 include::modules/oadp-about-disable-node-agent-dpa.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
+[role="_additional-resources_2"]
 .Additional resources
 
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc#oadp-installing-dpa-1-3_installing-oadp-kubevirt[Installing the Data Protection Application with the `kubevirt` and `openshift` plugins]

--- a/modules/oadp-ssec-encrypted-backups-velero.adoc
+++ b/modules/oadp-ssec-encrypted-backups-velero.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="oadp-ssec-encrypted-backups-velero_{context}"]
+= Downloading a file with an SSE-C encryption key for files backed up by Velero
+
+When you are verifying an SSE-C encryption key, you can also download the file with the additional encryption key for files that were backed up with Velcro.
+
+.Procedure
+
+* Download the file with the additional encryption key for files backed up by Velero by running the following command:
+
+[source,terminal]
+----
+$ aws s3api get-object \
+  --bucket <bucket> \
+  --key velero/backups/mysql-persistent-customerkeyencryptionfile4/mysql-persistent-customerkeyencryptionfile4.tar.gz \
+  --sse-customer-key fileb://sse.key \
+  --sse-customer-algorithm AES256 \
+  --debug \
+  velero_download.tar.gz
+----

--- a/modules/oadp-ssec-encrypted-backups.adoc
+++ b/modules/oadp-ssec-encrypted-backups.adoc
@@ -1,0 +1,165 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="oadp-ssec-encrypted-backups_{context}"]
+= Creating an OADP SSE-C encryption key for additional data security
+
+{aws-first} S3 applies server-side encryption with Amazon S3 managed keys (SSE-S3) as the base level of encryption for every bucket in Amazon S3.
+
+{oadp-first} encrypts data by using SSL/TLS, HTTPS, and the `velero-repo-credentials` secret when transferring the data from a cluster to storage. To protect backup data in case of lost or stolen AWS credentials, apply an additional layer of encryption.
+
+The velero-plugin-for-aws plugin provides several additional encryption methods. You should review its configuration options and consider implementing additional encryption.
+
+You can store your own encryption keys by using server-side encryption with customer-provided keys (SSE-C). This feature provides additional security if your AWS credentials become exposed.
+
+[WARNING]
+====
+Be sure to store cryptographic keys in a secure and safe manner. Encrypted data and backups cannot be recovered if you do not have the encryption key.
+====
+
+.Prerequisites
+
+* To make {oadp-short} mount a secret that contains your SSE-C key to the Velero pod at `/credentials`, use the following default secret name for AWS: `cloud-credentials`, and leave at least one of the following labels empty:
+
+** `dpa.spec.backupLocations[].velero.credential`
+** `dpa.spec.snapshotLocations[].velero.credential`
++
+This is a workaround for a known issue: https://issues.redhat.com/browse/OADP-3971.
+
+[NOTE]
+====
+The following procedure contains an example of a `spec:backupLocations` block that does not specify credentials. This example would trigger an OADP secret mounting.
+====
+
+* If you need the backup location to have credentials with a different name than `cloud-credentials`, you must add a snapshot location, such as the one in the following example, that does not contain a credential name. Because the example does not contain a credential name, the snapshot location will use `cloud-credentials` as its secret for taking snapshots.
+
+.Example snapshot location in a DPA without credentials specified
+[source,yaml]
+----
+ snapshotLocations:
+  - velero:
+      config:
+        profile: default
+        region: <region>
+      provider: aws
+# ...
+----
+
+.Procedure
+. Create an SSE-C encryption key:
+
+.. Generate a random number and save it as a file named `sse.key` by running the following command:
++
+[source,terminal]
+----
+$ dd if=/dev/urandom bs=1 count=32 > sse.key
+----
+
+.. Encode the `sse.key` by using Base64 and save the result as a file named `sse_encoded.key` by running the following command:
++
+[source,terminal]
+----
+$ cat sse.key | base64 > sse_encoded.key
+----
+
+.. Link the file named `sse_encoded.key` to a new file named `customer-key` by running the following command:
++
+[source,terminal]
+----
+$ ln -s sse_encoded.key customer-key
+----
+
+. Create an {product-title} secret:
+** If you are initially installing and configuring {oadp-short}, create the AWS credential and encryption key secret at the same time by running the following command:
++
+[source,terminal]
+----
+$ oc create secret generic cloud-credentials --namespace openshift-adp --from-file cloud=<path>/openshift_aws_credentials,customer-key=<path>/sse_encoded.key
+----
+** If you are updating an existing installation, edit the values of the `cloud-credential` `secret` block of the `DataProtectionApplication` CR manifest, as in the following example:
++
+[source,yaml]
+----
+apiVersion: v1
+data:
+  cloud: W2Rfa2V5X2lkPSJBS0lBVkJRWUIyRkQ0TlFHRFFPQiIKYXdzX3NlY3JldF9hY2Nlc3Nfa2V5P<snip>rUE1mNWVSbTN5K2FpeWhUTUQyQk1WZHBOIgo=
+  customer-key: v+<snip>TFIiq6aaXPbj8dhos=
+kind: Secret
+# ...
+----
+. Edit the value of the `customerKeyEncryptionFile` attribute in the `backupLocations` block of the `DataProtectionApplication` CR manifest, as in the following example:
++
+[source,yaml]
+----
+spec:
+  backupLocations:
+    - velero:
+        config:
+          customerKeyEncryptionFile: /credentials/customer-key
+          profile: default
+# ...
+----
++
+[WARNING]
+====
+You must restart the Velero pod to remount the secret credentials properly on an existing installation.
+====
++
+The installation is complete, and you can back up and restore {product-title} resources. The data saved in AWS S3 storage is encrypted with the new key, and you cannot download it from the AWS S3 console or API without the additional encryption key.
+
+.Verification
+
+To verify that you cannot download the encrypted files without the inclusion of an additional key, create a test file, upload it, and then try to download it.
+
+. Create a test file by running the following command:
++
+[source,terminal]
+----
+$ echo "encrypt me please" > test.txt
+----
+. Upload the test file by running the following command:
++
+[source,terminal]
+----
+$ aws s3api put-object \
+  --bucket <bucket> \
+  --key test.txt \
+  --body test.txt \
+  --sse-customer-key fileb://sse.key \
+  --sse-customer-algorithm AES256
+----
+. Try to download the file. In either the Amazon web console or the terminal, run the following command:
++
+[source,terminal]
+----
+$ s3cmd get s3://<bucket>/test.txt test.txt
+----
++
+The download fails because the file is encrypted with an additional key.
+
+. Download the file with the additional encryption key by running the following command:
++
+[source,terminal]
+----
+$ aws s3api get-object \
+    --bucket <bucket> \
+    --key test.txt \
+    --sse-customer-key fileb://sse.key \
+    --sse-customer-algorithm AES256 \
+    downloaded.txt
+----
+
+. Read the file contents by running the following command:
++
+[source,terminal]
+----
+$ cat downloaded.txt
+----
+.Example output
++
+[source,terminal]
+----
+encrypt me please
+----


### PR DESCRIPTION
OADP 1.3+, OCP 4.13+

Resolves https://issues.redhat.com/browse/OADP-3949 by adding a new section, "Creating a OADP SSE-C encryption key for additional data security."

Preview:  https://80336--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html#oadp-ssec-encrypted-backups_installing-oadp-aws