### PR TITLE
[Internal change] OSDOCS-11656-follow-ip: fix 4.16.7 z-stream note

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3379,6 +3379,8 @@ $ oc adm release info 4.16.7 --pullspecs
 
 * Previously, `HostedClusterConfigOperator` resource did not delete the `ImageDigestMirrorSet` (IDMS) object after a user removed the `ImageContentSources` field from the `HostedCluster` object. This caused the IDMS object to remain in the `HostedCluster` object. With this release, `HostedClusterConfigOperator` removes all IDMS resources in the `HostedCluster` object so that this issue no longer exists. (link:https://issues.redhat.com/browse/OCPBUGS-36766[*OCPBUGS-36766*])
 
+* Previously, in a cluster that runs {product-title} 4.16 with the Telco RAN DU reference configuration, long duration `cyclictest` or `timerlat` tests could fail with maximum latencies detected above `20` us. This issue occured because the `psi` kernel command line argument was being set to `1` by default when cgroup v2 is enabled. With this release, the issue is fixed by setting `psi=0` in the kernel arguments when enabling cgroup v2. The `cyclictest` latency issue reported in link:https://issues.redhat.com/browse/OCPBUGS-34022[*OCPBUGS-34022*] is now also fixed. (link:https://issues.redhat.com/browse/OCPBUGS-37271[*OCPBUGS-37271*])
+
 [id="ocp-4-16-7-updating_{context}"]
 ==== Updating
 
@@ -3454,8 +3456,6 @@ metadata:
 * Previously, the Open vSwitch (OVS) pinning procedure set the CPU affinity of the main thread, but other CPU threads did not pick up this affinity if they had already been created. As a consequence, some OVS threads did not run on the correct CPU set, which might interfere with the performance of pods with a Quality of Service (QoS) class of `Guaranteed`. With this update, the OVS pinning procedure updates the affinity of all the OVS threads, ensuring that all OVS threads run on the correct CPU set. (link:https://issues.redhat.com/browse/OCPBUGS-36608[*OCPBUGS-36608*])
 
 * Previously, the etcd Operator checked the health of etcd members in serial with an all-member timeout that matched the single-member timeout. That allowed one slow member check to consume the entire timeout, and cause later member checks to fail with the error `deadline-exceeded`, regardless of the health of that later member. Now, etcd checks the health of members in parallel so the health and speed of one member's check doesn't affect the other members' checks. (link:https://issues.redhat.com/browse/OCPBUGS-36489[*OCPBUGS-36489*])
-
-* Previously, in a cluster that runs {product-title} 4.16 with the Telco RAN DU reference configuration, long duration `cyclictest` or `timerlat` tests could fail with maximum latencies detected above `20`us. This issue occured because the `psi` kernel command line argument was being set to `1` by default when cgroups v2 is enabled. With this release, the issue is fixed by setting `psi=0` in the kernel arguments when enabling cgroups v2. The `cyclictest` latency issue reported in link:https://issues.redhat.com/browse/OCPBUGS-34022[*OCPBUGS-34022*] is now also fixed. (link:https://issues.redhat.com/browse/OCPBUGS-37271[*OCPBUGS-37271*])
 
 [id="ocp-4-16-6-updating_{context}"]
 ==== Updating


### PR DESCRIPTION
Follow on from #80295. The Telco note should be in 4.16.7 and not 4.16.6. Also fixed some rendering issues: 

![Screenshot from 2024-08-14 10-51-08](https://github.com/user-attachments/assets/252aa632-a7a8-4299-811a-4adebb2aa3d0)

Version(s):
4.16

Issue:
[OSDOCS-11656](https://issues.redhat.com/browse/OSDOCS-11656)

Link to docs preview:
[4.16.7](https://80451--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-7_release-notes)


