### PR TITLE
[enterprise-4.17+]: Update network-flow-matrix ports

### DIFF
--- a/snippets/network-flow-matrix.csv
+++ b/snippets/network-flow-matrix.csv
@@ -1,14 +1,16 @@
 Direction,Protocol,Port,Namespace,Service,Pod,Container,Node Role,Optional
 Ingress,TCP,22,Host system service,sshd,,,master,TRUE
 Ingress,TCP,53,openshift-dns,dns-default,dnf-default,dns,master,FALSE
+Ingress,TCP,80,openshift-ingress,router-default,router-default,router,master,FALSE
 Ingress,TCP,111,Host system service,rpcbind,,,master,TRUE
+Ingress,TCP,443,openshift-ingress,router-default,router-default,router,master,FALSE
 Ingress,TCP,2379,openshift-etcd,etcd,etcd,etcdctl,master,FALSE
 Ingress,TCP,2380,openshift-etcd,healthz,etcd,etcd,master,FALSE
 Ingress,TCP,5050,openshift-machine-api,,ironic-proxy,ironic-proxy,master,FALSE
 Ingress,TCP,6080,openshift-kube-apiserver,,kube-apiserver,kube-apiserver-insecure-readyz,master,FALSE
 Ingress,TCP,6385,openshift-machine-api,,ironic-proxy,ironic-proxy,master,FALSE
 Ingress,TCP,6443,openshift-kube-apiserver,apiserver,kube-apiserver,kube-apiserver,master,FALSE
-Ingress,TCP,8080,openshift-network-operator   ,,network-operator,network-operator,master,FALSE
+Ingress,TCP,8080,openshift-network-operator,,network-operator,network-operator,master,FALSE
 Ingress,TCP,8798,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,machine-config-daemon,master,FALSE
 Ingress,TCP,9001,openshift-machine-config-operator,machine-config-daemon,machine-config-daemon,kube-rbac-proxy,master,FALSE
 Ingress,TCP,9099,openshift-cluster-version,cluster-version-operator,cluster-version-operator,cluster-version-operator,master,FALSE
@@ -60,7 +62,7 @@ Ingress,TCP,9637,openshift-machine-config-operator,kube-rbac-proxy-crio,kube-rba
 Ingress,TCP,10250,Host system service,kubelet,,,worker,FALSE
 Ingress,TCP,10256,openshift-ovn-kubernetes,ovnkube,ovnkube,ovnkube-controller,worker,TRUE
 Ingress,TCP,10300,openshift-cluster-csi-drivers,csi-livenessprobe,csi-driver-node,csi-driver,worker,FALSE
-Ingress,TCP,10309,openshift-cluster-csi-drivers,csi-node-driver-registrar,csi-driver-node,csi-node-driver-registrar,worker,FALSE
+Ingress,TCP,10309,openshift-cluster-csi-drivers,csi-node-driver,csi-driver-node,csi-node-driver-registrar,worker,FALSE
 Ingress,TCP,18080,openshift-kni-infra,,coredns,coredns,worker,FALSE
 Ingress,UDP,53,openshift-dns,dns-default,dnf-default,dns,worker,FALSE
 Ingress,UDP,111,Host system service,rpcbind,,,worker,TRUE


### PR DESCRIPTION
Add missing ports and fix wrong info.

Version(s):
4.17

Link to docs preview:
https://80339--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall#network-flow-matrix_configuring-firewall
