### PR TITLE
Changed the product-title names for ROSA classic and ROSA with HCP

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -181,7 +181,7 @@ openshift-aro:
       name: '4'
       dir: aro/4
 openshift-rosa:
-  name: Red Hat OpenShift Service on AWS
+  name: Red Hat OpenShift Service on AWS (classical architecture)
   author: OpenShift Documentation Project <openshift-docs@redhat.com>
   site: commercial
   site_name: Documentation


### PR DESCRIPTION
This PR changes the distro names for HCP and ROSA:

* ROSA Classic = `Red Hat OpenShift Service on AWS (classical architecture)`
    * [Welcome](https://80362--ocpdocs-pr.netlify.app/openshift-rosa/latest/welcome/)
        ![image](https://github.com/user-attachments/assets/0dc3858e-51ee-46f1-99d9-764399c4f01f)

* ROSA with HCP = `Red Hat OpenShift Service on AWS`
    * [Welcome](https://file.rdu.redhat.com/eponvell/HCP-Distro-Name/rosa_architecture/index.html)
        ![image](https://github.com/user-attachments/assets/5a9b6906-5641-492b-8a5d-4d1319634500)