### PR TITLE
OSSM-6956 [DOC] Missing word in ossm-current-version-support Snippet

### DIFF
--- a/snippets/ossm-current-version-support-snippet.adoc
+++ b/snippets/ossm-current-version-support-snippet.adoc
@@ -4,4 +4,4 @@
 
 :_mod-docs-content-type: SNIPPET
 
-The most current version of the {SMProductName} Operator can be used with all supported versions of {SMProductShortName}. The version of {SMProductShortName} is specified using the `ServiceMeshControlPlane`.
+The most current version of the {SMProductName} Operator can be used with all supported versions of {SMProductShortName}. The version of {SMProductShortName} is specified by using the `ServiceMeshControlPlane` resource.


### PR DESCRIPTION
[OSSM-6956](https://issues.redhat.com//browse/OSSM-6956) [DOC] Missing word in ossm-current-version-support Snippet

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:

https://issues.redhat.com/browse/OSSM-6956

Link to docs preview:

The snippet is used in Release Notes: https://80547--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes 

QE review:

QE is not required for this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
