### PR TITLE
OSDOCS-11279: LVM storage resource footprint reduction is added in th…

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -68,8 +68,12 @@ This release adds improvements related to the following components and concepts.
 //[id="microshift-4-17-configure-route-admission-policy_{context}"]
 //==== Configuring the route admission policy now available
 
-[id="microshift-4-17-storage"]
+[id="microshift-4-17-storage_{context}"]
 === Storage
+
+[id="microshift-4-17-LVMS-resource-footprint-reduction_{context}"]
+==== Resource footprint reduction for LVM storage driver now available
+With this release, the resource footprint of the LVM storage driver is significantly reduced, particularly in terms of memory consumption.
 
 [id="microshift-4-17-running-apps_{context}"]
 === Running applications


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-11279](https://issues.redhat.com/browse/OSDOCS-11279)

Link to docs preview:
[Support for LVM storage resource footprint reduction](https://80628--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-storage)

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.
