### PR TITLE
OSDOCS-10292: 4.15.25 docs and rel notes

### DIFF
--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc
@@ -61,6 +61,9 @@ include::modules/machineset-azure-confidential-vms.adoc[leveloffset=+2]
 // Accelerated Networking for Microsoft Azure VMs
 include::modules/machineset-azure-accelerated-networking.adoc[leveloffset=+2]
 
+//Configuring Capacity Reservation by using machine sets
+include::modules/machineset-azure-capacity-reservation.adoc[leveloffset=+2]
+
 //Not applicable for 4.12, possibly 4.13?
 //[role="_additional-resources"]
 //.Additional resources

--- a/machine_management/creating_machinesets/creating-machineset-azure.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-azure.adoc
@@ -62,6 +62,9 @@ include::modules/machineset-azure-confidential-vms.adoc[leveloffset=+1]
 // Accelerated Networking for Microsoft Azure VMs
 include::modules/machineset-azure-accelerated-networking.adoc[leveloffset=+1]
 
+//Configuring Capacity Reservation by using machine sets
+include::modules/machineset-azure-capacity-reservation.adoc[leveloffset=+1]
+
 //Adding a GPU node to a machine set (stesmith)
 include::modules/nvidia-gpu-azure-adding-a-gpu-node.adoc[leveloffset=+1]
 

--- a/modules/machineset-azure-capacity-reservation.adoc
+++ b/modules/machineset-azure-capacity-reservation.adoc
@@ -1,0 +1,101 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating_machinesets/creating-machineset-azure.adoc
+// * machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc
+
+ifeval::["{context}" == "cpmso-config-options-azure"]
+:cpmso:
+endif::[]
+
+:_mod-docs-content-type: PROCEDURE
+[id="machineset-azure-capacity-reservation_{context}"]
+= Configuring Capacity Reservation by using machine sets
+
+{product-title} version 4.15.25 and later supports on-demand Capacity Reservation with Capacity Reservation groups on {azure-full} clusters.
+
+You can configure a machine set to deploy machines on any available resources that match the parameters of a capacity request that you define.
+These parameters specify the VM size, region, and number of instances that you want to reserve.
+If your {azure-short} subscription quota can accommodate the capacity request, the deployment succeeds.
+
+For more information, including limitations and suggested use cases for this {azure-short} instance type, see the {azure-full} documentation about link:https://learn.microsoft.com/en-us/azure/virtual-machines/capacity-reservation-overview[On-demand Capacity Reservation].
+
+[NOTE]
+====
+You cannot change an existing Capacity Reservation configuration for a machine set.
+To use a different Capacity Reservation group, you must replace the machine set and the machines that the previous machine set deployed.
+====
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You installed the {oc-first}.
+* You created a Capacity Reservation group.
++
+For more information, see the {azure-full} documentation link:https://learn.microsoft.com/en-us/azure/virtual-machines/capacity-reservation-create[Create a Capacity Reservation].
+
+.Procedure
+
+. In a text editor, open the YAML file for an existing machine set or create a new one.
+
+. Edit the following section under the `providerSpec` field:
++
+--
+.Sample configuration
+[source,yaml]
+----
+ifndef::cpmso[]
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+endif::cpmso[]
+ifdef::cpmso[]
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+endif::cpmso[]
+# ...
+spec:
+  template:
+ifndef::cpmso[]
+    spec:
+      providerSpec:
+        value:
+          capacityReservationGroupID: <capacity_reservation_group> # <1>
+endif::cpmso[]
+ifdef::cpmso[]
+    machines_v1beta1_machine_openshift_io:
+      spec:
+        providerSpec:
+          value:
+            capacityReservationGroupID: <capacity_reservation_group> # <1>
+endif::cpmso[]
+# ...
+----
+<1> Specify the ID of the Capacity Reservation group that you want the machine set to deploy machines on.
+--
+
+.Verification
+
+* To verify machine deployment, list the machines that the machine set created by running the following command:
++
+[source,terminal]
+----
+ifndef::cpmso[]
+$ oc get machines.machine.openshift.io \
+  -n openshift-machine-api \
+  -l machine.openshift.io/cluster-api-machineset=<machine_set_name>
+endif::cpmso[]
+ifdef::cpmso[]
+$ oc get machine \
+  -n openshift-machine-api \
+  -l machine.openshift.io/cluster-api-machine-role=master
+endif::cpmso[]
+----
+ifndef::cpmso[]
++
+where `<machine_set_name>` is the name of the compute machine set.
+endif::cpmso[]
++
+In the output, verify that the characteristics of the listed machines match the parameters of your Capacity Reservation.
+
+ifeval::["{context}" == "cpmso-config-options-azure"]
+:!cpmso:
+endif::[]

--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2801,6 +2801,17 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.15.25 --pullspecs
 ----
 
+[id="ocp-4-15-25-enhancements"]
+==== Enhancements
+
+The following enhancements are included in this z-stream release:
+
+[id="ocp-4-15-25-enhancements-azure-res-cap_{context}"]
+===== Configuring Capacity Reservation by using machine sets
+
+* {product-title} release {product-version}.25 introduces support for on-demand Capacity Reservation with Capacity Reservation groups on {azure-full} clusters.
+For more information, see _Configuring Capacity Reservation by using machine sets_ for xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#machineset-azure-capacity-reservation_creating-machineset-azure[compute] or xref:../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc#machineset-azure-capacity-reservation_cpmso-config-options-azure[control plane] machine sets. (link:https://issues.redhat.com/browse/OCPCLOUD-1646[*OCPCLOUD-1646*])
+
 [id="ocp-4-15-25-bug-fixes_{context}"]
 ==== Bug fixes
 


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-10292](https://issues.redhat.com//browse/OSDOCS-10292)

Link to docs preview:
* [Configuring Capacity Reservation by using machine sets](https://80548--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure.html#machineset-azure-capacity-reservation_creating-machineset-azure) (compute)
* [Configuring Capacity Reservation by using machine sets](https://80548--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.html#machineset-azure-capacity-reservation_cpmso-config-options-azure) (control plane)
* [RHSA-2024:4955 - OpenShift Container Platform 4.15.25 bug fix and security update](https://80548--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-25_release-notes) (enhancements section)

QE review:
- [x] QE has approved this change.

Additional information:
:warning: Peer review folks, this is basically a time-delayed manual cherrypick :warning: 
Followup on #78800
4.15.25 on 7 Aug 2024 got this feature backport.

Change management acks:
- [x] PX
- [x] QA engg
- [x] Dev engg
- [x] PM
- [x] Docs