### PR TITLE
Updating support information about masquerade subnets in documentation.

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -877,7 +877,7 @@ For more information about this feature, see xref:../networking/multiple_network
 [id="ocp-4-16-networking-changing-ovn-kubernetes-network-plugin-internal-range_{context}"]
 ==== Support for changing the OVN-Kubernetes network plugin internal IP address ranges
 
-If you use the OVN-Kubernetes network plugin, you can configure the transit, join, and masquerade subnets. The transit and join subnets can be configured either during cluster installation or after. The masquerade subnet must be configured during installation and cannot be changed after. The subnet defaults are:
+If you use the OVN-Kubernetes network plugin, you can configure the transit, join, and masquerade subnets. The transit, join and masquerade subnets can be configured either during cluster installation or after. The subnet defaults are:
 
 - Transit subnet: `100.88.0.0/16` and `fd97::/64`
 - Join subnet: `100.64.0.0/16` and `fd98::/64`


### PR DESCRIPTION
Updating information about changing the OVN-Kubernetes network plugin internal IP address ranges.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
https://issues.redhat.com/browse/OCPBUGS-37352

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-37352

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://docs.openshift.com/container-platform/4.16/release_notes/ocp-4-16-release-notes.html#ocp-4-16-networking-changing-ovn-kubernetes-network-plugin-internal-range_release-notes

QE review:
- [x] QE has approved this change.
- [x] SME approved
- [x] PX approved
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
As per the Internal article [1], we have procedure to modify the internalMasqueradeSubnet but in the release notes [2] updated that the masquerade subnet must be configured during installation only. We have also verifed during the hackathon that the masquerade subnet can be modified after the cluster installation.

[1]  https://access.redhat.com/articles/7076125
[2] https://docs.openshift.com/container-platform/4.16/release_notes/ocp-4-16-release-notes.html#ocp-4-16-networking-changing-ovn-kubernetes-network-plugin-internal-range_release-notes
    

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
