### PR TITLE
#CNV41848 - nhc vs mhc edit

### DIFF
--- a/virt/nodes/virt-triggering-vm-failover-resolving-failed-node.adoc
+++ b/virt/nodes/virt-triggering-vm-failover-resolving-failed-node.adoc
@@ -6,15 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-If a node fails and xref:../../machine_management/deploying-machine-health-checks.adoc#machine-health-checks-about_deploying-machine-health-checks[machine health checks] are not deployed on your cluster, virtual machines (VMs) with `runStrategy: Always` configured are not automatically relocated to healthy nodes. To trigger VM failover, you must manually delete the `Node` object.
-
-[NOTE]
-====
-If you installed your cluster by using xref:../../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[installer-provisioned infrastructure] and you properly configured machine health checks, the following events occur:
-
-* Failed nodes are automatically recycled.
-* Virtual machines with xref:../../virt/nodes/virt-node-maintenance.adoc#run-strategies[`runStrategy`] set to `Always` or `RerunOnFailure` are automatically scheduled on healthy nodes.
-====
+If a node fails and link:https://access.redhat.com/articles/7057929[node health checks] are not deployed on your cluster, virtual machines (VMs) with `runStrategy: Always` configured are not automatically relocated to healthy nodes.
 
 [id="prerequisites_{context}"]
 == Prerequisites


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-41848](https://issues.redhat.com//browse/CNV-41848)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://80515--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/nodes/virt-triggering-vm-failover-resolving-failed-node.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
