### PR TITLE
OADP-4677 updated restic to nodeAgent

### DIFF
--- a/modules/oadp-restic-issues.adoc
+++ b/modules/oadp-restic-issues.adoc
@@ -23,16 +23,21 @@ You can resolve this issue by creating a supplemental group for `Restic` and add
 
 . Create a supplemental group for `Restic` on the NFS data volume.
 . Set the `setgid` bit on the NFS directories so that group ownership is inherited.
-. Add the `spec.configuration.restic.supplementalGroups` parameter and the group ID to the `DataProtectionApplication` manifest, as in the following example:
+. Add the `spec.configuration.nodeAgent.supplementalGroups` parameter and the group ID to the `DataProtectionApplication` manifest, as shown in the following example:
 +
 [source,yaml]
 ----
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+# ...
 spec:
   configuration:
-    restic:
+    nodeAgent:
       enable: true
+      uploaderType: restic
       supplementalGroups:
       - <group_id> <1>
+# ...
 ----
 <1> Specify the supplemental group ID.
 

--- a/modules/oadp-restic-timeouts.adoc
+++ b/modules/oadp-restic-timeouts.adoc
@@ -6,9 +6,9 @@
 [id="restic-timeout_{context}"]
 = Restic timeout
 
-`timeout` defines the Restic timeout. The default value is `1h`.
+The `spec.configuration.nodeAgent.timeout` parameter defines the Restic timeout. The default value is `1h`.
 
-Use the Restic `timeout` for the following scenarios:
+Use the Restic `timeout` parameter in the `nodeAgent` section for the following scenarios:
 
 * For Restic backups with total PV data usage that is greater than 500GB.
 * If backups are timing out with the following error:
@@ -19,7 +19,7 @@ level=error msg="Error backing up item" backup=velero/monitoring error="timed ou
 ----
 
 .Procedure
-* Edit the values in the `spec.configuration.restic.timeout` block of the `DataProtectionApplication` CR manifest, as in the following example:
+* Edit the values in the `spec.configuration.nodeAgent.timeout` block of the `DataProtectionApplication` custom resource (CR) manifest, as shown in the following example:
 +
 [source,yaml]
 ----
@@ -29,7 +29,9 @@ metadata:
  name: <dpa_name>
 spec:
   configuration:
-    restic:
+    nodeAgent:
+      enable: true
+      uploaderType: restic
       timeout: 1h
 # ...
 ----


### PR DESCRIPTION
## Jira 

* [OADP-4677](https://issues.redhat.com/browse/OADP-4677)

Updated DPA.spec.configuration.restic to  spec.configuration.nodeAgent

##  Version

* OCP 4.13 → OCP 4.17

## Preview

* [Restic permission error](https://80629--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting.html#restic-permission-error-nfs-root-squash-enabled_oadp-troubleshooting)

* [Restic timeout](https://80629--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting.html#restic-timeout_oadp-troubleshooting)

## QE Review

* [x] QE has approved this change.
