### PR TITLE
OSSM 3.0TP1: OSSM-6961 [DOC] Installing the Kiali Operator provided by Red Hat

### DIFF
--- a/modules/ossm-install-kiali-operator.adoc
+++ b/modules/ossm-install-kiali-operator.adoc
@@ -1,0 +1,54 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/observability/ossm-observability-assembly.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-install-kiali-operator_{context}"]
+= Installing the {KialiProduct}
+:context: ossm-install-kiali-operator
+
+//ADD TO ASSEMBLY after PR 80434 is merged
+//Need some kind of intro
+//Possible file name may change
+//Possible assembly file may change
+//Assemblies, topic map info needs to be worked out still for 3.0, now that docs has a better idea of what is to be included for 3.0 TP1.
+
+//FIX THE STYLE THINGS ONCE DEV HAS REVIEWED/APPROVED THE CONTENT. Content came from different places, so the first priority is ensuring the steps are in the correct order, and are accurate for 3.0 TP1.
+
+The following steps show how to install the {KialiProduct}.
+
+[WARNING]
+====
+Do not install Community versions of the Operators. Community Operators are not supported.
+====
+
+.Prerequisites
+
+* Access to the {product-title} web console.
+
+.Procedure
+
+. Log in to the {product-title} web console.
+
+. Navigate to *Operators* -> *OperatorHub*.
+
+. Type *Kiali* into the filter box to find the {KialiProduct}.
+
+. Click the *{KialiProduct}* to display information about the Operator.
+
+. Click *Install*.
+
+. On the *Operator Installation* page, select the *stable* Update Channel.
+
+. Select *All namespaces on the cluster (default)*. This installs the Operator in the default `openshift-operators` project and makes the Operator available to all projects in the cluster.
+
+. Select the *Automatic* Approval Strategy.
++
+[NOTE]
+====
+The Manual approval strategy requires a user with appropriate credentials to approve the Operator install and subscription process.
+====
+
+. Click *Install*.
+
+. The *Installed Operators* page displays the Kiali Operator's installation progress.


### PR DESCRIPTION
**OSSM 3.0**

Merge to https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main

Cherry pick to https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1

[OSSM-6961](https://issues.redhat.com//browse/OSSM-6961) [DOC] Installing the Kiali Operator provided by Red Hat

This PR is part of the standalone doc set for the OpenShift Service Mesh project. Kathryn is aware that this content applies for a product that is part of a Technology Preview release. The project is seeking feedback from early adopters.

Version(s): Technology Preview

Service Mesh 3.0 docs have moved to the stand alone format. They will not be cherry-picked to OCP core branches.

Issue:
https://issues.redhat.com/browse/OSSM-6961

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
