### PR TITLE
OBSDOCS-1225: Logging 5.9.5 Release Notes

### DIFF
--- a/modules/logging-release-notes-5-9-5.adoc
+++ b/modules/logging-release-notes-5-9-5.adoc
@@ -1,0 +1,18 @@
+//module included in logging-5-9-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-5-9-5_{context}"]
+= Logging 5.9.5
+This release includes link:https://access.redhat.com/errata/RHBA-2024:5122[OpenShift Logging Bug Fix Release 5.9.5]
+
+[id="logging-release-notes-5-9-5-bug-fixes"]
+== Bug Fixes
+
+* Before this update, duplicate conditions in the LokiStack resource status led to invalid metrics from the Loki Operator. With this update, the Operator removes duplicate conditions from the status. (link:https://issues.redhat.com/browse/LOG-5855[LOG-5855])
+
+* Before this update, the Loki Operator did not trigger alerts when it dropped log events due to validation failures. With this update, the Loki Operator includes a new alert definition that triggers an alert if Loki drops log events due to validation failures. (link:https://issues.redhat.com/browse/LOG-5895[LOG-5895])
+
+* Before this update, the Loki Operator overwrote user annotations on the LokiStack Route resource, causing customizations to drop. With this update, the Loki Operator no longer overwrites Route annotations, fixing the issue. (link:https://issues.redhat.com/browse/LOG-5945[LOG-5945])
+
+[id="logging-release-notes-5-9-5-CVEs"]
+== CVEs
+None.

--- a/observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-release-notes-5-9-5.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-9-4.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-9-3.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Logging Z-Stream Release Notes - 5.9.5
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1225

Fix Version: 4.13, 4.14, 4.15, 4.16

Doc Preview: https://80344--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/logging_release_notes/logging-5-9-release-notes.html#logging-release-notes-5-9-5_logging-5-9-release-notes

SME Review: @xperimental 
QE Review: @kabirbhartiRH 
Peer Review: @ShaunaDiaz 