### PR TITLE
OSDOCS-10036:Exporting Network Observability metrics to OpenTelemetry

### DIFF
--- a/modules/network-observability-enriched-flows.adoc
+++ b/modules/network-observability-enriched-flows.adoc
@@ -6,10 +6,11 @@
 [id="network-observability-enriched-flows_{context}"]
 = Export enriched network flow data
 
-You can send network flows to Kafka, IPFIX, or both at the same time. Any processor or storage that supports Kafka or IPFIX input, such as Splunk, Elasticsearch, or Fluentd, can consume the enriched network flow data.
+You can send network flows to Kafka, IPFIX, the Red{nbsp}Hat build of OpenTelemetry, or all three at the same time. For Kafka or IPFIX, any processor or storage that supports those inputs, such as Splunk, Elasticsearch, or Fluentd, can consume the enriched network flow data. For OpenTelemetry, network flow data and metrics can be exported to a compatible OpenTelemetry endpoint, such as Red{nbsp}Hat build of OpenTelemetry, Jaeger, or Prometheus. 
 
 .Prerequisites
-* Your Kafka or IPFIX collector endpoint(s) are available from Network Observability `flowlogs-pipeline` pods.
+* Your Kafka, IPFIX, or OpenTelemetry collector endpoints are available from Network Observability `flowlogs-pipeline` pods.
+
 
 .Procedure
 
@@ -26,22 +27,41 @@ metadata:
   name: cluster
 spec:
   exporters:
-  - type: Kafka                         <3>
+  - type: Kafka                         <1>
       kafka:
         address: "kafka-cluster-kafka-bootstrap.netobserv"
-        topic: netobserv-flows-export   <1>
+        topic: netobserv-flows-export   <2>
         tls:
-          enable: false                 <2>
-  - type: IPFIX                         <3>
+          enable: false                 <3>
+  - type: IPFIX                         <1>
       ipfix:
         targetHost: "ipfix-collector.ipfix.svc.cluster.local"
         targetPort: 4739
         transport: tcp or udp           <4>
-
-
+ -  type: OpenTelemetry                 <1>
+      openTelemetry:
+        targetHost: my-otelcol-collector-headless.otlp.svc
+        targetPort: 4317
+        type: grpc                      <5>
+        logs:                           <6>
+          enable: true
+        metrics:                        <7>
+          enable: true
+          prefix: netobserv
+          pushTimeInterval: 20s         <8>
+          expiryTime: 2m
+   #    fieldsMapping:                  <9>
+   #      input: SrcAddr
+   #      output: source.address
 ----
-<1> The Network Observability Operator exports all flows to the configured Kafka topic.
-<2> You can encrypt all communications to and from Kafka with SSL/TLS or mTLS. When enabled, the Kafka CA certificate must be available as a ConfigMap or a Secret, both in the namespace where the `flowlogs-pipeline` processor component is deployed (default: netobserv). It must be referenced with `spec.exporters.tls.caCert`. When using mTLS, client secrets must be available in these namespaces as well (they can be generated for instance using the AMQ Streams User Operator) and referenced with `spec.exporters.tls.userCert`.
-<3> You can export flows to IPFIX instead of or in conjunction with exporting flows to Kafka.
+<1> You can export flows to IPFIX, OpenTelemetry, and Kafka individually or concurrently.
+<2> The Network Observability Operator exports all flows to the configured Kafka topic.
+<3> You can encrypt all communications to and from Kafka with SSL/TLS or mTLS. When enabled, the Kafka CA certificate must be available as a ConfigMap or a Secret, both in the namespace where the `flowlogs-pipeline` processor component is deployed (default: netobserv). It must be referenced with `spec.exporters.tls.caCert`. When using mTLS, client secrets must be available in these namespaces as well (they can be generated for instance using the AMQ Streams User Operator) and referenced with `spec.exporters.tls.userCert`. 
 <4> You have the option to specify transport. The default value is `tcp` but you can also specify `udp`.
-. After configuration, network flows data can be sent to an available output in a JSON format. For more information, see _Network flows format reference_.
+<5> The protocol of OpenTelemetry connection. The available options are `http` and `grpc`.
+<6> OpenTelemetry configuration for exporting logs, which are the same as the logs created for Loki. 
+<7> OpenTelemetry configuration for exporting metrics, which are the same as the metrics created for Prometheus. These configurations are specified in the `spec.processor.metrics.includeList` parameter of the `FlowCollector` custom resource, along with any custom metrics you defined using the `FlowMetrics` custom resource.
+<8> The time interval that metrics are sent to the OpenTelemetry collector.
+<9> *Optional*:Network Observability network flows formats get automatically renamed to an OpenTelemetry compliant format. The `fieldsMapping` specification gives you the ability to customize the OpenTelemetry format output. For example in the YAML sample, `SrcAddr` is the Network Observability input field, and it is being renamed `source.address` in OpenTelemetry output. You can see both Network Observability and OpenTelemetry formats in the "Network flows format reference".
+
+After configuration, network flows data can be sent to an available output in a JSON format. For more information, see "Network flows format reference".


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Merge only to `no-1.7`. On GA 10/21/24, Sara will open a branch to integrate `no-1.7` with `main`, and that branch will go to 4.12+.
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-10036
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://80555--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/configuring-operator.html#network-observability-enriched-flows_network_observability
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
