### PR TITLE
[enterprise-4.15] TELCODOCS#1913: Added T-GM metrics table

### DIFF
--- a/modules/nw-ptp-operator-metrics-reference.adoc
+++ b/modules/nw-ptp-operator-metrics-reference.adoc
@@ -8,11 +8,6 @@
 
 The following table describes the PTP fast events metrics that are available from cluster nodes where the `linuxptp-daemon` service is running.
 
-[NOTE]
-====
-Some of the following metrics are applicable for PTP grandmaster clocks (T-GM) only.
-====
-
 .PTP fast event metrics
 [cols="1,4,3", options="header"]
 |====
@@ -23,7 +18,6 @@ Some of the following metrics are applicable for PTP grandmaster clocks (T-GM) o
 |`openshift_ptp_clock_class`
 |Returns the PTP clock class for the interface.
 Possible values for PTP clock class are 6 (`LOCKED`), 7 (`PRC UNLOCKED IN-SPEC`), 52 (`PRC UNLOCKED OUT-OF-SPEC`), 187 (`PRC UNLOCKED OUT-OF-SPEC`), 135 (`T-BC HOLDOVER IN-SPEC`), 165 (`T-BC HOLDOVER OUT-OF-SPEC`), 248 (`DEFAULT`), or 255 (`SLAVE ONLY CLOCK`).
-Applicable to T-GM clocks only.
 |`{node="compute-1.example.com",process="ptp4l"} 6`
 
 |`openshift_ptp_clock_state`
@@ -35,21 +29,16 @@ Possible values for PTP clock state are `FREERUN`, `LOCKED`, or `HOLDOVER`.
 |Returns the delay in nanoseconds between the primary clock sending the timing packet and the secondary clock receiving the timing packet.
 |`{from="master", iface="ens2fx", node="compute-1.example.com", process="ts2phc"} 0`
 
+|`openshift_ptp_ha_profile_status`
+|Returns the current status of the highly available system clock when there are multiple time sources on different NICs.
+Possible values are 0 (`INACTIVE`) and 1 (`ACTIVE`).
+|`{node="node1",process="phc2sys",profile="profile1"} 1`
+`{node="node1",process="phc2sys",profile="profile2"} 0`
+
 |`openshift_ptp_frequency_adjustment_ns`
 |Returns the frequency adjustment in nanoseconds between 2 PTP clocks.
 For example, between the upstream clock and the NIC, between the system clock and the NIC, or between the PTP hardware clock (`phc`) and the NIC.
-Applicable to T-GM clocks only.
 |`{from="phc", iface="CLOCK_REALTIME", node="compute-1.example.com", process="phc2sys"} -6768`
-
-|`openshift_ptp_frequency_status`
-|Returns the current status of the digital phase-locked loop (DPLL) frequency for the NIC.
-Possible values are -1 (`UNKNOWN`), 0 (`INVALID`), 1 (`FREERUN`), 2 (`LOCKED`), 3 (`LOCKED_HO_ACQ`), or 4 (`HOLDOVER`).
-|`{from="dpll",iface="ens2fx",node="compute-1.example.com",process="dpll"} 3`
-
-|`openshift_ptp_phase_status`
-|Returns the status of the DPLL phase for the NIC.
-Possible values are -1 (`UNKNOWN`), 0 (`INVALID`), 1 (`FREERUN`), 2 (`LOCKED`), 3 (`LOCKED_HO_ACQ`), or 4 (`HOLDOVER`).
-|`{from="dpll",iface="ens2fx",node="compute-1.example.com",process="dpll"} 3`
 
 |`openshift_ptp_interface_role`
 |Returns the configured PTP clock role for the interface.
@@ -59,20 +48,18 @@ Possible values are 0 (`PASSIVE`), 1 (`SLAVE`), 2 (`MASTER`), 3 (`FAULTY`), 4 (`
 |`openshift_ptp_max_offset_ns`
 |Returns the maximum offset in nanoseconds between 2 clocks or interfaces.
 For example, between the upstream GNSS clock and the NIC (`ts2phc`), or between the PTP hardware clock (`phc`) and the system clock (`phc2sys`).
-Applicable to T-GM clocks only.
 |`{from="master", iface="ens2fx", node="compute-1.example.com", process="ts2phc"} 1.038099569e+09`
 
 |`openshift_ptp_offset_ns`
 |Returns the offset in nanoseconds between the DPLL clock or the GNSS clock source and the NIC hardware clock.
-Applicable to T-GM clocks only.
 |`{from="phc", iface="CLOCK_REALTIME", node="compute-1.example.com", process="phc2sys"} -9`
 
 |`openshift_ptp_process_restart_count`
-|Returns a count of the number of times the `ptp4l` process was restarted.
+|Returns a count of the number of times the `ptp4l` and `ts2phc` processes were restarted.
 |`{config="ptp4l.0.config", node="compute-1.example.com",process="phc2sys"} 1`
 
 |`openshift_ptp_process_status`
-|Returns a status code that shows whether the PTP process is running or not.
+|Returns a status code that shows whether the PTP processes are running or not.
 |`{config="ptp4l.0.config", node="compute-1.example.com",process="phc2sys"} 1`
 
 |`openshift_ptp_threshold`
@@ -82,17 +69,41 @@ a|Returns values for `HoldOverTimeout`, `MaxOffsetThreshold`, and `MinOffsetThre
 * `maxOffsetThreshold` and `minOffsetThreshold` are offset values in nanoseconds that compare against the values for `CLOCK_REALTIME` (`phc2sys`) or master offset (`ptp4l`) values that you configure in the `PtpConfig` CR for the NIC.
 |`{node="compute-1.example.com", profile="grandmaster", threshold="HoldOverTimeout"} 5`
 
-|`openshift_ptp_pps_status`
-|Returns the current status of the NIC 1PPS connection.
-You use the 1PPS connection to synchronize timing between connected NICs.
-Possible values are 0 (`UNAVAILABLE`) and 1 (`AVAILABLE`).
-|`{from="dpll",iface="ens2fx",node="compute-1.example.com",process="dpll"} 1`
+|====
+
+[discrete]
+== PTP fast event metrics only when T-GM is enabled
+
+The following table describes the PTP fast event metrics that are available only when PTP grandmaster clock (T-GM) is enabled.
+
+.PTP fast event metrics when T-GM is enabled
+[cols="1,4,3", options="header"]
+|====
+|Metric
+|Description
+|Example
+
+|`openshift_ptp_frequency_status`
+|Returns the current status of the digital phase-locked loop (DPLL) frequency for the NIC.
+Possible values are -1 (`UNKNOWN`), 0 (`INVALID`), 1 (`FREERUN`), 2 (`LOCKED`), 3 (`LOCKED_HO_ACQ`), or 4 (`HOLDOVER`).
+|`{from="dpll",iface="ens2fx",node="compute-1.example.com",process="dpll"} 3`
 
 |`openshift_ptp_nmea_status`
 |Returns the current status of the NMEA connection.
 NMEA is the protocol that is used for 1PPS NIC connections.
 Possible values are 0 (`UNAVAILABLE`) and 1 (`AVAILABLE`).
 |`{iface="ens2fx",node="compute-1.example.com",process="ts2phc"} 1`
+
+|`openshift_ptp_phase_status`
+|Returns the status of the DPLL phase for the NIC.
+Possible values are -1 (`UNKNOWN`), 0 (`INVALID`), 1 (`FREERUN`), 2 (`LOCKED`), 3 (`LOCKED_HO_ACQ`), or 4 (`HOLDOVER`).
+|`{from="dpll",iface="ens2fx",node="compute-1.example.com",process="dpll"} 3`
+
+|`openshift_ptp_pps_status`
+|Returns the current status of the NIC 1PPS connection.
+You use the 1PPS connection to synchronize timing between connected NICs.
+Possible values are 0 (`UNAVAILABLE`) and 1 (`AVAILABLE`).
+|`{from="dpll",iface="ens2fx",node="compute-1.example.com",process="dpll"} 1`
 
 |`openshift_ptp_gnss_status`
 |Returns the current status of the global navigation satellite system (GNSS) connection.


### PR DESCRIPTION
Version(s):
4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Cherry-picked from: 38753ca0794f7566d9c9addaaea8a77f5c6b9d22

xref: https://github.com/openshift/openshift-docs/pull/78979