### PR TITLE
OSDOCS-11439: update microshift config defaults

### DIFF
--- a/modules/microshift-default-settings.adoc
+++ b/modules/microshift-default-settings.adoc
@@ -46,7 +46,8 @@ ingress:
   routeAdmissionPolicy:
     namespaceOwnership: InterNamespaceAllowed # <12>
   status: Managed # <13>
-manifests: # <14>
+kubelet: # <14>
+manifests: # <15>
   kustomizePaths:
     - /usr/lib/microshift/manifests
     - /usr/lib/microshift/manifests.d/*
@@ -54,13 +55,18 @@ manifests: # <14>
     - /etc/microshift/manifests.d/*
 network:
   clusterNetwork:
-    - 10.42.0.0/16 # <15>
+    - 10.42.0.0/16 # <16>
   serviceNetwork:
-    - 10.43.0.0/16 # <16>
-  serviceNodePortRange: 30000-32767 # <17>
+    - 10.43.0.0/16 # <17>
+  serviceNodePortRange: 30000-32767 # <18>
 node:
-  hostnameOverride: "" # <18>
-  nodeIP: "" # <19>
+  hostnameOverride: "" # <19>
+  nodeIP: "" # <20>
+  nodeIPv6: "" # <21>
+storage:
+  driver: "" # <22>
+  optionalCsiComponents:  # <23>
+    - ""
 ----
 <1> A string that specifies the IP address from which the API server is advertised to members of the cluster. The default value is calculated based on the address of the service network.
 <2> How long log files are kept before automatic deletion. The default value of `0` in the `maxFileAge` parameter means a log file is never deleted based on age. This value can be configured.
@@ -75,9 +81,13 @@ node:
 <11> Default ports shown. Configurable. Valid values for both port entries are a single, unique port in the 1-65535 range. The values of the `ports.http` and `ports.https` fields cannot be the same.
 <12> Describes how hostname claims across namespaces are handled. By default, allows routes to claim different paths of the same hostname across namespaces. Valid values are `Strict` and `InterNamespaceAllowed`. Specifying `Strict` prevents routes in different namespaces from claiming the same hostname. If the value is deleted in a customized {microshift-short} `config.yaml`, the `InterNamespaceAllowed` value is automatically set.
 <13> Default router status, can be `Managed` or `Removed`.
-<14> The locations on the file system to scan for `kustomization` files to use to load manifests. Set to a list of paths to scan only those paths. Set to an empty list to disable loading manifests. The entries in the list can be glob patterns to match multiple subdirectories.
-<15> A block of IP addresses from which pod IP addresses are allocated. This field is immutable after installation.
-<16> A block of virtual IP addresses for Kubernetes services. IP address pool for services. A single entry is supported. This field is immutable after installation.
-<17> The port range allowed for Kubernetes services of type `NodePort`. If not specified, the default range of 30000-32767 is used. Services without a `NodePort` specified are automatically allocated one from this range. This parameter can be updated after the cluster is installed.
-<18> The name of the node. The default value is the hostname. If non-empty, this string is used to identify the node instead of the hostname.
-<19> The IP address of the node. The default value is the IP address of the default route.
+<14> Parameter for configuring kubelet. Used for low-latency configuration. Default value is null.
+<15> The locations on the file system to scan for `kustomization` files to use to load manifests. Set to a list of paths to scan only those paths. Set to an empty list to disable loading manifests. The entries in the list can be glob patterns to match multiple subdirectories.
+<16> A block of IP addresses from which pod IP addresses are allocated. IPv4 is the default. Dual-stack entries are supported. The first entry in this field is immutable after installation.
+<17> A block of virtual IP addresses for Kubernetes services. IP address pool for services. IPv4 is the default. Dual-stack entries are supported. The first entry in this field is immutable after installation.
+<18> The port range allowed for Kubernetes services of type `NodePort`. If not specified, the default range of 30000-32767 is used. Services without a `NodePort` specified are automatically allocated one from this range. This parameter can be updated after the cluster is installed.
+<19> The name of the node. The default value is the hostname. If non-empty, this string is used to identify the node instead of the hostname.
+<20> The IPv4 address of the node. The default value is the IP address of the default route.
+<21> The IPv6 address for the node for dual-stack configurations. Cannot be configured in single stack for either IPv4 or IPv6. Default is empty or null.
+<22> Default value is empty. Valid values are "none" or "lvms". An empty value or null field defaults to LVMS deployment.
+<23> Array. Default value is null or an empty array. A null or empty array defaults to deploying `snapshot-controller` and `snapshot-webhook`. Expected values are `csi-snapshot-controller`, `csi-snapshot-webhook`, or `none`. An entry of `none` is mutually exclusive with all other values.


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OSDOCS-11439](https://issues.redhat.com/browse/OSDOCS-11439)

Link to docs preview:
[MicroShift default values](https://80598--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-using-config-tools.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
