### PR TITLE
[enterprise-4.16] OCPBUGS#33606: Added z-stream update note for SDN to OVNK migration

### DIFF
--- a/modules/nw-ovn-kubernetes-live-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-live-migration-about.adoc
@@ -6,6 +6,12 @@
 = Limited live migration to the OVN-Kubernetes network plugin overview
 
 The limited live migration method is the process in which the OpenShift SDN network plugin and its network configurations, connections, and associated resources, are migrated to the OVN-Kubernetes network plugin without service interruption. It is available for {product-title}.
+
+[IMPORTANT]
+====
+Before you migrate your {product-title} cluster to use the OVN-Kubernetes network plugin, update your cluster to the latest z-stream release so that all the latest bug fixes apply to your cluster.
+====
+
 // Azure Red Hat OpenShift deployment types will needed added in .z stream.
 It is not available for hosted control plane deployment types. This migration method is valuable for deployment types that require constant service availability and offers the following benefits:
 

--- a/modules/nw-ovn-kubernetes-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-migration-about.adoc
@@ -7,6 +7,11 @@
 
 The offline migration method is a manual process that includes some downtime, during which your cluster is unreachable. This method is primarily used for self-managed {product-title} deployments.
 
+[IMPORTANT]
+====
+Before you migrate your {product-title} cluster to use the OVN-Kubernetes network plugin, update your cluster to the latest z-stream release so that all the latest bug fixes apply to your cluster.
+====
+
 Although a rollback procedure is provided, the offline migration is intended to be a one-way process.
 
 ////

--- a/modules/nw-traditional-sharding.adoc
+++ b/modules/nw-traditional-sharding.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="nw-traditional-sharding_{context}"]
-== Traditional sharding example
+= Traditional sharding example
 
 An example of a configured Ingress Controller `finops-router` that has the label selector `spec.namespaceSelector.matchExpressions` with key values set to `finance` and `ops`:
 

--- a/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
@@ -3,6 +3,7 @@
 = Migrating from the OpenShift SDN network plugin
 include::_attributes/common-attributes.adoc[]
 :context: migrate-from-openshift-sdn
+// Unique attribute for the version of the release notes.
 
 toc::[]
 
@@ -18,6 +19,13 @@ To learn more about OVN-Kubernetes, read xref:../../networking/ovn_kubernetes_ne
 // Offline migration to the OVN-Kubernetes network plugin overview
 include::modules/nw-ovn-kubernetes-migration-about.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../updating/understanding_updates/understanding-update-channels-release.adoc#understanding-update-channels-release[Understanding update channels and releases] 
+
+* xref:../../release_notes/ocp-4-16-release-notes.adoc#ocp-4-16-asynchronous-errata-updates_release-notes[Asynchronous errata updates]
+
 // How the offline migration process works
 include::modules/nw-network-plugin-migration-process.adoc[leveloffset=+2]
 
@@ -26,6 +34,13 @@ include::modules/nw-ovn-kubernetes-migration.adoc[leveloffset=+2]
 
 // Limited live migration to the OVN-Kubernetes network plugin overview
 include::modules/nw-ovn-kubernetes-live-migration-about.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../updating/understanding_updates/understanding-update-channels-release.adoc#understanding-update-channels-release[Understanding update channels and releases] 
+
+* xref:../../release_notes/ocp-4-16-release-notes.adoc#ocp-4-16-asynchronous-errata-updates_release-notes[Asynchronous errata updates]
 
 // How the live migration process works
 include::modules/how-the-live-migration-process-works.adoc[leveloffset=+2]
@@ -79,3 +94,4 @@ include::modules/live-migration-metrics-information.adoc[leveloffset=+3]
 - xref:../../networking/openshift_sdn/enabling-multicast.adoc#enabling-multicast[Enabling multicast for a project]
 - xref:../../networking/openshift_sdn/deploying-egress-router-layer3-redirection.adoc#deploying-egress-router-layer3-redirection[Deploying an egress router pod in redirect mode]
 * xref:../../rest_api/operator_apis/network-operator-openshift-io-v1.adoc#network-operator-openshift-io-v1[Network [operator.openshift.io/v1]]
+

--- a/virt/release_notes/virt-4-16-release-notes.adoc
+++ b/virt/release_notes/virt-4-16-release-notes.adoc
@@ -70,7 +70,7 @@ This release adds new features and enhancements related to the following compone
 === Virtualization
 
 //CNV-29170 Real-time cluster configuration (Uncomment the note below when feature goes out with a 4.16.z release)
-//* You can xref:../../virt/virtual_machines/advanced_vm_management/virt-configuring-cluster-realtime-workloads.adoc#virt-configuring-cluster-realtime-workloads[configure an {product-title} cluster] to run real-time virtual machine (VM) workloads that require low and predictable latency.
+//* You can :../../virt/virtual_machines/advanced_vm_management/virt-configuring-cluster-realtime-workloads.adoc#virt-configuring-cluster-realtime-workloads[configure an {product-title} cluster] to run real-time virtual machine (VM) workloads that require low and predictable latency.
 
 //CNV-29192 Running real-time checkup (Uncomment the note below when feature goes out with a 4.16.z release)
 //* You can now run a predefined xref:../../virt/monitoring/virt-running-cluster-checkups.adoc#virt-running-real-time-checkup_virt-running-cluster-checkups[checkup] to verify that your {product-title} cluster is configured to run virtualized real-time workloads.


### PR DESCRIPTION
APPROVALS ON THIS PR REFLECT APPROVALS ON THE PR FOR OTHER BRANCHES: 4.15, AND SO ON. Individual branches needed because of a link to the release note doc. No CM required as nothing is really been changed with the product. It's more of adding a "tip".

Version(s):
4.16 (because of SDN doc removal and doc structure). Separate PRs needed for 4.12-4.15. SDN docs were removed from 4.17.

Issue:
[OCPBUGS-33606](https://issues.redhat.com/browse/OCPBUGS-33606)

Link to docs preview:
* [Migrating from the OpenShift SDN network plugin](https://80521--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html)

- [x] SME has approved this change (Peng Liu)
- [x] QE has approved this change (Zhanqi Zhao)

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
