### PR TITLE
OBSDOCS-1229: Correct the name of the mentioned exporter

### DIFF
--- a/observability/otel/otel-collector/otel-collector-exporters.adoc
+++ b/observability/otel/otel-collector/otel-collector-exporters.adoc
@@ -91,15 +91,21 @@ The Debug Exporter prints traces and metrics to the standard output.
     exporters:
       debug:
         verbosity: detailed # <1>
+        sampling_initial: 5 # <2>
+        sampling_thereafter: 200 # <3>
+        use_internal_logger: true # <4>
     service:
       pipelines:
         traces:
-          exporters: [logging]
+          exporters: [debug]
         metrics:
-          exporters: [logging]
+          exporters: [debug]
 # ...
 ----
-<1> Verbosity of the debug export: `detailed` or `normal` or `basic`. When set to `detailed`, pipeline data is verbosely logged. Defaults to `normal`.
+<1> Verbosity of the debug export: `detailed`, `normal`, or `basic`. When set to `detailed`, pipeline data are verbosely logged. Defaults to `normal`.
+<2> Initial number of messages logged per second. The default value is `2` messages per second.
+<3> Sampling rate after the initial number of messages, the value in `sampling_initial`, has been logged. Disabled by default with the default `1` value. Sampling is enabled with values greater than `1`. For more information, see the page for the link:https://pkg.go.dev/go.uber.org/zap/zapcore?utm_source=godoc#NewSamplerWithOptions[sampler function in the `zapcore` package] on the Go Project's website.
+<4> When set to `true`, enables output from the Collector's internal logger for the exporter.
 
 [id="load-balancing-exporter_{context}"]
 == Load Balancing Exporter


### PR DESCRIPTION
Target branch: `main`

:warning: Peer reviewer, please ignore the first peer review, which was requested by mistake (https://github.com/openshift/openshift-docs/pull/80452#issuecomment-2338392844).

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12, 4.13, 4.14, 4.15, 4.16, 4.17

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OBSDOCS-1229

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://80452--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-collector/otel-collector-exporters.html#debug-exporter_otel-collector-exporters

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
