### PR TITLE
Organizes release notes content for OMR

### DIFF
--- a/modules/mirror-registry-release-notes.adoc
+++ b/modules/mirror-registry-release-notes.adoc
@@ -9,10 +9,13 @@ The _mirror registry for Red Hat OpenShift_ is a small and streamlined container
 
 These release notes track the development of the _mirror registry for Red Hat OpenShift_ in {product-title}.
 
-For an overview of the _mirror registry for Red Hat OpenShift_, see xref:../../installing/disconnected_install/installing-mirroring-creating-registry.adoc#mirror-registry-flags_installing-mirroring-creating-registry[Creating a mirror registry with mirror registry for Red Hat OpenShift].
+[id="mirror-registry-release-notes-1-3_{context}"]
+== Mirror registry for Red Hat OpenShift 1.3 release notes
 
-[id="mirror-registry-for-openshift-1-3-11"]
-== Mirror registry for Red Hat OpenShift 1.3.11
+The following sections provide details for each 1.3.z release of the _mirror registry for Red Hat OpenShift_
+
+[id="mirror-registry-for-openshift-1-3-11_{context}"]
+=== Mirror registry for Red Hat OpenShift 1.3.11
 
 Issued: 2024-04-23
 
@@ -22,8 +25,8 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 
 * link:https://access.redhat.com/errata/RHBA-2024:1758[RHBA-2024:1758 - mirror registry for Red Hat OpenShift 1.3.11]
 
-[id="mirror-registry-for-openshift-1-3-10"]
-== Mirror registry for Red Hat OpenShift 1.3.10
+[id="mirror-registry-for-openshift-1-3-10_{context}"]
+=== Mirror registry for Red Hat OpenShift 1.3.10
 
 Issued: 2023-12-07
 
@@ -33,8 +36,8 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 
 * link:https://access.redhat.com/errata/RHBA-2023:7628[RHBA-2023:7628 - mirror registry for Red Hat OpenShift 1.3.10]
 
-[id="mirror-registry-for-openshift-1-3-9"]
-== Mirror registry for Red Hat OpenShift 1.3.9
+[id="mirror-registry-for-openshift-1-3-9_{context}"]
+=== Mirror registry for Red Hat OpenShift 1.3.9
 
 Issued: 2023-09-19
 
@@ -44,8 +47,8 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 
 * link:https://access.redhat.com/errata/RHBA-2023:5241[RHBA-2023:5241 - mirror registry for Red Hat OpenShift 1.3.9]
 
-[id="mirror-registry-for-openshift-1-3-8"]
-== Mirror registry for Red Hat OpenShift 1.3.8
+[id="mirror-registry-for-openshift-1-3-8_{context}"]
+=== Mirror registry for Red Hat OpenShift 1.3.8
 
 Issued: 2023-08-16
 
@@ -55,8 +58,8 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 
 * link:https://access.redhat.com/errata/RHBA-2023:4622[RHBA-2023:4622 - mirror registry for Red Hat OpenShift 1.3.8]
 
-[id="mirror-registry-for-openshift-1-3-7"]
-== Mirror registry for Red Hat OpenShift 1.3.7
+[id="mirror-registry-for-openshift-1-3-7_{context}"]
+=== Mirror registry for Red Hat OpenShift 1.3.7
 
 Issued: 2023-07-19
 
@@ -66,8 +69,8 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 
 * link:https://access.redhat.com/errata/RHBA-2023:4087[RHBA-2023:4087 - mirror registry for Red Hat OpenShift 1.3.7]
 
-[id="mirror-registry-for-openshift-1-3-6"]
-== Mirror registry for Red Hat OpenShift 1.3.6
+[id="mirror-registry-for-openshift-1-3-6_{context}"]
+=== Mirror registry for Red Hat OpenShift 1.3.6
 
 Issued: 2023-05-30
 
@@ -77,8 +80,8 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 
 * link:https://access.redhat.com/errata/RHBA-2023:3302[RHBA-2023:3302 - mirror registry for Red Hat OpenShift 1.3.6]
 
-[id="mirror-registry-for-openshift-1-3-5"]
-== Mirror registry for Red Hat OpenShift 1.3.5
+[id="mirror-registry-for-openshift-1-3-5_{context}"]
+=== Mirror registry for Red Hat OpenShift 1.3.5
 
 Issued: 2023-05-18
 
@@ -88,8 +91,8 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 
 * link:https://access.redhat.com/errata/RHBA-2023:3225[RHBA-2023:3225 - mirror registry for Red Hat OpenShift 1.3.5]
 
-[id="mirror-registry-for-openshift-1-3-4"]
-== Mirror registry for Red Hat OpenShift 1.3.4
+[id="mirror-registry-for-openshift-1-3-4_{context}"]
+=== Mirror registry for Red Hat OpenShift 1.3.4
 
 Issued: 2023-04-25
 
@@ -99,8 +102,8 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 
 * link:https://access.redhat.com/errata/RHBA-2023:1914[RHBA-2023:1914 - mirror registry for Red Hat OpenShift 1.3.4]
 
-[id="mirror-registry-for-openshift-1-3-3"]
-== Mirror registry for Red Hat OpenShift 1.3.3
+[id="mirror-registry-for-openshift-1-3-3_{context}"]
+=== Mirror registry for Red Hat OpenShift 1.3.3
 
 Issued: 2023-04-05
 
@@ -110,8 +113,8 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 
 * link:https://access.redhat.com/errata/RHBA-2023:1528[RHBA-2023:1528 - mirror registry for Red Hat OpenShift 1.3.3]
 
-[id="mirror-registry-for-openshift-1-3-2"]
-== Mirror registry for Red Hat OpenShift 1.3.2
+[id="mirror-registry-for-openshift-1-3-2_{context}"]
+=== Mirror registry for Red Hat OpenShift 1.3.2
 
 Issued: 2023-03-21
 
@@ -121,8 +124,8 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 
 * link:https://access.redhat.com/errata/RHBA-2023:1376[RHBA-2023:1376 - mirror registry for Red Hat OpenShift 1.3.2]
 
-[id="mirror-registry-for-openshift-1-3-1"]
-== Mirror registry for Red Hat OpenShift 1.3.1
+[id="mirror-registry-for-openshift-1-3-1_{context}"]
+=== Mirror registry for Red Hat OpenShift 1.3.1
 
 Issued: 2023-03-7
 
@@ -132,8 +135,8 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 
 * link:https://access.redhat.com/errata/RHBA-2023:1086[RHBA-2023:1086 - mirror registry for Red Hat OpenShift 1.3.1]
 
-[id="mirror-registry-for-openshift-1-3-0"]
-== Mirror registry for Red Hat OpenShift 1.3.0
+[id="mirror-registry-for-openshift-1-3-0_{context}"]
+=== Mirror registry for Red Hat OpenShift 1.3.0
 
 Issued: 2023-02-20
 
@@ -143,7 +146,8 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 
 * link:https://access.redhat.com/errata/RHBA-2023:0558[RHBA-2023:0558 - mirror registry for Red Hat OpenShift 1.3.0]
 
-=== New features
+[id="mirror-registry-new-features-1-3-0_{context}"]
+==== New features
 
 * _Mirror registry for Red Hat OpenShift_ is now supported on {op-system-base-full} 9 installations.
 
@@ -161,13 +165,18 @@ When _mirror registry for Red Hat OpenShift_ was installed with `sudo`, an `/etc
 +
 To override the default directories that these files are stored in, you can use the command line arguments for _mirror registry for Red Hat OpenShift_. For more information about _mirror registry for Red Hat OpenShift_ command line arguments, see "_Mirror registry for Red Hat OpenShift_ flags".
 
-=== Bug fixes
+[id="mirror-registry-bug-fixes-1-3-0_{context}"]
+==== Bug fixes
 
 * Previously, the following error could be returned when attempting to uninstall _mirror registry for Red Hat OpenShift_: `["Error: no container with name or ID \"quay-postgres\" found: no such container"], "stdout": "", "stdout_lines": []***`. With this update, the order that _mirror registry for Red Hat OpenShift_ services are stopped and uninstalled have been changed so that the error no longer occurs when uninstalling _mirror registry for Red Hat OpenShift_. For more information, see link:https://issues.redhat.com/browse/PROJQUAY-4629[*PROJQUAY-4629*].
 
+[id="mirror-registry-release-notes-1-2_{context}"]
+== Mirror registry for Red Hat OpenShift 1.2 release notes
 
-[id="mirror-registry-for-openshift-1-2-9"]
-== Mirror registry for Red Hat OpenShift 1.2.9
+The following sections provide details for each 1.2.z release of the _mirror registry for Red Hat OpenShift_
+
+[id="mirror-registry-for-openshift-1-2-9_{context}"]
+=== Mirror registry for Red Hat OpenShift 1.2.9
 
 _Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.7.10.
 
@@ -176,8 +185,8 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 * link:https://access.redhat.com/errata/RHBA-2022:7369[RHBA-2022:7369 - mirror registry for Red Hat OpenShift 1.2.9]
 
 
-[id="mirror-registry-for-openshift-1-2-8"]
-== Mirror registry for Red Hat OpenShift 1.2.8
+[id="mirror-registry-for-openshift-1-2-8_{context}"]
+=== Mirror registry for Red Hat OpenShift 1.2.8
 
 _Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.7.9.
 
@@ -186,8 +195,8 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 * link:https://access.redhat.com/errata/RHBA-2022:7065[RHBA-2022:7065 - mirror registry for Red Hat OpenShift 1.2.8]
 
 
-[id="mirror-registry-for-openshift-1-2-7"]
-== Mirror registry for Red Hat OpenShift 1.2.7
+[id="mirror-registry-for-openshift-1-2-7_{context}"]
+=== Mirror registry for Red Hat OpenShift 1.2.7
 
 _Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.7.8.
 
@@ -195,12 +204,13 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 
 * link:https://access.redhat.com/errata/RHBA-2022:6500[RHBA-2022:6500 - mirror registry for Red Hat OpenShift 1.2.7]
 
-=== Bug fixes
+[id="mirror-registry-bug-fixes-1-2-7_{context}"]
+==== Bug fixes
 
 * Previously, `getFQDN()` relied on the fully-qualified domain name (FQDN) library to determine its FQDN, and the FQDN library tried to read the `/etc/hosts` folder directly. Consequently, on some {op-system-first} installations with uncommon DNS configurations, the FQDN library would fail to install and abort the installation. With this update, _mirror registry for Red Hat OpenShift_ uses `hostname` to determine the FQDN. As a result, the FQDN library does not fail to install. (link:https://issues.redhat.com/browse/PROJQUAY-4139[*PROJQUAY-4139*])
 
-[id="mirror-registry-for-openshift-1-2-6"]
-== Mirror registry for Red Hat OpenShift 1.2.6
+[id="mirror-registry-for-openshift-1-2-6_{context}"]
+=== Mirror registry for Red Hat OpenShift 1.2.6
 
 _Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.7.7.
 
@@ -208,12 +218,13 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 
 * link:https://access.redhat.com/errata/RHBA-2022:6278[RHBA-2022:6278 - mirror registry for Red Hat OpenShift 1.2.6]
 
-=== New features
+[id="mirror-registry-new-features-1-2-6_{context}"]
+==== New features
 
 A new feature flag, `--no-color` (`-c`) has been added. This feature flag allows users to disable color sequences and propagate that to Ansible when running install, uninstall, and upgrade commands.
 
-[id="mirror-registry-for-openshift-1-2-5"]
-== Mirror registry for Red Hat OpenShift 1.2.5
+[id="mirror-registry-for-openshift-1-2-5_{context}"]
+=== Mirror registry for Red Hat OpenShift 1.2.5
 
 _Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.7.6.
 
@@ -221,8 +232,8 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 
 * link:https://access.redhat.com/errata/RHBA-2022:6071[RHBA-2022:6071 - mirror registry for Red Hat OpenShift 1.2.5]
 
-[id="mirror-registry-for-openshift-1-2-4"]
-== Mirror registry for Red Hat OpenShift 1.2.4
+[id="mirror-registry-for-openshift-1-2-4_{context}"]
+=== Mirror registry for Red Hat OpenShift 1.2.4
 
 _Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.7.5.
 
@@ -230,8 +241,8 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 
 * link:https://access.redhat.com/errata/RHBA-2022:5884[RHBA-2022:5884 - mirror registry for Red Hat OpenShift 1.2.4]
 
-[id="mirror-registry-for-openshift-1-2-3"]
-== Mirror registry for Red Hat OpenShift 1.2.3
+[id="mirror-registry-for-openshift-1-2-3_{context}"]
+=== Mirror registry for Red Hat OpenShift 1.2.3
 
 _Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.7.4.
 
@@ -239,8 +250,8 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 
 * link:https://access.redhat.com/errata/RHBA-2022:5649[RHBA-2022:5649 - mirror registry for Red Hat OpenShift 1.2.3]
 
-[id="mirror-registry-for-openshift-1-2-2"]
-== Mirror registry for Red Hat OpenShift 1.2.2
+[id="mirror-registry-for-openshift-1-2-2_{context}"]
+=== Mirror registry for Red Hat OpenShift 1.2.2
 
 _Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.7.3.
 
@@ -250,7 +261,7 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 
 
 [id="mirror-registry-for-openshift-1-2-1"]
-== Mirror registry for Red Hat OpenShift 1.2.1
+=== Mirror registry for Red Hat OpenShift 1.2.1
 
 _Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.7.2.
 
@@ -258,8 +269,8 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 
 * link:https://access.redhat.com/errata/RHBA-2022:5200[RHBA-2022:4986 - mirror registry for Red Hat OpenShift 1.2.1]
 
-[id="mirror-registry-for-openshift-1-2-0"]
-== Mirror registry for Red Hat OpenShift 1.2.0
+[id="mirror-registry-for-openshift-1-2-0_{context}"]
+=== Mirror registry for Red Hat OpenShift 1.2.0
 
 _Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.7.1.
 
@@ -267,21 +278,25 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 
 * link:https://access.redhat.com/errata/RHBA-2022:4986[RHBA-2022:4986 - mirror registry for Red Hat OpenShift 1.2.0]
 
-
-[id="mirror-registry-1-2-0-bug-fixes"]
-=== Bug fixes
+[id="mirror-registry-1-2-0-bug-fixes_{context}"]
+==== Bug fixes
 
 * Previously, all components and workers running inside of the Quay pod Operator had log levels set to `DEBUG`. As a result, large traffic logs were created that consumed unnecessary space. With this update, log levels are set to `WARN` by default, which reduces traffic information while emphasizing problem scenarios. (link:https://issues.redhat.com/browse/PROJQUAY-3504[*PROJQUAY-3504*])
 
-[id="mirror-registry-for-openshift-1-1-0"]
-== Mirror registry for Red Hat OpenShift 1.1.0
+[id="mirror-registry-release-notes-1-1_{context}"]
+== Mirror registry for Red Hat OpenShift 1.1 release notes
+
+The following section provides details 1.1.0 release of the _mirror registry for Red Hat OpenShift_
+
+[id="mirror-registry-for-openshift-1-1-0_{context}"]
+=== Mirror registry for Red Hat OpenShift 1.1.0
 
 The following advisory is available for the _mirror registry for Red Hat OpenShift_:
 
 * link:https://access.redhat.com/errata/RHBA-2022:0956[RHBA-2022:0956 - mirror registry for Red Hat OpenShift 1.1.0]
 
-[id="mirror-registry-1-2-0-new-features"]
-=== New features
+[id="mirror-registry-1-2-0-new-feature_{context}"]
+==== New features
 
 * A new command, `mirror-registry upgrade` has been added. This command upgrades all container images without interfering with configurations or data.
 +
@@ -290,8 +305,8 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 If `quayRoot` was previously set to something other than default, it must be passed into the upgrade command.
 ====
 
-[id="mirror-registry-1-1-0-bug-fixes"]
-=== Bug fixes
+[id="mirror-registry-1-1-0-bug-fixes_{context}"]
+==== Bug fixes
 
 * Previously, the absence of `quayHostname` or `targetHostname` did not default to the local hostname. With this update, `quayHostname` and `targetHostname` now default to the local hostname if they are missing. (link:https://issues.redhat.com/browse/PROJQUAY-3079[*PROJQUAY-3079*])
 


### PR DESCRIPTION
Be sure to check the preview! 

Version(s):
4.11+

Issue:
Part of https://issues.redhat.com/browse/OSDOCS-11690

Link to docs preview:
https://80433--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-creating-registry.html#mirror-registry-release-notes_installing-mirroring-creating-registry

Content org. QE is not necessary.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
