### PR TITLE
WMCO 10.15.3 release notes

### DIFF
--- a/windows_containers/wmco_rn/windows-containers-release-notes-10-15-x-past.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-10-15-x-past.adoc
@@ -8,6 +8,20 @@ toc::[]
 
 The following release notes are for previous versions of the Windows Machine Config Operator (WMCO).
 
+[id="wmco-10-15-2"]
+== Release notes for Red{nbsp}Hat Windows Machine Config Operator 10.15.2
+
+This release of the WMCO provides new features and bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.15.2 were released in link:https://access.redhat.com/errata/RHBA-2024:2704[RHBA-2024:2704].
+
+[id="wmco-10-15-2-bug-fixes"]
+=== Bug fixes
+
+* Previously, on Azure clusters the WMCO would check if an external Cloud Controller Manager (CCM) was being used on the cluster. CCM use is the default. If a CCM is being used, the Operator would adjust configuration logic accordingly. Because the status condition that the WMCO used to check for the CCM was removed, the WMCO proceeded as if a CCM was not in use. This fix removes the check. As a result, the WMCO always configures the required logic on Azure clusters. (link:https://issues.redhat.com/browse/OCPBUGS-31704[*OCPBUGS-31704*])
+
+* Previously, the kubelet was unable to authenticate with private Elastic Container Registries (ECR) registries. Because of this error, the kubelet was not able to pull images from these registries. With this fix, the kubelet is able to pull images from these registries as expected. (link:https://issues.redhat.com/browse/OCPBUGS-26602[*OCPBUGS-26602*])
+
+* Previously, the WMCO was logging error messages when any commands being run through an SSH connection to a Windows instance failed. This was incorrect behavior because some commands are expected to fail. For example, when WMCO reboots a node the Operator runs PowerShell commands on the instance until they fail, meaning the SSH connection rebooted as expected. With this fix, only actualy errors are now logged. (link:https://issues.redhat.com/browse/OCPBUGS-20255[*OCPBUGS-20255*])
+
 [id="wmco-10-15-1"]
 == Release notes for Red{nbsp}Hat Windows Machine Config Operator 10.15.1
 

--- a/windows_containers/wmco_rn/windows-containers-release-notes-10-15-x.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-10-15-x.adoc
@@ -14,18 +14,19 @@ The release notes for Red{nbsp}Hat OpenShift for Windows Containers tracks the d
 
 Starting with this release, y-stream releases of the WMCO will be in step with {product-title}, with only z-stream releases between {product-title} releases. The WMCO numbering reflects the associated {product-title} version in the y-stream position. For example, the current release of WMCO is associated with {product-title} version 4.15. Thus, the numbering is WMCO 10.15.z.
 
-[id="wmco-10-15-2"]
-== Release notes for Red{nbsp}Hat Windows Machine Config Operator 10.15.2
+[id="wmco-10-15-3"]
+== Release notes for Red{nbsp}Hat Windows Machine Config Operator 10.15.3
 
-This release of the WMCO provides new features and bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.15.2 were released in link:https://access.redhat.com/errata/RHBA-2024:2704[RHBA-2024:2704].
+This release of the WMCO provides new features and bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.15.3 were released in link:https://access.redhat.com/errata//RHSA-2024:5745[RHSA-2024:5745].
 
-[id="wmco-10-15-2-bug-fixes"]
+[id="wmco-10-13-2-bug-fixes"]
 === Bug fixes
 
-* Previously, on Azure clusters the WMCO would check if an external Cloud Controller Manager (CCM) was being used on the cluster. CCM use is the default. If a CCM is being used, the Operator would adjust configuration logic accordingly. Because the status condition that the WMCO used to check for the CCM was removed, the WMCO proceeded as if a CCM was not in use. This fix removes the check. As a result, the WMCO always configures the required logic on Azure clusters. (link:https://issues.redhat.com/browse/OCPBUGS-31704[*OCPBUGS-31704*])
+// Previously reviewed for WMCO 4.16
+* Previously, after rotating the `kube-apiserver-to-kubelet-client-ca certificate`, the contents of the `kubetl-ca.crt file` on Windows nodes was not populated correctly. With this fix, after certificate rotation, the `kubetl-ca.crt` file contains the correct certificates. (link:https://issues.redhat.com/browse/OCPBUGS-33875[*OCPBUGS-33875*])
 
-* Previously, the kubelet was unable to authenticate with private Elastic Container Registries (ECR) registries. Because of this error, the kubelet was not able to pull images from these registries. With this fix, the kubelet is able to pull images from these registries as expected. (link:https://issues.redhat.com/browse/OCPBUGS-26602[*OCPBUGS-26602*])
+* Previously, if reverse DNS lookup failed due to an error, such as the reverse DNS lookup services being unavailable, the WMCO would not fall back to using the VM hostname to determine if a certificate signing requests (CSR) should be approved. As a consequence, Bring-Your-Own-Host (BYOH) Windows nodes configured with an IP address would not become available. With this fix, BYOH nodes are properly added if reverse DNS is not available. (link:https://issues.redhat.com/browse/OCPBUGS-37533[*OCPBUGS-37533*])
 
-* Previously, the WMCO was logging error messages when any commands being run through an SSH connection to a Windows instance failed. This was incorrect behavior because some commands are expected to fail. For example, when WMCO reboots a node the Operator runs PowerShell commands on the instance until they fail, meaning the SSH connection rebooted as expected. With this fix, only actualy errors are now logged. (link:https://issues.redhat.com/browse/OCPBUGS-20255[*OCPBUGS-20255*])
+* Previously, if there were multiple service account token secrets in the WMCO namespace, the scaling of Windows nodes would fail. With this fix, the WMCO uses only the secret it creates, ignoring any other service account token secrets in the WMCO namespace. As a result, Windows nodes scale properly.  (link:https://issues.redhat.com/browse/OCPBUGS-38485[*OCPBUGS-38485*])
 
 include::modules/windows-containers-release-notes-limitations.adoc[leveloffset=+1]


### PR DESCRIPTION
https://errata.devel.redhat.com/docs/show/137314

**PEER REVIEWER** -- The two bugs in the [10.15.3 release notes](https://github.com/openshift/openshift-docs/compare/enterprise-4.15...mburke5678:wmco-10.15.3-rn?expand=1#diff-4c52096a3bdd8b6d5ba6ad17196a7b789376e6746db03ca2b67f9c3c4b8e07e9) were previously reviewed for the WMCO 10.16.0 release notes (via OCPBUGS-22237 and OCPBUGS-36643). No need to re-review the text.  

The 10.15.2 release notes were moved to the Past Releases assembly without change to the text. No need to re-review the text.

**DO NOT MERGE UNTIL WMCO 10.15.3 GOES GA, currently 8/22.**