### PR TITLE
HCIDOCS-216: Adding a workaround module forward to 4.12.

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -106,4 +106,6 @@ include::modules/ipi-install-mirroring-for-disconnected-registry.adoc[leveloffse
 
 include::modules/ipi-modify-install-config-for-a-disconnected-registry.adoc[leveloffset=+2]
 
+include::modules/ipi-install-assigning-a-static-ip-address-to-the-bootstrap-vm.adoc[leveloffset=+1]
+
 include::modules/ipi-install-validation-checklist-for-installation.adoc[leveloffset=+1]

--- a/modules/ipi-install-assigning-a-static-ip-address-to-the-bootstrap-vm.adoc
+++ b/modules/ipi-install-assigning-a-static-ip-address-to-the-bootstrap-vm.adoc
@@ -1,0 +1,67 @@
+// This is included in the following assemblies:
+//
+// ipi-install-installation-workflow.adoc
+
+:_content-type: PROCEDURE
+[id="assigning-a-static-ip-address-to-the-bootstrap-vm_{context}"]
+= Assigning a static IP address to the bootstrap VM
+
+If you are deploying {product-title} without a DHCP server on the `baremetal` network, you must configure a static IP address for the bootstrap VM using Ignition.
+
+.Procedure
+
+. Create the ignition configuration files:
++
+[source,terminal]
+----
+$ ./openshift-baremetal-install --dir <cluster_configs> create ignition-configs
+----
++
+Replace `<cluster_configs>` with the path to your cluster configuration files.
+
+. Create the `bootstrap_config.sh` file:
++
+[source,bash]
+----
+#!/bin/bash
+
+BOOTSTRAP_CONFIG="[connection]
+type=ethernet
+interface-name=ens3
+[ethernet]
+[ipv4]
+method=manual
+addresses=<ip_address>/<cidr>
+gateway=<gateway_ip_address>
+dns=<dns_ip_address>"
+
+cat <<_EOF_ > bootstrap_network_config.ign
+{
+  "path": "/etc/NetworkManager/system-connections/ens3.nmconnection",
+  "mode": 384,
+  "contents": {
+    "source": "data:text/plain;charset=utf-8;base64,$(echo "${BOOTSTRAP_CONFIG}" | base64 -w 0)"
+  }
+}
+_EOF_
+
+mv <cluster_configs>/bootstrap.ign <cluster_configs>/bootstrap.ign.orig
+
+jq '.storage.files += $input' <cluster_configs>/bootstrap.ign.orig --slurpfile input bootstrap_network_config.ign > <cluster_configs>/bootstrap.ign
+----
++
+Replace `<ip_address>` and `<cidr>` with the IP address and CIDR of the address range. Replace `<gateway_ip_address>` with the IP address of the gateway on the `baremetal` network. Replace `<dns_ip_address>` with the IP address of the DNS server on the `baremetal` network. Replace `<cluster_configs>` with the path to your cluster configuration files.
+
+. Make the `bootstrap_config.sh` file executable:
++
+[source,terminal]
+----
+$ chmod 755 bootstrap_config.sh
+----
+
+. Run the `bootstrap_config.sh` script to create the `bootstrap_network_config.ign` file:
++
+[source,terminal]
+----
+$ ./bootstrap_config.sh
+----


### PR DESCRIPTION
Added a workaround module to 4.12. This module has not changed. It was originally published in 4.10.

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/HCIDOCS-216
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://80373--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#assigning-a-static-ip-address-to-the-bootstrap-vm_ipi-install-installation-workflow
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
