### PR TITLE
OCPBUGS-17177: changed registrySource to registrySources

### DIFF
--- a/modules/images-configuration-blocked-payload.adoc
+++ b/modules/images-configuration-blocked-payload.adoc
@@ -48,7 +48,7 @@ $ oc edit image.config.openshift.io cluster
 [source,yaml]
 ----
 spec:
-  registrySource:
+  registrySources:
     blockedRegistries:
      - quay.io/openshift-payload
 ----


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-17177

Link to docs preview:
https://80649--ocpdocs-pr.netlify.app/openshift-dedicated/latest/openshift_images/image-configuration.html
https://80649--ocpdocs-pr.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration.html
https://80649--ocpdocs-pr.netlify.app/openshift-rosa/latest/openshift_images/image-configuration.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
