### PR TITLE
OBSDOCS-1137: Log Output Types

### DIFF
--- a/modules/log6x-log-output-types-description.adoc
+++ b/modules/log6x-log-output-types-description.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/logging-6.0/log6x-loki.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="log6x-log-output-types_{context}"]
+== Output type descriptions
+
+`default`:: The on-cluster, Red{nbsp}Hat managed log store. You are not required to configure the default output.
++
+[NOTE]
+====
+If you configure a `default` output, you receive an error message, because the `default` output name is reserved for referencing the on-cluster, Red{nbsp}Hat managed log store.
+====
+`googlecloudlogging`:: Google Cloud Logging, a monitoring and log storage service hosted by Google Cloud Platform (GCP).
+`http`:: <TBD>.
+`kafka`:: A Kafka broker. The `kafka` output can use a TCP or TLS connection.
+`loki`:: Loki, a horizontally scalable, highly available, multi-tenant log aggregation system.
+`lokiStack`:: <TBD>.
+`splunk`:: <TBD>.
+`syslog`:: An external log aggregation solution that supports the syslog link:https://tools.ietf.org/html/rfc3164[RFC3164] or link:https://tools.ietf.org/html/rfc5424[RFC5424] protocols. The `syslog` output can use a UDP, TCP, or TLS connection.

--- a/modules/log6x-log-outputs.adoc
+++ b/modules/log6x-log-outputs.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/logging-6.0/log6x-loki.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="log-output-types_{context}"]
+= Log output types
+
+Outputs define the destination where logs are sent to from a log forwarder. You can configure multiple types of outputs in the `ClusterLogForwarder` custom resource (CR) to send logs to servers that support different protocols.
+
+Outputs can be any of the following types:
+
+.Supported log output types
+[cols="4",options="header"]
+|===
+|Output type
+|Protocol
+|Tested with
+|Logging versions
+
+|Google Cloud Logging
+|REST over HTTPS
+|Latest
+|5.7+
+
+|HTTP
+|HTTP 1.1
+|Fluentd 1.14.6, Vector 0.21
+|5.7+
+
+|Kafka
+|Kafka 0.11
+|Kafka 2.4.1, 2.7.0, 3.3.1
+|5.4+
+
+|Loki
+|REST over HTTP and HTTPS
+|2.3.0, 2.5.0, 2.7, 2.2.1
+|5.4+
+
+|Splunk
+|HEC
+|8.2.9, 9.0.0
+|5.7+
+
+|Syslog
+|RFC3164, RFC5424
+|Rsyslog 8.37.0-9.el7, rsyslog-8.39.0
+|5.4+
+|===
+
+[NOTE]
+--
+Vector supports Syslog in the {logging} version 5.7 and higher.
+--

--- a/observability/logging/logging-6.0/log6x-loki.adoc
+++ b/observability/logging/logging-6.0/log6x-loki.adoc
@@ -15,6 +15,11 @@ You can configure a `LokiStack` CR to store application, audit, and infrastructu
 
 
 // All of these need to be validated by engineering for 6.0.
+
+include::modules/log6x-log-outputs.adoc[leveloffset=+1]
+
+include::modules/log6x-log-output-types-description.adoc[leveloffset=+1]
+
 include::modules/logging-enabling-loki-alerts.adoc[leveloffset=+1]
 
 include::modules/logging-loki-memberlist-ip.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Logging 6.0
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-1137

Doc Preview: https://80682--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging-6.0/log6x-loki.html

SME Review: 
QE Review: 
Peer Review: