### PR TITLE
TELCODOCS#1915: Removed TP status for 4.16 features

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -1283,7 +1283,7 @@ In addition to the OCI image, the image-based upgrade uses the `ostree` library 
 For more information, see xref:../edge_computing/image_based_upgrade/cnf-understanding-image-based-upgrade.adoc#understanding-image-based-upgrade-for-sno[Understanding the image-based upgrade for {sno} clusters].
 
 [id="ocp-4-16-edge-computing-ipsec-encryption-for-managed-clusters-ztp_{context}"]
-==== Deploying IPsec encryption to managed clusters with {ztp} and {rh-rhacm} (Technology Preview)
+==== Deploying IPsec encryption to managed clusters with {ztp} and {rh-rhacm}
 
 You can now enable IPsec encryption in managed {sno} clusters that you deploy with {ztp} and {rh-rhacm-first}.
 You can encrypt external traffic between pods and IPsec endpoints external to the managed cluster.
@@ -3206,11 +3206,6 @@ In the following tables, features are marked with the following statuses:
 |Feature |4.14 |4.15 |4.16
 
 |Accelerated provisioning of {ztp}
-|Not Available
-|Not Available
-|Technology Preview
-
-|Deploying IPsec encryption to managed clusters with {ztp} and {rh-rhacm}
 |Not Available
 |Not Available
 |Technology Preview


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[TELCODOCS-1915](https://issues.redhat.com/browse/TELCODOCS-1915)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Deploying IPsec encryption to managed clusters with GitOps ZTP and RHACM](https://80627--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-edge-computing_release-notes)
- [Technology Preview features status](https://80627--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-technology-preview-tables_release-notes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->