### PR TITLE
ROX-25673: Add instructions to set POD_NAMESPACE to the docs

### DIFF
--- a/modules/add-pod-namespace-to-sensor-and-admission-control.adoc
+++ b/modules/add-pod-namespace-to-sensor-and-admission-control.adoc
@@ -18,7 +18,7 @@ If you are using Kubernetes, use `kubectl` instead of `oc` for the commands list
 . Navigate to your secured cluster bundle.
 . Open the `sensor.yaml` file in an editor
 . Navigate to `spec -> template -> spec -> containers -> env`
-. Add the following `env` entry:
+. Add the following entry under `env`:
 +
 [source,yaml,subs=attributes+]
 ----
@@ -27,4 +27,11 @@ If you are using Kubernetes, use `kubectl` instead of `oc` for the commands list
       fieldRef:
         fieldPath: metadata.namespace
 ----
-. Add the same entry to `admission-controller.yaml`
+. Apply the modified deployment `sensor.yaml` file to the cluster
++
+[source,terminal,subs=attributes+]
+----
+$ oc -n stackrox apply -f sensor.yaml
+----
+
+Repeat this procedure for `admission-controller.yaml`

--- a/modules/add-pod-namespace-to-sensor-and-admission-control.adoc
+++ b/modules/add-pod-namespace-to-sensor-and-admission-control.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * upgrade/upgrade-from-45.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="add-pod-namespace-to-sensor-and-admission-control_{context}"]
+= Add `POD_NAMESPACE` to `sensor` and `admission-control` deployments
+
+[role="_abstract"]
+You must update the sensor and admission-control deployment .yaml files to set the `POD_NAMESPACE` environment variable.
+
+[NOTE]
+====
+If you are using Kubernetes, use `kubectl` instead of `oc` for the commands listed in this procedure.
+====
+
+.Procedure
+
+. Navigate to your secured cluster bundle.
+. Open the `sensor.yaml` file in an editor
+. Navigate to `spec -> template -> spec -> containers -> env`
+. Add the following `env` entry:
++
+[source,yaml,subs=attributes+]
+----
+  - name: POD_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+----
+. Add the same entry to `admission-controller.yaml`

--- a/modules/add-pod-namespace-to-sensor-and-admission-control.adoc
+++ b/modules/add-pod-namespace-to-sensor-and-admission-control.adoc
@@ -15,23 +15,15 @@ If you are using Kubernetes, use `kubectl` instead of `oc` for the commands list
 
 .Procedure
 
-. Navigate to your secured cluster bundle.
-. Open the `sensor.yaml` file in an editor
-. Navigate to `spec -> template -> spec -> containers -> env`
-. Add the following entry under `env`:
-+
-[source,yaml,subs=attributes+]
-----
-  - name: POD_NAMESPACE
-    valueFrom:
-      fieldRef:
-        fieldPath: metadata.namespace
-----
-. Apply the modified deployment `sensor.yaml` file to the cluster
+. Patch sensor to ensure `POD_NAMESPACE` is set:
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox apply -f sensor.yaml
+$ oc -n stackrox patch deployment sensor --type=json -p '[{"op":"add","path":"/spec/template/spec/containers/0/env/-","value":{"name":"POD_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}}}]'
 ----
-
-Repeat this procedure for `admission-controller.yaml`
+. Patch admission-control to ensure `POD_NAMESPACE` is set:
++
+[source,terminal,subs=attributes+]
+----
+$ oc -n stackrox patch deployment admission-control --type=json -p '[{"op":"add","path":"/spec/template/spec/containers/0/env/-","value":{"name":"POD_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}}}]'
+----

--- a/upgrading/upgrade-roxctl.adoc
+++ b/upgrading/upgrade-roxctl.adoc
@@ -73,6 +73,8 @@ To complete manual upgrades of each secured cluster running Sensor, Collector, a
 
 include::modules/update-other-images.adoc[leveloffset=+2]
 
+include::modules/add-pod-namespace-to-sensor-and-admission-control.adoc[leveloffset=+2]
+
 .Next steps
 * xref:../upgrading/upgrade-roxctl.adoc#verify-secured-cluster-upgrade_upgrade-roxctl[Verifying secured cluster upgrade]
 


### PR DESCRIPTION
Version(s):
4.6+

[Issue](https://issues.redhat.com/browse/ROX-25673)

Links to doc preview:

QE review:

Additional comments:

[ROX-25673](https://issues.redhat.com//browse/ROX-25673) introduces a change in the way that our `sensor` and `admission-control` deployments determine their own namespace. Instead of querying the serviceaccount namespace file, we now uniformly rely on setting the `POD_NAMESPACE` env var in the deployment via the k8s Downward API. This will be our one source of truth for the namespace a pod is in.

Since `sensor` and `admission-control` deployments were previously NOT always setting this env variable, it is imperative that users of our manifest-based manual installation method update their `.yaml` files for those two deployments. This PR adds manual upgrade instructions for release 4.6 for this purpose.

Related JIRA: https://issues.redhat.com/browse/ROX-25673
Related Stackrox PR:  https://github.com/stackrox/stackrox/pull/12278