### PR TITLE
GH#79339: Update the command syntax for 4.13 version

### DIFF
--- a/modules/nw-ovn-kubernetes-migration.adoc
+++ b/modules/nw-ovn-kubernetes-migration.adoc
@@ -64,7 +64,8 @@ EOT
 +
 [source,terminal]
 ----
-oc patch Network.operator.openshift.io cluster --type='merge' /  --patch '{"spec":{"migration":null}}'
+$ oc patch Network.operator.openshift.io cluster --type='merge' \
+--patch '{"spec":{"migration":null}}'
 ----
 
 . To prepare all the nodes for the migration, set the `migration` field on the CNO configuration object by running the following command:


### PR DESCRIPTION
GH#79339: Fix patch command syntax for CNO migration from SDN to OVN

Version(s):
4.13 and 4.12
Note: For versions 4.14+, see https://github.com/openshift/openshift-docs/pull/80390

Issue:
https://github.com/openshift/openshift-docs/issues/79339

Link to docs preview:
https://80396--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#nw-ovn-kubernetes-migration_migrate-from-openshift-sdn

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

