### PR TITLE
HCIDOCS-441: Update sandboxed containers attributes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -47,11 +47,7 @@ endif::[]
 :rh-rhacm-first: Red Hat Advanced Cluster Management (RHACM)
 :rh-rhacm: RHACM
 :rh-rhacm-version: 2.11
-:sandboxed-containers-first: OpenShift sandboxed containers
-:sandboxed-containers-operator: OpenShift sandboxed containers Operator
-:sandboxed-containers-version: 1.5
-:sandboxed-containers-version-z: 1.5.0
-:sandboxed-containers-legacy-version: 1.4.1
+:osc: OpenShift sandboxed containers
 :cert-manager-operator: cert-manager Operator for Red Hat OpenShift
 :secondary-scheduler-operator-full: Secondary Scheduler Operator for Red Hat OpenShift
 :secondary-scheduler-operator: Secondary Scheduler Operator

--- a/modules/security-compliance-nist.adoc
+++ b/modules/security-compliance-nist.adoc
@@ -1,17 +1,10 @@
 // Module included in the following assemblies:
 //
 // * security/container_security/security-compliance.adoc
-// * understanding-sandboxed-containers.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="security-compliance-nist_{context}"]
 = Understanding compliance and risk management
-
-ifeval::["{context}" == "understanding-sandboxed-containers"]
-{sandboxed-containers-first} can be used on FIPS enabled clusters.
-
-When running in FIPS mode, {sandboxed-containers-first} components, VMs, and VM images are adapted to comply with FIPS.
-endif::[]
 
 ifndef::openshift-origin[]
 FIPS compliance is one of the most critical components required in

--- a/sandboxed_containers/sandboxed-containers-moved.adoc
+++ b/sandboxed_containers/sandboxed-containers-moved.adoc
@@ -4,4 +4,4 @@
 include::_attributes/common-attributes.adoc[]
 :context: sandboxed-containers-moved
 
-The {sandboxed-containers-first} user guide and release notes have moved to a new link:https://access.redhat.com/documentation/en-us/openshift_sandboxed_containers/[location].
+The {osc} user guide and release notes have moved to a new link:https://access.redhat.com/documentation/en-us/openshift_sandboxed_containers/[location].

--- a/welcome/oke_about.adoc
+++ b/welcome/oke_about.adoc
@@ -215,8 +215,8 @@ derived from the istio.io open source project, is not supported in {oke}. Also,
 the Kourier Ingress Controller found in OpenShift Serverless is not supported
 on {oke}.
 
-=== {sandboxed-containers-first}
-{oke} does not include {sandboxed-containers-first}. Use {product-title} for this support.
+=== {osc}
+{oke} does not include {osc}. Use {product-title} for this support.
 
 === Developer experience
 With {oke}, the following capabilities are not supported:


### PR DESCRIPTION
Removed unused OpenShift Sandboxed containers attributes.

Updated remaining attribute to align with OSC docs attributes.

(The Vale rule for OCP SuggestAttributes will be fixed in a separate PR)

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [HCIDOCS-441](https://issues.redhat.com//browse/HCIDOCS-441)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [preview](https://80397--ocpdocs-pr.netlify.app/openshift-enterprise/latest/sandboxed_containers/sandboxed-containers-moved)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: NA
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
