### PR TITLE
OSDOCS-10923: adds 4.16.7 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -252,3 +252,11 @@ Issued: 2024-08-06
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
 
+[id="microshift-4-16-7-dp_{context}"]
+=== RHBA-2024:5109 - {microshift-short} 4.16.7 bug fix and enhancement advisory
+
+Issued: 2024-08-13
+
+{product-title} release 4.16.7 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:5109[RHBA-2024:5109] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:5107[RHSA-2024:5107] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-10923](https://issues.redhat.com/browse/OSDOCS-10923)

Link to docs preview:
[4-16-7 async relnote](https://80346--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-7-dp_release-notes)

QE review:
- N/A stock text

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
