### PR TITLE
OCPBUGS-38402: Updated the Example policy configurations for differen…

### DIFF
--- a/modules/virt-nmstate-example-policy-configurations.adoc
+++ b/modules/virt-nmstate-example-policy-configurations.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="virt-nmstate-example-policy-configurations_{context}"]
+= Example policy configurations for different interfaces
+
+Before you read the different example `NodeNetworkConfigurationPolicy` (NNCP) manifest configurations, consider the following factors when you apply a policy so that your cluster runs at its best performance conditions:
+
+* When you need to apply a policy to more than one node, create a `NodeNetworkConfigurationPolicy` manifest for each target node. The Kubernetes NMState Operator applies the policy to each node with an NNCP in an unspecified order. Scoping a policy with this approach reduces the length of time for policy application but risks a cluster-wide outage if an error is in the cluster's configuration. To avoid this type of error, initially apply NNCP to some nodes, and after you confirm they are configured correctly, proceed with applying the policy to the remaining nodes.
+
+* When you need to apply a policy to many nodes but you only want to create a single NNCP for all target nodes, the Kubernetes NMState Operator applies the policy to each node in sequence. You can set the speed and coverage of policy application for target nodes with the `maxUnavailable` parameter in the cluster configuration. By setting a lower percentage value for the parameter, you can reduce the risk of a cluster-wide outage if the outage impacts the small percentage of nodes that are receiving the policy application.
+
+* Consider specifying all related network configurations in a single policy.
+
+* When a node restarts, the Kubernetes NMState Operator cannot control the order that it applies policies to nodes. The Kubernetes NMState Operator might apply interdependent policies in a sequence that results in a degraded network object.

--- a/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
@@ -35,20 +35,8 @@ include::modules/virt-confirming-policy-updates-on-nodes.adoc[leveloffset=+2]
 
 include::modules/virt-removing-interface-from-nodes.adoc[leveloffset=+2]
 
-[id="virt-nmstate-example-policy-configurations"]
-== Example policy configurations for different interfaces
-
-The following examples show different `NodeNetworkConfigurationPolicy` manifest configurations.
-
-For best performance, consider the following factors when applying a policy:
-
-* When you need to apply a policy to more than one node, create a `NodeNetworkConfigurationPolicy` manifest for each target node. Scoping a policy to a single node reduces the overall length of time for the Kubernetes NMState Operator to apply the policies.
-+
-In contrast, if a single policy includes configurations for several nodes, the Kubernetes NMState Operator applies the policy to each node in sequence, which increases the overall length of time for policy application.
-
-* All related network configurations should be specified in a single policy.
-+
-When a node restarts, the Kubernetes NMState Operator cannot control the order in which policies are applied. Therefore, the Kubernetes NMState Operator might apply interdependent policies in a sequence that results in a degraded network object.
+// Example policy configurations for different interfaces
+include::modules/virt-nmstate-example-policy-configurations.adoc[leveloffset=+1]
 
 include::modules/virt-example-bridge-nncp.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-38402](https://issues.redhat.com/browse/OCPBUGS-38402)

Link to docs preview:
[Example policy configurations for different interfaces](https://80393--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#virt-nmstate-example-policy-configurations_k8s_nmstate-updating-node-network-config)

- [x] SME has approved this change.
- [x] QE has approved this change. (Zhanqi Zhao)

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
