### PR TITLE
OADP-2340 -- Mention support for Red Hat Container Storage and OpenShift Data Foundation for Ceph RADOS Gateway

### DIFF
--- a/modules/oadp-about-backup-snapshot-locations-secrets.adoc
+++ b/modules/oadp-about-backup-snapshot-locations-secrets.adoc
@@ -16,7 +16,7 @@ You specify backup and snapshot locations and their secrets in the `DataProtecti
 [discrete]
 == Backup locations
 
-You specify AWS S3-compatible object storage as a backup location, such as Multicloud Object Gateway; Ceph RADOS Gateway, also known as Ceph Object Gateway;  or MinIO.
+You specify AWS S3-compatible object storage as a backup location, such as Multicloud Object Gateway; Ceph RADOS Gateway (Ceph Object Gateway) on Red Hat Container Storage or {odf-full}; or MinIO.
 
 Velero backs up {product-title} resources, Kubernetes objects, and internal images as an archive file on object storage.
 

--- a/modules/oadp-s3-compatible-backup-storage-providers.adoc
+++ b/modules/oadp-s3-compatible-backup-storage-providers.adoc
@@ -18,7 +18,7 @@ The following AWS S3 compatible object storage providers are fully supported by 
 * Multicloud Object Gateway (MCG)
 * Amazon Web Services (AWS) S3
 * {ibm-cloud-name} Object Storage S3
-* Ceph RADOS Gateway (Ceph Object Gateway)
+* Ceph RADOS Gateway (Ceph Object Gateway) on Red Hat Container Storage or {odf-full}
 
 [NOTE]
 ====


### PR DESCRIPTION
OADP 1.4.x, OCP 4.13+

Resolves https://issues.redhat.com/browse/OADP-2340 by mentioning that Ceph RADOS Gateway on Red Hat Container Storage and OpenShift Data Foundation can be used as a backup storage location. 

Previews: 

- https://80621--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.html#oadp-s3-compatible-backup-storage-providers-supported
- https://80621--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws#oadp-about-backup-snapshot-locations_installing-oadp-aws [repeated for different platforms] 
