### PR TITLE
OBSDOCS-1223: Logging 5.6.22 rn 4.13

### DIFF
--- a/modules/logging-release-notes-5-6-22.adoc
+++ b/modules/logging-release-notes-5-6-22.adoc
@@ -1,0 +1,17 @@
+// module included in /logging/logging-5-6-release-notes
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-5-6-22_{context}"]
+= Logging 5.6.22
+This release includes link:https://access.redhat.com/errata/RHBA-2024:5125[OpenShift Logging Bug Fix 5.6.22]
+
+[id="logging-release-notes-5-6-22-bug-fixes"]
+== Bug fixes
+* Before this update, the Loki Operator overwrote user annotations on the LokiStack Route resource, causing customizations to drop. With this update, the Loki Operator no longer overwrites Route annotations, fixing the issue. (link:https://issues.redhat.com/browse/LOG-5947[LOG-5947])
+
+[id="logging-release-notes-5-6-22-CVEs"]
+== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2023-2953[CVE-2023-2953]
+* link:https://access.redhat.com/security/cve/CVE-2024-3651[CVE-2024-3651]
+* link:https://access.redhat.com/security/cve/CVE-2024-24806[CVE-2024-24806]
+* link:https://access.redhat.com/security/cve/CVE-2024-28182[CVE-2024-28182]
+* link:https://access.redhat.com/security/cve/CVE-2024-35235[CVE-2024-35235]

--- a/observability/logging/logging_release_notes/logging-5-6-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-6-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-6-22.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-6-21.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-6-20.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Logging Z-Stream Release Notes - 5.6.22
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1223

Fix Version: 4.12, 4.13

Doc Preview: https://80342--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging_release_notes/logging-5-6-release-notes.html#logging-release-notes-5-6-22_logging-5-6-release-notes

SME Review: @xperimental 
QE Review: @anpingli 
Peer Review: @lahinson 