### PR TITLE
OCP 4.17: IPI docs correction

### DIFF
--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -502,7 +502,7 @@ For `platform.gcp.network`, specify the name for the existing Google VPC. For `p
 endif::gcp+restricted[]
 
 ifdef::ibm-power-vs+restricted[]
-.. Define the network and subnets for the VPC to install the cluster in under the parent `platform.ibmcloud` field:
+.. Define the network and subnets for the VPC to install the cluster in under the parent `platform.powervs` field:
 +
 [source,yaml]
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): applies to all versions 4.13+

Issue: https://jsw.ibm.com/browse/POCPQE-186
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://80448--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs#installation-initializing_installing-restricted-networks-ibm-power-vs

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
