### PR TITLE
[virt]: DPDK - Bump container disk images to RHEL9

### DIFF
--- a/modules/virt-building-vm-containerdisk-image.adoc
+++ b/modules/virt-building-vm-containerdisk-image.adoc
@@ -6,25 +6,24 @@
 [id="virt-building-vm-containerdisk-image_{context}"]
 = Building a container disk image for {op-system-base} virtual machines
 
-You can build a custom {op-system-base-full} 8 OS image in `qcow2` format and use it to create a container disk image. You can store the container disk image in a registry that is accessible from your cluster and specify the image location in the `spec.param.vmContainerDiskImage` attribute of the DPDK checkup config map.
+You can build a custom {op-system-base-full} 9 OS image in `qcow2` format and use it to create a container disk image. You can store the container disk image in a registry that is accessible from your cluster and specify the image location in the `spec.param.vmContainerDiskImage` attribute of the DPDK checkup config map.
 
-To build a container disk image, you must create an image builder virtual machine (VM). The _image builder VM_ is a {op-system-base} 8 VM that can be used to build custom {op-system-base} images.
+To build a container disk image, you must create an image builder virtual machine (VM). The _image builder VM_ is a {op-system-base} 9 VM that can be used to build custom {op-system-base} images.
 
 .Prerequisites
-* The image builder VM must run {op-system-base} 8.7 and must have a minimum of 2 CPU cores, 4 GiB RAM, and 20 GB of free space in the `/var` directory.
-* You have installed the image builder tool and its CLI (`composer-cli`) on the VM.
-
+* The image builder VM must run {op-system-base} 9.4 and must have a minimum of 2 CPU cores, 4 GiB RAM, and 20 GB of free space in the `/var` directory.
+* You have installed the image builder tool and its CLI (`composer-cli`) on the VM. For more information, see "Additional resources".
 * You have installed the `virt-customize` tool:
 +
 [source,terminal]
 ----
-# dnf install libguestfs-tools
+# dnf install guestfs-tools
 ----
 * You have installed the Podman CLI tool (`podman`).
 
 .Procedure
 
-. Verify that you can build a {op-system-base} 8.7 image:
+. Verify that you can build a {op-system-base} 9.4 image:
 +
 [source,terminal]
 ----
@@ -37,7 +36,7 @@ To run the `composer-cli` commands as non-root, add your user to the `weldr` or 
 
 [source,terminal]
 ----
-# usermod -a -G weldr user
+# usermod -a -G weldr <user>
 ----
 [source,terminal]
 ----
@@ -53,7 +52,7 @@ $ cat << EOF > dpdk-vm.toml
 name = "dpdk_image"
 description = "Image to use with the DPDK checkup"
 version = "0.0.1"
-distro = "rhel-87"
+distro = "rhel-9.4"
 
 [[customizations.user]]
 name = "root"
@@ -122,8 +121,10 @@ echo "hugetlbfs /mnt/huge hugetlbfs defaults,pagesize=1GB 0 0" >> /etc/fstab
 echo "options vfio enable_unsafe_noiommu_mode=1" > /etc/modprobe.d/vfio-noiommu.conf
 
 # Enable guest-exec,guest-exec-status on the qemu-guest-agent configuration
-sed -i '/^BLACKLIST_RPC=/ { s/guest-exec-status//; s/guest-exec//g }' /etc/sysconfig/qemu-ga
-sed -i '/^BLACKLIST_RPC=/ { s/,\+/,/g; s/^,\|,$//g }' /etc/sysconfig/qemu-ga
+sed -i 's/\(--allow-rpcs=[^"]*\)/\1,guest-exec-status,guest-exec/' /etc/sysconfig/qemu-ga
+
+# Disable Bracketed-paste mode
+echo "set enable-bracketed-paste off" >> /root/.inputrc
 EOF
 ----
 


### PR DESCRIPTION
Version(s):
CNV4.17+

Issue:
[CNV-45762](https://issues.redhat.com//browse/CNV-45762)

Link to docs preview:
https://80685--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-running-cluster-checkups.html#virt-building-vm-containerdisk-image_virt-running-cluster-checkups

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
