### PR TITLE
CNV-39711: Updated correct api version in snapshot restore

### DIFF
--- a/modules/virt-restoring-vm-from-snapshot-cli.adoc
+++ b/modules/virt-restoring-vm-from-snapshot-cli.adoc
@@ -18,7 +18,7 @@ You can restore an existing virtual machine (VM) to a previous configuration by 
 +
 [source,yaml]
 ----
-apiVersion: snapshot.kubevirt.io/v1beta1
+apiVersion: snapshot.kubevirt.io/v1alpha1
 kind: VirtualMachineRestore
 metadata:
   name: <vm_restore>


### PR DESCRIPTION
Version(s):
4.16, 4.15, 4.14

Issue: [CNV-39711](https://issues.redhat.com/browse/CNV-39711)

[Link to docs preview](https://80391--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-backup-restore-snapshots.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This is a very small change that is duplicated across 3 product branches, and the targeted feature docs exist in the backported releases. I would be happy if we could cherry pick this PR to the other branches to prevent extra busy work for my QEs, if at all possible. If not, then I'll create separate PRs.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
