### PR TITLE
[OSDOCS-11001]: Migrating HCP resource utilization content from RHACM to OCP

### DIFF
--- a/hosted_control_planes/hcp-prepare/hcp-override-resource-util.adoc
+++ b/hosted_control_planes/hcp-prepare/hcp-override-resource-util.adoc
@@ -6,3 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+The set of baseline measurements for resource utilization can vary in every hosted cluster.
+
+include::modules/hcp-override.adoc[leveloffset=+1]
+include::modules/hcp-disable-metrics.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-prepare/hcp-override-resource-util.adoc
+++ b/hosted_control_planes/hcp-prepare/hcp-override-resource-util.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The set of baseline measurements for resource utilization can vary in every hosted cluster.
+The set of baseline measurements for resource utilization can vary in each hosted cluster.
 
 include::modules/hcp-override.adoc[leveloffset=+1]
 include::modules/hcp-disable-metrics.adoc[leveloffset=+1]

--- a/modules/hcp-disable-metrics.adoc
+++ b/modules/hcp-disable-metrics.adoc
@@ -6,11 +6,11 @@
 [id="hcp-disable-metrics_{context}"]
 = Disabling the metric service monitoring
 
-After enabling the `hypershift-addon` managed cluster addon, the metric service monitoring is configured by default so that {product-title} monitoring can gather metrics from `hypershift-addon`. 
+After you enable the `hypershift-addon` managed cluster add-on, metric service monitoring is configured by default so that {product-title} monitoring can gather metrics from `hypershift-addon`. 
 
 .Procedure
 
-You can disable the metric service monitoring by completing the following steps:
+You can disable metric service monitoring by completing the following steps:
 
 . Log in to your hub cluster by running the following command:
 +
@@ -19,7 +19,7 @@ You can disable the metric service monitoring by completing the following steps:
 $ oc login
 ----
 
-. Open the `hypershift-addon-deploy-config` add-on deployment configuration specification for editing by running the following command:
+. Edit the `hypershift-addon-deploy-config` add-on deployment configuration specification by running the following command:
 +
 [source,terminal]
 ----
@@ -45,6 +45,11 @@ spec:
     value: "true"
 ----
 +
-<1> The `disableMetrics=true` customized variable disables the metric service monitoring configuration for both new and existing `hypershift-addon` managed cluster add-ons.
+<1> The `disableMetrics=true` customized variable disables metric service monitoring for both new and existing `hypershift-addon` managed cluster add-ons.
 
-. Save the changes.
+. Apply the changes to the configuration specification by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----

--- a/modules/hcp-disable-metrics.adoc
+++ b/modules/hcp-disable-metrics.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-prepare/hcp-override-resource-util.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-disable-metrics_{context}"]
+= Disabling the metric service monitoring
+
+After enabling the `hypershift-addon` managed cluster addon, the metric service monitoring is configured by default so that {product-title} monitoring can gather metrics from `hypershift-addon`. 
+
+.Procedure
+
+You can disable the metric service monitoring by completing the following steps:
+
+. Log in to your hub cluster by running the following command:
++
+[source,terminal]
+----
+$ oc login
+----
+
+. Open the `hypershift-addon-deploy-config` add-on deployment configuration specification for editing by running the following command:
++
+[source,terminal]
+----
+$ oc edit addondeploymentconfig hypershift-addon-deploy-config -n multicluster-engine
+----
+
+. Add the `disableMetrics=true` customized variable to the specification, as shown in the following example:
++
+[source,yaml]
+----
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnDeploymentConfig
+metadata:
+  name: hypershift-addon-deploy-config
+  namespace: multicluster-engine
+spec:
+  customizedVariables:
+  - name: hcMaxNumber
+    value: "80"
+  - name: hcThresholdNumber
+    value: "60"
+  - name: disableMetrics <1>
+    value: "true"
+----
++
+<1> The `disableMetrics=true` customized variable disables the metric service monitoring configuration for both new and existing `hypershift-addon` managed cluster add-ons.
+
+. Save the changes.

--- a/modules/hcp-override.adoc
+++ b/modules/hcp-override.adoc
@@ -6,7 +6,7 @@
 [id="hcp-override_{context}"]
 = Overriding resource utilization measurements for a hosted cluster
 
-You can override the resource utilization measurements based on the type and pace of your cluster workload. Complete the following steps:
+You can override resource utilization measurements based on the type and pace of your cluster workload.
 
 .Procedure
 

--- a/modules/hcp-override.adoc
+++ b/modules/hcp-override.adoc
@@ -1,0 +1,70 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-prepare/hcp-override-resource-util.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-override_{context}"]
+= Overriding resource utilization measurements for a hosted cluster
+
+You can override the resource utilization measurements based on the type and pace of your cluster workload. Complete the following steps:
+
+.Procedure
+
+. Create the `ConfigMap` resource by running the following command:
++
+[source,terminal]
+----
+$ oc create -f <your-config-map-file.yaml>
+----
++
+Replace `<your-config-map-file.yaml>` with the name of your YAML file that contains your `hcp-sizing-baseline` config map.
+
+. Create the `hcp-sizing-baseline` config map in the `local-cluster` namespace to specify the measurements you want to override. Your config map might resemble the following YAML file:
++
+[source,yaml]
+----
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: hcp-sizing-baseline
+  namespace: local-cluster
+data:
+  incrementalCPUUsagePer1KQPS: "9.0"
+  memoryRequestPerHCP: "18"
+  minimumQPSPerHCP: "50.0"
+----
+
+. Delete the `hypershift-addon-agent` deployment to restart the `hypershift-addon-agent` pod by running the following command:
++
+[source,terminal]
+----
+$ oc delete deployment hypershift-addon-agent -n open-cluster-management-agent-addon
+----
+
+.Verification
+
+* Observe the `hypershift-addon-agent` pod logs. Verify that the overridden measurements are updated in the config map by running the following command:
++
+[source,terminal]
+----
+$ oc logs hypershift-addon-agent -n open-cluster-management-agent-addon
+----
++
+Your logs might resemble the following output:
++
+.Example output
+[source,terminal]
+----
+2024-01-05T19:41:05.392Z	INFO	agent.agent-reconciler	agent/agent.go:793	setting cpuRequestPerHCP to 5
+2024-01-05T19:41:05.392Z	INFO	agent.agent-reconciler	agent/agent.go:802	setting memoryRequestPerHCP to 18
+2024-01-05T19:53:54.070Z	INFO	agent.agent-reconciler	agent/hcp_capacity_calculation.go:141	The worker nodes have 12.000000 vCPUs
+2024-01-05T19:53:54.070Z	INFO	agent.agent-reconciler	agent/hcp_capacity_calculation.go:142	The worker nodes have 49.173369 GB memory
+----
++
+If the overridden measurements are not updated properly in the `hcp-sizing-baseline` config map, you might see the following error message in the `hypershift-addon-agent` pod logs:
++
+.Example error
+[source,terminal]
+----
+2024-01-05T19:53:54.052Z	ERROR	agent.agent-reconciler	agent/agent.go:788	failed to get configmap from the hub. Setting the HCP sizing baseline with default values.	{"error": "configmaps \"hcp-sizing-baseline\" not found"}
+----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-11724
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://80620--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-prepare/hcp-override-resource-util.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

**NOTE FOR PEER REVIEWERS:** This PR moves the HCP resource utilization content from the RHACM docs repo to the OCP docs repo. The content has not been changed since it was peer reviewed and approved by the RHACM docs team.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
