### PR TITLE
OCPBUGS-11653: Update abstract for private DNS config module

### DIFF
--- a/modules/private-clusters-setting-dns-private.adoc
+++ b/modules/private-clusters-setting-dns-private.adoc
@@ -4,13 +4,20 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="private-clusters-setting-dns-private_{context}"]
-= Setting DNS to private
+= Configuring DNS records to be published in a private zone
 
-After you deploy a cluster, you can modify its DNS to use only a private zone.
+For all {product-title} clusters, whether public or private, DNS records are published in a public zone by default.
+
+You can remove the public zone from the cluster DNS configuration to avoid exposing DNS records to the public. You might want to avoid exposing sensitive information, such as internal domain names, internal IP addresses, or the number of clusters at an organization, or you might simply have no need to publish records publicly. If all the clients that should be able to connect to services within the cluster use a private DNS service that has the DNS records from the private zone, then there is no need to have a public DNS record for the cluster.
+
+After you deploy a cluster, you can modify its DNS to use only a private zone by modifying the `DNS` custom resource (CR).
+Modifying the `DNS` CR in this way means that any DNS records that are subsequently created are not published to public DNS servers, which keeps knowledge of the DNS records isolated to internal users. This can be done when you configure the cluster to be private, or if you never want DNS records to be publicly resolvable.
+
+Alternatively, even in a private cluster, you might keep the public zone for DNS records because it allows clients to resolve DNS names for applications running on that cluster. For example, an organization can have machines that connect to the public internet and then establish VPN connections for certain private IP ranges in order to connect to private IP addresses. The DNS lookups from these machines use the public DNS to determine the private addresses of those services, and then connect to the private addresses over the VPN.
 
 .Procedure
 
-. Review the `DNS` custom resource for your cluster:
+. Review the `DNS` CR for your cluster by running the following command and observing the output:
 +
 [source,terminal]
 ----
@@ -42,22 +49,29 @@ status: {}
 +
 Note that the `spec` section contains both a private and a public zone.
 
-. Patch the `DNS` custom resource to remove the public zone:
+. Patch the `DNS` CR to remove the public zone by running the following command:
 +
 [source,terminal]
 ----
 $ oc patch dnses.config.openshift.io/cluster --type=merge --patch='{"spec": {"publicZone": null}}'
+----
++
+.Example output
+[source,yaml]
+----
 dns.config.openshift.io/cluster patched
 ----
 +
-Because the Ingress Controller consults the `DNS` definition when it creates `Ingress` objects, when you create or modify `Ingress` objects, only private records are created.
+The Ingress Operator consults the `DNS` CR definition when it creates DNS records for `IngressController` objects. If only private zones are specified, only private records are created.
 +
 [IMPORTANT]
 ====
-DNS records for the existing Ingress objects are not modified when you remove the public zone.
+Existing DNS records are not modified when you remove the public zone. You must manually delete previously published public DNS records if you no longer want them to be published publicly.
 ====
 
-. Optional: Review the `DNS` custom resource for your cluster and confirm that the public zone was removed:
+.Verification
+
+* Review the `DNS` CR for your cluster and confirm that the public zone was removed, by running the following command and observing the output:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-11653

Link to docs preview:
https://80597--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-private-cluster.html#private-clusters-setting-dns-private_configuring-private-cluster

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
