### PR TITLE
WMCO update link to cost management in Known Limitations

### DIFF
--- a/modules/windows-containers-release-notes-limitations.adoc
+++ b/modules/windows-containers-release-notes-limitations.adoc
@@ -18,7 +18,7 @@ Note the following limitations when working with Windows nodes managed by the WM
 ** Vertical Pod Autoscaling
 
 * The following Red Hat features are not supported on Windows nodes:
-** link:https://access.redhat.com/documentation/en-us/cost_management_service/2022/html/getting_started_with_cost_management/assembly-introduction-cost-management?extIdCarryOver=true&sc_cid=701f2000001OH74AAG#about-cost-management_getting-started[Red Hat cost management]
+** link:https://docs.redhat.com/en/documentation/cost_management_service/1-latest[Red Hat Insights cost management]
 ** link:https://developers.redhat.com/products/openshift-local/overview[Red Hat OpenShift Local]
 
 * Windows nodes do not support workloads created by using deployment configs. You can use a deployment or other method to deploy workloads.


### PR DESCRIPTION
As pointed out in https://github.com/openshift/openshift-docs/pull/80445#pullrequestreview-2238286913

Preview:
WMCO release notes -> Known limitations: [Red Hat Insights cost management link in second bullet](https://80512--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-6-x.html#windows-containers-release-notes-limitations_windows-containers-release-notes)