### PR TITLE
OCPBUGS-35405-414-2 Updating note Currently, disabling CPU load balancing i…

### DIFF
--- a/modules/cnf-understanding-low-latency.adoc
+++ b/modules/cnf-understanding-low-latency.adoc
@@ -26,7 +26,7 @@ To revert all nodes in the cluster to the cgroups v2 configuration, you must edi
 
 [NOTE]
 ====
-Currently, disabling CPU load balancing is not supported by cgroup v2. As a result, you might not get the desired behavior from performance profiles if you have cgroup v2 enabled. Enabling cgroup v2 is not recommended if you are using performance profiles.
+In Telco, clusters using `PerformanceProfile` for low latency, real-time, and Data Plane Development Kit (DPDK) workloads automatically revert to cgroups v1 due to the lack of cgroups v2 support. Enabling cgroup v2 is not supported if you are using `PerformanceProfile`.
 ====
 
 {product-title} also supports workload hints for the Node Tuning Operator that can tune the `PerformanceProfile` to meet the demands of different industry environments. Workload hints are available for `highPowerConsumption` (very low latency at the cost of increased power consumption) and `realTime` (priority given to optimum latency). A combination of `true/false` settings for these hints can be used to deal with application-specific workload profiles and requirements.


### PR DESCRIPTION
[OCPBUGS-35405 ]: Enabling cgroup v2 is not possible if you are using performance profiles

Version(s): 4.14

Issue: https://issues.redhat.com/browse/OCPBUGS-35405

Link to docs preview: not available


QE review:

QE has approved this change.

Additional information: This is another instance of the note that was updated for clarity in https://github.com/openshift/openshift-docs/pull/80214