### PR TITLE
ROX-25673: Add instructions to set POD_NAMESPACE to the docs 2

### DIFF
--- a/modules/add-pod-namespace-to-sensor-and-admission-control.adoc
+++ b/modules/add-pod-namespace-to-sensor-and-admission-control.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * upgrade/upgrade-from-45.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="add-pod-namespace-to-sensor-and-admission-control_{context}"]
+= Adding POD_NAMESPACE to sensor and admission-control deployments
+
+[role="_abstract"]
+When upgrading to version 4.6 or later from a version earlier than 4.6, you must patch the sensor and admission-control deployments  to set the `POD_NAMESPACE` environment variable.
+
+[NOTE]
+====
+If you are using Kubernetes, use `kubectl` instead of `oc` for the commands listed in this procedure.
+====
+
+.Procedure
+
+. Patch sensor to ensure `POD_NAMESPACE` is set by running the following command:
++
+[source,terminal,subs=attributes+]
+----
+$ [[ -z "$(oc -n stackrox get deployment sensor -o yaml | grep POD_NAMESPACE)" ]] && oc -n stackrox patch deployment sensor --type=json -p '[{"op":"add","path":"/spec/template/spec/containers/0/env/-","value":{"name":"POD_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}}}]'
+----
+. Patch admission-control to ensure `POD_NAMESPACE` is set by running the following command:
++
+[source,terminal,subs=attributes+]
+----
+$ [[ -z "$(oc -n stackrox get deployment admission-control -o yaml | grep POD_NAMESPACE)" ]] && oc -n stackrox patch deployment admission-control --type=json -p '[{"op":"add","path":"/spec/template/spec/containers/0/env/-","value":{"name":"POD_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}}}]'
+----

--- a/upgrading/upgrade-roxctl.adoc
+++ b/upgrading/upgrade-roxctl.adoc
@@ -73,6 +73,8 @@ To complete manual upgrades of each secured cluster running Sensor, Collector, a
 
 include::modules/update-other-images.adoc[leveloffset=+2]
 
+include::modules/add-pod-namespace-to-sensor-and-admission-control.adoc[leveloffset=+2]
+
 .Next steps
 * xref:../upgrading/upgrade-roxctl.adoc#verify-secured-cluster-upgrade_upgrade-roxctl[Verifying secured cluster upgrade]
 


### PR DESCRIPTION
Followup to https://github.com/stackrox/stackrox/pull/12278, this time merging against the correct branch

Version(s):
4.6+

[Issue](https://issues.redhat.com/browse/ROX-25673)

[link to doc preview
](https://80466--ocpdocs-pr.netlify.app/openshift-acs/latest/upgrading/upgrade-roxctl.html#add-pod-namespace-to-sensor-and-admission-control_upgrade-roxctl)

QE review:

[x] QE has approved this change. (**ACS has no QE, approved by SME**)

[ROX-25673](https://issues.redhat.com//browse/ROX-25673) introduces a change in the way that our sensor and admission-control deployments determine their own namespace. Instead of querying the serviceaccount namespace file, we now uniformly rely on setting the POD_NAMESPACE env var in the deployment via the k8s Downward API. This will be our one source of truth for the namespace a pod is in.

Since sensor and admission-control deployments were previously NOT always setting this env variable, it is imperative that users of our manifest-based manual installation method update their .yaml files for those two deployments. This PR adds manual upgrade instructions for release 4.6 for this purpose.

Related JIRA: https://issues.redhat.com/browse/ROX-25673
Related Stackrox PR: https://github.com/stackrox/stackrox/pull/12278