### PR TITLE
OSDOCS#10932: Preliminary work for SDN-to-OVN migration

### DIFF
--- a/_attributes/attributes-openshift-dedicated.adoc
+++ b/_attributes/attributes-openshift-dedicated.adoc
@@ -17,6 +17,7 @@
 :hybrid-console-url: link:https://console.redhat.com[Red Hat Hybrid Cloud Console]
 :AWS: Amazon Web Services (AWS)
 :GCP: Google Cloud Platform (GCP)
+:openshift-networking: Red Hat OpenShift Networking
 :product-registry: OpenShift image registry
 :kebab: image:kebab.png[title="Options menu"]
 :rhq-short: Red Hat Quay

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -814,6 +814,8 @@ Name: Networking
 Dir: networking
 Distros: openshift-dedicated
 Topics:
+- Name: About networking
+  File: about-managed-networking
 - Name: Understanding the DNS Operator
   File: dns-operator
 - Name: Understanding the Ingress Operator
@@ -844,6 +846,11 @@ Topics:
       File: deleting-network-policy
     - Name: Configuring multitenant isolation with network policy
       File: multitenant-network-policy
+- Name: OVN-Kubernetes network plugin
+  Dir: ovn_kubernetes_network_provider
+  Topics:
+  - Name: About the OpenShift SDN network plugin
+    File: about-ovn-kubernetes
 - Name: Configuring Routes
   Dir: routes
   Topics:

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1068,6 +1068,8 @@ Name: Networking
 Dir: networking
 Distros: openshift-rosa
 Topics:
+- Name: About networking
+  File: about-managed-networking
 - Name: Understanding the DNS Operator
   File: dns-operator
 - Name: Understanding the Ingress Operator
@@ -1117,6 +1119,8 @@ Topics:
 - Name: OVN-Kubernetes network plugin
   Dir: ovn_kubernetes_network_provider
   Topics:
+  - Name: About the OpenShift SDN network plugin
+    File: about-ovn-kubernetes
   - Name: Configuring an egress IP address
     File: configuring-egress-ips-ovn
 - Name: Configuring Routes

--- a/networking/about-managed-networking.adoc
+++ b/networking/about-managed-networking.adoc
@@ -1,0 +1,22 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="about-managed-networking"]
+= About networking
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: about-managed-networking
+
+toc::[]
+
+{openshift-networking} is an ecosystem of features, plugins, and advanced networking capabilities that enhance Kubernetes networking with advanced networking-related features that your cluster needs to manage network traffic for one or multiple hybrid clusters. This ecosystem of networking capabilities integrates ingress, egress, load balancing, high-performance throughput, security, and inter- and intra-cluster traffic management. The {openshift-networking} ecosystem also provides role-based observability tooling to reduce its natural complexities.
+
+The following are some of the most commonly used {openshift-networking} features available on your cluster:
+
+- Primary cluster network provided by either of the following Container Network Interface (CNI) plugins:
+  * xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes network plugin] - the default plugin
+  * link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.14/html/networking/openshift-sdn-network-plugin#nw-openshift-sdn-modes_about-openshift-sdn[OpenShift SDN network plugin]- deprecated for clusters as of OpenShift 4.14
+- Cluster Network Operator for network plugin management
+
+{product-title} clusters created with OpenShift 4.11 and above use OVN-Kubernetes network plugin by default. {product-title} clusters created before OpenShift version 4.11 use the OpenShift SDN plugin after they are upgraded to OpenShift version 4.11 and above.
+
+include::snippets/sdn-deprecation-statement-managed.adoc[]
+
+You will soon be able to migrate from OpenShift SDN to OVN for clusters running on OpenShift version 4.15 and later. This migration tool is not currently available. For more information about the OpenShift SDN deprecation and the OVN migration, see the KCS article about link:https://access.redhat.com/articles/7065170[OpenShift SDN CNI removal in OCP 4.17].

--- a/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+++ b/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
@@ -43,6 +43,7 @@ include::modules/nw-ovn-kuberentes-limitations.adoc[leveloffset=+1]
 
 include::modules/nw-ovn-kubernetes-session-affinity.adoc[leveloffset=+1]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [role="_additional-resources"]
 .Additional resources
 
@@ -52,3 +53,4 @@ include::modules/nw-ovn-kubernetes-session-affinity.adoc[leveloffset=+1]
 * xref:../../networking/ovn_kubernetes_network_provider/enabling-multicast.adoc#nw-ovn-kubernetes-enabling-multicast[Enabling multicast for a project]
 * xref:../../networking/network_security/configuring-ipsec-ovn.adoc#configuring-ipsec-ovn[Configuring IPsec encryption]
 * xref:../../rest_api/operator_apis/network-operator-openshift-io-v1.adoc#network-operator-openshift-io-v1[Network [operator.openshift.io/v1\]]
+endif::openshift-rosa,openshift-dedicated[]

--- a/snippets/sdn-deprecation-statement-managed.adoc
+++ b/snippets/sdn-deprecation-statement-managed.adoc
@@ -1,0 +1,35 @@
+// Text snippet included in the following assemblies:
+//
+// * networking/about-networking.adoc
+// * networking/openshift_sdn/assigning-egress-ips.adoc
+// * networking/openshift_sdn/editing-egress-firewall.adoc
+// * networking/openshift_sdn/enabling-multicast.adoc
+// * networking/openshift_sdn/migrate-to-openshift-sdn.adoc
+// * networking/openshift_sdn/multitenant-isolation.adoc
+// * networking/openshift_sdn/removing-egress-firewall.adoc
+// * networking/ovn_kubernetes_network_provider/rollback-to-openshift-sdn.adoc
+// * networking/ovn_kubernetes_network_provider/viewing-egress-firewall-ovn.adoc
+// * networking/openshift_sdn/about-openshift-sdn.adoc
+// * networking/openshift_sdn/rollback-to-ovn-kubernetes.adoc
+// * networking/openshift_sdn/configuring-egress-firewall.adoc
+//
+// Text snippet included in the following modules:
+//
+// * modules/nw-networking-glossary-terms.adoc
+// * modules/nw-ovn-kubernetes-migration-about.adoc
+// * modules/optimizing-mtu-networking.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+[IMPORTANT]
+====
+{product-title} follows the life cycle of SDN according to OpenShift Core Platform:  
+
+* SDN is deprecated for clusters as of OpenShift version 4.14.
+* Clusters that already use the OpenShift SDN plugin continue to use the plugin after they are upgraded to OpenShift versions 4.11 and above.
+* Clusters can be upgraded up to OpenShift version 4.16.
+
+* Clusters running on OpenShift 4.16:
+** Clusters using OpenShift version 4.16 cannot upgrade if the clusters are using the SDN plugin.
+* The SDN plugin will be discontinued in OpenShift version 4.17.
+====


### PR DESCRIPTION
Version(s):
`ROSA classic architecture & OSD 4.16+`

Issue:
**[OSDOCS-10932](https://issues.redhat.com/browse/OSDOCS-10932)**

Link to docs preview:
- **[About networking](https://80570--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/about-managed-networking)** on ROSA classic architecture
- **[About networking](https://80570--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/about-managed-networking.html)** on OSD

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR creates an Understanding networking page for both OSD and ROSA classic architecture. This page contains preliminary warnings against using the SDN network Operator.