### PR TITLE
HCIDOCS-376: Fix indents in networkConfig stanza, install-config.yml (IPI)

### DIFF
--- a/modules/ipi-install-configuring-host-dual-network-interfaces-in-the-install-config.yaml-file.adoc
+++ b/modules/ipi-install-configuring-host-dual-network-interfaces-in-the-install-config.yaml-file.adoc
@@ -6,7 +6,7 @@
 [id="configuring-host-dual-network-interfaces-in-the-install-config-yaml-file_{context}"]
 = Configuring host network interfaces for dual port NIC
 
-Before installation, you can set the `networkConfig` configuration setting in the `install-config.yaml` file to configure host network interfaces using NMState to support dual port NIC.
+Before installation, you can set the `networkConfig` configuration setting in the `install-config.yaml` file to configure host network interfaces by using NMState to support dual port NIC.
 
 :FeatureName: Support for Day 1 operations associated with enabling NIC partitioning for SR-IOV devices
 include::snippets/technology-preview.adoc[leveloffset=+1]
@@ -24,7 +24,7 @@ include::snippets/technology-preview.adoc[leveloffset=+1]
 
 [NOTE]
 ====
-Errors in the YAML syntax might result in a failure to apply the network configuration. Additionally, maintaining the validated YAML syntax is useful when applying changes using Kubernetes NMState after deployment or when expanding the cluster.
+Errors in the YAML syntax might result in a failure to apply the network configuration. Additionally, maintaining the validated YAML syntax is useful when applying changes by using Kubernetes NMState after deployment or when expanding the cluster.
 ====
 
 .Procedure
@@ -109,19 +109,20 @@ Errors in the YAML syntax might result in a failure to apply the network configu
                enabled: true
              ipv6:
                enabled: false
-             dns-resolver:
-               config:
-                 server:
-                   - 10.11.5.160
-                   - 10.2.70.215
-             routes:
-               config:
-                 - destination: 0.0.0.0/0
-                   next-hop-address: 10.19.17.254
-                   next-hop-interface: bond0 <14>
-                   table-id: 254
+          dns-resolver:
+            config:
+              server:
+                - 10.11.5.160
+                - 10.2.70.215
+          routes:
+            config:
+              - destination: 0.0.0.0/0
+                next-hop-address: 10.19.17.254
+                next-hop-interface: bond0 <14>
+                table-id: 254
+
 ----
-<1> The `networkConfig` field contains information about the network configuration of the host, with subfields including `interfaces`, `dns-resolver`, and `routes`.
+<1> The `networkConfig` field has information about the network configuration of the host, with subfields including `interfaces`, `dns-resolver`, and `routes`.
 <2> The `interfaces` field is an array of network interfaces defined for the host.
 <3> The name of the interface.
 <4> The type of interface. This example creates a ethernet interface.
@@ -134,11 +135,11 @@ Errors in the YAML syntax might result in a failure to apply the network configu
     * Intel NICs do not support the `min-tx-rate` parameter. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1772847[*BZ#1772847*].
 <10> Sets a maximum transmission rate, in Mbps, for the VF. This sample value sets a rate of 200 Mbps.
 <11> Sets the desired bond mode.
-<12> Sets the preferred port of the bonding interface. The primary device is the first of the bonding interfaces to be used and is not abandoned unless it fails. This setting is particularly useful when one NIC in the bonding interface is faster and, therefore, able to handle a bigger load. This setting is only valid when the bonding interface is in active-backup mode (mode 1) and balance-tlb (mode 5).
+<12> Sets the preferred port of the bonding interface. The bond uses the primary device as the first device of the bonding interfaces. The bond does not abandon the primary device interface unless it fails. This setting is particularly useful when one NIC in the bonding interface is faster and, therefore, able to handle a bigger load. This setting is only valid when the bonding interface is in active-backup mode (mode 1) and balance-tlb (mode 5).
 <13> Sets a static IP address for the bond interface. This is the node IP address.
 <14> Sets `bond0` as the gateway for the default route.
 +
 [IMPORTANT]
 ====
-After deploying the cluster, you cannot modify the `networkConfig` configuration setting of `install-config.yaml` file to make changes to the host network interface. Use the Kubernetes NMState Operator to make changes to the host network interface after deployment.
+After deploying the cluster, you cannot change the `networkConfig` configuration setting of the `install-config.yaml` file to make changes to the host network interface. Use the Kubernetes NMState Operator to make changes to the host network interface after deployment.
 ====


### PR DESCRIPTION
Adjust placement of YAML fields.

Fixes: [HCIDOCS-376](https://issues.redhat.com//browse/HCIDOCS-376)

See https://issues.redhat.com/browse/HCIDOCS-376 for additional details.

Preview URL: http://jowilkin.com:8080/HCIDOCS-376/welcome/index.html

For release(s): 4.13-4.17
QE Review: 

- [x] QE has approved this change. 

Signed-off-by:  <jowilkin@redhat.com>
