### PR TITLE
WMCO 10.16.1 release notes for OCP 4.16

### DIFF
--- a/windows_containers/windows-containers-release-notes-10-16-x.adoc
+++ b/windows_containers/windows-containers-release-notes-10-16-x.adoc
@@ -28,6 +28,16 @@ For more information, see the Red{nbsp}Hat OpenShift Container Platform Life Cyc
 If you do not have this additional Red{nbsp}Hat subscription, you can use the Community Windows Machine Config Operator, a distribution that lacks official support.
 endif::openshift-origin[]
 
+[id="wmco-10-16-1"]
+== Release notes for Red{nbsp}Hat Windows Machine Config Operator 10.16.1
+
+This release of the WMCO provides new features and bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.16.1 were released in link:https://access.redhat.com/errata/RHBA-TBD[RHBA-TBD].
+
+[id="wmco-10-16-1-bug-fixes"]
+=== Bug fixes
+
+* Previously, if a Windows VM had its PowerShell `ExecutionPolicy` set to `Restricted`, the Windows Instance Config Daemon (WICD) could not run the commands on that VM that are necessary for creating Windows nodes. With this fix, the WICD now bypasses the execution policy on the VM when running PowerShell commands. As a result, the WICD can create Windows nodes on the VM as expected. (link:https://issues.redhat.com/browse/OCPBUGS-37609[*OCPBUGS-37609*])
+
 [id="wmco-10-16-0"]
 == Release notes for Red{nbsp}Hat Windows Machine Config Operator 10.16.0
 


### PR DESCRIPTION
https://errata.devel.redhat.com/docs/show/137314

**Errata link will not be in place until WMCO 10.16.1 GOES GA**

**DO NOT MERGE UNTIL WMCO 10.16.1 GOES GA, currently 8/22.**