### PR TITLE
Adds docs for OMR version 2

### DIFF
--- a/modules/mirror-registry-flags.adoc
+++ b/modules/mirror-registry-flags.adoc
@@ -14,10 +14,10 @@ The following flags are available for the _mirror registry for Red Hat OpenShift
 | `--initPassword` | The password of the init user created during Quay installation. Must be at least eight characters and contain no whitespace.
 |`--initUser string` | Shows the username of the initial user. Defaults to `init` if left unspecified.
 | `--no-color`, `-c` | Allows users to disable color sequences and propagate that to Ansible when running install, uninstall, and upgrade commands.
-| `--pgStorage` | The folder where Postgres persistent storage data is saved. Defaults to the `pg-storage` Podman volume. Root privileges are required to uninstall. 
 | `--quayHostname` | The fully-qualified domain name of the mirror registry that clients will use to contact the registry. Equivalent to `SERVER_HOSTNAME` in the Quay `config.yaml`. Must resolve by DNS. Defaults to `<targetHostname>:8443` if left unspecified. ^[1]^
 | `--quayStorage` | The folder where Quay persistent storage data is saved. Defaults to the `quay-storage` Podman volume. Root privileges are required to uninstall.  
 | `--quayRoot`, `-r` | The directory where container image layer and configuration data is saved, including `rootCA.key`, `rootCA.pem`, and `rootCA.srl` certificates. Defaults to `$HOME/quay-install` if left unspecified.
+| `--sqliteStorage` | The folder where SQLite database data is saved. Defaults to `sqlite-storage` Podman volume if not specified. Root is required to uninstall.
 | `--ssh-key`, `-k` | The path of your SSH identity key. Defaults to `~/.ssh/quay_installer` if left unspecified.
 | `--sslCert` | The path to the SSL/TLS public key / certificate. Defaults to `{quayRoot}/quay-config` and is auto-generated if left unspecified.
 | `--sslCheckSkip` | Skips the check for the certificate hostname against the `SERVER_HOSTNAME` in the `config.yaml` file. ^[2]^

--- a/modules/mirror-registry-localhost-update.adoc
+++ b/modules/mirror-registry-localhost-update.adoc
@@ -10,7 +10,12 @@ This procedure explains how to update the _mirror registry for Red Hat OpenShift
 
 [IMPORTANT]
 ====
-When updating, there is intermittent downtime of your mirror registry, as it is restarted during the update process.
+When upgrading from version 1 to version 2, be aware of the following constraints:
+* The worker count is set to `1` because multiple writes are not allowed in SQLite. 
+* You must not use the _mirror registry for Red{nbsp}Hat OpenShift_ user interface (UP).
+* Do not access the `sqlite-storage` Podman volume during the upgrade.
+* There is intermittent downtime of your mirror registry because it is restarted during the upgrade process.
+* PostgreSQL data is backed up under the `/$HOME/quay-instal/quay-postgres-backup/` directory for recovery.
 ====
 
 .Prerequisites
@@ -19,7 +24,7 @@ When updating, there is intermittent downtime of your mirror registry, as it is 
 
 .Procedure
 
-* If you are upgrading the _mirror registry for Red Hat OpenShift_ from 1.2.z -> 1.3.0, and your installation directory is the default at `/etc/quay-install`, you can enter the following command:
+* If you are upgrading the _mirror registry for Red Hat OpenShift_ from 1.3 -> 2.y, and your installation directory is the default at `/etc/quay-install`, you can enter the following command:
 +
 [source,terminal]
 ----
@@ -33,10 +38,16 @@ $ sudo ./mirror-registry upgrade -v
 * Users who upgrade _mirror registry for Red Hat OpenShift_ with the `./mirror-registry upgrade -v` flag must include the same credentials used when creating their mirror registry. For example, if you installed the _mirror registry for Red Hat OpenShift_ with `--quayHostname <host_example_com>` and `--quayRoot <example_directory_name>`, you must include that string to properly upgrade the mirror registry.
 ====
 
-* If you are upgrading the _mirror registry for Red Hat OpenShift_ from 1.2.z -> 1.3.0 and you used a specified directory in your 1.2.z deployment, you must pass in the new `--pgStorage` and `--quayStorage` flags. For example:
+* If you are upgrading _the mirror registry for Red Hat OpenShift_ from 1.3 -> 2.y and you used a custom quay configuration and storage directory in your 1.y deployment, you must pass in the `--quayRoot` and `--quayStorage` flags. For example:
 +
 [source,terminal]
 ----
-$ sudo ./mirror-registry upgrade --quayHostname <host_example_com> --quayRoot <example_directory_name> --pgStorage <example_directory_name>/pg-data --quayStorage <example_directory_name>/quay-storage -v
+$ sudo ./mirror-registry upgrade --quayHostname <host_example_com> --quayRoot <example_directory_name>  --quayStorage <example_directory_name>/quay-storage -v
 ----
 
+* If you are upgrading the  _mirror registry for Red Hat OpenShift_ from 1.3 -> 2.y and want to specify a custom SQLite storage path, you must pass in the `--sqliteStorage` flag, for example:
++
+[source,terminal]
+----
+$ sudo ./mirror-registry upgrade --sqliteStorage <example_directory_name>/quay-storage -v
+----

--- a/modules/mirror-registry-release-notes.adoc
+++ b/modules/mirror-registry-release-notes.adoc
@@ -3,179 +3,48 @@
 // * installing/disconnected_install/installing-mirroring-creating-registry.adoc
 
 [id="mirror-registry-release-notes_{context}"]
-= Mirror registry for Red Hat OpenShift release notes
+= Mirror registry for Red{nbsp}Hat OpenShift release notes
 
-The _mirror registry for Red Hat OpenShift_ is a small and streamlined container registry that you can use as a target for mirroring the required container images of {product-title} for disconnected installations.
+The _mirror registry for Red{nbsp}Hat OpenShift_ is a small and streamlined container registry that you can use as a target for mirroring the required container images of {product-title} for disconnected installations.
 
-These release notes track the development of the _mirror registry for Red Hat OpenShift_ in {product-title}.
+These release notes track the development of the _mirror registry for Red{nbsp}Hat OpenShift_ in {product-title}.
 
-[id="mirror-registry-release-notes-1-3_{context}"]
-== Mirror registry for Red Hat OpenShift 1.3 release notes
+[id="mirror-registry-release-notes-2-0_{context}"]
+== Mirror registry for Red{nbsp}Hat OpenShift 2.0 release notes
 
-The following sections provide details for each 1.3.z release of the _mirror registry for Red Hat OpenShift_
+The following sections provide details for each 2.0 release of the mirror registry for Red{nbsp}Hat OpenShift
 
-[id="mirror-registry-for-openshift-1-3-11_{context}"]
-=== Mirror registry for Red Hat OpenShift 1.3.11
+[id="mirror-registry-for-openshift-2-0-0_{context}"]
+=== Mirror registry for Red Hat OpenShift 2.0.0
 
-Issued: 2024-04-23
+Issued: 03 September 2024
 
-_Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.8.15.
-
-The following advisory is available for the _mirror registry for Red Hat OpenShift_:
-
-* link:https://access.redhat.com/errata/RHBA-2024:1758[RHBA-2024:1758 - mirror registry for Red Hat OpenShift 1.3.11]
-
-[id="mirror-registry-for-openshift-1-3-10_{context}"]
-=== Mirror registry for Red Hat OpenShift 1.3.10
-
-Issued: 2023-12-07
-
-_Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.8.14.
+_Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.12.0.
 
 The following advisory is available for the _mirror registry for Red Hat OpenShift_:
 
-* link:https://access.redhat.com/errata/RHBA-2023:7628[RHBA-2023:7628 - mirror registry for Red Hat OpenShift 1.3.10]
+* link:https://access.redhat.com/errata/RHBA-2023:5277[RHBA-2023:5277 - mirror registry for Red Hat OpenShift 2.0.0]
 
-[id="mirror-registry-for-openshift-1-3-9_{context}"]
-=== Mirror registry for Red Hat OpenShift 1.3.9
-
-Issued: 2023-09-19
-
-_Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.8.12.
-
-The following advisory is available for the _mirror registry for Red Hat OpenShift_:
-
-* link:https://access.redhat.com/errata/RHBA-2023:5241[RHBA-2023:5241 - mirror registry for Red Hat OpenShift 1.3.9]
-
-[id="mirror-registry-for-openshift-1-3-8_{context}"]
-=== Mirror registry for Red Hat OpenShift 1.3.8
-
-Issued: 2023-08-16
-
-_Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.8.11.
-
-The following advisory is available for the _mirror registry for Red Hat OpenShift_:
-
-* link:https://access.redhat.com/errata/RHBA-2023:4622[RHBA-2023:4622 - mirror registry for Red Hat OpenShift 1.3.8]
-
-[id="mirror-registry-for-openshift-1-3-7_{context}"]
-=== Mirror registry for Red Hat OpenShift 1.3.7
-
-Issued: 2023-07-19
-
-_Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.8.10.
-
-The following advisory is available for the _mirror registry for Red Hat OpenShift_:
-
-* link:https://access.redhat.com/errata/RHBA-2023:4087[RHBA-2023:4087 - mirror registry for Red Hat OpenShift 1.3.7]
-
-[id="mirror-registry-for-openshift-1-3-6_{context}"]
-=== Mirror registry for Red Hat OpenShift 1.3.6
-
-Issued: 2023-05-30
-
-_Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.8.8.
-
-The following advisory is available for the _mirror registry for Red Hat OpenShift_:
-
-* link:https://access.redhat.com/errata/RHBA-2023:3302[RHBA-2023:3302 - mirror registry for Red Hat OpenShift 1.3.6]
-
-[id="mirror-registry-for-openshift-1-3-5_{context}"]
-=== Mirror registry for Red Hat OpenShift 1.3.5
-
-Issued: 2023-05-18
-
-_Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.8.7.
-
-The following advisory is available for the _mirror registry for Red Hat OpenShift_:
-
-* link:https://access.redhat.com/errata/RHBA-2023:3225[RHBA-2023:3225 - mirror registry for Red Hat OpenShift 1.3.5]
-
-[id="mirror-registry-for-openshift-1-3-4_{context}"]
-=== Mirror registry for Red Hat OpenShift 1.3.4
-
-Issued: 2023-04-25
-
-_Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.8.6.
-
-The following advisory is available for the _mirror registry for Red Hat OpenShift_:
-
-* link:https://access.redhat.com/errata/RHBA-2023:1914[RHBA-2023:1914 - mirror registry for Red Hat OpenShift 1.3.4]
-
-[id="mirror-registry-for-openshift-1-3-3_{context}"]
-=== Mirror registry for Red Hat OpenShift 1.3.3
-
-Issued: 2023-04-05
-
-_Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.8.5.
-
-The following advisory is available for the _mirror registry for Red Hat OpenShift_:
-
-* link:https://access.redhat.com/errata/RHBA-2023:1528[RHBA-2023:1528 - mirror registry for Red Hat OpenShift 1.3.3]
-
-[id="mirror-registry-for-openshift-1-3-2_{context}"]
-=== Mirror registry for Red Hat OpenShift 1.3.2
-
-Issued: 2023-03-21
-
-_Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.8.4.
-
-The following advisory is available for the _mirror registry for Red Hat OpenShift_:
-
-* link:https://access.redhat.com/errata/RHBA-2023:1376[RHBA-2023:1376 - mirror registry for Red Hat OpenShift 1.3.2]
-
-[id="mirror-registry-for-openshift-1-3-1_{context}"]
-=== Mirror registry for Red Hat OpenShift 1.3.1
-
-Issued: 2023-03-7
-
-_Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.8.3.
-
-The following advisory is available for the _mirror registry for Red Hat OpenShift_:
-
-* link:https://access.redhat.com/errata/RHBA-2023:1086[RHBA-2023:1086 - mirror registry for Red Hat OpenShift 1.3.1]
-
-[id="mirror-registry-for-openshift-1-3-0_{context}"]
-=== Mirror registry for Red Hat OpenShift 1.3.0
-
-Issued: 2023-02-20
-
-_Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.8.1.
-
-The following advisory is available for the _mirror registry for Red Hat OpenShift_:
-
-* link:https://access.redhat.com/errata/RHBA-2023:0558[RHBA-2023:0558 - mirror registry for Red Hat OpenShift 1.3.0]
-
-[id="mirror-registry-new-features-1-3-0_{context}"]
+[id="mirror-registry-new-features-2-0_{context}"]
 ==== New features
 
-* _Mirror registry for Red Hat OpenShift_ is now supported on {op-system-base-full} 9 installations.
-
-* IPv6 support is now available on _mirror registry for Red Hat OpenShift_ local host installations.
+* With the release of _mirror registry for Red{nbsp}Hat OpenShift_, the internal database has been upgraded from PostgreSQL to SQLite. As a result, data is now stored on the `sqlite-storage` Podman volume by default, and the overall tarball size is reduced by 300 MB. 
 +
-IPv6 is currently unsupported on _mirror registry for Red Hat OpenShift_ remote host installations.
+New installations use SQLite by default. Before upgrading to version 2.0, see "Updating mirror registry for Red Hat OpenShift from a local host" or "Updating mirror registry for Red Hat OpenShift from a remote host" depending on your environment.
 
-* A new feature flag, `--quayStorage`, has been added. By specifying this flag, you can manually set the location for the Quay persistent storage.
+* A new feature flag, `--sqliteStorage` has been added. With this flag, you can manually set the location where SQLite database data is saved.
 
-* A new feature flag, `--pgStorage`, has been added. By specifying this flag, you can manually set the location for the Postgres persistent storage.
+[id="mirror-registry-release-notes-1-3_{context}"]
+== Mirror registry for Red{nbsp}Hat OpenShift 1.3 release notes
 
-* Previously, users were required to have root privileges (`sudo`) to install _mirror registry for Red Hat OpenShift_. With this update, `sudo` is no longer required to install _mirror registry for Red Hat OpenShift_.
-+
-When _mirror registry for Red Hat OpenShift_ was installed with `sudo`, an `/etc/quay-install` directory that contained installation files, local storage, and the configuration bundle was created. With the removal of the `sudo` requirement, installation files and the configuration bundle are now installed to `$HOME/quay-install`. Local storage, for example Postgres and Quay, are now stored in named volumes automatically created by Podman.
-+
-To override the default directories that these files are stored in, you can use the command line arguments for _mirror registry for Red Hat OpenShift_. For more information about _mirror registry for Red Hat OpenShift_ command line arguments, see "_Mirror registry for Red Hat OpenShift_ flags".
-
-[id="mirror-registry-bug-fixes-1-3-0_{context}"]
-==== Bug fixes
-
-* Previously, the following error could be returned when attempting to uninstall _mirror registry for Red Hat OpenShift_: `["Error: no container with name or ID \"quay-postgres\" found: no such container"], "stdout": "", "stdout_lines": []***`. With this update, the order that _mirror registry for Red Hat OpenShift_ services are stopped and uninstalled have been changed so that the error no longer occurs when uninstalling _mirror registry for Red Hat OpenShift_. For more information, see link:https://issues.redhat.com/browse/PROJQUAY-4629[*PROJQUAY-4629*].
+To view the _mirror registry for Red{nbsp}Hat OpenShift_ 1.3 release notes, see link:https://docs.openshift.com/container-platform/4.16/installing/disconnected_install/installing-mirroring-creating-registry.html#mirror-registry-release-notes-1-3_installing-mirroring-creating-registry[Mirror registry for Red{nbsp}Hat OpenShift 1.3 release notes].
 
 [id="mirror-registry-release-notes-1-2_{context}"]
-== Mirror registry for Red Hat OpenShift 1.2 release notes
+== Mirror registry for Red{nbsp}Hat OpenShift 1.2 release notes
 
-To view the _mirror registry for Red Hat OpenShift_ 1.2 release notes, see link:https://docs.openshift.com/container-platform/4.15/installing/disconnected_install/installing-mirroring-creating-registry.html#mirror-registry-release-notes-1-2_installing-mirroring-creating-registry[Mirror registry for Red Hat OpenShift 1.2 release notes].
+To view the _mirror registry for Red{nbsp}Hat OpenShift_ 1.2 release notes, see link:https://docs.openshift.com/container-platform/4.15/installing/disconnected_install/installing-mirroring-creating-registry.html#mirror-registry-release-notes-1-2_installing-mirroring-creating-registry[Mirror registry for Red{nbsp}Hat OpenShift 1.2 release notes].
 
 [id="mirror-registry-release-notes-1-1_{context}"]
-== Mirror registry for Red Hat OpenShift 1.1 release notes
+== Mirror registry for Red{nbsp}Hat OpenShift 1.1 release notes
 
-To view the _mirror registry for Red Hat OpenShift_ 1.1 release notes, see link:https://docs.openshift.com/container-platform/4.15/installing/disconnected_install/installing-mirroring-creating-registry.html#mirror-registry-release-notes-1-1_installing-mirroring-creating-registry[Mirror registry for Red Hat OpenShift 1.1 release notes].
+To view the _mirror registry for Red{nbsp}Hat OpenShift_ 1.1 release notes, see link:https://docs.openshift.com/container-platform/4.15/installing/disconnected_install/installing-mirroring-creating-registry.html#mirror-registry-release-notes-1-1_installing-mirroring-creating-registry[Mirror registry for Red Hat OpenShift 1.1 release notes].

--- a/modules/mirror-registry-remote-host-update.adoc
+++ b/modules/mirror-registry-remote-host-update.adoc
@@ -10,7 +10,12 @@ This procedure explains how to update the _mirror registry for Red Hat OpenShift
 
 [IMPORTANT]
 ====
-When updating, there is intermittent downtime of your mirror registry, as it is restarted during the update process.
+When upgrading from version 1 to version 2, be aware of the following constraints:
+* The worker count is set to `1` because multiple writes are not allowed in SQLite. 
+* You must not use the _mirror registry for Red{nbsp}Hat OpenShift_ user interface (UP).
+* Do not access the `sqlite-storage` Podman volume during the upgrade.
+* There is intermittent downtime of your mirror registry because it is restarted during the upgrade process.
+* PostgreSQL data is backed up under the `/$HOME/quay-instal/quay-postgres-backup/` directory for recovery.
 ====
 
 .Prerequisites
@@ -30,3 +35,10 @@ $ ./mirror-registry upgrade -v --targetHostname <remote_host_url> --targetUserna
 ====
 Users who upgrade the _mirror registry for Red Hat OpenShift_ with the `./mirror-registry upgrade -v` flag must include the same credentials used when creating their mirror registry. For example, if you installed the _mirror registry for Red Hat OpenShift_ with `--quayHostname <host_example_com>` and `--quayRoot <example_directory_name>`, you must include that string to properly upgrade the mirror registry.
 ====
+
+* If you are upgrading the  _mirror registry for Red Hat OpenShift_ from 1.3 -> 2.y and want to specify a custom SQLite storage path, you must pass in the `--sqliteStorage` flag, for example:
++
+[source,terminal]
+----
+$ ./mirror-registry upgrade -v --targetHostname <remote_host_url> --targetUsername <user_name> -k ~/.ssh/my_ssh_key --sqliteStorage <example_directory_name>/quay-storage
+----


### PR DESCRIPTION
A portion of these docs will need cherry-picked to 4.12-4.15. This specific PR is for 4.16+ due to how OMR is supported.

I know that {nbsp} needs placed between "Red Hat". That should be addressed in a separate PR. 

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-11690

Link to docs preview:
https://80603--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-creating-registry.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
