### PR TITLE
TELCODOCS-1488-All: Outdated must gather images - All Versions (excl 4.13)

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -55,17 +55,14 @@ ifndef::openshift-rosa,openshift-dedicated[]
 |`registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel8:v<installed_version_sandboxed_containers>`
 |Data collection for {sandboxed-containers-first}.
 
-|`registry.redhat.io/workload-availability/self-node-remediation-must-gather-rhel8:v<installed-version-SNR>`
-|Data collection for the Self Node Remediation (SNR) Operator and the Node Health Check (NHC) Operator.
+|`registry.redhat.io/workload-availability/node-healthcheck-must-gather-rhel8:v<installed-version-NHC>`
+|Data collection for the Red{nbsp}Hat Workload Availability Operators, including the Self Node Remediation (SNR) Operator, the Fence Agents Remediation (FAR) Operator, the Machine Deletion Remediation (MDR) Operator, the Node Health Check Operator (NHC) Operator, and the Node Maintenance Operator (NMO) Operator.
 
 |`registry.redhat.io/numaresources/numaresources-must-gather-rhel9:v<installed-version-nro>`
 |Data collection for the NUMA Resources Operator (NRO).
 
 |`registry.redhat.io/openshift4/ptp-must-gather-rhel8:v<installed-version-ptp>`
 |Data collection for the PTP Operator.
-
-|`registry.redhat.io/workload-availability/node-maintenance-must-gather-rhel8:v<installed-version-NMO>`
-|Data collection for the Node Maintenance Operator (NMO).
 endif::openshift-rosa,openshift-dedicated[]
 
 |`registry.redhat.io/openshift-gitops-1/must-gather-rhel8:v<installed_version_GitOps>`


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-1488: Outdated must gather images - All Versions (excl 4.13)

Applies to OCP version : 4.14+

NOTE: For Preview links and Approval details - see the original PR - https://github.com/openshift/openshift-docs/pull/79128

Thank you.