### PR TITLE
OCPBUGS-38416: Update detaching seed sno cluster via GitOps ZTP

### DIFF
--- a/modules/cnf-image-based-upgrade-generate-seed-image.adoc
+++ b/modules/cnf-image-based-upgrade-generate-seed-image.adoc
@@ -33,9 +33,9 @@ $ oc delete managedcluster sno-worker-example
 
 ... Wait until the `ManagedCluster` CR is removed. After the CR is removed, create the proper `SeedGenerator` CR. The {lcao} cleans up the {rh-rhacm} artifacts.
 
-.. If you are using {ztp}, detach your cluster by removing the seed cluster's `SiteConfig` CR from the `kustomization.yaml`:
+.. If you are using {ztp}, detach your cluster by removing the seed cluster's `SiteConfig` CR from the `kustomization.yaml`.
 
-... Remove your seed cluster's `SiteConfig` CR from the `kustomization.yaml`.
+... If you have a `kustomization.yaml` file that references multiple `SiteConfig` CRs, remove your seed cluster's `SiteConfig` CR from the `kustomization.yaml`:
 +
 [source,yaml]
 ----
@@ -48,7 +48,17 @@ generators:
 - example-target-sno3.yaml
 ----
 
-... Commit the `kustomization.yaml` changes in your Git repository and push the changes.
+... If you have a `kustomization.yaml` that references one `SiteConfig` CR, remove your seed cluster's `SiteConfig` CR from the `kustomization.yaml` and add the `generators: {}` line:
++
+[source,yaml]
+----
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generators: {}
+----
+
+... Commit the `kustomization.yaml` changes in your Git repository and push the changes to your repository.
 +
 The ArgoCD pipeline detects the changes and removes the managed cluster.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16, 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-38416
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://80415--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/cnf-image-based-upgrade-generate-seed.html#cnf-image-based-upgrade-generate-seed-image_generate-seed
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
