### PR TITLE
OSDOCS-11712: Documented the 4.15.28 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2740,6 +2740,38 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.15.28 
+[id="ocp-4-15-28_{context}"]
+=== RHSA-2024:5439 - {product-title} 4.15.28 bug fix and security update
+
+Issued: 2024-08-22
+
+{product-title} release 4.15.28, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2024:5439[RHSA-2024:5439] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHSA-2024:5442[RHSA-2024:5442] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.28 --pullspecs
+----
+
+[id="ocp-4-15-28-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the {product-title} web console failed to restart a bare metal node. This release fixes this issue so that you can restart a bare metal node by using the {product-title} web console. (link:https://issues.redhat.com/browse/OCPBUGS-37099[*OCPBUGS-37099*])
+
+[id="ocp-4-15-28-known-issues_{context}"]
+==== Known issues
+
+* An error might occur when deleting a pod that uses an SR-IOV network device. This error is caused by a change in {op-system-base} 9 where the previous name of a network interface is added to its alternative names list when it is renamed. As a consequence, when a pod attached to an SR-IOV virtual function (VF) is deleted, the VF returns to the pool with a new unexpected name; for example, `dev69`, instead of its original name,`ensf0v2`. Although this error is non-fatal, Multus and SR-IOV logs might show the error while the system reboots. Deleting the pod might take a few extra seconds due to this error. (link:https://issues.redhat.com/browse/OCPBUGS-11281[*OCPBUGS-11281*],link:https://issues.redhat.com/browse/OCPBUGS-18822[*OCPBUGS-18822*], link:https://issues.redhat.com/browse/RHEL-5988[*RHEL-5988*])
+
+[id="ocp-4-15-28-updating_{context}"]
+==== Updating
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+
 // 4.15.27
 [id="ocp-4-15-27_{context}"]
 === RHSA-2024:5160 - {product-title} 4.15.27 bug fix and security update


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-11712](https://issues.redhat.com/browse/OSDOCS-11712)

Link to docs preview:
* [4.15.28](https://80632--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-28_release-notes)

