### PR TITLE
WMCO Added dual NIC limitation to networking module in RN

### DIFF
--- a/modules/windows-containers-release-notes-limitations.adoc
+++ b/modules/windows-containers-release-notes-limitations.adoc
@@ -21,9 +21,9 @@ Note the following limitations when working with Windows nodes managed by the WM
 ** link:https://docs.redhat.com/en/documentation/cost_management_service/1-latest[Red Hat Insights cost management]
 ** link:https://developers.redhat.com/products/openshift-local/overview[Red Hat OpenShift Local]
 
-* Windows nodes do not support workloads created by using deployment configs. You can use a deployment or other method to deploy workloads.
+* Dual NIC is not supported on WMCO-managed Windows instances.
 
-* Windows nodes are not supported in clusters that are in a disconnected environment.
+* Windows nodes do not support workloads created by using deployment configs. You can use a deployment or other method to deploy workloads.
 
 * {productwinc} does not support adding Windows nodes to a cluster through a trunk port. The only supported networking configuration for adding Windows nodes is through an access port that carries traffic for the VLAN.
 

--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -42,6 +42,11 @@ a|* Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic
 
 Hybrid networking with OVN-Kubernetes is the only supported networking configuration. See the additional resources below for more information on this functionality. The following tables outline the type of networking configuration and Windows Server versions to use based on your platform. You must specify the network configuration when you install the cluster. Be aware that OpenShift SDN networking is the default network for {product-title} clusters. However, OpenShift SDN is not supported by WMCO.
 
+[NOTE]
+====
+* The WMCO does not support OVN-Kubernetes without hybrid networking or OpenShift SDN.
+* Dual NIC is not supported on WMCO-managed Windows instances.
+====
 
 .Platform networking support
 [cols="2",options="header"]

--- a/windows_containers/enabling-windows-container-workloads.adoc
+++ b/windows_containers/enabling-windows-container-workloads.adoc
@@ -33,7 +33,7 @@ Windows instances deployed by the WMCO are configured with the containerd contai
 
 [role="_additional-resources"]
 .Additional resources
-* For the comprehensive prerequisites for the Windows Machine Config Operator, see xref:../windows_containers/understanding-windows-container-workloads.adoc#wmco-prerequisites_understanding-windows-container-workloads[Understanding Windows container workloads].
+* For the comprehensive prerequisites for the Windows Machine Config Operator, see xref:../windows_containers/windows-containers-release-notes-6-x#wmco-prerequisites_windows-containers-release-notes[Windows Machine Config Operator prerequisites].
 
 [id="installing-the-wmco"]
 == Installing the Windows Machine Config Operator

--- a/windows_containers/understanding-windows-container-workloads.adoc
+++ b/windows_containers/understanding-windows-container-workloads.adoc
@@ -17,8 +17,6 @@ Hostile multi-tenant clusters introduce security concerns in all Kubernetes envi
 Windows Server Containers provide resource isolation using a shared kernel but are not intended to be used in hostile multitenancy scenarios. Scenarios that involve hostile multitenancy should use Hyper-V Isolated Containers to strongly isolate tenants.
 ====
 
-include::modules/wmco-prerequisites.adoc[leveloffset=+1]
-
 [role="_additional-resources"]
 .Additional resources
 * See xref:../networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc#configuring-hybrid-ovnkubernetes_configuring-hybrid-networking[Configuring hybrid networking with OVN-Kubernetes]
@@ -26,7 +24,5 @@ include::modules/wmco-prerequisites.adoc[leveloffset=+1]
 include::modules/windows-workload-management.adoc[leveloffset=+1]
 
 include::modules/windows-node-services.adoc[leveloffset=+1]
-
-include::modules/windows-containers-release-notes-limitations.adoc[leveloffset=+1]
 
 //modules/windows-linux-containers-differences.adoc[leveloffset=+1]


### PR DESCRIPTION
Based on [comments in Slack](https://redhat-internal.slack.com/archives/CM4ERHBJS/p1723726917498239).

Also removed redundant assemblies from Understanding Windows Container Workloads.

Previews
WMCO release notes -> [Known limitations](https://80578--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-6-x#windows-containers-release-notes-limitations_windows-containers-release-notes) - Added existing statement on dual NIC support to known limitations, 3rd bullet. See [dual NIC support statement in current docs](https://docs.openshift.com/container-platform/4.16/windows_containers/enabling-windows-container-workloads.html).
WMCO release notes -> [Supported networking](https://80578--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-6-x#supported-networking) - Added existing statement on dual NIC support, 2nd bullet in note.
Enabling Windows container workloads -> [Additional resources](https://80578--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/enabling-windows-container-workloads) - Updated link.
Understanding Windows container workloads: Removed redundant _Windows Machine Config Operator prerequisites_ and Known Limitations modules. [Prereqs module still in RN](https://80578--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-6-x#wmco-prerequisites_windows-containers-release-notes) and [Known Limitations](https://80578--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-6-x#windows-containers-release-notes-limitations_windows-containers-release-notes).  [Prereqs in current docs](https://docs.openshift.com/container-platform/4.16/windows_containers/understanding-windows-container-workloads.html) and [Limitations in current docs](https://docs.openshift.com/container-platform/4.16/windows_containers/understanding-windows-container-workloads.html#windows-containers-release-notes-limitations_understanding-windows-container-workloads). 

No QE needed, as it is reorganizations only.
