### PR TITLE
OSSM-6938 [DOC] Update sample SMCP to show .spec.tracing.type: None

### DIFF
--- a/modules/ossm-control-plane-cli.adoc
+++ b/modules/ossm-control-plane-cli.adoc
@@ -47,14 +47,9 @@ metadata:
 spec:
   version: v{MaistraVersion}
   tracing:
-    type: Jaeger
+    type: None
     sampling: 10000
   addons:
-    jaeger:
-      name: jaeger
-      install:
-        storage:
-          type: Memory
     kiali:
       enabled: true
       name: kiali
@@ -79,17 +74,13 @@ spec:
     identity:
       type: ThirdParty <1>
   tracing:
-    type: Jaeger
+    type: None
     sampling: 10000
   policy:
     type: Istiod
   addons:
     grafana:
       enabled: true
-    jaeger:
-      install:
-        storage:
-          type: Memory
     kiali:
       enabled: true
     prometheus:
@@ -98,10 +89,10 @@ spec:
     type: Istiod
 ----
 ifdef::openshift-rosa[]
-<1> Specifies a required setting for {product-rosa}. 
+<1> Specifies a required setting for {product-rosa}.
 endif::openshift-rosa[]
 ifdef::openshift-dedicated[]
-<1> Specifies a required setting for {product-dedicated}. 
+<1> Specifies a required setting for {product-dedicated}.
 endif::openshift-dedicated[]
 endif::openshift-rosa,openshift-dedicated[]
 +


### PR DESCRIPTION
[OSSM-6938](https://issues.redhat.com//browse/OSSM-6938) [DOC] Update sample SMCP to show .spec.tracing.type: None

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSSM-6938

Link to docs preview:
https://80400--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-create-smcp.html#ossm-control-plane-deploy-cli_ossm-create-smcp

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

2 additional spaces were automatically removed from ROSA-added content.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
