### PR TITLE
HCIDOCS-376: Fix indents in networkConfig stanza, install-config.yml (IPI)

### DIFF
--- a/modules/ipi-install-configuring-host-network-interfaces-for-subnets.adoc
+++ b/modules/ipi-install-configuring-host-network-interfaces-for-subnets.adoc
@@ -13,11 +13,11 @@ For edge computing scenarios, it can be beneficial to locate compute nodes close
 When using the default load balancer, `OpenShiftManagedDefault` and adding remote nodes to your {product-title} cluster, all control plane nodes must run in the same subnet. When using more than one subnet, you can also configure the Ingress VIP to run on the control plane nodes by using a manifest. See "Configuring network components to run on the control plane" for details.
 ====
 
-If you have established different network segments or subnets for remote nodes as described in the section on "Establishing communication between subnets", you must specify the subnets in the `machineNetwork` configuration setting if the workers are using static IP addresses, bonds or other advanced networking. When setting the node IP address in the `networkConfig` parameter for each remote node, you must also specify the gateway and the DNS server for the subnet containing the control plane nodes when using static IP addresses. This ensures the remote nodes can reach the subnet containing the control plane nodes and that they can receive network traffic from the control plane.
+If you have established different network segments or subnets for remote nodes as described in the section on "Establishing communication between subnets", you must specify the subnets in the `machineNetwork` configuration setting if the workers are using static IP addresses, bonds or other advanced networking. When setting the node IP address in the `networkConfig` parameter for each remote node, you must also specify the gateway and the DNS server for the subnet containing the control plane nodes when using static IP addresses. This ensures that the remote nodes can reach the subnet containing the control plane and that they can receive network traffic from the control plane.
 
 [NOTE]
 ====
-Deploying a cluster with multiple subnets requires using virtual media, such as `redfish-virtualmedia` and `idrac-virtualmedia`, because remote nodes cannot access the local provisioning network.
+Deploying a cluster with multiple subnets requires using virtual media, such as `redfish-virtualmedia` or `idrac-virtualmedia`, because remote nodes cannot access the local provisioning network.
 ====
 
 .Procedure
@@ -49,10 +49,10 @@ networkConfig:
       - ip: <node_ip> <2>
         prefix-length: 24
       gateway: <gateway_ip> <3>
-      dns-resolver:
-        config:
-          server:
-          - <dns_ip> <4>
+  dns-resolver:
+    config:
+      server:
+      - <dns_ip> <4>
 ----
 +
 <1> Replace `<interface_name>` with the interface name.


### PR DESCRIPTION
Fixed indents.

Fixes: [HCIDOCS-376](https://issues.redhat.com//browse/HCIDOCS-376)

See https://issues.redhat.com/browse/HCIDOCS-376 for additional details.

Preview URL:https://80609--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#ipi-install-configuring-host-network-interfaces-for-subnets_ipi-install-installation-workflow

For release(s): 4.12-4.17
QE Review: 

- [x] QE has approved this change. 

Signed-off-by:  <jowilkin@redhat.com>
