### PR TITLE
OSDOCS-10924: adds 4.16.8 async relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -187,7 +187,7 @@ This section is updated over time to provide notes on enhancements and bug fixes
 [id="microshift-4-16-0-dp_{context}"]
 === RHEA-2024:0043 - {microshift-short} 4.16.0 bug fix and security update advisory
 
-Issued: 2024-06-27
+Issued: 27 June 2024
 
 {product-title} release 4.16.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:0043[RHSA-2024:0043] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0041[RHSA-2024:0041] advisory.
 
@@ -196,7 +196,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-16-1-dp_{context}"]
 === RHBA-2024:4158 - {microshift-short} 4.16.1 bug fix and enhancement advisory
 
-Issued: 2024-07-03
+Issued: 3 July 2024
 
 {product-title} release 4.16.1 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4158[RHBA-2024:4158] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4156[RHSA-2024:4156] advisory.
 
@@ -205,7 +205,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-16-2-dp_{context}"]
 === RHBA-2024:4318 - {microshift-short} 4.16.2 bug fix and enhancement advisory
 
-Issued: 2024-07-09
+Issued: 9 July 2024
 
 {product-title} release 4.16.2 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4318[RHBA-2024:4318] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4316[RHSA-2024:4316] advisory.
 
@@ -214,7 +214,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-16-3-dp_{context}"]
 === RHBA-2024:4318 - {microshift-short} 4.16.3 bug fix and enhancement advisory
 
-Issued: 2024-07-16
+Issued: 16 July 2024
 
 {product-title} release 4.16.3 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4471[RHBA-2024:4471] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4469[RHSA-2024:4469] advisory.
 
@@ -228,7 +228,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-16-4-dp_{context}"]
 === RHBA-2024:4615 - {microshift-short} 4.16.4 bug fix and enhancement advisory
 
-Issued: 2024-07-24
+Issued: 24 July 2024
 
 {product-title} release 4.16.4 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4615[RHBA-2024:4615] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4613[RHSA-2024:4613] advisory.
 
@@ -237,7 +237,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-16-5-dp_{context}"]
 === RHBA-2024:4857 - {microshift-short} 4.16.5 bug fix and enhancement advisory
 
-Issued: 2024-07-31
+Issued: 31 July 2024
 
 {product-title} release 4.16.5 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4857[RHBA-2024:4857] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:4855[RHBA-2024:4855] advisory.
 
@@ -246,7 +246,7 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-16-6-dp_{context}"]
 === RHBA-2024:4967 - {microshift-short} 4.16.6 bug fix and enhancement advisory
 
-Issued: 2024-08-06
+Issued: 6 August 2024
 
 {product-title} release 4.16.6 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4967[RHBA-2024:4967] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4965[RHSA-2024:4965] advisory.
 
@@ -255,8 +255,17 @@ For the latest images included with {microshift-short}, view the contents of the
 [id="microshift-4-16-7-dp_{context}"]
 === RHBA-2024:5109 - {microshift-short} 4.16.7 bug fix and enhancement advisory
 
-Issued: 2024-08-13
+Issued: 13 August 2024
 
 {product-title} release 4.16.7 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:5109[RHBA-2024:5109] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:5107[RHSA-2024:5107] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-16-8-dp_{context}"]
+=== RHBA-2024:5424 - {microshift-short} 4.16.8 bug fix and enhancement advisory
+
+Issued: 20 August 2024
+
+{product-title} release 4.16.8 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:5424[RHBA-2024:5424] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:5422[RHSA-2024:5422] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-10924](https://issues.redhat.com/browse/OSDOCS-10924)

Link to docs preview:
[4.16.8 release note](https://80593--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-8-dp_release-notes)

QE review:
- N/A stock text

Additional information:
Includes a backported date-style update per the IBM Style Guide.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
