### PR TITLE
OSDOCS-11648 Adding -since and -since-time flags to must-gather docs

### DIFF
--- a/modules/support-gather-time-limit.adoc
+++ b/modules/support-gather-time-limit.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * support/gathering-cluster-data.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="support_gathering_time_limit_{context}"]
+= Flags to limit the time period for gathering data
+// The flags are still labeled experimental in 4.16. Should this doc update be included in 4.16 docs?
+You can gather debugging information about your cluster from within a specific time period by using the `since` and `since-time` flags with the `oc adm must-gather` command. Only one of these flags can be used at a time.
+
+Flags::
+* `-since`: Gathers data logs that are newer than the specified time period. The time period can be in seconds, minutes, hours, days, or months. The command defaults to gathering all logs.
+** Example: `oc adm must-gather -since 5h` will return data logs from the previous 5 hours.
+//Are hours the longest time period you can do this for? Months? Years? Days?
+* `since-time`: Gathers data logs that are from after a specified date. The date format must be Day Month Year. The command defaults to gathering all logs.
+//How should the date be formatted/does it matter?
+** Example: `oc adm must-gather -since-time 1 August 2024` will return data logs from August 1st, 2024 to the present.

--- a/support/gathering-cluster-data.adoc
+++ b/support/gathering-cluster-data.adoc
@@ -31,6 +31,11 @@ ifndef::openshift-origin[]
 include::modules/support-gather-data.adoc[leveloffset=+2]
 endif::openshift-origin[]
 
+ifndef::openshift-origin[]
+// Gathering data since a specific time period
+include::support/modules/support-gather-time-limit.adoc[leveloffset=+2]
+endif::openshift-origin[]
+
 // Gathering data about specific features
 include::modules/gathering-data-specific-features.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s): 4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-11648](https://issues.redhat.com/browse/OSDOCS-11648)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
