### PR TITLE
OCPBUGS#22760: Fix xref in OSDK release notes (4.14)

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -1018,7 +1018,7 @@ With this release, Operator authors can configure their Operator projects with s
 * Building a manifest list that specifies the platforms that the Operator supports.
 * Setting the Operator’s node affinity to support multi-architecture compute machines.
 
-For more information, see xref:../operators/operator_sdk/osdk-multi-arch-support.adoc#osdk-multi-arch[Configuring Operator projects for multi-platform support].
+For more information, see xref:../operators/operator_sdk/osdk-multi-arch-support.adoc#osdk-multi-platform-support[Configuring Operator projects for multi-platform support].
 
 [id="ocp-4.14-builds"]
 === Builds


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUGS-22760](https://issues.redhat.com/browse/OCPBUGS-22760)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 
* https://80435--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-osdk-multi-platform
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

~QE review:~
~- [ ] QE has approved this change.~
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
Fixing a broken xref. No QE or SME review required.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
