### PR TITLE
OSDOCS-11723-13: Documented known issue on vSphere for OVNK plugin

### DIFF
--- a/networking/openshift_sdn/about-openshift-sdn.adoc
+++ b/networking/openshift_sdn/about-openshift-sdn.adoc
@@ -6,11 +6,16 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Part of {openshift-networking}, OpenShift SDN is a network plugin that uses a
-software-defined networking (SDN) approach to provide a unified cluster network
-that enables communication between pods across the {product-title} cluster. This
-pod network is established and maintained by OpenShift SDN, which configures
-an overlay network using Open vSwitch (OVS).
+Part of {openshift-networking}, OpenShift SDN is a network plugin that uses a software-defined networking (SDN) approach to provide a unified cluster network that enables communication between pods across the {product-title} cluster. This pod network is established and maintained by OpenShift SDN, which configures an overlay network by using Open vSwitch (OVS).
+
+[IMPORTANT]
+====
+For a cloud controller manager (CCM) with the `--cloud-provider=external` option set to `cloud-provider-vsphere`, a known issue exists for a cluster that operates in a networking environment with multiple subnets. 
+
+When you upgrade your cluster from {product-title} 4.12 to {product-title} {product-version}, the CCM selects a wrong node IP address and this operation generates an error message in the `namespaces/openshift-cloud-controller-manager/pods/vsphere-cloud-controller-manager` logs. The error message indicates a mismatch with the node IP address and the `vsphere-cloud-controller-manager` pod IP address in your cluster.
+
+The known issue might not impact the cluster upgrade operation, but you can set the correct IP address in both the `nodeNetworking.external.networkSubnetCidr` and the `nodeNetworking.internal.networkSubnetCidr` parameters for the `nodeNetworking` object that your cluster uses for its networking requirements.
+====
 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 include::modules/nw-openshift-sdn-modes.adoc[leveloffset=+1]

--- a/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+++ b/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
@@ -10,6 +10,16 @@ The {product-title} cluster uses a virtualized network for pod and service netwo
 
 Part of {openshift-networking}, the OVN-Kubernetes network plugin is the default network provider for {product-title}.
 OVN-Kubernetes is based on Open Virtual Network (OVN) and provides an overlay-based networking implementation.
+
+[IMPORTANT]
+====
+For a cloud controller manager (CCM) with the `--cloud-provider=external` option set to `cloud-provider-vsphere`, a known issue exists for a cluster that operates in a networking environment with multiple subnets. 
+
+When you upgrade your cluster from {product-title} 4.12 to {product-title} {product-version}, the CCM selects a wrong node IP address and this operation generates an error message in the `namespaces/openshift-cloud-controller-manager/pods/vsphere-cloud-controller-manager` logs. The error message indicates a mismatch with the node IP address and the `vsphere-cloud-controller-manager` pod IP address in your cluster.
+
+The known issue might not impact the cluster upgrade operation, but you can set the correct IP address in both the `nodeNetworking.external.networkSubnetCidr` and the `nodeNetworking.internal.networkSubnetCidr` parameters for the `nodeNetworking` object that your cluster uses for its networking requirements.
+====
+
 A cluster that uses the OVN-Kubernetes plugin also runs Open vSwitch (OVS) on each node.
 OVN configures OVS on each node to implement the declared network configuration.
 

--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -2746,6 +2746,12 @@ In the following tables, features are marked with the following statuses:
 [id="ocp-4-13-known-issues"]
 == Known issues
 
+* For a cloud controller manager (CCM) with the `--cloud-provider=external` option set to `cloud-provider-vsphere`, a known issue exists for a cluster that operates in a networking environment with multiple subnets. 
++
+When you upgrade your cluster from {product-title} 4.12 to {product-title} {product-version}, the CCM selects a wrong node IP address and this operation generates an error message in the `namespaces/openshift-cloud-controller-manager/pods/vsphere-cloud-controller-manager` logs. The error message indicates a mismatch with the node IP address and the `vsphere-cloud-controller-manager` pod IP address in your cluster.
++
+The known issue might not impact the cluster upgrade operation, but you can set the correct IP address in both the `nodeNetworking.external.networkSubnetCidr` and the `nodeNetworking.internal.networkSubnetCidr` parameters for the `nodeNetworking` object that your cluster uses for its networking requirements.
+
 // TODO: This known issue should carry forward to 4.8 and beyond! This needs some SME/QE review before being updated for 4.11. Need to check if KI should be removed or should stay.
 * In {product-title} 4.1, anonymous users could access discovery endpoints. Later releases revoked this access to reduce the possible attack surface for security exploits because some discovery endpoints are forwarded to aggregated API servers. However, unauthenticated access is preserved in upgraded clusters so that existing use cases are not broken.
 +


### PR DESCRIPTION
**CM:**
CM sent out on the 5th of September. See the email named "[Notice of change] Networking known issue in 4.13 when upgrading your cluster".

**Version(s):**
4.13 only

**Issue:**
[OSDOCS-11723](https://issues.redhat.com/browse/OSDOCS-11723)

**Link to docs preview:**
* [About the OpenShift SDN network plugin](https://80633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/about-openshift-sdn.html)
* [About the OVN-Kubernetes network plugin](https://80633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes)
* [4.13 Release Notes KNown Issues](https://80633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes#ocp-4-13-known-issues)


- [x] SME has approved this change. (Ben Bennett)
- [x] QE has approved this change. (Ross Brattain)


Additional information:
* https://issues.redhat.com/browse/OCPSTRAT-1369
* https://docs.openshift.com/container-platform/4.16/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-network-customizations.html#nw-operator-vsphere-multiple-subnets_installing-vsphere-installer-provisioned-network-customizations
* For more information about setting the parameter, see xref:../../installing-vsphere-installer-provisioned-network-customizations.adoc#nw-operator-vsphere-multiple-subnets_installing-vsphere-installer-provisioned-network-customizations[Specifying multiple subnets for your network] (Installing on vSphere).
