### PR TITLE
OCPBUGS-38405 Remove note Currently, disabling CPU load balancing is …

### DIFF
--- a/modules/nodes-clusters-cgroups-2.adoc
+++ b/modules/nodes-clusters-cgroups-2.adoc
@@ -38,11 +38,6 @@ endif::nodes[]
 :FeatureName: cgroup v1
 include::snippets/deprecated-feature.adoc[]
 
-[NOTE]
-====
-Currently, disabling CPU load balancing is not supported by cgroup v2. As a result, you might not get the desired behavior from performance profiles if you have cgroup v2 enabled. Enabling cgroup v2 is not recommended if you are using performance profiles.
-====
-
 .Prerequisites
 * You have a running {product-title} cluster that uses version 4.12 or later.
 * You are logged in to the cluster as a user with administrative privileges.


### PR DESCRIPTION
[OCPBUGS-38405]: Issue in file nodes/clusters/nodes-cluster-cgroups-2.adoc
Version(s): 4.16, 4.17  and main

Issue: https://issues.redhat.com/browse/OCPBUGS-38405 and https://issues.redhat.com/browse/TELCODOCS-1930

Link to docs preview:

https://80389--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-cgroups-2.html
https://80389--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html

QE review:

 QE has approved this change.

Additional information: Another instance of note found in published doc needs removed as per https://issues.redhat.com/browse/TELCODOCS-1930

