### PR TITLE
[serverless-docs-1.32] Manual CP for SRVCOM-3239: Add a release notes entry about "SRVCOM-3203" in Serverless version 1.32.2

### DIFF
--- a/about/serverless-release-notes.adoc
+++ b/about/serverless-release-notes.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-release-notes"]
+include::_attributes/common-attributes.adoc[]
 = Release notes
 :context: serverless-release-notes
 
@@ -27,7 +27,9 @@ include::modules/serverless-tech-preview-features.adoc[leveloffset=+1]
 include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 
 // Release notes included, most to least recent
+
 // OCP + OSD + ROSA
+include::modules/serverless-rn-1-32-2.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-32-0.adoc[leveloffset=+1]
 
 // OCP + OSD + ROSA

--- a/modules/serverless-rn-1-32-2.adoc
+++ b/modules/serverless-rn-1-32-2.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies
+//
+// * about/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-32-2_{context}"]
+= Red Hat {ServerlessProductName} 1.32.2
+
+{ServerlessProductName} 1.32.2 is now available. Fixed issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes:
+
+[id="fixed-issues-1-32-2_{context}"]
+== Fixed issues
+
+* Previously, post-install batch jobs were removed after a certain period, leaving privileged service accounts unbound. This caused compliance systems to flag the issue. The problem has been resolved by retaining completed jobs, ensuring that service accounts remain bound.


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/openshift-docs/pull/80283

**Affecting version:** `serverless-docs-1.32`

**Doc Preview:** https://80392--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-rn-1-32-2_serverless-release-notes

**cherry picked from:** https://github.com/openshift/openshift-docs/pull/80283/commits/5950b14d039626d46836839411b1aa63b3f89508

**Merge Reviewer:** @ShaunaDiaz