### PR TITLE
[OSDOCS-11718]: Edit ingress docs incorrectly identify "non-default" ingresses

### DIFF
--- a/cli_reference/rosa_cli/rosa-manage-objects-cli.adoc
+++ b/cli_reference/rosa_cli/rosa-manage-objects-cli.adoc
@@ -26,6 +26,11 @@ include::modules/rosa-create-objects.adoc[leveloffset=+1]
 * See xref:../../rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc#rosa-security-groups_prerequisites[Additional custom security groups] for information about security group requirements.
 
 include::modules/rosa-edit-objects.adoc[leveloffset=+1]
+
+[role="_additional-resources_1"]
+== Additional resources
+* See xref:../../networking/ingress-operator.adoc#configuring-ingress-controller[Configuring the Ingress Controller] for information regarding editing non-default application routers.
+
 include::modules/rosa-delete-objects.adoc[leveloffset=+1]
 include::modules/rosa-install-uninstall-addon.adoc[leveloffset=+1]
 include::modules/rosa-list-objects.adoc[leveloffset=+1]

--- a/modules/rosa-edit-objects.adoc
+++ b/modules/rosa-edit-objects.adoc
@@ -79,8 +79,12 @@ $ rosa edit cluster --cluster=mycluster --interactive
 [id="rosa-edit-ingress_{context}"]
 == edit ingress
 
-Edits the additional non-default application router for a cluster.
+Edits the default application router for a cluster.
 
+[NOTE]
+====
+For information about editing non-default application routers, see _Additional resources_.
+====
 .Syntax
 [source,terminal]
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.17+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-11718
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://80588--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli.html#rosa-edit-ingress_rosa-managing-objects-cli
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
