### PR TITLE
OSDOCS-11684: Remove distro line left behind in topic map

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -650,7 +650,6 @@ Topics:
   File: ibmz-post-install
 - Name: Regions and zones for a VMware vCenter
   File: post-install-vsphere-zones-regions-configuration
-  Distros: openshift-origin,openshift-enterprise
 - Name: AWS Local Zone or Wavelength Zone tasks
   File: aws-compute-edge-zone-tasks
   Distros: openshift-enterprise


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-11684

Link to docs preview:
N/A - doesn't affect anything that's visible in docs, just the topic map

QE review:
N/A

Additional information:
Removing a line about a distro that was accidentally left behind after a different topic was removed
